### PR TITLE
Run the tournament: materialize round-robin draws + live standings (#788, #789)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -426,6 +426,48 @@ running tournament (a table breaks, a table frees up).
 _Avoid_: group (a pool is not a grouping abstraction separate from the venue
 slice), division.
 
+**Materialize**:
+Turning a **ready** **fixture** into a real **match**: the fixture's two known
+sides become the match's two sides, the event's `match_settings` (rated flag,
+game count) become the match's rules, and it runs the normal propose/accept
+lifecycle. Materialization happens **only once the tournament is `live`** — never
+while registration is open — and going live materializes every ready fixture in
+one stroke (for a round-robin, the whole pool). A fixture materializes **at most
+once**: its `match_id` is what makes creating the match idempotent, so an
+`advance()` re-run never proposes the same match twice. Today only **singles**
+events materialize (one player per side); other formats are refused.
+_Avoid_: schedule, start (materializing *creates* the match; *when it is played*
+is the schedule's concern).
+
+**Results**:
+How an event turned out, computed for display — a concept **universal across draw
+types but shaped differently by each**: a round-robin's results are its
+**standings**; a single-elimination's (later) are its final placement and
+**champion**. Computed **live from the fixtures' completed matches**, so a
+**correction** or **voided match** is reflected at once — never stored, never a
+snapshot. An event is **complete** when every fixture is **decided**; only then
+are its results final. Each draw type computes its own results shape; the display
+renders each its own way.
+_Avoid_: standings (the round-robin *shape* of results, not the general concept),
+score, summary.
+
+**Standings**:
+The round-robin **shape** of an event's **results**: the pool's entrants ordered
+by an extensible chain of tiebreakers — **wins**, then **head-to-head** when
+exactly two are tied, then **game difference** (games won minus games lost), then
+**games won**. Renders **live** as matches complete, not only at the end. Ordered
+server-side.
+_Avoid_: ranking (a **rank** is a league rating position; standings live inside one
+pool), league table, points diff (points are not modelled — the finest
+granularity is a **game**, so it is *game* difference).
+
+**Champion**:
+The entrant atop a **complete** event's **results** — for a round-robin, first in
+the **standings**. **Derived, never stored**: a **correction** can re-crown, so
+the champion is always read from the current results.
+_Avoid_: winner (a **winner** is one side of one match; the champion is the whole
+event's), first place.
+
 ## Dashboard
 
 **First-match**:

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -37,13 +37,14 @@ from app.models import (
     NotificationPreference,
     RatingHistory,
     Tournament,
+    TournamentEntry,
     TournamentEntryStatus,
     User,
     UserLeagueRating,
     UserRole,
     UserToken,
 )
-from app.tournament_draws import uncut_draw
+from app.tournament_draws import draw_has_play, uncut_draw
 
 # Must match ``app.sessions.SESSION_TOKEN_CONTEXT``. Hardcoded to avoid a
 # circular import (sessions imports this module). Session tokens are KEPT on the
@@ -492,16 +493,24 @@ async def _resolve_entry_collisions(
     and it is wrong throughout. The un-cut is scoped to the colliding events —
     another event of the same tournament keeps the draw it legitimately holds.
 
+    **The played-event case (ADR-0786 parked it for #788, now closed).** Steps 2–3
+    apply only to a collided event whose draw is **unplayed**. Once an event's draw
+    has begun — a fixture has a ``match_id`` (it materialized at go-live, #788) or a
+    ``winner_entry_id`` (``draw_has_play``) — it can be neither deleted (the guest's
+    entry seats played fixtures, and a hard delete would cascade those matches and
+    their results away) nor un-cut (the play guard forbids it). So the guest's
+    colliding entry is **withdrawn** (soft-deleted) rather than deleted: the row —
+    and every fixture and match hanging off it — survives, and the entry leaves the
+    ``entered`` state so the unconditional ``user_id`` re-point in ``merge_user``
+    cannot collide with the survivor's own active row. The self-play *matches* this
+    exposes (the guest and survivor drawn against each other, now one human on both
+    sides) are transferred to the survivor and voided by ``merge_user``'s existing
+    ADR-0013 machinery (``_self_play_collision`` + ``void_match``) — the "transfer
+    then void" ADR-0786 pointed at. The draw itself is left exactly as it was played:
+    a field that double-counted a human and then *ran* cannot be un-run.
+
     The merge itself is **never refused** (consistent with the self-play-collision
     doctrine): nobody is locked out of their own account by a registration.
-
-    *Out of scope, deliberately:* a collision on an event whose play has already
-    begun (a fixture with a ``winner_entry_id`` or a ``match_id`` —
-    ``draw_has_play``). Un-cutting there would eat a recorded result, so that case
-    needs the self-play-collision machinery (transfer the match, then void it)
-    rather than this. It is **unreachable today** — nothing materializes a fixture
-    into a match until #788 — and building it now would mean guessing at machinery
-    that does not exist. When #788 lands, this is the gap to close.
 
     "Active" is bound as ``:active`` from ``_ACTIVE_ENTRY_STATUS`` (see the module
     top) in every statement here, so none of them can drift from the enum that the
@@ -542,6 +551,35 @@ async def _resolve_entry_collisions(
     if not collided_event_ids:
         return
 
+    # Partition the collided events by evidence of play (a fixture with a ``match_id``
+    # or a ``winner_entry_id`` — the ``draw_has_play`` the cut/un-cut verbs gate on).
+    # An **unplayed** event's draw is regenerated (steps 1–3 below); a **played** one's
+    # cannot be — its matches exist and may carry scores — so its guest entry is
+    # withdrawn instead, and its self-play matches ride ``merge_user``'s ADR-0013 path.
+    played_event_ids = {
+        event_id for event_id in collided_event_ids if await draw_has_play(db, event_id)
+    }
+    unplayed_event_ids = collided_event_ids - played_event_ids
+
+    if played_event_ids:
+        # Withdraw (soft-delete), never delete: the guest's entry seats fixtures that
+        # materialized into played matches, and a hard delete would cascade those away.
+        # Withdrawing preserves them AND takes the entry out of ``entered``, so the
+        # unconditional re-point in ``merge_user`` moves a *withdrawn* duplicate onto
+        # the survivor (legal — the partial unique index only covers active entries)
+        # rather than a second active row that would trip it. It also removes the
+        # guest's active entry from the self-joins in steps 1–2, which is what scopes
+        # those to the unplayed events without a second event filter on their SQL.
+        await db.execute(
+            update(TournamentEntry)
+            .where(
+                TournamentEntry.user_id == from_user_id,
+                TournamentEntry.status == TournamentEntryStatus.entered,
+                TournamentEntry.event_id.in_(played_event_ids),
+            )
+            .values(status=TournamentEntryStatus.withdrawn)
+        )
+
     # (1) Registration order and seed follow the earlier registration onto the
     # survivor.
     await db.execute(
@@ -579,12 +617,15 @@ async def _resolve_entry_collisions(
         params,
     )
 
-    # (3) Un-cut the draws the double-counted field invalidated. ``uncut_draw`` is
-    # the one place a draw is deleted (ADR-0786) — a hand-rolled DELETE here would
-    # be a second spelling of "this event has no draw" to keep in step with the
-    # first. It takes the ids straight: the events themselves are never needed, so
+    # (3) Un-cut the draws the double-counted field invalidated — the **unplayed** ones
+    # only. A played event's draw cannot be un-cut (the play guard, and it would delete
+    # the fixtures its matches hang off); its guest entry was withdrawn above instead.
+    # ``uncut_draw`` is the one place a draw is deleted (ADR-0786) — a hand-rolled
+    # DELETE here would be a second spelling of "this event has no draw" to keep in step
+    # with the first — and it no-ops on an empty set, so an all-played collision deletes
+    # nothing. It takes the ids straight: the events themselves are never needed, so
     # loading them would be a SELECT run purely to read back the ids we already hold.
-    await uncut_draw(db, collided_event_ids)
+    await uncut_draw(db, unplayed_event_ids)
 
 
 async def _self_play_collision(

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -42,7 +42,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import NewType, Protocol
 
-from app.models.tournament import DrawType
+from app.models.tournament import DrawType, EventFormat
 
 # Distinct id types, so the checker rejects handing a fixture id to something that
 # wants an entry id. They are plain ``uuid.UUID`` at runtime.
@@ -86,6 +86,30 @@ class DegenerateDraw(DrawError):
     ghost), so we refuse the cut rather than silently emit a pool of one. The director
     fixes the input — fewer pools, or more entrants — and re-cuts.
     """
+
+
+class NonSinglesDraw(DrawError):
+    """The event is not **singles**, so it cannot be given a draw (ADR-0788).
+
+    Every draw this module cuts is over :class:`Entrant`\\ s that are **one entry per
+    person** — a fixture seats one entry on each side, and a materialized match seats
+    that entry's single user (side 1 ← ``entry_a``, side 2 ← ``entry_b``). A doubles or
+    teams event has no way to say *which two people* form one side: ``TournamentEntry``
+    is a single ``user_id``, there is no partner or roster model. So a round-robin over
+    such an event would be meaningless, and it is refused at the **cut** — the earliest,
+    clearest point — rather than left to fail obscurely at go-live.
+
+    Carries the offending :class:`~app.models.tournament.EventFormat` **structurally**,
+    so the HTTP layer composes the director-facing sentence from the fact rather than
+    parsing it out of a message (the same shape as :class:`UnsupportedDrawType`).
+    """
+
+    def __init__(self, event_format: EventFormat) -> None:
+        self.event_format = event_format
+        super().__init__(
+            f"A {event_format.value} event cannot be given a draw — draws are "
+            "singles-only."
+        )
 
 
 class Side(enum.Enum):

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -67,11 +67,10 @@ from app.rate_limiting import RedisRateLimiter
 from app.result_acceptance import (
     PostedGamesNotDecisiveError,
     StandingResultConflictError,
-    _apply_rating_update,
     _game_winner_side,
     _games_to_win,
-    _set_side_won,
     accept_standing_result,
+    finalize_match,
     side_win_counts,
 )
 from app.result_chain import accepted_result, standing_result
@@ -1781,9 +1780,12 @@ async def post_match_result(
         # proposer's own id is recorded as the acceptor.
         result.accepted_by_user_id = current_user.id
         result.accepted_at = datetime.now(UTC)
-        match.mark_completed()
-        _set_side_won(match, decided_side)
-        await _apply_rating_update(db, match)
+        # The one completion path shared with the rated accept (``finalize_match``):
+        # mark completed, stamp ``side.won``, run the rating update, and advance any
+        # tournament draw this match belongs to (#789). Funnelling both sites through
+        # it is what keeps a tournament match's draw from being left un-advanced when
+        # its unrated result self-accepts here instead of at acceptance.
+        await finalize_match(db, match, decided_side)
     else:
         # Rated path: the result stays standing (unaccepted) and ``side.won``
         # stays unset until the opposing side accepts. Status is (re)set to

--- a/api/app/models/tournament_fixture.py
+++ b/api/app/models/tournament_fixture.py
@@ -113,8 +113,13 @@ class TournamentFixture(Base):
     #: corrupted draw would silently satisfy it and go live. The merge instead **un-cuts
     #: the event's draw** (a draw cut from a field that double-counted a human is wrong
     #: throughout — its pool sizes and seeding were computed against N+1 entrants), and
-    #: the director re-cuts. See ADR-786; ``_resolve_entry_collisions`` is where it is
-    #: done.
+    #: the director re-cuts. That un-cut path is only for an **unplayed** draw. Once
+    #: play has begun (a fixture here has a ``match_id`` or a ``winner_entry_id`` —
+    #: ``draw_has_play``), the draw cannot be un-cut, so instead the guest's colliding
+    #: entry is **withdrawn** (soft-deleted, not hard-deleted — these rows survive) and
+    #: the exposed guest-vs-survivor self-play match is transferred then voided
+    #: (ADR-0788). See ADR-786 and ADR-788; ``_resolve_entry_collisions`` holds both
+    #: paths.
     entry_a_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("tournament_entries.id", ondelete="CASCADE"),

--- a/api/app/result_acceptance.py
+++ b/api/app/result_acceptance.py
@@ -52,6 +52,7 @@ from app.ratings import (
     validate_state,
 )
 from app.result_chain import standing_result
+from app.tournament_advancement import on_match_completed
 
 
 class StandingResultConflictError(Exception):
@@ -358,6 +359,26 @@ async def accept_standing_result(
 
     standing.accepted_by_user_id = accepted_by_user_id
     standing.accepted_at = datetime.now(UTC)
+    await finalize_match(db, match, _posted_decided_side(match))
+
+
+async def finalize_match(db: AsyncSession, match: Match, decided_side: int) -> None:
+    """Complete a match: stamp it done, record the W/L, run the rating update, and
+    advance any tournament draw it belongs to (ADR-0788).
+
+    **The one place a match becomes ``completed``.** Both completion sites funnel
+    through here — the rated accept/retire path (:func:`accept_standing_result`) and the
+    unrated immediate-self-accept path (``app.matches``) — so the four things a
+    completion must do happen together and in one order, and a future third completion
+    path cannot do three of them and forget the fourth. ``decided_side`` is the winning
+    side number, computed by the caller from the agreed board (``_posted_decided_side``
+    on accept, the finalize validator's ``decided_side`` on the unrated post).
+
+    The tournament hook runs **last and unconditionally**: :func:`on_match_completed`
+    early-returns on a non-tournament match (the overwhelmingly common case), so a plain
+    ladder match pays only an indexed lookup that misses. Runs in the caller's
+    transaction under the match row lock; does **not** commit."""
     match.mark_completed()
-    _set_side_won(match, _posted_decided_side(match))
+    _set_side_won(match, decided_side)
     await _apply_rating_update(db, match)
+    await on_match_completed(db, match)

--- a/api/app/results.py
+++ b/api/app/results.py
@@ -1,0 +1,312 @@
+"""An event's **results** — how it turned out — as a *pure* per-draw-type strategy
+family (ADR-0788).
+
+``app.draws`` is the strategy family that *runs* a draw (``plan_initial`` +
+``advance``); this is the separate family that reads a draw's decided matches back
+into a **result**. They are kept apart because results are *shaped* differently per
+draw type — a round-robin's result is its **standings** table, a single-elim's is a
+placement and a **champion** — so a single shared method on ``DrawStrategy`` would
+force every draw type to implement a table it does not have (ADR-0788, "results are a
+separate strategy family"). ``results_for(draw_type)`` mirrors ``strategy_for``'s
+exhaustive ``match`` / ``UnsupportedResultsType``, so a new
+:class:`~app.models.tournament.DrawType` is a type error here until somebody says how
+it reads out.
+
+Like ``app.draws`` this module is **pure**: it holds no session, issues no query, and
+imports no SQLAlchemy construct. Its whole input is small frozen value objects
+(:class:`MatchOutcome`, grouped into :class:`PoolInput`) that the persistence layer
+projects from the fixtures' **currently-completed** matches — so nothing here is a
+snapshot, and a corrected or voided match re-orders the standings the instant it leaves
+``completed``, with no bookkeeping to keep in step (ADR-0788, "everything derives from
+the live matches").
+
+This slice implements only :class:`RoundRobinResults`.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from app.draws import EntryId, PoolId
+from app.models.tournament import DrawType
+
+
+class UnsupportedResultsType(Exception):
+    """This draw type has no results strategy yet.
+
+    Raised by :func:`results_for`, whose ``match`` is exhaustive with no catch-all —
+    so a new :class:`~app.models.tournament.DrawType` member is a *type* error until it
+    is handled here, and a member handled-but-unimplemented is a catchable domain error
+    rather than a 500. The exact mirror of ``app.draws.UnsupportedDrawType``.
+    """
+
+    def __init__(self, draw_type: DrawType) -> None:
+        self.draw_type = draw_type
+        super().__init__(f"Draw type {draw_type.value!r} has no results strategy yet.")
+
+
+@dataclass(frozen=True, slots=True)
+class MatchOutcome:
+    """One decided fixture, as the standings need to see it: who was in it, who won,
+    and the games each side took.
+
+    Projected by the caller from a fixture whose match is **currently completed** — so
+    it is a fact about live state, never a snapshot. The games are the count each entry
+    *won*, which is all the game-difference and games-won tiebreakers need — and the
+    winner falls out of them.
+    """
+
+    entry_a_id: EntryId
+    entry_b_id: EntryId
+    entry_a_games: int
+    entry_b_games: int
+
+    @property
+    def winner_entry_id(self) -> EntryId:
+        """Whichever entry took more games. A decided match has no tie (odd best-of),
+        so the higher count is always the winner — derived here rather than stored, so
+        it cannot be handed in disagreeing with the counts beside it."""
+        return (
+            self.entry_a_id
+            if self.entry_a_games > self.entry_b_games
+            else self.entry_b_id
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PoolInput:
+    """One pool's whole input to the standings: every entry seated in it, how many
+    fixtures it has, and the outcomes of the ones already decided.
+
+    ``entrants`` is the full seated field — not just the entries that have played — so a
+    player who has not played yet still appears in the table with a row of zeros
+    (partial, live standings). ``fixture_count`` is the pool's total number of pairings,
+    against which ``len(outcomes)`` decides whether the pool is **complete**.
+    """
+
+    pool_id: PoolId
+    entrants: tuple[EntryId, ...]
+    fixture_count: int
+    outcomes: tuple[MatchOutcome, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class StandingRow:
+    """One entry's line in a pool's standings table, at its settled rank.
+
+    ``rank`` is 1-based and every row's is distinct (the ordering is a total one — see
+    :class:`RoundRobinResults`), so position 1 is the pool leader.
+    """
+
+    entry_id: EntryId
+    rank: int
+    played: int
+    wins: int
+    losses: int
+    games_won: int
+    games_lost: int
+
+    @property
+    def game_difference(self) -> int:
+        """Games won minus games lost — the third link in the tiebreak chain."""
+        return self.games_won - self.games_lost
+
+
+@dataclass(frozen=True, slots=True)
+class PoolStandings:
+    """One pool's standings: its rows in finishing order, and whether every fixture in
+    it has been decided."""
+
+    pool_id: PoolId
+    rows: tuple[StandingRow, ...]
+    complete: bool
+
+
+@dataclass(frozen=True, slots=True)
+class EventResults:
+    """A round-robin event's results: a standings table per pool, whether the whole
+    event is decided, and its champion when there is one.
+
+    ``champion`` is the leader of a **complete, single-pool** event — a pure
+    round-robin's winner. A multi-pool round-robin has no single champion without a
+    knockout stage to join its pool winners (that is ``rr_then_ko``, not this slice), so
+    ``champion`` is ``None`` there even when the event is complete. ``None`` also while
+    any fixture is still to be played.
+    """
+
+    pools: tuple[PoolStandings, ...]
+    complete: bool
+    champion: EntryId | None
+
+
+@dataclass(slots=True)
+class _Stat:
+    """A mutable per-entry accumulator — private to the tabulation, never returned."""
+
+    entry_id: EntryId
+    played: int = 0
+    wins: int = 0
+    losses: int = 0
+    games_won: int = 0
+    games_lost: int = 0
+
+    @property
+    def game_difference(self) -> int:
+        return self.games_won - self.games_lost
+
+
+# The tiebreak chain, after wins (which groups) and the two-way head-to-head (which
+# refines a pair): each entry maps to a value where HIGHER is better, tried in order.
+# A new comparator is **appended** here, not surgically inserted between the existing
+# ones — the chain is data, so extending it touches nothing already in it (ADR-0788).
+_TIEBREAKERS: tuple[Callable[[_Stat], int], ...] = (
+    lambda stat: stat.game_difference,
+    lambda stat: stat.games_won,
+)
+
+
+def results_for(draw_type: DrawType) -> RoundRobinResults:
+    """The results strategy for this draw type.
+
+    An exhaustive ``match`` with **no catch-all**, exactly as
+    ``app.draws.strategy_for``: adding a member to
+    :class:`~app.models.tournament.DrawType` makes this fail to type-check until the
+    member is handled, so a new format cannot read out its results silently
+    unimplemented. The formats without a strategy yet raise
+    :class:`UnsupportedResultsType` — a catchable domain error, not a 500.
+
+    Only round-robin has one today, so the return type is concrete; a second draw type
+    lands its own strategy and widens this the way ``strategy_for`` already is.
+    """
+    match draw_type:
+        case DrawType.round_robin:
+            return RoundRobinResults()
+        case (
+            DrawType.single_elim
+            | DrawType.double_elim
+            | DrawType.rr_then_ko
+            | DrawType.swiss
+        ):
+            raise UnsupportedResultsType(draw_type)
+
+
+@dataclass(frozen=True, slots=True)
+class RoundRobinResults:
+    """A round-robin event's results: a standings table per pool.
+
+    Each pool is ordered by an extensible chain of tiebreakers (ADR-0788):
+
+    1. **wins** — most match wins first;
+    2. **head-to-head**, *only when exactly two entries are tied* on wins — the one
+       that beat the other ranks above it. A three-or-more-way tie can cycle (A beat B
+       beat C beat A), so it is **not** broken head-to-head; it falls straight through
+       to the game tiebreakers rather than a recursive mini-league;
+    3. **game difference** — games won minus games lost;
+    4. **games won**.
+
+    The entry id is the final, deterministic tiebreak, so a pool in which two entries
+    are genuinely level on every count still orders the same way on every read.
+    """
+
+    def tabulate(self, pools: Sequence[PoolInput]) -> EventResults:
+        standings = tuple(_pool_standings(pool) for pool in pools)
+        # Complete = every pool's every fixture decided. ``all(())`` is vacuously true,
+        # so an event with no pools at all is deliberately *not* called complete.
+        complete = bool(standings) and all(pool.complete for pool in standings)
+        champion: EntryId | None = None
+        if complete and len(standings) == 1 and standings[0].rows:
+            champion = standings[0].rows[0].entry_id
+        return EventResults(pools=standings, complete=complete, champion=champion)
+
+
+def _pool_standings(pool: PoolInput) -> PoolStandings:
+    stats: dict[EntryId, _Stat] = {
+        entry_id: _Stat(entry_id=entry_id) for entry_id in pool.entrants
+    }
+    for outcome in pool.outcomes:
+        _record(stats[outcome.entry_a_id], stats[outcome.entry_b_id], outcome)
+    ordered = _order(list(stats.values()), pool.outcomes)
+    rows = tuple(
+        StandingRow(
+            entry_id=stat.entry_id,
+            rank=rank,
+            played=stat.played,
+            wins=stat.wins,
+            losses=stat.losses,
+            games_won=stat.games_won,
+            games_lost=stat.games_lost,
+        )
+        for rank, stat in enumerate(ordered, start=1)
+    )
+    return PoolStandings(
+        pool_id=pool.pool_id,
+        rows=rows,
+        complete=len(pool.outcomes) == pool.fixture_count,
+    )
+
+
+def _record(a: _Stat, b: _Stat, outcome: MatchOutcome) -> None:
+    a.played += 1
+    b.played += 1
+    a.games_won += outcome.entry_a_games
+    a.games_lost += outcome.entry_b_games
+    b.games_won += outcome.entry_b_games
+    b.games_lost += outcome.entry_a_games
+    if outcome.winner_entry_id == outcome.entry_a_id:
+        a.wins += 1
+        b.losses += 1
+    else:
+        b.wins += 1
+        a.losses += 1
+
+
+def _order(stats: list[_Stat], outcomes: Sequence[MatchOutcome]) -> list[_Stat]:
+    """The pool's finishing order: group by wins (descending), then break each tie."""
+    by_wins: dict[int, list[_Stat]] = defaultdict(list)
+    for stat in stats:
+        by_wins[stat.wins].append(stat)
+    ordered: list[_Stat] = []
+    for wins in sorted(by_wins, reverse=True):
+        ordered.extend(_break_tie(by_wins[wins], outcomes))
+    return ordered
+
+
+def _break_tie(group: list[_Stat], outcomes: Sequence[MatchOutcome]) -> list[_Stat]:
+    """Order a group of entries level on wins.
+
+    A **two-way** tie is broken head-to-head when the pair has actually met — the
+    winner of that match ranks above the loser. A larger tie (which can cycle) and a
+    two-way tie whose pair has not met yet (mid-pool) fall through to the game
+    tiebreakers.
+    """
+    if len(group) == 2:
+        decided = _head_to_head(group[0], group[1], outcomes)
+        if decided is not None:
+            return decided
+    return sorted(group, key=_scalar_key)
+
+
+def _head_to_head(
+    first: _Stat, second: _Stat, outcomes: Sequence[MatchOutcome]
+) -> list[_Stat] | None:
+    """``[winner, loser]`` if these two have met, else ``None`` (not yet played)."""
+    pair = {first.entry_id, second.entry_id}
+    for outcome in outcomes:
+        if {outcome.entry_a_id, outcome.entry_b_id} == pair:
+            if outcome.winner_entry_id == first.entry_id:
+                return [first, second]
+            return [second, first]
+    return None
+
+
+def _scalar_key(stat: _Stat) -> tuple[int, ...]:
+    """The tiebreak-chain sort key: each comparator negated (higher is better ⇒
+    earlier), then the entry id as the final deterministic tiebreak so the order is
+    total."""
+    return (*(-tiebreaker(stat) for tiebreaker in _TIEBREAKERS), _entry_order(stat))
+
+
+def _entry_order(stat: _Stat) -> int:
+    return int.from_bytes(stat.entry_id.bytes, "big")

--- a/api/app/results.py
+++ b/api/app/results.py
@@ -82,8 +82,11 @@ class PoolInput:
 
     ``entrants`` is the full seated field — not just the entries that have played — so a
     player who has not played yet still appears in the table with a row of zeros
-    (partial, live standings). ``fixture_count`` is the pool's total number of pairings,
-    against which ``len(outcomes)`` decides whether the pool is **complete**.
+    (partial, live standings). ``fixture_count`` is the number of the pool's pairings
+    that can still yield a result — every pairing except any whose match was **voided**
+    (which never will) — against which ``len(outcomes)`` decides whether the pool is
+    **complete**. Counting voided pairings would leave a pool that hit one (e.g. a
+    self-play match voided by an account merge) unable to ever reach ``complete``.
     """
 
     pool_id: PoolId

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -14,6 +14,7 @@ from pydantic import (
     model_validator,
 )
 
+from app.models.match import MatchStatus
 from app.models.tournament import DrawType, EventFormat, TournamentStatus
 
 # ----- bounded numerics (the column is a constraint too) ---------------------
@@ -483,8 +484,9 @@ class TournamentFixtureRead(BaseModel):
     """One planned pairing of an event's draw (ADR-0786): a round and a position —
     plus a pool, when the draw is pooled — whose sides may still be unknown.
 
-    A fixture is **not** a match. It materializes into one later (#788), and until it
-    does ``match_id`` is ``null``.
+    A fixture is **not** a match. It materializes into one at go-live (#788): once the
+    tournament is ``live``, every ready fixture becomes a real ``in_progress`` match and
+    gains a ``match_id``. Until then ``match_id`` (and ``match_status``) is ``null``.
 
     **Every ``null`` on this model is a fact, not a missing field**, and a client that
     dropped them would lose the draw's whole point:
@@ -495,7 +497,13 @@ class TournamentFixtureRead(BaseModel):
       (ADR-0786), so there is no ``is_bye`` flag here to tell the two apart.
     * ``winner_entry_id`` — ``null`` while the fixture is undecided.
     * ``match_id`` — ``null`` until the fixture becomes a real match, which only happens
-      once the tournament is ``live``.
+      once the tournament is ``live``. When set, it is the id of the match the slot
+      links to (``GET /v1/matches/{match_id}``), so a client can deep-link a slot.
+    * ``match_status`` — the live status of that match (``in_progress`` at go-live,
+      moving to ``completed`` / ``voided`` as it is played), or ``null`` when the
+      fixture has not materialized. It rides on the fixture so a bracket shows a slot's
+      state without a per-slot round-trip; it is the match's *current* status, read
+      live, not a copy frozen at go-live.
     * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
       un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
       set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
@@ -518,6 +526,77 @@ class TournamentFixtureRead(BaseModel):
     entry_b_id: uuid.UUID | None
     winner_entry_id: uuid.UUID | None
     match_id: uuid.UUID | None
+    # The linked match's live status, or ``null`` when the fixture has not materialized.
+    # Read from the match row on every load (never snapshotted), so it tracks the match
+    # as it is played rather than freezing at go-live. See ``match_id`` above.
+    match_status: MatchStatus | None
+
+
+class StandingRowRead(BaseModel):
+    """One entry's line in a pool's standings (ADR-0788), at its settled rank.
+
+    The entry is carried as an **id only**, exactly as a fixture carries its sides: the
+    username behind ``entry_id`` is on the event's ``entrants`` list already, keyed by
+    that same id, so a client joins the two rather than reading a copy that could drift.
+
+    ``rank`` is 1-based and distinct per row — the pool's order is total (wins → two-way
+    head-to-head → game difference → games won → id), so position 1 is the leader.
+    ``game_difference`` (``games_won - games_lost``) rides along because it is the third
+    tiebreaker and a client shows it in the table; it is a pure function of the two game
+    counts beside it, computed once on the server so the two cannot disagree."""
+
+    entry_id: uuid.UUID
+    rank: int
+    played: int
+    wins: int
+    losses: int
+    games_won: int
+    games_lost: int
+
+    @computed_field  # type: ignore[prop-decorator]  # pydantic: decorate the property, not its getter
+    @property
+    def game_difference(self) -> int:
+        """``games_won - games_lost`` — the third tiebreaker, on the wire for the table
+        to show but derived here so it cannot disagree with the two counts beside it."""
+        return self.games_won - self.games_lost
+
+
+class PoolStandingsRead(BaseModel):
+    """One pool's standings: its rows in finishing order, and whether every one of its
+    fixtures has been decided.
+
+    ``pool_id`` names a ``Pool`` in this same event's ``pools`` — the string ref a
+    fixture also carries — so a client titles the table from the pool it already
+    holds."""
+
+    pool_id: str
+    rows: list[StandingRowRead]
+    complete: bool
+
+
+class EventResultsRead(BaseModel):
+    """A round-robin event's results (ADR-0788): a standings table per pool, whether the
+    whole event is decided, and its champion when there is one.
+
+    It rides on the tournament-detail payload (one endpoint per page) and is **derived
+    live** from the fixtures' currently-completed matches — never a snapshot — so a
+    corrected or voided match re-orders the standings the instant it leaves
+    ``completed``.
+
+    ``champion`` is the leader of a **complete, single-pool** event — a pure
+    round-robin's winner. A multi-pool round-robin has no single champion without a
+    knockout stage to join its pool winners (``rr_then_ko``, a later slice), so it is
+    ``null`` there even when ``complete``; and ``null`` while any fixture is still to be
+    played.
+
+    ``results`` on the event is ``null`` for an event that has **no draw** (nothing to
+    stand) or one whose draw type has no results strategy yet (only round-robin does
+    today) — an honest "no results here", not an empty table that would read as a played
+    event with nobody in it."""
+
+    pools: list[PoolStandingsRead]
+    complete: bool
+    champion: uuid.UUID | None
 
 
 class TournamentEventRead(BaseModel):
@@ -573,6 +652,14 @@ class TournamentEventRead(BaseModel):
     # event ever created (cutting is an explicit act, ADR-0786), so it answers ``[]``
     # and the client renders "no draw yet" from a list it can iterate either way.
     fixtures: list[TournamentFixtureRead]
+    # The event's RESULTS: its per-pool standings, event-complete flag and champion
+    # (ADR-0788), derived live from the fixtures' completed matches — the standings fill
+    # in as results land and a champion appears when the last one does. ``null`` for an
+    # event with no draw cut (nothing to stand) or one whose draw type has no results
+    # strategy yet — only round-robin does today. It rides on this same payload for the
+    # same one-endpoint-per-page reason ``fixtures`` does: the standings table is part
+    # of the tournament-detail page, not a second round-trip.
+    results: EventResultsRead | None
 
     @computed_field  # type: ignore[prop-decorator]  # pydantic wraps the property
     @property

--- a/api/app/tournament_advancement.py
+++ b/api/app/tournament_advancement.py
@@ -1,0 +1,78 @@
+"""The completion→advance seam (ADR-0788): when a match completes, move its draw.
+
+A tournament match is an ordinary :class:`~app.models.match.Match` that a fixture
+materialized into (#788). When one *completes*, the draw it belongs to has to reflect
+it: the fixture's ``winner_entry_id`` is written, the draw is re-``advance()``d, and any
+fixture the result just made ready becomes a match in turn. :func:`on_match_completed`
+is that one synchronous call, run **inside the completion transaction** the score
+endpoints already hold (ADR-0009's match row lock) — so "result accepted ⟹ the draw
+reflects it" is atomic, not eventually-consistent, and there is no queue or event bus to
+reason about for a mechanism with exactly one consumer.
+
+It is called from a single :func:`~app.result_acceptance.finalize_match` helper that
+both completion sites funnel through — the rated accept/retire path and the unrated
+immediate-self-accept path — so a future third path cannot forget the hook.
+
+The dependency points **one way**: this imports the match models, the draw layer and the
+materializer; nothing in the match or draw domain imports it, and it is imported only by
+``app.result_acceptance``, so there is no cycle.
+
+For round-robin — the only draw type with a strategy today — the pool is already whole
+at go-live, so ``advance()`` after a completion is empty and nothing new materializes:
+the seam records the winner and does no more. That is the uniform seam being *honestly*
+empty, not dead code — the same call seats a single-elim winner into the next round the
+moment #785 lands.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Match, Tournament, TournamentEvent, TournamentFixture
+from app.tournament_materialization import materialize_event
+
+
+async def on_match_completed(db: AsyncSession, match: Match) -> None:
+    """Advance the draw a just-completed ``match`` belongs to (ADR-0788).
+
+    Looks the fixture up by ``match_id`` (indexed) and **returns early on a miss** — the
+    common case, since almost no match is a tournament match. Otherwise it writes the
+    fixture's ``winner_entry_id`` from the winning side (**side 1 → ``entry_a``, side 2
+    → ``entry_b``**, the fixed materialization convention of #788), then re-runs the
+    draw's ``advance()`` and materializes anything newly ready via
+    :func:`~app.tournament_materialization.materialize_event`.
+
+    Runs in the caller's transaction under the match row lock; does **not** commit. The
+    match's sides carry their ``won`` flags already — ``finalize_match`` stamped them
+    immediately before calling this — so the winning side is read straight off the
+    loaded match with no extra query.
+
+    ``winner_entry_id`` is written on every completion for the uniform mechanism (and as
+    the substrate single-elim's ``advance()`` will plan from), even though **no
+    round-robin read path reads it** — the standings derive from the live matches for
+    correction-safety (ADR-0788). It is written-but-unread in round-robin, the accepted
+    price of one seam; a correction that un-completes the match simply stops
+    re-advancing it until it is re-accepted.
+    """
+    fixture = (
+        await db.execute(
+            select(TournamentFixture).where(TournamentFixture.match_id == match.id)
+        )
+    ).scalar_one_or_none()
+    if fixture is None:
+        return
+
+    winning_side = next((side for side in match.sides if side.won is True), None)
+    if winning_side is not None:
+        fixture.winner_entry_id = (
+            fixture.entry_a_id if winning_side.side_number == 1 else fixture.entry_b_id
+        )
+
+    event = (
+        await db.execute(
+            select(TournamentEvent).where(TournamentEvent.id == fixture.event_id)
+        )
+    ).scalar_one()
+    tournament = (
+        await db.execute(select(Tournament).where(Tournament.id == event.tournament_id))
+    ).scalar_one()
+    await materialize_event(db, tournament, event)

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -35,11 +35,16 @@ from app.draws import (
     DrawConfig,
     Entrant,
     EntryId,
+    FixtureId,
+    FixtureState,
+    MatchId,
+    NonSinglesDraw,
     PoolId,
     order_entrants,
     strategy_for,
 )
 from app.models import (
+    EventFormat,
     TournamentEntry,
     TournamentEntryStatus,
     TournamentEvent,
@@ -80,6 +85,36 @@ async def active_draw_entrants(db: AsyncSession, event_id: uuid.UUID) -> list[En
         Entrant(entry_id=EntryId(entry_id), seed=seed, created_at=created_at)
         for entry_id, seed, created_at in rows
     ]
+
+
+def fixture_state(fixture: TournamentFixture) -> FixtureState:
+    """Project a persisted :class:`~app.models.tournament_fixture.TournamentFixture` row
+    into the pure :class:`~app.draws.FixtureState` a strategy's ``advance()`` reads.
+
+    The ORM↔domain bridge, kept here rather than in ``app.draws`` so that module stays
+    constructible from literals and free of any SQLAlchemy import — the same split that
+    lets every rule about the *shape* of a draw be tested without a database. Shared by
+    every path that advances a draw (materialization at go-live #788, completion #789),
+    so the projection is written once.
+    """
+    return FixtureState(
+        fixture_id=FixtureId(fixture.id),
+        pool_id=PoolId(fixture.pool_id) if fixture.pool_id is not None else None,
+        round=fixture.round,
+        position=fixture.position,
+        entry_a_id=(
+            EntryId(fixture.entry_a_id) if fixture.entry_a_id is not None else None
+        ),
+        entry_b_id=(
+            EntryId(fixture.entry_b_id) if fixture.entry_b_id is not None else None
+        ),
+        winner_entry_id=(
+            EntryId(fixture.winner_entry_id)
+            if fixture.winner_entry_id is not None
+            else None
+        ),
+        match_id=MatchId(fixture.match_id) if fixture.match_id is not None else None,
+    )
 
 
 def draw_config(event: TournamentEvent) -> DrawConfig:
@@ -356,7 +391,18 @@ async def cut_draw(db: AsyncSession, event: TournamentEvent) -> None:
     **The caller must hold the tournament's row lock**, and must commit. The field this
     reads is the field the fixtures are derived from, and an entry that lands between
     the two would produce a draw that never matched any real field of players.
+
+    Refuses a **non-singles** event with :class:`~app.draws.NonSinglesDraw` (the route
+    turns it into a 422), *before* the field is read or anything is deleted. A doubles
+    or teams event cannot be materialized — a fixture seats one entry per side, a match
+    seats that entry's single user (ADR-0788) — so a draw that could never become
+    playable is refused at the cut, the earliest and clearest point, rather than at
+    go-live. Checked here beside ``strategy_for`` so the two "this event cannot be cut"
+    refusals sit together and neither reads the field of an event that has no business
+    being cut.
     """
+    if event.format is not EventFormat.singles:
+        raise NonSinglesDraw(event.format)
     strategy = strategy_for(event.draw_type)
     planned = strategy.plan_initial(
         draw_config(event), order_entrants(await active_draw_entrants(db, event.id))

--- a/api/app/tournament_materialization.py
+++ b/api/app/tournament_materialization.py
@@ -1,0 +1,206 @@
+"""Materializing ready fixtures into real matches (ADR-0788).
+
+A **fixture** is a planned pairing; a **match** is the real, playable thing it becomes.
+Materialization is the crossing: at go-live, every *ready* round-robin fixture — both
+sides known, no match yet — is turned into an ordinary ``in_progress`` match and linked
+back to its fixture by ``fixture.match_id``.
+
+The pure planning half lives in ``app.draws`` (which fixtures are ready), the fixture
+persistence in ``app.tournament_draws`` (the rows, and the ORM↔domain ``fixture_state``
+bridge); this module owns only the one thing neither does — building a ``Match`` +
+``MatchSettings`` + two ``MatchSide``\\ s out of a fixture and the event's rules.
+
+The dependency points **one way**: this imports the match models and the draw layer,
+and is imported by the tournament transition (``app.tournaments``). Nothing in the match
+domain imports it, so the completion seam (#789) can import *this* without a cycle.
+"""
+
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.draws import strategy_for
+from app.models import (
+    Match,
+    MatchSettings,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    Tournament,
+    TournamentEntry,
+    TournamentEvent,
+    TournamentFixture,
+)
+from app.schemas.tournament import MatchSettings as EventMatchSettings
+from app.tournament_draws import fixture_state
+
+
+async def materialize_live_draw(db: AsyncSession, tournament: Tournament) -> None:
+    """The go-live transition's final act (ADR-0788): consume the first ``advance()``
+    of every event's draw, turning each **ready** fixture into an ``in_progress`` match.
+
+    For round-robin this is the whole pool at once — every pairing is known at the cut,
+    so a freshly-cut draw's ``advance()`` reports every fixture ready — and it is a
+    one-time crossing: a fixture that already has a ``match_id`` is never ready again
+    (``app.draws.ready_fixtures`` excludes it), so materialization is **idempotent** on
+    ``match_id``, and re-running it materializes nothing.
+
+    Runs inside the transition's row lock and transaction — the go-live precondition
+    (``_enforce_ready_to_go_live``) has already guaranteed every event has a current
+    draw, so the fixtures read here seat exactly the field the matches are created for.
+    Does **not** commit: the caller (the transition) owns the transaction, so the status
+    write and the matches it creates land together or not at all.
+    """
+    events = (
+        (
+            await db.execute(
+                select(TournamentEvent).where(
+                    TournamentEvent.tournament_id == tournament.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for event in events:
+        await materialize_event(db, tournament, event)
+
+
+async def materialize_event(
+    db: AsyncSession, tournament: Tournament, event: TournamentEvent
+) -> None:
+    """Materialize the ready fixtures of one event.
+
+    ``advance()`` — not a hand-rolled "both sides known?" — decides what is ready, so
+    the one definition of readiness (both sides known, no match yet, not decided) is
+    honoured here exactly as everywhere else. Shared by the two paths that advance a
+    draw: go-live materialization (#788) and the completion seam
+    (``app.tournament_advancement``, #789), which re-runs it after every result so a
+    fixture made ready by a decided one becomes a match at once.
+
+    It consumes only ``ready_fixture_ids``, never ``advance()``'s ``side_fills``. For
+    round-robin — the only strategy today — the plan carries no side-fills at all (every
+    pairing is known at the cut), so there is nothing to drop. Applying the side-fills a
+    *future* strategy would emit (single-elim seating a winner into the next round,
+    #785) is that strategy's slice to add here; it is deferred with the strategy it
+    belongs to.
+    """
+    fixtures = (
+        (
+            await db.execute(
+                select(TournamentFixture).where(TournamentFixture.event_id == event.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not fixtures:
+        # An event with no draw materializes nothing — but go-live's precondition means
+        # this is unreachable on that path (every event has a current draw). Guarding it
+        # keeps the function honest for a future caller that has no such precondition.
+        return
+    plan = strategy_for(event.draw_type).advance([fixture_state(f) for f in fixtures])
+    ready = set(plan.ready_fixture_ids)
+    ready_fixtures = [f for f in fixtures if f.id in ready]
+    if not ready_fixtures:
+        return
+
+    entry_users = await _entry_user_ids(db, ready_fixtures)
+    settings = EventMatchSettings.model_validate(event.match_settings)
+    built: list[tuple[TournamentFixture, Match]] = []
+    for fixture in ready_fixtures:
+        # A ready fixture always has both sides known (that is what "ready" means); the
+        # guard narrows the Optional for the type checker and can never actually skip a
+        # fixture ``advance()`` reported ready.
+        if fixture.entry_a_id is None or fixture.entry_b_id is None:
+            continue
+        match = _build_match(
+            tournament,
+            settings,
+            side_1_user_id=entry_users[fixture.entry_a_id],
+            side_2_user_id=entry_users[fixture.entry_b_id],
+        )
+        db.add(match)
+        built.append((fixture, match))
+
+    # Insert the matches BEFORE writing ``fixture.match_id``: the fixture's FK
+    # (``ON DELETE SET NULL``) points at ``matches``, and there is no ORM relationship
+    # on the fixture for the unit-of-work to infer that ordering from — so without an
+    # explicit flush the fixture UPDATE can race ahead of the match INSERT and trip the
+    # foreign key. One flush for the whole event's matches, then the links.
+    await db.flush()
+    for fixture, match in built:
+        fixture.match_id = match.id
+
+
+async def _entry_user_ids(
+    db: AsyncSession, fixtures: Sequence[TournamentFixture]
+) -> dict[uuid.UUID, uuid.UUID]:
+    """Map each seated entry id to the user behind it — the user a materialized match
+    seats on the corresponding side. One batched read for every entry in the ready set.
+    """
+    entry_ids: set[uuid.UUID] = set()
+    for fixture in fixtures:
+        if fixture.entry_a_id is not None:
+            entry_ids.add(fixture.entry_a_id)
+        if fixture.entry_b_id is not None:
+            entry_ids.add(fixture.entry_b_id)
+    rows = (
+        await db.execute(
+            select(TournamentEntry.id, TournamentEntry.user_id).where(
+                TournamentEntry.id.in_(entry_ids)
+            )
+        )
+    ).all()
+    return {entry_id: user_id for entry_id, user_id in rows}
+
+
+def _build_match(
+    tournament: Tournament,
+    settings: EventMatchSettings,
+    *,
+    side_1_user_id: uuid.UUID,
+    side_2_user_id: uuid.UUID,
+) -> Match:
+    """The real match one ready fixture becomes (ADR-0788) — built, not yet persisted.
+
+    The match is born ``in_progress``: both players are known and committed, and
+    propose/accept is about the *result*, not about starting. It carries the
+    **tournament's** league and is created by the tournament **owner** (a tournament
+    match has no player-initiator — the director's go-live created it; the field grants
+    no scoring rights, which are by side participation). Its ``MatchSettings`` copy the
+    only two things the event holds — ``best_of ← length_games``, ``affects_rating ←
+    rated`` — with ``team_size = 1`` and the model's default verification policy and
+    retirement window (the event has nothing else to copy).
+
+    **side 1 ← ``entry_a``, side 2 ← ``entry_b``** is a fixed convention, not a detail:
+    it is what lets a completed match's winning ``side_number`` map back to the winning
+    entry (1 → ``entry_a``, 2 → ``entry_b``) with no extra column (#789).
+    """
+    match = Match(
+        match_settings=MatchSettings(
+            team_size=1,
+            best_of=settings.length_games,
+            affects_rating=settings.rated,
+        ),
+        league_id=tournament.league_id,
+        created_by_user_id=tournament.created_by_user_id,
+        status=MatchStatus.in_progress,
+    )
+    _add_side(match, side_number=1, user_id=side_1_user_id)
+    _add_side(match, side_number=2, user_id=side_2_user_id)
+    return match
+
+
+def _add_side(match: Match, *, side_number: int, user_id: uuid.UUID) -> None:
+    """Attach one populated side to ``match`` (mirrors ``app.matches._add_side``).
+
+    A tournament match always has two real players — there is no opponent-less sentinel
+    side here — so every side carries exactly one ``MatchSidePlayer``. Wiring the
+    ``match`` relationship on both the side and the side-player is what populates their
+    denormalized ``match_id`` columns on flush.
+    """
+    side = MatchSide(match=match, side_number=side_number)
+    side.players.append(MatchSidePlayer(match=match, user_id=user_id))

--- a/api/app/tournament_queries.py
+++ b/api/app/tournament_queries.py
@@ -18,6 +18,9 @@ from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import (
+    Match,
+    MatchGame,
+    MatchGameScore,
     Tournament,
     TournamentEntry,
     TournamentEntryStatus,
@@ -155,6 +158,12 @@ async def fixtures_by_event(
     un-pooled fixture meets a pooled one, and the defensive coalesce that usually
     follows (``f.pool_id or ""``) would quietly sort the KO stage FIRST.
 
+    A materialized fixture carries its match's **live status** (``match_status``), read
+    by LEFT-joining ``matches`` on ``fixture.match_id`` (#788) — still ONE statement,
+    still one row per fixture (a fixture links to at most one match). It is read on
+    every load rather than snapshotted, so a slot reflects its match as played; an
+    un-materialized fixture joins to ``NULL`` and reports a ``None`` status.
+
     The rows are validated into read models here, at the loader — the same boundary the
     entrants cross — so no ORM instance and no lazily-loadable relationship escapes into
     the serializer.
@@ -165,23 +174,83 @@ async def fixtures_by_event(
     if not fixtures:
         return fixtures
     rows = (
-        (
-            await db.execute(
-                select(TournamentFixture)
-                .where(TournamentFixture.event_id.in_(fixtures.keys()))
-                .order_by(
-                    TournamentFixture.pool_id.asc().nulls_last(),
-                    TournamentFixture.round,
-                    TournamentFixture.position,
-                )
+        await db.execute(
+            select(TournamentFixture, Match.status)
+            .outerjoin(Match, Match.id == TournamentFixture.match_id)
+            .where(TournamentFixture.event_id.in_(fixtures.keys()))
+            .order_by(
+                TournamentFixture.pool_id.asc().nulls_last(),
+                TournamentFixture.round,
+                TournamentFixture.position,
             )
         )
-        .scalars()
-        .all()
-    )
-    for fixture in rows:
-        fixtures[fixture.event_id].append(TournamentFixtureRead.model_validate(fixture))
+    ).all()
+    for fixture, match_status in rows:
+        fixtures[fixture.event_id].append(
+            TournamentFixtureRead(
+                id=fixture.id,
+                pool_id=fixture.pool_id,
+                round=fixture.round,
+                position=fixture.position,
+                entry_a_id=fixture.entry_a_id,
+                entry_b_id=fixture.entry_b_id,
+                winner_entry_id=fixture.winner_entry_id,
+                match_id=fixture.match_id,
+                match_status=match_status,
+            )
+        )
     return fixtures
+
+
+async def game_counts_by_match(
+    db: AsyncSession, match_ids: Sequence[uuid.UUID]
+) -> dict[uuid.UUID, tuple[int, int]]:
+    """For each match in ``match_ids``, the games each **side** won — ``(side_1_games,
+    side_2_games)`` — read off its scored games. Keyed by match id.
+
+    The raw material the round-robin standings are projected from (ADR-0788): a fixture
+    seats ``entry_a`` on side 1 and ``entry_b`` on side 2 (#788), so a side's game count
+    *is* that entry's, and the winner is the side that took more. Derived live from the
+    match's games rather than the fixture's ``winner_entry_id``, so a correction to a
+    completed match re-shapes the standings the instant it lands (ADR-0788 —
+    round-robin reads never read the written-back winner).
+
+    ONE statement for the whole batch (none at all when there are no matches to count),
+    and every id gets a key — a completed match whose games somehow carry no scores maps
+    to ``(0, 0)`` rather than dropping out, so the caller never tells "no scores" apart
+    from "not loaded". Batched over **every** completed tournament match on the page for
+    the same reason the entrants and fixtures are: a per-match count would be an N+1
+    that grows with the field the page describes.
+
+    Only **completed** matches should be passed — an in-progress match's part-scored
+    board is not a result and must not reach the standings; the caller filters on
+    ``match_status`` before it collects the ids.
+
+    A tie in a single game cannot happen (``MatchGameScoreWrite`` forbids it), so a
+    scored game always moves exactly one side's counter; the ``==`` arm is unreachable
+    and simply counts nothing, keeping the projection total rather than guessing a
+    winner.
+    """
+    counts: dict[uuid.UUID, list[int]] = {match_id: [0, 0] for match_id in match_ids}
+    if not counts:
+        return {}
+    rows = (
+        await db.execute(
+            select(
+                MatchGame.match_id,
+                MatchGameScore.side_1_points,
+                MatchGameScore.side_2_points,
+            )
+            .join(MatchGameScore, MatchGameScore.match_game_id == MatchGame.id)
+            .where(MatchGame.match_id.in_(counts.keys()))
+        )
+    ).all()
+    for match_id, side_1_points, side_2_points in rows:
+        if side_1_points > side_2_points:
+            counts[match_id][0] += 1
+        elif side_2_points > side_1_points:
+            counts[match_id][1] += 1
+    return {match_id: (side_1, side_2) for match_id, (side_1, side_2) in counts.items()}
 
 
 async def active_entry_count(db: AsyncSession, event_id: uuid.UUID) -> int:

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -343,7 +343,16 @@ def _event_results(
             PoolInput(
                 pool_id=PoolId(pool_id),
                 entrants=tuple(EntryId(entry_id) for entry_id in entrants),
-                fixture_count=len(pool_fixtures),
+                # Count only the pairings that can still produce a result. A **voided**
+                # fixture never will — its match is terminal and ``ready_fixtures`` will
+                # not re-materialize it — so it is excluded, not counted-but-missing.
+                # Without this, a played-event account-merge collision (which voids the
+                # guest-vs-survivor self-play match) would hold the pool one outcome
+                # short of ``fixture_count`` forever: permanently un-``complete``, no
+                # champion — the opposite of ADR-0788's live-standings guarantee.
+                fixture_count=sum(
+                    1 for f in pool_fixtures if f.match_status is not MatchStatus.voided
+                ),
                 outcomes=tuple(outcomes),
             )
         )
@@ -382,7 +391,7 @@ def _serialize_event(
     entrants: list[TournamentEntrantRead],
     fixtures: list[TournamentFixtureRead],
     rating: float | None,
-    game_counts: dict[uuid.UUID, tuple[int, int]],
+    game_counts: dict[uuid.UUID, tuple[int, int]] | None,
 ) -> TournamentEventRead:
     # ``entrants`` is not on the ORM row in the shape the read model wants (it
     # needs the entrant's username, and only the *active* entries), so the fields
@@ -425,7 +434,17 @@ def _serialize_event(
             # the page's one batched game load — ``None`` for an uncut or
             # non-round-robin event (ADR-0788). Computed in the serializer, not fetched
             # per event, for the same reason ``fixtures`` is: no read may become an N+1.
-            "results": _event_results(e, fixtures=fixtures, game_counts=game_counts),
+            #
+            # ``game_counts is None`` is the tournaments *list*'s signal to skip the
+            # projection entirely: its cards render no standings (only event and table
+            # counts), so the list neither runs the game-count query nor tabulates a
+            # results object nobody reads — standings are a detail-BFF concern. A
+            # detail surface passes a real map (``{}`` when nothing is played).
+            "results": (
+                None
+                if game_counts is None
+                else _event_results(e, fixtures=fixtures, game_counts=game_counts)
+            ),
         }
     )
 
@@ -438,7 +457,7 @@ def _serialize_detail(
     events: list[TournamentEvent],
     entrants_by_event: dict[uuid.UUID, list[TournamentEntrantRead]],
     fixtures_by_event: dict[uuid.UUID, list[TournamentFixtureRead]],
-    game_counts: dict[uuid.UUID, tuple[int, int]],
+    game_counts: dict[uuid.UUID, tuple[int, int]] | None,
     rating: float | None,
 ) -> TournamentDetailRead:
     # The full aggregate: tournament fields plus its events (each event's JSONB
@@ -786,11 +805,11 @@ async def list_tournaments(
     # event. Uncut draws come back as ``[]``, so an event nobody has cut a draw for
     # costs nothing and answers with an empty list rather than a null.
     event_fixtures = await fixtures_by_event(db, event_ids)
-    # And ONE batch for the games of every completed tournament match on the page — the
-    # raw material each event's standings are projected from (ADR-0788). One statement,
-    # not one per event, and none at all when nothing has been played yet (an uncut or
-    # unplayed page collects no completed match ids), so the statement-count pin holds.
-    game_counts = await game_counts_by_match(db, _completed_match_ids(event_fixtures))
+    # The list deliberately does NOT project standings: its cards render only event and
+    # table counts, never a results table, so it skips the game-count query and the
+    # per-event tabulation a results object would need (``game_counts=None`` below).
+    # Standings are a detail-BFF concern (ADR-0788); computing them here would be work a
+    # page throws away — the same shape as #1051 for fixtures/entrants.
     # ONE batch for the caller's ratings, keyed by league — deduplicated, because
     # every tournament on the default league shares the one number, and because the
     # ladders a page happens to list is not a reason to ask the same question twice.
@@ -805,7 +824,7 @@ async def list_tournaments(
             events=events_by_tournament[tournament.id],
             entrants_by_event=entrants_by_event,
             fixtures_by_event=event_fixtures,
-            game_counts=game_counts,
+            game_counts=None,
             rating=ratings[tournament.league_id],
         )
         for tournament, username in rows

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -1,4 +1,5 @@
 import uuid
+from collections import defaultdict
 from typing import Any, Literal, assert_never
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
@@ -7,11 +8,19 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_session
-from app.draws import DegenerateDraw, DrawError, PoolId, UnsupportedDrawType
+from app.draws import (
+    DegenerateDraw,
+    DrawError,
+    EntryId,
+    NonSinglesDraw,
+    PoolId,
+    UnsupportedDrawType,
+)
 from app.leagues import resolve_league
 from app.models import (
     DrawType,
     EventFormat,
+    MatchStatus,
     Tournament,
     TournamentEntry,
     TournamentEntryStatus,
@@ -20,11 +29,15 @@ from app.models import (
     User,
 )
 from app.rbac import require_permission, user_has_permission
+from app.results import EventResults, MatchOutcome, PoolInput, results_for
 from app.schemas.tournament import (
     EventEntryFull,
     EventEntryOpen,
     EventEntryRatingIneligible,
     EventEntryState,
+    EventResultsRead,
+    PoolStandingsRead,
+    StandingRowRead,
     TournamentCreate,
     TournamentDetailRead,
     TournamentEntrantRead,
@@ -55,12 +68,14 @@ from app.tournament_eligibility import (
     event_is_full,
 )
 from app.tournament_entry_refusals import EntryRefusal, entry_refused
+from app.tournament_materialization import materialize_live_draw
 from app.tournament_queries import (
     active_entrants_by_event,
     active_entry_count,
     entrant_rating,
     entrant_ratings_by_league,
     fixtures_by_event,
+    game_counts_by_match,
 )
 
 # Reads are gated on ``tournament.view``, creation on ``tournament.create``, and
@@ -234,12 +249,140 @@ def _entry_state(
             assert_never(decision)
 
 
+def _completed_match_ids(
+    fixtures_by_event: dict[uuid.UUID, list[TournamentFixtureRead]],
+) -> list[uuid.UUID]:
+    """The ids of the matches of every **completed** fixture across the page.
+
+    The one list ``game_counts_by_match`` is batched over, gathered before any event is
+    serialized so the standings of every event are projected from a single game load
+    (ADR-0788) rather than a query per event. Only ``completed`` fixtures contribute: an
+    in-progress match's part-scored board is not a result and must not reach a standings
+    table."""
+    return [
+        f.match_id
+        for fixtures in fixtures_by_event.values()
+        for f in fixtures
+        if f.match_status is MatchStatus.completed and f.match_id is not None
+    ]
+
+
+def _event_results(
+    e: TournamentEvent,
+    *,
+    fixtures: list[TournamentFixtureRead],
+    game_counts: dict[uuid.UUID, tuple[int, int]],
+) -> EventResultsRead | None:
+    """The event's results (ADR-0788), projected from its fixtures' completed matches,
+    or ``None`` when there are none to compute.
+
+    ``None`` in two cases, both meaning "no results here" rather than an empty table: a
+    draw type with no results strategy yet (``results_for`` raises for it — only
+    round-robin has one today), and an event whose draw has not been cut (no fixtures to
+    stand). Everything else is a real :class:`EventResultsRead`, whose standings are
+    empty of *decided* rows but full of *seated* ones while the pool is still played.
+
+    The projection is the fixed materialization convention read backwards (#788): side 1
+    is ``entry_a`` and side 2 is ``entry_b``, so the ``(side_1, side_2)`` game counts
+    are the ``(entry_a, entry_b)`` game counts, and the winner is whichever took more
+    games — derived from the live match, never from the fixture's written-back
+    ``winner_entry_id`` (which no round-robin read reads, for correction-safety)."""
+    match e.draw_type:
+        case DrawType.round_robin:
+            pass  # the projection below is round-robin-shaped
+        case (
+            DrawType.single_elim
+            | DrawType.double_elim
+            | DrawType.rr_then_ko
+            | DrawType.swiss
+        ):
+            # No results projection for these yet (``results_for`` has no strategy for
+            # them either). Spelled as a checked dispatch with an ``assert_never``
+            # catch-all rather than a bare ``is not round_robin``, so a new ``DrawType``
+            # is a type error here until its projection is written — the same guarantee
+            # ``strategy_for``/``results_for`` give (ADR-0788).
+            return None
+        case _:
+            assert_never(e.draw_type)
+    if not fixtures:
+        return None
+    by_pool: dict[str, list[TournamentFixtureRead]] = defaultdict(list)
+    for f in fixtures:
+        # A round-robin fixture is always pooled; a NULL pool would be a different draw
+        # type's fixture and has no pool table to stand in. Skip it rather than key a
+        # pool on ``None``.
+        if f.pool_id is not None:
+            by_pool[f.pool_id].append(f)
+    pool_inputs: list[PoolInput] = []
+    for pool_id, pool_fixtures in by_pool.items():
+        entrants = {
+            entry_id
+            for f in pool_fixtures
+            for entry_id in (f.entry_a_id, f.entry_b_id)
+            if entry_id is not None
+        }
+        outcomes: list[MatchOutcome] = []
+        for f in pool_fixtures:
+            if (
+                f.match_status is not MatchStatus.completed
+                or f.match_id is None
+                or f.entry_a_id is None
+                or f.entry_b_id is None
+            ):
+                continue
+            side_1_games, side_2_games = game_counts[f.match_id]
+            outcomes.append(
+                MatchOutcome(
+                    entry_a_id=EntryId(f.entry_a_id),
+                    entry_b_id=EntryId(f.entry_b_id),
+                    entry_a_games=side_1_games,
+                    entry_b_games=side_2_games,
+                )
+            )
+        pool_inputs.append(
+            PoolInput(
+                pool_id=PoolId(pool_id),
+                entrants=tuple(EntryId(entry_id) for entry_id in entrants),
+                fixture_count=len(pool_fixtures),
+                outcomes=tuple(outcomes),
+            )
+        )
+    return _serialize_results(results_for(e.draw_type).tabulate(pool_inputs))
+
+
+def _serialize_results(results: EventResults) -> EventResultsRead:
+    return EventResultsRead(
+        pools=[
+            PoolStandingsRead(
+                pool_id=pool.pool_id,
+                rows=[
+                    StandingRowRead(
+                        entry_id=row.entry_id,
+                        rank=row.rank,
+                        played=row.played,
+                        wins=row.wins,
+                        losses=row.losses,
+                        games_won=row.games_won,
+                        games_lost=row.games_lost,
+                    )
+                    for row in pool.rows
+                ],
+                complete=pool.complete,
+            )
+            for pool in results.pools
+        ],
+        complete=results.complete,
+        champion=results.champion,
+    )
+
+
 def _serialize_event(
     e: TournamentEvent,
     *,
     entrants: list[TournamentEntrantRead],
     fixtures: list[TournamentFixtureRead],
     rating: float | None,
+    game_counts: dict[uuid.UUID, tuple[int, int]],
 ) -> TournamentEventRead:
     # ``entrants`` is not on the ORM row in the shape the read model wants (it
     # needs the entrant's username, and only the *active* entries), so the fields
@@ -278,6 +421,11 @@ def _serialize_event(
             "entrants": entrants,
             "entry_state": _entry_state(e, entered=len(entrants), rating=rating),
             "fixtures": fixtures,
+            # The standings, projected here from the fixtures' completed matches plus
+            # the page's one batched game load — ``None`` for an uncut or
+            # non-round-robin event (ADR-0788). Computed in the serializer, not fetched
+            # per event, for the same reason ``fixtures`` is: no read may become an N+1.
+            "results": _event_results(e, fixtures=fixtures, game_counts=game_counts),
         }
     )
 
@@ -290,6 +438,7 @@ def _serialize_detail(
     events: list[TournamentEvent],
     entrants_by_event: dict[uuid.UUID, list[TournamentEntrantRead]],
     fixtures_by_event: dict[uuid.UUID, list[TournamentFixtureRead]],
+    game_counts: dict[uuid.UUID, tuple[int, int]],
     rating: float | None,
 ) -> TournamentDetailRead:
     # The full aggregate: tournament fields plus its events (each event's JSONB
@@ -312,6 +461,7 @@ def _serialize_detail(
                     entrants=entrants_by_event[e.id],
                     fixtures=fixtures_by_event[e.id],
                     rating=rating,
+                    game_counts=game_counts,
                 )
                 for e in events
             ],
@@ -636,6 +786,11 @@ async def list_tournaments(
     # event. Uncut draws come back as ``[]``, so an event nobody has cut a draw for
     # costs nothing and answers with an empty list rather than a null.
     event_fixtures = await fixtures_by_event(db, event_ids)
+    # And ONE batch for the games of every completed tournament match on the page — the
+    # raw material each event's standings are projected from (ADR-0788). One statement,
+    # not one per event, and none at all when nothing has been played yet (an uncut or
+    # unplayed page collects no completed match ids), so the statement-count pin holds.
+    game_counts = await game_counts_by_match(db, _completed_match_ids(event_fixtures))
     # ONE batch for the caller's ratings, keyed by league — deduplicated, because
     # every tournament on the default league shares the one number, and because the
     # ladders a page happens to list is not a reason to ask the same question twice.
@@ -650,6 +805,7 @@ async def list_tournaments(
             events=events_by_tournament[tournament.id],
             entrants_by_event=entrants_by_event,
             fixtures_by_event=event_fixtures,
+            game_counts=game_counts,
             rating=ratings[tournament.league_id],
         )
         for tournament, username in rows
@@ -760,11 +916,18 @@ async def get_tournament(
     # route, that orders them (pool → round → position) and answers ``[]`` for an
     # event whose draw has not been cut.
     event_fixtures = await fixtures_by_event(db, event_ids)
-    # A FIFTH and last query: the caller's rating on the tournament's league, read
-    # ONCE for the whole page. It is what every event's ``entry_state`` is judged
-    # against (ADR-0783), and a tournament has exactly one ladder — so a rating read
-    # inside the per-event loop would issue a query per event to learn the same
-    # number, on the page whose whole job is to describe a field of events.
+    # ONE more query batches the games of every completed tournament match on the page
+    # — what each event's standings are projected from (ADR-0788). One statement for the
+    # whole page, and **none at all** until something has been played (an unplayed
+    # detail collects no completed match ids), so an unplayed tournament still costs
+    # five and the statement-count pin holds; a played one costs the one extra.
+    game_counts = await game_counts_by_match(db, _completed_match_ids(event_fixtures))
+    # The FIFTH query (and last on an unplayed page): the caller's rating on the
+    # tournament's league, read ONCE for the whole page. It is what every event's
+    # ``entry_state`` is judged against (ADR-0783), and a tournament has exactly one
+    # ladder — so a rating read inside the per-event loop would issue a query per event
+    # to learn the same number, on the page whose whole job is to describe a field of
+    # events.
     rating = await entrant_rating(db, tournament.league_id, current_user.id)
     return _serialize_detail(
         tournament,
@@ -773,6 +936,7 @@ async def get_tournament(
         events=events,
         entrants_by_event=entrants_by_event,
         fixtures_by_event=event_fixtures,
+        game_counts=game_counts,
         rating=rating,
     )
 
@@ -1069,11 +1233,16 @@ async def create_tournament_transition(
         await _enforce_ready_to_go_live(db, tournament)
 
     tournament.status = payload.to
-    # #788 (materialization) hangs HERE, as the transition's final act: once the status
-    # is ``live``, the first ``advance()`` turns every ready fixture into a real match,
-    # in the same transaction as the status write. Nothing creates matches yet —
-    # fixtures are the whole of a draw today — and the precondition above is what
-    # guarantees that when it does, it will have a complete, current draw to work from.
+    # Materialization (#788), as the transition's final act: once the status is
+    # ``live``, the first ``advance()`` turns every ready fixture into a real
+    # ``in_progress`` match — for round-robin, the whole pool — in the SAME transaction
+    # as the status write, so a tournament is never seen ``live`` without the matches
+    # its go-live created. Run only on the ``published → live`` edge (nothing else
+    # materializes), and only after the precondition above, which is what guarantees a
+    # complete, current draw to work from. It is idempotent on ``fixture.match_id``, so
+    # it can never double-create.
+    if payload.to is TournamentStatus.live:
+        await materialize_live_draw(db, tournament)
     await db.commit()
     await db.refresh(tournament)
     # The owner is the current user (``_require_owner`` just said so), so the
@@ -1127,7 +1296,12 @@ async def create_event(
     # tournament's league: answering with a state the endpoint had guessed rather
     # than computed is how the read and the guard come apart.
     rating = await entrant_rating(db, tournament.league_id, current_user.id)
-    return _serialize_event(event, entrants=[], fixtures=[], rating=rating)
+    # No fixtures on a one-statement-old event, so no results either —
+    # ``_event_results`` answers ``None`` for an uncut draw whatever the game counts, so
+    # an empty map is all this needs.
+    return _serialize_event(
+        event, entrants=[], fixtures=[], rating=rating, game_counts={}
+    )
 
 
 def _pool_set_refusal(removed: list[str], added: list[str]) -> HTTPException:
@@ -1383,12 +1557,23 @@ async def update_event(
     # answering ``[]`` here would tell the director their draw had just been thrown
     # away, and the page would render it that way.
     entrants = (await active_entrants_by_event(db, [event.id]))[event.id]
-    fixtures = (await fixtures_by_event(db, [event.id]))[event.id]
+    event_fixtures = await fixtures_by_event(db, [event.id])
+    fixtures = event_fixtures[event.id]
+    # Its RESULTS survive the edit too (a PATCH is not a re-cut), so they are
+    # reprojected from the same completed-match games as the read paths — one game load,
+    # so an edit to a played event still answers its live standings, not drops them.
+    game_counts = await game_counts_by_match(db, _completed_match_ids(event_fixtures))
     # And its ``entry_state`` is recomputed from the event as it now stands: an owner
     # who has just tightened a rule or lowered ``max_players`` is answered with what
     # the event says NOW, not with what it said before their edit.
     rating = await entrant_rating(db, tournament.league_id, current_user.id)
-    return _serialize_event(event, entrants=entrants, fixtures=fixtures, rating=rating)
+    return _serialize_event(
+        event,
+        entrants=entrants,
+        fixtures=fixtures,
+        rating=rating,
+        game_counts=game_counts,
+    )
 
 
 @router.delete(
@@ -2034,6 +2219,18 @@ def _draw_refusal(error: DrawError) -> HTTPException:
             detail = (
                 f"A {error.draw_type.value} draw cannot be cut yet. "
                 "Change the event's draw type to one that can, or wait for support."
+            )
+        case NonSinglesDraw():
+            # Composed from the structural ``event_format``, like
+            # ``UnsupportedDrawType`` above: a doubles/teams event can never be cut in
+            # any state (an entry is
+            # one row per player, with nowhere to record a partner or a team, ADR-0788),
+            # so a director is told which event is un-drawable and why — a permanent
+            # fact, not a retryable one.
+            detail = (
+                f"A {error.event_format.value} event cannot be given a draw — only "
+                "singles events can. A fixture seats one entrant on each side, and "
+                "there is nowhere to record a doubles pairing or a team."
             )
         case DegenerateDraw():
             detail = str(error)

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -13,7 +13,6 @@ from sqlalchemy.exc import IntegrityError, MissingGreenlet
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from app.matches import (
-    _apply_rating_update,
     _load_match,
     match_eager_options,
     match_rating_eager_options,
@@ -39,6 +38,7 @@ from app.ratings import (
     validate_state,
 )
 from app.ratings.glicko2 import CALCULATOR as GLICKO2
+from app.result_acceptance import _apply_rating_update
 from tests._helpers import (
     accept_standing_result,
     make_user,

--- a/api/tests/test_results.py
+++ b/api/tests/test_results.py
@@ -1,0 +1,251 @@
+"""Pure tests for the round-robin results strategy (ADR-0788).
+
+No database: ``app.results`` is pure, so every rule about how a pool stands is exercised
+against literal :class:`~app.results.MatchOutcome` / :class:`~app.results.PoolInput`
+value objects — the same shape the BFF projects from completed matches. The ordering is
+hand-computed in each test's docstring so a green assertion means the *table* is right,
+not merely that some deterministic order came out.
+"""
+
+import uuid
+
+import pytest
+
+from app.draws import EntryId, PoolId
+from app.models.tournament import DrawType
+from app.results import (
+    MatchOutcome,
+    PoolInput,
+    RoundRobinResults,
+    UnsupportedResultsType,
+    results_for,
+)
+
+
+def _eid(n: int) -> EntryId:
+    """A stable entry id — ``uuid.UUID(int=n)`` — so the final id tiebreak is a fact of
+    the test, not of ``uuid4``'s luck."""
+    return EntryId(uuid.UUID(int=n))
+
+
+A, B, C, D = _eid(1), _eid(2), _eid(3), _eid(4)
+
+
+def _outcome(
+    first: EntryId, second: EntryId, first_games: int, second_games: int
+) -> MatchOutcome:
+    """One decided fixture: ``first`` took ``first_games``, ``second`` took
+    ``second_games``; the winner is whoever took more (the boards below are all
+    decisive)."""
+    return MatchOutcome(
+        entry_a_id=first,
+        entry_b_id=second,
+        entry_a_games=first_games,
+        entry_b_games=second_games,
+    )
+
+
+def _single_pool(
+    entrants: tuple[EntryId, ...],
+    fixture_count: int,
+    outcomes: list[MatchOutcome],
+) -> PoolInput:
+    return PoolInput(
+        pool_id=PoolId("p-a"),
+        entrants=entrants,
+        fixture_count=fixture_count,
+        outcomes=tuple(outcomes),
+    )
+
+
+def _order(pool: PoolInput) -> list[EntryId]:
+    (standings,) = RoundRobinResults().tabulate([pool]).pools
+    return [row.entry_id for row in standings.rows]
+
+
+def test_results_for_returns_the_round_robin_strategy() -> None:
+    assert isinstance(results_for(DrawType.round_robin), RoundRobinResults)
+
+
+@pytest.mark.parametrize(
+    "draw_type",
+    [
+        DrawType.single_elim,
+        DrawType.double_elim,
+        DrawType.rr_then_ko,
+        DrawType.swiss,
+    ],
+)
+def test_results_for_refuses_the_draw_types_without_a_strategy(
+    draw_type: DrawType,
+) -> None:
+    with pytest.raises(UnsupportedResultsType) as excinfo:
+        results_for(draw_type)
+    assert excinfo.value.draw_type is draw_type
+
+
+def test_orders_by_wins_descending() -> None:
+    """Three players, all matches played, distinct win counts: A wins both, B wins one,
+    C wins none. Order is purely by wins — A, B, C — no tiebreak needed."""
+    pool = _single_pool(
+        (A, B, C),
+        fixture_count=3,
+        outcomes=[
+            _outcome(A, B, 2, 0),
+            _outcome(A, C, 2, 0),
+            _outcome(B, C, 2, 0),
+        ],
+    )
+    assert _order(pool) == [A, B, C]
+    (standings,) = RoundRobinResults().tabulate([pool]).pools
+    assert [(r.wins, r.losses, r.rank) for r in standings.rows] == [
+        (2, 0, 1),
+        (1, 1, 2),
+        (0, 2, 3),
+    ]
+
+
+def test_two_way_tie_on_wins_is_broken_head_to_head_over_game_difference() -> None:
+    """A and B both finish on 2 wins; C and D on 1 each. The head-to-head rule ranks a
+    two-way tie by who beat whom, **ahead of** game difference — and here it has to
+    override it:
+
+    * A beat B, beat C, lost to D  → 2 wins, games 5–3 (diff **+2**)
+    * B lost to A, beat C, beat D  → 2 wins, games 5–2 (diff **+3**)
+
+    On game difference alone B (+3) would outrank A (+2); but A won their head-to-head,
+    so A is first and B second. C and D are a second two-way tie on 1 win, and C beat D,
+    so C is third and D fourth. Final table: A, B, C, D."""
+    outcomes = [
+        _outcome(A, B, 2, 1),  # A beat B
+        _outcome(A, C, 2, 0),  # A beat C
+        _outcome(D, A, 2, 1),  # D beat A
+        _outcome(B, C, 2, 0),  # B beat C
+        _outcome(B, D, 2, 0),  # B beat D
+        _outcome(C, D, 2, 1),  # C beat D
+    ]
+    pool = _single_pool((A, B, C, D), fixture_count=6, outcomes=outcomes)
+    (standings,) = RoundRobinResults().tabulate([pool]).pools
+    assert [(r.entry_id, r.wins, r.game_difference) for r in standings.rows] == [
+        (A, 2, 2),
+        (B, 2, 3),
+        (C, 1, -3),
+        (D, 1, -2),
+    ]
+
+
+def test_three_way_tie_is_not_broken_head_to_head_and_falls_to_game_difference() -> (
+    None
+):
+    """The cyclic case head-to-head must refuse: A beat B, B beat C, C beat A — each on
+    one win, a rock-paper-scissors that has no head-to-head winner. So the three-way tie
+    falls straight through to game difference rather than a cycle:
+
+    * A: beat B 2–0, lost to C 0–2 → diff **0**
+    * B: lost to A 0–2, beat C 2–1 → diff **-1**
+    * C: lost to B 1–2, beat A 2–0 → diff **+1**
+
+    Order by game difference: C, A, B."""
+    outcomes = [
+        _outcome(A, B, 2, 0),
+        _outcome(B, C, 2, 1),
+        _outcome(C, A, 2, 0),
+    ]
+    pool = _single_pool((A, B, C), fixture_count=3, outcomes=outcomes)
+    assert _order(pool) == [C, A, B]
+
+
+def test_game_difference_ties_break_on_games_won() -> None:
+    """Mid-pool, A and B each have one win and have **not** met — a two-way tie on wins
+    whose head-to-head is unplayed, so it falls to game difference, then to games won. A
+    won 3–1, B won 2–0: both +2 game difference, but A took **3** games to B's **2**, so
+    games won puts A first. (C and D, both winless and not yet met, tie behind them.)"""
+    outcomes = [
+        _outcome(A, C, 3, 1),
+        _outcome(B, D, 2, 0),
+    ]
+    pool = _single_pool((A, B, C, D), fixture_count=6, outcomes=outcomes)
+    (standings,) = RoundRobinResults().tabulate([pool]).pools
+    assert [(r.entry_id, r.game_difference, r.games_won) for r in standings.rows] == [
+        (A, 2, 3),
+        (B, 2, 2),
+        (C, -2, 1),
+        (D, -2, 0),
+    ]
+
+
+def test_partial_standings_seat_unplayed_entrants_and_are_incomplete() -> None:
+    """Mid-pool: only A–B has been played (A won 2–0); C has not played at all. Every
+    seated entrant still has a row — C appears with zeros — the pool is **not**
+    complete, and there is no champion yet.
+
+    B and C are level on zero wins and have not met, so their two-way tie cannot be
+    broken head-to-head; it falls to game difference, where C (0) sits above B (-2).
+    Order: A, C, B."""
+    pool = _single_pool(
+        (A, B, C),
+        fixture_count=3,
+        outcomes=[_outcome(A, B, 2, 0)],
+    )
+    results = RoundRobinResults().tabulate([pool])
+    (standings,) = results.pools
+    assert [r.entry_id for r in standings.rows] == [A, C, B]
+    assert [(r.entry_id, r.played) for r in standings.rows] == [
+        (A, 1),
+        (C, 0),
+        (B, 1),
+    ]
+    assert standings.complete is False
+    assert results.complete is False
+    assert results.champion is None
+
+
+def test_a_complete_single_pool_event_has_a_champion() -> None:
+    """Every fixture decided in a single pool → the event is complete and its leader is
+    champion. A wins both, so A is champion."""
+    pool = _single_pool(
+        (A, B, C),
+        fixture_count=3,
+        outcomes=[
+            _outcome(A, B, 2, 0),
+            _outcome(A, C, 2, 0),
+            _outcome(B, C, 2, 0),
+        ],
+    )
+    results = RoundRobinResults().tabulate([pool])
+    assert results.complete is True
+    assert results.champion == A
+
+
+def test_a_complete_multi_pool_event_crowns_no_single_champion() -> None:
+    """Two pools, both fully played: the event is complete, but a multi-pool round-robin
+    has no single champion (that needs a knockout stage to join the pool winners), so
+    ``champion`` is ``None`` while each pool still has its own leader."""
+    pool_a = PoolInput(
+        pool_id=PoolId("p-a"),
+        entrants=(A, B),
+        fixture_count=1,
+        outcomes=(_outcome(A, B, 2, 0),),
+    )
+    pool_b = PoolInput(
+        pool_id=PoolId("p-b"),
+        entrants=(C, D),
+        fixture_count=1,
+        outcomes=(_outcome(C, D, 2, 0),),
+    )
+    results = RoundRobinResults().tabulate([pool_a, pool_b])
+    assert results.complete is True
+    assert results.champion is None
+    assert [pool.rows[0].entry_id for pool in results.pools] == [A, C]
+
+
+def test_a_corrected_result_re_orders_the_standings() -> None:
+    """Nothing is snapshotted, so a correction is just a re-tabulation over the new
+    outcomes (ADR-0788). A beats B → A leads; correct the match to B beating A and
+    re-tabulate → B leads. The table follows the live result with no bookkeeping."""
+    entrants = (A, B)
+    before = _single_pool(entrants, fixture_count=1, outcomes=[_outcome(A, B, 2, 0)])
+    assert RoundRobinResults().tabulate([before]).champion == A
+
+    after = _single_pool(entrants, fixture_count=1, outcomes=[_outcome(A, B, 0, 2)])
+    assert RoundRobinResults().tabulate([after]).champion == B

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -25,7 +25,9 @@ from httpx import AsyncClient, Response
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.orm import selectinload
 
+from app.account_merge import merge_user
 from app.draws import DrawError
 from app.leagues import seed_user_league_rating
 from app.models import (
@@ -33,6 +35,8 @@ from app.models import (
     LeagueVisibility,
     Match,
     MatchSettings,
+    MatchSide,
+    MatchStatus,
     RatingStrategy,
     Tournament,
     TournamentEntry,
@@ -52,6 +56,7 @@ from app.schemas.tournament import (
 )
 from app.tournament_draws import DrawCurrency, draw_currency_by_event
 from app.tournament_entry_refusals import EntryRefusal
+from app.tournament_materialization import materialize_live_draw
 from app.tournaments import (
     TOURNAMENT_CREATE,
     TOURNAMENT_VIEW,
@@ -65,10 +70,12 @@ from app.tournaments import (
     update_event,
 )
 from tests._helpers import (
+    accept_standing_result,
     counted_statements,
     grant_permissions,
     make_client,
     make_user,
+    opponent_session,
     rate_player,
     start_session,
 )
@@ -3684,9 +3691,9 @@ async def test_a_tbd_side_comes_back_as_null_rather_than_a_missing_key(
     was never told about, and "the key is missing" and "the side is unknown" are not the
     same fact.
 
-    ``winner_entry_id`` and ``match_id`` are the same story — undecided, and not yet a
-    match. The exact key set is asserted, so a field silently dropped (or a username
-    silently *added*) fails here.
+    ``winner_entry_id``, ``match_id`` and ``match_status`` are the same story —
+    undecided, not yet a match, so no live match status. The exact key set is asserted,
+    so a field silently dropped (or a username silently *added*) fails here.
     """
     client, _ = authed_client
     tournament_id, (event,) = await _tournament_with_events(client, _event_payload())
@@ -3708,12 +3715,14 @@ async def test_a_tbd_side_comes_back_as_null_rather_than_a_missing_key(
         "entry_b_id",
         "winner_entry_id",
         "match_id",
+        "match_status",
     }
     assert fixture["entry_a_id"] == str(entry.id)
-    # The three facts that are not known yet — each present, each null.
+    # The facts that are not known yet — each present, each null.
     assert fixture["entry_b_id"] is None
     assert fixture["winner_entry_id"] is None
     assert fixture["match_id"] is None
+    assert fixture["match_status"] is None
 
 
 async def test_a_fixtures_sides_are_entry_ids_the_events_entrants_list_resolves(
@@ -4463,6 +4472,55 @@ async def test_cutting_an_unimplemented_draw_type_is_422(
     # who has to go implement it.
     assert "cannot be cut yet" in detail, detail
     assert await _fixture_rows(db_session, event["id"]) == []
+
+
+@pytest.mark.parametrize("event_format", ["doubles", "teams"])
+async def test_cutting_a_non_singles_event_is_422(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    event_format: str,
+) -> None:
+    """A draw is **singles-only** (ADR-0788), refused at the cut with a 422 naming the
+    format. A ``TournamentEntry`` is one ``user_id``, so a round-robin over a doubles or
+    teams event could never say which two people form one side — and could never
+    materialize into a match. So it is refused at the earliest, clearest point (the
+    cut), not left to fail obscurely at go-live.
+
+    The refusal is about the FORMAT, and to prove it the field is a full, legal one —
+    four entrants over one pool, which a *singles* event cuts into six fixtures (the
+    next test). Nothing is written, as with the unimplemented-type and degenerate
+    refusals.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, format=event_format)
+    )
+    await _seed_field(db_session, event["id"], 4)
+
+    response = await client.post(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert event_format in detail and "singles" in detail, detail
+    assert await _fixture_rows(db_session, event["id"]) == []
+
+
+async def test_cutting_a_singles_event_is_allowed(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The mirror of the guard above: the *same* four-entrant, one-pool field on a
+    **singles** event cuts cleanly into its six round-robin fixtures. So the 422 next
+    door refuses the doubles/teams format, not the round-robin or the field.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    await _seed_field(db_session, event["id"], 4)
+
+    response = await client.post(_draw_url(tournament_id, event["id"]))
+
+    assert response.status_code == 201, response.text
+    assert len(await _fixture_rows(db_session, event["id"])) == 6
 
 
 @pytest.mark.parametrize(
@@ -5676,3 +5734,576 @@ async def test_the_draw_type_freeze_is_scoped_to_the_event_being_patched(
     assert free.status_code == 200, free.text
     assert await _draw_type_of(db_session, undrawn["id"]) is DrawType.single_elim
     assert await _draw_type_of(db_session, drawn["id"]) is DrawType.round_robin
+
+
+# ----- materialization at go-live (#788) ------------------------------------
+#
+# Going live consumes the first ``advance()``: every ready round-robin fixture becomes a
+# real ``in_progress`` match, seated **side 1 ← entry_a, side 2 ← entry_b**, linked back
+# by ``fixture.match_id``. It is idempotent on ``match_id`` — a second advance sees the
+# link and materializes nothing — and it happens in the same transaction as the status
+# write, so a tournament is never seen ``live`` without the matches its go-live created.
+
+
+async def _load_match(db_session: AsyncSession, match_id: uuid.UUID) -> Match:
+    """One materialized match with its settings and sides+players, read fresh (the
+    go-live route wrote it on its own session, so ``populate_existing`` steps past any
+    stale copy this test session may hold)."""
+    return (
+        await db_session.execute(
+            select(Match)
+            .where(Match.id == match_id)
+            .options(
+                selectinload(Match.match_settings),
+                selectinload(Match.sides).selectinload(MatchSide.players),
+            )
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+
+
+async def _match_count(db_session: AsyncSession) -> int:
+    """Every match row in the database. The suite truncates between tests, so within one
+    test this counts exactly the matches this tournament's go-live created — which
+    catches a re-materialization that spawns a second, fixture-less match."""
+    return (
+        await db_session.execute(select(func.count()).select_from(Match))
+    ).scalar_one()
+
+
+async def _active_entries(
+    db_session: AsyncSession, event_id: str
+) -> list[TournamentEntry]:
+    return list(
+        (
+            await db_session.execute(
+                select(TournamentEntry)
+                .where(
+                    TournamentEntry.event_id == uuid.UUID(event_id),
+                    TournamentEntry.status == TournamentEntryStatus.entered,
+                )
+                .execution_options(populate_existing=True)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+@pytest.mark.parametrize(("rated", "length_games"), [(True, 5), (False, 3)])
+async def test_going_live_materializes_the_whole_pool(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    rated: bool,
+    length_games: int,
+) -> None:
+    """Going live turns **every** ready fixture of a round-robin pool into a real
+    ``in_progress`` match in one stroke (ADR-0788), and each match is exactly the
+    fixture made real:
+
+    * ``status`` is ``in_progress`` — both players are known and committed;
+    * ``league_id`` is the tournament's, ``created_by_user_id`` is its owner (the
+      director whose go-live created it);
+    * its ``MatchSettings`` copy the only two things the event holds — ``best_of`` from
+      ``length_games`` and ``affects_rating`` from ``rated`` — with ``team_size = 1``;
+    * **side 1 seats ``entry_a``'s user, side 2 seats ``entry_b``'s** — the fixed
+      convention that lets a completed match's winning side map back to the winning
+      entry (#789).
+
+    Parametrized over a rated best-of-5 and an unrated best-of-3 so the settings mapping
+    is pinned in both directions, not just the default.
+    """
+    client, owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client,
+        _rr_payload(
+            POOL_A, match_settings={"rated": rated, "length_games": length_games}
+        ),
+    )
+    # One pool of three → three fixtures, each a distinct pairing — enough to see the
+    # whole pool materialize and to check the side↔entry mapping on every one of them.
+    entries = await _seed_field(db_session, event["id"], 3)
+    await _cut_the_draw(client, tournament_id, event["id"])
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+
+    response = await _go_live(client, tournament_id)
+    assert response.status_code == 201, response.text
+
+    tournament = (
+        await db_session.execute(
+            select(Tournament).where(Tournament.id == uuid.UUID(tournament_id))
+        )
+    ).scalar_one()
+
+    fixtures = await _fixture_rows(db_session, event["id"])
+    assert len(fixtures) == 3
+    assert all(f.match_id is not None for f in fixtures), (
+        "every ready fixture must have materialized into a match at go-live"
+    )
+    assert await _match_count(db_session) == 3, "the whole pool, and nothing more"
+
+    entry_user = {e.id: e.user_id for e in entries}
+    for fixture in fixtures:
+        assert fixture.match_id is not None
+        match = await _load_match(db_session, fixture.match_id)
+        assert match.status == MatchStatus.in_progress
+        assert match.league_id == tournament.league_id
+        assert match.created_by_user_id == owner.id
+        assert match.match_settings.team_size == 1
+        assert match.match_settings.best_of == length_games
+        assert match.match_settings.affects_rating is rated
+        by_number = {side.side_number: side for side in match.sides}
+        assert [p.user_id for p in by_number[1].players] == [
+            entry_user[fixture.entry_a_id]
+        ], "side 1 seats entry_a's user"
+        assert [p.user_id for p in by_number[2].players] == [
+            entry_user[fixture.entry_b_id]
+        ], "side 2 seats entry_b's user"
+
+
+async def test_the_detail_bff_links_a_materialized_fixture_to_its_live_match(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The tournament-detail BFF carries each fixture's ``match_id`` and the live
+    ``match_status`` (#788), so the front-end can link a bracket slot to its match and
+    show its state — one endpoint per page, no per-slot round-trip.
+
+    Read through the real detail route (not the database), because the field the wire
+    carries is the point: an un-materialized fixture answers ``null`` on both, and a
+    materialized one answers its match's id and its *current* status (``in_progress``
+    the moment it is created).
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+
+    # Before go-live: cut but not materialized — the slot links to nothing yet.
+    await _seed_field(db_session, event["id"], 3)
+    await _cut_the_draw(client, tournament_id, event["id"])
+    (read,) = await _events_of(client, tournament_id)
+    assert read["fixtures"], "the draw is cut, so there are fixtures to look at"
+    assert all(f["match_id"] is None for f in read["fixtures"])
+    assert all(f["match_status"] is None for f in read["fixtures"])
+
+    # After go-live: every slot links to its live, in-progress match.
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    assert (await _go_live(client, tournament_id)).status_code == 201
+
+    (read,) = await _events_of(client, tournament_id)
+    fixtures = read["fixtures"]
+    assert len(fixtures) == 3
+    assert all(f["match_id"] is not None for f in fixtures), (
+        "a materialized slot carries the id of the match it links to"
+    )
+    assert all(f["match_status"] == "in_progress" for f in fixtures), (
+        "and the match's live status, read fresh — in_progress the moment it is created"
+    )
+
+
+async def test_go_live_materialization_is_idempotent(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Materialization is idempotent on ``fixture.match_id`` (ADR-0786's readiness
+    definition): a fixture that already has a match is never ready again, so re-running
+    the first ``advance()`` after go-live creates no second match.
+
+    Proven by running the real ``materialize_live_draw`` primitive a *second* time,
+    after the go-live route already ran it once, and asserting the match count does not
+    move — if readiness ignored ``match_id`` this would double every fixture's match.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    await _seed_field(db_session, event["id"], 3)
+    await _cut_the_draw(client, tournament_id, event["id"])
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    assert (await _go_live(client, tournament_id)).status_code == 201
+
+    before = await _match_count(db_session)
+    assert before == 3
+
+    tournament = (
+        await db_session.execute(
+            select(Tournament).where(Tournament.id == uuid.UUID(tournament_id))
+        )
+    ).scalar_one()
+    await materialize_live_draw(db_session, tournament)
+    await db_session.commit()
+
+    assert await _match_count(db_session) == before, (
+        "a second advance over already-materialized fixtures must create nothing"
+    )
+
+
+async def test_a_merge_collision_on_a_played_event_does_not_corrupt_the_draw(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The one #788 case ADR-0786 explicitly deferred: a merge collision on an event
+    whose draw has already **materialized into matches**.
+
+    An unplayed collision un-cuts the draw (a field that double-counted a human is wrong
+    throughout). But a *played* draw cannot be un-cut — its fixtures hang real matches
+    off, and deleting them would eat the results. So the guest's colliding entry is
+    **withdrawn** rather than deleted (its fixture, and the match, survive), the draw is
+    left cut, and the self-play match the collision exposes — one human now on both
+    sides — is transferred to the survivor and **voided** by the ADR-0013 machinery.
+    """
+    client, _owner = authed_client
+    # A rated round-robin, so its materialized match is rated and the self-play
+    # collision takes the void path (an unrated collision would not be voided).
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    guest = await make_user(db_session, "guest-ghost-collision")
+    survivor = await make_user(db_session, "survivor-collision")
+    # Both actively entered in the one event — the collision. Two players in a single
+    # pool is exactly one fixture, drawing the guest against the survivor, so it seats
+    # one human on each side and the merge turns that match into self-play.
+    await _enter(db_session, event["id"], guest)
+    await _enter(db_session, event["id"], survivor)
+    await _cut_the_draw(client, tournament_id, event["id"])
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    assert (await _go_live(client, tournament_id)).status_code == 201
+
+    before = await _fixture_rows(db_session, event["id"])
+    assert len(before) == 1
+    match_id = before[0].match_id
+    assert match_id is not None, "the fixture materialized into a real match at go-live"
+
+    await merge_user(db_session, from_user_id=guest.id, to_user_id=survivor.id)
+    await db_session.commit()
+
+    # The draw is NOT un-cut: the fixture survives with the same id, still linked to its
+    # match. A played draw is never thrown away — that would eat the recorded match.
+    after = await _fixture_rows(db_session, event["id"])
+    assert [f.id for f in after] == [before[0].id], (
+        "the played draw's fixture must survive the merge, not be un-cut"
+    )
+    assert after[0].match_id == match_id, "and stay linked to its match"
+
+    # The self-play match the collision exposed is voided (ADR-0013), not left standing
+    # as one human playing themselves.
+    match = await _load_match(db_session, match_id)
+    assert match.status == MatchStatus.voided
+
+    # One human, one active entry: the guest's colliding entry was withdrawn (which is
+    # why its fixture survived above), and the survivor's is the one that stands.
+    active = await _active_entries(db_session, event["id"])
+    assert [e.user_id for e in active] == [survivor.id]
+
+
+# ----- Slice 2: completion advances the draw; results/standings render live (#789) ----
+# The seam (``on_match_completed`` via ``finalize_match``) writes the fixture's winner
+# on BOTH completion paths — rated (accept) and unrated (immediate self-accept) — and
+# the detail BFF projects live standings from the fixtures' completed matches
+# (ADR-0788). The ordering rules themselves live in the pure ``tests/test_results.py``;
+# these prove the wiring end-to-end through the real score endpoints.
+
+
+async def _win_fixture_match(
+    fixture: TournamentFixture,
+    *,
+    clients_by_entry: dict[uuid.UUID, AsyncClient],
+    winner_entry_id: uuid.UUID,
+    rated: bool,
+    best_of: int = 3,
+) -> None:
+    """Play a materialized fixture's match to completion through the real score
+    endpoints, with ``winner_entry_id`` taking it.
+
+    The winner's own client proposes a decided board (their side clinches), and — on a
+    rated match — the loser's client accepts, which is the second verb that actually
+    completes it. An unrated match self-accepts on the proposal, so no acceptance is
+    posted. Side 1 is ``entry_a`` and side 2 is ``entry_b`` (#788), so which side must
+    win the board is read off the fixture."""
+    assert fixture.match_id is not None
+    match_id = str(fixture.match_id)
+    side_1_wins = winner_entry_id == fixture.entry_a_id
+    side_1_points, side_2_points = (11, 5) if side_1_wins else (5, 11)
+    needed = best_of // 2 + 1
+    post = await clients_by_entry[winner_entry_id].post(
+        f"/v1/matches/{match_id}/results",
+        json={
+            "games": [
+                {
+                    "game_number": n,
+                    "side_1_points": side_1_points,
+                    "side_2_points": side_2_points,
+                }
+                for n in range(1, needed + 1)
+            ]
+        },
+    )
+    assert post.status_code == 201, post.text
+    if rated:
+        loser_entry = fixture.entry_b_id if side_1_wins else fixture.entry_a_id
+        assert loser_entry is not None
+        await accept_standing_result(clients_by_entry[loser_entry], match_id)
+
+
+async def _live_two_player_pool(
+    client: AsyncClient,
+    owner: User,
+    opponent: User,
+    db_session: AsyncSession,
+    *,
+    rated: bool,
+) -> tuple[str, dict[str, Any], TournamentEntry, TournamentEntry, TournamentFixture]:
+    """A round-robin event of two seeded players, taken all the way to ``live`` so its
+    one fixture has materialized into a real match. ``owner`` is seed 1, so the draw
+    seats them as ``entry_a`` (side 1)."""
+    tournament_id, (event,) = await _tournament_with_events(
+        client,
+        _rr_payload(
+            POOL_A,
+            match_settings={"rated": rated, "length_games": 3},
+            predicates=[],
+        ),
+    )
+    base = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+    e_owner = await _enter(
+        db_session, event["id"], owner, seed=1, created_at=base + timedelta(minutes=1)
+    )
+    e_opp = await _enter(
+        db_session,
+        event["id"],
+        opponent,
+        seed=2,
+        created_at=base + timedelta(minutes=2),
+    )
+    await _cut_the_draw(client, tournament_id, event["id"])
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    assert (await _go_live(client, tournament_id)).status_code == 201
+    (fixture,) = await _fixture_rows(db_session, event["id"])
+    return tournament_id, event, e_owner, e_opp, fixture
+
+
+async def _live_three_player_pool(
+    client: AsyncClient,
+    owner: User,
+    second: User,
+    third: User,
+    db_session: AsyncSession,
+    *,
+    rated: bool,
+) -> tuple[
+    str,
+    dict[str, Any],
+    tuple[TournamentEntry, TournamentEntry, TournamentEntry],
+    list[TournamentFixture],
+]:
+    """A round-robin pool of three seeded players (seeds 1, 2, 3), live, so its three
+    fixtures have all materialized into matches."""
+    tournament_id, (event,) = await _tournament_with_events(
+        client,
+        _rr_payload(
+            POOL_A,
+            match_settings={"rated": rated, "length_games": 3},
+            predicates=[],
+        ),
+    )
+    base = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+    seated: list[TournamentEntry] = []
+    for seed, user in ((1, owner), (2, second), (3, third)):
+        seated.append(
+            await _enter(
+                db_session,
+                event["id"],
+                user,
+                seed=seed,
+                created_at=base + timedelta(minutes=seed),
+            )
+        )
+    await _cut_the_draw(client, tournament_id, event["id"])
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    assert (await _go_live(client, tournament_id)).status_code == 201
+    fixtures = await _fixture_rows(db_session, event["id"])
+    entries = (seated[0], seated[1], seated[2])
+    return tournament_id, event, entries, fixtures
+
+
+async def test_a_completed_rated_tournament_match_writes_the_winner_to_its_fixture(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The rated completion path (propose → accept) drives the seam: the draw does not
+    move on a bare proposal, only once the opponent accepts. After acceptance the
+    fixture's ``winner_entry_id`` is the winning side's entry (side 1 → ``entry_a``)."""
+    client, owner = authed_client
+    async with opponent_session(db_session, "rr-rated-opp") as (opp_client, opp):
+        _tid, event, e_owner, e_opp, fixture = await _live_two_player_pool(
+            client, owner, opp, db_session, rated=True
+        )
+
+        # Propose a decided board but do not accept it: the match stays in_progress, so
+        # the seam has not run and the fixture is still undecided.
+        post = await client.post(
+            f"/v1/matches/{fixture.match_id}/results",
+            json={
+                "games": [
+                    {"game_number": n, "side_1_points": 11, "side_2_points": 5}
+                    for n in range(1, 3)
+                ]
+            },
+        )
+        assert post.status_code == 201, post.text
+        (still_pending,) = await _fixture_rows(db_session, event["id"])
+        assert still_pending.winner_entry_id is None, (
+            "an unaccepted proposal must not move the draw"
+        )
+
+        # Accept: now the match completes and the seam writes the winner.
+        await accept_standing_result(opp_client, str(fixture.match_id))
+
+    (decided,) = await _fixture_rows(db_session, event["id"])
+    assert decided.winner_entry_id == e_owner.id, (
+        "acceptance completes the match, and the seam records side 1's entry as winner"
+    )
+    assert e_opp.id != e_owner.id
+
+
+async def test_a_completed_unrated_tournament_match_writes_the_winner_to_its_fixture(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The unrated completion path self-accepts on the proposal — no second verb — and
+    the same seam runs: posting the result completes the match immediately, and the
+    fixture's winner is written the instant it lands."""
+    client, owner = authed_client
+    async with opponent_session(db_session, "rr-unrated-opp") as (opp_client, opp):
+        _tid, event, e_owner, e_opp, fixture = await _live_two_player_pool(
+            client, owner, opp, db_session, rated=False
+        )
+        await _win_fixture_match(
+            fixture,
+            clients_by_entry={e_owner.id: client, e_opp.id: opp_client},
+            winner_entry_id=e_owner.id,
+            rated=False,
+        )
+
+    (decided,) = await _fixture_rows(db_session, event["id"])
+    assert decided.winner_entry_id == e_owner.id
+
+
+async def test_completing_a_round_robin_match_materializes_nothing_new(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Round-robin's ``advance()`` is empty after go-live — the whole pool is already
+    materialized — so the completion seam records the one winner and creates no new
+    match. Proven by completing one match of a three-fixture pool and pinning the
+    match count."""
+    client, owner = authed_client
+    async with (
+        opponent_session(db_session, "rr-empty-2") as (c2, u2),
+        opponent_session(db_session, "rr-empty-3") as (c3, u3),
+    ):
+        _tid, event, entries, fixtures = await _live_three_player_pool(
+            client, owner, u2, u3, db_session, rated=True
+        )
+        e1, e2, e3 = entries
+        before = await _match_count(db_session)
+        assert before == 3, "the pool materialized into three matches at go-live"
+
+        by_pair = {frozenset({f.entry_a_id, f.entry_b_id}): f for f in fixtures}
+        clients = {e1.id: client, e2.id: c2, e3.id: c3}
+        await _win_fixture_match(
+            by_pair[frozenset({e2.id, e3.id})],
+            clients_by_entry=clients,
+            winner_entry_id=e2.id,
+            rated=True,
+        )
+
+    assert await _match_count(db_session) == 3, (
+        "completing a round-robin match materializes no new match — advance() is empty"
+    )
+    fixtures_after = await _fixture_rows(db_session, event["id"])
+    decided = [f for f in fixtures_after if f.winner_entry_id is not None]
+    assert [f.winner_entry_id for f in decided] == [e2.id], (
+        "exactly the one completed fixture is decided; the seam touched no other"
+    )
+
+
+async def test_the_detail_bff_surfaces_live_standings_then_a_champion(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The tournament-detail BFF carries each round-robin event's standings, derived
+    live from its fixtures' completed matches (ADR-0788):
+
+    * mid-pool it is present but **incomplete**, with every seated entrant already on
+      the table (even one who has not played) and no champion;
+    * once every fixture is decided it is **complete**, ordered by wins, and its leader
+      is the champion.
+
+    Player 1 wins both their matches; player 2 beats player 3. Final table: p1 (2 wins),
+    p2 (1), p3 (0), champion p1."""
+    client, owner = authed_client
+    async with (
+        opponent_session(db_session, "rr-bff-2") as (c2, u2),
+        opponent_session(db_session, "rr-bff-3") as (c3, u3),
+    ):
+        tournament_id, event, entries, fixtures = await _live_three_player_pool(
+            client, owner, u2, u3, db_session, rated=True
+        )
+        e1, e2, e3 = entries
+        clients = {e1.id: client, e2.id: c2, e3.id: c3}
+        by_pair = {frozenset({f.entry_a_id, f.entry_b_id}): f for f in fixtures}
+
+        # One match in: standings are live but incomplete, and everyone is seated.
+        await _win_fixture_match(
+            by_pair[frozenset({e2.id, e3.id})],
+            clients_by_entry=clients,
+            winner_entry_id=e2.id,
+            rated=True,
+        )
+        (read,) = await _events_of(client, tournament_id)
+        partial = read["results"]
+        assert partial is not None, "a cut round-robin event carries a results object"
+        assert partial["complete"] is False
+        assert partial["champion"] is None
+        (pool,) = partial["pools"]
+        assert {row["entry_id"] for row in pool["rows"]} == {
+            str(e1.id),
+            str(e2.id),
+            str(e3.id),
+        }, "every seated entrant is on the table, even before they've played"
+
+        # Finish the pool: p1 wins both of their matches.
+        await _win_fixture_match(
+            by_pair[frozenset({e1.id, e3.id})],
+            clients_by_entry=clients,
+            winner_entry_id=e1.id,
+            rated=True,
+        )
+        await _win_fixture_match(
+            by_pair[frozenset({e1.id, e2.id})],
+            clients_by_entry=clients,
+            winner_entry_id=e1.id,
+            rated=True,
+        )
+        (read,) = await _events_of(client, tournament_id)
+
+    results = read["results"]
+    assert results["complete"] is True
+    assert results["champion"] == str(e1.id)
+    (pool,) = results["pools"]
+    assert [(row["entry_id"], row["wins"], row["rank"]) for row in pool["rows"]] == [
+        (str(e1.id), 2, 1),
+        (str(e2.id), 1, 2),
+        (str(e3.id), 0, 3),
+    ]
+
+
+async def test_an_uncut_event_carries_no_results(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """An event whose draw has not been cut has nothing to stand, so ``results`` is
+    ``null`` — not an empty table, which would read as a played event with nobody
+    in it."""
+    client, _owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    await _seed_field(db_session, event["id"], 3)
+    (read,) = await _events_of(client, tournament_id)
+    assert read["fixtures"] == [], "no draw cut yet"
+    assert read["results"] is None

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -5990,6 +5990,14 @@ async def test_a_merge_collision_on_a_played_event_does_not_corrupt_the_draw(
     active = await _active_entries(db_session, event["id"])
     assert [e.user_id for e in active] == [survivor.id]
 
+    # And the standings are not frozen by the void. A voided fixture never yields an
+    # outcome, so it is excluded from the pool's completeness count (ADR-0788). The
+    # event reports ``complete`` rather than hanging one short of its count forever —
+    # before this fix it stuck at incomplete permanently, with no champion. (The pool
+    # is degenerate after the merge, one human on an N+1 draw; a director re-cuts it.)
+    (read,) = await _events_of(client, tournament_id)
+    assert read["results"]["complete"] is True
+
 
 # ----- Slice 2: completion advances the draw; results/standings render live (#789) ----
 # The seam (``on_match_completed`` via ``finalize_match``) writes the fixture's winner
@@ -6307,3 +6315,28 @@ async def test_an_uncut_event_carries_no_results(
     (read,) = await _events_of(client, tournament_id)
     assert read["fixtures"] == [], "no draw cut yet"
     assert read["results"] is None
+
+
+async def test_the_list_endpoint_does_not_ship_standings(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Standings are a detail-BFF concern. The tournaments *list* renders only event and
+    table counts — never a results table — so it must not compute or ship a ``results``
+    object (ADR-0788): doing so would run a game-count query and the tiebreak tabulation
+    per event for data a card throws away. A cut event proves the split — the detail
+    carries its standings, the list carries ``None`` for the same event."""
+    client, _owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    await _seed_field(db_session, event["id"], 3)
+    await _cut_the_draw(client, tournament_id, event["id"])
+
+    # Detail: a cut round-robin event carries its (here, unplayed) standings.
+    (detail_event,) = await _events_of(client, tournament_id)
+    assert detail_event["results"] is not None
+
+    # List: the very same event carries no results — the projection is skipped whole.
+    listing = (await client.get("/v1/tournaments")).json()
+    (listed,) = [t for t in listing if t["id"] == tournament_id]
+    (listed_event,) = listed["events"]
+    assert listed_event["results"] is None

--- a/docs/adr/0788-materialize-at-go-live-and-results-are-a-per-draw-type-strategy.md
+++ b/docs/adr/0788-materialize-at-go-live-and-results-are-a-per-draw-type-strategy.md
@@ -1,0 +1,161 @@
+# 788. Tournament matches materialize at go-live; an event's results are a per-draw-type strategy
+
+Date: 2026-07-13 (numbered by issue #788 — sequential numbers collide across
+concurrent worktrees; see ADR-0786's note and the duplicate 0008s in this directory)
+
+## Status
+
+Accepted — design for slices C1/C2 of epic #780 (#788, #789), decided before
+implementation. Refines two positions ADR-0786 left open or stated differently
+(the completion→advance seam, and "standings is not a strategy method").
+
+## Context
+
+ADR-0786 laid the substrate: persisted `tournament_fixtures`, a pure
+`DrawStrategy` per draw type (`plan_initial` + idempotent `advance`),
+materialization gated on the tournament being `live`, and a completion-driven
+"write `winner_entry_id`, run `advance()`" mechanism. It deliberately deferred
+the *mechanics* of C to "a later slice": how a completed match writes back and
+re-advances, how a fixture becomes a real propose/accept match, and what an
+event's **results** are. This ADR pins those.
+
+Three facts constrain the slice:
+
+- **Only round-robin has a strategy.** #785's `SingleElimStrategy` is unmerged
+  (`strategy_for` still raises `UnsupportedDrawType` for it), so round-robin is
+  the only draw type that can be cut today. Round-robin's `advance()` fills **no**
+  sides — every pairing is known at the cut — so after go-live materializes the
+  pool, its `advance()` is *always* empty. The "fill the winner into the next
+  round" behaviour is entirely single-elim's, and there is nothing to test it
+  against yet.
+- **A match completes at two sites, split on rated-ness.** `matches.py`'s result
+  path self-accepts and completes an **unrated** match immediately; the
+  `result_acceptance.py` path completes a **rated** match on acceptance (or
+  retirement auto-accept, ADR-0008). Both call `Match.mark_completed()`.
+- **The event carries almost nothing to copy.** `TournamentEvent.match_settings`
+  is only `{rated, length_games}`. `TournamentEntry` is a **single** `user_id` —
+  there is no partner/roster model — so a `doubles`/`teams` event has no way to
+  say *which two people* form one side.
+
+## Decision
+
+### Scope: round-robin, singles
+
+C1/C2 target **round-robin** and **singles**. Single-elim advancement rides
+along for free when #785 lands, because every mechanism below is
+draw-type-agnostic. A non-singles event is **refused at draw-cut** (`POST
+…/draw`), not at go-live: a round-robin draw over single-`user_id` entries is
+meaningless for doubles, so there is nothing worth cutting or previewing, and the
+earliest failure is the clearest one.
+
+### A ready fixture materializes into an ordinary match at go-live
+
+Materialization (ADR-0786 gated it on `live`) is now *consumed*: the go-live
+transition's first `advance()` turns **every** ready round-robin fixture into a
+real `Match` in one stroke — the whole pool. The match is created:
+
+- `status = in_progress` — both players are known and committed; there is no
+  accept-to-*start* step (propose/accept is about the *result*).
+- `league_id` = the tournament's league; a new `MatchSettings` with `best_of =
+  length_games`, `affects_rating = rated`, `team_size = 1`, and **default**
+  `verification_policy`/`retirement_window` (the event holds nothing to copy —
+  capturing tournament-specific retirement is a later slice).
+- `created_by_user_id` = the tournament **owner** (director). A tournament match
+  has no player-initiator; the director's go-live created it. The field grants no
+  scoring rights (those are by side participation) and appears in no player-facing
+  list, so this is honest provenance, not a privilege.
+- **side 1 ← `entry_a`, side 2 ← `entry_b`.** This fixed convention is what lets
+  the winner read back with **no new column**: the completed match's winning
+  `MatchSide.side_number` maps `1 → entry_a_id`, `2 → entry_b_id`.
+
+Idempotence is `fixture.match_id`: a re-run of `advance()` never re-proposes.
+
+### The completion→advance seam is one synchronous call, wired at both sites
+
+A single domain function — `on_match_completed(db, match)` in a new
+`tournament_advancement` module (not the tournaments *router*, so the dependency
+points one way: the match-completion services import tournaments, never the
+reverse) — runs **synchronously, inside the completion transaction/row-lock** the
+score endpoints already hold (ADR-0009). It looks the fixture up by `match_id`
+(indexed), returns early on a miss (the common non-tournament case), records
+`winner_entry_id`, and runs `strategy_for(draw_type).advance(...)`, materializing
+anything newly ready.
+
+It is called from **both** `mark_completed()` sites, so it covers rated *and*
+unrated tournament matches uniformly — an unrated match moves the draw forward the
+instant its result is posted; a rated one the instant it is accepted. The draw
+never moves on an *un*accepted proposal, and a **correction** (which un-completes
+the match) correctly stops moving it until re-accepted. The safest wiring is a
+single `finalize_match()` helper both paths call, so a future third completion
+path cannot forget the hook.
+
+A **synchronous** call (not an RQ job or an event bus) is deliberate: the advance
+is cheap, an atomic "result accepted ⟹ the draw reflects it" is far simpler to
+reason about than an eventually-consistent one, and there is exactly one consumer
+— an event bus would be machinery without a second subscriber.
+
+For round-robin the seam materializes nothing after go-live (the pool is already
+whole) and `advance()` is empty. That is the uniform seam being honestly empty,
+not dead code: the same call is load-bearing the moment single-elim lands.
+
+### An event's results are a *separate* per-draw-type strategy family
+
+ADR-0786 said pool standings are "a read-model over decided fixtures —
+deliberately **not** a strategy method." That still holds for the **shared
+`DrawStrategy`** interface: `standings()` there would force single-elim and
+double-elim to implement a table they do not have. But the underlying concept —
+**results**, *how an event turned out* — **is** universal across draw types; it is
+only *shaped* differently (a round-robin's results are its **standings** table; a
+single-elim's are its placement and **champion**). So results get their **own**
+strategy family, `results_for(draw_type)`, mirroring `strategy_for`'s exhaustive
+`match`/`UnsupportedDrawType`, in a pure `results` module. This slice implements
+only `RoundRobinResults`.
+
+`RoundRobinResults` orders a pool by an **extensible chain** of tiebreakers: wins
+→ head-to-head *when exactly two are tied* → game difference (games won minus
+lost) → games won. (Head-to-head is applied only to two-way ties; a 3+-way tie
+can cycle, so it falls straight through to game difference rather than a recursive
+mini-league.) "points diff" from issue #789 is dropped: points are not modelled,
+so the finest granularity is a **game**.
+
+### Everything derives from the live matches; nothing is a snapshot
+
+Standings, **event-complete** ("every fixture decided"), and **champion**
+(standings position 1 of a complete event) are all computed **live from the
+fixtures' currently-`completed` matches** — the results strategy is fed small
+frozen **outcome value objects** (winner + per-side games) projected from those
+matches, keeping the `results` module pure. Because nothing is snapshotted, a
+**correction** or **voided match** is reflected the instant it leaves `completed`,
+with **no extra hooks** — the single completion hook suffices.
+
+`winner_entry_id` *is* still written on completion, for the uniform mechanism and
+as the substrate single-elim's `advance()` will plan from — but **no round-robin
+read path reads it** (they derive from the matches, for correction-safety). It is
+therefore written-but-unread in round-robin: the acceptable price of one uniform
+seam. Zero drift would cost an un-completion/void hook to clear it; not worth it,
+since displays never read it.
+
+**Champion and event-completion are derived, never stored, and `archived` stays a
+manual director action** — auto-archiving on the last result is a surprising
+side-effect on an irreversible status edge, and a multi-event tournament is not
+"done" because one event finished.
+
+## Consequences
+
+- The completion path gains one synchronous call at two sites (ideally one
+  `finalize_match()` helper); no queue, no event bus, no per-draw-type code at
+  result sites — `on_match_completed` is the one mechanism.
+- There are now **two** strategy families: `DrawStrategy` (run the draw) and the
+  results strategy (compute the outcome). Each is pure, registry-dispatched, and
+  exhaustive-`match`ed, so a new `DrawType` is a type error in both until handled.
+- A corrected or voided tournament match needs no bespoke round-robin handling:
+  standings/complete/champion recompute from live match state. Single-elim's
+  "un-advance a reversed result" (a downstream match built on a now-reversed one)
+  is genuinely harder and is deferred to #785, consistent with ADR-0786 parking
+  the "play has begun" merge-collision case there too.
+- Results appear inside the existing tournament-detail BFF (one endpoint per
+  page); the only structural additions are the `results` module and the
+  materialization/advancement wiring. Standings render live throughout play.
+- Doubles/teams tournaments remain unplayable by construction (refused at cut)
+  until an entry-partner model exists — an explicit no, recorded so it is not
+  mistaken for an oversight.

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -2873,6 +2873,54 @@ internal enum Components {
             case doubles = "doubles"
             case teams = "teams"
         }
+        /// A round-robin event's results (ADR-0788): a standings table per pool, whether the
+        /// whole event is decided, and its champion when there is one.
+        ///
+        /// It rides on the tournament-detail payload (one endpoint per page) and is **derived
+        /// live** from the fixtures' currently-completed matches — never a snapshot — so a
+        /// corrected or voided match re-orders the standings the instant it leaves
+        /// ``completed``.
+        ///
+        /// ``champion`` is the leader of a **complete, single-pool** event — a pure
+        /// round-robin's winner. A multi-pool round-robin has no single champion without a
+        /// knockout stage to join its pool winners (``rr_then_ko``, a later slice), so it is
+        /// ``null`` there even when ``complete``; and ``null`` while any fixture is still to be
+        /// played.
+        ///
+        /// ``results`` on the event is ``null`` for an event that has **no draw** (nothing to
+        /// stand) or one whose draw type has no results strategy yet (only round-robin does
+        /// today) — an honest "no results here", not an empty table that would read as a played
+        /// event with nobody in it.
+        ///
+        /// - Remark: Generated from `#/components/schemas/EventResultsRead`.
+        internal struct EventResultsRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/EventResultsRead/pools`.
+            internal var pools: [Components.Schemas.PoolStandingsRead]
+            /// - Remark: Generated from `#/components/schemas/EventResultsRead/complete`.
+            internal var complete: Swift.Bool
+            /// - Remark: Generated from `#/components/schemas/EventResultsRead/champion`.
+            internal var champion: Swift.String?
+            /// Creates a new `EventResultsRead`.
+            ///
+            /// - Parameters:
+            ///   - pools:
+            ///   - complete:
+            ///   - champion:
+            internal init(
+                pools: [Components.Schemas.PoolStandingsRead],
+                complete: Swift.Bool,
+                champion: Swift.String? = nil
+            ) {
+                self.pools = pools
+                self.complete = complete
+                self.champion = champion
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case pools
+                case complete
+                case champion
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/HTTPValidationError`.
         internal struct HTTPValidationError: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/HTTPValidationError/detail`.
@@ -5700,6 +5748,42 @@ internal enum Components {
                 ])
             }
         }
+        /// One pool's standings: its rows in finishing order, and whether every one of its
+        /// fixtures has been decided.
+        ///
+        /// ``pool_id`` names a ``Pool`` in this same event's ``pools`` — the string ref a
+        /// fixture also carries — so a client titles the table from the pool it already
+        /// holds.
+        ///
+        /// - Remark: Generated from `#/components/schemas/PoolStandingsRead`.
+        internal struct PoolStandingsRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/PoolStandingsRead/pool_id`.
+            internal var poolId: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PoolStandingsRead/rows`.
+            internal var rows: [Components.Schemas.StandingRowRead]
+            /// - Remark: Generated from `#/components/schemas/PoolStandingsRead/complete`.
+            internal var complete: Swift.Bool
+            /// Creates a new `PoolStandingsRead`.
+            ///
+            /// - Parameters:
+            ///   - poolId:
+            ///   - rows:
+            ///   - complete:
+            internal init(
+                poolId: Swift.String,
+                rows: [Components.Schemas.StandingRowRead],
+                complete: Swift.Bool
+            ) {
+                self.poolId = poolId
+                self.rows = rows
+                self.complete = complete
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case poolId = "pool_id"
+                case rows
+                case complete
+            }
+        }
         /// An eligibility rule. ``field`` names the one fact we actually hold about a
         /// player — their rating on the tournament's league (ADR-0783) — so ``value`` is a
         /// number, or a ``[min, max]`` pair for the ``between`` operator (either bound may
@@ -6616,6 +6700,80 @@ internal enum Components {
                 ])
             }
         }
+        /// One entry's line in a pool's standings (ADR-0788), at its settled rank.
+        ///
+        /// The entry is carried as an **id only**, exactly as a fixture carries its sides: the
+        /// username behind ``entry_id`` is on the event's ``entrants`` list already, keyed by
+        /// that same id, so a client joins the two rather than reading a copy that could drift.
+        ///
+        /// ``rank`` is 1-based and distinct per row — the pool's order is total (wins → two-way
+        /// head-to-head → game difference → games won → id), so position 1 is the leader.
+        /// ``game_difference`` (``games_won - games_lost``) rides along because it is the third
+        /// tiebreaker and a client shows it in the table; it is a pure function of the two game
+        /// counts beside it, computed once on the server so the two cannot disagree.
+        ///
+        /// - Remark: Generated from `#/components/schemas/StandingRowRead`.
+        internal struct StandingRowRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/StandingRowRead/entry_id`.
+            internal var entryId: Swift.String
+            /// - Remark: Generated from `#/components/schemas/StandingRowRead/rank`.
+            internal var rank: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/StandingRowRead/played`.
+            internal var played: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/StandingRowRead/wins`.
+            internal var wins: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/StandingRowRead/losses`.
+            internal var losses: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/StandingRowRead/games_won`.
+            internal var gamesWon: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/StandingRowRead/games_lost`.
+            internal var gamesLost: Swift.Int
+            /// ``games_won - games_lost`` — the third tiebreaker, on the wire for the table
+            /// to show but derived here so it cannot disagree with the two counts beside it.
+            ///
+            /// - Remark: Generated from `#/components/schemas/StandingRowRead/game_difference`.
+            internal var gameDifference: Swift.Int
+            /// Creates a new `StandingRowRead`.
+            ///
+            /// - Parameters:
+            ///   - entryId:
+            ///   - rank:
+            ///   - played:
+            ///   - wins:
+            ///   - losses:
+            ///   - gamesWon:
+            ///   - gamesLost:
+            ///   - gameDifference: ``games_won - games_lost`` — the third tiebreaker, on the wire for the table
+            internal init(
+                entryId: Swift.String,
+                rank: Swift.Int,
+                played: Swift.Int,
+                wins: Swift.Int,
+                losses: Swift.Int,
+                gamesWon: Swift.Int,
+                gamesLost: Swift.Int,
+                gameDifference: Swift.Int
+            ) {
+                self.entryId = entryId
+                self.rank = rank
+                self.played = played
+                self.wins = wins
+                self.losses = losses
+                self.gamesWon = gamesWon
+                self.gamesLost = gamesLost
+                self.gameDifference = gameDifference
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case entryId = "entry_id"
+                case rank
+                case played
+                case wins
+                case losses
+                case gamesWon = "games_won"
+                case gamesLost = "games_lost"
+                case gameDifference = "game_difference"
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/Status`.
         internal enum Status: String, Codable, Hashable, Sendable, CaseIterable {
             case scheduled = "scheduled"
@@ -7159,6 +7317,26 @@ internal enum Components {
             internal var entryState: Components.Schemas.TournamentEventRead.EntryStatePayload
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/fixtures`.
             internal var fixtures: [Components.Schemas.TournamentFixtureRead]
+            /// - Remark: Generated from `#/components/schemas/TournamentEventRead/results`.
+            internal struct ResultsPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/TournamentEventRead/results/value1`.
+                internal var value1: Components.Schemas.EventResultsRead
+                /// Creates a new `ResultsPayload`.
+                ///
+                /// - Parameters:
+                ///   - value1:
+                internal init(value1: Components.Schemas.EventResultsRead) {
+                    self.value1 = value1
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    self.value1 = try .init(from: decoder)
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    try self.value1.encode(to: encoder)
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/TournamentEventRead/results`.
+            internal var results: Components.Schemas.TournamentEventRead.ResultsPayload?
             /// The registration count. Derived — there is no stored counter (ADR-0016).
             ///
             /// It is ``len(entrants)`` rather than a field of its own precisely so the
@@ -7186,6 +7364,7 @@ internal enum Components {
             ///   - entrants:
             ///   - entryState:
             ///   - fixtures:
+            ///   - results:
             ///   - entered: The registration count. Derived — there is no stored counter (ADR-0016).
             internal init(
                 id: Swift.String,
@@ -7204,6 +7383,7 @@ internal enum Components {
                 entrants: [Components.Schemas.TournamentEntrantRead],
                 entryState: Components.Schemas.TournamentEventRead.EntryStatePayload,
                 fixtures: [Components.Schemas.TournamentFixtureRead],
+                results: Components.Schemas.TournamentEventRead.ResultsPayload? = nil,
                 entered: Swift.Int
             ) {
                 self.id = id
@@ -7222,6 +7402,7 @@ internal enum Components {
                 self.entrants = entrants
                 self.entryState = entryState
                 self.fixtures = fixtures
+                self.results = results
                 self.entered = entered
             }
             internal enum CodingKeys: String, CodingKey {
@@ -7241,6 +7422,7 @@ internal enum Components {
                 case entrants
                 case entryState = "entry_state"
                 case fixtures
+                case results
                 case entered
             }
         }
@@ -7454,8 +7636,9 @@ internal enum Components {
         /// One planned pairing of an event's draw (ADR-0786): a round and a position —
         /// plus a pool, when the draw is pooled — whose sides may still be unknown.
         ///
-        /// A fixture is **not** a match. It materializes into one later (#788), and until it
-        /// does ``match_id`` is ``null``.
+        /// A fixture is **not** a match. It materializes into one at go-live (#788): once the
+        /// tournament is ``live``, every ready fixture becomes a real ``in_progress`` match and
+        /// gains a ``match_id``. Until then ``match_id`` (and ``match_status``) is ``null``.
         ///
         /// **Every ``null`` on this model is a fact, not a missing field**, and a client that
         /// dropped them would lose the draw's whole point:
@@ -7466,7 +7649,13 @@ internal enum Components {
         ///   (ADR-0786), so there is no ``is_bye`` flag here to tell the two apart.
         /// * ``winner_entry_id`` — ``null`` while the fixture is undecided.
         /// * ``match_id`` — ``null`` until the fixture becomes a real match, which only happens
-        ///   once the tournament is ``live``.
+        ///   once the tournament is ``live``. When set, it is the id of the match the slot
+        ///   links to (``GET /v1/matches/{match_id}``), so a client can deep-link a slot.
+        /// * ``match_status`` — the live status of that match (``in_progress`` at go-live,
+        ///   moving to ``completed`` / ``voided`` as it is played), or ``null`` when the
+        ///   fixture has not materialized. It rides on the fixture so a bracket shows a slot's
+        ///   state without a per-slot round-trip; it is the match's *current* status, read
+        ///   live, not a copy frozen at go-live.
         /// * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
         ///   un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
         ///   set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
@@ -7496,6 +7685,26 @@ internal enum Components {
             internal var winnerEntryId: Swift.String?
             /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/match_id`.
             internal var matchId: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/match_status`.
+            internal struct MatchStatusPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/match_status/value1`.
+                internal var value1: Components.Schemas.MatchStatus
+                /// Creates a new `MatchStatusPayload`.
+                ///
+                /// - Parameters:
+                ///   - value1:
+                internal init(value1: Components.Schemas.MatchStatus) {
+                    self.value1 = value1
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    self.value1 = try decoder.decodeFromSingleValueContainer()
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    try encoder.encodeToSingleValueContainer(self.value1)
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/match_status`.
+            internal var matchStatus: Components.Schemas.TournamentFixtureRead.MatchStatusPayload?
             /// Creates a new `TournamentFixtureRead`.
             ///
             /// - Parameters:
@@ -7507,6 +7716,7 @@ internal enum Components {
             ///   - entryBId:
             ///   - winnerEntryId:
             ///   - matchId:
+            ///   - matchStatus:
             internal init(
                 id: Swift.String,
                 poolId: Swift.String? = nil,
@@ -7515,7 +7725,8 @@ internal enum Components {
                 entryAId: Swift.String? = nil,
                 entryBId: Swift.String? = nil,
                 winnerEntryId: Swift.String? = nil,
-                matchId: Swift.String? = nil
+                matchId: Swift.String? = nil,
+                matchStatus: Components.Schemas.TournamentFixtureRead.MatchStatusPayload? = nil
             ) {
                 self.id = id
                 self.poolId = poolId
@@ -7525,6 +7736,7 @@ internal enum Components {
                 self.entryBId = entryBId
                 self.winnerEntryId = winnerEntryId
                 self.matchId = matchId
+                self.matchStatus = matchStatus
             }
             internal enum CodingKeys: String, CodingKey {
                 case id
@@ -7535,6 +7747,7 @@ internal enum Components {
                 case entryBId = "entry_b_id"
                 case winnerEntryId = "winner_entry_id"
                 case matchId = "match_id"
+                case matchStatus = "match_status"
             }
         }
         /// - Remark: Generated from `#/components/schemas/TournamentRead`.

--- a/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
+++ b/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
@@ -173,6 +173,45 @@ export class TournamentDetailPage {
     return this.drawPanel(eventName).locator('[data-testid^="fixture-line-"]')
   }
 
+  // ----- the standings (ADR-0788) ------------------------------------------
+  //
+  // The results block below the fixtures on a round-robin card: a table per pool (in the
+  // server's finishing order — never re-sorted here), and a champion once the event is
+  // decided. Scoped to one event card, like the draw, because the tab renders one per
+  // event and every "Standings" region / "Pool A" table would otherwise be ambiguous.
+
+  /** One event's results block — the `<section>` headed "Standings" on its card. Absent
+   * (count 0) for an event with no results: an uncut or non-round-robin event stands
+   * nothing. */
+  standingsPanel(eventName: string): Locator {
+    return this.eventCard(eventName).getByRole('region', { name: 'Standings' })
+  }
+
+  /** One pool's standings table, by the pool name in its accessible label — the whole
+   * point being that a screen reader reads a real `<table>` by column, so this goes
+   * through the accessibility tree, not a test id. */
+  standingsTable(eventName: string, poolName: string): Locator {
+    return this.eventCard(eventName).getByRole('table', {
+      name: `Standings for ${poolName}`,
+    })
+  }
+
+  /** The player names down one pool's table, top to bottom — the ORDER the server settled
+   * and the FE renders untouched (ADR-0788). The Player cell is the second cell of each
+   * body row (`<th scope=col>`s are `columnheader`s, not rows here). */
+  standingsRowNames(eventName: string, poolName: string): Locator {
+    return this.standingsTable(eventName, poolName)
+      .locator('tbody tr')
+      .locator('td:nth-child(2)')
+  }
+
+  /** The champion callout on one card — shown only for a complete, single-champion event.
+   * Addressed by the testid prefix (the id carries the event's id, which a spec has no
+   * business knowing), scoped to the card. Absent when there is no single champion. */
+  standingsChampion(eventName: string): Locator {
+    return this.eventCard(eventName).locator('[data-testid^="standings-champion-"]')
+  }
+
   // ----- the event card's entry control ------------------------------------
 
   enterButton(eventName: string): Locator {

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -3,6 +3,9 @@ import type { Page, Route } from '@playwright/test'
 import type { components } from '../../../src/api/schema'
 import { PERM } from '../../../src/lib/permissions'
 import {
+  buildEventResultsRead,
+  buildPoolStandingsRead,
+  buildStandingRowRead,
   buildTournamentDetailRead,
   buildTournamentEventRead,
   buildTournamentEntrantRead,
@@ -16,6 +19,7 @@ type TournamentEventRead = components['schemas']['TournamentEventRead']
 type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
 type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
 type Pool = components['schemas']['Pool']
+type EventResultsRead = components['schemas']['EventResultsRead']
 /** The wire's status enum — the specs drive the store with it, so it is the
  * generated schema's, not a re-typed union of four strings. */
 export type TournamentStatus = TournamentDetailRead['status']
@@ -250,6 +254,44 @@ const PLAY_POOLS: Pool[] = [
  * across two pools snakes to 3 + 2 — see `EVENT.POOLS`. */
 const PLAY_FIELD = 5
 
+/** The played-out result for `EVENT.JOURNEY` (`standings: true`): its one pool
+ * (`p-journey-a`) decided, `player.1` over `player.2`, so it is complete with a champion.
+ * The row entry ids are the JOURNEY event's own (`entry-1`, `entry-2`), so the FE's join to
+ * a username lands — a table of raw ids would render, and prove nothing. Built through the
+ * generated-schema-typed factory, so a change to the results contract reds this file. */
+const JOURNEY_RESULTS: EventResultsRead = buildEventResultsRead({
+  complete: true,
+  champion: 'entry-1',
+  pools: [
+    buildPoolStandingsRead({
+      pool_id: 'p-journey-a',
+      complete: true,
+      rows: [
+        buildStandingRowRead({
+          entry_id: 'entry-1',
+          rank: 1,
+          played: 1,
+          wins: 1,
+          losses: 0,
+          games_won: 2,
+          games_lost: 0,
+          game_difference: 2,
+        }),
+        buildStandingRowRead({
+          entry_id: 'entry-2',
+          rank: 2,
+          played: 1,
+          wins: 0,
+          losses: 1,
+          games_won: 0,
+          games_lost: 2,
+          game_difference: -2,
+        }),
+      ],
+    }),
+  ],
+})
+
 /** The round-robin tournament: two events, both cuttable, nothing cut yet. `drawn`
  * decides which of them arrive with a draw already standing.
  *
@@ -454,6 +496,12 @@ export interface TournamentsStoreOptions {
    * pools, so a seeded draw is one this stub could have dealt — never a hand-written
    * list of fixtures no cut would ever produce. */
   drawn?: string[]
+  /** Attach a **played-out** result to `EVENT.JOURNEY` (ADR-0788): its one pool decided,
+   * with a champion — the standings the tournament detail renders once matches complete.
+   * Opt-in, and only meaningful with `drawable`, because standings ride on a round-robin
+   * event's draw. Its rows name the drawable JOURNEY's own two entrants (`entry-1`,
+   * `entry-2`), so the FE's name join lands. */
+  standings?: boolean
 }
 
 /** The options for a tournament that can actually be **started**: every event drawable,
@@ -752,6 +800,12 @@ export class TournamentsStore {
       const refusal = cutRefusal(event)
       if (refusal) throw new Error(`cannot seed a draw for ${name}: ${refusal}`)
       this.mutateEvent(event.id, (e) => ({ ...e, fixtures: planDraw(e) }))
+    }
+    // The played-out result (ADR-0788), last: standings are derived from a decided draw, so
+    // this rides on the seeded JOURNEY draw above rather than inventing one.
+    if (options.standings ?? false) {
+      const event = this.eventNamed(EVENT.JOURNEY)
+      this.mutateEvent(event.id, (e) => ({ ...e, results: JOURNEY_RESULTS }))
     }
   }
 

--- a/web-client/e2e/tournaments/tournament-standings.spec.ts
+++ b/web-client/e2e/tournaments/tournament-standings.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * The **standings** (ADR-0788), through the real browser: a played-out round-robin pool's
+ * results table, rendered on the tournament detail below its fixtures, and the champion of
+ * a decided event.
+ *
+ * What only a browser proves here, and why the vitest suite could not:
+ *
+ *   1. **The results render as a table, joined to names, in the SERVER's order.** The
+ *      standings arrive as rows of entry *ids* and numbers; the FE joins each id to a
+ *      username off the event's entrants, and renders the rows in the exact order the
+ *      server sent them — the order *is* the result (wins → head-to-head → game difference
+ *      → games won), and re-sorting client-side would silently disagree with a tiebreak the
+ *      client cannot see. A table of raw uuids, or one re-sorted here, would pass a "renders
+ *      standings" check and be a lie; this asserts the names, in order.
+ *
+ *   2. **The champion is shown once the event is decided.** A complete single-pool
+ *      round-robin has a champion; the callout names them (joined to a username, not an id).
+ *
+ *   3. **This whole surface runs with MSW OFF.** vitest exercises the component against the
+ *      MSW factory; this exercises it against the real bundle and the inline `page.route`
+ *      stub, which is the only place a schema/BFF mismatch on the new `results` field would
+ *      surface (the stub returns it, the client parses it, the table draws).
+ */
+import { expect, test } from '@playwright/test'
+
+import { TournamentDetailPage } from '../page-objects/tournaments/tournament-detail.page'
+import { EVENT } from '../page-objects/tournaments/tournaments-store'
+
+/** The drawable seed's JOURNEY event, with its one pool played out (`standings: true`):
+ * `player.1` (1–0, +2) over `player.2` (0–1, −2), so it is complete with `player.1` its
+ * champion. The draw must be cut for the result to sit on a real draw, so JOURNEY is drawn
+ * too. */
+const STANDINGS_SEED = {
+  drawable: true,
+  drawn: [EVENT.JOURNEY],
+  standings: true,
+} as const
+
+test.describe('Tournaments · pool standings', () => {
+  test('renders a played-out pool’s standings table, named and in the server’s order, with the champion', async ({
+    page,
+  }) => {
+    const { pom, store } = await TournamentDetailPage.navigateTo(page, STANDINGS_SEED)
+    const event = EVENT.JOURNEY
+
+    // The results block is on the card…
+    await expect(pom.standingsPanel(event)).toBeVisible()
+    await expect(pom.standingsTable(event, 'Pool A')).toBeVisible()
+
+    // …with the entrants joined to their NAMES, in the finishing order the server sent —
+    // `player.1` (the winner) first, `player.2` second. Not re-sorted, not raw ids.
+    await expect(pom.standingsRowNames(event, 'Pool A')).toHaveText([
+      'player.1',
+      'player.2',
+    ])
+
+    // The four columns the chore asks for, found by the FULL word a screen reader hears —
+    // the terse `W`/`L`/`Diff`/`GW` glyph on screen is aria-hidden, so a header that shipped
+    // only the glyph would fail these.
+    const table = pom.standingsTable(event, 'Pool A')
+    for (const name of ['Wins', 'Losses', 'Game difference', 'Games won']) {
+      await expect(table.getByRole('columnheader', { name })).toBeVisible()
+    }
+
+    // The champion, named — `player.1`, not their entry id. Shown because the pool is
+    // complete and single (a decided pure round-robin has one).
+    await expect(pom.standingsChampion(event)).toBeVisible()
+    await expect(pom.standingsChampion(event)).toContainText('player.1')
+
+    // Every request landed on a route this stub has, and nothing raised an error surface —
+    // the results are just BFF data on the detail read, so drawing them fires no toast.
+    expect(store.unhandled).toEqual([])
+    await expect(pom.toasts).toHaveCount(0)
+  })
+
+  test('a viewer sees the standings too — results are public', async ({ page }) => {
+    // A player wants to know how their pool finished. Standings are read-only for everyone,
+    // so a non-owner sees the same table (and never a control — the table carries none).
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      ...STANDINGS_SEED,
+      canEdit: false,
+    })
+    const event = EVENT.JOURNEY
+
+    await expect(pom.standingsRowNames(event, 'Pool A')).toHaveText([
+      'player.1',
+      'player.2',
+    ])
+    await expect(pom.standingsChampion(event)).toContainText('player.1')
+  })
+
+  test('an event with no results stands nothing', async ({ page }) => {
+    // The drawable seed WITHOUT `standings`: JOURNEY has a draw but no result yet, so there
+    // is nothing to stand — the panel is absent, a designed empty state, not an empty table.
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      drawable: true,
+      drawn: [EVENT.JOURNEY],
+    })
+
+    await expect(pom.drawPanel(EVENT.JOURNEY)).toBeVisible()
+    await expect(pom.standingsPanel(EVENT.JOURNEY)).toHaveCount(0)
+  })
+})

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1634,6 +1634,35 @@ export interface components {
          * @enum {string}
          */
         EventFormat: "singles" | "doubles" | "teams";
+        /**
+         * EventResultsRead
+         * @description A round-robin event's results (ADR-0788): a standings table per pool, whether the
+         *     whole event is decided, and its champion when there is one.
+         *
+         *     It rides on the tournament-detail payload (one endpoint per page) and is **derived
+         *     live** from the fixtures' currently-completed matches — never a snapshot — so a
+         *     corrected or voided match re-orders the standings the instant it leaves
+         *     ``completed``.
+         *
+         *     ``champion`` is the leader of a **complete, single-pool** event — a pure
+         *     round-robin's winner. A multi-pool round-robin has no single champion without a
+         *     knockout stage to join its pool winners (``rr_then_ko``, a later slice), so it is
+         *     ``null`` there even when ``complete``; and ``null`` while any fixture is still to be
+         *     played.
+         *
+         *     ``results`` on the event is ``null`` for an event that has **no draw** (nothing to
+         *     stand) or one whose draw type has no results strategy yet (only round-robin does
+         *     today) — an honest "no results here", not an empty table that would read as a played
+         *     event with nobody in it.
+         */
+        EventResultsRead: {
+            /** Pools */
+            pools: components["schemas"]["PoolStandingsRead"][];
+            /** Complete */
+            complete: boolean;
+            /** Champion */
+            champion: string | null;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -2731,6 +2760,23 @@ export interface components {
             table_ids: string[];
         };
         /**
+         * PoolStandingsRead
+         * @description One pool's standings: its rows in finishing order, and whether every one of its
+         *     fixtures has been decided.
+         *
+         *     ``pool_id`` names a ``Pool`` in this same event's ``pools`` — the string ref a
+         *     fixture also carries — so a client titles the table from the pool it already
+         *     holds.
+         */
+        PoolStandingsRead: {
+            /** Pool Id */
+            pool_id: string;
+            /** Rows */
+            rows: components["schemas"]["StandingRowRead"][];
+            /** Complete */
+            complete: boolean;
+        };
+        /**
          * Predicate
          * @description An eligibility rule. ``field`` names the one fact we actually hold about a
          *     player — their rating on the tournament's league (ADR-0783) — so ``value`` is a
@@ -3085,6 +3131,45 @@ export interface components {
             end: string;
         };
         /**
+         * StandingRowRead
+         * @description One entry's line in a pool's standings (ADR-0788), at its settled rank.
+         *
+         *     The entry is carried as an **id only**, exactly as a fixture carries its sides: the
+         *     username behind ``entry_id`` is on the event's ``entrants`` list already, keyed by
+         *     that same id, so a client joins the two rather than reading a copy that could drift.
+         *
+         *     ``rank`` is 1-based and distinct per row — the pool's order is total (wins → two-way
+         *     head-to-head → game difference → games won → id), so position 1 is the leader.
+         *     ``game_difference`` (``games_won - games_lost``) rides along because it is the third
+         *     tiebreaker and a client shows it in the table; it is a pure function of the two game
+         *     counts beside it, computed once on the server so the two cannot disagree.
+         */
+        StandingRowRead: {
+            /**
+             * Entry Id
+             * Format: uuid
+             */
+            entry_id: string;
+            /** Rank */
+            rank: number;
+            /** Played */
+            played: number;
+            /** Wins */
+            wins: number;
+            /** Losses */
+            losses: number;
+            /** Games Won */
+            games_won: number;
+            /** Games Lost */
+            games_lost: number;
+            /**
+             * Game Difference
+             * @description ``games_won - games_lost`` — the third tiebreaker, on the wire for the table
+             *     to show but derived here so it cannot disagree with the two counts beside it.
+             */
+            readonly game_difference: number;
+        };
+        /**
          * Status
          * @enum {string}
          */
@@ -3311,6 +3396,7 @@ export interface components {
             entry_state: components["schemas"]["EventEntryOpen"] | components["schemas"]["EventEntryFull"] | components["schemas"]["EventEntryRatingIneligible"];
             /** Fixtures */
             fixtures: components["schemas"]["TournamentFixtureRead"][];
+            results: components["schemas"]["EventResultsRead"] | null;
             /**
              * Entered
              * @description The registration count. Derived — there is no stored counter (ADR-0016).
@@ -3364,8 +3450,9 @@ export interface components {
          * @description One planned pairing of an event's draw (ADR-0786): a round and a position —
          *     plus a pool, when the draw is pooled — whose sides may still be unknown.
          *
-         *     A fixture is **not** a match. It materializes into one later (#788), and until it
-         *     does ``match_id`` is ``null``.
+         *     A fixture is **not** a match. It materializes into one at go-live (#788): once the
+         *     tournament is ``live``, every ready fixture becomes a real ``in_progress`` match and
+         *     gains a ``match_id``. Until then ``match_id`` (and ``match_status``) is ``null``.
          *
          *     **Every ``null`` on this model is a fact, not a missing field**, and a client that
          *     dropped them would lose the draw's whole point:
@@ -3376,7 +3463,13 @@ export interface components {
          *       (ADR-0786), so there is no ``is_bye`` flag here to tell the two apart.
          *     * ``winner_entry_id`` — ``null`` while the fixture is undecided.
          *     * ``match_id`` — ``null`` until the fixture becomes a real match, which only happens
-         *       once the tournament is ``live``.
+         *       once the tournament is ``live``. When set, it is the id of the match the slot
+         *       links to (``GET /v1/matches/{match_id}``), so a client can deep-link a slot.
+         *     * ``match_status`` — the live status of that match (``in_progress`` at go-live,
+         *       moving to ``completed`` / ``voided`` as it is played), or ``null`` when the
+         *       fixture has not materialized. It rides on the fixture so a bracket shows a slot's
+         *       state without a per-slot round-trip; it is the match's *current* status, read
+         *       live, not a copy frozen at go-live.
          *     * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
          *       un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
          *       set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
@@ -3408,6 +3501,7 @@ export interface components {
             winner_entry_id: string | null;
             /** Match Id */
             match_id: string | null;
+            match_status: components["schemas"]["MatchStatus"] | null;
         };
         /** TournamentRead */
         TournamentRead: {

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -998,6 +998,7 @@ describe('useCutDraw', () => {
         entryBId: 'entry-2',
         winnerEntryId: null,
         matchId: null,
+        matchStatus: null,
       },
     ])
   })

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -198,6 +198,7 @@ describe('apiToEvent — the draw', () => {
         entryBId: 'entry-2',
         winnerEntryId: null,
         matchId: null,
+        matchStatus: null,
       },
       {
         id: 'fx-2',
@@ -208,13 +209,15 @@ describe('apiToEvent — the draw', () => {
         entryBId: 'entry-4',
         winnerEntryId: null,
         matchId: null,
+        matchStatus: null,
       },
     ])
   })
 
   // Every null on a fixture is a FACT (ADR-0786), and a mapper that coalesced any of
   // them would erase the thing the draw exists to say: a null side is TBD, a null
-  // winner is undecided, a null match is un-materialized, a null pool is un-pooled.
+  // winner is undecided, a null match (and null status) is un-materialized, a null pool
+  // is un-pooled.
   it('carries every null through — TBD sides, undecided, un-materialized, un-pooled', () => {
     const event = apiToEvent(
       buildTournamentEventRead({
@@ -240,6 +243,7 @@ describe('apiToEvent — the draw', () => {
       entryBId: null,
       winnerEntryId: null,
       matchId: null,
+      matchStatus: null,
     })
   })
 
@@ -577,6 +581,8 @@ const event: TournamentEvent = {
   // No draw cut (ADR-0786). The write bodies below must not carry one either — a draw
   // is written by the two draw verbs and by nothing else.
   fixtures: [],
+  // No results (ADR-0788): no draw, nothing to stand.
+  results: null,
 }
 
 describe('eventToCreateBody', () => {
@@ -645,6 +651,9 @@ describe('eventToCreateBody', () => {
       // The DRAW is absent from the create body too, and for a third reason: a brand-new
       // event has no field to cut one from. Cutting is its own verb (ADR-0786).
       fixtures: [],
+      // Results are absent from the create body for the same reason the draw is — nothing
+      // to stand. Supplied as `null` so the round-trip reproduces the read shape.
+      results: null,
       created_at: '2026-06-01T00:00:00Z',
       updated_at: '2026-06-01T00:00:00Z',
     })
@@ -713,6 +722,7 @@ describe('eventToUpdateBody', () => {
           entryBId: 'entry-2',
           winnerEntryId: null,
           matchId: null,
+          matchStatus: null,
         },
       ],
     })

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -19,6 +19,7 @@ import { notifyError } from '@/lib/notify-error'
 import type { components } from '@/api/schema'
 import { entryRefusalNotice } from './entry-refusal'
 import { parseFixtures } from './fixtures'
+import { parseResults } from './results'
 import type { LifecycleEdge } from './lifecycle'
 import type {
   Entrant,
@@ -142,6 +143,13 @@ export function apiToEvent(e: TournamentEventRead): TournamentEvent {
     // primed with the bad payload, and the boundary renders. An event whose draw has
     // not been cut parses to `[]` — the designed empty state, not an error.
     fixtures: parseFixtures(e.fixtures),
+    // PARSED, not cast — the same boundary the draw crosses (`./results`,
+    // `.claude/rules/parse-at-boundaries.md`). Standings are the one other structure on
+    // this payload a renderer walks by shape (a table of numbers, joined to names), so a
+    // malformed row must fail HERE, inside the fetch, rather than surface as a `NaN` in a
+    // cell. `null` is the designed "no results" state (an uncut or non-round-robin event),
+    // and parses straight through to `null`.
+    results: parseResults(e.results),
   }
 }
 

--- a/web-client/src/components/tournaments/data/draw.ts
+++ b/web-client/src/components/tournaments/data/draw.ts
@@ -21,6 +21,7 @@
 // rather than asserted through a DOM.
 
 import { ApiError } from '@/api/client'
+import type { MatchStatus } from '@/api/matches'
 
 import { fallbackNotice, type Notice } from './notice'
 import { DRAW_TYPE_OPTIONS, labelFor } from './options'
@@ -56,12 +57,31 @@ export type FixtureSide =
    * (`WITHDRAWN_LABEL`). */
   | { kind: 'withdrawn' }
 
+/** The **materialized match** behind a fixture — the real, playable match a fixture
+ * became at go-live (#788). Present exactly when the fixture has one; `null` while the
+ * slot is still a planned pairing (see `FixtureLine.match`).
+ *
+ * A single object rather than a loose `matchId`/`matchStatus` pair, because the two are
+ * one fact: on the wire they move in lockstep (both `null`, then both set), so pairing
+ * them here makes "an id with no status" — the half-materialized slot the renderer would
+ * have to guess at — unrepresentable. */
+export interface FixtureMatch {
+  /** The match this slot links to (`GET /v1/matches/{id}`). */
+  id: string
+  /** The match's live status, read fresh off the fixture each load. */
+  status: MatchStatus
+}
+
 /** One fixture, ready to render as a named "A vs B" line. */
 export interface FixtureLine {
   id: string
   position: number
   a: FixtureSide
   b: FixtureSide
+  /** The real match this slot became at go-live, or `null` while it is still a *planned*
+   * pairing. When set, the line links to that match and shows its status; when `null` the
+   * line is inert (#788). */
+  match: FixtureMatch | null
 }
 
 /** The fixtures of one round, in position order. An odd round-robin pool has *fewer*
@@ -130,6 +150,16 @@ function sideOf(entryId: string | null, byId: Map<string, Entrant>): FixtureSide
   return entrant ? { kind: 'entrant', name: entrant.username } : { kind: 'withdrawn' }
 }
 
+/** The materialized match of a fixture, or `null` while it is un-materialized.
+ *
+ * `matchId` and `matchStatus` move in lockstep on the wire, so the `&&` is a belt: a
+ * fixture carrying an id but no status (a shape the server never sends) is treated as
+ * un-materialized rather than rendered as a link to a match whose state we cannot show. */
+function matchOf(fixture: Fixture): FixtureMatch | null {
+  if (fixture.matchId === null || fixture.matchStatus === null) return null
+  return { id: fixture.matchId, status: fixture.matchStatus }
+}
+
 /** Group a flat fixture list into rounds, ascending, each in position order.
  *
  * It **sorts**, rather than trusting the payload's order (the server sends pool → round
@@ -155,6 +185,7 @@ function roundsOf(fixtures: Fixture[], byId: Map<string, Entrant>): DrawRound[] 
           position: f.position,
           a: sideOf(f.entryAId, byId),
           b: sideOf(f.entryBId, byId),
+          match: matchOf(f),
         })),
     }))
 }

--- a/web-client/src/components/tournaments/data/fixtures.test.ts
+++ b/web-client/src/components/tournaments/data/fixtures.test.ts
@@ -32,6 +32,7 @@ describe('parseFixtures — the happy path', () => {
         entryBId: 'entry-6',
         winnerEntryId: null,
         matchId: null,
+        matchStatus: null,
       },
     ])
   })
@@ -63,13 +64,18 @@ describe('parseFixtures — the happy path', () => {
     expect(fixture.entryBId).toBeNull()
   })
 
-  it('carries a decided, materialized fixture through — winner and match id both', () => {
+  it('carries a decided, materialized fixture through — winner, match id, and live status', () => {
     const [fixture] = parseFixtures([
-      wire({ winner_entry_id: 'entry-2', match_id: 'm-7' }),
+      wire({
+        winner_entry_id: 'entry-2',
+        match_id: 'm-7',
+        match_status: 'completed',
+      }),
     ])
 
     expect(fixture.winnerEntryId).toBe('entry-2')
     expect(fixture.matchId).toBe('m-7')
+    expect(fixture.matchStatus).toBe('completed')
   })
 })
 
@@ -93,6 +99,10 @@ describe('parseFixtures — the boundary', () => {
     // would invent a fixture waiting for a player who is never coming.
     { what: 'an absent side', payload: [{ ...(wire() as object), entry_a_id: undefined }] },
     { what: 'an absent match_id', payload: [{ ...(wire() as object), match_id: undefined }] },
+    // `match_status` is a fact that moves with `match_id`; absent is not `null`, and a
+    // value outside the closed `MatchStatus` set is a status this client cannot render.
+    { what: 'an absent match_status', payload: [{ ...(wire() as object), match_status: undefined }] },
+    { what: 'a match_status outside the enum', payload: [wire({ match_status: 'archived' })] },
     // A draw is a LIST. `null` is not an empty draw: an event with no draw sends `[]`,
     // and a server that sent null would be sending something this client cannot read.
     { what: 'null instead of a list', payload: null },

--- a/web-client/src/components/tournaments/data/fixtures.ts
+++ b/web-client/src/components/tournaments/data/fixtures.ts
@@ -24,7 +24,24 @@
 
 import { z } from 'zod'
 
+import type { MatchStatus } from '@/api/matches'
+
 import type { Fixture } from './types'
+
+/** The four match statuses, as the wire's `MatchStatus` enum spells them. `satisfies
+ * readonly MatchStatus[]` guards against a typo — every literal here must be a real
+ * `MatchStatus` — so this closed set and the generated `schema.d.ts` cannot drift into a
+ * status the app accepts but the server never sends (or vice versa). Exported because a
+ * materialized fixture is not the only place a status crosses the boundary (Slice 2's
+ * standings will want it too). */
+const MATCH_STATUSES = [
+  'pending',
+  'in_progress',
+  'completed',
+  'voided',
+] as const satisfies readonly MatchStatus[]
+
+export const matchStatusSchema = z.enum(MATCH_STATUSES)
 
 /** The wire shape (`TournamentFixtureRead`), as it really arrives: snake_case, with
  * five nullable columns that all mean something. Kept separate from the transform
@@ -44,6 +61,9 @@ const fixtureWireSchema = z.object({
   winner_entry_id: z.string().nullable(),
   /** `null` until the fixture materializes into a real match (#788). */
   match_id: z.string().nullable(),
+  /** The materialized match's live status, or `null` when the fixture has not
+   * materialized. Moves in lockstep with `match_id`. */
+  match_status: matchStatusSchema.nullable(),
 })
 
 /** The parser: one wire fixture → one domain `Fixture`.
@@ -62,6 +82,7 @@ export const fixtureSchema = fixtureWireSchema.transform(
     entryBId: f.entry_b_id,
     winnerEntryId: f.winner_entry_id,
     matchId: f.match_id,
+    matchStatus: f.match_status,
   }),
 )
 

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -322,5 +322,8 @@ export function emptyEvent(t: Tournament): TournamentEvent {
     // No draw (ADR-0786), and there could not be one: a draw is cut from a field, and
     // an event that does not exist on the server yet has no entrants to cut it from.
     fixtures: [],
+    // No results (ADR-0788): with no draw there is nothing to stand. The server sends the
+    // real thing once the event exists and its draw is cut.
+    results: null,
   }
 }

--- a/web-client/src/components/tournaments/data/results.test.ts
+++ b/web-client/src/components/tournaments/data/results.test.ts
@@ -1,0 +1,114 @@
+import type { components } from '@/api/schema'
+
+import { parseResults } from './results'
+
+type EventResultsRead = components['schemas']['EventResultsRead']
+type StandingRowRead = components['schemas']['StandingRowRead']
+
+/** A wire standings row (`StandingRowRead`), snake_case — the shape the server actually
+ * sends, kept next to the parser it feeds. */
+function wireRow(overrides: Partial<StandingRowRead> = {}): StandingRowRead {
+  return {
+    entry_id: 'entry-1',
+    rank: 1,
+    played: 2,
+    wins: 2,
+    losses: 0,
+    games_won: 4,
+    games_lost: 1,
+    game_difference: 3,
+    ...overrides,
+  }
+}
+
+/** A complete single-pool results block off the wire. */
+function wireResults(overrides: Partial<EventResultsRead> = {}): EventResultsRead {
+  return {
+    pools: [{ pool_id: 'p-a', complete: true, rows: [wireRow()] }],
+    complete: true,
+    champion: 'entry-1',
+    ...overrides,
+  }
+}
+
+describe('parseResults', () => {
+  it('maps a wire results block to the camelCase domain shape', () => {
+    expect(parseResults(wireResults())).toEqual({
+      pools: [
+        {
+          poolId: 'p-a',
+          complete: true,
+          rows: [
+            {
+              entryId: 'entry-1',
+              rank: 1,
+              played: 2,
+              wins: 2,
+              losses: 0,
+              gamesWon: 4,
+              gamesLost: 1,
+              gameDifference: 3,
+            },
+          ],
+        },
+      ],
+      complete: true,
+      champion: 'entry-1',
+    })
+  })
+
+  it('carries the server’s row order through — it does not sort', () => {
+    // The order IS the result (ADR-0788); the parse must not reorder. Feed the rows out of
+    // rank order and expect them back exactly as sent.
+    const parsed = parseResults(
+      wireResults({
+        pools: [
+          {
+            pool_id: 'p-a',
+            complete: true,
+            rows: [
+              wireRow({ entry_id: 'entry-5', rank: 3 }),
+              wireRow({ entry_id: 'entry-1', rank: 1 }),
+            ],
+          },
+        ],
+      }),
+    )
+
+    expect(parsed?.pools[0].rows.map((r) => r.entryId)).toEqual([
+      'entry-5',
+      'entry-1',
+    ])
+  })
+
+  it('accepts an explicit null — the designed "no results" state', () => {
+    expect(parseResults(null)).toBeNull()
+  })
+
+  it('keeps a null champion (a live or multi-pool event) null', () => {
+    expect(parseResults(wireResults({ champion: null }))?.champion).toBeNull()
+  })
+
+  it('rejects the ABSENT case — results must be present (null), never missing', () => {
+    // `.nullable()`, not `.optional()`: a payload that omitted the field is one we cannot
+    // tell apart from "no results", so it fails loudly at the boundary.
+    expect(() => parseResults(undefined)).toThrow()
+  })
+
+  it('rejects a malformed row rather than letting a NaN leak inward', () => {
+    expect(() =>
+      parseResults(
+        wireResults({
+          pools: [
+            {
+              pool_id: 'p-a',
+              complete: true,
+              // `wins` as a string is exactly the shape a cast would wave through.
+              rows: [{ ...wireRow(), wins: 'two' } as unknown as StandingRowRead],
+            },
+          ],
+        }),
+      ),
+    ).toThrow()
+  })
+})

--- a/web-client/src/components/tournaments/data/results.ts
+++ b/web-client/src/components/tournaments/data/results.ts
@@ -1,0 +1,116 @@
+// The **results** boundary (ADR-0788): where an event's standings stop being bytes off
+// the wire and become a typed domain value.
+//
+// An event's results are its pool standings, whether the whole event is decided, and its
+// champion — all derived *live* on the server from the fixtures' currently-completed
+// matches (never a snapshot). This is the runtime parse that guards them, the twin of
+// `./fixtures` for the draw.
+//
+// Why a Zod parse and not just the generated types: `schema.d.ts` is a *compile-time*
+// claim about what the server sends (root `CLAUDE.md`), and `api.GET` casts the decoded
+// JSON to it without looking. The network is untrusted
+// (`.claude/rules/parse-at-boundaries.md`), so the results are **parsed** here, at the
+// fetch boundary, and only the parsed value travels inward — a standings row missing its
+// `wins`, or carrying a `rank` that is a string, fails HERE, in the queryFn, before it
+// can prime the cache and surface three components later as a `NaN` in a table cell.
+//
+// **`results` is `.nullable()`, and the null is a FACT** (`.nullable()` demands the key be
+// present, unlike `.optional()`): `null` means the event has no results to stand — it has
+// no draw, or its draw type has no results strategy yet (only round-robin does today). An
+// event whose payload simply *omitted* the field would be one we could not tell apart from
+// one that means "no results", so the schema refuses the absent case and accepts only an
+// explicit `null` or a real results object.
+
+import { z } from 'zod'
+
+import type { EventResults, PoolStandings, StandingRow } from './types'
+
+/** The wire shape (`StandingRowRead`), snake_case, every field required — a standings row
+ * has no nullable columns: an entry that has played nothing still has a row of zeroes, not
+ * a row of nulls. `game_difference` arrives already reduced (`games_won - games_lost`),
+ * computed once on the server so it cannot disagree with the two counts beside it; the
+ * parse carries it through rather than re-deriving a second copy. */
+const standingRowWireSchema = z.object({
+  entry_id: z.string(),
+  rank: z.number().int(),
+  played: z.number().int(),
+  wins: z.number().int(),
+  losses: z.number().int(),
+  games_won: z.number().int(),
+  games_lost: z.number().int(),
+  game_difference: z.number().int(),
+})
+
+/** One wire row → one domain `StandingRow`. Annotated `: StandingRow` on purpose — that
+ * is what keeps the domain interface in `./types` and this schema one thing: drop a field
+ * from either and this line is a compile error, so the runtime parser and the type the app
+ * holds cannot drift apart. */
+const standingRowSchema = standingRowWireSchema.transform(
+  (r): StandingRow => ({
+    entryId: r.entry_id,
+    rank: r.rank,
+    played: r.played,
+    wins: r.wins,
+    losses: r.losses,
+    gamesWon: r.games_won,
+    gamesLost: r.games_lost,
+    gameDifference: r.game_difference,
+  }),
+)
+
+/** The wire shape (`PoolStandingsRead`): a pool's rows **in the server's finishing order**
+ * plus whether every one of its fixtures is decided. The order is untrusted like any other
+ * data, but it is NOT re-sorted here (ADR-0788 — the order *is* the result); it is parsed
+ * as given and carried inward unchanged. */
+const poolStandingsWireSchema = z.object({
+  pool_id: z.string(),
+  rows: z.array(standingRowSchema),
+  complete: z.boolean(),
+})
+
+const poolStandingsSchema = poolStandingsWireSchema.transform(
+  (p): PoolStandings => ({
+    poolId: p.pool_id,
+    rows: p.rows,
+    complete: p.complete,
+  }),
+)
+
+/** The wire shape (`EventResultsRead`): the pools, whether the whole event is decided, and
+ * its champion (an **entry id**, or `null`). */
+const eventResultsWireSchema = z.object({
+  pools: z.array(poolStandingsSchema),
+  complete: z.boolean(),
+  /** `null` while any fixture is unplayed, and for a multi-pool event, which has no single
+   * champion without a knockout stage (a later slice). */
+  champion: z.string().nullable(),
+})
+
+export const eventResultsSchema = eventResultsWireSchema.transform(
+  (r): EventResults => ({
+    pools: r.pools,
+    complete: r.complete,
+    champion: r.champion,
+  }),
+)
+
+/** An event's `results`, or `null`. **`.nullable()`, never `.optional()`** — the key must
+ * be present, and a `null` is the designed "no results here" state, not a missing field
+ * (an event with no draw, or a draw type with no results strategy yet). */
+export const resultsSchema = eventResultsSchema.nullable()
+
+/**
+ * Parse an event's `results` off the wire, or throw.
+ *
+ * Takes `unknown`, deliberately: the value it is handed is typed
+ * `EventResultsRead | null` by the generated schema, and that type is exactly the claim
+ * this function exists to check at runtime. Accepting the typed shape would let the
+ * compiler talk us out of the runtime guarantee.
+ *
+ * Throws a `ZodError`. Called from the tournament queries' `queryFn` (via `apiToEvent`,
+ * `./api.ts`), so a malformed results block fails the *query* — the error boundary gets
+ * it, the cache is never primed with it, and no component ever renders a half-row.
+ */
+export function parseResults(input: unknown): EventResults | null {
+  return resultsSchema.parse(input)
+}

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -7,9 +7,12 @@ import type {
   Address,
   Entrant,
   EventEntryState,
+  EventResults,
   Fixture,
   Pool,
+  PoolStandings,
   Predicate,
+  StandingRow,
   Tournament,
   TournamentEvent,
   TournamentTable,
@@ -133,6 +136,11 @@ export function buildEvent(
     // derivation: the same field makes a different draw across two pools than across
     // three, so a fixture that quietly cut one would be inventing a decision.
     fixtures: [],
+    // NO RESULTS (ADR-0788) — `null` is the designed state of an event with no draw (and
+    // of any non-round-robin event): there is nothing to stand. Standings only appear once
+    // a draw is cut, so a bare event carries `null` and the tests that want a table pass a
+    // `buildEventResults` override (or use `buildStandingsEvent`).
+    results: null,
     ...overrides,
   } satisfies Omit<TournamentEvent, 'entered'>
   // An **uncapped** event (`maxPlayers: null`, ADR-0935) is never `event_full` —
@@ -236,6 +244,7 @@ export function buildFixture(overrides: Partial<Fixture> = {}): Fixture {
     entryBId: 'entry-2',
     winnerEntryId: null,
     matchId: null,
+    matchStatus: null,
     ...overrides,
   }
 }
@@ -312,6 +321,102 @@ export function buildDrawnEvent(
         entryBId: 'entry-3',
       }),
     ],
+    ...overrides,
+  })
+}
+
+/** One line of a pool's standings (ADR-0788): entry `entry-1`, sitting 1st with a clean
+ * 2–0 record and a +3 game difference. `gameDifference` is `gamesWon - gamesLost`; the
+ * factory keeps them consistent by default, but a test that wants an inconsistent wire
+ * (to prove the client SHOWS the server's figure rather than recomputing it) overrides it
+ * on its own. */
+export function buildStandingRow(overrides: Partial<StandingRow> = {}): StandingRow {
+  return {
+    entryId: 'entry-1',
+    rank: 1,
+    played: 2,
+    wins: 2,
+    losses: 0,
+    gamesWon: 4,
+    gamesLost: 1,
+    gameDifference: 3,
+    ...overrides,
+  }
+}
+
+/** One pool's standings — a **complete** three-player pool in finishing order:
+ * `entry-1` (2–0) over `entry-4` (1–1) over `entry-5` (0–2). In the server's order, which
+ * the view renders untouched (ADR-0788 — the order *is* the result), so a factory that
+ * returned them sorted would let a re-sorting bug pass. */
+export function buildPoolStandings(
+  overrides: Partial<PoolStandings> = {},
+): PoolStandings {
+  return {
+    poolId: 'p-a',
+    complete: true,
+    rows: [
+      buildStandingRow({
+        entryId: 'entry-1',
+        rank: 1,
+        wins: 2,
+        losses: 0,
+        gamesWon: 4,
+        gamesLost: 1,
+        gameDifference: 3,
+      }),
+      buildStandingRow({
+        entryId: 'entry-4',
+        rank: 2,
+        wins: 1,
+        losses: 1,
+        gamesWon: 3,
+        gamesLost: 3,
+        gameDifference: 0,
+      }),
+      buildStandingRow({
+        entryId: 'entry-5',
+        rank: 3,
+        wins: 0,
+        losses: 2,
+        gamesWon: 1,
+        gamesLost: 4,
+        gameDifference: -3,
+      }),
+    ],
+    ...overrides,
+  }
+}
+
+/** An event's results (ADR-0788): one **complete single pool** with a champion —
+ * `entry-1`, who won it. Single-pool so `champion` is meaningful (a multi-pool event has
+ * no single champion without a knockout stage yet — pass `pools` + `champion: null` for
+ * that case). */
+export function buildEventResults(
+  overrides: Partial<EventResults> = {},
+): EventResults {
+  return {
+    pools: [buildPoolStandings()],
+    complete: true,
+    champion: 'entry-1',
+    ...overrides,
+  }
+}
+
+/** A round-robin event **with results**: the drawn U1200 pool play (`buildDrawnEvent`)
+ * projected forward to a finished single pool whose standings and champion the panel
+ * renders. The entrant ids the results name (`entry-1`, `entry-4`, `entry-5`) are the ones
+ * the drawn event lists, so the name join lands. */
+export function buildStandingsEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  return buildEvent({
+    id: 'ev-u1200',
+    name: 'U1200 Singles',
+    drawType: 'round-robin',
+    maxPlayers: 24,
+    entrants: buildEntrants(5),
+    pools: [buildPool({ id: 'p-a', name: 'Pool A' })],
+    results: buildEventResults(),
     ...overrides,
   })
 }

--- a/web-client/src/components/tournaments/data/standings.test.ts
+++ b/web-client/src/components/tournaments/data/standings.test.ts
@@ -1,0 +1,105 @@
+import { WITHDRAWN_LABEL } from './draw'
+import {
+  buildEntrants,
+  buildEvent,
+  buildEventResults,
+  buildPool,
+  buildPoolStandings,
+  buildStandingRow,
+  buildStandingsEvent,
+} from './seed.factory'
+import { eventStandings } from './standings'
+
+describe('eventStandings', () => {
+  it('returns null for an event with no results', () => {
+    // An uncut or non-round-robin event carries `results: null` — there is nothing to
+    // stand, and the panel renders nothing off this.
+    expect(eventStandings(buildEvent())).toBeNull()
+  })
+
+  it('joins each row’s entry id to a username, and titles each pool from the event', () => {
+    const view = eventStandings(buildStandingsEvent())
+
+    expect(view?.pools).toHaveLength(1)
+    expect(view?.pools[0].name).toBe('Pool A')
+    expect(view?.pools[0].rows.map((r) => r.name)).toEqual([
+      'player.1',
+      'player.4',
+      'player.5',
+    ])
+  })
+
+  it('carries every server number and order through untouched', () => {
+    // The client shows the figures, it does not compute them (ADR-0788). Feed rows out of
+    // finishing order and expect them back in that same order, numbers intact.
+    const view = eventStandings(
+      buildStandingsEvent({
+        results: buildEventResults({
+          pools: [
+            buildPoolStandings({
+              rows: [
+                buildStandingRow({ entryId: 'entry-5', rank: 3, gameDifference: -3 }),
+                buildStandingRow({ entryId: 'entry-1', rank: 1, gameDifference: 3 }),
+              ],
+            }),
+          ],
+        }),
+      }),
+    )
+
+    expect(view?.pools[0].rows.map((r) => r.entryId)).toEqual(['entry-5', 'entry-1'])
+    expect(view?.pools[0].rows.map((r) => r.gameDifference)).toEqual([-3, 3])
+  })
+
+  it('joins the champion to a name', () => {
+    const view = eventStandings(buildStandingsEvent())
+
+    expect(view?.complete).toBe(true)
+    expect(view?.champion).toBe('player.1')
+  })
+
+  it('keeps a null champion null — a live or multi-pool event', () => {
+    const view = eventStandings(
+      buildStandingsEvent({
+        results: buildEventResults({ complete: false, champion: null }),
+      }),
+    )
+
+    expect(view?.champion).toBeNull()
+  })
+
+  it('shows a row naming a no-longer-listed entry as Withdrawn', () => {
+    // A player who withdrew after playing: their completed matches still count toward the
+    // numbers, but they are no longer an entrant, so the join has no username. It is the
+    // withdrawn word, never a blank and never the raw id — shared with the draw.
+    const view = eventStandings(
+      buildStandingsEvent({
+        entrants: buildEntrants(4), // entry-5 is gone
+        results: buildEventResults({
+          pools: [
+            buildPoolStandings({
+              rows: [buildStandingRow({ entryId: 'entry-5', rank: 1 })],
+            }),
+          ],
+        }),
+      }),
+    )
+
+    expect(view?.pools[0].rows[0].name).toBe(WITHDRAWN_LABEL)
+  })
+
+  it('falls back to the pool id if the event does not list the pool', () => {
+    // A pool the standings name but the event does not carry is a payload the server cannot
+    // send; the fallback keeps the table titled rather than blank if it ever did.
+    const view = eventStandings(
+      buildStandingsEvent({
+        pools: [buildPool({ id: 'p-a', name: 'Pool A' })],
+        results: buildEventResults({
+          pools: [buildPoolStandings({ poolId: 'p-ghost' })],
+        }),
+      }),
+    )
+
+    expect(view?.pools[0].name).toBe('p-ghost')
+  })
+})

--- a/web-client/src/components/tournaments/data/standings.ts
+++ b/web-client/src/components/tournaments/data/standings.ts
@@ -1,0 +1,106 @@
+// What an event's **results** look like to a reader (ADR-0788) — the pure derivation
+// behind the Events tab's standings tables, the twin of `./draw` for the results block.
+//
+// The wire gives us `EventResults` (parsed at the boundary by `./results`): pool
+// standings keyed by pool id, rows keyed by entry id, and a champion that is an entry id.
+// A director reads standings as a **named** table per pool, with a **named** champion.
+// Nothing on the wire is shaped that way, and deliberately so — the same two joins the
+// draw makes:
+//
+// - **Names are not on a row.** A row carries an entry *id*; the username behind it is
+//   already on the event (`entrants` is keyed by that id), so the join happens here, once.
+//   Copying the username onto the row would carry a field and its own derivation, and the
+//   two copies would drift the moment a player is renamed.
+// - **Pool names are not on a pool's standings.** They carry a `poolId`, a string ref into
+//   the event's own `pools` — so the table titles itself from the pool the page holds.
+//
+// What it deliberately does **not** do is re-order or recompute anything: the server owns
+// the finishing order and every number (ADR-0788 — "the order *is* the result"), so the
+// rows are mapped **in the order they arrive**, untouched. This module only joins the two
+// ids to names.
+//
+// All of it is a pure function of one event, so it is unit-tested (`./standings.test.ts`)
+// rather than asserted through a DOM.
+
+import { WITHDRAWN_LABEL } from './draw'
+import type { StandingRow, TournamentEvent } from './types'
+
+/** One standings line, ready to render: the server's row, plus the entrant's name joined
+ * from the event. The row's every number is carried through unchanged — see the module
+ * note: the client shows them, it does not compute them. */
+export interface StandingLine extends StandingRow {
+  /** The entrant's username (bare, no `@` — `web-client/CLAUDE.md`), or `WITHDRAWN_LABEL`
+   * when the row names an entry the event no longer lists: a player who withdrew after
+   * playing, whose completed matches still count toward the numbers but who is no longer
+   * an entrant (ADR-0016). Never a blank, and never the raw id. */
+  name: string
+}
+
+/** One pool's standings table, named and joined: the pool's name (from the event's
+ * `pools`), its rows in the server's finishing order, and whether it is decided. */
+export interface PoolStandingsView {
+  poolId: string
+  name: string
+  rows: StandingLine[]
+  complete: boolean
+}
+
+/** An event's results, shaped for the reader: named pool tables, whether the event is
+ * complete, and the champion's *name* (joined) when there is one. */
+export interface StandingsView {
+  pools: PoolStandingsView[]
+  complete: boolean
+  /** The champion's username when the event is a complete single pool, else `null` — the
+   * server's own `champion`, joined to a name. `null` while any fixture is unplayed, and
+   * for a multi-pool event (no single champion without a knockout stage yet). */
+  champion: string | null
+}
+
+/** Join one entry id to a display name. An id the event no longer lists is a withdrawal
+ * (`WITHDRAWN_LABEL`, shared with `./draw`) — never a blank, and never the raw id. */
+function nameOf(entryId: string, byId: Map<string, string>): string {
+  return byId.get(entryId) ?? WITHDRAWN_LABEL
+}
+
+/**
+ * An event's results, shaped for the reader — or `null` when the event has none (an uncut
+ * or non-round-robin event; `results` is `null` on the wire, and this returns `null`
+ * straight through, so the panel renders nothing).
+ *
+ * The rows are mapped **in the order the server sent them**: standings are a total order
+ * the server computed (wins → two-way head-to-head → game difference → games won), and
+ * re-sorting them here — even by the same visible keys — would be the client second-
+ * guessing a result it does not own, and would silently disagree the day a tiebreaker the
+ * client cannot see (head-to-head) decides two equal rows.
+ */
+export function eventStandings(event: TournamentEvent): StandingsView | null {
+  const results = event.results
+  if (results === null) return null
+
+  const nameByEntryId = new Map(event.entrants.map((e) => [e.id, e.username]))
+  const poolNameById = new Map(event.pools.map((p) => [p.id, p.name]))
+
+  const pools = results.pools.map(
+    (pool): PoolStandingsView => ({
+      poolId: pool.poolId,
+      // A pool the standings name but the event does not list would be a payload the
+      // server cannot send; falling back to the id keeps the table titled rather than
+      // blank if it ever did.
+      name: poolNameById.get(pool.poolId) ?? pool.poolId,
+      rows: pool.rows.map(
+        (row): StandingLine => ({
+          ...row,
+          name: nameOf(row.entryId, nameByEntryId),
+        }),
+      ),
+      complete: pool.complete,
+    }),
+  )
+
+  return {
+    pools,
+    complete: results.complete,
+    champion:
+      results.champion === null ? null : nameOf(results.champion, nameByEntryId),
+  }
+}

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -4,6 +4,8 @@
 
 // Type-only, and so fully erased: `./options` imports its domain types from
 // here, but nothing crosses back at runtime.
+import type { MatchStatus } from '@/api/matches'
+
 import type { PredicateOp } from './options'
 
 export type TournamentStatus = 'draft' | 'published' | 'live' | 'archived'
@@ -101,6 +103,10 @@ export interface Pool {
  *   bye; a bye is the *absence of a fixture*, not a fixture with an empty side.
  * - `winnerEntryId` — undecided.
  * - `matchId` — not yet materialized.
+ * - `matchStatus` — the live status of the materialized match, or `null` when there is
+ *   no match yet. It moves in lockstep with `matchId` (both `null` before go-live, both
+ *   set after), and it is the match's *current* status read live, never a copy frozen at
+ *   go-live.
  * - `poolId` — this fixture belongs to no pool: the draw is un-pooled (single-elim), or
  *   this is the KO stage of an rr-then-ko. When set, it names a `Pool` in this same
  *   event's `pools`.
@@ -116,6 +122,73 @@ export interface Fixture {
   entryBId: string | null
   winnerEntryId: string | null
   matchId: string | null
+  /** The materialized match's live status, or `null` until go-live (#788). Moves in
+   * lockstep with `matchId`. */
+  matchStatus: MatchStatus | null
+}
+
+/**
+ * One entry's line in a pool's standings (ADR-0788), at the rank the **server**
+ * settled it at.
+ *
+ * The entry is an **id only** — exactly as a fixture carries its sides — and the
+ * username behind it is joined on at render from the event's `entrants` (the same
+ * argument the draw makes: copying the username here would carry a field and its own
+ * derivation, and the two would drift the moment a player is renamed). A row can name an
+ * entry the event no longer lists — a player who withdrew after playing, whose completed
+ * matches still count toward the numbers — so the join must have a word for that, never a
+ * blank or a raw id.
+ *
+ * Every number is the **server's**, computed once on it and read straight through: the FE
+ * neither re-sorts the rows nor recomputes a figure (ADR-0788 — "the order *is* the
+ * result"). `gameDifference` (= `gamesWon - gamesLost`) rides along already reduced,
+ * because it is the third tiebreaker and a client shows it, and computing it here as well
+ * would be a second copy that could disagree with the two counts beside it.
+ */
+export interface StandingRow {
+  entryId: string
+  /** 1-based and distinct per row — position 1 is the pool leader. */
+  rank: number
+  played: number
+  wins: number
+  losses: number
+  gamesWon: number
+  gamesLost: number
+  gameDifference: number
+}
+
+/** One pool's standings: its rows in the server's finishing order (**never re-sorted on
+ * the client**), and whether every one of the pool's fixtures is decided. `poolId` names
+ * a `Pool` in this same event's `pools`, so the table titles itself from the pool the
+ * page already holds. */
+export interface PoolStandings {
+  poolId: string
+  rows: StandingRow[]
+  complete: boolean
+}
+
+/**
+ * A round-robin event's **results** (ADR-0788): a standings table per pool, whether the
+ * whole event is decided, and its champion when there is one.
+ *
+ * Derived **live** on the server from the fixtures' currently-`completed` matches — never
+ * a snapshot — so a corrected or voided match re-orders the standings the instant it
+ * leaves `completed`. On the FE it is just BFF data, so TanStack Query invalidation drives
+ * the live update; nothing here polls or recomputes.
+ *
+ * On the event it is `null` for an event with **no draw** (nothing to stand) or one whose
+ * draw type has no results strategy yet (only round-robin does today) — an honest "no
+ * results", never an empty table that would read as a played event with nobody in it.
+ */
+export interface EventResults {
+  pools: PoolStandings[]
+  /** True when every fixture of every pool is decided. */
+  complete: boolean
+  /** The winning **entry id** of a complete, single-pool event — a pure round-robin's
+   * winner. `null` while any fixture is unplayed, and `null` for a multi-pool event,
+   * which has no single champion without a knockout stage to join its pool winners
+   * (a later slice). Joined to a username at render, like a row's `entryId`. */
+  champion: string | null
 }
 
 /** One *active* entry in an event. Withdrawn entries are not entrants — they
@@ -220,6 +293,12 @@ export interface TournamentEvent {
    * draw verbs, never through an event PATCH (which is why `eventToUpdateBody` omits
    * it, exactly as it omits the server-derived `entered`). */
   fixtures: Fixture[]
+  /** This event's **results** — its pool standings, whether it is complete, and its
+   * champion (ADR-0788) — or `null` for an uncut or non-round-robin event (nothing to
+   * stand). Server-derived, live, from the fixtures' completed matches; read it, never
+   * write it, and never re-sort or recompute it (the order and the numbers *are* the
+   * result). */
+  results: EventResults | null
 }
 
 /** A physical table in the venue catalogue, referenced by id from a

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
@@ -10,6 +10,7 @@ import type { TournamentEvent } from '../../data/types'
 import { LeadReason } from './lead-reason'
 import { PoolDraw } from './draw-panel/pool-draw'
 import { RoundList } from './draw-panel/round-list'
+import { StandingsPanel } from './draw-panel/standings/standings-panel'
 
 export interface DrawPanelProps {
   tournamentId: string
@@ -165,6 +166,15 @@ export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
       )}
 
       <DrawBody state={state} canEdit={canEdit} />
+
+      {/* The results (ADR-0788): pool standings, and the champion once the event is
+          decided. Dropped in unconditionally — it renders NOTHING for an event with no
+          results (`event.results === null`: uncut, or a non-round-robin draw type), which
+          is the designed data state, so there is no branch to keep in sync here. It sits
+          below the fixtures because a director reads the pairings first and the table they
+          fill in second; it is live BFF data, so it updates on the same refetch the rest
+          of the card does, with no wiring of its own. */}
+      <StandingsPanel event={event} />
     </section>
   )
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.factory.tsx
@@ -1,8 +1,14 @@
-import type { FixtureLine, FixtureSide } from '../../../../data/draw'
+import type {
+  FixtureLine,
+  FixtureMatch,
+  FixtureSide,
+} from '../../../../data/draw'
 import type { FixtureLineProps } from './fixture-line'
 
 /** A fixture line between two named entrants — the ordinary case, and the only one a
- * round-robin draw produces. Pass `a`/`b` for the TBD and withdrawn sides. */
+ * round-robin draw produces. `match: null` is the default because a *planned* pairing is
+ * the state a director sees the morning of; pass `a`/`b` for the TBD and withdrawn sides,
+ * and `buildFixtureMatch()` (or `match`) for a materialized slot. */
 export function buildFixtureLineView(
   overrides: Partial<FixtureLine> = {},
 ): FixtureLine {
@@ -11,8 +17,17 @@ export function buildFixtureLineView(
     position: 1,
     a: { kind: 'entrant', name: 'player.1' },
     b: { kind: 'entrant', name: 'player.4' },
+    match: null,
     ...overrides,
   }
+}
+
+/** The materialized match behind a fixture — an `in_progress` match, the state every slot
+ * is in the moment its draw goes live (#788). Pass `status` for a played-out slot. */
+export function buildFixtureMatch(
+  overrides: Partial<FixtureMatch> = {},
+): FixtureMatch {
+  return { id: 'm-fx-a-1', status: 'in_progress', ...overrides }
 }
 
 /** A side that is **not decided yet** — never a bye (ADR-0786). */

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.page.tsx
@@ -1,5 +1,6 @@
+import { renderWithRoutes } from '@/test/router'
 import { interactiveElementsIn } from '@/test/read-only'
-import { render, screen, within, type Container } from '@/test/utilities'
+import { screen, within, type Container } from '@/test/utilities'
 
 import { FixtureLine, type FixtureLineProps } from './fixture-line'
 import { buildFixtureLineProps } from './fixture-line.factory'
@@ -38,27 +39,57 @@ const scoped = (container: Container) => ({
       .queryAllByTestId(FIXTURE_LINE_TESTID)
       .map((el: HTMLElement) => lineText(el))
   },
-  /** Everything interactive in a line. Must always be empty: a fixture is a *planned*
-   * pairing, not a match — there is nothing to click yet (#788). */
+  /** Everything interactive in a line. Empty for a *planned* pairing — there is nothing
+   * to click on it until it materializes (#788) — and exactly the "View match" link once
+   * it has. */
   getControls(fixtureId: string) {
     return interactiveElementsIn(container.getByTestId(`fixture-line-${fixtureId}`))
+  },
+  /** The "View match" link a materialized slot carries, scoped to its line. */
+  getMatchLink(fixtureId: string) {
+    return within(container.getByTestId(`fixture-line-${fixtureId}`)).getByRole(
+      'link',
+    )
+  },
+  queryMatchLink(fixtureId: string) {
+    return within(container.getByTestId(`fixture-line-${fixtureId}`)).queryByRole(
+      'link',
+    )
+  },
+  /** The slot's match-status text (`In progress`, `Completed`, …). */
+  getMatchStatus(fixtureId: string) {
+    return within(container.getByTestId(`fixture-line-${fixtureId}`)).getByTestId(
+      'fixture-match-status',
+    )
   },
 })
 
 /**
  * Test page-object for `FixtureLine`.
  *
- * `render` wraps the component in a `<ul>`: it renders an `<li>`, which is only valid
- * inside a list, and a page object that dropped it into a bare `<div>` would be
- * asserting against markup the app never produces.
+ * A materialized fixture line renders a typed `<Link>` to its match, which needs a
+ * `RouterProvider` whose route tree registers `/matches/$matchId` — so `render` mounts
+ * the line under `renderWithRoutes`. That router resolves asynchronously, so tests start
+ * with `await fixtureLinePage.findLine(id)` before reading the synchronous accessors.
+ *
+ * The line is an `<li>`, valid only inside a list, so it renders wrapped in a `<ul>`: a
+ * page object that dropped it into a bare `<div>` would be asserting against markup the
+ * app never produces.
  */
 export const fixtureLinePage = {
   render(overrides: Partial<FixtureLineProps> = {}) {
-    render(
+    renderWithRoutes(
       <ul>
         <FixtureLine {...buildFixtureLineProps(overrides)} />
       </ul>,
+      { linkTargets: ['/matches/$matchId'] },
     )
+  },
+
+  /** Async-first: the router resolves the route tree on the first paint, so tests await
+   * this before reading the synchronous accessors. */
+  findLine(fixtureId: string) {
+    return screen.findByTestId(`fixture-line-${fixtureId}`)
   },
 
   within(container: Container = screen) {

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.test.tsx
@@ -1,12 +1,13 @@
 import {
   buildFixtureLineView,
+  buildFixtureMatch,
   buildTbdSide,
   buildWithdrawnSide,
 } from './fixture-line.factory'
 import { fixtureLinePage as page } from './fixture-line.page'
 
 describe('FixtureLine', () => {
-  it('reads as a named pairing: "A vs B"', () => {
+  it('reads as a named pairing: "A vs B"', async () => {
     page.render({
       fixture: buildFixtureLineView({
         id: 'fx-a-1',
@@ -14,13 +15,14 @@ describe('FixtureLine', () => {
         b: { kind: 'entrant', name: 'player.4' },
       }),
     })
+    await page.findLine('fx-a-1')
 
     // The NAMES, not the entry ids — a line that printed uuids would still have three
     // children and still pass a "renders a fixture" assertion.
     expect(page.getLineTexts()).toEqual(['player.1 vs player.4'])
   })
 
-  it('renders an undecided side as TBD rather than a blank half-line', () => {
+  it('renders an undecided side as TBD rather than a blank half-line', async () => {
     page.render({
       fixture: buildFixtureLineView({
         id: 'fx-ko-1',
@@ -28,11 +30,12 @@ describe('FixtureLine', () => {
         b: buildTbdSide(),
       }),
     })
+    await page.findLine('fx-ko-1')
 
     expect(page.getLineTexts()).toEqual(['player.3 vs TBD'])
   })
 
-  it('renders a side the event no longer lists as withdrawn — the draw is stale', () => {
+  it('renders a side the event no longer lists as withdrawn — the draw is stale', async () => {
     page.render({
       fixture: buildFixtureLineView({
         id: 'fx-a-2',
@@ -40,16 +43,56 @@ describe('FixtureLine', () => {
         b: { kind: 'entrant', name: 'player.5' },
       }),
     })
+    await page.findLine('fx-a-2')
 
     expect(page.getLineTexts()).toEqual(['Withdrawn vs player.5'])
   })
 
-  // A fixture is not a match (CONTEXT.md): there is nothing to click on it until it
-  // materializes into one (#788). Nor does it sit under the card's stretched open
-  // target as a second, competing control.
-  it('is inert — a planned pairing carries no controls', () => {
-    page.render({ fixture: buildFixtureLineView({ id: 'fx-a-1' }) })
+  // A *planned* pairing is not a match (CONTEXT.md): there is nothing to click on it
+  // until it materializes into one (#788). Nor does it sit under the card's stretched
+  // open target as a second, competing control.
+  it('is inert while un-materialized — a planned pairing carries no controls', async () => {
+    page.render({ fixture: buildFixtureLineView({ id: 'fx-a-1', match: null }) })
+    await page.findLine('fx-a-1')
 
     expect(page.getControls('fx-a-1')).toHaveLength(0)
+    expect(page.queryMatchLink('fx-a-1')).toBeNull()
+  })
+
+  // The whole point of #788: once a slot has materialized it stops being inert and links
+  // to the real match it became, showing that match's live status.
+  it('links a materialized slot to its live match and shows the match status', async () => {
+    page.render({
+      fixture: buildFixtureLineView({
+        id: 'fx-a-1',
+        a: { kind: 'entrant', name: 'player.1' },
+        b: { kind: 'entrant', name: 'player.4' },
+        match: buildFixtureMatch({ id: 'm-99', status: 'in_progress' }),
+      }),
+    })
+    await page.findLine('fx-a-1')
+
+    // The pairing still reads as itself — the match affordance is added, not swapped in.
+    const link = page.getMatchLink('fx-a-1')
+    expect(link).toHaveTextContent('View match')
+    // Deep-links the match the slot became — the app's one match route, not a hand-rolled
+    // path — so a director opens it and plays it through the normal flow.
+    expect(link).toHaveAttribute('href', '/matches/m-99')
+    // The status is a real word on the line, not a colour: a director (and a screen
+    // reader) learns the match is under way.
+    expect(page.getMatchStatus('fx-a-1')).toHaveTextContent('In progress')
+    expect(link).toHaveAttribute('aria-label', 'View match — In progress')
+  })
+
+  it('shows a completed slot as completed', async () => {
+    page.render({
+      fixture: buildFixtureLineView({
+        id: 'fx-a-1',
+        match: buildFixtureMatch({ id: 'm-100', status: 'completed' }),
+      }),
+    })
+    await page.findLine('fx-a-1')
+
+    expect(page.getMatchStatus('fx-a-1')).toHaveTextContent('Completed')
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/round-list/fixture-line.tsx
@@ -1,12 +1,27 @@
+import { Link } from '@tanstack/react-router'
+
+import { matchDetailRoute, type MatchStatus } from '@/api/matches'
+
 import {
   TBD_LABEL,
   WITHDRAWN_LABEL,
   type FixtureLine as FixtureLineView,
+  type FixtureMatch,
   type FixtureSide,
 } from '../../../../data/draw'
 
 export interface FixtureLineProps {
   fixture: FixtureLineView
+}
+
+/** A materialized fixture's status, in words a director reads rather than the wire's
+ * enum key. `in_progress` is the state every slot is in at go-live, so it leads; a slot
+ * never *starts* as `pending`, but a match can be reset to it, so it is covered too. */
+const MATCH_STATUS_LABEL: Record<MatchStatus, string> = {
+  pending: 'Not started',
+  in_progress: 'In progress',
+  completed: 'Completed',
+  voided: 'Voided',
 }
 
 /** One side of the "A vs B" line. The three kinds of side are three different facts
@@ -41,12 +56,44 @@ const Side = ({ side }: { side: FixtureSide }) => {
   }
 }
 
+/** The materialized half of a fixture line: a **link to the live match** and its
+ * **status**, shown only once the slot has become a real match at go-live (#788).
+ *
+ * The link is built with `matchDetailRoute` — the one typed builder every "open this
+ * match" affordance in the app goes through (the matches list row, the profile's Recent
+ * matches) — so a fixture slot deep-links a match exactly the way the rest of the app
+ * does, and a route rename touches one place. Its accessible name carries the status, so
+ * a screen reader hears "View match — In progress" rather than a bare "View match" it
+ * cannot tell from the next slot's. */
+const MatchLink = ({ match }: { match: FixtureMatch }) => {
+  const label = MATCH_STATUS_LABEL[match.status]
+  return (
+    <>
+      <span
+        data-testid="fixture-match-status"
+        className="text-[11px] font-medium text-[color:var(--fg-3)]"
+      >
+        {label}
+      </span>{' '}
+      <Link
+        {...matchDetailRoute(match.id)}
+        aria-label={`View match — ${label}`}
+        className="text-[color:var(--ball-500)] hover:underline"
+      >
+        View match
+      </Link>
+    </>
+  )
+}
+
 /**
  * One **fixture** of a cut draw, as a named line: `player.1 vs player.4`.
  *
- * A fixture is not a match (CONTEXT.md) — it is the *planned* pairing, and it may not
- * even have both its sides yet — so the line is deliberately inert: no score, no link,
- * no control. Materializing it into a real match is #788.
+ * A fixture is a *planned* pairing, not a match (CONTEXT.md) — so **until it materializes
+ * the line is inert**: no score, no link, no control. At go-live it becomes a real match
+ * (#788), and from then on the line links to that match (`MatchLink`) and shows the
+ * match's live status. The `match` field is the whole switch: `null` is the planned
+ * pairing, a `FixtureMatch` is the live one.
  *
  * Rendered as the `<li>` of the round's list, so a round stays a list of its fixtures
  * and a screen reader can count them. The "vs" is a real word in the DOM, not a
@@ -56,7 +103,7 @@ const Side = ({ side }: { side: FixtureSide }) => {
 export const FixtureLine = ({ fixture }: FixtureLineProps) => (
   <li
     data-testid={`fixture-line-${fixture.id}`}
-    className="flex items-baseline gap-1.5 py-0.5 text-[13px] leading-snug"
+    className="flex flex-wrap items-baseline gap-x-1.5 py-0.5 text-[13px] leading-snug"
   >
     {/* The `{' '}`s are LOAD-BEARING, and they are not the flex gap. The gap is
         *layout*: whitespace-only text between flex items is not rendered, so these cost
@@ -67,5 +114,10 @@ export const FixtureLine = ({ fixture }: FixtureLineProps) => (
     <Side side={fixture.a} />{' '}
     <span className="text-[color:var(--fg-3)]">vs</span>{' '}
     <Side side={fixture.b} />
+    {fixture.match && (
+      <span className="ml-auto flex items-baseline gap-x-1.5">
+        <MatchLink match={fixture.match} />
+      </span>
+    )}
   </li>
 )

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.factory.tsx
@@ -1,0 +1,76 @@
+import type { PoolStandingsView, StandingLine } from '../../../../data/standings'
+import type { PoolStandingsTableProps } from './pool-standings-table'
+
+/** One standings line, joined to a name (`StandingLine`): `player.1`, 1st, 2–0, +3. The
+ * view-model's output shape — a `StandingRow` plus the name join — so the table's tests
+ * never re-run the join, they render the result of it. */
+export function buildStandingLine(
+  overrides: Partial<StandingLine> = {},
+): StandingLine {
+  return {
+    entryId: 'entry-1',
+    name: 'player.1',
+    rank: 1,
+    played: 2,
+    wins: 2,
+    losses: 0,
+    gamesWon: 4,
+    gamesLost: 1,
+    gameDifference: 3,
+    ...overrides,
+  }
+}
+
+/** A complete three-player pool, in the server's finishing order: `player.1` (2–0) over
+ * `player.4` (1–1) over `player.5` (0–2). The middle row's `gameDifference` is `0` and the
+ * last is negative, so a test can prove the sign is rendered (`+3`, `0`, `-3`). Returned in
+ * order, which the table renders untouched (ADR-0788). */
+export function buildPoolStandingsView(
+  overrides: Partial<PoolStandingsView> = {},
+): PoolStandingsView {
+  return {
+    poolId: 'p-a',
+    name: 'Pool A',
+    complete: true,
+    rows: [
+      buildStandingLine({
+        entryId: 'entry-1',
+        name: 'player.1',
+        rank: 1,
+        wins: 2,
+        losses: 0,
+        gamesWon: 4,
+        gamesLost: 1,
+        gameDifference: 3,
+      }),
+      buildStandingLine({
+        entryId: 'entry-4',
+        name: 'player.4',
+        rank: 2,
+        wins: 1,
+        losses: 1,
+        gamesWon: 3,
+        gamesLost: 3,
+        gameDifference: 0,
+      }),
+      buildStandingLine({
+        entryId: 'entry-5',
+        name: 'player.5',
+        rank: 3,
+        wins: 0,
+        losses: 2,
+        gamesWon: 1,
+        gamesLost: 4,
+        gameDifference: -3,
+      }),
+    ],
+    ...overrides,
+  }
+}
+
+/** Props for `PoolStandingsTable`. */
+export function buildPoolStandingsTableProps(
+  overrides: Partial<PoolStandingsTableProps> = {},
+): PoolStandingsTableProps {
+  return { pool: buildPoolStandingsView(), ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.page.tsx
@@ -1,0 +1,68 @@
+import { interactiveElementsIn } from '@/test/read-only'
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import { PoolStandingsTable, type PoolStandingsTableProps } from './pool-standings-table'
+import { buildPoolStandingsTableProps } from './pool-standings-table.factory'
+
+const scoped = (container: Container) => {
+  /** The pool's table, by the pool name in its accessible label — a draw shows several
+   * side by side, so every "in *this* pool" assertion narrows to it. */
+  const table = (poolName: string) =>
+    container.getByRole('table', { name: `Standings for ${poolName}` })
+
+  return {
+    getTable: table,
+
+    /** The pool's whole section, by pool id — the scope the inert sweep narrows to. */
+    getSection(poolId: string) {
+      return container.getByTestId(`pool-standings-${poolId}`)
+    },
+
+    /** One column header, by its ACCESSIBLE name — which is the FULL word a screen reader
+     * hears (`Wins`), not the terse glyph on screen (`W`): the glyph span is
+     * `aria-hidden`, so it is excluded from the accessible name, and the sr-only word is
+     * what remains. `getByRole` here is the whole proof that the two channels are wired
+     * right — it would not find a header whose only text was the bare glyph. */
+    getColumnHeader(poolName: string, name: string) {
+      return within(table(poolName)).getByRole('columnheader', { name })
+    },
+
+    /** The player names, top to bottom — the ORDER the table renders, which must be the
+     * server's order untouched (ADR-0788). The Player cell is the second cell of each body
+     * row. */
+    getRowNames(poolName: string) {
+      return within(table(poolName))
+        .getAllByRole('row')
+        // Drop the header row — `getAllByRole('row')` includes it.
+        .slice(1)
+        .map((row) => (within(row).getAllByRole('cell')[1].textContent ?? '').trim())
+    },
+
+    /** One row's cells as text, left to right (`['1', 'player.1', '2', '0', '+3', '4']`) —
+     * for asserting the numbers, and the sign on the game difference. */
+    getRowCells(entryId: string) {
+      return within(container.getByTestId(`standing-row-${entryId}`))
+        .getAllByRole('cell')
+        .map((cell) => (cell.textContent ?? '').trim())
+    },
+
+    /** Everything interactive in the pool section — must be empty. Standings are a read
+     * surface: a table of results has no controls of its own. */
+    getControls(poolId: string) {
+      return interactiveElementsIn(container.getByTestId(`pool-standings-${poolId}`))
+    },
+  }
+}
+
+/** Test page-object for `PoolStandingsTable`. */
+export const poolStandingsTablePage = {
+  render(overrides: Partial<PoolStandingsTableProps> = {}) {
+    render(<PoolStandingsTable {...buildPoolStandingsTableProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.test.tsx
@@ -1,0 +1,89 @@
+import {
+  buildPoolStandingsView,
+  buildStandingLine,
+} from './pool-standings-table.factory'
+import { poolStandingsTablePage as page } from './pool-standings-table.page'
+
+describe('PoolStandingsTable', () => {
+  it('heads the table with its pool name', () => {
+    page.render({ pool: buildPoolStandingsView({ name: 'Pool B' }) })
+
+    expect(page.getTable('Pool B')).toBeInTheDocument()
+  })
+
+  it('has a column for wins, losses, game difference and games won — named for a screen reader', () => {
+    page.render({ pool: buildPoolStandingsView({ name: 'Pool A' }) })
+
+    // Each header is found by its ACCESSIBLE name — the full word a reader hears, not the
+    // terse `W`/`L`/`Diff`/`GW` glyph on screen. A header that shipped only the glyph would
+    // fail these lookups, which is the whole point of asserting the accessible name.
+    for (const name of [
+      'Rank',
+      'Player',
+      'Wins',
+      'Losses',
+      'Game difference',
+      'Games won',
+    ]) {
+      expect(page.getColumnHeader('Pool A', name)).toBeInTheDocument()
+    }
+  })
+
+  it('renders every entrant by NAME, one row per row', () => {
+    page.render({ pool: buildPoolStandingsView({ name: 'Pool A' }) })
+
+    expect(page.getRowNames('Pool A')).toEqual(['player.1', 'player.4', 'player.5'])
+  })
+
+  it('renders rows in the SERVER’s order — it does not re-sort them', () => {
+    // A pool handed out of finishing order: the 0–2 player first, the 2–0 leader last.
+    // The table must render exactly this order — the order IS the result (ADR-0788), and a
+    // client that re-sorted by wins would silently disagree with a head-to-head tiebreak it
+    // cannot see. So the assertion is: input order out, unchanged.
+    page.render({
+      pool: buildPoolStandingsView({
+        name: 'Pool A',
+        rows: [
+          buildStandingLine({ entryId: 'entry-5', name: 'player.5', rank: 3, wins: 0 }),
+          buildStandingLine({ entryId: 'entry-1', name: 'player.1', rank: 1, wins: 2 }),
+          buildStandingLine({ entryId: 'entry-4', name: 'player.4', rank: 2, wins: 1 }),
+        ],
+      }),
+    })
+
+    expect(page.getRowNames('Pool A')).toEqual(['player.5', 'player.1', 'player.4'])
+  })
+
+  it('shows each row’s numbers, with the SIGN on the game difference', () => {
+    page.render({ pool: buildPoolStandingsView() })
+
+    // rank, player, wins, losses, game difference (signed), games won.
+    expect(page.getRowCells('entry-1')).toEqual(['1', 'player.1', '2', '0', '+3', '4'])
+    // A zero difference is bare — neither `+0` nor `-0`.
+    expect(page.getRowCells('entry-4')).toEqual(['2', 'player.4', '1', '1', '0', '3'])
+    // A negative difference keeps its minus — `-3` and `+3` are different standings, and a
+    // bare `3` would read as both.
+    expect(page.getRowCells('entry-5')).toEqual(['3', 'player.5', '0', '2', '-3', '1'])
+  })
+
+  it('shows a WITHDRAWN entrant’s name where the join could not resolve one', () => {
+    // A row can name an entry the event no longer lists — someone who withdrew after
+    // playing. The view-model joins that to `Withdrawn`; the table renders it as any other
+    // name, never a raw id or a blank.
+    page.render({
+      pool: buildPoolStandingsView({
+        rows: [buildStandingLine({ entryId: 'entry-gone', name: 'Withdrawn' })],
+      }),
+    })
+
+    expect(page.getRowCells('entry-gone')[1]).toBe('Withdrawn')
+  })
+
+  // Standings are a READ surface: a table of results has no controls of its own, and it
+  // sits under the event card's stretched open target where a stray control would fight it.
+  it('is inert — the table carries no controls', () => {
+    page.render({ pool: buildPoolStandingsView({ poolId: 'p-a' }) })
+
+    expect(page.getControls('p-a')).toHaveLength(0)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.tsx
@@ -1,0 +1,109 @@
+import { useId } from 'react'
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import type { PoolStandingsView } from '../../../../data/standings'
+
+export interface PoolStandingsTableProps {
+  pool: PoolStandingsView
+}
+
+/** One numeric column's header: a terse glyph on screen (`W`, `L`) and the full word for a
+ * screen reader, which cannot guess what `W` abbreviates. Both channels carry the meaning;
+ * neither is left to infer it. */
+const NumHead = ({ short, full }: { short: string; full: string }) => (
+  <TableHead className="text-right font-mono tabular-nums">
+    <span aria-hidden="true">{short}</span>
+    <span className="sr-only">{full}</span>
+  </TableHead>
+)
+
+/**
+ * One **pool's standings** as a table (ADR-0788): the entrants in the server's finishing
+ * order, one row each, with wins, losses, game difference and games won.
+ *
+ * **Nothing here re-sorts or recomputes.** The rows arrive in the pool's total order (wins
+ * → two-way head-to-head → game difference → games won, decided on the server) and are
+ * rendered in exactly that order — the order *is* the result. `game_difference` is the
+ * server's own figure, shown, not derived from the two counts beside it (which would be a
+ * second copy that could disagree). The view-model (`data/standings`) has already joined
+ * each row's entry id to a username; a row is never a raw uuid.
+ *
+ * A real `<table>`, not a grid of divs: standings are tabular data, and a screen reader
+ * reads a `<th scope>`-headed table by column ("player.1, Wins 2, Losses 0") rather than
+ * as a wall of numbers. The numeric headers say their full word to it (`NumHead`).
+ */
+export const PoolStandingsTable = ({ pool }: PoolStandingsTableProps) => {
+  const captionId = useId()
+
+  return (
+    <section
+      data-testid={`pool-standings-${pool.poolId}`}
+      aria-labelledby={captionId}
+      className="rounded-[10px] border border-[color:var(--border-subtle)] p-3"
+    >
+      <h4
+        id={captionId}
+        className="text-[13px] font-semibold text-[color:var(--fg-1)]"
+      >
+        {pool.name}
+      </h4>
+
+      <Table
+        aria-label={`Standings for ${pool.name}`}
+        className="mt-2 text-[13px]"
+      >
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-8 text-right font-mono tabular-nums">
+              <span aria-hidden="true">#</span>
+              <span className="sr-only">Rank</span>
+            </TableHead>
+            <TableHead>Player</TableHead>
+            <NumHead short="W" full="Wins" />
+            <NumHead short="L" full="Losses" />
+            <NumHead short="Diff" full="Game difference" />
+            <NumHead short="GW" full="Games won" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {pool.rows.map((row) => (
+            <TableRow
+              key={row.entryId}
+              data-testid={`standing-row-${row.entryId}`}
+            >
+              <TableCell className="text-right font-mono tabular-nums text-[color:var(--fg-3)]">
+                {row.rank}
+              </TableCell>
+              <TableCell className="text-[color:var(--fg-1)]">
+                {row.name}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {row.wins}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {row.losses}
+              </TableCell>
+              {/* The sign is load-bearing — `+2` and `-2` are different standings, and a
+                  bare `2` would read as both. A screen reader hears "plus 2" / "minus 2"
+                  from the same glyph. */}
+              <TableCell className="text-right font-mono tabular-nums text-[color:var(--fg-2)]">
+                {row.gameDifference > 0 ? `+${row.gameDifference}` : row.gameDifference}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {row.gamesWon}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </section>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.factory.tsx
@@ -1,0 +1,13 @@
+import { buildStandingsEvent } from '../../../../data/seed.factory'
+import type { StandingsPanelProps } from './standings-panel'
+
+/** Props for `StandingsPanel`: a round-robin event **with results** — a complete single
+ * pool and a champion (`buildStandingsEvent`). The event owns the `results` and the
+ * `entrants` the panel joins them against, so a test tweaks the whole event (e.g.
+ * `buildEvent()` for the no-results case, `results: buildEventResults({ complete: false })`
+ * for a live one). */
+export function buildStandingsPanelProps(
+  overrides: Partial<StandingsPanelProps> = {},
+): StandingsPanelProps {
+  return { event: buildStandingsEvent(), ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.page.tsx
@@ -1,0 +1,50 @@
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import { StandingsPanel, type StandingsPanelProps } from './standings-panel'
+import { buildStandingsPanelProps } from './standings-panel.factory'
+
+const scoped = (container: Container) => ({
+  /** The whole results block, by event id. `query…` because the panel renders NOTHING for
+   * an event with no results — the assertion for that state is that this is absent. */
+  getPanel(eventId: string) {
+    return container.getByTestId(`standings-panel-${eventId}`)
+  },
+  queryPanel(eventId: string) {
+    return container.queryByTestId(`standings-panel-${eventId}`)
+  },
+
+  /** The champion callout, by event id — shown only for a complete, single-champion event.
+   * `query…` because its absence is half of what the tests assert. */
+  queryChampion(eventId: string) {
+    return container.queryByTestId(`standings-champion-${eventId}`)
+  },
+
+  /** Every pool table in the panel, by their accessible names — one per pool. */
+  getPoolTableNames() {
+    return container
+      .getAllByRole('table')
+      .map((t: HTMLElement) => t.getAttribute('aria-label') ?? '')
+  },
+
+  /** One pool table's player names, top to bottom (the rendered order) — for the "the
+   * panel shows each pool, joined to names" assertion. */
+  getRowNames(poolName: string) {
+    return within(container.getByRole('table', { name: `Standings for ${poolName}` }))
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => (within(row).getAllByRole('cell')[1].textContent ?? '').trim())
+  },
+})
+
+/** Test page-object for `StandingsPanel`. */
+export const standingsPanelPage = {
+  render(overrides: Partial<StandingsPanelProps> = {}) {
+    render(<StandingsPanel {...buildStandingsPanelProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.test.tsx
@@ -1,0 +1,105 @@
+import {
+  buildEvent,
+  buildEventResults,
+  buildPool,
+  buildPoolStandings,
+  buildStandingRow,
+  buildStandingsEvent,
+} from '../../../../data/seed.factory'
+import { standingsPanelPage as page } from './standings-panel.page'
+
+describe('StandingsPanel', () => {
+  it('shows a standings table per pool, entrants joined to their names', () => {
+    // The default: a complete single-pool U1200 event (`ev-u1200`), Pool A of player.1 /
+    // player.4 / player.5. The panel joins each row's entry id to a name off the event's
+    // entrants — a table of raw uuids would pass a "renders standings" check and tell a
+    // director nothing.
+    page.render()
+
+    expect(page.getPoolTableNames()).toEqual(['Standings for Pool A'])
+    expect(page.getRowNames('Pool A')).toEqual(['player.1', 'player.4', 'player.5'])
+  })
+
+  it('names the champion once the event is complete', () => {
+    page.render()
+
+    const champion = page.queryChampion('ev-u1200')
+    expect(champion).not.toBeNull()
+    // The champion is `entry-1`, joined to a name — not the entry id.
+    expect(champion).toHaveTextContent('player.1')
+  })
+
+  it('does NOT show a champion while the event is still being played', () => {
+    // Live standings: the table fills in as matches complete, but there is no champion
+    // until every fixture is decided. `champion` is `null` and `complete` is false, so the
+    // callout is absent while the pool table is present.
+    page.render({
+      event: buildStandingsEvent({
+        results: buildEventResults({
+          complete: false,
+          champion: null,
+          pools: [buildPoolStandings({ complete: false })],
+        }),
+      }),
+    })
+
+    expect(page.queryChampion('ev-u1200')).toBeNull()
+    expect(page.getPoolTableNames()).toEqual(['Standings for Pool A'])
+  })
+
+  it('shows every pool but NO champion for a complete multi-pool event', () => {
+    // A multi-pool round-robin has no single champion without a knockout stage to join its
+    // pool winners (a later slice), so `champion` is `null` even when complete — the pool
+    // tables render, the callout does not.
+    page.render({
+      event: buildStandingsEvent({
+        pools: [
+          buildPool({ id: 'p-a', name: 'Pool A' }),
+          buildPool({ id: 'p-b', name: 'Pool B' }),
+        ],
+        results: buildEventResults({
+          complete: true,
+          champion: null,
+          pools: [
+            buildPoolStandings({ poolId: 'p-a' }),
+            buildPoolStandings({
+              poolId: 'p-b',
+              rows: [
+                buildStandingRow({ entryId: 'entry-2', rank: 1 }),
+                buildStandingRow({ entryId: 'entry-3', rank: 2 }),
+              ],
+            }),
+          ],
+        }),
+      }),
+    })
+
+    expect(page.getPoolTableNames()).toEqual([
+      'Standings for Pool A',
+      'Standings for Pool B',
+    ])
+    expect(page.queryChampion('ev-u1200')).toBeNull()
+  })
+
+  it('renders NOTHING for an event with no results', () => {
+    // An uncut event (and any non-round-robin one) has `results: null` — nothing to stand.
+    // The panel is a designed empty state: it renders no section at all, rather than an
+    // empty table that would read as a played event with nobody in it.
+    page.render({ event: buildEvent() })
+
+    expect(page.queryPanel('ev-open-singles')).toBeNull()
+  })
+
+  it('shows a withdrawn champion as “Withdrawn”, never a raw id', () => {
+    // The champion could name an entry the event no longer lists — a winner who withdrew
+    // afterward. The view-model joins that to `Withdrawn`; the callout shows the word, not
+    // the uuid.
+    page.render({
+      event: buildStandingsEvent({
+        results: buildEventResults({ complete: true, champion: 'entry-gone' }),
+      }),
+    })
+
+    expect(page.queryChampion('ev-u1200')).toHaveTextContent('Withdrawn')
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.tsx
@@ -1,0 +1,81 @@
+import { Trophy } from 'lucide-react'
+import { useId } from 'react'
+
+import { eventStandings } from '../../../../data/standings'
+import type { TournamentEvent } from '../../../../data/types'
+import { PoolStandingsTable } from './pool-standings-table'
+
+export interface StandingsPanelProps {
+  event: TournamentEvent
+}
+
+/**
+ * An event's **results** on its card in the Events tab (ADR-0788): a standings table per
+ * pool, and — once the event is decided — its champion.
+ *
+ * It renders **nothing** for an event with no results (`event.results === null`, so
+ * `eventStandings` returns `null`): an uncut event, or a non-round-robin one, has no
+ * standings to show, and an empty table would read as a played event with nobody in it.
+ * That is why this can be dropped into the panel unconditionally — it is a designed data
+ * state, not a gap.
+ *
+ * ## Live, with no machinery of its own
+ *
+ * The standings are just BFF data: they arrive on the tournament-detail payload, derived
+ * live on the server from the fixtures' completed matches. As matches complete, the
+ * completion hook re-derives them and the mutations that drive play invalidate the
+ * tournament — so the table fills in on the next read with **no polling and no client
+ * recompute** here. This component is a pure view over `event`; it never sorts a row or
+ * computes a number (the order and the figures *are* the result — ADR-0788).
+ *
+ * ## The champion
+ *
+ * Shown only when the event is **complete** and has a single champion (a complete,
+ * single-pool round-robin). A multi-pool event has no single champion without a knockout
+ * stage to join its pool winners (a later slice), so `champion` is `null` there even when
+ * complete, and the callout simply does not appear — the pool tables still do.
+ */
+export const StandingsPanel = ({ event }: StandingsPanelProps) => {
+  const headingId = useId()
+  const standings = eventStandings(event)
+
+  // No results to stand: an uncut or non-round-robin event. Render nothing — a designed
+  // data state, not a spinner and not a gap.
+  if (standings === null) return null
+
+  return (
+    <section
+      data-testid={`standings-panel-${event.id}`}
+      aria-labelledby={headingId}
+      className="mt-2.5"
+    >
+      <h3
+        id={headingId}
+        className="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase"
+      >
+        Standings
+      </h3>
+
+      {/* The champion — a decided event's result, in the app's "featured" voice
+          (`web-client/CLAUDE.md`, design system: the `--ball-500` tint + glow). Not an
+          Alert: it is not the app talking back to an action and it does not dismiss, it is
+          a fact about the finished event. Shown only when there IS one champion. */}
+      {standings.complete && standings.champion !== null && (
+        <p
+          data-testid={`standings-champion-${event.id}`}
+          className="mt-1.5 flex items-center gap-1.5 rounded-[10px] border border-[color:rgba(255,122,26,0.3)] bg-[color:var(--bg-accent-soft)] px-3 py-2 text-[13px] font-medium text-[color:var(--fg-1)] [box-shadow:var(--shadow-glow)]"
+        >
+          <Trophy size={14} className="text-[color:var(--ball-500)]" />
+          <span className="text-[color:var(--fg-3)]">Champion</span>
+          <span className="text-[color:var(--ball-500)]">{standings.champion}</span>
+        </p>
+      )}
+
+      <div className="mt-2 flex flex-col gap-2.5">
+        {standings.pools.map((pool) => (
+          <PoolStandingsTable key={pool.poolId} pool={pool} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -6,6 +6,9 @@ type TournamentEventRead = components['schemas']['TournamentEventRead']
 type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
 type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
 type TournamentTable = components['schemas']['TournamentTable']
+type EventResultsRead = components['schemas']['EventResultsRead']
+type PoolStandingsRead = components['schemas']['PoolStandingsRead']
+type StandingRowRead = components['schemas']['StandingRowRead']
 
 /** A single physical table, `T1` on court 1. */
 export function buildTournamentTable(
@@ -60,7 +63,8 @@ export function buildTournamentEntrantReads(
  * side is **TBD** (never a bye — a bye is the absence of a fixture row), a null
  * `winner_entry_id` is undecided, a null `match_id` is un-materialized, and a null
  * `pool_id` is an un-pooled draw. The defaults are the ordinary case a director sees
- * the morning of: a planned pairing, both players known, nothing played. */
+ * the morning of: a planned pairing, both players known, nothing played — so
+ * `match_status` is `null` too, moving in lockstep with `match_id`. */
 export function buildTournamentFixtureRead(
   overrides: Partial<TournamentFixtureRead> = {},
 ): TournamentFixtureRead {
@@ -73,6 +77,7 @@ export function buildTournamentFixtureRead(
     entry_b_id: 'entry-2',
     winner_entry_id: null,
     match_id: null,
+    match_status: null,
     ...overrides,
   }
 }
@@ -151,6 +156,82 @@ export function planRoundRobinFixtures(
   return fixtures
 }
 
+/** One wire standings row (`StandingRowRead`, ADR-0788): entry `entry-1`, 1st, a clean
+ * 2–0 with a +3 game difference. `game_difference` is the server's own figure
+ * (`games_won - games_lost`), carried as-is; the factory keeps it consistent by default. */
+export function buildStandingRowRead(
+  overrides: Partial<StandingRowRead> = {},
+): StandingRowRead {
+  return {
+    entry_id: 'entry-1',
+    rank: 1,
+    played: 2,
+    wins: 2,
+    losses: 0,
+    games_won: 4,
+    games_lost: 1,
+    game_difference: 3,
+    ...overrides,
+  }
+}
+
+/** One wire pool's standings (`PoolStandingsRead`): a complete three-player pool in the
+ * server's finishing order — `entry-1` (2–0) over `entry-4` (1–1) over `entry-5` (0–2). In
+ * order, which the client renders untouched (ADR-0788). */
+export function buildPoolStandingsRead(
+  overrides: Partial<PoolStandingsRead> = {},
+): PoolStandingsRead {
+  return {
+    pool_id: 'p-a',
+    complete: true,
+    rows: [
+      buildStandingRowRead({
+        entry_id: 'entry-1',
+        rank: 1,
+        wins: 2,
+        losses: 0,
+        games_won: 4,
+        games_lost: 1,
+        game_difference: 3,
+      }),
+      buildStandingRowRead({
+        entry_id: 'entry-4',
+        rank: 2,
+        wins: 1,
+        losses: 1,
+        games_won: 3,
+        games_lost: 3,
+        game_difference: 0,
+      }),
+      buildStandingRowRead({
+        entry_id: 'entry-5',
+        rank: 3,
+        wins: 0,
+        losses: 2,
+        games_won: 1,
+        games_lost: 4,
+        game_difference: -3,
+      }),
+    ],
+    ...overrides,
+  }
+}
+
+/** A wire event's results (`EventResultsRead`, ADR-0788): one complete single pool with a
+ * champion (`entry-1`, who won it). Single-pool so `champion` is meaningful — a multi-pool
+ * event has no single champion without a knockout stage yet (pass extra `pools` +
+ * `champion: null` for that). */
+export function buildEventResultsRead(
+  overrides: Partial<EventResultsRead> = {},
+): EventResultsRead {
+  return {
+    pools: [buildPoolStandingsRead()],
+    complete: true,
+    champion: 'entry-1',
+    ...overrides,
+  }
+}
+
 /**
  * What the event says about the CALLER entering it (ADR-0783), derived the way the
  * server derives the half of it that is derivable: an event holding `max_players`
@@ -226,6 +307,10 @@ export function buildTournamentEventRead(
         table_ids: ['t1', 't2', 't3', 't4'],
       },
     ],
+    // NO RESULTS (ADR-0788) — `null` is the designed state of an event with no draw (and of
+    // any non-round-robin event); standings only appear once a draw is cut and matches
+    // land. A fixture that wants a table passes a `buildEventResultsRead()` override.
+    results: null,
     created_at: '2026-06-01T09:05:00Z',
     updated_at: '2026-06-09T12:00:00Z',
     ...overrides,

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -774,6 +774,27 @@ describe('transitionTournament', () => {
     expect(findTournament(id)!.status).toBe('live')
   })
 
+  it('MATERIALIZES every ready fixture into an in_progress match at go-live (#788)', () => {
+    // Go-live is the act that turns a draw's planned pairings into real, playable
+    // matches: after it, every ready fixture (both sides known) carries a match id and a
+    // live status, which is what gives the draw panel its "View match" links. Before it,
+    // the same fixtures are inert — `match_id` null.
+    const id = at('published')
+    const before = findTournament(id)!.events.flatMap((e) => e.fixtures)
+    expect(before.length).toBeGreaterThan(0)
+    expect(before.every((f) => f.match_id === null)).toBe(true)
+
+    const result = transitionTournament(id, 'live')
+    expect(result.ok).toBe(true)
+
+    const after = findTournament(id)!.events.flatMap((e) => e.fixtures)
+    // A round-robin draw has both sides known on every fixture, so every one is ready.
+    for (const fixture of after) {
+      expect(fixture.match_id).not.toBeNull()
+      expect(fixture.match_status).toBe('in_progress')
+    }
+  })
+
   it('refuses to start on a STALE draw — somebody entered after it was cut', () => {
     // Registration stays open right up to go-live, which is exactly how a draw goes
     // stale: the field the fixtures were dealt from is not the field that would play.

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -24,6 +24,7 @@ import {
   entryStateFor,
   planRoundRobinFixtures,
 } from '@/mocks/factories/tournaments/tournament.factory'
+import { mockUuid } from '@/mocks/mock-uuid'
 
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
 type TournamentRead = components['schemas']['TournamentRead']
@@ -205,6 +206,8 @@ function seed(): StoredTournament[] {
           // NO DRAW CUT (ADR-0786) — the state every event starts in, and the state
           // all but one of this seed's events stay in. `[]`, never null.
           fixtures: [],
+          // NO RESULTS (ADR-0788) — no draw, so nothing to stand.
+          results: null,
           created_at: '2026-06-01T09:05:00Z',
           updated_at: '2026-06-09T12:00:00Z',
         },
@@ -224,6 +227,7 @@ function seed(): StoredTournament[] {
           predicates: [{ id: 'pr-2', field: 'rating', op: '<', value: 1500 }],
           pools: [],
           fixtures: [],
+          results: null,
           created_at: '2026-06-01T09:06:00Z',
           updated_at: '2026-06-09T12:00:00Z',
         },
@@ -245,6 +249,7 @@ function seed(): StoredTournament[] {
           predicates: [],
           pools: [],
           fixtures: [],
+          results: null,
           created_at: '2026-06-01T09:06:30Z',
           updated_at: '2026-06-09T12:00:00Z',
         },
@@ -282,6 +287,40 @@ function seed(): StoredTournament[] {
             otherEntrants('ev-u1200', 9).map((e) => e.id),
             U1200_POOLS.map((p) => p.id),
           ),
+          // Representative RESULTS (ADR-0788) so `npm run dev` shows standings live: Pool
+          // A still being played (`complete: false` — the table fills in as matches land),
+          // Pool B decided. Multi-pool, so there is no single champion without a knockout
+          // stage (a later slice) — `champion: null` even where a pool is done. The entry
+          // ids match this event's entrants (`entry-ev-u1200-N`) and its pool ids
+          // (`p-u1200-a/b`), so the name and pool joins land; the rows are in finishing
+          // order, which the client renders untouched.
+          results: {
+            complete: false,
+            champion: null,
+            pools: [
+              {
+                pool_id: 'p-u1200-a',
+                complete: false,
+                rows: [
+                  { entry_id: 'entry-ev-u1200-1', rank: 1, played: 2, wins: 2, losses: 0, games_won: 4, games_lost: 1, game_difference: 3 },
+                  { entry_id: 'entry-ev-u1200-5', rank: 2, played: 1, wins: 1, losses: 0, games_won: 2, games_lost: 0, game_difference: 2 },
+                  { entry_id: 'entry-ev-u1200-4', rank: 3, played: 2, wins: 1, losses: 1, games_won: 3, games_lost: 3, game_difference: 0 },
+                  { entry_id: 'entry-ev-u1200-8', rank: 4, played: 1, wins: 0, losses: 1, games_won: 1, games_lost: 2, game_difference: -1 },
+                  { entry_id: 'entry-ev-u1200-9', rank: 5, played: 2, wins: 0, losses: 2, games_won: 1, games_lost: 4, game_difference: -3 },
+                ],
+              },
+              {
+                pool_id: 'p-u1200-b',
+                complete: true,
+                rows: [
+                  { entry_id: 'entry-ev-u1200-2', rank: 1, played: 3, wins: 3, losses: 0, games_won: 6, games_lost: 2, game_difference: 4 },
+                  { entry_id: 'entry-ev-u1200-3', rank: 2, played: 3, wins: 2, losses: 1, games_won: 5, games_lost: 4, game_difference: 1 },
+                  { entry_id: 'entry-ev-u1200-6', rank: 3, played: 3, wins: 1, losses: 2, games_won: 4, games_lost: 5, game_difference: -1 },
+                  { entry_id: 'entry-ev-u1200-7', rank: 4, played: 3, wins: 0, losses: 3, games_won: 2, games_lost: 6, game_difference: -4 },
+                ],
+              },
+            ],
+          },
           created_at: '2026-06-01T09:06:45Z',
           updated_at: '2026-06-09T12:00:00Z',
         },
@@ -302,6 +341,7 @@ function seed(): StoredTournament[] {
           predicates: [],
           pools: [],
           fixtures: [],
+          results: null,
           created_at: '2026-06-01T09:07:00Z',
           updated_at: '2026-06-09T12:00:00Z',
         },
@@ -358,6 +398,9 @@ function seed(): StoredTournament[] {
             otherEntrants('ev-slam-open', 8).map((e) => e.id),
             SLAM_POOLS.map((p) => p.id),
           ),
+          // Drawn but unplayed — go-live materializes its fixtures into matches, but no
+          // result has landed, so there is nothing to stand yet (ADR-0788).
+          results: null,
           created_at: '2026-06-05T15:31:00Z',
           updated_at: '2026-06-05T15:31:00Z',
         },
@@ -447,6 +490,7 @@ function seed(): StoredTournament[] {
           // Un-drawn, and it stays that way through the UI: the dev user does not own
           // this tournament, and cutting a draw is owner-only (`cutDraw` 403s them).
           fixtures: [],
+          results: null,
           created_at: '2026-05-20T10:05:00Z',
           updated_at: '2026-06-12T08:00:00Z',
         },
@@ -899,6 +943,29 @@ function goLiveRefusal(tournament: StoredTournament): string | null {
   )
 }
 
+/** Materialize an event's ready fixtures into real matches — the go-live step (#788,
+ * `api/app/tournaments.py`). A fixture is **ready** when both its sides are known; a TBD
+ * fixture (a null side — a KO round whose feeder is undecided) is not, and is left to be
+ * materialized later. Idempotent on `match_id`: a fixture that already has a match keeps
+ * it, so a re-run (or a store that somehow re-enters go-live) never mints a second match.
+ *
+ * The mint mirrors the server: each ready fixture becomes an `in_progress` match, and the
+ * fixture records its id + live status. The id is a deterministic v4 (`mockUuid`) keyed
+ * off the fixture, so the same draw materializes to the same match every time — a stable
+ * deep-link a page can be built against. */
+function materializeFixtures(event: StoredEvent): StoredEvent {
+  const fixtures = event.fixtures.map((fixture) => {
+    const ready = fixture.entry_a_id !== null && fixture.entry_b_id !== null
+    if (!ready || fixture.match_id !== null) return fixture
+    return {
+      ...fixture,
+      match_id: mockUuid(`match:fixture:${fixture.id}`),
+      match_status: 'in_progress' as const,
+    }
+  })
+  return { ...event, fixtures }
+}
+
 /** `POST /v1/tournaments/{id}/transitions` — move a tournament along its
  * lifecycle. Owner-only, like every other tournament mutation, and the ONLY way
  * a status changes: `updateTournament` above leaves `status` alone by design. */
@@ -939,8 +1006,15 @@ export function transitionTournament(
     const detail = goLiveRefusal(existing)
     if (detail) return { ok: false, status: 409, detail }
   }
+  // Go-live materializes every event's ready fixtures into real `in_progress` matches
+  // (#788) — the same act that makes each pool pairing playable and gives the draw panel
+  // its "View match" links. Only on `published → live`; publishing and archiving touch no
+  // fixtures.
+  const events =
+    to === 'live' ? existing.events.map(materializeFixtures) : existing.events
   const next: StoredTournament = {
     ...existing,
+    events,
     status: to,
     updated_at: new Date().toISOString(),
   }
@@ -1005,6 +1079,8 @@ export function createEvent(
     // A brand-new event has NO DRAW (ADR-0786). Cutting one is an explicit act against
     // a field that does not exist yet — there is nobody entered to draw.
     fixtures: [],
+    // …and NO RESULTS (ADR-0788): with no draw, there is nothing to stand.
+    results: null,
     created_at: now,
     updated_at: now,
   }


### PR DESCRIPTION
C1/C2 of the **Run the tournament** epic (#780). Turns a cut round-robin draw into real, playable matches and computes live pool standings. **Round-robin + singles** scope; single-elim advancement rides free when #785 lands, since the mechanisms here are draw-type-agnostic.

## #788 — Materialize draw slots into real matches
- **Go-live** consumes the first `advance()` and materializes every ready round-robin fixture into a real propose/accept `Match` in one stroke — `in_progress`, `best_of ← length_games`, `affects_rating ← rated`, `team_size=1`, **side 1 ← entry_a / side 2 ← entry_b**, linked via `fixture.match_id` (idempotent on it).
- **Singles-only**, refused cleanly at draw-cut.
- **Account-merge collision on a played event** withdraws the guest's duplicate entry (preserving its fixtures/matches) and routes the exposed self-play matches through the existing ADR-0013 transfer-then-void path — closing the case ADR-0786 explicitly parked for #788.

## #789 — Result feedback advances / computes standings
- A single **`finalize_match()`** completion tail funnels **both** completion paths (rated accept/retire, and unrated immediate self-accept) → records `winner_entry_id`, runs `advance()`. One mechanism, both rated and unrated move the draw.
- An event's **results are a separate per-draw-type strategy family** (`results_for`, mirroring `strategy_for`), pure and fed **live match-outcome value objects**. `RoundRobinResults` computes pool **standings** (extensible chain: wins → 2-way head-to-head → game difference → games won), completeness, and **champion** — all derived live from the fixtures' completed matches, so a **correction or void is reflected at once** with no snapshot.
- Surfaced in the tournament-detail **BFF**; the standings table renders live.

## Design
- **ADR-0788** (`docs/adr/`) records the C-slice decisions and where they refine ADR-0786; `CONTEXT.md` gains the **Materialize / Results / Standings / Champion** glossary terms.
- Derivable-state cleanups from `/simplify`: `game_difference` is a Pydantic `@computed_field`, `MatchOutcome.winner_entry_id` is derived from the game counts, and the results-projection guard is a checked `match`/`assert_never` dispatch.

## Testing
- **API:** `ruff` + `ruff format --check` + `mypy --strict` clean; **`pytest` 1173 passed** (new `test_results.py` incl. a two-way head-to-head tiebreak and a three-way-cycle fall-through; Slice-1/2 integration covering both completion paths, correction re-order, and the played-event merge collision).
- **Web:** `tsc` + `eslint` clean; **vitest 2524 passed**; **Playwright tournament e2e 80 passed** (MSW off).
- **iOS:** clean `xcodebuild` **BUILD SUCCEEDED** (regenerated `Types.swift` compiles).
- **OpenAPI:** `schema.d.ts` + `ios/…/Types.swift` regenerated and in sync.
- Root composed-stack `e2e/` not run (stack not up; feature covered by pytest + web e2e).

Closes #788
Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)