### PR TITLE
Run the tournament: fixture placement + Schedule tab, spectator view, lifecycle e2e (#790, #791, #792)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -468,6 +468,43 @@ the champion is always read from the current results.
 _Avoid_: winner (a **winner** is one side of one match; the champion is the whole
 event's), first place.
 
+**Schedule**:
+Where and when a tournament's **matches** are played: the assignment of each
+**match** to a **table** and a **wall-clock time**, within the reserved window of its
+**pool** (or, for an un-pooled draw, its event). It is **tournament-scoped, not
+per-event** — the venue's tables are shared across events, so "two matches on one
+table at once" is a cross-event fact — which is why it is its own surface rather than
+a panel inside a single event's draw. A **placement** is written two ways that touch
+the same fields: a director **places** a match by hand, and (a later slice) a
+**scheduler** auto-packs the unplayed remainder and **recomputes it repeatedly** as
+the tournament runs. A match with no table/time is **unassigned**.
+_Avoid_: draw (the *pairings* are the draw; the schedule is *when they are played*),
+slot (a **Slot** is a pool's reserved time window — an input to the schedule, not the
+schedule itself), bracket.
+
+**Placement**:
+One match's spot in the **schedule**: a **table** and a **predicted start time**. It
+lives on the **fixture** (not the match), so it can be set before the match even
+exists and survives **materialization**. The time is a real moment but a **prediction,
+not a promise** — a match beginning earlier or later than its placement is normal, not
+an error. It is stored as a **naive local timestamp** in the venue's wall-clock frame —
+the *same* frame as a pool's **Slot** window (also naive), so "is this placement inside
+its window" is a plain comparison; matching Slot's frame is why it is not `timestamptz`
+(that would need a venue timezone this domain does not model, and a Slot migration to
+match). Its constraints (table belongs to the pool, time inside the window, no table or
+player double-booked) are **not invariants** and never hard-block: a pool's tables and
+window even stay editable under a standing draw, stranding placements a later edit
+outranges. They are judged as **flags derived on read**, never silently rewritten.
+_Avoid_: schedule slot, booking, appointment, start time (it is a *predicted* start).
+
+**Pinned / free** (scheduler-era):
+Once the **scheduler** exists, a **placement** is **free** — the solver may move it —
+unless **pinned**: **started** (`in_progress`/`completed`, its table and time now
+history) or **manually placed** by a director. The solver holds pinned placements fixed
+and packs the free ones around them. Before the scheduler, every placement is a manual
+one and the distinction is dormant.
+_Avoid_: locked (reserve for other domains), fixed (ambiguous with a *fixture*).
+
 ## Dashboard
 
 **First-match**:

--- a/api/app/models/tournament_fixture.py
+++ b/api/app/models/tournament_fixture.py
@@ -144,6 +144,21 @@ class TournamentFixture(Base):
         ForeignKey("matches.id", ondelete="SET NULL"),
         nullable=True,
     )
+    #: A **placement**'s table: a *string ref* into the tournament's
+    #: ``table_catalogue`` JSONB (names a ``TournamentTable.id``), the same string-ref
+    #: pattern as ``pool_id`` — deliberately not a foreign key, there is no tables
+    #: table. ``NULL`` = unassigned. ``(table_id, scheduled_start) = (NULL, NULL)``
+    #: means the fixture is unplaced (ADR-0790).
+    table_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    #: A **placement**'s predicted start — a **naive** wall-clock timestamp
+    #: (``TIMESTAMP WITHOUT TIME ZONE``), a *deliberate* exemption from the "datetimes
+    #: are always timezone-aware" rule (ADR-0790). It is checked against a pool's
+    #: ``Slot`` window, which is itself stored as naive wall-clock; matching that frame
+    #: is the whole point, so do NOT "fix" this to ``timezone=True``. ``NULL`` =
+    #: unassigned.
+    scheduled_start: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=False), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -508,6 +508,14 @@ class TournamentFixtureRead(BaseModel):
       un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
       set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
       JSONB, not a foreign key, because pools are value-objects with no table.
+    * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means
+      **unassigned to a table**. When set, it names a ``TournamentTable`` in the
+      tournament's ``table_catalogue`` — a string ref into JSONB, not a foreign key,
+      the same pattern as ``pool_id``.
+    * ``scheduled_start`` — the placement's **predicted** start (ADR-0790): ``null``
+      means **unscheduled**. It is a *naive* wall-clock timestamp (no timezone), in the
+      venue's frame, a prediction rather than a commitment — a match starting
+      off-prediction is normal, not an error.
 
     The entries are carried as **ids only**. The name and username behind
     ``entry_a_id`` are already on this page — the event's ``entrants`` list carries
@@ -530,6 +538,10 @@ class TournamentFixtureRead(BaseModel):
     # Read from the match row on every load (never snapshotted), so it tracks the match
     # as it is played rather than freezing at go-live. See ``match_id`` above.
     match_status: MatchStatus | None
+    # A placement (ADR-0790). ``table_id`` string-refs the tournament's table_catalogue;
+    # ``scheduled_start`` is a naive wall-clock prediction. Both ``null`` = unassigned.
+    table_id: str | None
+    scheduled_start: datetime | None
 
 
 class StandingRowRead(BaseModel):
@@ -907,3 +919,63 @@ class TournamentEventUpdate(BaseModel):
         if value is None:
             raise ValueError("must not be null")
         return value
+
+
+def _naive_wall_clock(value: datetime) -> datetime:
+    """A placement's ``scheduled_start`` is a **naive** wall-clock timestamp, in the
+    venue's local frame (ADR-0790), stored in a ``TIMESTAMP WITHOUT TIME ZONE`` column
+    — a deliberate exemption from the "datetimes are always timezone-aware" rule,
+    because it is checked against a pool's ``Slot`` window, which is itself naive
+    wall-clock.
+
+    An offset-**aware** datetime carries a timezone this domain does not model, and
+    asyncpg cannot bind one to a ``timestamp without time zone`` parameter — so it is
+    refused *here*, at the boundary (422), rather than reaching the driver as a 500.
+    Same reasoning as the fee/player-limit bounds above: a boundary that admits what
+    the column cannot hold is not a boundary. This is a representational floor, not one
+    of the *soft* placement constraints (table-in-pool, time-in-window, no
+    double-booking) ADR-0790 keeps off the write path — those still save.
+    """
+    if value.tzinfo is not None:
+        raise ValueError(
+            "scheduled_start is a naive wall-clock time (no timezone), in the venue's "
+            "local frame."
+        )
+    return value
+
+
+PlacementStart = Annotated[datetime, AfterValidator(_naive_wall_clock)]
+"""A placement's predicted start: a naive wall-clock ``datetime`` (ADR-0790). The
+``AfterValidator`` refuses an offset-aware value (422) rather than let it 500 in the
+driver against the naive column; it contributes nothing to the JSON schema, exactly like
+``_fits_the_fee_column``."""
+
+
+class TournamentFixturePlacementUpdate(BaseModel):
+    """A fixture's **placement** (ADR-0790): the table it sits at and its predicted
+    start.
+
+    The body is the placement in full — both fields are stated together. ``null`` on
+    either clears that half, and ``(null, null)`` unassigns the fixture entirely.
+
+    **Soft, deliberately.** ``scheduled_start`` is a *prediction*, not a commitment,
+    and the placement's constraints — the table belongs to the fixture's pool, the time
+    falls inside the pool's window, nothing is double-booked — are **flags derived on
+    read, not invariants** (ADR-0790). So this write does **not** reject an
+    out-of-window time, nor a ``table_id`` that names no table in the tournament's
+    ``table_catalogue`` (a later pool/catalogue edit can dangle the ref; that is a
+    flag-on-read concern). They save. Conflict detection is a future scheduler slice.
+
+    ``table_id`` is a **string ref** into the tournament's ``table_catalogue`` (names a
+    ``TournamentTable.id``) — the same pattern as a fixture's ``pool_id``, not a
+    foreign key — and per the soft rule above an unknown id is stored, not refused.
+
+    The one thing the *route* refuses is moving a fixture whose linked match is
+    ``completed`` or ``voided``: its placement is history (409). A fixture with no match
+    yet, or an ``in_progress`` one, is freely (re)placeable.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    table_id: str | None
+    scheduled_start: PlacementStart | None

--- a/api/app/tournament_queries.py
+++ b/api/app/tournament_queries.py
@@ -197,6 +197,8 @@ async def fixtures_by_event(
                 winner_entry_id=fixture.winner_entry_id,
                 match_id=fixture.match_id,
                 match_status=match_status,
+                table_id=fixture.table_id,
+                scheduled_start=fixture.scheduled_start,
             )
         )
     return fixtures

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -2558,15 +2558,26 @@ async def place_fixture(
     Owner-only, like every other tournament mutation: an absent tournament, or a fixture
     that is not part of it, is a `404`; a non-owner is a `403`.
     """
-    # 404 → 403 → 409, the ordering ADR-0017 fixed for this whole module. The
-    # owner-scoped loader welds the 404 (tournament absent) to the 403 (not the
-    # caller's), before the fixture — let alone its placement state — is looked at, so a
-    # stranger probing ids learns nothing. No row lock: this route reads no tournament
-    # *status*, and the one state it judges (is the fixture's match history?) is a fact
-    # about the MATCH row, which the tournament lock would not serialize anyway — so
-    # locking here would queue writers for no protection. The non-locking owner loader
-    # is the right one, as for ``delete_tournament`` and ``create_event``.
-    await _get_owned_tournament_or_404(db, tournament_id, current_user)
+    # 404 → 403 → 409, the ordering ADR-0017 fixed for this whole module. The locked
+    # loader welds the 404 (tournament absent) to the row lock; ``_require_owner`` then
+    # adds the 403 (not the caller's), before the fixture — let alone its placement
+    # state — is looked at, so a stranger probing ids learns nothing.
+    #
+    # It takes the row lock, like the other fixture-writers, because this route WRITES
+    # ``TournamentFixture`` rows, and ``cut_draw``/``uncut_draw`` delete-and-replace an
+    # event's fixtures wholesale under this same tournament lock (``uncut_draw`` also
+    # runs cross-actor from ``account_merge``'s un-cut of a collided entrant's events).
+    # Without the lock, that DELETE can commit between this route's fixture SELECT and
+    # its flush, so the UPDATE matches zero rows and SQLAlchemy raises a
+    # ``StaleDataError`` — an unhandled 500. Holding the lock first serializes the whole
+    # read-judge-write against a concurrent cut/uncut of the same event. It does NOT
+    # save the placement from a re-cut that wins the lock: that placement is discarded,
+    # the accepted ADR-0790 consequence. What the lock buys is a *clean* outcome — the
+    # placement is made and then discarded by the re-cut, or the fixture is already gone
+    # and this answers a 404 — never a 500. Same lock, same row, taken first, as the
+    # transition, entry, and draw routes: one lock, one order, so no pair can deadlock.
+    tournament = await _get_tournament_for_update_or_404(db, tournament_id)
+    _require_owner(tournament, current_user)
     # The fixture, scoped to this tournament (a mismatched pair is a 404), and its
     # match's live status — the single fact the freeze judges.
     fixture, match_status = await _get_fixture_or_404(db, tournament_id, fixture_id)

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -20,11 +20,13 @@ from app.leagues import resolve_league
 from app.models import (
     DrawType,
     EventFormat,
+    Match,
     MatchStatus,
     Tournament,
     TournamentEntry,
     TournamentEntryStatus,
     TournamentEvent,
+    TournamentFixture,
     TournamentStatus,
     User,
 )
@@ -45,6 +47,7 @@ from app.schemas.tournament import (
     TournamentEventCreate,
     TournamentEventRead,
     TournamentEventUpdate,
+    TournamentFixturePlacementUpdate,
     TournamentFixtureRead,
     TournamentRead,
     TournamentTransitionCreate,
@@ -2433,3 +2436,150 @@ async def uncut_event_draw(
     await uncut_draw(db, [event.id])
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ----- fixture placement (ADR-0790) -----------------------------------------
+#
+# A placement is two nullable columns on a fixture — ``table_id`` (a string ref into
+# the tournament's ``table_catalogue``) and ``scheduled_start`` (a naive, predicted
+# wall-clock time). A human PATCHes them here; a future scheduler slice writes the same
+# two fields. The placement RIDES the tournament-detail BFF on read (2a put the fields
+# on ``TournamentFixtureRead``), so there is deliberately no ``GET …/placement``.
+#
+# The write is **soft**: the placement's constraints (table-in-pool, time-in-window, no
+# double-booking) are flags derived on read, NOT invariants (ADR-0790), so this route
+# stores an out-of-window time and an unknown ``table_id`` without complaint. Its one
+# hard rule is the freeze below.
+
+
+async def _get_fixture_or_404(
+    db: AsyncSession, tournament_id: uuid.UUID, fixture_id: uuid.UUID
+) -> tuple[TournamentFixture, MatchStatus | None]:
+    """The fixture named in the URL, scoped to the tournament, plus its linked match's
+    live status (``None`` when the fixture has not materialized).
+
+    Scoped by BOTH ids — fixture → event → tournament — so a fixture that exists but
+    hangs off a *different* tournament is a 404, not a cross-tournament placement,
+    exactly the way ``_get_event_or_404`` scopes an event by its tournament and
+    ``_get_entry_or_404`` an entry by its event. A well-formed id that names no
+    addressable fixture is a 404.
+
+    The match status rides on the same statement (a LEFT join on ``match_id``, one row
+    per fixture) because it is the single fact the freeze rule judges (ADR-0790): a
+    fixture whose match is ``completed``/``voided`` is history and can no longer be
+    moved. Reading it here, at the load, keeps the judgment on the same read as the row
+    it judges.
+    """
+    row = (
+        await db.execute(
+            select(TournamentFixture, Match.status)
+            .join(TournamentEvent, TournamentEvent.id == TournamentFixture.event_id)
+            .outerjoin(Match, Match.id == TournamentFixture.match_id)
+            .where(
+                TournamentFixture.id == fixture_id,
+                TournamentEvent.tournament_id == tournament_id,
+            )
+        )
+    ).one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Fixture not found.")
+    fixture, match_status = row
+    return fixture, match_status
+
+
+def _enforce_fixture_placeable(match_status: MatchStatus | None) -> None:
+    """Raise the 409 unless this fixture may still be (re)placed — the ONE hard rule of
+    an otherwise-soft endpoint (ADR-0790).
+
+    A fixture whose linked match is ``completed`` or ``voided`` is **history**: its
+    placement records where and when the match actually happened, so the move is
+    refused. A fixture with no match yet (``None``) or a ``pending``/``in_progress`` one
+    is freely (re)placeable — every round-robin match is ``in_progress`` from go-live,
+    so ``in_progress`` is emphatically **not** the freeze trigger; the plan for an
+    unplayed-but-live match is exactly the thing a scheduler moves. Only
+    ``completed``/``voided`` freezes.
+
+    409, not 403 (this module's refusal-code doctrine, ADR-0017): the caller is the
+    owner and the request is well-formed — it is the *fixture* that is past the point
+    where a placement means anything. "Not you" would be a lie; the truth is "not any
+    more".
+
+    A ``match`` with ``assert_never``, not an ``in {completed, voided}`` test: a new
+    ``MatchStatus`` is a type error here until somebody decides whether a fixture in it
+    may be moved, rather than falling through to placeable — a freeze must never fail in
+    the permissive direction.
+    """
+    match match_status:
+        case MatchStatus.completed | MatchStatus.voided:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"This fixture's match is already {match_status.value}, so its "
+                    "placement can no longer be changed."
+                ),
+            )
+        case MatchStatus.pending | MatchStatus.in_progress | None:
+            return
+        case _:
+            assert_never(match_status)
+
+
+@router.patch(
+    "/tournaments/{tournament_id}/fixtures/{fixture_id}/placement",
+    response_model=TournamentFixtureRead,
+)
+async def place_fixture(
+    tournament_id: uuid.UUID,
+    fixture_id: uuid.UUID,
+    payload: TournamentFixturePlacementUpdate,
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> TournamentFixtureRead:
+    """Set (or clear) a fixture's **placement** — its table and its predicted start
+    (ADR-0790) — and answer with the updated fixture.
+
+    The body is the placement in full: `table_id` (a string ref into the tournament's
+    `table_catalogue`) and `scheduled_start` (a **naive** wall-clock time, in the
+    venue's local frame — an offset-aware value is a `422`). `null` on either clears
+    that half; `(null, null)` unassigns the fixture.
+
+    **The placement is soft.** `scheduled_start` is a *prediction*, and the placement's
+    constraints — the table belongs to the fixture's pool, the time falls inside the
+    pool's window, nothing is double-booked — are flags derived on read, **not**
+    invariants. So an out-of-window time, or a `table_id` that names no table in the
+    catalogue, is **stored, not rejected**. There is no conflict detection here; that is
+    a future scheduler slice.
+
+    **The one hard rule:** a fixture whose linked match is `completed` or `voided` is
+    history, so its placement can no longer be changed — a `409`. A fixture with no
+    match yet, or an `in_progress` one, is freely (re)placeable (every round-robin match
+    is `in_progress` from go-live, so that is not the freeze trigger).
+
+    Owner-only, like every other tournament mutation: an absent tournament, or a fixture
+    that is not part of it, is a `404`; a non-owner is a `403`.
+    """
+    # 404 → 403 → 409, the ordering ADR-0017 fixed for this whole module. The
+    # owner-scoped loader welds the 404 (tournament absent) to the 403 (not the
+    # caller's), before the fixture — let alone its placement state — is looked at, so a
+    # stranger probing ids learns nothing. No row lock: this route reads no tournament
+    # *status*, and the one state it judges (is the fixture's match history?) is a fact
+    # about the MATCH row, which the tournament lock would not serialize anyway — so
+    # locking here would queue writers for no protection. The non-locking owner loader
+    # is the right one, as for ``delete_tournament`` and ``create_event``.
+    await _get_owned_tournament_or_404(db, tournament_id, current_user)
+    # The fixture, scoped to this tournament (a mismatched pair is a 404), and its
+    # match's live status — the single fact the freeze judges.
+    fixture, match_status = await _get_fixture_or_404(db, tournament_id, fixture_id)
+    # The one hard rule, before anything is written: a played-out fixture keeps its
+    # placement. Everything else — an odd time, a dangling table ref — saves.
+    _enforce_fixture_placeable(match_status)
+    fixture.table_id = payload.table_id
+    fixture.scheduled_start = payload.scheduled_start
+    await db.commit()
+    # Read back through the SAME loader the detail page reads fixtures through, so the
+    # placed fixture this answers with is byte-for-byte the one the page will show —
+    # ``match_status`` live (not the value the freeze just judged, which was a means to
+    # an end), same read model. The fixture is in the batch we just committed, so the
+    # lookup always finds it.
+    fixtures = (await fixtures_by_event(db, [fixture.event_id]))[fixture.event_id]
+    return next(f for f in fixtures if f.id == fixture.id)

--- a/api/migrations/versions/20260712_0000_0012_create_tournament_fixtures_table.py
+++ b/api/migrations/versions/20260712_0000_0012_create_tournament_fixtures_table.py
@@ -84,6 +84,16 @@ def upgrade() -> None:
             sa.ForeignKey("matches.id", ondelete="SET NULL"),
             nullable=True,
         ),
+        # A *placement* (ADR-0790). ``table_id`` is a string ref into the tournament's
+        # ``table_catalogue`` JSONB (a ``TournamentTable.id``), the same pattern as
+        # ``pool_id`` — NOT a foreign key, there is no tables table. NULL = unassigned.
+        sa.Column("table_id", sa.Text(), nullable=True),
+        # ``scheduled_start`` is a placement's predicted start — a NAIVE wall-clock
+        # timestamp (TIMESTAMP WITHOUT TIME ZONE), a DELIBERATE exemption from the
+        # "datetimes are always timezone-aware" rule (ADR-0790): it is checked against a
+        # pool's Slot window, which is itself stored as naive wall-clock, and matching
+        # that frame is the point. Do NOT "fix" this to timezone=True. NULL = unassigned.
+        sa.Column("scheduled_start", sa.DateTime(timezone=False), nullable=True),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -3692,7 +3692,9 @@ async def test_a_tbd_side_comes_back_as_null_rather_than_a_missing_key(
     same fact.
 
     ``winner_entry_id``, ``match_id`` and ``match_status`` are the same story —
-    undecided, not yet a match, so no live match status. The exact key set is asserted,
+    undecided, not yet a match, so no live match status. ``table_id`` and
+    ``scheduled_start`` are the fixture's **placement** (ADR-0790), both ``null`` on a
+    freshly-cut draw: unassigned to a table, unscheduled. The exact key set is asserted,
     so a field silently dropped (or a username silently *added*) fails here.
     """
     client, _ = authed_client
@@ -3716,6 +3718,8 @@ async def test_a_tbd_side_comes_back_as_null_rather_than_a_missing_key(
         "winner_entry_id",
         "match_id",
         "match_status",
+        "table_id",
+        "scheduled_start",
     }
     assert fixture["entry_a_id"] == str(entry.id)
     # The facts that are not known yet — each present, each null.
@@ -3723,6 +3727,9 @@ async def test_a_tbd_side_comes_back_as_null_rather_than_a_missing_key(
     assert fixture["winner_entry_id"] is None
     assert fixture["match_id"] is None
     assert fixture["match_status"] is None
+    # A freshly-cut draw carries an unassigned placement: no table, no predicted start.
+    assert fixture["table_id"] is None
+    assert fixture["scheduled_start"] is None
 
 
 async def test_a_fixtures_sides_are_entry_ids_the_events_entrants_list_resolves(
@@ -6340,3 +6347,264 @@ async def test_the_list_endpoint_does_not_ship_standings(
     (listed,) = [t for t in listing if t["id"] == tournament_id]
     (listed_event,) = listed["events"]
     assert listed_event["results"] is None
+
+
+# ----- fixture placement (ADR-0790) -----------------------------------------
+
+
+def _placement_url(tournament_id: str, fixture_id: str) -> str:
+    return f"/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement"
+
+
+async def _fixture_in_detail(
+    client: AsyncClient, tournament_id: str, fixture_id: str
+) -> dict[str, Any]:
+    """The one fixture, as the tournament-detail BFF carries it — the surface a client
+    reads a placement off (ADR-0790 adds no ``GET …/placement``), so an assertion made
+    here proves the placement is on the page a client actually loads."""
+    detail = (await client.get(f"/v1/tournaments/{tournament_id}")).json()
+    for event in detail["events"]:
+        for fixture in event["fixtures"]:
+            if fixture["id"] == fixture_id:
+                return fixture
+    raise AssertionError(f"fixture {fixture_id} is not on the detail payload")
+
+
+async def _drawn_fixture(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    *,
+    prefix: str = "pl",
+    **tournament: Any,
+) -> tuple[str, str, TournamentFixture]:
+    """A one-pool round-robin over three players, cut through the real route, and the
+    first of the fixtures it produced — the smallest field that gives a placeable slot.
+
+    ``prefix`` names the seeded players, so two draws in one test don't collide on
+    usernames (``make_user`` mints one real ``User`` per name)."""
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A), **tournament
+    )
+    await _seed_field(db_session, event["id"], 3, prefix=prefix)
+    await _cut_the_draw(client, tournament_id, event["id"])
+    fixture, *_ = await _fixture_rows(db_session, event["id"])
+    return tournament_id, event["id"], fixture
+
+
+async def test_owner_sets_a_fixture_placement_and_the_detail_reflects_it(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The owner assigns a fixture a table and a predicted start; the PATCH echoes them,
+    and re-reading the tournament detail shows them on the fixture (ADR-0790 — placement
+    rides the detail BFF, so this is where a client sees it)."""
+    client, _ = authed_client
+    tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+
+    response = await client.patch(
+        _placement_url(tournament_id, str(fixture.id)),
+        json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == str(fixture.id)
+    assert body["table_id"] == "t1"
+    assert body["scheduled_start"] == "2026-06-13T10:00:00"
+
+    placed = await _fixture_in_detail(client, tournament_id, str(fixture.id))
+    assert placed["table_id"] == "t1"
+    assert placed["scheduled_start"] == "2026-06-13T10:00:00"
+
+
+async def test_owner_clears_a_fixture_placement_back_to_null(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """``(null, null)`` unassigns a fixture (ADR-0790). The owner places it, then clears
+    both halves; the detail shows an unplaced fixture again."""
+    client, _ = authed_client
+    tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    url = _placement_url(tournament_id, str(fixture.id))
+    await client.patch(
+        url, json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"}
+    )
+
+    response = await client.patch(url, json={"table_id": None, "scheduled_start": None})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["table_id"] is None
+    assert body["scheduled_start"] is None
+
+    placed = await _fixture_in_detail(client, tournament_id, str(fixture.id))
+    assert placed["table_id"] is None
+    assert placed["scheduled_start"] is None
+
+
+async def test_a_non_owner_cannot_place_a_fixture(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Placement is a property of OWNING the tournament, like every other tournament
+    mutation — no permission grants it. A fully-permitted stranger gets a 403, and the
+    fixture is left unplaced."""
+    owner_client, _ = authed_client
+    tournament_id, _event_id, fixture = await _drawn_fixture(owner_client, db_session)
+
+    async with make_client() as stranger:
+        user = await start_session(stranger, db_session)
+        await _grant_tournament_perms(db_session, user)
+        response = await stranger.patch(
+            _placement_url(tournament_id, str(fixture.id)),
+            json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"},
+        )
+        assert response.status_code == 403
+
+    placed = await _fixture_in_detail(owner_client, tournament_id, str(fixture.id))
+    assert placed["table_id"] is None
+    assert placed["scheduled_start"] is None
+
+
+@pytest.mark.parametrize(
+    "table_id",
+    [
+        pytest.param("t2", id="off-pool"),  # in the catalogue, but not in Pool A
+        pytest.param("ghost-table", id="not-in-catalogue"),  # names no table at all
+    ],
+)
+async def test_an_out_of_window_or_off_pool_placement_still_saves(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    table_id: str,
+) -> None:
+    """The placement is **soft** (ADR-0790): ``scheduled_start`` is a prediction, and
+    the constraints (table-in-pool, time-in-window, no double-booking) are flags on
+    read, not invariants — so the write does not reject them. Pool A reserves ``t1`` for
+    09:00–12:30; a table off the pool (or naming nothing in the catalogue at all) and a
+    23:00 start both **save** rather than 4xx. Conflict detection is a later slice."""
+    client, _ = authed_client
+    tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+
+    response = await client.patch(
+        _placement_url(tournament_id, str(fixture.id)),
+        json={"table_id": table_id, "scheduled_start": "2026-06-13T23:00:00"},
+    )
+
+    assert 200 <= response.status_code < 300, response.text
+    body = response.json()
+    assert body["table_id"] == table_id
+    assert body["scheduled_start"] == "2026-06-13T23:00:00"
+
+
+@pytest.mark.parametrize("frozen_status", [MatchStatus.completed, MatchStatus.voided])
+async def test_a_played_out_fixture_refuses_a_placement_move(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    default_league: League,
+    frozen_status: MatchStatus,
+) -> None:
+    """The ONE hard rule (ADR-0790): a fixture whose linked match is ``completed`` or
+    ``voided`` is history, so its placement can no longer be changed — a 409, and the
+    existing placement is left exactly as it was.
+
+    The fixture is placed while it is still just a plan, its match then becomes
+    history, and an attempt to move it to a different table/time is refused — proving
+    both the 409 and that the historical placement survives the refusal."""
+    client, owner = authed_client
+    tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    url = _placement_url(tournament_id, str(fixture.id))
+    await client.patch(
+        url, json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"}
+    )
+
+    match = await _make_match(db_session, owner, default_league)
+    match.status = frozen_status
+    fixture.match_id = match.id
+    await db_session.commit()
+
+    response = await client.patch(
+        url, json={"table_id": "t2", "scheduled_start": "2026-06-13T14:00:00"}
+    )
+
+    assert response.status_code == 409, response.text
+    assert frozen_status.value in response.json()["detail"]
+    # The move changed nothing: the placement recorded before the match went to history
+    # is the placement the fixture still carries.
+    placed = await _fixture_in_detail(client, tournament_id, str(fixture.id))
+    assert placed["table_id"] == "t1"
+    assert placed["scheduled_start"] == "2026-06-13T10:00:00"
+
+
+async def test_an_in_progress_fixture_is_freely_placeable(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """``in_progress`` is NOT the freeze trigger (ADR-0790): every round-robin match is
+    ``in_progress`` from go-live, and its plan is exactly what a scheduler moves. Only
+    ``completed``/``voided`` freezes, so a live-match fixture still (re)places."""
+    client, owner = authed_client
+    tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    match = await _make_match(db_session, owner, default_league)
+    match.status = MatchStatus.in_progress
+    fixture.match_id = match.id
+    await db_session.commit()
+
+    response = await client.patch(
+        _placement_url(tournament_id, str(fixture.id)),
+        json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["table_id"] == "t1"
+
+
+async def test_an_offset_aware_start_is_a_422(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """``scheduled_start`` is a naive wall-clock time (ADR-0790). An offset-aware value
+    carries a timezone the domain does not model and the ``TIMESTAMP WITHOUT TIME
+    ZONE`` column cannot hold, so it is refused at the boundary (422) rather than
+    500-ing in the driver — the same discipline the fee/player-limit bounds keep."""
+    client, _ = authed_client
+    tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+
+    response = await client.patch(
+        _placement_url(tournament_id, str(fixture.id)),
+        json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00Z"},
+    )
+
+    assert response.status_code == 422, response.text
+
+
+async def test_placement_404s_for_a_fixture_not_under_the_named_tournament(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The fixture is scoped by BOTH ids: a fixture that names nothing, or one belonging
+    to a *different* tournament, is a 404 — not a cross-tournament placement — the same
+    way an event or an entry is scoped to its parent."""
+    client, _ = authed_client
+    tournament_id, _event_id, _fixture = await _drawn_fixture(client, db_session)
+    other_id, _other_event, foreign = await _drawn_fixture(
+        client, db_session, prefix="ot", name="Other Open"
+    )
+
+    # A fixture id that names nothing at all.
+    assert (
+        await client.patch(
+            _placement_url(tournament_id, str(uuid.uuid4())),
+            json={"table_id": None, "scheduled_start": None},
+        )
+    ).status_code == 404
+    # A real fixture, but of the OTHER tournament, addressed through this one.
+    assert (
+        await client.patch(
+            _placement_url(tournament_id, str(foreign.id)),
+            json={"table_id": None, "scheduled_start": None},
+        )
+    ).status_code == 404
+    # The foreign fixture is untouched under its own tournament.
+    assert other_id != tournament_id

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -52,9 +52,10 @@ from app.schemas.tournament import (
     EventEntryFull,
     EventEntryRatingIneligible,
     TournamentEventUpdate,
+    TournamentFixturePlacementUpdate,
     TournamentTransitionCreate,
 )
-from app.tournament_draws import DrawCurrency, draw_currency_by_event
+from app.tournament_draws import DrawCurrency, draw_currency_by_event, uncut_draw
 from app.tournament_entry_refusals import EntryRefusal
 from app.tournament_materialization import materialize_live_draw
 from app.tournaments import (
@@ -66,6 +67,7 @@ from app.tournaments import (
     cut_event_draw,
     get_tournament,
     list_tournaments,
+    place_fixture,
     uncut_event_draw,
     update_event,
 )
@@ -4822,6 +4824,87 @@ async def test_both_draw_verbs_take_the_tournaments_row_lock(
             current_user=User(id=owner_id),
         )
     assert any("FOR UPDATE" in s for s in statements), statements
+
+
+async def test_place_fixture_blocks_on_a_concurrent_uncut_then_404s_the_gone_fixture(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+) -> None:
+    """Placing a fixture takes the tournament's row lock **before** it reads the
+    fixture, so a concurrent un-cut of the same event that deletes it cannot slip
+    between the read and the ``UPDATE`` — the caller gets a clean 404, never a 500.
+
+    ``place_fixture`` *writes* a ``TournamentFixture`` row, and ``uncut_draw`` (the
+    account-merge un-cut, and every re-cut) delete-and-replaces an event's fixtures
+    wholesale under that same lock. A gatekeeper holds the tournament's row lock, its
+    DELETE of the event's fixtures already issued but **uncommitted** — the instant the
+    race lives in. The owner presses *place*, and it *blocks*, because the route reads
+    that row ``FOR UPDATE`` before it looks at the fixture (the ``done()`` check catches
+    it if it does not). When the un-cut commits, place's lock is granted, it re-reads
+    against the committed state, finds the fixture gone, and answers 404.
+
+    Without the lock (the reintroduced ``9692872``/#782 bug) place would read the
+    fixture from its own snapshot — still there — set the placement, and then block on
+    the *fixture* row lock the uncommitted DELETE holds. When the DELETE commits its
+    ``UPDATE`` would match zero rows, and SQLAlchemy would raise ``StaleDataError`` — an
+    unhandled 500 rather than a 404. That path raises straight out of ``place`` here (it
+    catches only ``HTTPException``), reddening the test. The lock is the whole
+    mechanism, and this is the test that says so.
+    """
+    client, owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _event_payload())
+    ada = await make_user(db_session, "ada-placed")
+    entry = await _enter(db_session, event["id"], ada)
+    fixture = await _cut(
+        db_session, event["id"], pool_id="p-a", round=1, position=1, entry_a=entry
+    )
+
+    tournament_uuid = uuid.UUID(tournament_id)
+    event_uuid = uuid.UUID(event["id"])
+    fixture_id, owner_id = fixture.id, owner.id
+    make_session = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def place() -> int:
+        async with make_session() as session:
+            actor = (
+                await session.execute(select(User).where(User.id == owner_id))
+            ).scalar_one()
+            payload = TournamentFixturePlacementUpdate(
+                table_id="t1", scheduled_start=None
+            )
+            try:
+                await place_fixture(
+                    tournament_uuid, fixture_id, payload, session, actor
+                )
+                return 200
+            except HTTPException as exc:
+                return exc.status_code
+
+    async with make_session() as gatekeeper:
+        # The un-cut's own shape: the tournament's row lock first, then the bulk DELETE
+        # of the event's fixtures — held open, uncommitted, exactly as a re-cut or an
+        # account-merge un-cut holds it mid-transaction.
+        await gatekeeper.execute(
+            select(Tournament).where(Tournament.id == tournament_uuid).with_for_update()
+        )
+        await uncut_draw(gatekeeper, [event_uuid])
+        placing = asyncio.create_task(place())
+        # Every chance to finish — and it cannot, because it is parked on the
+        # tournament's row lock, in the handler, before it has read the fixture at all.
+        await asyncio.sleep(0.25)
+        if placing.done():
+            pytest.fail(
+                "place_fixture did not block on the tournament's row lock: it ran to "
+                f"completion against an in-flight un-cut ({placing.result()!r})"
+            )
+        await gatekeeper.commit()
+        outcome = await placing
+
+    # A clean 404 for the now-deleted fixture — not a StaleDataError/500.
+    assert outcome == 404, outcome
+    async with make_session() as verify:
+        assert await _fixture_rows(verify, event["id"]) == []
 
 
 # ----- the pool-set freeze (409) --------------------------------------------

--- a/docs/adr/0790-a-placement-is-a-naive-predicted-time-on-the-fixture.md
+++ b/docs/adr/0790-a-placement-is-a-naive-predicted-time-on-the-fixture.md
@@ -1,0 +1,98 @@
+# 790. A placement is a naive, predicted start time on the fixture
+
+Date: 2026-07-14 (numbered by issue #790 — sequential numbers collide across
+concurrent worktrees, as the duplicate 0008s in this directory attest)
+
+## Status
+
+Accepted — design for slice D1 of epic #780 (#790), decided before
+implementation. The auto-packing **scheduler** it anticipates is a separate,
+later slice; this ADR fixes only the data model and the read-only surface D1
+ships.
+
+## Context
+
+The Schedule tab (`web-client/.../schedule-tab.tsx`) is a display-only mock: it
+draws each pool's reserved **Slot** window on a timeline and knows nothing of
+the real matches. #790 as originally written asks to "assign matches to tables +
+time slots" with manual assignment first and an auto-packer "optional later,"
+plus conflict flagging.
+
+Two facts reshaped that:
+
+- **The real intent is a CP-SAT scheduler that repeatedly re-packs the *unplayed*
+  remainder** as the tournament runs (the RQ `solver` queue, today only a
+  health-check stub). Manual placement is not a stopgap the solver replaces — it
+  is the **director override** the solver must respect. So the durable thing D1
+  must get right is the *placement datum and its semantics*, not a throwaway
+  hand-assignment UI.
+- **C1/C2 already ship the read side.** The detail BFF (`TournamentDetailRead`,
+  one-endpoint-per-page) already carries each event's `fixtures` (with `match_id`
+  + live `match_status`) and `results` (standings + champion), all Zod-parsed
+  client-side, and the Events tab already renders draws + standings. Every
+  materialized match is already visible.
+
+## Decision
+
+### The placement lives on the fixture, not the match
+
+A **placement** is two nullable columns on `tournament_fixtures`: `table_id` (a
+string-ref into the tournament's `table_catalogue`, the same pattern as
+`pool_id`) and a predicted start time. Not on `matches`: the match model is
+shared with all non-tournament play and must not grow tournament-only columns;
+and a placement can be set **before the match exists** (a round-robin fixture is
+known at the cut, before go-live materializes it) and must **survive
+materialization** — both of which the fixture, not the match, is the stable home
+for. A human PATCH and a future solver write the *same* fields.
+
+### The start time is a naive local timestamp, deliberately not `timestamptz`
+
+`scheduled_start` is a **naive** timestamp (`TIMESTAMP WITHOUT TIME ZONE`) in the
+venue's wall-clock frame. This is a deliberate deviation from
+`api/CLAUDE.md`'s "datetimes are always timezone-aware" rule — **do not "fix" it
+to `timestamptz`.** The placement is validated against its pool's **Slot**
+window, and a Slot is *already* naive wall-clock (`date`/`start`/`end` strings,
+per that schema's own exemption). A `timestamptz` placement checked against a
+naive Slot would need a **venue timezone that this domain does not model**, and
+keeping the two consistent would force migrating every Slot into the same frame.
+Matching one representation beats introducing a second. (Modelling a tournament
+timezone and moving both onto `timestamptz` is the more-correct long-term answer;
+it is a larger decision than D1 needs, and is left open.)
+
+An earlier draft split this into a bare time-of-day with the date inherited from
+the pool's Slot. Rejected: the time is a real moment (a *prediction* is still an
+instant, just a soft one), and the split forces date-inheritance at every read,
+breaks on multi-day placements, and turns overlap detection into date arithmetic.
+
+### The time is a prediction; constraints are flags, not invariants
+
+The start time forecasts when a match will begin — a match starting off-prediction
+is normal, not an error. The placement's rules (table belongs to the pool, time
+inside the window, no table or player double-booked) are **not durable
+invariants**: a pool's tables and window stay editable under a standing draw
+(ADR-0786's mutable venue attributes), so a later edit can strand a placement
+out-of-window or on a removed table. They are therefore judged as **flags derived
+on read**, never a silent rewrite of a director's work, and the PATCH never
+hard-blocks on them.
+
+### Scope boundaries
+
+- **D1 is model + a read-only, tournament-scoped Schedule grid.** The schedule is
+  tournament-scoped, not per-event, because tables are shared across events — a
+  same-table collision is a cross-event fact.
+- **Deferred to the scheduler slice:** the CP-SAT auto-packer, the **pinned/free**
+  distinction (its only consumer is the solver; D1's sole immovability rule —
+  "a started match cannot move" — derives from `match_status`), a per-match
+  **duration** estimate, and therefore meaningful **conflict flagging** (overlap
+  needs durations, which do not exist — `length_games` is the only signal).
+- **No new BFF:** placement rides the existing detail payload.
+
+## Consequences
+
+- A **re-cut** replaces fixtures wholesale (`delete-orphan`), and the
+  account-merge un-cut path does too, so both silently discard placements. Re-cut
+  is refused once there is evidence of *play*, but placements are not play — a
+  director who places matches and then re-cuts loses them without warning.
+- **D2** (the read-only spectator view) gets the schedule for free once these
+  fields ride the detail payload. **D3**'s lifecycle e2e does not depend on this
+  slice.

--- a/docs/adr/0790-a-placement-is-a-naive-predicted-time-on-the-fixture.md
+++ b/docs/adr/0790-a-placement-is-a-naive-predicted-time-on-the-fixture.md
@@ -7,8 +7,10 @@ concurrent worktrees, as the duplicate 0008s in this directory attest)
 
 Accepted — design for slice D1 of epic #780 (#790), decided before
 implementation. The auto-packing **scheduler** it anticipates is a separate,
-later slice; this ADR fixes only the data model and the read-only surface D1
-ships.
+later slice; this ADR fixes only the data model, the owner-only manual
+placement path (the PATCH + control), and the tournament-scoped Schedule grid
+D1 ships — the grid is read-only for a non-owner viewer, and the *solver* is
+deferred, but D1 is not itself read-only.
 
 ## Context
 
@@ -77,7 +79,9 @@ hard-blocks on them.
 
 ### Scope boundaries
 
-- **D1 is model + a read-only, tournament-scoped Schedule grid.** The schedule is
+- **D1 is model + the owner-only manual placement path + a tournament-scoped
+  Schedule grid** (read-only for a non-owner viewer; the owner gets the placement
+  control). The schedule is
   tournament-scoped, not per-event, because tables are shared across events — a
   same-table collision is a cross-event fact.
 - **Deferred to the scheduler slice:** the CP-SAT auto-packer, the **pinned/free**

--- a/e2e/page-objects/score-entry.page.ts
+++ b/e2e/page-objects/score-entry.page.ts
@@ -21,6 +21,24 @@ export class ScoreEntryPage {
     return new ScoreEntryPage(page)
   }
 
+  /** Open a game's *new* screen (no score yet) — how the winner of a freshly
+   * materialized tournament match records its result. */
+  static async navigateToNew(
+    page: Page,
+    matchId: string,
+    gameNumber: number,
+  ): Promise<ScoreEntryPage> {
+    await page.goto(`/matches/${matchId}/games/${gameNumber}/scores/new`)
+    return new ScoreEntryPage(page)
+  }
+
+  /** The submit button once the typed board decides the match: it swaps to
+   * finalize. On an **unrated** match this is "Finalize result" (an immediate
+   * self-accept), on a rated one "Post result" — matched loosely to cover both. */
+  get finalizeButton(): Locator {
+    return this.page.getByRole('button', { name: /Finalize result|Post result/ })
+  }
+
   /** A participant's numeric score input, by their username (its accessible
    * label is `"<username> score"`, see `score-pad-side.tsx`). */
   scoreInput(username: string): Locator {

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -1,0 +1,117 @@
+import { Locator, Page } from '@playwright/test'
+
+/**
+ * The tournament detail page (`/tournaments/$tournamentId`) — scoped to the
+ * lifecycle round-robin spec's load-bearing surfaces: the header's lifecycle
+ * button (Publish → Start tournament → End tournament, `LifecycleActions`), an
+ * event card's Enter control and draw panel (both on the default **Events** tab),
+ * the fixture's link into its materialized match, and the standings the completed
+ * event derives.
+ *
+ * Raw selectors stay here; the spec reads intent-named locators. Locators are
+ * user-facing (`getByRole`/`getByTestId`) and, where a page holds one per event,
+ * named by the event so the accessor resolves the right card.
+ */
+export class TournamentDetailPage {
+  constructor(private readonly page: Page) {}
+
+  /** Open a tournament's detail page and return the instance. The Events tab is
+   * the default, so no tab click is needed for the entry/draw/standings surfaces. */
+  static async navigateTo(
+    page: Page,
+    tournamentId: string,
+  ): Promise<TournamentDetailPage> {
+    await page.goto(`/tournaments/${tournamentId}`)
+    return new TournamentDetailPage(page)
+  }
+
+  /** Re-navigate to pick up server state changed out-of-band (a director-entry
+   * made over the API), returning to a freshly-loaded Events tab. */
+  async reload(tournamentId: string): Promise<void> {
+    await this.page.goto(`/tournaments/${tournamentId}`)
+  }
+
+  // ----- lifecycle (header) -------------------------------------------------
+
+  /** `draft → published`. Present only for the owner, only while `draft`. */
+  get publishButton(): Locator {
+    return this.page.getByRole('button', { name: 'Publish' })
+  }
+
+  /** `published → live` — the edge that materializes the draw into real matches. */
+  get startButton(): Locator {
+    return this.page.getByRole('button', { name: 'Start tournament' })
+  }
+
+  /** `live → archived`. Its appearance is how a spec confirms go-live landed —
+   * the tournament is now `live`, so this is the only edge it offers. */
+  get endButton(): Locator {
+    return this.page.getByRole('button', { name: 'End tournament' })
+  }
+
+  /** The inline `Alert` a refused transition raises (e.g. Start on a stale draw). */
+  get lifecycleNotice(): Locator {
+    return this.page.getByTestId('lifecycle-notice')
+  }
+
+  // ----- entry (event card) -------------------------------------------------
+
+  /** The self-registration **Enter** button on an event's card, by event name. */
+  enterButton(eventName: string): Locator {
+    return this.page.getByRole('button', { name: `Enter ${eventName}` })
+  }
+
+  /** The **Withdraw** button that replaces Enter once the signed-in player is in
+   * the event — a spec asserts on it to prove the self-entry landed. */
+  withdrawButton(eventName: string): Locator {
+    return this.page.getByRole('button', { name: `Withdraw from ${eventName}` })
+  }
+
+  /** The roster `<ul>` for an event, named "Entrants in <event>". */
+  entrantsList(eventName: string): Locator {
+    return this.page.getByRole('list', { name: `Entrants in ${eventName}` })
+  }
+
+  // ----- draw (event card) --------------------------------------------------
+
+  /** **Generate draw** — cuts an undrawn event's draw, by event name. */
+  generateDrawButton(eventName: string): Locator {
+    return this.page.getByRole('button', { name: `Generate draw for ${eventName}` })
+  }
+
+  /** The draw panel section for an event, scoping fixtures + the match link. */
+  drawPanel(eventId: string): Locator {
+    return this.page.getByTestId(`draw-panel-${eventId}`)
+  }
+
+  /** The "View match" deep-link a fixture grows once it materializes at go-live. */
+  viewMatchLink(eventId: string): Locator {
+    return this.drawPanel(eventId).getByRole('link', { name: /View match/ })
+  }
+
+  /** A materialized fixture's live match status ("In progress" → "Completed"). */
+  fixtureMatchStatus(eventId: string): Locator {
+    return this.drawPanel(eventId).getByTestId('fixture-match-status')
+  }
+
+  // ----- standings (event card) ---------------------------------------------
+
+  /** The event's standings section — present only once the round-robin has a
+   * cut draw (before that, `event.results` is null and nothing renders). */
+  standingsPanel(eventId: string): Locator {
+    return this.page.getByTestId(`standings-panel-${eventId}`)
+  }
+
+  /** The champion callout — shown only for a **complete, single-pool** event, so
+   * its presence *is* the "there is a rank-#1 champion" fact. Its text carries the
+   * champion's username. */
+  standingsChampion(eventId: string): Locator {
+    return this.page.getByTestId(`standings-champion-${eventId}`)
+  }
+
+  /** A pool's standings table, by pool id — its rows are in finishing order, so
+   * the first data row is rank 1. */
+  poolStandings(poolId: string): Locator {
+    return this.page.getByTestId(`pool-standings-${poolId}`)
+  }
+}

--- a/e2e/support/rbac-grant.ts
+++ b/e2e/support/rbac-grant.ts
@@ -1,0 +1,87 @@
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+// Grant an RBAC role to a minted user directly in Postgres, over the same
+// `docker compose … exec` seam `global-setup` owns the stack through.
+//
+// Why this exists: a guest/ephemeral user holds only the default `User` role,
+// which carries NO permissions. Creating, viewing, or entering a tournament is
+// gated on `tournament.create` / `tournament.view` / `tournament.enter`, and the
+// only role that bundles those — **"Beta tester"** (`api/scripts/seed_rbac.py`)
+// — is granted to NOBODY by the seed. So a spec that drives the tournament flow
+// as a real director has to hand its test user that role first, or every write
+// 403s. There is no HTTP endpoint to self-assign a role (`authorization.manage`
+// is itself an admin-only grant nobody holds), so the sanctioned seam is the
+// database, reached the way the suite reaches everything else it manages: the
+// composed stack's own `postgres` container.
+//
+// This is a **stack-management** operation, exactly like `global-setup`'s
+// `docker compose up`. When `E2E_BASE_URL` points at a stack this suite does not
+// own, it is skipped (there is no compose project to `exec` into) — the caller
+// must arrange the grant on that stack itself.
+
+const repoRoot = resolve(__dirname, '..', '..')
+const baseFile = resolve(repoRoot, 'docker-compose.dev.yml')
+const overrideFile = resolve(repoRoot, 'docker-compose.e2e.yml')
+
+const BETA_TESTER_ROLE = 'Beta tester'
+
+// Auto-minted usernames are alphanumerics plus `.`/`_`/`-`; anything else is not
+// a username this suite produces, and letting it reach a `-c` string would be an
+// injection. Refuse it rather than quote-escape — the value is always ours.
+const SAFE_USERNAME = /^[A-Za-z0-9._-]+$/
+
+/**
+ * Grant the **"Beta tester"** role (`tournament.view`/`create`/`enter`) to the
+ * user with `username`, so a spec can drive the tournament flow as that director.
+ *
+ * Idempotent — a `WHERE NOT EXISTS` guard means a re-grant inserts nothing, so a
+ * retried test is safe. No-op (returns `false`) when `E2E_BASE_URL` is set: the
+ * stack is not ours to `exec` into, and the caller owns provisioning there.
+ *
+ * Throws if the `docker compose … exec psql` fails — a silent grant that did not
+ * land would surface far away as an inexplicable 403 on the first tournament write.
+ */
+export function grantBetaTester(username: string): boolean {
+  if (process.env.E2E_BASE_URL) return false
+  if (!SAFE_USERNAME.test(username)) {
+    throw new Error(`refusing to grant a role to an unexpected username: ${username}`)
+  }
+
+  // CROSS JOIN the one matching user against the one matching role, guarded by a
+  // NOT EXISTS so the (user_id, role_id) composite PK is never violated on a
+  // re-run. No ON CONFLICT target needed, so it does not depend on the
+  // constraint's name.
+  const sql =
+    'INSERT INTO user_roles (user_id, role_id) ' +
+    'SELECT u.id, r.id FROM users u CROSS JOIN roles r ' +
+    `WHERE u.username = '${username}' AND r.name = '${BETA_TESTER_ROLE}' ` +
+    'AND NOT EXISTS (SELECT 1 FROM user_roles ur ' +
+    'WHERE ur.user_id = u.id AND ur.role_id = r.id);'
+
+  const result = spawnSync(
+    'docker',
+    [
+      'compose',
+      '-f', baseFile,
+      '-f', overrideFile,
+      'exec', '-T', 'postgres',
+      'psql', '-U', 'postgres', '-d', 'fortymm',
+      '-v', 'ON_ERROR_STOP=1',
+      '-c', sql,
+    ],
+    { encoding: 'utf-8' },
+  )
+
+  if (result.status !== 0) {
+    throw new Error(
+      `granting "${BETA_TESTER_ROLE}" to ${username} failed ` +
+        `(exit ${result.status}): ${result.stderr || result.stdout}`,
+    )
+  }
+  // psql prints the affected-row count ("INSERT 0 1" first run, "INSERT 0 0" on a
+  // re-grant); either is success. A username that matched no row (INSERT 0 0 with
+  // no prior grant) would be a mis-wired test, but is indistinguishable from an
+  // idempotent re-run here — the tournament write's own 403 is the real backstop.
+  return true
+}

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -1,0 +1,172 @@
+import type { Guest } from './match-api'
+
+// Composed-stack API helpers for provisioning the **inert scaffolding** of a
+// tournament directly against the real API (through nginx at `/api`), so a spec
+// can drive the load-bearing lifecycle steps — entering, cutting the draw, going
+// live, recording the result, reading the standings — through the browser
+// instead. Mirrors `match-api.ts`: writes ride the double-submit CSRF defense
+// (`app/main.py`), echoing the guest's `csrf_token` cookie back in the
+// `x-csrf-token` header.
+//
+// What is seeded here is everything a tournament needs to *exist* but that has no
+// interesting UI of its own: the tournament, one singles round-robin event, its
+// single pool with a table, and (see `enterPlayer`) the second entrant, added by
+// director-entry — for which there is deliberately no web UI today (the entry
+// card only self-registers the signed-in player). The director's own entry is
+// left for the browser to make through the Enter control.
+//
+// Everything created here is created **as the director** (the caller's own guest
+// context), so the tournament comes back with `can_edit: true` and the browser,
+// signed in as that same guest, sees the owner-only controls (Publish, Generate
+// draw, Start tournament).
+
+const API = '/api/v1'
+const CSRF_HEADER = 'x-csrf-token'
+
+/** The id of the one table seeded into the tournament's catalogue, referenced by
+ * the event's single pool. A round-robin pool wants at least one table. */
+const TABLE_ID = 't1'
+/** The id of the event's single pool — a round-robin needs ≥1 pool, and two
+ * entrants in one pool is exactly one fixture: the minimal playable draw. */
+const POOL_ID = 'pool-a'
+
+/** A seeded tournament and the ids a spec needs to address it and its event. */
+export interface SeededTournament {
+  readonly tournamentId: string
+  readonly eventId: string
+  /** The event's single pool id, so a spec can scope its standings assertions. */
+  readonly poolId: string
+}
+
+/**
+ * Create a **draft** tournament with one singles, **round-robin**, **unrated**,
+ * best-of-1 event, drawn across a single pool that holds one table — the minimal
+ * shape that can go live and produce a champion.
+ *
+ * `rated: false` + `length_games: 1` is load-bearing, not incidental: an unrated
+ * tournament match takes the immediate self-accept completion path, so recording
+ * its result COMPLETES it with no second party accepting — one browser session
+ * can drive the whole thing. `max_players` is left uncapped (omitted): the spec
+ * enters exactly two, and a cap only adds a way to fail.
+ *
+ * Two API calls, both as the director: `POST /tournaments` then
+ * `POST /tournaments/{id}/events`. The lifecycle (publish → cut → go live) and
+ * the entries are the browser's job.
+ */
+export async function seedTournament(
+  director: Guest,
+  name: string,
+): Promise<SeededTournament> {
+  const slot = { date: '2026-08-01', start: '09:00', end: '17:00' }
+
+  const tournamentRes = await director.ctx.post(`${API}/tournaments`, {
+    headers: { [CSRF_HEADER]: director.csrf },
+    data: {
+      name,
+      address: {
+        venue: 'Test Arena',
+        street: '1 Test Way',
+        city: 'Testville',
+        region: 'TS',
+        postal: '00000',
+        country: 'Testland',
+      },
+      // The pool references this table by id, so the catalogue must carry it.
+      table_catalogue: [{ id: TABLE_ID, label: 'Table 1', court: 'A' }],
+    },
+  })
+  if (tournamentRes.status() !== 201) {
+    throw new Error(
+      `create tournament failed: ${tournamentRes.status()} ${await tournamentRes.text()}`,
+    )
+  }
+  const tournamentId = ((await tournamentRes.json()) as { id: string }).id
+
+  const eventRes = await director.ctx.post(
+    `${API}/tournaments/${tournamentId}/events`,
+    {
+      headers: { [CSRF_HEADER]: director.csrf },
+      data: {
+        name: 'Open Singles',
+        format: 'singles',
+        draw_type: 'round-robin',
+        entry_fee: 0,
+        slot,
+        match_settings: { rated: false, length_games: 1 },
+        predicates: [],
+        pools: [{ id: POOL_ID, name: 'Pool A', slot, table_ids: [TABLE_ID] }],
+      },
+    },
+  )
+  if (eventRes.status() !== 201) {
+    throw new Error(
+      `create event failed: ${eventRes.status()} ${await eventRes.text()}`,
+    )
+  }
+  const eventId = ((await eventRes.json()) as { id: string }).id
+
+  return { tournamentId, eventId, poolId: POOL_ID }
+}
+
+/**
+ * Enter `userId` into the event as the tournament's **director** (ADR-0784):
+ * `POST …/entries` with a `{ user_id }` body, which only the owner may send.
+ *
+ * This is how the second entrant gets in without a web UI — the entry card only
+ * self-registers the signed-in player, so director-entry has no browser surface
+ * to drive. Requires the tournament to be **published** (registration open), so
+ * the caller publishes first.
+ */
+export async function enterPlayer(
+  director: Guest,
+  tournamentId: string,
+  eventId: string,
+  userId: string,
+): Promise<void> {
+  const res = await director.ctx.post(
+    `${API}/tournaments/${tournamentId}/events/${eventId}/entries`,
+    {
+      headers: { [CSRF_HEADER]: director.csrf },
+      data: { user_id: userId },
+    },
+  )
+  if (res.status() !== 201) {
+    throw new Error(
+      `director-entry failed: ${res.status()} ${await res.text()}`,
+    )
+  }
+}
+
+/**
+ * Read the tournament detail and return the `match_id` of the event's first
+ * fixture — the real match a fixture materialized into at go-live (#788).
+ *
+ * The spec uses it to deep-link the browser into that match's score entry the
+ * same way `score-conflict.spec.ts` deep-links a seeded match: learn the URL over
+ * the API, drive the surface in the browser. Throws if the fixture has not
+ * materialized (no `match_id`) — which would mean go-live had not happened.
+ */
+export async function firstFixtureMatchId(
+  viewer: Guest,
+  tournamentId: string,
+  eventId: string,
+): Promise<string> {
+  const res = await viewer.ctx.get(`${API}/tournaments/${tournamentId}`)
+  if (!res.ok()) {
+    throw new Error(`load tournament failed: ${res.status()} ${await res.text()}`)
+  }
+  const detail = (await res.json()) as {
+    events: ReadonlyArray<{
+      id: string
+      fixtures: ReadonlyArray<{ match_id: string | null }>
+    }>
+  }
+  const event = detail.events.find((e) => e.id === eventId)
+  const matchId = event?.fixtures.find((f) => f.match_id !== null)?.match_id
+  if (!matchId) {
+    throw new Error(
+      `no materialized fixture for event ${eventId} — did the tournament go live?`,
+    )
+  }
+  return matchId
+}

--- a/e2e/tests/tournament-lifecycle.spec.ts
+++ b/e2e/tests/tournament-lifecycle.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+
+import { ScoreEntryPage } from '../page-objects/score-entry.page'
+import { TournamentDetailPage } from '../page-objects/tournament-detail.page'
+import { findUserId, guestFromContext, mintGuest } from '../support/match-api'
+import { grantBetaTester } from '../support/rbac-grant'
+import {
+  enterPlayer,
+  firstFixtureMatchId,
+  seedTournament,
+} from '../support/tournament-api'
+
+const EVENT_NAME = 'Open Singles'
+
+/**
+ * End-to-end coverage for the round-robin tournament lifecycle (the C1/C2
+ * orchestration), against the REAL composed stack — no stubs.
+ *
+ * A director creates a tournament with one singles, round-robin, **unrated**,
+ * best-of-1 event drawn across a single pool → publishes → enters two players →
+ * cuts the draw → goes live (materializing the one fixture into a real
+ * `in_progress` match) → records the result → the standings crown the winner
+ * champion at rank #1.
+ *
+ * ## Why unrated is load-bearing
+ *
+ * An unrated tournament match takes the **immediate self-accept** completion path:
+ * proposing the result COMPLETES it with no second party accepting. So one browser
+ * session (the director, who is also a participant) drives the whole thing — there
+ * is no opponent tab to run.
+ *
+ * ## Seed vs UI split
+ *
+ * The inert scaffolding — the tournament, its event, its pool, and the second
+ * entrant (director-entry, which has no web UI) — is provisioned over the API
+ * (`support/tournament-api.ts`). The load-bearing lifecycle steps are driven
+ * through the browser: publishing, the director's own Enter, cutting the draw,
+ * going live, recording the result, and reading the standings.
+ *
+ * ## RBAC
+ *
+ * A minted user holds only the default `User` role, which carries no permissions.
+ * `grantBetaTester` hands the director the `tournament.view`/`create`/`enter`
+ * bundle over the stack's own `postgres` container before any tournament write —
+ * without it every one of them 403s. On an external `E2E_BASE_URL` stack the grant
+ * is skipped (the caller must arrange it), and the API seed's 403 is the honest
+ * signal if they did not.
+ */
+test.describe('Tournament — round-robin lifecycle', () => {
+  test('a 2-player unrated round-robin goes live, is played, and crowns its champion', async ({
+    page,
+    baseURL,
+  }) => {
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    // The director IS the browser's own session (`page.request` shares the page
+    // context's cookie jar), so page navigations run authenticated as them.
+    const director = await guestFromContext(page.request)
+    // Grant the tournament permissions the flow needs; a no-op against a stack
+    // this suite does not own (E2E_BASE_URL), where the caller provisions it.
+    grantBetaTester(director.username)
+
+    // The inert scaffolding, over the API, as the director (so it comes back
+    // `can_edit: true` and the browser sees the owner controls).
+    const name = `RR ${faker.string.alphanumeric(8)}`
+    const { tournamentId, eventId, poolId } = await seedTournament(director, name)
+
+    // The second entrant — a wholly separate guest, searchable as an opponent.
+    const opponent = await mintGuest(baseURL!)
+    const opponentId = await findUserId(director, opponent.username)
+
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+
+    // ----- publish: draft → published (opens registration) ------------------
+    await detail.publishButton.click()
+    await expect(detail.startButton).toBeVisible()
+
+    // ----- enter the director themselves, through the UI --------------------
+    await detail.enterButton(EVENT_NAME).click()
+    // The control flips to Withdraw once the entry lands — the entry took.
+    await expect(detail.withdrawButton(EVENT_NAME)).toBeVisible()
+    await expect(detail.entrantsList(EVENT_NAME)).toContainText(director.username)
+
+    // ----- enter the second player by director-entry (no web UI) ------------
+    await enterPlayer(director, tournamentId, eventId, opponentId)
+    await detail.reload(tournamentId)
+    await expect(detail.entrantsList(EVENT_NAME)).toContainText(director.username)
+    await expect(detail.entrantsList(EVENT_NAME)).toContainText(opponent.username)
+
+    // ----- cut the draw: 2 entrants in 1 pool = exactly 1 fixture -----------
+    await detail.generateDrawButton(EVENT_NAME).click()
+    // The one fixture pairs the two entrants. It is not yet a match — no link.
+    await expect(detail.drawPanel(eventId)).toContainText(director.username)
+    await expect(detail.drawPanel(eventId)).toContainText(opponent.username)
+    await expect(detail.viewMatchLink(eventId)).toBeHidden()
+
+    // ----- go live: published → live (materializes the fixture) -------------
+    await detail.startButton.click()
+    // Now live: the only edge left is End, and the fixture is a real, in-progress
+    // match with a deep-link.
+    await expect(detail.endButton).toBeVisible()
+    await expect(detail.fixtureMatchStatus(eventId)).toHaveText('In progress')
+    await expect(detail.viewMatchLink(eventId)).toBeVisible()
+
+    // ----- record the result, through the score-entry UI --------------------
+    // Learn the materialized match's id over the API, then drive its score entry
+    // in the browser (the pattern score-conflict.spec.ts uses).
+    const matchId = await firstFixtureMatchId(director, tournamentId, eventId)
+    const score = await ScoreEntryPage.navigateToNew(page, matchId, 1)
+    // The director wins 11–5, so they are the sole pool winner → champion. Inputs
+    // are labelled by username, so this is correct whichever side each was drawn on.
+    await score.scoreInput(director.username).fill('11')
+    await score.scoreInput(opponent.username).fill('5')
+    // On an unrated match "Finalize result" proposes AND self-accepts in one POST,
+    // completing the match with no opponent tab. Wait for that 201 to settle.
+    const resultsPost = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/matches/${matchId}/results`) &&
+        r.request().method() === 'POST',
+    )
+    await score.finalizeButton.click()
+    expect((await resultsPost).status()).toBe(201)
+
+    // ----- the standings crown the champion ---------------------------------
+    const played = await TournamentDetailPage.navigateTo(page, tournamentId)
+    // The champion callout renders ONLY for the rank-#1 leader of a complete,
+    // single-pool round-robin, so its presence with the director's name is the
+    // "winner ranked #1 as champion" fact itself.
+    await expect(played.standingsChampion(eventId)).toBeVisible()
+    await expect(played.standingsChampion(eventId)).toContainText(director.username)
+    // And the pool table shows both entrants, with the director in the top row.
+    const standings = played.poolStandings(poolId)
+    await expect(standings).toContainText(director.username)
+    await expect(standings).toContainText(opponent.username)
+    // Row 0 is the header; row 1 is rank 1 — the director, the champion.
+    await expect(standings.getByRole('row').nth(1)).toContainText(director.username)
+
+    await opponent.ctx.dispose()
+  })
+})

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -743,6 +743,34 @@ internal protocol APIProtocol: Sendable {
     /// - Remark: HTTP `DELETE /v1/tournaments/{tournament_id}/events/{event_id}/draw`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/events/{event_id}/draw/delete(uncut_event_draw_v1_tournaments__tournament_id__events__event_id__draw_delete)`.
     func uncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete(_ input: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Input) async throws -> Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Output
+    /// Place Fixture
+    ///
+    /// Set (or clear) a fixture's **placement** — its table and its predicted start
+    /// (ADR-0790) — and answer with the updated fixture.
+    ///
+    /// The body is the placement in full: `table_id` (a string ref into the tournament's
+    /// `table_catalogue`) and `scheduled_start` (a **naive** wall-clock time, in the
+    /// venue's local frame — an offset-aware value is a `422`). `null` on either clears
+    /// that half; `(null, null)` unassigns the fixture.
+    ///
+    /// **The placement is soft.** `scheduled_start` is a *prediction*, and the placement's
+    /// constraints — the table belongs to the fixture's pool, the time falls inside the
+    /// pool's window, nothing is double-booked — are flags derived on read, **not**
+    /// invariants. So an out-of-window time, or a `table_id` that names no table in the
+    /// catalogue, is **stored, not rejected**. There is no conflict detection here; that is
+    /// a future scheduler slice.
+    ///
+    /// **The one hard rule:** a fixture whose linked match is `completed` or `voided` is
+    /// history, so its placement can no longer be changed — a `409`. A fixture with no
+    /// match yet, or an `in_progress` one, is freely (re)placeable (every round-robin match
+    /// is `in_progress` from go-live, so that is not the freeze trigger).
+    ///
+    /// Owner-only, like every other tournament mutation: an absent tournament, or a fixture
+    /// that is not part of it, is a `404`; a non-owner is a `403`.
+    ///
+    /// - Remark: HTTP `PATCH /v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/patch(place_fixture_v1_tournaments__tournament_id__fixtures__fixture_id__placement_patch)`.
+    func placeFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch(_ input: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Input) async throws -> Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Output
     /// Health
     ///
     /// - Remark: HTTP `GET /v1/health`.
@@ -1952,6 +1980,44 @@ extension APIProtocol {
         try await uncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete(Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Input(
             path: path,
             headers: headers
+        ))
+    }
+    /// Place Fixture
+    ///
+    /// Set (or clear) a fixture's **placement** — its table and its predicted start
+    /// (ADR-0790) — and answer with the updated fixture.
+    ///
+    /// The body is the placement in full: `table_id` (a string ref into the tournament's
+    /// `table_catalogue`) and `scheduled_start` (a **naive** wall-clock time, in the
+    /// venue's local frame — an offset-aware value is a `422`). `null` on either clears
+    /// that half; `(null, null)` unassigns the fixture.
+    ///
+    /// **The placement is soft.** `scheduled_start` is a *prediction*, and the placement's
+    /// constraints — the table belongs to the fixture's pool, the time falls inside the
+    /// pool's window, nothing is double-booked — are flags derived on read, **not**
+    /// invariants. So an out-of-window time, or a `table_id` that names no table in the
+    /// catalogue, is **stored, not rejected**. There is no conflict detection here; that is
+    /// a future scheduler slice.
+    ///
+    /// **The one hard rule:** a fixture whose linked match is `completed` or `voided` is
+    /// history, so its placement can no longer be changed — a `409`. A fixture with no
+    /// match yet, or an `in_progress` one, is freely (re)placeable (every round-robin match
+    /// is `in_progress` from go-live, so that is not the freeze trigger).
+    ///
+    /// Owner-only, like every other tournament mutation: an absent tournament, or a fixture
+    /// that is not part of it, is a `404`; a non-owner is a `403`.
+    ///
+    /// - Remark: HTTP `PATCH /v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/patch(place_fixture_v1_tournaments__tournament_id__fixtures__fixture_id__placement_patch)`.
+    internal func placeFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch(
+        path: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Input.Path,
+        headers: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Input.Headers = .init(),
+        body: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Input.Body
+    ) async throws -> Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Output {
+        try await placeFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch(Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Input(
+            path: path,
+            headers: headers,
+            body: body
         ))
     }
     /// Health
@@ -7633,6 +7699,66 @@ internal enum Components {
                 ])
             }
         }
+        /// A fixture's **placement** (ADR-0790): the table it sits at and its predicted
+        /// start.
+        ///
+        /// The body is the placement in full — both fields are stated together. ``null`` on
+        /// either clears that half, and ``(null, null)`` unassigns the fixture entirely.
+        ///
+        /// **Soft, deliberately.** ``scheduled_start`` is a *prediction*, not a commitment,
+        /// and the placement's constraints — the table belongs to the fixture's pool, the time
+        /// falls inside the pool's window, nothing is double-booked — are **flags derived on
+        /// read, not invariants** (ADR-0790). So this write does **not** reject an
+        /// out-of-window time, nor a ``table_id`` that names no table in the tournament's
+        /// ``table_catalogue`` (a later pool/catalogue edit can dangle the ref; that is a
+        /// flag-on-read concern). They save. Conflict detection is a future scheduler slice.
+        ///
+        /// ``table_id`` is a **string ref** into the tournament's ``table_catalogue`` (names a
+        /// ``TournamentTable.id``) — the same pattern as a fixture's ``pool_id``, not a
+        /// foreign key — and per the soft rule above an unknown id is stored, not refused.
+        ///
+        /// The one thing the *route* refuses is moving a fixture whose linked match is
+        /// ``completed`` or ``voided``: its placement is history (409). A fixture with no match
+        /// yet, or an ``in_progress`` one, is freely (re)placeable.
+        ///
+        /// - Remark: Generated from `#/components/schemas/TournamentFixturePlacementUpdate`.
+        internal struct TournamentFixturePlacementUpdate: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/TournamentFixturePlacementUpdate/table_id`.
+            internal var tableId: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/TournamentFixturePlacementUpdate/scheduled_start`.
+            internal var scheduledStart: Foundation.Date?
+            /// Creates a new `TournamentFixturePlacementUpdate`.
+            ///
+            /// - Parameters:
+            ///   - tableId:
+            ///   - scheduledStart:
+            internal init(
+                tableId: Swift.String? = nil,
+                scheduledStart: Foundation.Date? = nil
+            ) {
+                self.tableId = tableId
+                self.scheduledStart = scheduledStart
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case tableId = "table_id"
+                case scheduledStart = "scheduled_start"
+            }
+            internal init(from decoder: any Swift.Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.tableId = try container.decodeIfPresent(
+                    Swift.String.self,
+                    forKey: .tableId
+                )
+                self.scheduledStart = try container.decodeIfPresent(
+                    Foundation.Date.self,
+                    forKey: .scheduledStart
+                )
+                try decoder.ensureNoAdditionalProperties(knownKeys: [
+                    "table_id",
+                    "scheduled_start"
+                ])
+            }
+        }
         /// One planned pairing of an event's draw (ADR-0786): a round and a position —
         /// plus a pool, when the draw is pooled — whose sides may still be unknown.
         ///
@@ -7660,6 +7786,14 @@ internal enum Components {
         ///   un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
         ///   set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
         ///   JSONB, not a foreign key, because pools are value-objects with no table.
+        /// * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means
+        ///   **unassigned to a table**. When set, it names a ``TournamentTable`` in the
+        ///   tournament's ``table_catalogue`` — a string ref into JSONB, not a foreign key,
+        ///   the same pattern as ``pool_id``.
+        /// * ``scheduled_start`` — the placement's **predicted** start (ADR-0790): ``null``
+        ///   means **unscheduled**. It is a *naive* wall-clock timestamp (no timezone), in the
+        ///   venue's frame, a prediction rather than a commitment — a match starting
+        ///   off-prediction is normal, not an error.
         ///
         /// The entries are carried as **ids only**. The name and username behind
         /// ``entry_a_id`` are already on this page — the event's ``entrants`` list carries
@@ -7705,6 +7839,10 @@ internal enum Components {
             }
             /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/match_status`.
             internal var matchStatus: Components.Schemas.TournamentFixtureRead.MatchStatusPayload?
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/table_id`.
+            internal var tableId: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/scheduled_start`.
+            internal var scheduledStart: Foundation.Date?
             /// Creates a new `TournamentFixtureRead`.
             ///
             /// - Parameters:
@@ -7717,6 +7855,8 @@ internal enum Components {
             ///   - winnerEntryId:
             ///   - matchId:
             ///   - matchStatus:
+            ///   - tableId:
+            ///   - scheduledStart:
             internal init(
                 id: Swift.String,
                 poolId: Swift.String? = nil,
@@ -7726,7 +7866,9 @@ internal enum Components {
                 entryBId: Swift.String? = nil,
                 winnerEntryId: Swift.String? = nil,
                 matchId: Swift.String? = nil,
-                matchStatus: Components.Schemas.TournamentFixtureRead.MatchStatusPayload? = nil
+                matchStatus: Components.Schemas.TournamentFixtureRead.MatchStatusPayload? = nil,
+                tableId: Swift.String? = nil,
+                scheduledStart: Foundation.Date? = nil
             ) {
                 self.id = id
                 self.poolId = poolId
@@ -7737,6 +7879,8 @@ internal enum Components {
                 self.winnerEntryId = winnerEntryId
                 self.matchId = matchId
                 self.matchStatus = matchStatus
+                self.tableId = tableId
+                self.scheduledStart = scheduledStart
             }
             internal enum CodingKeys: String, CodingKey {
                 case id
@@ -7748,6 +7892,8 @@ internal enum Components {
                 case winnerEntryId = "winner_entry_id"
                 case matchId = "match_id"
                 case matchStatus = "match_status"
+                case tableId = "table_id"
+                case scheduledStart = "scheduled_start"
             }
         }
         /// - Remark: Generated from `#/components/schemas/TournamentRead`.
@@ -20425,6 +20571,224 @@ internal enum Operations {
             /// - Throws: An error if `self` is not `.unprocessableContent`.
             /// - SeeAlso: `.unprocessableContent`.
             internal var unprocessableContent: Operations.UncutEventDrawV1TournamentsTournamentIdEventsEventIdDrawDelete.Output.UnprocessableContent {
+                get throws {
+                    switch self {
+                    case let .unprocessableContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        internal enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            internal init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            internal var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            internal static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Place Fixture
+    ///
+    /// Set (or clear) a fixture's **placement** — its table and its predicted start
+    /// (ADR-0790) — and answer with the updated fixture.
+    ///
+    /// The body is the placement in full: `table_id` (a string ref into the tournament's
+    /// `table_catalogue`) and `scheduled_start` (a **naive** wall-clock time, in the
+    /// venue's local frame — an offset-aware value is a `422`). `null` on either clears
+    /// that half; `(null, null)` unassigns the fixture.
+    ///
+    /// **The placement is soft.** `scheduled_start` is a *prediction*, and the placement's
+    /// constraints — the table belongs to the fixture's pool, the time falls inside the
+    /// pool's window, nothing is double-booked — are flags derived on read, **not**
+    /// invariants. So an out-of-window time, or a `table_id` that names no table in the
+    /// catalogue, is **stored, not rejected**. There is no conflict detection here; that is
+    /// a future scheduler slice.
+    ///
+    /// **The one hard rule:** a fixture whose linked match is `completed` or `voided` is
+    /// history, so its placement can no longer be changed — a `409`. A fixture with no
+    /// match yet, or an `in_progress` one, is freely (re)placeable (every round-robin match
+    /// is `in_progress` from go-live, so that is not the freeze trigger).
+    ///
+    /// Owner-only, like every other tournament mutation: an absent tournament, or a fixture
+    /// that is not part of it, is a `404`; a non-owner is a `403`.
+    ///
+    /// - Remark: HTTP `PATCH /v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement`.
+    /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/patch(place_fixture_v1_tournaments__tournament_id__fixtures__fixture_id__placement_patch)`.
+    internal enum PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch {
+        internal static let id: Swift.String = "place_fixture_v1_tournaments__tournament_id__fixtures__fixture_id__placement_patch"
+        internal struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/PATCH/path`.
+            internal struct Path: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/PATCH/path/tournament_id`.
+                internal var tournamentId: Swift.String
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/PATCH/path/fixture_id`.
+                internal var fixtureId: Swift.String
+                /// Creates a new `Path`.
+                ///
+                /// - Parameters:
+                ///   - tournamentId:
+                ///   - fixtureId:
+                internal init(
+                    tournamentId: Swift.String,
+                    fixtureId: Swift.String
+                ) {
+                    self.tournamentId = tournamentId
+                    self.fixtureId = fixtureId
+                }
+            }
+            internal var path: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Input.Path
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/PATCH/header`.
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            internal var headers: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Input.Headers
+            /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/PATCH/requestBody`.
+            internal enum Body: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/PATCH/requestBody/content/application\/json`.
+                case json(Components.Schemas.TournamentFixturePlacementUpdate)
+            }
+            internal var body: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Input.Body
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - path:
+            ///   - headers:
+            ///   - body:
+            internal init(
+                path: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Input.Path,
+                headers: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Input.Headers = .init(),
+                body: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Input.Body
+            ) {
+                self.path = path
+                self.headers = headers
+                self.body = body
+            }
+        }
+        internal enum Output: Sendable, Hashable {
+            internal struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/PATCH/responses/200/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/PATCH/responses/200/content/application\/json`.
+                    case json(Components.Schemas.TournamentFixtureRead)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.TournamentFixtureRead {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/patch(place_fixture_v1_tournaments__tournament_id__fixtures__fixture_id__placement_patch)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            internal var ok: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct UnprocessableContent: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/PATCH/responses/422/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/PATCH/responses/422/content/application\/json`.
+                    case json(Components.Schemas.HTTPValidationError)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.HTTPValidationError {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Output.UnprocessableContent.Body
+                /// Creates a new `UnprocessableContent`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Output.UnprocessableContent.Body) {
+                    self.body = body
+                }
+            }
+            /// Validation Error
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement/patch(place_fixture_v1_tournaments__tournament_id__fixtures__fixture_id__placement_patch)/responses/422`.
+            ///
+            /// HTTP response code: `422 unprocessableContent`.
+            case unprocessableContent(Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Output.UnprocessableContent)
+            /// The associated value of the enum case if `self` is `.unprocessableContent`.
+            ///
+            /// - Throws: An error if `self` is not `.unprocessableContent`.
+            /// - SeeAlso: `.unprocessableContent`.
+            internal var unprocessableContent: Operations.PlaceFixtureV1TournamentsTournamentIdFixturesFixtureIdPlacementPatch.Output.UnprocessableContent {
                 get throws {
                     switch self {
                     case let .unprocessableContent(response):

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1273,6 +1273,47 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Place Fixture
+         * @description Set (or clear) a fixture's **placement** — its table and its predicted start
+         *     (ADR-0790) — and answer with the updated fixture.
+         *
+         *     The body is the placement in full: `table_id` (a string ref into the tournament's
+         *     `table_catalogue`) and `scheduled_start` (a **naive** wall-clock time, in the
+         *     venue's local frame — an offset-aware value is a `422`). `null` on either clears
+         *     that half; `(null, null)` unassigns the fixture.
+         *
+         *     **The placement is soft.** `scheduled_start` is a *prediction*, and the placement's
+         *     constraints — the table belongs to the fixture's pool, the time falls inside the
+         *     pool's window, nothing is double-booked — are flags derived on read, **not**
+         *     invariants. So an out-of-window time, or a `table_id` that names no table in the
+         *     catalogue, is **stored, not rejected**. There is no conflict detection here; that is
+         *     a future scheduler slice.
+         *
+         *     **The one hard rule:** a fixture whose linked match is `completed` or `voided` is
+         *     history, so its placement can no longer be changed — a `409`. A fixture with no
+         *     match yet, or an `in_progress` one, is freely (re)placeable (every round-robin match
+         *     is `in_progress` from go-live, so that is not the freeze trigger).
+         *
+         *     Owner-only, like every other tournament mutation: an absent tournament, or a fixture
+         *     that is not part of it, is a `404`; a non-owner is a `403`.
+         */
+        patch: operations["place_fixture_v1_tournaments__tournament_id__fixtures__fixture_id__placement_patch"];
+        trace?: never;
+    };
     "/v1/health": {
         parameters: {
             query?: never;
@@ -3446,6 +3487,36 @@ export interface components {
             pools?: components["schemas"]["Pool"][] | null;
         };
         /**
+         * TournamentFixturePlacementUpdate
+         * @description A fixture's **placement** (ADR-0790): the table it sits at and its predicted
+         *     start.
+         *
+         *     The body is the placement in full — both fields are stated together. ``null`` on
+         *     either clears that half, and ``(null, null)`` unassigns the fixture entirely.
+         *
+         *     **Soft, deliberately.** ``scheduled_start`` is a *prediction*, not a commitment,
+         *     and the placement's constraints — the table belongs to the fixture's pool, the time
+         *     falls inside the pool's window, nothing is double-booked — are **flags derived on
+         *     read, not invariants** (ADR-0790). So this write does **not** reject an
+         *     out-of-window time, nor a ``table_id`` that names no table in the tournament's
+         *     ``table_catalogue`` (a later pool/catalogue edit can dangle the ref; that is a
+         *     flag-on-read concern). They save. Conflict detection is a future scheduler slice.
+         *
+         *     ``table_id`` is a **string ref** into the tournament's ``table_catalogue`` (names a
+         *     ``TournamentTable.id``) — the same pattern as a fixture's ``pool_id``, not a
+         *     foreign key — and per the soft rule above an unknown id is stored, not refused.
+         *
+         *     The one thing the *route* refuses is moving a fixture whose linked match is
+         *     ``completed`` or ``voided``: its placement is history (409). A fixture with no match
+         *     yet, or an ``in_progress`` one, is freely (re)placeable.
+         */
+        TournamentFixturePlacementUpdate: {
+            /** Table Id */
+            table_id: string | null;
+            /** Scheduled Start */
+            scheduled_start: string | null;
+        };
+        /**
          * TournamentFixtureRead
          * @description One planned pairing of an event's draw (ADR-0786): a round and a position —
          *     plus a pool, when the draw is pooled — whose sides may still be unknown.
@@ -3474,6 +3545,14 @@ export interface components {
          *       un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
          *       set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
          *       JSONB, not a foreign key, because pools are value-objects with no table.
+         *     * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means
+         *       **unassigned to a table**. When set, it names a ``TournamentTable`` in the
+         *       tournament's ``table_catalogue`` — a string ref into JSONB, not a foreign key,
+         *       the same pattern as ``pool_id``.
+         *     * ``scheduled_start`` — the placement's **predicted** start (ADR-0790): ``null``
+         *       means **unscheduled**. It is a *naive* wall-clock timestamp (no timezone), in the
+         *       venue's frame, a prediction rather than a commitment — a match starting
+         *       off-prediction is normal, not an error.
          *
          *     The entries are carried as **ids only**. The name and username behind
          *     ``entry_a_id`` are already on this page — the event's ``entrants`` list carries
@@ -3502,6 +3581,10 @@ export interface components {
             /** Match Id */
             match_id: string | null;
             match_status: components["schemas"]["MatchStatus"] | null;
+            /** Table Id */
+            table_id: string | null;
+            /** Scheduled Start */
+            scheduled_start: string | null;
         };
         /** TournamentRead */
         TournamentRead: {
@@ -5950,6 +6033,44 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    place_fixture_v1_tournaments__tournament_id__fixtures__fixture_id__placement_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tournament_id: string;
+                fixture_id: string;
+            };
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TournamentFixturePlacementUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TournamentFixtureRead"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -16,6 +16,7 @@ import { renderHook, waitFor } from '@/test/utilities'
 import {
   mockEventCutDrawEndpoint,
   mockEventEnterEndpoint,
+  mockFixturePlacementEndpoint,
   mockEventUncutDrawEndpoint,
   mockEventWithdrawEndpoint,
   mockTournamentCreateEndpoint,
@@ -43,6 +44,7 @@ import {
   useCreateTournament,
   useCutDraw,
   useEnterEvent,
+  usePlaceFixture,
   useTournament,
   useTournaments,
   useTransitionTournament,
@@ -999,6 +1001,8 @@ describe('useCutDraw', () => {
         winnerEntryId: null,
         matchId: null,
         matchStatus: null,
+        tableId: null,
+        scheduledStart: null,
       },
     ])
   })
@@ -1159,6 +1163,82 @@ describe('useUncutDraw', () => {
     // No toast here either — the panel renders the play-guard refusal inline, beside the
     // draw it refused to remove.
     expect(toast.error).not.toHaveBeenCalled()
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('usePlaceFixture', () => {
+  it('PATCHes the placement to the fixture resource and resolves the parsed fixture', async () => {
+    let seen: { url: string; body: unknown } | null = null
+    mockFixturePlacementEndpoint(server, async ({ request }) => {
+      seen = { url: request.url, body: await request.json() }
+      return HttpResponse.json(
+        buildTournamentFixtureRead({
+          id: 'fx-1',
+          table_id: 't2',
+          scheduled_start: '2026-06-13T10:30:00',
+        }),
+      )
+    })
+
+    const { result } = renderHook(() => usePlaceFixture('t-1'))
+    const fixture = await result.current.mutateAsync({
+      fixtureId: 'fx-1',
+      body: { table_id: 't2', scheduled_start: '2026-06-13T10:30:00' },
+    })
+
+    expect(seen!.url).toContain('/v1/tournaments/t-1/fixtures/fx-1/placement')
+    expect(seen!.body).toEqual({ table_id: 't2', scheduled_start: '2026-06-13T10:30:00' })
+    // Parsed into the domain's camelCase, like every other fixture the layer returns.
+    expect(fixture).toMatchObject({
+      id: 'fx-1',
+      tableId: 't2',
+      scheduledStart: '2026-06-13T10:30:00',
+    })
+  })
+
+  // THE invalidation contract (the map at the top of `./api`): exactly the two keys, the
+  // list and this tournament's detail — the placement rides the detail payload, so it
+  // re-renders from the refetch, with no schedule query of its own.
+  it('invalidates EXACTLY the list and the detail — the placement re-renders from the server', async () => {
+    mockFixturePlacementEndpoint(server, () =>
+      HttpResponse.json(buildTournamentFixtureRead({ id: 'fx-1', table_id: 't2' })),
+    )
+    const { invalidateSpy, wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => usePlaceFixture('t-1'), { wrapper })
+    result.current.mutate({
+      fixtureId: 'fx-1',
+      body: { table_id: 't2', scheduled_start: '2026-06-13T10:30:00' },
+    })
+
+    await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments'] })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
+    expect(invalidateSpy).toHaveBeenCalledTimes(2)
+  })
+
+  // Reconciles on FAILURE too (`onSettled`), and toasts — a lost race against a match
+  // that finished is a 409, and the refetch corrects the view while the toast reports it.
+  it('invalidates on a 409 too, and surfaces it as a toast', async () => {
+    mockFixturePlacementEndpoint(server, () =>
+      HttpResponse.json({ detail: 'This match is finished.' }, { status: 409 }),
+    )
+    const { invalidateSpy, wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => usePlaceFixture('t-1'), { wrapper })
+
+    await expect(
+      result.current.mutateAsync({
+        fixtureId: 'fx-1',
+        body: { table_id: null, scheduled_start: null },
+      }),
+    ).rejects.toBeInstanceOf(ApiError)
+
+    await waitForRaw(() => expect(toast.error).toHaveBeenCalled())
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments'] })
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tournaments', 't-1'] })
     expect(invalidateSpy).toHaveBeenCalledTimes(2)

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -199,6 +199,8 @@ describe('apiToEvent — the draw', () => {
         winnerEntryId: null,
         matchId: null,
         matchStatus: null,
+        tableId: null,
+        scheduledStart: null,
       },
       {
         id: 'fx-2',
@@ -210,6 +212,8 @@ describe('apiToEvent — the draw', () => {
         winnerEntryId: null,
         matchId: null,
         matchStatus: null,
+        tableId: null,
+        scheduledStart: null,
       },
     ])
   })
@@ -244,6 +248,8 @@ describe('apiToEvent — the draw', () => {
       winnerEntryId: null,
       matchId: null,
       matchStatus: null,
+      tableId: null,
+      scheduledStart: null,
     })
   })
 
@@ -723,6 +729,8 @@ describe('eventToUpdateBody', () => {
           winnerEntryId: null,
           matchId: null,
           matchStatus: null,
+          tableId: null,
+          scheduledStart: null,
         },
       ],
     })

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -44,6 +44,8 @@ type TournamentEventUpdate = components['schemas']['TournamentEventUpdate']
 type ApiPool = components['schemas']['Pool']
 type ApiPredicate = components['schemas']['Predicate']
 type ApiEntryState = TournamentEventRead['entry_state']
+type TournamentFixturePlacementUpdate =
+  components['schemas']['TournamentFixturePlacementUpdate']
 
 /** The API types a `between` predicate's value as a variable-length
  * `(number | null)[]`; the prototype narrows it to a `[min, max]` tuple. Coerce
@@ -385,6 +387,7 @@ export function useTables(id: string): TournamentTable[] {
 // | useWithdrawEntry        | ['tournaments'], ['tournaments', id]     | onSettled |
 // | useCutDraw              | ['tournaments'], ['tournaments', id]     | onSettled |
 // | useUncutDraw            | ['tournaments'], ['tournaments', id]     | onSettled |
+// | usePlaceFixture         | ['tournaments'], ['tournaments', id]     | onSettled |
 //
 // There are only two keys, because there are only two queries: the list and one
 // tournament's detail (events, entrants, the table catalogue AND every event's draw all
@@ -776,5 +779,54 @@ export function useUncutDraw(tournamentId: string) {
     },
     // Reconcile on BOTH paths — see the note above.
     onSettled: () => invalidateTournament(qc, tournamentId),
+  })
+}
+
+// ----- the schedule (ADR-0790) ---------------------------------------------
+//
+// A **placement** is a fixture's table + predicted start (ADR-0790). Like the draw
+// verbs, it has NO query of its own — the fixture's `table_id` / `scheduled_start` ride
+// the tournament detail payload the Schedule tab already reads (`event.fixtures`), so a
+// placement invalidates the tournament (list + detail) and the refetched fixture carries
+// the new table/time. That is the whole invalidation set: the same two keys
+// `invalidateTournament` covers, no schedule query to add.
+
+/** Set (or clear) a fixture's **placement**: `PATCH …/fixtures/{fixture_id}/placement`
+ * with the table and predicted start in full (ADR-0790). Owner-only.
+ *
+ * The body is the placement whole — `table_id` + `scheduled_start`, both required, and
+ * **`null` on either clears that half** (`(null, null)` unassigns the fixture). The
+ * server stores it soft: an out-of-window time or a `table_id` that names no catalogue
+ * table is saved, not refused (those are flags-on-read, a later scheduler slice). The one
+ * refusal is a **409** on a fixture whose match is `completed`/`voided` — its placement is
+ * history. The Schedule tab does not offer the control for a finished match, so the 409
+ * only surfaces on a lost race; the toast carries the server's word for it.
+ *
+ * Reconciles **`onSettled`** — the placement re-renders from the refetched tournament,
+ * never from an optimistic local write, so what the grid shows is always the server's. */
+export function usePlaceFixture(tournamentId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: {
+      fixtureId: string
+      body: TournamentFixturePlacementUpdate
+    }): Promise<Fixture> => {
+      const fixture = unwrap(
+        'place the match',
+        await api.PATCH(
+          '/v1/tournaments/{tournament_id}/fixtures/{fixture_id}/placement',
+          {
+            params: {
+              path: { tournament_id: tournamentId, fixture_id: input.fixtureId },
+            },
+            body: input.body,
+          },
+        ),
+      )
+      // The response is untrusted like every other payload — parse it, don't cast it.
+      return parseFixtures([fixture])[0]
+    },
+    onSettled: () => invalidateTournament(qc, tournamentId),
+    onError: notifyError('place the match'),
   })
 }

--- a/web-client/src/components/tournaments/data/fixtures.test.ts
+++ b/web-client/src/components/tournaments/data/fixtures.test.ts
@@ -33,6 +33,8 @@ describe('parseFixtures — the happy path', () => {
         winnerEntryId: null,
         matchId: null,
         matchStatus: null,
+        tableId: null,
+        scheduledStart: null,
       },
     ])
   })
@@ -77,6 +79,21 @@ describe('parseFixtures — the happy path', () => {
     expect(fixture.matchId).toBe('m-7')
     expect(fixture.matchStatus).toBe('completed')
   })
+
+  // A placed fixture (ADR-0790): assigned a table and a predicted start. Both are
+  // carried through as-is — the naive wall-clock start stays the string it arrives as,
+  // never coerced to a `Date` at this boundary.
+  it('carries a placed fixture through — table id and predicted start', () => {
+    const [fixture] = parseFixtures([
+      wire({
+        table_id: 'table-3',
+        scheduled_start: '2026-06-09T14:30:00',
+      }),
+    ])
+
+    expect(fixture.tableId).toBe('table-3')
+    expect(fixture.scheduledStart).toBe('2026-06-09T14:30:00')
+  })
 })
 
 // THE point of this module. `schema.d.ts` is a compile-time claim about a server we do
@@ -103,6 +120,12 @@ describe('parseFixtures — the boundary', () => {
     // value outside the closed `MatchStatus` set is a status this client cannot render.
     { what: 'an absent match_status', payload: [{ ...(wire() as object), match_status: undefined }] },
     { what: 'a match_status outside the enum', payload: [wire({ match_status: 'archived' })] },
+    // Placement (ADR-0790): every null is a fact — unassigned / unscheduled — so an
+    // absent key is not a null, and a wrong-typed one is a placement this client cannot read.
+    { what: 'an absent table_id', payload: [{ ...(wire() as object), table_id: undefined }] },
+    { what: 'a table_id of the wrong type', payload: [wire({ table_id: 7 })] },
+    { what: 'an absent scheduled_start', payload: [{ ...(wire() as object), scheduled_start: undefined }] },
+    { what: 'a scheduled_start of the wrong type', payload: [wire({ scheduled_start: 7 })] },
     // A draw is a LIST. `null` is not an empty draw: an event with no draw sends `[]`,
     // and a server that sent null would be sending something this client cannot read.
     { what: 'null instead of a list', payload: null },

--- a/web-client/src/components/tournaments/data/fixtures.ts
+++ b/web-client/src/components/tournaments/data/fixtures.ts
@@ -64,6 +64,16 @@ const fixtureWireSchema = z.object({
   /** The materialized match's live status, or `null` when the fixture has not
    * materialized. Moves in lockstep with `match_id`. */
   match_status: matchStatusSchema.nullable(),
+  /** The fixture's **placement** table (ADR-0790): `null` = **unassigned**. When
+   * set it is a **string ref** into the tournament's `table_catalogue` — not a
+   * foreign key, the same pattern as `pool_id`. */
+  table_id: z.string().nullable(),
+  /** The placement's **predicted** start (ADR-0790): `null` = **unscheduled**. A
+   * *naive* wall-clock timestamp string (no timezone), in the venue's frame — a
+   * prediction, not a commitment. Kept as the string it arrives as, exactly as the
+   * slot's `date`/`start`/`end` and the event's `created_at` are: this surface does
+   * not coerce wire datetimes to `Date` at the boundary. */
+  scheduled_start: z.string().nullable(),
 })
 
 /** The parser: one wire fixture → one domain `Fixture`.
@@ -83,6 +93,8 @@ export const fixtureSchema = fixtureWireSchema.transform(
     winnerEntryId: f.winner_entry_id,
     matchId: f.match_id,
     matchStatus: f.match_status,
+    tableId: f.table_id,
+    scheduledStart: f.scheduled_start,
   }),
 )
 

--- a/web-client/src/components/tournaments/data/schedule.test.ts
+++ b/web-client/src/components/tournaments/data/schedule.test.ts
@@ -1,0 +1,173 @@
+import {
+  buildDrawnEvent,
+  buildEntrants,
+  buildEvent,
+  buildFixture,
+  buildPool,
+  buildTables,
+  buildTournament,
+} from './seed.factory'
+import {
+  buildSchedule,
+  composeScheduledStart,
+  matchLabel,
+  scheduleStatusLabel,
+  sideLabel,
+  timeOfDay,
+} from './schedule'
+
+const at = (time: string) => `2026-06-13T${time}:00`
+
+describe('buildSchedule', () => {
+  it('groups placed matches under their table, in predicted-time order', () => {
+    const tournament = buildTournament({
+      events: [
+        buildDrawnEvent({
+          fixtures: [
+            buildFixture({
+              id: 'late',
+              poolId: 'p-a',
+              tableId: 't1',
+              scheduledStart: at('11:00'),
+            }),
+            buildFixture({
+              id: 'early',
+              poolId: 'p-a',
+              tableId: 't1',
+              scheduledStart: at('09:00'),
+            }),
+          ],
+        }),
+      ],
+    })
+
+    const { tables } = buildSchedule(tournament, buildTables())
+    expect(tables).toHaveLength(1)
+    expect(tables[0].tableId).toBe('t1')
+    // Sorted by predicted start, not by the order they arrived — a schedule that only
+    // happened to come out right is one paginated payload away from wrong.
+    expect(tables[0].matches.map((m) => m.fixtureId)).toEqual(['early', 'late'])
+  })
+
+  it('puts fixtures with no table in the awaiting group', () => {
+    const tournament = buildTournament({
+      events: [buildDrawnEvent()], // every fixture unplaced by default
+    })
+    const { tables, awaiting, isEmpty } = buildSchedule(tournament, buildTables())
+    expect(isEmpty).toBe(false)
+    expect(tables).toHaveLength(0)
+    expect(awaiting).toHaveLength(4)
+  })
+
+  it('is empty when no draw has been cut anywhere', () => {
+    const tournament = buildTournament({ events: [buildEvent({ fixtures: [] })] })
+    expect(buildSchedule(tournament, buildTables()).isEmpty).toBe(true)
+  })
+
+  it('resolves a table from the catalogue, and shows a dangling ref rather than dropping it', () => {
+    const tournament = buildTournament({
+      events: [
+        buildDrawnEvent({
+          fixtures: [
+            buildFixture({ id: 'known', poolId: 'p-a', tableId: 't1' }),
+            buildFixture({ id: 'gone', poolId: 'p-a', tableId: 't-removed' }),
+          ],
+        }),
+      ],
+    })
+    const { tables } = buildSchedule(tournament, buildTables())
+    const known = tables.find((t) => t.tableId === 't1')
+    const gone = tables.find((t) => t.tableId === 't-removed')
+    expect(known?.table?.label).toBe('T1')
+    // A placement can name a table the catalogue no longer lists (ADR-0790): it is SHOWN
+    // under its raw id, never silently dropped.
+    expect(gone?.table).toBeNull()
+    expect(gone?.matches.map((m) => m.fixtureId)).toEqual(['gone'])
+  })
+
+  it('gathers matches across events onto a shared table — the schedule is tournament-scoped', () => {
+    const a = buildEvent({
+      id: 'ev-a',
+      name: 'Event A',
+      entrants: buildEntrants(2),
+      pools: [buildPool({ id: 'pa', tableIds: ['t1'] })],
+      fixtures: [buildFixture({ id: 'a1', poolId: 'pa', tableId: 't1', scheduledStart: at('09:00') })],
+    })
+    const b = buildEvent({
+      id: 'ev-b',
+      name: 'Event B',
+      entrants: buildEntrants(2),
+      pools: [buildPool({ id: 'pb', tableIds: ['t1'] })],
+      fixtures: [buildFixture({ id: 'b1', poolId: 'pb', tableId: 't1', scheduledStart: at('10:00') })],
+    })
+    const { tables } = buildSchedule(buildTournament({ events: [a, b] }), buildTables())
+    expect(tables).toHaveLength(1)
+    expect(tables[0].matches.map((m) => m.fixtureId)).toEqual(['a1', 'b1'])
+  })
+
+  it('marks a finished match unplaceable and a live/planned one placeable', () => {
+    const tournament = buildTournament({
+      events: [
+        buildDrawnEvent({
+          fixtures: [
+            buildFixture({ id: 'planned', poolId: 'p-a' }),
+            buildFixture({ id: 'live', poolId: 'p-a', matchId: 'm1', matchStatus: 'in_progress' }),
+            buildFixture({ id: 'done', poolId: 'p-a', matchId: 'm2', matchStatus: 'completed' }),
+            buildFixture({ id: 'void', poolId: 'p-a', matchId: 'm3', matchStatus: 'voided' }),
+          ],
+        }),
+      ],
+    })
+    const placeable = Object.fromEntries(
+      buildSchedule(tournament, buildTables()).awaiting.map((m) => [m.fixtureId, m.placeable]),
+    )
+    expect(placeable).toEqual({ planned: true, live: true, done: false, void: false })
+  })
+
+  it('inherits the placement window from the fixture’s pool slot', () => {
+    const tournament = buildTournament({
+      events: [
+        buildDrawnEvent({
+          pools: [buildPool({ id: 'p-a', slot: { date: '2026-07-01', start: '13:00', end: '17:00' } })],
+          fixtures: [buildFixture({ id: 'x', poolId: 'p-a' })],
+        }),
+      ],
+    })
+    const [match] = buildSchedule(tournament, buildTables()).awaiting
+    expect(match.window).toEqual({ date: '2026-07-01', start: '13:00', end: '17:00' })
+  })
+})
+
+describe('placement helpers', () => {
+  it('composes a naive timestamp from a fixed date + a chosen time', () => {
+    expect(composeScheduledStart('2026-06-13', '09:30')).toBe('2026-06-13T09:30:00')
+  })
+
+  it('reads the time-of-day back out, tolerating an unscheduled fixture', () => {
+    expect(timeOfDay('2026-06-13T09:30:00')).toBe('09:30')
+    expect(timeOfDay(null)).toBe('')
+  })
+
+  it('names a status in a director’s words', () => {
+    expect(scheduleStatusLabel(null)).toBe('Not started')
+    expect(scheduleStatusLabel({ id: 'm', status: 'in_progress' })).toBe('Unplayed')
+    expect(scheduleStatusLabel({ id: 'm', status: 'completed' })).toBe('Completed')
+  })
+
+  it('labels a side and a pairing by name, never a raw id', () => {
+    expect(sideLabel({ kind: 'entrant', name: 'player.1' })).toBe('player.1')
+    expect(sideLabel({ kind: 'tbd' })).toBe('TBD')
+    expect(sideLabel({ kind: 'withdrawn' })).toBe('Withdrawn')
+    const [match] = buildSchedule(
+      buildTournament({
+        events: [
+          buildDrawnEvent({
+            fixtures: [buildFixture({ id: 'x', poolId: 'p-a', entryAId: 'entry-1', entryBId: 'entry-4' })],
+          }),
+        ],
+      }),
+      buildTables(),
+    ).awaiting
+    expect(matchLabel(match)).toBe('player.1 vs player.4')
+  })
+})

--- a/web-client/src/components/tournaments/data/schedule.ts
+++ b/web-client/src/components/tournaments/data/schedule.ts
@@ -1,0 +1,273 @@
+// What a tournament's **schedule** looks like to a reader (ADR-0790) — the pure
+// derivation behind the Schedule tab.
+//
+// The schedule is **tournament-scoped, not per-event** (CONTEXT.md): the venue's tables
+// are shared across events, so "two matches on one table at once" is a cross-event fact,
+// and this reduces *every* event's fixtures into one view organized by the venue —
+// grouped by table, plus an "awaiting placement" group for the fixtures no table/time
+// has been chosen for yet.
+//
+// A fixture carries a **placement** (ADR-0790): `tableId` (a string ref into the
+// tournament's table catalogue, like `poolId`) and a naive `scheduledStart` — a
+// *predicted* wall-clock timestamp, not a promise. The placement's **date is fixed** by
+// the fixture's pool Slot (or the event Slot when un-pooled), so a director only ever
+// chooses a *time within that window*; `composeScheduledStart` puts the two back
+// together, in the same naive frame the Slot is already in (never a `Date`/UTC coercion).
+//
+// All of it is a pure function of one tournament + its table catalogue, so it is
+// unit-tested (`./schedule.test.ts`) rather than asserted through a DOM — the same shape
+// `./draw.ts` takes for the same reason.
+
+import type { MatchStatus } from '@/api/matches'
+
+import type { FixtureMatch, FixtureSide } from './draw'
+import type {
+  Entrant,
+  Fixture,
+  Slot,
+  Tournament,
+  TournamentEvent,
+  TournamentTable,
+} from './types'
+
+/** A fixture the placement control cannot move: its match is `completed` or `voided`, so
+ * its table and time are history and the PATCH would 409 (ADR-0790). Everything else — a
+ * fixture with no match yet, or an `in_progress` one — is freely (re)placeable. */
+const FROZEN_STATUSES: ReadonlySet<MatchStatus> = new Set(['completed', 'voided'])
+
+/**
+ * One fixture as a schedulable **match** on the tournament schedule (ADR-0790).
+ *
+ * It is keyed by the **fixture** id, not a match id: a placement lives on the fixture and
+ * can be set before the match exists (a round-robin fixture is known at the cut), so the
+ * fixture id is the stable address a placement PATCH is sent to.
+ *
+ * The two sides are joined to names exactly as the draw does (`FixtureSide`, `./draw`) —
+ * an entrant's username, or `TBD` / `Withdrawn` — never a blank or a raw entry id.
+ */
+export interface ScheduleMatch {
+  /** The fixture id — the address `usePlaceFixture` PATCHes. */
+  fixtureId: string
+  eventId: string
+  eventName: string
+  a: FixtureSide
+  b: FixtureSide
+  /** The materialized match, or `null` while the fixture is still a planned pairing —
+   * the same lockstep pair the draw carries. `null` reads as "not started". */
+  match: FixtureMatch | null
+  /** The placement's table (`null` = unassigned), a string ref into the catalogue. */
+  tableId: string | null
+  /** The placement's predicted start, a naive wall-clock timestamp (`null` = unscheduled). */
+  scheduledStart: string | null
+  /** The window whose **date** the placement is fixed to: the fixture's pool Slot, or the
+   * event Slot when the fixture is un-pooled (ADR-0790). The time picker chooses within it. */
+  window: Slot
+  /** The tables the fixture's pool reserves — the natural suggestion for a placement
+   * (empty for an un-pooled fixture, whose whole venue is fair game). */
+  suggestedTableIds: string[]
+  /** Whether the placement can still be changed. `false` once the match is
+   * `completed`/`voided` — its placement is frozen server-side, so the control is hidden
+   * rather than offered and refused (ADR-0790). */
+  placeable: boolean
+}
+
+/**
+ * One table's column on the schedule: the table (resolved from the catalogue) and its
+ * matches in **predicted-time order**.
+ *
+ * `table` is `null` when a placement names a table the catalogue no longer lists — a
+ * dangling ref a later catalogue edit can leave (ADR-0790: an unknown `table_id` is
+ * *stored*, not refused). It is **shown** under its raw id, never dropped, exactly as a
+ * withdrawn draw side is shown rather than blanked.
+ */
+export interface ScheduleTable {
+  tableId: string
+  table: TournamentTable | null
+  matches: ScheduleMatch[]
+}
+
+/** A tournament's schedule: its matches grouped by table, plus the fixtures still
+ * awaiting a placement. `isEmpty` is the designed "nothing to schedule" state — no
+ * fixtures anywhere (no draw cut yet), never an error. */
+export interface TournamentSchedule {
+  /** One column per table that has at least one placed match, in catalogue order
+   * (dangling refs last). */
+  tables: ScheduleTable[]
+  /** Fixtures with no table yet — a freshly-live tournament's every match starts here
+   * (ADR-0790), not in an empty grid. */
+  awaiting: ScheduleMatch[]
+  /** True when there is no fixture anywhere to schedule. */
+  isEmpty: boolean
+}
+
+/** Join one entry id to a side — TBD when the feeder is undecided (`null`), Withdrawn
+ * when the event no longer lists the id, else the entrant's username. The same rule
+ * `./draw.ts` joins a draw line by; kept local, like `./results.ts` keeps its own, so a
+ * schedule row and a draw line derive independently rather than through a shared private. */
+function sideOf(entryId: string | null, byId: Map<string, Entrant>): FixtureSide {
+  if (entryId === null) return { kind: 'tbd' }
+  const entrant = byId.get(entryId)
+  return entrant ? { kind: 'entrant', name: entrant.username } : { kind: 'withdrawn' }
+}
+
+/** The materialized match of a fixture, or `null`. `matchId`/`matchStatus` move in
+ * lockstep on the wire, so the `&&` is a belt against a half-materialized shape. */
+function matchOf(fixture: Fixture): FixtureMatch | null {
+  if (fixture.matchId === null || fixture.matchStatus === null) return null
+  return { id: fixture.matchId, status: fixture.matchStatus }
+}
+
+function toScheduleMatch(
+  fixture: Fixture,
+  event: TournamentEvent,
+  byId: Map<string, Entrant>,
+  poolById: Map<string, TournamentEvent['pools'][number]>,
+): ScheduleMatch {
+  const pool = fixture.poolId !== null ? (poolById.get(fixture.poolId) ?? null) : null
+  return {
+    fixtureId: fixture.id,
+    eventId: event.id,
+    eventName: event.name,
+    a: sideOf(fixture.entryAId, byId),
+    b: sideOf(fixture.entryBId, byId),
+    match: matchOf(fixture),
+    tableId: fixture.tableId,
+    scheduledStart: fixture.scheduledStart,
+    // The pool fixes the date the placement falls on; an un-pooled fixture inherits the
+    // event's own Slot (ADR-0790).
+    window: pool?.slot ?? event.slot,
+    suggestedTableIds: pool?.tableIds ?? [],
+    placeable:
+      fixture.matchStatus === null || !FROZEN_STATUSES.has(fixture.matchStatus),
+  }
+}
+
+/** Order two matches by predicted start, **unscheduled last**. A placement with no time
+ * yet (a half-placed fixture) sorts to the bottom of its table rather than to the top on
+ * an empty-string compare. */
+function byScheduledStart(a: ScheduleMatch, b: ScheduleMatch): number {
+  if (a.scheduledStart === b.scheduledStart) return 0
+  if (a.scheduledStart === null) return 1
+  if (b.scheduledStart === null) return -1
+  return a.scheduledStart < b.scheduledStart ? -1 : 1
+}
+
+/**
+ * Reduce a tournament (+ its table catalogue) to its schedule: every fixture of every
+ * event, grouped by the table it is placed on, with the unplaced ones set aside.
+ *
+ * It **groups and sorts** rather than trusting any order the payload happens to arrive in
+ * — order is a claim about untrusted data like any other (the same stance `./draw.ts`
+ * takes on rounds).
+ */
+export function buildSchedule(
+  tournament: Tournament,
+  catalogue: TournamentTable[],
+): TournamentSchedule {
+  const tableById = new Map(catalogue.map((t) => [t.id, t]))
+  // Catalogue order is the venue's own order (t1, t2, …); a dangling ref sorts after all
+  // of it rather than jumping the queue on a string compare.
+  const catalogueIndex = new Map(catalogue.map((t, i) => [t.id, i]))
+
+  const matches: ScheduleMatch[] = []
+  for (const event of tournament.events) {
+    const byId = new Map(event.entrants.map((e) => [e.id, e]))
+    const poolById = new Map(event.pools.map((p) => [p.id, p]))
+    for (const fixture of event.fixtures) {
+      matches.push(toScheduleMatch(fixture, event, byId, poolById))
+    }
+  }
+
+  const byTable = new Map<string, ScheduleMatch[]>()
+  const awaiting: ScheduleMatch[] = []
+  for (const match of matches) {
+    // A fixture belongs to a table column exactly when it has a table; otherwise it is
+    // awaiting placement, whatever its time (a table with no time is still placed).
+    if (match.tableId === null) {
+      awaiting.push(match)
+      continue
+    }
+    const bucket = byTable.get(match.tableId)
+    if (bucket) bucket.push(match)
+    else byTable.set(match.tableId, [match])
+  }
+
+  const tables: ScheduleTable[] = [...byTable.entries()]
+    .map(([tableId, tableMatches]) => ({
+      tableId,
+      table: tableById.get(tableId) ?? null,
+      matches: tableMatches.slice().sort(byScheduledStart),
+    }))
+    .sort(
+      (a, b) =>
+        (catalogueIndex.get(a.tableId) ?? Number.MAX_SAFE_INTEGER) -
+        (catalogueIndex.get(b.tableId) ?? Number.MAX_SAFE_INTEGER),
+    )
+
+  return {
+    tables,
+    awaiting: awaiting.slice().sort(byScheduledStart),
+    isEmpty: matches.length === 0,
+  }
+}
+
+/** What a schedule match's status reads as, in a director's words (ADR-0790: unplayed vs
+ * done). `null` (no match yet) and `pending` (a match reset before it started) both read
+ * "Not started"; an `in_progress` match is the ordinary live one — "Unplayed"; a done
+ * match says which done. Keyed so a new `MatchStatus` is a compile error until it is
+ * given a word, never a blank cell. */
+const STATUS_LABEL: Record<MatchStatus, string> = {
+  pending: 'Not started',
+  in_progress: 'Unplayed',
+  completed: 'Completed',
+  voided: 'Voided',
+}
+
+export function scheduleStatusLabel(match: FixtureMatch | null): string {
+  return match === null ? 'Not started' : STATUS_LABEL[match.status]
+}
+
+/** The label a side reads as on the schedule — the entrant's username, or the same `TBD`
+ * / `Withdrawn` words the draw uses. Used for a control's accessible name (`Place …`), so
+ * two rows of one event are told apart by the pairing they name, not by a bare "Place". */
+export function sideLabel(side: FixtureSide): string {
+  switch (side.kind) {
+    case 'entrant':
+      return side.name
+    case 'tbd':
+      return 'TBD'
+    case 'withdrawn':
+      return 'Withdrawn'
+    default: {
+      const exhaustive: never = side
+      return exhaustive
+    }
+  }
+}
+
+/** The `A vs B` pairing as one string, for a control's accessible name. */
+export function matchLabel(match: ScheduleMatch): string {
+  return `${sideLabel(match.a)} vs ${sideLabel(match.b)}`
+}
+
+/**
+ * Compose the naive wall-clock timestamp a placement stores (ADR-0790) from the window's
+ * fixed **date** and a chosen **time** (`HH:MM`): `YYYY-MM-DDTHH:MM:SS`, no timezone.
+ *
+ * This is the whole reason the control only asks for a time: the date is the pool/event
+ * Slot's, and the placement lives in the *same naive frame* the Slot does — so this is
+ * plain string assembly, never a `Date` (which would drag a timezone in and coerce the
+ * wall-clock instant to UTC, the exact thing ADR-0790 refuses).
+ */
+export function composeScheduledStart(date: string, time: string): string {
+  return `${date}T${time}:00`
+}
+
+/** The `HH:MM` time-of-day of a naive placement timestamp — for prefilling the picker and
+ * showing the placement. Tolerant of a bare date or a seconds-bearing stamp; `''` when
+ * there is no time (an unscheduled fixture). */
+export function timeOfDay(scheduledStart: string | null): string {
+  if (!scheduledStart) return ''
+  const time = scheduledStart.split('T')[1]
+  return time ? time.slice(0, 5) : ''
+}

--- a/web-client/src/components/tournaments/data/schedule.ts
+++ b/web-client/src/components/tournaments/data/schedule.ts
@@ -20,7 +20,7 @@
 
 import type { MatchStatus } from '@/api/matches'
 
-import type { FixtureMatch, FixtureSide } from './draw'
+import { type FixtureMatch, type FixtureSide, TBD_LABEL, WITHDRAWN_LABEL } from './draw'
 import type {
   Entrant,
   Fixture,
@@ -235,9 +235,9 @@ export function sideLabel(side: FixtureSide): string {
     case 'entrant':
       return side.name
     case 'tbd':
-      return 'TBD'
+      return TBD_LABEL
     case 'withdrawn':
-      return 'Withdrawn'
+      return WITHDRAWN_LABEL
     default: {
       const exhaustive: never = side
       return exhaustive

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -233,7 +233,8 @@ export function buildIneligibleEvent(
  *
  * Every `null` is a fact, so none of them is a default worth having *silently*: pass
  * `entryBId: null` for a **TBD** side (never a bye — a bye is the ABSENCE of a fixture),
- * `poolId: null` for an un-pooled (knockout) fixture. */
+ * `poolId: null` for an un-pooled (knockout) fixture. Placement (ADR-0790) defaults
+ * empty: `tableId: null` unassigned, `scheduledStart: null` unscheduled. */
 export function buildFixture(overrides: Partial<Fixture> = {}): Fixture {
   return {
     id: 'fx-1',
@@ -245,6 +246,8 @@ export function buildFixture(overrides: Partial<Fixture> = {}): Fixture {
     winnerEntryId: null,
     matchId: null,
     matchStatus: null,
+    tableId: null,
+    scheduledStart: null,
     ...overrides,
   }
 }

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -110,6 +110,13 @@ export interface Pool {
  * - `poolId` — this fixture belongs to no pool: the draw is un-pooled (single-elim), or
  *   this is the KO stage of an rr-then-ko. When set, it names a `Pool` in this same
  *   event's `pools`.
+ * - `tableId` — the fixture's **placement** table (ADR-0790): `null` means **unassigned
+ *   to a table**. When set, it names a `TournamentTable` in the tournament's table
+ *   catalogue — a string ref, the same pattern as `poolId`.
+ * - `scheduledStart` — the placement's **predicted** start (ADR-0790): `null` means
+ *   **unscheduled**. A *naive* wall-clock timestamp string (no timezone), in the venue's
+ *   frame — a prediction, not a commitment, so an off-prediction start is normal, not an
+ *   error. Carried as the string it arrives as (like the slot's `date`/`start`/`end`).
  *
  * Parsed at the boundary by `./fixtures` — this interface is what comes out.
  */
@@ -125,6 +132,12 @@ export interface Fixture {
   /** The materialized match's live status, or `null` until go-live (#788). Moves in
    * lockstep with `matchId`. */
   matchStatus: MatchStatus | null
+  /** The placement table this fixture is assigned to (ADR-0790), or `null` when
+   * **unassigned**. A string ref into the tournament's table catalogue, like `poolId`. */
+  tableId: string | null
+  /** The placement's predicted start (ADR-0790): a naive wall-clock timestamp string, or
+   * `null` when **unscheduled**. A prediction, not a commitment. */
+  scheduledStart: string | null
 }
 
 /**

--- a/web-client/src/components/tournaments/page-heading.tsx
+++ b/web-client/src/components/tournaments/page-heading.tsx
@@ -23,7 +23,7 @@ export const PageHeading = ({
   action,
 }: PageHeadingProps) => {
   return (
-    <div className="mb-8 flex items-start gap-6">
+    <div className="mb-8 flex flex-col gap-6 sm:flex-row sm:items-start">
       <div className="min-w-0 flex-1">
         {breadcrumb.length > 0 && (
           <nav
@@ -73,7 +73,7 @@ export const PageHeading = ({
           </p>
         )}
       </div>
-      {action && <div className="shrink-0 pt-7">{action}</div>}
+      {action && <div className="shrink-0 sm:pt-7">{action}</div>}
     </div>
   )
 }

--- a/web-client/src/components/tournaments/tournament-detail-page.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.page.tsx
@@ -1,3 +1,5 @@
+import { interactiveElementsIn } from '@/test/read-only'
+import { SessionProbe } from '@/test/session-probe'
 import { render, screen, type Container } from '@/test/utilities'
 
 import {
@@ -8,8 +10,27 @@ import { buildTournamentDetailPageProps } from './tournament-detail-page.factory
 import { eventsTabPage } from './tournament-detail-page/events-tab.page'
 
 const scoped = (container: Container) => ({
-  getTab(name: string) {
+  getTab(name: string | RegExp) {
     return container.getByRole('tab', { name })
+  },
+  /** The currently-active tab panel — Radix unmounts the inactive ones, so there
+   * is exactly one in the DOM. The scope a per-tab read-only sweep runs over: the
+   * tab STRIP (its triggers) sits outside it, so it is never miscounted as a
+   * control. */
+  getActiveTabPanel() {
+    return container.getByRole('tabpanel')
+  },
+  /** Every interactive control in the active tab panel, swept over the DOM
+   * (ADR-0015 rule 6 — never an ARIA-role sweep, which under-proves). The guard a
+   * "this tab is a read-only view for a non-owner" assertion needs. */
+  getActiveTabControls() {
+    return interactiveElementsIn(container.getByRole('tabpanel'))
+  },
+  /** Resolves once `/v1/session` has landed (`SessionProbe`). Gate a non-owner
+   * *absence* assertion on this: permission-gated controls read as absent while the
+   * session is still in flight, so an un-gated assertion passes vacuously. */
+  findSessionReady() {
+    return container.findByTestId('session-ready')
   },
   getBackCrumb() {
     return container.getByRole('button', { name: 'Tournaments' })
@@ -52,7 +73,15 @@ const scoped = (container: Container) => ({
 /** Test page-object for `TournamentDetailPage`. */
 export const tournamentDetailPagePage = {
   render(overrides: Partial<TournamentDetailPageProps> = {}) {
-    render(<TournamentDetailPage {...buildTournamentDetailPageProps(overrides)} />)
+    render(
+      <>
+        {/* Inert marker so a test can `await findSessionReady()` before asserting a
+            permission-gated control is absent (the page already fetches the session
+            itself — this only exposes when it lands). */}
+        <SessionProbe />
+        <TournamentDetailPage {...buildTournamentDetailPageProps(overrides)} />
+      </>,
+    )
   },
   /** The event editor's save button (the sheet portals to the body). */
   getEditorSaveButton() {

--- a/web-client/src/components/tournaments/tournament-detail-page.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.test.tsx
@@ -2,12 +2,22 @@ import userEvent from '@testing-library/user-event'
 import { HttpResponse } from 'msw'
 
 import { ApiError } from '@/api/client'
+import { mockSessionEndpoint } from '@/mocks/endpoints/session/session.endpoint'
 import { mockTournamentTransitionEndpoint } from '@/mocks/endpoints/tournaments/tournaments.endpoint'
 import { buildTournamentDetailRead } from '@/mocks/factories/tournaments/tournament.factory'
 import { server } from '@/mocks/server'
+import { PERM } from '@/lib/permissions'
+import { sessionResponse } from '@/test/factories'
 import { waitFor } from '@/test/utilities'
 
-import { buildAddress, buildEvent, buildTournament } from './data/seed.factory'
+import {
+  buildAddress,
+  buildDrawnEvent,
+  buildEvent,
+  buildFixture,
+  buildTables,
+  buildTournament,
+} from './data/seed.factory'
 import { tournamentDetailPagePage } from './tournament-detail-page.page'
 
 describe('TournamentDetailPage', () => {
@@ -327,5 +337,160 @@ describe('TournamentDetailPage', () => {
     })
     await userEvent.click(tournamentDetailPagePage.getBackCrumb())
     expect(onBack).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * Slice 3 (#791): a **permissioned non-owner viewer** — a beta user who holds
+   * `tournament.view` but is neither the creator nor entitled to enter — opening a
+   * published tournament gets it **fully read-only on every tab** (ADR-0015). This
+   * is the page-level integration proof that `can_edit === false` reaches every tab:
+   * the per-tab quartets each guard their own surface, but only this walks all four
+   * of one page and sweeps each for the controls that must have leaked nowhere —
+   * the edit forms, the cut/re-cut/delete draw verbs, the lifecycle transitions, the
+   * table-catalogue editor, the placement control, and any Enter/Withdraw the viewer
+   * was never granted.
+   *
+   * The tournament carries a **cut, partly-scheduled draw** so every tab has real
+   * content to be read-only *about*: the Events tab shows the draw, the Schedule tab
+   * shows a placed match and an awaiting one — the exact surfaces the owner's verbs
+   * would hang off.
+   */
+  describe('a permissioned non-owner viewer gets a read-only page (#791, ADR-0015)', () => {
+    /** A drawn event with one fixture PLACED on `t1` and one still awaiting a table
+     * — the two groups the Schedule tab renders. The placed fixture carries a
+     * `tableId` + time but NO `matchId`: a published tournament's fixtures are placed
+     * before go-live, and only materialize into real matches when the tournament
+     * starts (ADR-0790), so no match-link renders here. */
+    const buildScheduledEvent = () =>
+      buildDrawnEvent({
+        fixtures: [
+          buildFixture({
+            id: 'fx-a-1',
+            poolId: 'p-a',
+            round: 1,
+            position: 1,
+            entryAId: 'entry-1',
+            entryBId: 'entry-4',
+            tableId: 't1',
+            scheduledStart: '2026-06-13T09:00:00',
+          }),
+          buildFixture({
+            id: 'fx-a-2',
+            poolId: 'p-a',
+            round: 2,
+            position: 1,
+            entryAId: 'entry-1',
+            entryBId: 'entry-5',
+          }),
+        ],
+      })
+
+    /** A published tournament (a non-owner can see it — a draft would 404, #967)
+     * with the scheduled draw, seen by a spectator who holds `tournament.view` only
+     * (no `tournament.enter`, and `can_edit: false`). */
+    const renderAsSpectator = () => {
+      mockSessionEndpoint(server, () =>
+        HttpResponse.json(
+          sessionResponse({
+            user: { username: 'spectator', permissions: [PERM.TOURNAMENT_VIEW] },
+          }),
+        ),
+      )
+      tournamentDetailPagePage.render({
+        tournament: buildTournament({
+          status: 'published',
+          canEdit: false,
+          events: [buildScheduledEvent()],
+        }),
+        allTables: buildTables(6),
+      })
+    }
+
+    it('renders the Details tab as values, with no edit controls', async () => {
+      renderAsSpectator()
+      await tournamentDetailPagePage.findSessionReady()
+
+      await userEvent.click(tournamentDetailPagePage.getTab(/^Details/))
+      expect(tournamentDetailPagePage.getActiveTabControls()).toHaveLength(0)
+    })
+
+    it('renders the Tables tab as a list, with no catalogue editor', async () => {
+      renderAsSpectator()
+      await tournamentDetailPagePage.findSessionReady()
+
+      await userEvent.click(tournamentDetailPagePage.getTab(/^Tables/))
+      // The list is still there to read…
+      expect(tournamentDetailPagePage.getActiveTabPanel()).toHaveTextContent('T1')
+      // …but the add-table form and the per-row Remove buttons are gone.
+      expect(tournamentDetailPagePage.getActiveTabControls()).toHaveLength(0)
+    })
+
+    it('renders the Schedule tab as a view, with no placement control', async () => {
+      renderAsSpectator()
+      await tournamentDetailPagePage.findSessionReady()
+
+      await userEvent.click(tournamentDetailPagePage.getTab(/^Schedule/))
+      // The schedule renders (the placed match sits in its table column)…
+      expect(tournamentDetailPagePage.getActiveTabPanel()).toHaveTextContent(
+        'player.1 vs player.4',
+      )
+      // …with no Place / Move trigger anywhere.
+      expect(tournamentDetailPagePage.getActiveTabControls()).toHaveLength(0)
+    })
+
+    it('renders the Events tab with only the read-only "View" open target — no owner or entry affordance', async () => {
+      renderAsSpectator()
+      await tournamentDetailPagePage.findSessionReady()
+
+      // Events is the default tab; select it explicitly so the assertion is uniform.
+      await userEvent.click(tournamentDetailPagePage.getTab(/^Events/))
+
+      const controls = tournamentDetailPagePage.getActiveTabControls()
+      // The card is openable — into a read-only view (ADR 0015). That open target is
+      // the ONLY interactive control the tab offers a viewer: no "New event", no
+      // Generate/Re-cut/Delete draw verbs, and no Enter/Withdraw (the spectator holds
+      // no `tournament.enter`).
+      expect(controls.length).toBeGreaterThan(0)
+      expect(
+        controls.every((el) => /^View /.test(el.getAttribute('aria-label') ?? '')),
+      ).toBe(true)
+      expect(tournamentDetailPagePage.queryNewEventButtons()).toHaveLength(0)
+    })
+
+    it('offers no lifecycle transition in the header', async () => {
+      renderAsSpectator()
+      await tournamentDetailPagePage.findSessionReady()
+
+      // Published → the OWNER would be offered "Start tournament"; a viewer is not.
+      expect(
+        tournamentDetailPagePage.queryLifecycleButton(/Start tournament/),
+      ).toBeNull()
+    })
+
+    // The other half of ADR-0015: the gating must not be over-broad. The owner of the
+    // very same tournament still gets the full controls on every tab — so a "hide it
+    // from everyone" regression that satisfied the sweeps above is caught here.
+    it('still gives the OWNER interactive controls on every tab', async () => {
+      tournamentDetailPagePage.render({
+        tournament: buildTournament({
+          status: 'published',
+          canEdit: true,
+          events: [buildScheduledEvent()],
+        }),
+        allTables: buildTables(6),
+      })
+
+      // The header lifecycle action (Publish/Start/End) is the owner's alone.
+      expect(
+        tournamentDetailPagePage.getLifecycleButton(/Start tournament/),
+      ).toBeInTheDocument()
+
+      for (const tab of [/^Events/, /^Tables/, /^Schedule/, /^Details/]) {
+        await userEvent.click(tournamentDetailPagePage.getTab(tab))
+        expect(
+          tournamentDetailPagePage.getActiveTabControls().length,
+        ).toBeGreaterThan(0)
+      }
+    })
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.tsx
@@ -218,7 +218,7 @@ export const TournamentDetailPage = ({
             />
           </TabsContent>
           <TabsContent value="schedule">
-            <ScheduleTab tournament={tournament} />
+            <ScheduleTab tournament={tournament} tables={allTables} />
           </TabsContent>
           <TabsContent value="details">
             <DetailsTab

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.factory.tsx
@@ -1,9 +1,20 @@
-import { buildTournament } from '../data/seed.factory'
+import {
+  buildDrawnEvent,
+  buildTables,
+  buildTournament,
+} from '../data/seed.factory'
 import type { ScheduleTabProps } from './schedule-tab'
 
-/** Props for `ScheduleTab` — the seeded tournament with one scheduled pool. */
+/** Props for `ScheduleTab` — a tournament with a cut draw (real fixtures, all awaiting a
+ * placement by default) plus the full table catalogue the placements resolve against. A
+ * test that wants placed matches overrides the events' fixtures with `tableId` /
+ * `scheduledStart` set. */
 export function buildScheduleTabProps(
   overrides: Partial<ScheduleTabProps> = {},
 ): ScheduleTabProps {
-  return { tournament: buildTournament(), ...overrides }
+  return {
+    tournament: buildTournament({ events: [buildDrawnEvent()] }),
+    tables: buildTables(),
+    ...overrides,
+  }
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.page.tsx
@@ -1,22 +1,121 @@
-import { render, screen, type Container } from '@/test/utilities'
+import { interactiveElementsIn } from '@/test/read-only'
+import { fireEvent, render, screen, within, type Container } from '@/test/utilities'
 
 import { ScheduleTab, type ScheduleTabProps } from './schedule-tab'
 import { buildScheduleTabProps } from './schedule-tab.factory'
 
+/** Every match row, wherever it is — the id prefix is the only thing that identifies one. */
+const MATCH_TESTID = /^schedule-match-/
+
+const rowText = (el: HTMLElement) =>
+  (el.textContent ?? '').replace(/\s+/g, ' ').trim()
+
 const scoped = (container: Container) => ({
-  queryText(text: string) {
-    return container.queryByText(text)
+  /** The whole tab — the scope a read-only guard sweeps. */
+  getTab() {
+    return container.getByTestId('schedule-tab')
+  },
+
+  /** One table's column, by table id. */
+  queryTableColumn(tableId: string) {
+    return container.queryByTestId(`schedule-table-${tableId}`)
+  },
+  getTableColumn(tableId: string) {
+    return container.getByTestId(`schedule-table-${tableId}`)
+  },
+
+  /** The awaiting-placement group — the matches with no table/time yet. */
+  queryAwaiting() {
+    return container.queryByTestId('schedule-awaiting')
+  },
+  getAwaiting() {
+    return container.getByTestId('schedule-awaiting')
+  },
+
+  /** The reserved pool windows shown as lightweight context. */
+  queryWindows() {
+    return container.queryByTestId('schedule-windows')
+  },
+
+  /** One match row, by fixture id. */
+  getMatch(fixtureId: string) {
+    return container.getByTestId(`schedule-match-${fixtureId}`)
+  },
+  queryMatch(fixtureId: string) {
+    return container.queryByTestId(`schedule-match-${fixtureId}`)
+  },
+  /** The fixture ids of the match rows inside a scope, in DOM order. */
+  matchIdsIn(scope: HTMLElement): string[] {
+    return within(scope)
+      .queryAllByTestId(MATCH_TESTID)
+      .map((el) => el.getAttribute('data-testid')!.replace('schedule-match-', ''))
+  },
+  /** One match row as text — `09:00 player.1 vs player.4 · U1200 Singles Unplayed`. */
+  getMatchText(fixtureId: string) {
+    return rowText(container.getByTestId(`schedule-match-${fixtureId}`))
+  },
+  /** A match's status label (`Unplayed`, `Completed`, …). */
+  getStatus(fixtureId: string) {
+    return container.getByTestId(`schedule-status-${fixtureId}`)
+  },
+
+  /** The **Place** / **Move** trigger the owner sees on a match — absent for a non-owner
+   * and for a finished (frozen) match. */
+  queryPlaceTrigger(fixtureId: string) {
+    return container.queryByTestId(`place-trigger-${fixtureId}`)
+  },
+  getPlaceTrigger(fixtureId: string) {
+    return container.getByTestId(`place-trigger-${fixtureId}`)
+  },
+  /** Open the placement editor for a match (clicks its trigger). */
+  openPlacement(fixtureId: string) {
+    fireEvent.click(container.getByTestId(`place-trigger-${fixtureId}`))
+  },
+  queryPlaceEditor(fixtureId: string) {
+    return container.queryByTestId(`place-editor-${fixtureId}`)
+  },
+  /** The predicted-start time input in an open editor. */
+  getPlaceTime(fixtureId: string) {
+    return container.getByTestId(`place-time-${fixtureId}`) as HTMLInputElement
+  },
+  setPlaceTime(fixtureId: string, value: string) {
+    fireEvent.change(container.getByTestId(`place-time-${fixtureId}`), {
+      target: { value },
+    })
+  },
+  /** Save / Clear the placement in an open editor. */
+  savePlacement(fixtureId: string) {
+    fireEvent.click(container.getByTestId(`place-save-${fixtureId}`))
+  },
+  clearPlacement(fixtureId: string) {
+    fireEvent.click(container.getByTestId(`place-clear-${fixtureId}`))
+  },
+  queryClear(fixtureId: string) {
+    return container.queryByTestId(`place-clear-${fixtureId}`)
+  },
+
+  /** EVERY interactive control in the tab — the sweep a "a non-owner is offered nothing"
+   * guard needs (ADR-0015: no control at all, not a disabled one). */
+  getControls() {
+    return interactiveElementsIn(container.getByTestId('schedule-tab'))
+  },
+
+  within(node: Container = screen) {
+    return scoped(node)
   },
 })
 
-/** Test page-object for `ScheduleTab`. */
+/**
+ * Test page-object for `ScheduleTab`.
+ *
+ * The tab owns the placement mutation (`usePlaceFixture`), so a test that saves a
+ * placement stubs the endpoint itself — `mockFixturePlacementEndpoint`
+ * (`@/mocks/endpoints/tournaments/tournaments.endpoint`). Rendering alone fetches
+ * nothing: the schedule is derived from the tournament it is handed.
+ */
 export const scheduleTabPage = {
   render(overrides: Partial<ScheduleTabProps> = {}) {
     render(<ScheduleTab {...buildScheduleTabProps(overrides)} />)
-  },
-
-  within(container: Container = screen) {
-    return scoped(container)
   },
 
   ...scoped(screen),

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.test.tsx
@@ -109,6 +109,38 @@ describe('ScheduleTab', () => {
     expect(sent).toMatchObject({ scheduled_start: '2026-06-13T10:30:00' })
   })
 
+  it('places a match with no predicted time as a table-only placement (scheduled_start: null)', async () => {
+    let sent: unknown = null
+    mockFixturePlacementEndpoint(server, async ({ request }) => {
+      sent = await request.json()
+      return HttpResponse.json(
+        buildTournamentFixtureRead({
+          id: 'fx-a-2',
+          table_id: 't1',
+          scheduled_start: null,
+        }),
+      )
+    })
+
+    page.render({
+      tournament: buildTournament({ events: [buildScheduledEvent()] }),
+      tables: buildTables(),
+    })
+
+    page.openPlacement('fx-a-2')
+    // Clear the predicted-start time, then Save — this must NOT be a silent no-op.
+    page.setPlaceTime('fx-a-2', '')
+    page.savePlacement('fx-a-2')
+
+    // The editor closes on success — an empty time is a valid table-only placement,
+    // not a malformed timestamp the server rejects and the panel silently swallows.
+    await waitFor(() => expect(page.queryPlaceEditor('fx-a-2')).not.toBeInTheDocument())
+    // The mutation carries an explicit null time — the fixture is placed on the table
+    // (its pool's first suggested table, `t1`) with no prediction, never a composed
+    // `YYYY-MM-DDT:00`.
+    expect(sent).toMatchObject({ table_id: 't1', scheduled_start: null })
+  })
+
   it('does not offer to move a finished match (its placement is frozen)', () => {
     page.render({
       tournament: buildTournament({

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.test.tsx
@@ -1,31 +1,153 @@
-import { buildEvent, buildPool, buildTournament } from '../data/seed.factory'
-import { scheduleTabPage } from './schedule-tab.page'
+import { HttpResponse } from 'msw'
+
+import { waitFor, within } from '@/test/utilities'
+import { mockFixturePlacementEndpoint } from '@/mocks/endpoints/tournaments/tournaments.endpoint'
+import { buildTournamentFixtureRead } from '@/mocks/factories/tournaments/tournament.factory'
+import { server } from '@/mocks/server'
+
+import {
+  buildDrawnEvent,
+  buildFixture,
+  buildTables,
+  buildTournament,
+} from '../data/seed.factory'
+import { scheduleTabPage as page } from './schedule-tab.page'
+
+/** A drawn event with one match PLACED on table `t1` (in progress) and one still
+ * awaiting a table — the two groups the schedule sorts fixtures into. */
+const buildScheduledEvent = () =>
+  buildDrawnEvent({
+    fixtures: [
+      buildFixture({
+        id: 'fx-a-1',
+        poolId: 'p-a',
+        round: 1,
+        position: 1,
+        entryAId: 'entry-1',
+        entryBId: 'entry-4',
+        matchId: 'm-a-1',
+        matchStatus: 'in_progress',
+        tableId: 't1',
+        scheduledStart: '2026-06-13T09:00:00',
+      }),
+      buildFixture({
+        id: 'fx-a-2',
+        poolId: 'p-a',
+        round: 2,
+        position: 1,
+        entryAId: 'entry-1',
+        entryBId: 'entry-5',
+      }),
+    ],
+  })
 
 describe('ScheduleTab', () => {
-  it('lists each scheduled pool under its day', () => {
-    scheduleTabPage.render({
+  it('groups the tournament’s real matches by table, with an awaiting-placement group', () => {
+    page.render({
+      tournament: buildTournament({ events: [buildScheduledEvent()] }),
+      tables: buildTables(),
+    })
+
+    // The placed match sits in its table's column, named — not a mock pool window.
+    const t1 = page.getTableColumn('t1')
+    expect(page.matchIdsIn(t1)).toEqual(['fx-a-1'])
+    expect(within(t1).getByTestId('schedule-match-fx-a-1')).toHaveTextContent(
+      'player.1 vs player.4',
+    )
+    expect(page.getStatus('fx-a-1')).toHaveTextContent('Unplayed')
+
+    // The unplaced match is in the awaiting group — a live tournament's matches start
+    // here, not in an empty grid.
+    const awaiting = page.getAwaiting()
+    expect(page.matchIdsIn(awaiting)).toEqual(['fx-a-2'])
+  })
+
+  it('keeps the reserved pool windows visible as context', () => {
+    page.render({
+      tournament: buildTournament({ events: [buildScheduledEvent()] }),
+      tables: buildTables(),
+    })
+    expect(page.queryWindows()).toBeInTheDocument()
+  })
+
+  it('shows the designed empty state when no draw has been cut anywhere', () => {
+    page.render({
+      tournament: buildTournament({ events: [buildDrawnEvent({ fixtures: [] })] }),
+      tables: buildTables(),
+    })
+    expect(page.getTab()).toHaveTextContent('Nothing to schedule yet')
+  })
+
+  it('lets the owner place an awaiting match, and the mutation carries the composed time', async () => {
+    let sent: unknown = null
+    mockFixturePlacementEndpoint(server, async ({ request }) => {
+      sent = await request.json()
+      return HttpResponse.json(
+        buildTournamentFixtureRead({
+          id: 'fx-a-2',
+          table_id: 't2',
+          scheduled_start: '2026-06-13T10:30:00',
+        }),
+      )
+    })
+
+    page.render({
+      tournament: buildTournament({ events: [buildScheduledEvent()] }),
+      tables: buildTables(),
+    })
+
+    page.openPlacement('fx-a-2')
+    expect(page.queryPlaceEditor('fx-a-2')).toBeInTheDocument()
+    page.setPlaceTime('fx-a-2', '10:30')
+    page.savePlacement('fx-a-2')
+
+    // The editor closes on success — the placement re-renders from the refetched
+    // tournament, not from a local write.
+    await waitFor(() => expect(page.queryPlaceEditor('fx-a-2')).not.toBeInTheDocument())
+    // The naive timestamp is composed from the pool window's DATE + the chosen time
+    // (ADR-0790) — no timezone, no Date coercion.
+    expect(sent).toMatchObject({ scheduled_start: '2026-06-13T10:30:00' })
+  })
+
+  it('does not offer to move a finished match (its placement is frozen)', () => {
+    page.render({
       tournament: buildTournament({
         events: [
-          buildEvent({
-            name: 'Open Singles',
-            pools: [
-              buildPool({
-                name: 'Pool A',
-                slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
+          buildDrawnEvent({
+            fixtures: [
+              buildFixture({
+                id: 'fx-done',
+                poolId: 'p-a',
+                entryAId: 'entry-1',
+                entryBId: 'entry-4',
+                matchId: 'm-done',
+                matchStatus: 'completed',
+                tableId: 't1',
+                scheduledStart: '2026-06-13T09:00:00',
               }),
             ],
           }),
         ],
       }),
+      tables: buildTables(),
     })
-    expect(scheduleTabPage.queryText('Open Singles')).toBeInTheDocument()
-    expect(scheduleTabPage.queryText('09:00–12:30')).toBeInTheDocument()
+    expect(page.getStatus('fx-done')).toHaveTextContent('Completed')
+    expect(page.queryPlaceTrigger('fx-done')).not.toBeInTheDocument()
   })
 
-  it('shows an empty state when nothing is scheduled', () => {
-    scheduleTabPage.render({
-      tournament: buildTournament({ events: [buildEvent({ pools: [] })] }),
+  // ADR-0015: a non-owner sees the schedule as a VIEW — the same matches, and zero
+  // interactive controls (no placement control, not a disabled one).
+  it('renders no interactive controls for a non-owner', () => {
+    page.render({
+      tournament: buildTournament({
+        canEdit: false,
+        events: [buildScheduledEvent()],
+      }),
+      tables: buildTables(),
     })
-    expect(scheduleTabPage.queryText('Nothing scheduled')).toBeInTheDocument()
+    // The schedule still renders for them.
+    expect(page.queryTableColumn('t1')).toBeInTheDocument()
+    expect(page.queryPlaceTrigger('fx-a-2')).not.toBeInTheDocument()
+    expect(page.getControls()).toHaveLength(0)
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.tsx
@@ -1,142 +1,413 @@
-import { Calendar } from 'lucide-react'
+import { CalendarClock, MapPin, Pencil, Plus } from 'lucide-react'
+import { useState } from 'react'
 
+import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 
-import { fmtDate } from '../data/helpers'
-import type { Pool, Tournament, TournamentEvent } from '../data/types'
+import { usePlaceFixture } from '../data/api'
+import type { FixtureSide } from '../data/draw'
+import { EM_DASH, fmtDateShort, fmtTimeWindow } from '../data/helpers'
+import {
+  buildSchedule,
+  composeScheduledStart,
+  matchLabel,
+  scheduleStatusLabel,
+  timeOfDay,
+  type ScheduleMatch,
+  type ScheduleTable,
+} from '../data/schedule'
+import type { Tournament, TournamentTable } from '../data/types'
 import { EmptyState } from '../empty-state'
+import { OptionSelect } from './event-editor/option-select'
 import { SectionHeader } from './section-header'
+
+/** The body the placement PATCH takes — the placement whole, `null` to clear. */
+type PlacementBody = { table_id: string | null; scheduled_start: string | null }
 
 export interface ScheduleTabProps {
   tournament: Tournament
+  /** The tournament's table catalogue (labels + courts), resolving a placement's
+   * `tableId` to a table. Passed alongside the tournament because the domain
+   * `Tournament` carries only table *ids* — the labels live on the catalogue. */
+  tables: TournamentTable[]
 }
 
-const DAY_START = 8 * 60
-const DAY_END = 22 * 60
-const HOURS = [8, 10, 12, 14, 16, 18, 20, 22]
-
-function timeToMin(t: string): number {
-  const [h, m] = t.split(':').map(Number)
-  return h * 60 + m
-}
-function pct(t: string): number {
-  return ((timeToMin(t) - DAY_START) / (DAY_END - DAY_START)) * 100
-}
-
-interface Slotted {
-  event: TournamentEvent
-  pool: Pool
-}
-
-/** The Schedule tab: a read-only timeline of how each event's pools land on the
- * calendar, grouped by day, on an 8:00–22:00 scale. */
-export const ScheduleTab = ({ tournament }: ScheduleTabProps) => {
-  const byDay = new Map<string, Slotted[]>()
-  for (const event of tournament.events) {
-    for (const pool of event.pools) {
-      const list = byDay.get(pool.slot.date) ?? []
-      list.push({ event, pool })
-      byDay.set(pool.slot.date, list)
+/** One side of the `A vs B` pairing — the entrant's username, or the same `TBD` /
+ * `Withdrawn` words the draw uses (a side is never a blank or a raw id). */
+const Side = ({ side }: { side: FixtureSide }) => {
+  switch (side.kind) {
+    case 'entrant':
+      return <span className="text-[color:var(--fg-1)]">{side.name}</span>
+    case 'tbd':
+      return <span className="text-[color:var(--fg-3)] italic">TBD</span>
+    case 'withdrawn':
+      return <span className="text-[color:var(--warn)]">Withdrawn</span>
+    default: {
+      const exhaustive: never = side
+      return exhaustive
     }
   }
-  const days = [...byDay.keys()].sort()
+}
+
+/** The director's placement editor for one match (owner only): pick a **table** (the
+ * pool's own tables are marked as the natural suggestion) and a **time** within the
+ * fixture's window, then Save — or Clear an existing placement.
+ *
+ * Only the **time** is asked: the placement's date is fixed by the pool/event Slot
+ * (ADR-0790), so the naive timestamp is composed from that date + this time
+ * (`composeScheduledStart`) — no `Date`, no timezone. The control is a plain
+ * reveal-on-click panel, not a portal'd popover, so what a director (and a test) sees is
+ * the DOM, in place. */
+const PlacementControl = ({
+  match,
+  tables,
+  onSubmit,
+  isPending,
+}: {
+  match: ScheduleMatch
+  tables: TournamentTable[]
+  onSubmit: (body: PlacementBody) => Promise<void>
+  isPending: boolean
+}) => {
+  const placed = match.tableId !== null
+  const [editing, setEditing] = useState(false)
+  const [tableId, setTableId] = useState(
+    () => match.tableId ?? match.suggestedTableIds[0] ?? tables[0]?.id ?? '',
+  )
+  const [time, setTime] = useState(
+    () => timeOfDay(match.scheduledStart) || match.window.start,
+  )
+
+  const options = tables.map((t) => ({
+    value: t.id,
+    label: match.suggestedTableIds.includes(t.id) ? `${t.label} · pool table` : t.label,
+  }))
+  // A placement can name a table the catalogue no longer lists (a dangling ref, ADR-0790):
+  // keep it selectable so the editor can *see* what it is on before moving off it, rather
+  // than silently showing an empty trigger.
+  if (match.tableId !== null && !tables.some((t) => t.id === match.tableId)) {
+    options.unshift({ value: match.tableId, label: `${match.tableId} · removed` })
+  }
+
+  const label = matchLabel(match)
+
+  const submit = async () => {
+    try {
+      await onSubmit({
+        table_id: tableId,
+        scheduled_start: composeScheduledStart(match.window.date, time),
+      })
+      setEditing(false)
+    } catch {
+      // The mutation toasts its own failure; keep the panel open so the work survives.
+    }
+  }
+  const clear = async () => {
+    try {
+      await onSubmit({ table_id: null, scheduled_start: null })
+      setEditing(false)
+    } catch {
+      // As above.
+    }
+  }
+
+  if (!editing) {
+    return (
+      <Button
+        size="sm"
+        variant={placed ? 'ghost' : 'outline'}
+        data-testid={`place-trigger-${match.fixtureId}`}
+        aria-label={`${placed ? 'Edit placement for' : 'Place'} ${match.eventName} — ${label}`}
+        onClick={() => setEditing(true)}
+      >
+        {placed ? <Pencil size={14} /> : <Plus size={14} />}
+        {placed ? 'Move' : 'Place'}
+      </Button>
+    )
+  }
 
   return (
-    <div>
+    <div
+      data-testid={`place-editor-${match.fixtureId}`}
+      className="mt-1.5 flex flex-wrap items-end gap-2"
+    >
+      <OptionSelect
+        value={tableId}
+        options={options}
+        onChange={setTableId}
+        ariaLabel={`Table for ${label}`}
+        className="w-44"
+      />
+      <Input
+        type="time"
+        value={time}
+        onChange={(e) => setTime(e.target.value)}
+        aria-label={`Predicted start for ${label}`}
+        data-testid={`place-time-${match.fixtureId}`}
+        className="w-32"
+      />
+      <Button
+        size="sm"
+        data-testid={`place-save-${match.fixtureId}`}
+        disabled={isPending}
+        onClick={submit}
+      >
+        Save
+      </Button>
+      {placed && (
+        <Button
+          size="sm"
+          variant="ghost"
+          data-testid={`place-clear-${match.fixtureId}`}
+          disabled={isPending}
+          onClick={clear}
+        >
+          Clear
+        </Button>
+      )}
+      <Button
+        size="sm"
+        variant="ghost"
+        data-testid={`place-cancel-${match.fixtureId}`}
+        disabled={isPending}
+        onClick={() => setEditing(false)}
+      >
+        Cancel
+      </Button>
+    </div>
+  )
+}
+
+/** One match on the schedule: its pairing, its status, its predicted time (in a table
+ * column) and — for the owner — the placement control. Rendered inside a table column or
+ * the awaiting-placement group; `showTime` is on in a column, where the time is the fact
+ * that orders the rows, and off in awaiting, where there is none. */
+const MatchRow = ({
+  match,
+  tables,
+  canEdit,
+  onSubmit,
+  isPending,
+  showTime,
+}: {
+  match: ScheduleMatch
+  tables: TournamentTable[]
+  canEdit: boolean
+  onSubmit: (fixtureId: string, body: PlacementBody) => Promise<void>
+  isPending: boolean
+  showTime: boolean
+}) => {
+  const time = timeOfDay(match.scheduledStart)
+  return (
+    <div
+      data-testid={`schedule-match-${match.fixtureId}`}
+      className="flex flex-col gap-1 border-t border-[color:var(--border-subtle)] px-4 py-2.5 first:border-t-0"
+    >
+      <div className="flex flex-wrap items-baseline gap-x-2 text-[13px]">
+        {showTime && (
+          <span className="font-mono text-[12px] tabular-nums text-[color:var(--ball-500)]">
+            {time || EM_DASH}
+          </span>
+        )}
+        <span className="flex items-baseline gap-x-1.5">
+          <Side side={match.a} />{' '}
+          <span className="text-[color:var(--fg-3)]">vs</span>{' '}
+          <Side side={match.b} />
+        </span>
+        <span className="text-[11px] text-[color:var(--fg-3)]">
+          · {match.eventName}
+        </span>
+        <span
+          data-testid={`schedule-status-${match.fixtureId}`}
+          className="ml-auto text-[11px] font-medium text-[color:var(--fg-3)]"
+        >
+          {scheduleStatusLabel(match.match)}
+        </span>
+      </div>
+      {/* The control, for the director alone. A finished match (`!placeable`) is frozen
+          server-side, so it gets no control — not a disabled one (ADR-0015). A non-owner
+          gets none either way. */}
+      {canEdit && match.placeable && (
+        <PlacementControl
+          match={match}
+          tables={tables}
+          isPending={isPending}
+          onSubmit={(body) => onSubmit(match.fixtureId, body)}
+        />
+      )}
+    </div>
+  )
+}
+
+/** The reserved pool windows — real, director-entered data (ADR-0790), kept visible as
+ * lightweight context beneath the real matches: which pools reserve which tables, when.
+ * Not the schedule itself (that is the matches above); an *input* to it. */
+const ReservedWindows = ({ tournament }: { tournament: Tournament }) => {
+  const rows = tournament.events.flatMap((event) =>
+    event.pools.map((pool) => ({
+      key: `${event.id}-${pool.id}`,
+      event: event.name,
+      pool: pool.name,
+      date: pool.slot.date,
+      window: fmtTimeWindow(pool.slot.start, pool.slot.end),
+      tables: pool.tableIds.length,
+    })),
+  )
+  if (rows.length === 0) return null
+  return (
+    <section data-testid="schedule-windows" className="mt-6">
+      <h3 className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
+        <MapPin size={13} />
+        Reserved windows
+      </h3>
+      <Card className="gap-0 p-0">
+        {rows.map((row) => (
+          <div
+            key={row.key}
+            className="flex flex-wrap items-baseline gap-x-2 border-t border-[color:var(--border-subtle)] px-4 py-2 text-[12px] first:border-t-0"
+          >
+            <span className="font-semibold text-[color:var(--fg-1)]">{row.event}</span>
+            <span className="text-[color:var(--fg-3)]">·</span>
+            <span className="text-[color:var(--fg-2)]">{row.pool}</span>
+            <span className="ml-auto font-mono tabular-nums text-[color:var(--fg-3)]">
+              {fmtDateShort(row.date)} · {row.window} · {row.tables}×
+            </span>
+          </div>
+        ))}
+      </Card>
+    </section>
+  )
+}
+
+/** One table's column: the table's label/court, then its matches in predicted-time
+ * order. `table` is `null` for a placement on a table the catalogue no longer lists — it
+ * is shown under its raw id, never dropped (ADR-0790). */
+const TableColumn = ({
+  column,
+  tables,
+  canEdit,
+  onSubmit,
+  isPending,
+}: {
+  column: ScheduleTable
+  tables: TournamentTable[]
+  canEdit: boolean
+  onSubmit: (fixtureId: string, body: PlacementBody) => Promise<void>
+  isPending: boolean
+}) => (
+  <section data-testid={`schedule-table-${column.tableId}`}>
+    <div className="mb-2 flex items-baseline gap-2">
+      <div className="font-display text-[20px] tracking-[0.02em] text-[color:var(--fg-1)]">
+        {column.table ? column.table.label : column.tableId}
+      </div>
+      {column.table ? (
+        <span className="text-[11px] text-[color:var(--fg-3)]">
+          Court {column.table.court}
+        </span>
+      ) : (
+        <span className="text-[11px] text-[color:var(--warn)]">
+          Removed from the catalogue
+        </span>
+      )}
+    </div>
+    <Card className="gap-0 p-0">
+      {column.matches.map((match) => (
+        <MatchRow
+          key={match.fixtureId}
+          match={match}
+          tables={tables}
+          canEdit={canEdit}
+          onSubmit={onSubmit}
+          isPending={isPending}
+          showTime
+        />
+      ))}
+    </Card>
+  </section>
+)
+
+/**
+ * The Schedule tab: the tournament's **real matches**, organized by the venue (ADR-0790).
+ *
+ * It is **tournament-scoped**, not per-event — the tables are shared across events, so a
+ * same-table clash is a cross-event fact — so it reduces every event's fixtures into one
+ * view: grouped by **table** (a table's matches in predicted-time order), with a distinct
+ * **awaiting-placement** group for the matches no table/time has been chosen for yet. A
+ * freshly-live tournament shows every match in that group, not an empty grid.
+ *
+ * The **placement control** is the director's alone (`canEdit`): pick a table and a time,
+ * and the placement re-renders from the server — the mutation invalidates the tournament
+ * detail query, so `tournament` arrives again with the new table/time and this recomputes
+ * (`buildSchedule`). A non-owner sees the same schedule with no control (ADR-0015: hidden,
+ * never disabled). Conflict flagging (double-booked tables/players) is a later scheduler
+ * slice and deliberately absent here — placement is soft (ADR-0790).
+ */
+export const ScheduleTab = ({ tournament, tables }: ScheduleTabProps) => {
+  const canEdit = tournament.canEdit
+  const place = usePlaceFixture(tournament.id)
+  const schedule = buildSchedule(tournament, tables)
+
+  const onSubmit = (fixtureId: string, body: PlacementBody) =>
+    place.mutateAsync({ fixtureId, body }).then(() => undefined)
+
+  return (
+    <div data-testid="schedule-tab">
       <SectionHeader
         title="Schedule"
-        subtitle="Read-only view of how pools land on the calendar. Conflicts flag in events."
+        subtitle={
+          canEdit
+            ? 'Every match, by table. Place a match on a table and a predicted time — the date comes from its pool window.'
+            : 'Every match, by table, with its predicted start time.'
+        }
       />
 
-      {days.length === 0 ? (
+      {schedule.isEmpty ? (
         <EmptyState
-          icon={<Calendar size={28} />}
-          title="Nothing scheduled"
-          hint="Add pools to events to see them here."
+          icon={<CalendarClock size={28} />}
+          title="Nothing to schedule yet"
+          hint="Cut a draw for an event to see its matches here."
         />
       ) : (
         <div className="flex flex-col gap-6">
-          {days.map((date) => {
-            const rows = byDay.get(date) ?? []
-            return (
-              <div key={date}>
-                <div className="mb-2.5 flex items-center gap-2.5">
-                  <div className="font-display text-[28px] tracking-[0.02em] text-[color:var(--fg-1)] uppercase">
-                    {fmtDate(date)}
-                  </div>
-                  <span className="rounded-full bg-[color:var(--bg-raised)] px-2 py-0.5 font-mono text-[11px] text-[color:var(--fg-2)]">
-                    {rows.length} pools
-                  </span>
+          {schedule.tables.map((column) => (
+            <TableColumn
+              key={column.tableId}
+              column={column}
+              tables={tables}
+              canEdit={canEdit}
+              onSubmit={onSubmit}
+              isPending={place.isPending}
+            />
+          ))}
+
+          {schedule.awaiting.length > 0 && (
+            <section data-testid="schedule-awaiting">
+              <div className="mb-2 flex items-baseline gap-2">
+                <div className="font-display text-[20px] tracking-[0.02em] text-[color:var(--fg-1)]">
+                  Awaiting placement
                 </div>
-                <Card className="gap-0 p-0">
-                  <div className="grid grid-cols-[180px_1fr] border-b border-[color:var(--border-subtle)] font-mono text-[11px] text-[color:var(--fg-3)]">
-                    <div className="px-4 py-2.5">Event / pool</div>
-                    <div className="relative py-2.5">
-                      {HOURS.map((h) => (
-                        <div
-                          key={h}
-                          className="absolute top-0 bottom-0 pl-1"
-                          style={{
-                            left: `${((h * 60 - DAY_START) / (DAY_END - DAY_START)) * 100}%`,
-                          }}
-                        >
-                          {h}:00
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                  {rows.map(({ event, pool }, i) => (
-                    <div
-                      key={pool.id}
-                      className="grid min-h-14 grid-cols-[180px_1fr] items-center"
-                      style={{
-                        borderBottom:
-                          i === rows.length - 1
-                            ? 'none'
-                            : '1px solid var(--border-subtle)',
-                      }}
-                    >
-                      <div className="px-4 py-2.5">
-                        <div className="text-[13px] font-semibold text-[color:var(--fg-1)]">
-                          {event.name}
-                        </div>
-                        <div className="text-[11px] text-[color:var(--fg-3)]">
-                          {pool.name} · {pool.tableIds.length} tables
-                        </div>
-                      </div>
-                      <div className="relative mr-3 h-8">
-                        {HOURS.map((h) => (
-                          <div
-                            key={h}
-                            className="absolute top-0 bottom-0 w-px bg-[color:var(--border-subtle)]"
-                            style={{
-                              left: `${((h * 60 - DAY_START) / (DAY_END - DAY_START)) * 100}%`,
-                            }}
-                          />
-                        ))}
-                        <div
-                          className="absolute top-1 bottom-1 flex items-center gap-1.5 overflow-hidden rounded-[4px] border border-[color:rgba(255,122,26,0.5)] px-2 whitespace-nowrap"
-                          style={{
-                            left: `${pct(pool.slot.start)}%`,
-                            width: `${pct(pool.slot.end) - pct(pool.slot.start)}%`,
-                            background:
-                              'linear-gradient(90deg, rgba(255,122,26,0.3), rgba(255,122,26,0.15))',
-                          }}
-                        >
-                          <span className="font-mono text-[11px] font-bold text-[color:var(--ball-500)]">
-                            {pool.slot.start}–{pool.slot.end}
-                          </span>
-                          <span className="text-[11px] text-[color:var(--fg-2)]">
-                            {pool.tableIds.length}×
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </Card>
+                <span className="rounded-full bg-[color:var(--bg-raised)] px-2 py-0.5 font-mono text-[11px] text-[color:var(--fg-2)]">
+                  {schedule.awaiting.length}
+                </span>
               </div>
-            )
-          })}
+              <Card className="gap-0 p-0">
+                {schedule.awaiting.map((match) => (
+                  <MatchRow
+                    key={match.fixtureId}
+                    match={match}
+                    tables={tables}
+                    canEdit={canEdit}
+                    onSubmit={onSubmit}
+                    isPending={place.isPending}
+                    showTime={false}
+                  />
+                ))}
+              </Card>
+            </section>
+          )}
+
+          <ReservedWindows tournament={tournament} />
         </div>
       )}
     </div>

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.tsx
@@ -104,7 +104,11 @@ const PlacementControl = ({
   const submit = () =>
     run({
       table_id: tableId,
-      scheduled_start: composeScheduledStart(match.window.date, time),
+      // A placement's time is a *prediction*: an empty time is a valid table-only
+      // placement (`scheduled_start: null`, ADR-0790), not a reason to compose a
+      // malformed `YYYY-MM-DDT:00` the server would reject and swallow (leaving Save a
+      // silent no-op). Only compose when there is a time to compose.
+      scheduled_start: time ? composeScheduledStart(match.window.date, time) : null,
     })
   const clear = () => run({ table_id: null, scheduled_start: null })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.tsx
@@ -6,7 +6,7 @@ import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 
 import { usePlaceFixture } from '../data/api'
-import type { FixtureSide } from '../data/draw'
+import { type FixtureSide, TBD_LABEL, WITHDRAWN_LABEL } from '../data/draw'
 import { EM_DASH, fmtDateShort, fmtTimeWindow } from '../data/helpers'
 import {
   buildSchedule,
@@ -40,9 +40,9 @@ const Side = ({ side }: { side: FixtureSide }) => {
     case 'entrant':
       return <span className="text-[color:var(--fg-1)]">{side.name}</span>
     case 'tbd':
-      return <span className="text-[color:var(--fg-3)] italic">TBD</span>
+      return <span className="text-[color:var(--fg-3)] italic">{TBD_LABEL}</span>
     case 'withdrawn':
-      return <span className="text-[color:var(--warn)]">Withdrawn</span>
+      return <span className="text-[color:var(--warn)]">{WITHDRAWN_LABEL}</span>
     default: {
       const exhaustive: never = side
       return exhaustive
@@ -92,25 +92,21 @@ const PlacementControl = ({
 
   const label = matchLabel(match)
 
-  const submit = async () => {
+  // The mutation toasts its own failure; on error keep the panel open so the work survives.
+  const run = async (body: PlacementBody) => {
     try {
-      await onSubmit({
-        table_id: tableId,
-        scheduled_start: composeScheduledStart(match.window.date, time),
-      })
+      await onSubmit(body)
       setEditing(false)
     } catch {
-      // The mutation toasts its own failure; keep the panel open so the work survives.
+      /* keep the panel open */
     }
   }
-  const clear = async () => {
-    try {
-      await onSubmit({ table_id: null, scheduled_start: null })
-      setEditing(false)
-    } catch {
-      // As above.
-    }
-  }
+  const submit = () =>
+    run({
+      table_id: tableId,
+      scheduled_start: composeScheduledStart(match.window.date, time),
+    })
+  const clear = () => run({ table_id: null, scheduled_start: null })
 
   if (!editing) {
     return (

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.page.tsx
@@ -1,3 +1,4 @@
+import { interactiveElementsIn } from '@/test/read-only'
 import { render, screen, type Container } from '@/test/utilities'
 
 import { TablesTab, type TablesTabProps } from './tables-tab'
@@ -24,6 +25,13 @@ const scoped = (container: Container) => ({
    * along with the rest of the add-table form. */
   queryAddButton() {
     return container.queryByRole('button', { name: 'Add table' })
+  },
+  /** EVERY interactive control in the tab, swept over the DOM (ADR-0015 rule 6) —
+   * the guard a "a non-owner is offered nothing to mutate" claim needs. A role sweep
+   * would under-prove: the add-table form's inputs are role-queryable, but the rule
+   * is *no control at all*, and the sweep is the one that holds that line. */
+  getControls() {
+    return interactiveElementsIn(container.getByTestId('tables-tab'))
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
@@ -55,6 +55,23 @@ describe('TablesTab', () => {
     expect(document.body).toHaveTextContent('T1')
   })
 
+  // ADR-0015 rule 6: a non-owner gets a rendering, never controls — and the DOM
+  // sweep (not a role query) is the discriminating guard. The catalogue's whole
+  // editor — the add-table inputs and every per-row Remove — is gone, not disabled.
+  it('renders no interactive controls for a non-creator', () => {
+    tablesTabPage.render({ catalogue: buildTables(3), canEdit: false })
+
+    expect(tablesTabPage.getControls()).toHaveLength(0)
+  })
+
+  // The other half, so the guard above cannot be satisfied by deleting the form for
+  // everyone: the creator still gets the full catalogue editor.
+  it('gives the creator the catalogue editor', () => {
+    tablesTabPage.render({ catalogue: buildTables(3), canEdit: true })
+
+    expect(tablesTabPage.getControls().length).toBeGreaterThan(0)
+  })
+
   // The subtitle's second sentence is an instruction only the organizer can
   // follow (ADR 0015, rule 5: copy addresses the reader). Both halves of this
   // pair matter: dropping the sentence for *everyone* would satisfy the

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.tsx
@@ -59,7 +59,7 @@ export const TablesTab = ({
   }
 
   return (
-    <div>
+    <div data-testid="tables-tab">
       <SectionHeader
         title="Tables"
         // "Add them to pools when configuring events" is an imperative only the

--- a/web-client/src/mocks/endpoints/tournaments/tournaments.endpoint.ts
+++ b/web-client/src/mocks/endpoints/tournaments/tournaments.endpoint.ts
@@ -225,6 +225,29 @@ export const mockEventUncutDrawEndpoint = (
     http.delete('*/v1/tournaments/:tournamentId/events/:eventId/draw', resolver),
   )
 
+/** Resolver for the **placement** endpoint (ADR-0790) — the updated
+ * `TournamentFixtureRead` (200), or an error envelope: 403 (not the owner), 404 (no such
+ * fixture), 409 (the match is finished, so its placement is frozen). The body is the
+ * placement whole — `table_id` + `scheduled_start`, `null` to clear. */
+export type FixturePlacementResolver = HttpResponseResolver<
+  { tournamentId: string; fixtureId: string },
+  components['schemas']['TournamentFixturePlacementUpdate'],
+  components['schemas']['TournamentFixtureRead'] | ErrorBody
+>
+
+/** PATCH /v1/tournaments/{id}/fixtures/{fixtureId}/placement — place (or clear) a
+ * fixture's table + predicted start. */
+export const mockFixturePlacementEndpoint = (
+  backend: Backend,
+  resolver: FixturePlacementResolver,
+) =>
+  backend.use(
+    http.patch(
+      '*/v1/tournaments/:tournamentId/fixtures/:fixtureId/placement',
+      resolver,
+    ),
+  )
+
 /** Resolver for the withdraw endpoint — a 204 with no body (including when the
  * entry was already withdrawn: withdrawal is idempotent), or an error envelope
  * on a 403 (someone else's entry) / 404. */

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -64,7 +64,9 @@ export function buildTournamentEntrantReads(
  * `winner_entry_id` is undecided, a null `match_id` is un-materialized, and a null
  * `pool_id` is an un-pooled draw. The defaults are the ordinary case a director sees
  * the morning of: a planned pairing, both players known, nothing played — so
- * `match_status` is `null` too, moving in lockstep with `match_id`. */
+ * `match_status` is `null` too, moving in lockstep with `match_id`. Its **placement**
+ * (ADR-0790) starts empty: `table_id` null is unassigned, `scheduled_start` null is
+ * unscheduled. */
 export function buildTournamentFixtureRead(
   overrides: Partial<TournamentFixtureRead> = {},
 ): TournamentFixtureRead {
@@ -78,6 +80,8 @@ export function buildTournamentFixtureRead(
     winner_entry_id: null,
     match_id: null,
     match_status: null,
+    table_id: null,
+    scheduled_start: null,
     ...overrides,
   }
 }

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -47,6 +47,7 @@ import {
   enterEvent as enterTournamentEvent,
   findTournament,
   listTournaments,
+  placeFixture as placeTournamentFixture,
   transitionTournament,
   uncutDraw as uncutTournamentDraw,
   updateEvent as updateTournamentEvent,
@@ -1771,6 +1772,35 @@ export const handlers = [
       // 204 whether or not there was a draw to remove — this is a DELETE, and asking
       // for a state the resource is already in is a success.
       return new HttpResponse(null, { status: 204 })
+    },
+  ),
+  // The placement (ADR-0790). Registered before the bare `:tournamentId` routes, like the
+  // draw routes above, so MSW never mistakes a fixtures path for a tournament path. Soft
+  // by design: an out-of-window time or an unknown table id is STORED, not refused — the
+  // one refusal is a 409 on a finished match, whose placement is frozen. 403 (not the
+  // owner), 404 (no such fixture).
+  http.patch(
+    '*/v1/tournaments/:tournamentId/fixtures/:fixtureId/placement',
+    async ({ params, request }) => {
+      await delay(250)
+      const body = (await readJson(request)) as
+        | components['schemas']['TournamentFixturePlacementUpdate']
+        | undefined
+      const result = placeTournamentFixture(
+        String(params.tournamentId),
+        String(params.fixtureId),
+        body ?? { table_id: null, scheduled_start: null },
+      )
+      if (!result.ok) {
+        if (result.status === 409) return detail(result.detail, 409)
+        return detail(
+          result.status === 403
+            ? 'Only the creator can place a match.'
+            : 'Fixture not found.',
+          result.status,
+        )
+      }
+      return HttpResponse.json(result.fixture)
     },
   ),
   http.patch(

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -1382,6 +1382,60 @@ export function markFixturePlayed(
   })
 }
 
+export type PlaceFixtureResult =
+  | { ok: true; fixture: TournamentFixtureRead }
+  | { ok: false; status: 403 | 404 }
+  | { ok: false; status: 409; detail: string }
+
+/** The server's sentence for a placement that can no longer be changed, verbatim in
+ * spirit (`api/app/tournaments.py`): a `completed`/`voided` match's table and time are
+ * history. */
+const PLACEMENT_FROZEN_DETAIL =
+  "This match is finished, so its placement can no longer be changed."
+
+/** `PATCH /v1/tournaments/{id}/fixtures/{fixtureId}/placement` — set (or clear) a
+ * fixture's placement (ADR-0790). Creator-only (403), 404 for a fixture that is not on
+ * any of the tournament's events.
+ *
+ * **Soft, deliberately**: an out-of-window time or a `table_id` that names no catalogue
+ * table is *stored*, not refused — those are flags-on-read, a later scheduler slice. The
+ * one refusal is a **409** on a fixture whose match is `completed`/`voided`; everything
+ * else — no match yet, or `in_progress` — is freely (re)placeable. */
+export function placeFixture(
+  tournamentId: string,
+  fixtureId: string,
+  body: components['schemas']['TournamentFixturePlacementUpdate'],
+): PlaceFixtureResult {
+  const owned = requireOwned(tournamentId)
+  if (!owned.ok) return owned
+  const existing = owned.tournament
+  const event = existing.events.find((e) =>
+    e.fixtures.some((f) => f.id === fixtureId),
+  )
+  if (!event) return { ok: false, status: 404 }
+  const fixture = event.fixtures.find((f) => f.id === fixtureId)!
+  if (fixture.match_status === 'completed' || fixture.match_status === 'voided') {
+    return { ok: false, status: 409, detail: PLACEMENT_FROZEN_DETAIL }
+  }
+  const placed: TournamentFixtureRead = {
+    ...fixture,
+    table_id: body.table_id,
+    scheduled_start: body.scheduled_start,
+  }
+  replace({
+    ...existing,
+    events: existing.events.map((e) =>
+      e.id === event.id
+        ? {
+            ...e,
+            fixtures: e.fixtures.map((f) => (f.id === fixtureId ? placed : f)),
+          }
+        : e,
+    ),
+  })
+  return { ok: true, fixture: placed }
+}
+
 /** Delete an event. Creator-only. */
 export function deleteEvent(
   tournamentId: string,


### PR DESCRIPTION
The D-slices of the **Run the tournament** epic (#780): give a fixture a schedule placement, surface it, prove the read-only spectator view, and lock the whole lifecycle under an e2e net.

## What's here

**Slice 1 — round-robin lifecycle e2e (#792).** A composed-stack Playwright spec driving create → enter → cut draw → go live → play → standings → champion for a round-robin, the first e2e coverage of the C1/C2 orchestration. Includes an API seeding helper and a Beta-tester RBAC grant seam (minted users hold the permissionless default role).

**Slice 2 — fixture placement seam + real Schedule tab (#790).** A **placement** is a table + a *predicted* wall-clock start on the fixture:
- API: two nullable columns on `tournament_fixtures` (`table_id` string-ref; `scheduled_start`, deliberately **naive** per ADR-0790, matching the pool `Slot` frame it's checked against), surfaced on `TournamentFixtureRead`; an owner-only `PATCH .../fixtures/{id}/placement` that validates **softly** (the time is a prediction) and freezes only `completed`/`voided` matches (409). Migration edited in place (pre-deploy).
- Web: the mock pool-window Schedule tab is rebuilt into a **tournament-scoped** grid of the real matches grouped by table (venue-organized, since tables are shared across events), with an owner placement control wired to the PATCH. Fixture Zod boundary carries the new fields.
- The CP-SAT auto-packer, conflict flagging, and pinned/free are a **deferred future scheduler slice** — this ships only the seam it writes through.

**Slice 3 — non-owner read-only view (#791).** The detail page was already viewer-aware; this adds a spectator-perspective test suite that DOM-sweeps every tab for zero owner/entrant affordances, with an owner counterpart proving the sweep isn't vacuous. Beta scope: reads stay behind `tournament.view`; truly-public access is a deferred post-beta flip, so there's no API change.

Design recorded in `docs/adr/0790-*` and the `CONTEXT.md` Schedule/Placement glossary.

## Testing
All suites green on the branch:
- API: ruff + format + mypy + **pytest 1184 passed**
- web-client: **vitest 2555**, lint 0 errors, tsc+vite build, **Playwright e2e 270**
- **root e2e 13 passed** (full composed stack)
- OpenAPI types regenerated (schema.d.ts + Types.swift), no drift; **iOS build succeeded**

🤖 Generated with [Claude Code](https://claude.com/claude-code)