### PR TITLE
Pin RBAC self-removal guard to id, not username

### DIFF
--- a/web-client/e2e/rbac-bugfixes.spec.ts
+++ b/web-client/e2e/rbac-bugfixes.spec.ts
@@ -52,6 +52,38 @@ test.describe('Bug #8 · Remove user must not allow self-removal', () => {
     await expect(pom.sheet).toBeVisible()
     await expect(pom.removeButton).toBeEnabled()
   })
+
+  test('Remove user is disabled for a matching id even with a different username', async ({
+    page,
+  }) => {
+    // Same id as the signed-in admin, but a different username — proves the
+    // guard keys off id, not username. A username-keyed guard would leave
+    // this row enabled.
+    const { pom } = await UsersPage.navigateTo(page, {
+      permissions: [],
+      roles: [],
+      users: [{ id: SESSION_USER_ID, username: 'someone.else', role_ids: [] }],
+    })
+    await pom.userRow('someone.else').click()
+    await expect(pom.sheet).toBeVisible()
+    await expect(pom.removeButton).toBeDisabled()
+  })
+
+  test('Remove user stays enabled for a matching username with a different id', async ({
+    page,
+  }) => {
+    // Same username as the signed-in admin, but a different id — proves a
+    // username collision alone does not trigger the guard. A username-keyed
+    // guard would incorrectly disable this row.
+    const { pom } = await UsersPage.navigateTo(page, {
+      permissions: [],
+      roles: [],
+      users: [{ id: 'u_other', username: 'rita.kovac', role_ids: [] }],
+    })
+    await pom.userRow('rita.kovac').click()
+    await expect(pom.sheet).toBeVisible()
+    await expect(pom.removeButton).toBeEnabled()
+  })
 })
 
 test.describe('Bug #3 · relative timestamps must not land in the future', () => {

--- a/web-client/src/components/rbac/users-page.page.tsx
+++ b/web-client/src/components/rbac/users-page.page.tsx
@@ -25,6 +25,10 @@ const scoped = (container: Container) => ({
   queryNoChangesButton() {
     return container.queryByRole('button', { name: /no changes/i })
   },
+  /** The "Remove user" button in the open drawer's footer. */
+  findRemoveButton() {
+    return container.findByRole('button', { name: /remove user/i })
+  },
   /** Anything carrying `text` as a native tooltip (`title`) — the wrapper span
    * around a disabled checkbox, mirroring the delete-role-tooltip host. */
   queryTooltip(text: string | RegExp) {

--- a/web-client/src/components/rbac/users-page.test.tsx
+++ b/web-client/src/components/rbac/users-page.test.tsx
@@ -1,4 +1,5 @@
 import { waitFor } from '@/test/utilities'
+import { mockSession } from '@/mocks/handlers'
 import { usersPage } from './users-page.page'
 import { DEFAULT_ROLE_ID, PLAIN_ROLE_ID, USER_ID } from './users-page.factory'
 
@@ -53,5 +54,40 @@ describe('UsersPage — the default role in the assignment editor', () => {
     // disabled. With no togglable state changed, Save reads "No changes".
     expect(await usersPage.findRoleCheckbox('User')).toBeDisabled()
     expect(usersPage.queryNoChangesButton()).toBeInTheDocument()
+  })
+})
+
+// Bug #8: the "Remove user" guard must key off `id`, not `username` — a rename
+// can't slip past it, and two users can't collide on a display name. Mirrors
+// the e2e coverage in `web-client/e2e/rbac-bugfixes.spec.ts` at the unit level.
+describe('UsersPage — self-removal guard keys off id, not username', () => {
+  it('disables Remove for a row whose id matches the session user, even with a different username', async () => {
+    const { id: sessionId } = mockSession.data.user
+    usersPage.render({
+      permissions: [],
+      roles: [],
+      users: [{ id: sessionId, username: 'someone.else', role_ids: [] }],
+    })
+
+    await usersPage.open('someone.else')
+
+    // The session loads asynchronously, so the guard flips on only once it
+    // resolves — poll rather than asserting immediately after the drawer opens.
+    await waitFor(async () => {
+      expect(await usersPage.findRemoveButton()).toBeDisabled()
+    })
+  })
+
+  it('leaves Remove enabled for a row whose username matches the session user but whose id differs', async () => {
+    const { username: sessionUsername } = mockSession.data.user
+    usersPage.render({
+      permissions: [],
+      roles: [],
+      users: [{ id: 'u_other', username: sessionUsername, role_ids: [] }],
+    })
+
+    await usersPage.open(sessionUsername)
+
+    expect(await usersPage.findRemoveButton()).toBeEnabled()
   })
 })


### PR DESCRIPTION
## Summary
- The self-removal guard in `users-page.tsx` was fixed in #915 to compare `user.id === session?.data?.user?.id` instead of usernames, but no test distinguished the two — the seeded self-row always shared both id and username with the session, so reverting to a username-based comparison stayed fully green.
- Adds e2e tests (`web-client/e2e/rbac-bugfixes.spec.ts`) and a unit test (`web-client/src/components/rbac/users-page.test.tsx`) that seed a row where `id` matches the session but `username` doesn't (and vice versa), so the guard can only pass if it's keyed on `id`.

## Test plan
- [x] `npm run test -- src/components/rbac/users-page.test.tsx` — new + existing unit tests pass
- [x] `npm run test:e2e` (rbac-bugfixes.spec.ts) — new + existing e2e tests pass
- [x] Falsification: reverted the guard to username-based comparison locally, confirmed the new tests fail; restored the correct guard (no diff in `users-page.tsx`)
- [x] Full `vitest run`, `tsc -b`, `vite build`, `eslint .` all clean

Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)