### PR TITLE
Switch tournament details tabs to the underline variant

### DIFF
--- a/web-client/src/components/tournaments/tournament-detail-page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.tsx
@@ -181,7 +181,10 @@ export const TournamentDetailPage = ({
       <Tabs value={tab} onValueChange={setTab}>
         <div className="border-b border-[color:var(--border-subtle)]">
           <div className="mx-auto w-full max-w-[1320px] px-12">
-            <TabsList className="h-auto gap-1 bg-transparent p-0">
+            <TabsList
+              variant="line"
+              className="h-auto p-0 [&_[data-slot=tabs-trigger]]:after:bg-[color:var(--ball-500)]"
+            >
               <TabsTrigger value="events">
                 Events
                 <span className="ml-1.5 rounded-full bg-[color:var(--bg-card)] px-1.5 font-mono text-[11px] tabular-nums">


### PR DESCRIPTION
## Summary
- The tournament details page tabs (Events / Tables / Schedule / Details) previously used an ad hoc `bg-transparent p-0` override of the default boxed `TabsList`.
- Switched to the existing `variant="line"` underline style already showcased on `/design-system` ("UNDERLINED" tabs), with the same `--ball-500` accent underline color used elsewhere on tournament surfaces (page heading dot, required-field asterisk).

## Test plan
- [x] `npx tsc -b` — clean
- [x] `npm run lint` — clean
- [x] `vitest run tournament-detail-page.test.tsx` — 22/22 passing
- [x] Verified visually via headless Playwright against the dev server (MSW-seeded "Bay Area Open 2026" tournament): active tab shows an orange underline, and it correctly moves between Events → Tables on click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)