### PR TITLE
Allow the model to invoke the /epic arc's skills directly

### DIFF
--- a/.claude/skills/do-chores/SKILL.md
+++ b/.claude/skills/do-chores/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: do-chores
 description: Drive a work order written by /to-chores — dispatch each chore to its domain-expert subagent in dependency order, verify, tick it off, and commit per slice. Resumable; leaves the PR to /land-the-plane.
-disable-model-invocation: true
 argument-hint: "[optional path to a work order, else .claude/work-order.md]"
 ---
 

--- a/.claude/skills/epic/SKILL.md
+++ b/.claude/skills/epic/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: epic
 description: Drive a change end-to-end through the fortymm arc — /grill-with-docs → /to-chores → /do-chores → /land-the-plane — as a GATED conductor. It sequences the four phases and carries the plan→work-order→PR artifact chain, stopping for your decision at every phase boundary; the merge itself is /land-the-plane's own gated step, and once it lands the arc moves the work order's tickets to Done. Use to run a whole feature/bugfix through the arc from one entry point; use the individual skills when you only want one phase.
-disable-model-invocation: true
 argument-hint: "[the goal to drive — an issue ref, a plan/PRD path, or a one-line description]"
 ---
 

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: grill-with-docs
 description: A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.
-disable-model-invocation: true
 ---
 
 Run a `/grilling` session, using the `/domain-modeling` skill.

--- a/.claude/skills/to-chores/SKILL.md
+++ b/.claude/skills/to-chores/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: to-chores
 description: Break an agreed plan into a work order of small, agent-tagged chores grouped under tracer-bullet slices, for the domain-expert subagents to implement. Decompose-only — writes the work order and stops; run /do-chores to drive it.
-disable-model-invocation: true
 argument-hint: "[optional path to a plan/PRD/issue, else uses the plan in context]"
 ---
 


### PR DESCRIPTION
## Summary
- `epic`, `grill-with-docs`, `to-chores`, and `do-chores` each had `disable-model-invocation: true` in their `SKILL.md` frontmatter, hiding them from the Skill tool and requiring a human to type the `/command`.
- Removed the flag from all four so Claude can invoke them directly. The phase gates documented inside `/epic` (stop and wait for explicit user go-ahead between phases) are unchanged.

## Test plan
- [x] Confirmed via the Skill tool's available-skills listing that all four now appear as model-invocable
- [x] Grepped `.claude/skills/*/SKILL.md` for `disable-model-invocation` to confirm none remain among the arc's skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)