### PR TITLE
Pad the event editor sheet header

### DIFF
--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -238,7 +238,7 @@ export const EventEditor = ({
         side="right"
         className="w-full gap-0 p-0 sm:w-[820px] sm:max-w-[820px]"
       >
-        <SheetHeader className="border-b border-[color:var(--border-subtle)]">
+        <SheetHeader className="mb-0 border-b border-[color:var(--border-subtle)] px-6 pt-6 pb-5">
           <SheetDescription
             data-testid="event-editor-overline"
             className="text-[11px] font-semibold tracking-[0.14em] uppercase"


### PR DESCRIPTION
## What

The edit-event slide-in panel felt cramped: the **EDIT EVENT** overline and event title sat flush against the top-left edge of the sheet and the divider, while the tabs, fields, and footer below them were all inset by `px-6`.

The panel's `SheetContent` is deliberately `p-0`, with each region applying its own inset. The header was the one region without any — it relied on the shadcn `SheetHeader` default (`mb-5 flex flex-col gap-1.5`, no padding). This gives it the same `px-6` gutter plus `pt-6 pb-5`, and drops the default `mb-5` so the body's own `py-5` provides the single gap below the divider.

## Testing

- `event-editor.test.tsx` — 46 passed.
- Visually verified the header now aligns with the body/footer gutter in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)