### PR TITLE
Enforce the rest floor across the match-completion boundary (#1075)

### DIFF
--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -365,6 +365,42 @@ def _slot_bounds(slot: Slot) -> tuple[datetime, datetime]:
     return start, end
 
 
+def _rest_shadows_for(
+    completed_at: datetime | None,
+    entry_ids: tuple[uuid.UUID, uuid.UUID],
+    entry_user: dict[uuid.UUID, uuid.UUID],
+    base: datetime,
+    now_min: int,
+) -> list[RestShadow]:
+    """The rest obligations a just-completed fixture leaves on its two humans.
+
+    Rest across the completion boundary (``app.scheduling`` module docstring):
+    a just-finished human keeps their ``REST_MIN`` floor even though the
+    completed fixture is dropped from the model. Anchor on the match's stable
+    completion stamp — no stamp (completed via winner alone) means no anchor, so
+    no shadow. Round the anchor UP to the whole minute in the shared offset
+    frame (NOT ``to_min``, which floors) so a grid-snapped start never lands a
+    sub-minute short of the floor, normalizing the aware stamp into the naive
+    wall-clock frame ``now`` and ``base`` live in first. Skip a window that has
+    already closed relative to ``now`` — no future grid start >= now can overlap
+    it (pure waste). One shadow per real human, on user-level ids so rest holds
+    across events.
+    """
+    if completed_at is None:
+        return []
+    completed_local = completed_at.astimezone().replace(tzinfo=None)
+    completed_at_min = math.ceil((completed_local - base).total_seconds() / 60)
+    if completed_at_min + REST_MIN <= now_min:
+        return []
+    return [
+        RestShadow(
+            player_id=PlayerId(str(entry_user[entry_id])),
+            completed_at_min=completed_at_min,
+        )
+        for entry_id in entry_ids
+    ]
+
+
 async def _load_solver_inputs(
     db: AsyncSession,
     tournament_id: uuid.UUID,
@@ -603,39 +639,22 @@ async def _load_solver_inputs(
                 )
             )
             if completed:
-                # Rest across the completion boundary (app.scheduling module
-                # docstring): a just-finished human keeps their REST_MIN floor
-                # even though the completed fixture is dropped from the model.
-                # Anchor on the match's stable completion stamp — no stamp
-                # (completed via winner alone) means no anchor, so no shadow.
-                completed_at = (
-                    match_completed_at.get(fixture.match_id)
-                    if fixture.match_id is not None
-                    else None
-                )
-                if completed_at is not None:
-                    # Round UP to the whole minute in the shared offset frame
-                    # (NOT ``to_min``, which floors): a grid-snapped start then
-                    # never lands a sub-minute short of the floor. Normalize
-                    # the aware stamp into the naive wall-clock frame ``now``
-                    # and ``base`` live in first.
-                    completed_local = completed_at.astimezone().replace(tzinfo=None)
-                    completed_at_min = math.ceil(
-                        (completed_local - base).total_seconds() / 60
+                # A just-finished human keeps their rest floor even though the
+                # completed fixture is dropped from the model (both entries are
+                # non-None — guarded above before this branch is reached).
+                rest_shadows.extend(
+                    _rest_shadows_for(
+                        completed_at=(
+                            match_completed_at.get(fixture.match_id)
+                            if fixture.match_id is not None
+                            else None
+                        ),
+                        entry_ids=(fixture.entry_a_id, fixture.entry_b_id),
+                        entry_user=entry_user,
+                        base=base,
+                        now_min=now_min,
                     )
-                    # Skip a window that has already closed relative to ``now``:
-                    # no future grid start >= now can overlap it (pure waste).
-                    if completed_at_min + REST_MIN > now_min:
-                        # One shadow per real human — user-level ids, so rest
-                        # holds across events. Both entries are set (guarded to
-                        # non-None above before this branch is reached).
-                        for entry_id in (fixture.entry_a_id, fixture.entry_b_id):
-                            rest_shadows.append(
-                                RestShadow(
-                                    player_id=PlayerId(str(entry_user[entry_id])),
-                                    completed_at_min=completed_at_min,
-                                )
-                            )
+                )
                 continue
             if (
                 pin is not None

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -112,6 +112,7 @@ fingerprint, so their arrival or resolution is drift like any other.
 import hashlib
 import json
 import logging
+import math
 import uuid
 from collections import defaultdict
 from collections.abc import Sequence
@@ -142,6 +143,7 @@ from app.models import (
 )
 from app.rq_async import run_async_db_job
 from app.scheduling import (
+    REST_MIN,
     EventId,
     EventSettings,
     FixtureId,
@@ -150,6 +152,7 @@ from app.scheduling import (
     PlayerId,
     PoolId,
     PreviousPlacement,
+    RestShadow,
     ScheduleFixture,
     SchedulePool,
     ScheduleSnapshot,
@@ -446,14 +449,23 @@ async def _load_solver_inputs(
                 withdrawn_entry_ids.add(entry_id)
 
     match_status: dict[uuid.UUID, MatchStatus] = {}
+    # A completed match's stable completion stamp (``None`` for one deemed
+    # completed via ``winner_entry_id`` alone), the anchor a rest shadow needs
+    # to project a just-finished player's rest floor across the completion
+    # boundary. Read alongside ``status`` from the same one query.
+    match_completed_at: dict[uuid.UUID, datetime | None] = {}
     match_ids = [f.match_id for f in fixture_rows if f.match_id is not None]
     if match_ids:
         match_rows = (
             await db.execute(
-                select(Match.id, Match.status).where(Match.id.in_(match_ids))
+                select(Match.id, Match.status, Match.completed_at).where(
+                    Match.id.in_(match_ids)
+                )
             )
         ).all()
-        match_status = {match_id: status for match_id, status in match_rows}
+        for match_id, status, completed_at in match_rows:
+            match_status[match_id] = status
+            match_completed_at[match_id] = completed_at
 
     # Parse the JSONB value-objects once, at this boundary, with the same
     # models the write boundary validated them with (parse, don't validate).
@@ -502,6 +514,8 @@ async def _load_solver_inputs(
     def to_min(moment: datetime) -> int:
         return int((moment - base).total_seconds() // 60)
 
+    now_min = to_min(now)
+
     schedule_pools = tuple(
         SchedulePool(
             id=PoolId(key),
@@ -518,6 +532,7 @@ async def _load_solver_inputs(
     schedule_fixtures: list[ScheduleFixture] = []
     in_progress: list[InProgressMatch] = []
     previous_plan: list[PreviousPlacement] = []
+    rest_shadows: list[RestShadow] = []
     broken_pin_moves: set[uuid.UUID] = set()
     broken_pin_voids: set[uuid.UUID] = set()
     for event, _settings, _pools in parsed_events:
@@ -588,6 +603,39 @@ async def _load_solver_inputs(
                 )
             )
             if completed:
+                # Rest across the completion boundary (app.scheduling module
+                # docstring): a just-finished human keeps their REST_MIN floor
+                # even though the completed fixture is dropped from the model.
+                # Anchor on the match's stable completion stamp — no stamp
+                # (completed via winner alone) means no anchor, so no shadow.
+                completed_at = (
+                    match_completed_at.get(fixture.match_id)
+                    if fixture.match_id is not None
+                    else None
+                )
+                if completed_at is not None:
+                    # Round UP to the whole minute in the shared offset frame
+                    # (NOT ``to_min``, which floors): a grid-snapped start then
+                    # never lands a sub-minute short of the floor. Normalize
+                    # the aware stamp into the naive wall-clock frame ``now``
+                    # and ``base`` live in first.
+                    completed_local = completed_at.astimezone().replace(tzinfo=None)
+                    completed_at_min = math.ceil(
+                        (completed_local - base).total_seconds() / 60
+                    )
+                    # Skip a window that has already closed relative to ``now``:
+                    # no future grid start >= now can overlap it (pure waste).
+                    if completed_at_min + REST_MIN > now_min:
+                        # One shadow per real human — user-level ids, so rest
+                        # holds across events. Both entries are set (guarded to
+                        # non-None above before this branch is reached).
+                        for entry_id in (fixture.entry_a_id, fixture.entry_b_id):
+                            rest_shadows.append(
+                                RestShadow(
+                                    player_id=PlayerId(str(entry_user[entry_id])),
+                                    completed_at_min=completed_at_min,
+                                )
+                            )
                 continue
             if (
                 pin is not None
@@ -622,9 +670,10 @@ async def _load_solver_inputs(
         pools=schedule_pools,
         events=event_settings,
         fixtures=tuple(schedule_fixtures),
-        now_min=to_min(now),
+        now_min=now_min,
         in_progress=tuple(in_progress),
         previous_plan=tuple(previous_plan),
+        rest_shadows=tuple(rest_shadows),
     )
 
     # The fingerprint payload is the *wall-clock* form of exactly these inputs

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -26,6 +26,18 @@ under an in-progress overrun) make the day **infeasible**, which the solve
 reports rather than papering over — the correction path (re-place / void, ADR)
 is the fix, and it runs *before* the next solve, not inside it.
 
+**Rest across the completion boundary.** A player's 10-minute rest floor
+(:data:`REST_MIN`) is a hard constraint, and it must survive a match *ending*,
+not just a match running. A completed fixture occupies nothing and appears in
+no output — it is dropped from the model like it never was — so a recently-
+completed match instead projects a per-human **rest shadow**: a fixed interval
+``[completed_at, completed_at + REST_MIN]`` on that human's per-player list,
+exactly like the rest padding an in-progress or pinned match carries. That
+keeps the freed table idle rather than re-calling the just-finished player into
+zero rest. A shadow is an orthogonal per-human input (one entry per human, not
+per match), independent of the fixtures; the module adds :data:`REST_MIN` so
+the floor stays this one module's single source of truth.
+
 **Objective**, three strictly separated tiers (minimized):
 
 1. **Makespan** — the max end over every active fixture. The day finishes as
@@ -224,13 +236,31 @@ class PreviousPlacement:
 
 
 @dataclass(frozen=True, slots=True)
+class RestShadow:
+    """A recently-completed match's lingering rest obligation on one human.
+
+    A completed fixture occupies nothing and appears in no output (see
+    :class:`ScheduleFixture`), but the moment it completes its player's rest
+    floor must still hold: they may not be re-called until :data:`REST_MIN`
+    minutes after they finished. This is that per-human obligation, orthogonal
+    to the fixtures — one entry per human who recently finished, carrying only
+    the completion time. The module (not the caller) adds :data:`REST_MIN`, so
+    the floor stays this module's single source of truth."""
+
+    player_id: PlayerId
+    completed_at_min: int
+
+
+@dataclass(frozen=True, slots=True)
 class ScheduleSnapshot:
     """Everything one solve reads, as one frozen value.
 
     ``table_ids`` is the venue catalogue — the universe every pool's
     ``table_ids`` must live inside. ``now_min`` is the current time in the
     same minute-offset frame as every other time here: unpinned fixtures may
-    not be scheduled before it.
+    not be scheduled before it. ``rest_shadows`` carries the rest obligation
+    of humans who just finished a match — orthogonal to ``fixtures``, whose
+    completed entries stay dropped and unplaced.
     """
 
     table_ids: tuple[TableId, ...]
@@ -240,6 +270,7 @@ class ScheduleSnapshot:
     now_min: int
     in_progress: tuple[InProgressMatch, ...] = ()
     previous_plan: tuple[PreviousPlacement, ...] = ()
+    rest_shadows: tuple[RestShadow, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -446,6 +477,22 @@ def solve(snapshot: ScheduleSnapshot, time_cap_s: float = 10.0) -> SolveResult:
                 )
             )
         fixed_ends.append(occ_end)
+
+    # Rest shadows: a human who just completed a match rests until
+    # completed_at + REST_MIN. A fixed interval on that player's list projects
+    # the floor across the completion boundary — the completed fixture itself
+    # is dropped and unplaced, but its rest lingers. Fixed (no variable): the
+    # window is a constant, so it needs no makespan/horizon bound, and a player
+    # who appears in nothing but a shadow is a harmless lone interval (per-
+    # player NoOverlap only fires with more than one).
+    for shadow in snapshot.rest_shadows:
+        player_intervals[shadow.player_id].append(
+            model.NewFixedSizeIntervalVar(
+                shadow.completed_at_min,
+                REST_MIN,
+                f"rest_{shadow.player_id}_{shadow.completed_at_min}",
+            )
+        )
 
     # Pins: constants. No window constraint (pins outrank windows), no start
     # variable (a promise does not drift), occupancy every variable respects.

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -49,6 +49,9 @@ from app.leagues import get_default_league
 from app.models import (
     DrawType,
     EventFormat,
+    Match,
+    MatchSettings,
+    MatchStatus,
     ScheduleSolve,
     ScheduleSolveStatus,
     ScheduleSolveTrigger,
@@ -66,7 +69,13 @@ from app.schedule_solves import (
     TIME_CAP_ERROR,
     request_solve,
 )
-from app.scheduling import ScheduleSnapshot, SolveResult, SolveStats, Verdict
+from app.scheduling import (
+    REST_MIN,
+    ScheduleSnapshot,
+    SolveResult,
+    SolveStats,
+    Verdict,
+)
 from app.tournament_draws import cut_draw
 from tests._helpers import make_user
 
@@ -240,6 +249,161 @@ def _hijack_solve(
         return result
 
     monkeypatch.setattr(schedule_solves, "_solve", wrapper)
+
+
+async def _fixture_user_ids(
+    db: AsyncSession, entry_a_id: uuid.UUID, entry_b_id: uuid.UUID
+) -> tuple[str, str]:
+    """The two entries' user-level ids (as the solver stringifies them) — what
+    a fixture's rest shadows are keyed on (rest holds on humans, across
+    events)."""
+    rows = (
+        await db.execute(
+            select(TournamentEntry.id, TournamentEntry.user_id).where(
+                TournamentEntry.id.in_([entry_a_id, entry_b_id])
+            )
+        )
+    ).all()
+    by_entry = {entry_id: str(user_id) for entry_id, user_id in rows}
+    return by_entry[entry_a_id], by_entry[entry_b_id]
+
+
+async def _mark_completed(
+    db: AsyncSession,
+    fixture: TournamentFixture,
+    *,
+    completed_at: datetime | None,
+    with_match: bool = True,
+) -> tuple[str, str]:
+    """Complete ``fixture`` and return its two humans' user ids.
+
+    ``with_match=True`` links a completed ``Match`` carrying ``completed_at``
+    (the rest-shadow anchor); ``with_match=False`` completes it via
+    ``winner_entry_id`` alone — no match, no stamp — the "completed but
+    unanchorable" case that must cast no shadow."""
+    entry_a_id, entry_b_id = fixture.entry_a_id, fixture.entry_b_id
+    assert entry_a_id is not None and entry_b_id is not None
+    if with_match:
+        league = await get_default_league(db)
+        assert league is not None
+        scorer = await make_user(db, f"scorer-{uuid.uuid4().hex[:8]}")
+        match = Match(
+            match_settings=MatchSettings(team_size=1, best_of=3, affects_rating=False),
+            league=league,
+            created_by_user_id=scorer.id,
+            status=MatchStatus.completed,
+            completed_at=completed_at,
+        )
+        db.add(match)
+        await db.flush()
+        fixture.match_id = match.id
+    fixture.winner_entry_id = entry_a_id
+    await db.commit()
+    return await _fixture_user_ids(db, entry_a_id, entry_b_id)
+
+
+class TestRestShadows:
+    """The snapshot builder feeds ``app.scheduling``'s rest floor across the
+    completion boundary: a just-finished human casts a per-human rest shadow so
+    the freed table is not re-called into zero rest (issue #1075). These probe
+    ``_load_solver_inputs`` directly and assert on the built snapshot."""
+
+    async def test_recent_completion_casts_a_shadow_per_human(
+        self, db_session: AsyncSession
+    ) -> None:
+        tournament_id, event_id = await _make_tournament(db_session)
+        target = (await _fixtures_of(db_session, event_id))[0]
+        # 30m20s past the 09:00 base: the anchor ceils to 31 where the shared
+        # (flooring) ``to_min`` would give 30 — so the assertion is only green
+        # if the builder used its dedicated ceil.
+        completed_wall = BASE + timedelta(minutes=30, seconds=20)
+        user_a, user_b = await _mark_completed(
+            db_session, target, completed_at=completed_wall.astimezone()
+        )
+        # now_min = 35; the window [31, 31+REST_MIN=41) is still open past it.
+        now = BASE + timedelta(minutes=35)
+
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=now, lock=False
+        )
+
+        assert inputs is not None
+        assert inputs.base == BASE
+        shadows = inputs.snapshot.rest_shadows
+        assert len(shadows) == 2
+        assert {shadow.player_id for shadow in shadows} == {user_a, user_b}
+        assert all(shadow.completed_at_min == 31 for shadow in shadows)
+
+    async def test_completion_without_a_stamp_casts_no_shadow(
+        self, db_session: AsyncSession
+    ) -> None:
+        tournament_id, event_id = await _make_tournament(db_session)
+        target = (await _fixtures_of(db_session, event_id))[0]
+        target_id = target.id
+        # Completed via winner alone (no match, so completed_at is NULL): there
+        # is no timestamp to anchor rest on, so no shadow — even though the
+        # fixture is genuinely completed.
+        await _mark_completed(db_session, target, completed_at=None, with_match=False)
+        now = BASE + timedelta(minutes=5)
+
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=now, lock=False
+        )
+
+        assert inputs is not None
+        completed = {
+            fixture.id: fixture.completed for fixture in inputs.snapshot.fixtures
+        }
+        assert completed[str(target_id)] is True  # the completed path was taken
+        assert inputs.snapshot.rest_shadows == ()
+
+    async def test_closed_rest_window_casts_no_shadow(
+        self, db_session: AsyncSession
+    ) -> None:
+        tournament_id, event_id = await _make_tournament(db_session)
+        target = (await _fixtures_of(db_session, event_id))[0]
+        # Anchor at offset 5; its window closes at 5 + REST_MIN. Set now right
+        # at that edge — completed_at_min + REST_MIN <= now_min — so the shadow
+        # is pure waste and is skipped.
+        completed_wall = BASE + timedelta(minutes=5)
+        await _mark_completed(
+            db_session, target, completed_at=completed_wall.astimezone()
+        )
+        now = BASE + timedelta(minutes=5 + REST_MIN)
+
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=now, lock=False
+        )
+
+        assert inputs is not None
+        assert inputs.snapshot.rest_shadows == ()
+
+    async def test_in_progress_fixture_casts_no_shadow(
+        self, db_session: AsyncSession
+    ) -> None:
+        tournament_id, event_id = await _make_tournament(db_session)
+        target = (await _fixtures_of(db_session, event_id))[0]
+        league = await get_default_league(db_session)
+        assert league is not None
+        scorer = await make_user(db_session, f"scorer-{uuid.uuid4().hex[:8]}")
+        match = Match(
+            match_settings=MatchSettings(team_size=1, best_of=3, affects_rating=False),
+            league=league,
+            created_by_user_id=scorer.id,
+            status=MatchStatus.in_progress,
+        )
+        db_session.add(match)
+        await db_session.flush()
+        target.match_id = match.id
+        await db_session.commit()
+        now = BASE + timedelta(minutes=5)
+
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=now, lock=False
+        )
+
+        assert inputs is not None
+        assert inputs.snapshot.rest_shadows == ()
 
 
 class TestRequestSolveCoalescing:

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -268,6 +268,31 @@ async def _fixture_user_ids(
     return by_entry[entry_a_id], by_entry[entry_b_id]
 
 
+async def _link_match(
+    db: AsyncSession,
+    fixture: TournamentFixture,
+    *,
+    status: MatchStatus,
+    completed_at: datetime | None = None,
+) -> None:
+    """Attach a fresh ``Match`` (with a minted scorer) to ``fixture`` — the
+    shared boilerplate behind completing or running a fixture. Flushes so
+    ``fixture.match_id`` is set; leaves committing to the caller."""
+    league = await get_default_league(db)
+    assert league is not None
+    scorer = await make_user(db, f"scorer-{uuid.uuid4().hex[:8]}")
+    match = Match(
+        match_settings=MatchSettings(team_size=1, best_of=3, affects_rating=False),
+        league=league,
+        created_by_user_id=scorer.id,
+        status=status,
+        completed_at=completed_at,
+    )
+    db.add(match)
+    await db.flush()
+    fixture.match_id = match.id
+
+
 async def _mark_completed(
     db: AsyncSession,
     fixture: TournamentFixture,
@@ -284,19 +309,9 @@ async def _mark_completed(
     entry_a_id, entry_b_id = fixture.entry_a_id, fixture.entry_b_id
     assert entry_a_id is not None and entry_b_id is not None
     if with_match:
-        league = await get_default_league(db)
-        assert league is not None
-        scorer = await make_user(db, f"scorer-{uuid.uuid4().hex[:8]}")
-        match = Match(
-            match_settings=MatchSettings(team_size=1, best_of=3, affects_rating=False),
-            league=league,
-            created_by_user_id=scorer.id,
-            status=MatchStatus.completed,
-            completed_at=completed_at,
+        await _link_match(
+            db, fixture, status=MatchStatus.completed, completed_at=completed_at
         )
-        db.add(match)
-        await db.flush()
-        fixture.match_id = match.id
     fixture.winner_entry_id = entry_a_id
     await db.commit()
     return await _fixture_user_ids(db, entry_a_id, entry_b_id)
@@ -383,18 +398,7 @@ class TestRestShadows:
     ) -> None:
         tournament_id, event_id = await _make_tournament(db_session)
         target = (await _fixtures_of(db_session, event_id))[0]
-        league = await get_default_league(db_session)
-        assert league is not None
-        scorer = await make_user(db_session, f"scorer-{uuid.uuid4().hex[:8]}")
-        match = Match(
-            match_settings=MatchSettings(team_size=1, best_of=3, affects_rating=False),
-            league=league,
-            created_by_user_id=scorer.id,
-            status=MatchStatus.in_progress,
-        )
-        db_session.add(match)
-        await db_session.flush()
-        target.match_id = match.id
+        await _link_match(db_session, target, status=MatchStatus.in_progress)
         await db_session.commit()
         now = BASE + timedelta(minutes=5)
 

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -26,6 +26,7 @@ from app.scheduling import (
     PlayerId,
     PoolId,
     PreviousPlacement,
+    RestShadow,
     ScheduleFixture,
     SchedulePool,
     ScheduleSnapshot,
@@ -81,6 +82,7 @@ def _one_pool_snapshot(
     now_min: int = 0,
     in_progress: tuple[InProgressMatch, ...] = (),
     previous_plan: tuple[PreviousPlacement, ...] = (),
+    rest_shadows: tuple[RestShadow, ...] = (),
 ) -> ScheduleSnapshot:
     table_ids = _tables(tables)
     return ScheduleSnapshot(
@@ -91,6 +93,7 @@ def _one_pool_snapshot(
         now_min=now_min,
         in_progress=in_progress,
         previous_plan=previous_plan,
+        rest_shadows=rest_shadows,
     )
 
 
@@ -184,6 +187,14 @@ def _assert_hard_constraints(snapshot: ScheduleSnapshot, result: SolveResult) ->
         by_table.setdefault(match.table_id, []).append((match.start_min, occ_end))
         for player in (fixture.player_a_id, fixture.player_b_id):
             by_player.setdefault(player, []).append((match.start_min, occ_end))
+
+    # A rest shadow is a just-completed match that ended at ``completed_at_min``
+    # and occupies no table — a zero-length player interval, so the shared rest-
+    # floor check below forces that player's next match to start ≥ end + rest.
+    for shadow in snapshot.rest_shadows:
+        by_player.setdefault(shadow.player_id, []).append(
+            (shadow.completed_at_min, shadow.completed_at_min)
+        )
 
     for intervals in by_table.values():
         intervals.sort()
@@ -442,6 +453,106 @@ class TestInProgress:
         result = solve(snapshot, time_cap_s=CAP)
         placed = {p.fixture_id: p for p in result.placements}
         assert placed[FixtureId("F2")].start_min >= 60 + BUCKET_MIN
+
+
+class TestRestShadows:
+    """The 10-minute rest floor must survive a match *ending*, not just a match
+    running (#1075). A completed fixture is dropped from the model, so its
+    player's rest is carried by a per-human ``RestShadow`` instead."""
+
+    def test_shadow_delays_a_freed_players_next_match(self) -> None:
+        """A human who just completed at ``C`` cannot be re-placed before
+        ``C + REST_MIN`` — even onto an idle table that would otherwise take
+        them at ``now``. Without the shadow this fixture starts at 0; with it
+        the earliest legal grid start is exactly ``C + REST_MIN``."""
+        p1, p2 = _players(2)
+        # A wide-open pool: three tables, an empty day, now at 0. The only
+        # thing keeping F1 off the very first slot is P1's rest shadow.
+        snapshot = _one_pool_snapshot(
+            (_fixture(1, p1, p2),),
+            rest_shadows=(RestShadow(p1, 0),),
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        _assert_hard_constraints(snapshot, result)
+        placed = {p.fixture_id: p for p in result.placements}
+        assert placed[FixtureId("F1")].start_min == REST_MIN  # == 0 + REST_MIN
+
+    def test_shadow_anchored_in_the_past_delays_relative_to_completion(
+        self,
+    ) -> None:
+        """The floor is measured from the completion time the shadow carries,
+        not from ``now``: a match that finished 3 minutes ago still owes 7."""
+        p1, p2 = _players(2)
+        snapshot = _one_pool_snapshot(
+            (_fixture(1, p1, p2),),
+            now_min=3,
+            rest_shadows=(RestShadow(p1, 0),),  # finished at 0, rest until 10
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        _assert_hard_constraints(snapshot, result)
+        placed = {p.fixture_id: p for p in result.placements}
+        assert placed[FixtureId("F1")].start_min == REST_MIN  # 0 + REST_MIN, > now
+
+    def test_lone_shadow_player_does_not_crash(self) -> None:
+        """A shadow for a human who is in no active fixture is a harmless lone
+        interval — per-player no-overlap only bites with more than one — so the
+        solve still places the unrelated fixture normally."""
+        p1, p2, ghost = _players(3)
+        snapshot = _one_pool_snapshot(
+            (_fixture(1, p1, p2),),
+            rest_shadows=(RestShadow(ghost, 0),),
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        _assert_hard_constraints(snapshot, result)
+        placed = {p.fixture_id: p for p in result.placements}
+        assert placed[FixtureId("F1")].start_min == 0  # ghost's rest binds no one
+
+    def test_issue_1075_freed_table_idles_rather_than_recalling(self) -> None:
+        """#1075 shape: 5 players, 2 tables, best-of-5 (35-minute matches), a
+        round-robin of fixtures, and P1 who *just* finished at ``now``. The two
+        tables are used immediately — but by matches that don't involve P1. P1
+        is not re-called within the rest floor; the table that just freed under
+        them idles rather than calling them straight back on.
+
+        Discriminating against the bug directly: the *same* snapshot without the
+        shadow re-calls P1 at ``now`` (start 0); adding the shadow strictly
+        pushes P1's first match to ``>= now + REST_MIN``. That gap is the fix."""
+        p1, p2, p3, p4, p5 = _players(5)
+        players = [p1, p2, p3, p4, p5]
+        pairs = [(players[i], players[j]) for i in range(5) for j in range(i + 1, 5)]
+        fixtures = tuple(_fixture(n, a, b) for n, (a, b) in enumerate(pairs, start=1))
+
+        def p1_earliest(result: SolveResult) -> int:
+            placed = {p.fixture_id: p for p in result.placements}
+            return min(
+                placed[f.id].start_min
+                for f in fixtures
+                if p1 in (f.player_a_id, f.player_b_id)
+            )
+
+        base = _one_pool_snapshot(fixtures, tables=2, length_games=5)
+        without = solve(base, time_cap_s=CAP)
+        _assert_hard_constraints(base, without)
+        # The bug: with nothing carrying P1's just-finished rest, P1 is re-called
+        # at now — zero rest coming out of a completed match.
+        assert p1_earliest(without) == 0
+
+        shadowed = dataclasses.replace(base, rest_shadows=(RestShadow(p1, 0),))
+        result = solve(shadowed, time_cap_s=CAP)
+        _assert_hard_constraints(shadowed, result)
+        # The fix: P1 is held out for the full rest floor.
+        assert p1_earliest(result) >= REST_MIN
+
+        # Both tables are nonetheless busy from the first slot — the day is not
+        # globally stalled, only P1 is held out — and every 0-start is P1-free.
+        placed = {p.fixture_id: p for p in result.placements}
+        fixtures_by_id = {f.id: f for f in fixtures}
+        started_at_zero = [
+            fixtures_by_id[fid] for fid, p in placed.items() if p.start_min == 0
+        ]
+        assert len(started_at_zero) == 2
+        for fixture in started_at_zero:
+            assert p1 not in (fixture.player_a_id, fixture.player_b_id)
 
 
 class TestDegenerateAndStability:


### PR DESCRIPTION
Closes #1075.

## Problem

The 10-minute rest floor (`REST_MIN`) — an ADR-declared **hard** constraint — was not enforced coming out of a *completed* match. The pure solver drops completed fixtures from the model entirely (`active = [f for f in ... if not f.completed]`), so the instant a match completed, that player's rest shadow vanished and the next re-solve could **place and call** them into a new match with **zero rest**. Observed on UAT: a player finished at 12:30:28 and was re-called onto the same table at 12:30 — 0 minutes rest instead of 10.

## Fix

Project a per-human **rest shadow** from each completion, so the floor survives the completion boundary. The rest floor stays a hard constraint; keeping a table busy stays a soft objective — the issue had them backwards for completed matches.

- **`scheduling.py` (pure solver):** new orthogonal snapshot input `RestShadow(player_id, completed_at_min)`. For each shadow, `solve()` appends a fixed `[completed_at_min, completed_at_min + REST_MIN]` interval to that player's interval list, enforced by the existing per-player `AddNoOverlap` — the same mechanism in-progress and pinned matches already use. Completed fixtures stay dropped/ignored; the shadow is orthogonal, keyed on the human (so rest holds across events). `REST_MIN` remains the module's single source of truth.
- **`schedule_solves.py` (snapshot builder):** `_load_solver_inputs` now selects `Match.completed_at` and emits one shadow per real human on each completed fixture, anchored at **`ceil(completed_at)`** (rounding *up* so a grid-snapped start never lands a sub-minute short of the floor). Skips a NULL stamp (completed via winner alone — no anchor) or an already-closed window (`completed_at_min + REST_MIN <= now_min`). Fingerprint untouched — a completion already drifts it via `match_status`/`winner`.

The two shadows hand off cleanly across the atomic `in_progress → completed` transition (before: in-progress occupancy shadow; after: completion shadow), so there is no uncovered window. Once rest is hard across the boundary, the makespan objective reaches for a rested pair to fill a freed table and idles only when no legal pair exists — exactly the issue's three-part invariant. (The 5-on-2 case where only one rested player exists correctly idles the freed table; that idle is inherent, not a bug.)

## Not a client-facing change

`RestShadow`/`rest_shadows` are internal solver dataclasses — no routes, Pydantic request/response schemas, or route docstrings changed. Verified `openapi.json` is unaffected (none of the new symbols appear in it), so no `schema.d.ts`/`Types.swift` regen is needed.

## Testing

- New pure-solver regression tests (`test_scheduling_solver.py::TestRestShadows`), incl. the #1075 5-on-2 best-of-5 reproduction: the same snapshot **without** the shadow re-calls the tired player at start 0 (the bug); **with** it, they're held to `>= REST_MIN` while both tables stay busy with rested pairs.
- New builder tests (`test_schedule_solve_service.py::TestRestShadows`): recent completion → one shadow per human at the ceil anchor; NULL stamp → none; closed window → none; in-progress → none.
- Full api suite green: **ruff + ruff format + mypy (strict) + 1330 pytest passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)