### PR TITLE
Show a completed match's actual end time on the schedule Gantt chart

### DIFF
--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -526,6 +526,16 @@ class TournamentFixtureRead(BaseModel):
       solver may move freely. When set, the placement is a promise — the players were
       notified, and no later solve will rearrange it. Naive wall-clock in the venue's
       frame, like ``scheduled_start``.
+    * ``completed_at`` — the match's **actual** completion time, as opposed to
+      ``scheduled_start``'s *predicted* one: ``null`` until the match is actually
+      decided (win or void), then the moment it was. This is the value a Gantt-style
+      schedule view should use as a played slot's real end, instead of projecting
+      ``scheduled_start + an estimated duration`` past a match that has already
+      finished. Converted to the same naive wall-clock frame as ``scheduled_start``
+      and ``pinned_at`` (ADR-0790) even though the underlying ``Match.completed_at``
+      column is an ordinary timezone-aware UTC timestamp — so a client can do simple
+      arithmetic across all three fields (e.g. a bar's width) without juggling
+      timezones itself.
 
     The entries are carried as **ids only**. The name and username behind
     ``entry_a_id`` are already on this page — the event's ``entrants`` list carries
@@ -557,6 +567,11 @@ class TournamentFixtureRead(BaseModel):
     # corrections), the number the UI prices a re-drag with.
     pinned_at: datetime | None
     call_notified_count: int
+    # The match's actual completion time — ``null`` until it is decided — already
+    # converted to the same naive wall-clock frame as ``scheduled_start``/``pinned_at``
+    # above (see the docstring). This is the Gantt chart's real end anchor for a
+    # played slot, as opposed to ``scheduled_start``'s predicted one.
+    completed_at: datetime | None
 
 
 class ScheduleSolveRead(BaseModel):

--- a/api/app/tournament_queries.py
+++ b/api/app/tournament_queries.py
@@ -13,6 +13,7 @@ regardless of how many events there are. A per-event count would be an N+1, and
 
 import uuid
 from collections.abc import Sequence
+from datetime import datetime
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -164,6 +165,17 @@ async def fixtures_by_event(
     every load rather than snapshotted, so a slot reflects its match as played; an
     un-materialized fixture joins to ``NULL`` and reports a ``None`` status.
 
+    The same join also carries the match's **actual completion time**
+    (``completed_at``) — the Gantt chart's real end anchor once a slot is played,
+    as opposed to ``scheduled_start``, which stays the solver's *predicted* one
+    forever. ``Match.completed_at`` is a normal timezone-aware UTC column, but
+    ``scheduled_start``/``pinned_at`` are naive wall-clock in the venue's local frame
+    (the ADR-0790 exemption — see ``TournamentFixture.scheduled_start``), so it is
+    converted to that same naive frame here, at the loader, with ``_to_wall_clock``
+    below. Mixed representations across the three timestamps on
+    ``TournamentFixtureRead`` would silently break a client doing simple arithmetic
+    between them (e.g. a Gantt bar's width).
+
     The rows are validated into read models here, at the loader — the same boundary the
     entrants cross — so no ORM instance and no lazily-loadable relationship escapes into
     the serializer.
@@ -175,7 +187,7 @@ async def fixtures_by_event(
         return fixtures
     rows = (
         await db.execute(
-            select(TournamentFixture, Match.status)
+            select(TournamentFixture, Match.status, Match.completed_at)
             .outerjoin(Match, Match.id == TournamentFixture.match_id)
             .where(TournamentFixture.event_id.in_(fixtures.keys()))
             .order_by(
@@ -185,7 +197,7 @@ async def fixtures_by_event(
             )
         )
     ).all()
-    for fixture, match_status in rows:
+    for fixture, match_status, match_completed_at in rows:
         fixtures[fixture.event_id].append(
             TournamentFixtureRead(
                 id=fixture.id,
@@ -201,9 +213,30 @@ async def fixtures_by_event(
                 scheduled_start=fixture.scheduled_start,
                 pinned_at=fixture.pinned_at,
                 call_notified_count=fixture.call_notified_count,
+                completed_at=(
+                    _to_wall_clock(match_completed_at)
+                    if match_completed_at is not None
+                    else None
+                ),
             )
         )
     return fixtures
+
+
+def _to_wall_clock(value: datetime) -> datetime:
+    """Convert an offset-**aware** timestamp to the same naive wall-clock frame
+    ``scheduled_start``/``pinned_at`` already live in (the ADR-0790 exemption).
+
+    Those two columns are never converted on read because they are never anything
+    but naive to begin with — the solver and the pin writer both stamp them with
+    ``app.match_calls._wall_now()``, which is exactly ``datetime.now()`` with no
+    timezone attached (the process's own local clock, standing in for "the venue's
+    clock" until real per-tournament timezones exist). ``Match.completed_at`` is a
+    normal aware UTC column, so producing a value in that same frame means doing the
+    inverse: convert to the process's local timezone, the frame ``_wall_now()``
+    reads from, then drop the offset now that both sides agree what it was.
+    """
+    return value.astimezone().replace(tzinfo=None)
 
 
 async def game_counts_by_match(

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -3708,8 +3708,9 @@ async def test_a_tbd_side_comes_back_as_null_rather_than_a_missing_key(
     freshly-cut draw: unassigned to a table, unscheduled. ``pinned_at`` and
     ``call_notified_count`` are its **pin facts** (ADR "the schedule is solved, the
     call is pinned"): unpinned — still an estimate, not a promise — and nobody told.
-    The exact key set is asserted, so a field silently dropped (or a username
-    silently *added*) fails here.
+    ``completed_at`` is the match's actual completion time — null until there is a
+    match to complete. The exact key set is asserted, so a field silently dropped (or
+    a username silently *added*) fails here.
     """
     client, _ = authed_client
     tournament_id, (event,) = await _tournament_with_events(client, _event_payload())
@@ -3736,6 +3737,7 @@ async def test_a_tbd_side_comes_back_as_null_rather_than_a_missing_key(
         "scheduled_start",
         "pinned_at",
         "call_notified_count",
+        "completed_at",
     }
     assert fixture["entry_a_id"] == str(entry.id)
     # The facts that are not known yet — each present, each null.
@@ -3749,6 +3751,8 @@ async def test_a_tbd_side_comes_back_as_null_rather_than_a_missing_key(
     # ... and it is unpinned: an estimate the solver may move, told to nobody.
     assert fixture["pinned_at"] is None
     assert fixture["call_notified_count"] == 0
+    # ... and there is no match yet, so no completion time either.
+    assert fixture["completed_at"] is None
 
 
 async def test_a_fixtures_sides_are_entry_ids_the_events_entrants_list_resolves(
@@ -6297,6 +6301,49 @@ async def test_a_completed_unrated_tournament_match_writes_the_winner_to_its_fix
 
     (decided,) = await _fixture_rows(db_session, event["id"])
     assert decided.winner_entry_id == e_owner.id
+
+
+async def test_a_completed_matchs_fixture_carries_its_actual_completion_time(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """``completed_at`` is ``null`` on a fixture whose match has not finished, and is
+    stamped the instant it does — the Gantt chart's real end anchor for a played slot,
+    as opposed to ``scheduled_start``'s predicted one.
+
+    ``Match.completed_at`` is an ordinary aware UTC column, but this field comes back
+    converted to the same **naive** wall-clock frame ``scheduled_start``/``pinned_at``
+    already live in (ADR-0790), so a client can do simple arithmetic across all three
+    without juggling timezones itself.
+    """
+    client, owner = authed_client
+    async with opponent_session(db_session, "gantt-opp") as (opp_client, opp):
+        tournament_id, event, e_owner, e_opp, fixture = await _live_two_player_pool(
+            client, owner, opp, db_session, rated=False
+        )
+        (before,) = await _events_of(client, tournament_id)
+        (fixture_before,) = before["fixtures"]
+        assert fixture_before["completed_at"] is None, (
+            "an in-progress match has not completed yet"
+        )
+
+        await _win_fixture_match(
+            fixture,
+            clients_by_entry={e_owner.id: client, e_opp.id: opp_client},
+            winner_entry_id=e_owner.id,
+            rated=False,
+        )
+
+    match = (
+        await db_session.execute(select(Match).where(Match.id == fixture.match_id))
+    ).scalar_one()
+    assert match.completed_at is not None
+    expected_wall_clock = match.completed_at.astimezone().replace(tzinfo=None)
+
+    (after,) = await _events_of(client, tournament_id)
+    (fixture_after,) = after["fixtures"]
+    assert fixture_after["completed_at"] is not None
+    assert datetime.fromisoformat(fixture_after["completed_at"]) == expected_wall_clock
 
 
 async def test_completing_a_round_robin_match_materializes_nothing_new(

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -8304,6 +8304,16 @@ internal enum Components {
         ///   solver may move freely. When set, the placement is a promise — the players were
         ///   notified, and no later solve will rearrange it. Naive wall-clock in the venue's
         ///   frame, like ``scheduled_start``.
+        /// * ``completed_at`` — the match's **actual** completion time, as opposed to
+        ///   ``scheduled_start``'s *predicted* one: ``null`` until the match is actually
+        ///   decided (win or void), then the moment it was. This is the value a Gantt-style
+        ///   schedule view should use as a played slot's real end, instead of projecting
+        ///   ``scheduled_start + an estimated duration`` past a match that has already
+        ///   finished. Converted to the same naive wall-clock frame as ``scheduled_start``
+        ///   and ``pinned_at`` (ADR-0790) even though the underlying ``Match.completed_at``
+        ///   column is an ordinary timezone-aware UTC timestamp — so a client can do simple
+        ///   arithmetic across all three fields (e.g. a bar's width) without juggling
+        ///   timezones itself.
         ///
         /// The entries are carried as **ids only**. The name and username behind
         /// ``entry_a_id`` are already on this page — the event's ``entrants`` list carries
@@ -8357,6 +8367,8 @@ internal enum Components {
             internal var pinnedAt: Foundation.Date?
             /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/call_notified_count`.
             internal var callNotifiedCount: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/TournamentFixtureRead/completed_at`.
+            internal var completedAt: Foundation.Date?
             /// Creates a new `TournamentFixtureRead`.
             ///
             /// - Parameters:
@@ -8373,6 +8385,7 @@ internal enum Components {
             ///   - scheduledStart:
             ///   - pinnedAt:
             ///   - callNotifiedCount:
+            ///   - completedAt:
             internal init(
                 id: Swift.String,
                 poolId: Swift.String? = nil,
@@ -8386,7 +8399,8 @@ internal enum Components {
                 tableId: Swift.String? = nil,
                 scheduledStart: Foundation.Date? = nil,
                 pinnedAt: Foundation.Date? = nil,
-                callNotifiedCount: Swift.Int
+                callNotifiedCount: Swift.Int,
+                completedAt: Foundation.Date? = nil
             ) {
                 self.id = id
                 self.poolId = poolId
@@ -8401,6 +8415,7 @@ internal enum Components {
                 self.scheduledStart = scheduledStart
                 self.pinnedAt = pinnedAt
                 self.callNotifiedCount = callNotifiedCount
+                self.completedAt = completedAt
             }
             internal enum CodingKeys: String, CodingKey {
                 case id
@@ -8416,6 +8431,7 @@ internal enum Components {
                 case scheduledStart = "scheduled_start"
                 case pinnedAt = "pinned_at"
                 case callNotifiedCount = "call_notified_count"
+                case completedAt = "completed_at"
             }
         }
         /// - Remark: Generated from `#/components/schemas/TournamentRead`.

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -3805,6 +3805,16 @@ export interface components {
          *       solver may move freely. When set, the placement is a promise — the players were
          *       notified, and no later solve will rearrange it. Naive wall-clock in the venue's
          *       frame, like ``scheduled_start``.
+         *     * ``completed_at`` — the match's **actual** completion time, as opposed to
+         *       ``scheduled_start``'s *predicted* one: ``null`` until the match is actually
+         *       decided (win or void), then the moment it was. This is the value a Gantt-style
+         *       schedule view should use as a played slot's real end, instead of projecting
+         *       ``scheduled_start + an estimated duration`` past a match that has already
+         *       finished. Converted to the same naive wall-clock frame as ``scheduled_start``
+         *       and ``pinned_at`` (ADR-0790) even though the underlying ``Match.completed_at``
+         *       column is an ordinary timezone-aware UTC timestamp — so a client can do simple
+         *       arithmetic across all three fields (e.g. a bar's width) without juggling
+         *       timezones itself.
          *
          *     The entries are carried as **ids only**. The name and username behind
          *     ``entry_a_id`` are already on this page — the event's ``entrants`` list carries
@@ -3841,6 +3851,8 @@ export interface components {
             pinned_at: string | null;
             /** Call Notified Count */
             call_notified_count: number;
+            /** Completed At */
+            completed_at: string | null;
         };
         /** TournamentRead */
         TournamentRead: {

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -1008,6 +1008,7 @@ describe('useCutDraw', () => {
         scheduledStart: null,
         pinnedAt: null,
         callNotifiedCount: 0,
+        completedAt: null,
       },
     ])
   })

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -203,6 +203,7 @@ describe('apiToEvent — the draw', () => {
         scheduledStart: null,
         pinnedAt: null,
         callNotifiedCount: 0,
+        completedAt: null,
       },
       {
         id: 'fx-2',
@@ -218,6 +219,7 @@ describe('apiToEvent — the draw', () => {
         scheduledStart: null,
         pinnedAt: null,
         callNotifiedCount: 0,
+        completedAt: null,
       },
     ])
   })
@@ -256,6 +258,7 @@ describe('apiToEvent — the draw', () => {
       scheduledStart: null,
       pinnedAt: null,
       callNotifiedCount: 0,
+        completedAt: null,
     })
   })
 
@@ -740,6 +743,7 @@ describe('eventToUpdateBody', () => {
           scheduledStart: null,
           pinnedAt: null,
           callNotifiedCount: 0,
+        completedAt: null,
         },
       ],
     })

--- a/web-client/src/components/tournaments/data/fixtures.test.ts
+++ b/web-client/src/components/tournaments/data/fixtures.test.ts
@@ -37,6 +37,7 @@ describe('parseFixtures — the happy path', () => {
         scheduledStart: null,
         pinnedAt: null,
         callNotifiedCount: 0,
+        completedAt: null,
       },
     ])
   })
@@ -96,6 +97,20 @@ describe('parseFixtures — the happy path', () => {
     expect(fixture.tableId).toBe('table-3')
     expect(fixture.scheduledStart).toBe('2026-06-09T14:30:00')
   })
+
+  // A decided fixture's actual completion time (as opposed to `scheduled_start`'s
+  // merely predicted one) — carried through as-is, naive wall-clock like the other
+  // two placement stamps.
+  it('carries a decided fixture’s actual completion time through', () => {
+    const [fixture] = parseFixtures([
+      wire({
+        match_status: 'completed',
+        completed_at: '2026-06-09T15:12:00',
+      }),
+    ])
+
+    expect(fixture.completedAt).toBe('2026-06-09T15:12:00')
+  })
 })
 
 // THE point of this module. `schema.d.ts` is a compile-time claim about a server we do
@@ -128,6 +143,8 @@ describe('parseFixtures — the boundary', () => {
     { what: 'a table_id of the wrong type', payload: [wire({ table_id: 7 })] },
     { what: 'an absent scheduled_start', payload: [{ ...(wire() as object), scheduled_start: undefined }] },
     { what: 'a scheduled_start of the wrong type', payload: [wire({ scheduled_start: 7 })] },
+    { what: 'an absent completed_at', payload: [{ ...(wire() as object), completed_at: undefined }] },
+    { what: 'a completed_at of the wrong type', payload: [wire({ completed_at: 7 })] },
     // A draw is a LIST. `null` is not an empty draw: an event with no draw sends `[]`,
     // and a server that sent null would be sending something this client cannot read.
     { what: 'null instead of a list', payload: null },

--- a/web-client/src/components/tournaments/data/fixtures.ts
+++ b/web-client/src/components/tournaments/data/fixtures.ts
@@ -81,6 +81,11 @@ const fixtureWireSchema = z.object({
   /** How many call/correction notifications this fixture's players have received —
    * `0` for a never-called fixture, never absent. */
   call_notified_count: z.number().int(),
+  /** The match's **actual** completion time, as opposed to `scheduled_start`'s
+   * *predicted* one: `null` until the match is actually decided (win or void).
+   * Naive wall-clock, like `scheduled_start`/`pinned_at` — kept as the string it
+   * arrives as, same as those two. */
+  completed_at: z.string().nullable(),
 })
 
 /** The parser: one wire fixture → one domain `Fixture`.
@@ -104,6 +109,7 @@ export const fixtureSchema = fixtureWireSchema.transform(
     scheduledStart: f.scheduled_start,
     pinnedAt: f.pinned_at,
     callNotifiedCount: f.call_notified_count,
+    completedAt: f.completed_at,
   }),
 )
 

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -253,6 +253,8 @@ export function buildFixture(overrides: Partial<Fixture> = {}): Fixture {
     // when one is set — is still an estimate, and nobody has been notified.
     pinnedAt: null,
     callNotifiedCount: 0,
+    // Not decided yet: no actual completion time.
+    completedAt: null,
     ...overrides,
   }
 }

--- a/web-client/src/components/tournaments/data/timeline.test.ts
+++ b/web-client/src/components/tournaments/data/timeline.test.ts
@@ -402,6 +402,133 @@ describe('buildTimelineBoard', () => {
     expect(board.players.find((p) => p.username === 'player.2')!.bars).toEqual([])
   })
 
+  // A decided match draws its ACTUAL end (`completedAt`), not a projection of the
+  // estimate — `startMin` still anchors to `scheduledStart` (we don't try to detect
+  // an actual start, only an actual end).
+  it("draws a completed match's bar to its actual completion time, past the estimate", () => {
+    const event = buildDrawnEvent({
+      fixtures: [
+        buildFixture({
+          id: 'fx-ran-long',
+          poolId: 'p-a',
+          tableId: 't1',
+          // Bo5 → 35 estimated minutes: 09:00 + 35 = 09:35. The match actually
+          // ran to 10:20 — 80 minutes, not 35.
+          scheduledStart: '2026-06-13T09:00:00',
+          matchId: 'm-1',
+          matchStatus: 'completed',
+          completedAt: '2026-06-13T10:20:00',
+        }),
+      ],
+    })
+    const board = boardOf(buildTournament({ events: [event] }))
+    const bar = board.tables.find((r) => r.tableId === 't1')!.bars[0]
+    expect(bar.startMin).toBe(9 * 60) // unchanged: still anchored to scheduledStart
+    expect(bar.durationMin).toBe(80)
+    expect(bar.endMin).toBe(9 * 60 + 80)
+    expect(bar.endClock).toBe('10:20')
+  })
+
+  it("draws a completed match's bar SHORTER than the estimate when it finished early", () => {
+    const event = buildDrawnEvent({
+      fixtures: [
+        buildFixture({
+          id: 'fx-ran-short',
+          poolId: 'p-a',
+          tableId: 't1',
+          // Bo5 → 35 estimated minutes, but the match finished in 12.
+          scheduledStart: '2026-06-13T09:00:00',
+          matchId: 'm-1',
+          matchStatus: 'completed',
+          completedAt: '2026-06-13T09:12:00',
+        }),
+      ],
+    })
+    const board = boardOf(buildTournament({ events: [event] }))
+    const bar = board.tables.find((r) => r.tableId === 't1')!.bars[0]
+    expect(bar.durationMin).toBe(12)
+    expect(bar.endMin).toBe(9 * 60 + 12)
+  })
+
+  it('also uses the actual completion time for a voided match — completedAt is set on decide, not just on a win', () => {
+    const event = buildDrawnEvent({
+      fixtures: [
+        buildFixture({
+          id: 'fx-voided',
+          poolId: 'p-a',
+          tableId: 't1',
+          scheduledStart: '2026-06-13T09:00:00',
+          matchId: 'm-1',
+          matchStatus: 'voided',
+          completedAt: '2026-06-13T09:05:00',
+        }),
+      ],
+    })
+    const board = boardOf(buildTournament({ events: [event] }))
+    const bar = board.tables.find((r) => r.tableId === 't1')!.bars[0]
+    expect(bar.durationMin).toBe(5)
+  })
+
+  it('clamps to a minimum 1-minute bar when completedAt is at or before scheduledStart, rather than a backwards/zero-width bar', () => {
+    const event = buildDrawnEvent({
+      fixtures: [
+        buildFixture({
+          id: 'fx-bad-stamp',
+          poolId: 'p-a',
+          tableId: 't1',
+          scheduledStart: '2026-06-13T09:00:00',
+          matchId: 'm-1',
+          matchStatus: 'completed',
+          // Untrusted network data: completedAt should always be after
+          // scheduledStart in practice, but don't trust it blindly.
+          completedAt: '2026-06-13T08:55:00',
+        }),
+      ],
+    })
+    const board = boardOf(buildTournament({ events: [event] }))
+    const bar = board.tables.find((r) => r.tableId === 't1')!.bars[0]
+    expect(bar.durationMin).toBe(1)
+    expect(bar.endMin).toBe(bar.startMin + 1)
+  })
+
+  it('keeps the estimated duration for a completed match with no completedAt (defensive: should not happen)', () => {
+    const event = buildDrawnEvent({
+      fixtures: [
+        buildFixture({
+          id: 'fx-no-stamp',
+          poolId: 'p-a',
+          tableId: 't1',
+          scheduledStart: '2026-06-13T09:00:00',
+          matchId: 'm-1',
+          matchStatus: 'completed',
+          completedAt: null,
+        }),
+      ],
+    })
+    const board = boardOf(buildTournament({ events: [event] }))
+    const bar = board.tables.find((r) => r.tableId === 't1')!.bars[0]
+    expect(bar.durationMin).toBe(35) // the estimate, Bo5
+  })
+
+  it('keeps the estimated duration for an in-progress (not yet decided) match even when completedAt is somehow set', () => {
+    const event = buildDrawnEvent({
+      fixtures: [
+        buildFixture({
+          id: 'fx-live',
+          poolId: 'p-a',
+          tableId: 't1',
+          scheduledStart: '2026-06-13T09:00:00',
+          matchId: 'm-1',
+          matchStatus: 'in_progress',
+          completedAt: '2026-06-13T09:05:00',
+        }),
+      ],
+    })
+    const board = boardOf(buildTournament({ events: [event] }))
+    const bar = board.tables.find((r) => r.tableId === 't1')!.bars[0]
+    expect(bar.durationMin).toBe(35) // the estimate, Bo5 — not decided yet
+  })
+
   it('rows no one for an entrant with no fixture, and no row for a withdrawn side', () => {
     const event = buildDrawnEvent({
       entrants: buildEntrants(5),

--- a/web-client/src/components/tournaments/data/timeline.ts
+++ b/web-client/src/components/tournaments/data/timeline.ts
@@ -254,6 +254,11 @@ export function axisTicks(startMin: number, endMin: number): AxisTick[] {
  * agree; the boards scroll inside their own container rather than compressing. */
 export const PX_PER_MIN = 3
 
+/** The floor on a bar's drawn duration — never zero-width or backwards, even if
+ * `completedAt` somehow lands at or before `scheduledStart` (it shouldn't, but the
+ * network is untrusted; see the `endMin` note on `TimelineBarData`). */
+const MIN_BAR_DURATION_MIN = 1
+
 // ----- the board -----------------------------------------------------------------
 
 /** One placed fixture as a positioned bar. Positions are minutes since the
@@ -277,8 +282,17 @@ export interface TimelineBarData {
   /** The placement's date (`YYYY-MM-DD`). */
   date: string
   startMin: number
+  /** Where the bar ends. For a **decided** fixture (`completed`/`voided`) with a
+   * `completedAt`, this is the *actual* end (`completedAt`), not a projection —
+   * `startMin` still anchors to `scheduledStart` (we don't try to detect an
+   * actual start), but the bar stops truthfully rather than running the estimate
+   * past a match that has already finished. Every other fixture keeps the
+   * estimated `startMin + durationMin`. */
   endMin: number
-  /** The **estimated** duration (`estimatedMatchMinutes`) — the bar's width. */
+  /** The bar's width in minutes: the **estimated** duration
+   * (`estimatedMatchMinutes`) for an undecided or still-estimate-only fixture, or
+   * the actual `completedAt - scheduledStart` (clamped to `MIN_BAR_DURATION_MIN`)
+   * once the match is decided and has a real completion time. */
   durationMin: number
   startClock: string
   endClock: string
@@ -435,7 +449,19 @@ export function buildTimelineBoard(
     if (fixture.tableId === null || fixture.scheduledStart === null) continue
     const stamp = splitStamp(fixture.scheduledStart)
     const startMin = minutesAt(stamp.date, stamp.time, originDate)
-    const durationMin = estimatedMatchMinutes(event.match.lengthGames)
+    // A decided fixture (`completed`/`voided`) with a real `completedAt` draws
+    // its actual end instead of projecting the estimate past a match that has
+    // already finished — `startMin` still anchors to `scheduledStart` (ADR-0790:
+    // we are not trying to detect an actual start, only an actual end). Guard
+    // against a `completedAt` at or before `scheduledStart`: the network is
+    // untrusted, and a negative/zero-width or backwards bar would be a lie
+    // either way.
+    let durationMin = estimatedMatchMinutes(event.match.lengthGames)
+    if (isDecided(fixture.matchStatus) && fixture.completedAt !== null) {
+      const completedStamp = splitStamp(fixture.completedAt)
+      const completedMin = minutesAt(completedStamp.date, completedStamp.time, originDate)
+      durationMin = Math.max(MIN_BAR_DURATION_MIN, completedMin - startMin)
+    }
     const endMin = startMin + durationMin
     const pool = event.pools.find((p) => p.id === fixture.poolId) ?? null
     const a = sideOf(fixture.entryAId, entrantById)

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -122,6 +122,11 @@ export interface Pool {
  *   call is pinned"): `null` means the placement is still an estimate the solver may
  *   move freely. When set, the placement is a promise — the players were notified,
  *   and no later solve rearranges it. Naive wall-clock, like `scheduledStart`.
+ * - `completedAt` — the match's **actual** completion time, as opposed to
+ *   `scheduledStart`'s *predicted* one: `null` until the match is actually decided
+ *   (win or void). Naive wall-clock, like `scheduledStart`/`pinnedAt` — this is what
+ *   a Gantt-style schedule view uses as a played slot's real end, instead of
+ *   projecting the estimated duration past a match that has already finished.
  *
  * Parsed at the boundary by `./fixtures` — this interface is what comes out.
  */
@@ -151,6 +156,9 @@ export interface Fixture {
   /** How many call/correction notifications this fixture's players have received.
    * `0` for a never-called fixture. Read-only, like `pinnedAt`. */
   callNotifiedCount: number
+  /** The match's actual completion time, or `null` until it is decided (win or
+   * void). Naive wall-clock, like `scheduledStart`/`pinnedAt`. Read-only. */
+  completedAt: string | null
 }
 
 /**

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -72,7 +72,9 @@ export function buildTournamentEntrantReads(
  * (ADR-0790) starts empty: `table_id` null is unassigned, `scheduled_start` null is
  * unscheduled — and **uncalled**: `pinned_at` null means the placement is still an
  * estimate the solver may move, and `call_notified_count` 0 means nobody has been
- * told anything (ADR "the schedule is solved, the call is pinned"). */
+ * told anything (ADR "the schedule is solved, the call is pinned"). `completed_at`
+ * null means the match has not actually finished yet, distinct from the placement's
+ * merely *predicted* `scheduled_start`. */
 export function buildTournamentFixtureRead(
   overrides: Partial<TournamentFixtureRead> = {},
 ): TournamentFixtureRead {
@@ -90,6 +92,7 @@ export function buildTournamentFixtureRead(
     scheduled_start: null,
     pinned_at: null,
     call_notified_count: 0,
+    completed_at: null,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary
- The tournament Schedule tab's Gantt/timeline bars always projected the solver's *estimated* duration, even after a match actually finished — so a completed match that ran long or short kept showing its original predicted slot indefinitely.
- Expose `Match.completed_at` (already existed, wasn't wired through) via the tournament-detail BFF as `TournamentFixtureRead.completed_at`, converted to the same naive tournament-local wall-clock frame as `scheduled_start`/`pinned_at`.
- The Gantt derivation (`buildTimelineBoard`) now draws a decided fixture's (completed/voided) bar ending at its actual `completedAt` instead of the estimate, clamped to a 1-minute floor against a bogus/backwards timestamp. `startMin` still anchors to `scheduled_start` — no attempt is made to detect an actual start time.
- Regenerated `web-client/src/api/schema.d.ts` and `ios/Fortymm/Generated/Types.swift` from the updated OpenAPI spec.

## Test plan
- [x] `pytest` (api) — 1323 passed
- [x] `mypy app` / `ruff check` / `ruff format --check` (api) — clean
- [x] `vitest run` (web-client) — 2764 passed
- [x] `tsc -b` / `vite build` / `eslint` (web-client) — clean
- [x] Targeted Playwright specs (tournament-schedule-board, tournament-schedule-solve, tournament-draw) — 23/23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)