### PR TITLE
Convert the match score-entry page to React Hook Form + Zod

### DIFF
--- a/docs/adr/0018-score-entry-validates-on-submit-never-disables-the-button.md
+++ b/docs/adr/0018-score-entry-validates-on-submit-never-disables-the-button.md
@@ -1,0 +1,95 @@
+# 18. Score entry validates on submit and never disables the submit button
+
+Date: 2026-07-17
+
+## Status
+
+Accepted
+
+## Context
+
+The single-game score-entry surface (`web-client/src/components/matches/score-entry.tsx`
++ the shared `score-pad`) hand-rolled its form: two `useState` strings
+(`meTyped`/`oppTyped`), a shared `validateGameScore` verdict recomputed every
+render, and a submit button gated on validity (`canSubmit={inputsValid && …}`,
+`disabled={!canSubmit}`). Errors painted **live** — a half-typed "8–5" went red
+before the user had finished, and the disabled button gave no reason it couldn't
+be pressed.
+
+We are moving the surface onto React Hook Form + Zod (the app's standard form
+stack — `@hookform/resolvers`, `event-editor.tsx`, the rbac pages), and the
+propose-a-result correction board (`correction-entry.tsx`, which shares
+`validate-game-score.ts` today) will follow in a later pass. That makes the form
+posture here a **pattern**, not a one-off, so it is worth pinning down.
+
+Two forces shape the decision. First, gating a submit button on `isValid` is a
+known foot-gun in this codebase (it forces a `useEffect(trigger)` dance for edit
+forms and tells the user "no" without saying why). Second, `score-entry.tsx` is
+mostly **not** a form: the two typed strings feed ~ten downstream live consumers
+— the finalize-vs-save prediction (`wouldFinalize`, `hypotheticalGames`), the
+unsaved-changes router blocker's failed-save-aware dirty baseline (ADR-0014), the
+cross-game `overrunAt` block, and the live button copy — none of which are form
+validation and several of which guard against silent data loss.
+
+## Decision
+
+**The submit button is always enabled; validation errors appear only after the
+first submit attempt; and React Hook Form owns only the two fields and their
+input validation — nothing else.**
+
+Concretely:
+
+1. **Never disable the button on validity.** `handleSubmit` is the only gate — an
+   invalid submit runs validation and fires nothing. The button is disabled only
+   by genuine *in-flight* locks (`inputsLocked`: finalize pending / 409-redirect
+   window), never by `isValid`. This is the general rule from the
+   don't-gate-submit-on-validity guidance, made explicit for this surface.
+
+2. **Errors are silent until the first submit.** `mode: 'onSubmit'` +
+   `reValidateMode: 'onChange'`: no red fields or messages while first typing;
+   the first click surfaces them; thereafter they re-validate live so a fix
+   clears the red immediately. Because the button is now always live, the
+   previously-unreachable **empty submit** must give feedback — a fully empty (or
+   half-filled) form submits to the soft "Enter both scores to save this game."
+   hint on the empty side(s), not silence.
+
+3. **RHF owns the two fields and Zod owns their validation — full stop.** The
+   fields are driven through a `Controller` (to keep the #624 keystroke input
+   filter, `isAcceptableScoreInput`), the live values are read back with
+   `useWatch`, and every downstream consumer — dirty tracking, finalize
+   prediction, `overrunAt`, server/finalize errors, the scoreline — stays
+   component logic reading the watched values, **outside** the form. We
+   deliberately do **not** route dirty state through `formState.isDirty` (it
+   compares to `defaultValues` and cannot see the failed-save scratch baseline —
+   the exact ADR-0014 silent-data-loss trap) nor server errors through
+   `setError('root')` (the finalize 409/422/500/network/redirect interplay,
+   #868/#827, is too subtle to launder through form state).
+
+4. **Cross-game and server errors follow the same "after submit" gate as Zod
+   errors where they can.** `overrunAt` (a locally-legal score the board can't
+   take) and the both-required hint render only once `submitCount > 0`. Server /
+   finalize errors are inherently post-submit and surface as they do today.
+
+5. **The Zod schema and its issues→UI mapper are built as reusable primitives**
+   in `score-pad/` (beside `validate-game-score.ts`), reusing the shared
+   `illegalScoreReason` rule, so the correction board can adopt them next without
+   a rewrite. `validateGameScore` is left untouched for correction-entry this
+   pass and retired when that surface migrates.
+
+## Consequences
+
+- The user can always press the button and always learns why a press did
+  nothing — no more silent disabled state, no `useEffect(trigger)` workaround.
+- The migration is behavior-preserving **except** the two intentional changes
+  (always-enabled button; errors-after-first-submit incl. the new empty-submit
+  hint). The existing 3,399-line `score-entry.test.tsx` suite must stay green
+  through it, extended with tests for those two behaviors.
+- Because RHF owns only the fields, the delicate data-loss guards (ADR-0014
+  dirty baseline, #868 finalize-network branch, #827 409-redirect calm notice)
+  are carried across unchanged rather than reimplemented on form state.
+- The new pure logic (schema + mapper) is small and fully testable; the mutation
+  bar is 100% mutants killed on it, measured via `test:mutation:changed`, with no
+  regression to the component's existing killed-mutant set. No CI `break` gate is
+  added (the Stryker config keeps `break: null`).
+- A second surface (correction-entry) is expected to follow this same posture;
+  the primitives in `score-pad/` are the seam it will reuse.

--- a/web-client/e2e/score-entry.spec.ts
+++ b/web-client/e2e/score-entry.spec.ts
@@ -314,17 +314,21 @@ test.describe('Score entry', () => {
     await expect(scoreEntry.oppInput).toBeVisible()
   })
 
-  test('keeps the save button disabled until a valid score is entered', async ({
+  test('keeps the save button enabled regardless of score validity', async ({
     page,
   }) => {
     const scoreEntry = await ScoreEntryPage.navigateTo(page)
 
-    await expect(scoreEntry.saveButton).toBeDisabled()
+    // Per ADR-0018 validity never gates the button — only in-flight locks
+    // disable it. Empty inputs: enabled (the old build disabled it here).
+    await expect(scoreEntry.saveButton).toBeEnabled()
 
-    // A drawn game is not a valid table tennis result.
+    // A drawn 11–11 is not a valid table tennis result, but the button stays
+    // enabled (the old build disabled it here too).
     await scoreEntry.enterScores('11', '11')
-    await expect(scoreEntry.saveButton).toBeDisabled()
+    await expect(scoreEntry.saveButton).toBeEnabled()
 
+    // A valid 11–7 is likewise enabled.
     await scoreEntry.enterScores('11', '7')
     await expect(scoreEntry.saveButton).toBeEnabled()
   })
@@ -374,13 +378,27 @@ test.describe('Score entry', () => {
   }) => {
     const scoreEntry = await ScoreEntryPage.navigateTo(page)
 
-    // 11-10 isn't a legal final score — at 10-10 the game enters deuce. The
-    // client catches this so Save stays disabled and never round-trips.
+    // 11-10 isn't a legal final score — at 10-10 the game enters deuce.
     await scoreEntry.enterScores('11', '10')
 
-    await expect(scoreEntry.saveButton).toBeDisabled()
+    // Per ADR-0018 nothing is red before the first submit: no inline error, no
+    // aria-invalid, and the button is enabled (the old build reddened here).
+    await expect(scoreEntry.saveButton).toBeEnabled()
+    await expect(scoreEntry.inlineError).toHaveCount(0)
+    await expect(scoreEntry.meInput).not.toHaveAttribute('aria-invalid', 'true')
+    await expect(scoreEntry.oppInput).not.toHaveAttribute('aria-invalid', 'true')
+
+    // The first submit surfaces the deuce error, reddens BOTH sides, and the
+    // client catches the illegal score so it never round-trips: the URL and
+    // heading stay on game 3 (a valid save advances to game 4).
+    await scoreEntry.saveButton.click()
+
     await expect(scoreEntry.inlineError).toContainText(/deuce/i)
     await expect(scoreEntry.meInput).toHaveAttribute('aria-invalid', 'true')
     await expect(scoreEntry.oppInput).toHaveAttribute('aria-invalid', 'true')
+    await expect(page).toHaveURL(
+      new RegExp(`/matches/${SEED.matchId}/games/3/scores/new$`),
+    )
+    await expect(scoreEntry.heading).toHaveText('Enter game 3 score.')
   })
 })

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -16,7 +16,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { server } from '@/mocks/server'
 import { matchDetails } from '@/test/factories'
 import type { components } from '@/api/schema'
@@ -138,11 +138,17 @@ function renderScoreEntry(spec: RouteSpec, options: { path?: string } = {}) {
     ]),
     history: createMemoryHistory({ initialEntries: [options.path ?? '/entry'] }),
   })
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>,
-  )
+  // Expose the router so a timing test can `vi.spyOn(router, 'navigate')` —
+  // `useNavigate` reads `router.navigate` at call time, so the spy captures the
+  // component's imperative hops (see the #567 synchronous-navigation test).
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    ),
+    router,
+  }
 }
 
 // Like `renderScoreEntry`, but also mounts a caller-supplied sibling control
@@ -377,6 +383,63 @@ describe('ScoreEntry — create', () => {
     // Already on game 4 even though the game-3 save is still pending.
     await waitFor(() =>
       expect(screen.getByText('scoring-new m-1 4')).toBeInTheDocument(),
+    )
+  })
+
+  it('fires the save + next-game navigation SYNCHRONOUSLY inside the Save tap, not a microtask later (#567)', async () => {
+    // The #567 mobile-keyboard guarantee is a TIMING contract: iOS Safari only
+    // keeps the soft keyboard open across games if the next input's autofocus
+    // fires inside the same tap gesture. Routing the *valid* submit through
+    // RHF's async `handleSubmit` (which `await`s the Zod resolver before its
+    // callback) would defer this navigation into a microtask AFTER the tap,
+    // silently dropping the keyboard — a regression neither jsdom nor Playwright
+    // can feel (neither models the soft keyboard). This locks the timing in
+    // instead: `fireEvent.click` dispatches synchronously and does NOT flush
+    // microtasks, so had the navigation only fired after awaiting the resolver
+    // the spy would still be empty right after the click. It must already have
+    // been called. (The actual keyboard behaviour is only verifiable on device;
+    // this is the closest reliable proxy — it fails against the async-
+    // handleSubmit version.)
+    const user = userEvent.setup()
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      // Never resolves — the save stays in flight, so any synchronous
+      // navigation can't be piggy-backing on the request settling.
+      http.post(
+        '*/v1/matches/m-1/games/3/scores/new',
+        () => new Promise<Response>(() => {}),
+      ),
+    )
+
+    const { router } = renderScoreEntry({
+      kind: 'create',
+      matchId: 'm-1',
+      gameNumber: 3,
+    })
+
+    await screen.findByRole('heading', { name: /enter game 3 score/i })
+    await user.type(
+      screen.getByRole('textbox', { name: 'rita.kovac score' }),
+      '11',
+    )
+    await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '4')
+
+    // Spy AFTER typing so only the submit's imperative hop is captured (the
+    // mount-time `<Navigate>` guards don't fire for this valid game-3 create).
+    const navigateSpy = vi.spyOn(router, 'navigate')
+    const save = screen.getByRole('button', { name: /save game & next/i })
+
+    // Synchronous dispatch. The async `handleSubmit` path would leave this spy
+    // empty here; the synchronous valid path calls `navigate` during the tap.
+    fireEvent.click(save)
+
+    expect(navigateSpy).toHaveBeenCalledTimes(1)
+    expect(navigateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/matches/$matchId/games/$gameNumber/scores/new',
+        params: { matchId: 'm-1', gameNumber: '4' },
+        ignoreBlocker: true,
+      }),
     )
   })
 

--- a/web-client/src/components/matches/score-entry.test.tsx
+++ b/web-client/src/components/matches/score-entry.test.tsx
@@ -742,17 +742,27 @@ describe('ScoreEntry — create', () => {
     })
     const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
 
-    // 11–10 is illegal (win-by-1). The submit button stays disabled and an
-    // inline hint explains why — no request is made.
+    // 11–10 is illegal (win-by-1). Per ADR-0018 the submit button stays ENABLED
+    // and nothing is red while typing — the error only appears on submit, and
+    // pressing it fires no request (handleSubmit is the only gate).
     await user.type(meInput, '11')
     await user.type(oppInput, '10')
     const save = screen.getByRole('button', { name: /save/i })
-    expect(save).toBeDisabled()
-    expect(screen.getByRole('alert')).toHaveTextContent(/deuce/i)
+    expect(save).toBeEnabled()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(meInput).not.toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
+
+    // The first submit surfaces the illegal-score error and reddens both sides,
+    // without hitting the server.
+    await user.click(save)
+    expect(await screen.findByRole('alert')).toHaveTextContent(/deuce/i)
     expect(meInput).toHaveAttribute('aria-invalid', 'true')
     expect(oppInput).toHaveAttribute('aria-invalid', 'true')
+    expect(posted).toBe(0)
 
-    // Correcting to a legal score clears the hint and re-enables Save.
+    // Correcting to a legal score re-validates live (reValidateMode: onChange)
+    // and clears the error; the button stays enabled throughout.
     await user.clear(oppInput)
     await user.type(oppInput, '9')
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
@@ -761,9 +771,9 @@ describe('ScoreEntry — create', () => {
   })
 
   it('explains that both scores are required when only one field is filled (#387)', async () => {
-    // With exactly one score entered, Save is disabled with no reason given.
-    // Surface an inline hint and flag the still-empty field so the disabled
-    // button isn't a silent dead end.
+    // With exactly one score entered, pressing Save (always enabled per
+    // ADR-0018) surfaces the soft hint and flags the still-empty field so the
+    // press isn't a silent no-op. Nothing is red before that first submit.
     const user = userEvent.setup()
     server.use(
       http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
@@ -774,21 +784,32 @@ describe('ScoreEntry — create', () => {
       name: 'rita.kovac score',
     })
     const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    const save = screen.getByRole('button', { name: /save/i })
 
-    // Untouched: no hint, no red.
+    // Untouched: no hint, no red, button live.
     expect(screen.queryByText(/enter both scores/i)).not.toBeInTheDocument()
+    expect(save).toBeEnabled()
 
+    // One side filled and still no submit → no hint yet (errors-after-submit).
     await user.type(meInput, '11')
-    // One side filled → hint appears, Save disabled, the empty field flagged.
-    expect(screen.getByText(/enter both scores to save this game/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled()
+    expect(screen.queryByText(/enter both scores/i)).not.toBeInTheDocument()
+    expect(save).toBeEnabled()
+    expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
+
+    // First submit → hint appears and the empty field is flagged; the button
+    // stays live.
+    await user.click(save)
+    expect(
+      await screen.findByText(/enter both scores to save this game/i),
+    ).toBeInTheDocument()
+    expect(save).toBeEnabled()
     expect(oppInput).toHaveAttribute('aria-invalid', 'true')
     expect(meInput).not.toHaveAttribute('aria-invalid', 'true')
 
-    // Filling the second score clears the hint and enables Save.
+    // Filling the second score re-validates live and clears the hint.
     await user.type(oppInput, '9')
     expect(screen.queryByText(/enter both scores/i)).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled()
+    expect(save).toBeEnabled()
     expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
   })
 
@@ -812,14 +833,19 @@ describe('ScoreEntry — create', () => {
     expect(meInput).toHaveValue('15')
 
     // The illegal-score hint references the typed value, not a mutated one:
-    // 15–12 is a deuce game that doesn't lead by exactly 2.
+    // 15–12 is a deuce game that doesn't lead by exactly 2. The hint appears on
+    // submit (ADR-0018 errors-after-submit); after that, edits re-validate live.
     await user.type(oppInput, '12')
     expect(oppInput).toHaveValue('12')
-    expect(screen.getByRole('alert')).toHaveTextContent(/leads by exactly 2/i)
+    await user.click(screen.getByRole('button', { name: /save/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /leads by exactly 2/i,
+    )
 
     // A 3rd digit is no longer truncated to a plausible 2-digit score (#624,
     // #771 — the FE input caps at 99, matching the server's per-side cap):
-    // the over-long value is kept verbatim and flagged as malformed instead.
+    // the over-long value is kept verbatim and flagged as malformed instead
+    // (live, since we've already submitted once).
     await user.clear(meInput)
     await user.type(meInput, '100')
     expect(meInput).toHaveValue('100')
@@ -841,13 +867,16 @@ describe('ScoreEntry — create', () => {
       name: 'rita.kovac score',
     })
 
-    // A decimal stays "11.5" — it never becomes "115" — and is flagged.
+    // A decimal stays "11.5" — it never becomes "115" — and is flagged on
+    // submit (ADR-0018 errors-after-submit); thereafter edits re-validate live.
     await user.type(meInput, '11.5')
     expect(meInput).toHaveValue('11.5')
+    await user.click(screen.getByRole('button', { name: /save/i }))
     expect(meInput).toHaveAttribute('aria-invalid', 'true')
-    expect(screen.getByRole('alert')).toHaveTextContent(/whole number/i)
+    expect(await screen.findByRole('alert')).toHaveTextContent(/whole number/i)
 
-    // Overflowing digits stay "999999" — not capped to a plausible "999".
+    // Overflowing digits stay "999999" — not capped to a plausible "999" — and
+    // are flagged live (we've already submitted once).
     await user.clear(meInput)
     await user.type(meInput, '999999')
     expect(meInput).toHaveValue('999999')
@@ -2941,12 +2970,14 @@ describe('ScoreEntry — games past the decider', () => {
       '2',
     )
 
-    // The actionable message is shown and the write is never fired (the score
-    // 11-2 is legal, but it would decide the match at game 4 with game 5 scored).
-    expect(
-      screen.getByText(/already decided at game 4/i),
-    ).toBeInTheDocument()
+    // Per ADR-0018 the overrun block, like the Zod errors, surfaces on submit
+    // (not live). Pressing Save shows the actionable message and fires no write
+    // (the score 11-2 is legal, but it would decide the match at game 4 with
+    // game 5 scored) — handleSubmit's onValid returns early on the overrun.
     await user.click(screen.getByRole('button', { name: /save/i }))
+    expect(
+      await screen.findByText(/already decided at game 4/i),
+    ).toBeInTheDocument()
     expect(posted).toBe(false)
   })
 
@@ -3390,6 +3421,184 @@ describe('ScoreEntry — stale finalize hits a posted result (409 → redirect) 
     ).toBeEnabled()
     // And no refetch was triggered — the string 409 doesn't invalidate.
     expect(getCalls).toBe(getsBeforePost)
+  })
+})
+
+// The ADR-0018 posture: the submit button is always enabled (never gated on
+// validity); validation errors appear only after the first submit and then
+// re-validate live; the always-live button means an empty submit must give the
+// soft "enter both scores" feedback rather than silently doing nothing.
+describe('ScoreEntry — submit-gated validation (ADR-0018)', () => {
+  async function renderCreateGame3() {
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+    )
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+    const save = () => screen.getByRole('button', { name: /save/i })
+    return { meInput, oppInput, save }
+  }
+
+  it('leaves the submit button enabled with empty and with invalid input', async () => {
+    const user = userEvent.setup()
+    const { meInput, oppInput, save } = await renderCreateGame3()
+
+    // Empty: enabled (the old build disabled it here).
+    expect(save()).toBeEnabled()
+
+    // An illegal 8–5 (no win-by-2, under 11): still enabled — validity never
+    // gates the button.
+    await user.type(meInput, '8')
+    await user.type(oppInput, '5')
+    expect(save()).toBeEnabled()
+  })
+
+  it('shows no error and no red before the first submit, even with an invalid score typed', async () => {
+    const user = userEvent.setup()
+    const { meInput, oppInput } = await renderCreateGame3()
+
+    await user.type(meInput, '8')
+    await user.type(oppInput, '5')
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(meInput).not.toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
+    expect(screen.queryByText(/enter both scores/i)).not.toBeInTheDocument()
+  })
+
+  it('first submit with an invalid score surfaces the error and fires no save', async () => {
+    const user = userEvent.setup()
+    let posted = 0
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      http.post('*/v1/matches/m-1/games/3/scores/new', () => {
+        posted += 1
+        return HttpResponse.json(inProgressMatch(), { status: 201 })
+      }),
+    )
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    const oppInput = screen.getByRole('textbox', { name: 'nguyen.t score' })
+
+    await user.type(meInput, '8')
+    await user.type(oppInput, '5')
+    await user.click(screen.getByRole('button', { name: /save/i }))
+
+    // The error appears (illegal score) — but no request left the boundary.
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    expect(posted).toBe(0)
+  })
+
+  it('first submit with BOTH fields empty shows the soft hint on both sides', async () => {
+    const user = userEvent.setup()
+    const { meInput, oppInput, save } = await renderCreateGame3()
+
+    await user.click(save())
+
+    // The empty submit is no longer a silent no-op: the soft "enter both scores"
+    // hint shows and BOTH sides are flagged.
+    expect(
+      await screen.findByText(/enter both scores to save this game/i),
+    ).toBeInTheDocument()
+    expect(meInput).toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('after a failed submit, fixing the score clears the error live', async () => {
+    const user = userEvent.setup()
+    const { meInput, oppInput, save } = await renderCreateGame3()
+
+    await user.type(meInput, '11')
+    await user.type(oppInput, '10') // illegal
+    await user.click(save())
+    expect(await screen.findByRole('alert')).toBeInTheDocument()
+
+    // reValidateMode: 'onChange' — a single keystroke to a legal 11–9 clears the
+    // error without another submit.
+    await user.clear(oppInput)
+    await user.type(oppInput, '9')
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(meInput).not.toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('post-submit: a malformed single side reddens only that side; an illegal score reddens both', async () => {
+    const user = userEvent.setup()
+    const { meInput, oppInput, save } = await renderCreateGame3()
+
+    // Malformed `me` (a decimal), legal-looking `opp` — only `me` is flagged.
+    await user.type(meInput, '11.5')
+    await user.type(oppInput, '9')
+    await user.click(save())
+    expect(await screen.findByRole('alert')).toHaveTextContent(/whole number/i)
+    expect(meInput).toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).not.toHaveAttribute('aria-invalid', 'true')
+
+    // Fix to an illegal 8–5 (both well-formed, no win) — now BOTH sides redden.
+    await user.clear(meInput)
+    await user.type(meInput, '8')
+    await user.clear(oppInput)
+    await user.type(oppInput, '5')
+    expect(meInput).toHaveAttribute('aria-invalid', 'true')
+    expect(oppInput).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('a legal score still fires the save and advances to the next game', async () => {
+    const user = userEvent.setup()
+    let captured: unknown = null
+    server.use(
+      http.get('*/v1/matches/m-1', () => HttpResponse.json(inProgressMatch())),
+      http.post(
+        '*/v1/matches/m-1/games/3/scores/new',
+        async ({ request }) => {
+          captured = await request.json()
+          return HttpResponse.json(inProgressMatch(), { status: 201 })
+        },
+      ),
+    )
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    await user.type(meInput, '11')
+    await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '4')
+    await user.click(screen.getByRole('button', { name: /save game & next/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText('scoring-new m-1 4')).toBeInTheDocument(),
+    )
+    expect(captured).toEqual({ side_1_points: 11, side_2_points: 4 })
+  })
+
+  it('a match-ending score still finalizes and navigates to the match page', async () => {
+    const user = userEvent.setup()
+    let resultsBody: unknown = null
+    server.use(
+      http.get('*/v1/matches/m-1', () =>
+        HttpResponse.json(decidingGameMatch()),
+      ),
+      http.post('*/v1/matches/m-1/results', async ({ request }) => {
+        resultsBody = await request.json()
+        return HttpResponse.json(decidingGameMatch())
+      }),
+    )
+    renderScoreEntry({ kind: 'create', matchId: 'm-1', gameNumber: 3 })
+    const meInput = await screen.findByRole('textbox', {
+      name: 'rita.kovac score',
+    })
+    await user.type(meInput, '11')
+    await user.type(screen.getByRole('textbox', { name: 'nguyen.t score' }), '4')
+    await user.click(screen.getByRole('button', { name: /post result/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText('match-page m-1')).toBeInTheDocument(),
+    )
+    expect(resultsBody).not.toBeNull()
   })
 })
 

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useController, useForm, useWatch } from 'react-hook-form'
+import { useController, useForm } from 'react-hook-form'
 import {
   Link,
   Navigate,
@@ -200,13 +200,14 @@ function ScoreEntryInner({
   })
   // Each side is driven through a controller so the #624 keystroke filter
   // (`isAcceptableScoreInput`) can reject a change outright — the value never
-  // updates — while RHF still owns the field. The live values are read back with
-  // `useWatch` and every downstream consumer (dirty tracking, finalize
-  // prediction, `overrunAt`, `toBody`, the copy, the scoreline) reads them.
+  // updates — while RHF still owns the field. `useController` already subscribes
+  // to its field, so the live value is read straight off `field.value` (no
+  // separate `useWatch`), and every downstream consumer (dirty tracking, finalize
+  // prediction, `overrunAt`, `toBody`, the copy, the scoreline) reads it.
   const meField = useController({ control: form.control, name: 'me' })
   const oppField = useController({ control: form.control, name: 'opp' })
-  const me = useWatch({ control: form.control, name: 'me' }) ?? ''
-  const opp = useWatch({ control: form.control, name: 'opp' }) ?? ''
+  const me = meField.field.value ?? ''
+  const opp = oppField.field.value ?? ''
   const submitted = form.formState.submitCount > 0
   const meRef = useRef<HTMLInputElement>(null)
   const oppRef = useRef<HTMLInputElement>(null)
@@ -388,16 +389,16 @@ function ScoreEntryInner({
   // scratch save, else the persisted score, else empty. Input is "dirty"
   // (worth guarding on exit) only when the user has actually typed something
   // that diverges from that baseline: a clean page, or input that merely
-  // matches what's already saved, must not nag. Updating the ref here (rather
-  // than in an effect) keeps the blocker reading the current-render truth.
-  const baselineMe =
-    failedMe != null ? String(failedMe) : persistedMe != null ? String(persistedMe) : ''
-  const baselineOpp =
-    failedOpp != null
-      ? String(failedOpp)
-      : persistedOpp != null
-        ? String(persistedOpp)
-        : ''
+  // matches what's already saved, must not nag. Derived from the SAME helper
+  // that seeds RHF's `values` above, so the seed and the dirty check can't drift
+  // — `keepDirtyValues` must agree with `computeDirty` (ADR-0014). The
+  // decomposed `persistedMe`/`failedMe`/… above stay for the conflict notice,
+  // `keepCommittedScore`, and retry.
+  const { me: baselineMe, opp: baselineOpp } = seedScoreValues(
+    data,
+    gameNumber,
+    ownSave,
+  )
   // Whether the live inputs (me/opp) diverge from the baseline — i.e. there's
   // genuinely-unsaved typing worth guarding on exit. Recomputed by the change
   // handlers below as the user types (a clean page, or input matching the
@@ -435,14 +436,14 @@ function ScoreEntryInner({
   // (`submitted`) — nothing is red while the user first types.
   const parseResult = gameScoreSchema.safeParse({ me, opp })
   const inputsValid = parseResult.success
-  const ui = mapGameScoreValidation(parseResult, { me, opp })
-  // Gate the local Zod verdict behind the first submit. Before then the fields
-  // stay clean even with an illegal or half-typed score; after, `onChange`
-  // re-validation clears the red as the user fixes it.
-  const localScoreError = submitted ? ui.scoreError : null
-  const localMeInvalid = submitted && ui.meInvalid
-  const localOppInvalid = submitted && ui.oppInvalid
-  const localBothRequired = submitted && ui.showBothRequired
+  // Map the parse result to per-side red flags / error line ONLY after the first
+  // submit — before then the fields stay clean even with an illegal or half-typed
+  // score, and the mapper's output is discarded anyway; after, `onChange`
+  // re-validation clears the red as the user fixes it. A single gate here (rather
+  // than one per field) is the whole ADR-0018 "errors-after-first-submit"
+  // posture. `inputsValid` above stays UNGATED — it feeds the finalize prediction
+  // and the overrun block regardless of submit.
+  const ui = submitted ? mapGameScoreValidation(parseResult) : null
   const finalizeApiError =
     finalizeMutation.error instanceof ApiError ? finalizeMutation.error : null
   // A finalize error that ISN'T an `ApiError` is a transport-level drop:
@@ -547,17 +548,17 @@ function ScoreEntryInner({
   // Single `scoreError` slot, in ADR-0018 precedence: local Zod error (after
   // submit) → overrun (after submit) → finalize API error (409/500) → finalize
   // network drop.
-  const scoreError = localScoreError ?? overrunError ?? finalizeErrorText
+  const scoreError = ui?.scoreError ?? overrunError ?? finalizeErrorText
   // The "both scores required" hint is its own, lower-severity line — the schema
   // emits it (post-submit) when either side is empty, but only show it when
   // there's no harder error to surface.
-  const showBothRequired = localBothRequired && scoreError === null
+  const showBothRequired = (ui?.showBothRequired ?? false) && scoreError === null
   // Per-side red flags: the mapper already paints only the malformed side, both
   // sides for an illegal score, and the empty side for the soft hint (all gated
-  // post-submit via `localMeInvalid`/`localOppInvalid`); a server 422 drift
+  // post-submit — `ui` is null until the first submit); a server 422 drift
   // paints both inputs.
-  const meInvalid = localMeInvalid || finalize422
-  const oppInvalid = localOppInvalid || finalize422
+  const meInvalid = (ui?.meInvalid ?? false) || finalize422
+  const oppInvalid = (ui?.oppInvalid ?? false) || finalize422
 
   function predictNextScoringRoute() {
     if (!data) return matchDetailRoute(matchId)

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -585,19 +585,43 @@ function ScoreEntryInner({
       : { side_1_points: Number(opp), side_2_points: Number(me) }
   }
 
-  // The submit gesture, always live (ADR-0018): `handleSubmit` is the ONLY
-  // gate — it runs Zod validation and calls `onValid` only when the parse
-  // succeeds (an invalid submit fires nothing but bumps `submitCount`, which is
-  // what surfaces the errors). The button is never disabled on validity; the
-  // in-flight/overrun guards below stay inside `onValid`.
-  const submit = form.handleSubmit(onValid)
+  // Async handler used ONLY to reveal validation errors on an invalid submit.
+  // React Hook Form's `handleSubmit` returns an async function that `await`s the
+  // Zod resolver before deciding — bumping `submitCount` (which flips
+  // `submitted` on and turns on live re-validation) either way. Its callback is
+  // a no-op: this path never writes and never navigates, so its post-`await`
+  // timing is harmless (there is no autofocus to preserve on the error path).
+  const revealErrors = form.handleSubmit(() => {})
 
-  function onValid() {
-    // The score is legal on its own but the board can't take it (it would leave
-    // the match decided before its last game). Block the write — the inline
-    // `overrunError` (now visible, `submitCount > 0`) tells the user to clear the
-    // trailing games first.
-    if (overrunAt !== null) return
+  // The submit gesture, always live (ADR-0018). The button is never disabled on
+  // validity; `onSubmit` is the only gate. It splits by validity SYNCHRONOUSLY:
+  // an invalid / board-illegal submit routes through the async `revealErrors`
+  // (fine — it only surfaces messages), while a valid, board-legal submit runs
+  // the sanctioned write path inline, inside the tap gesture. That synchronous
+  // valid path is load-bearing for #567 (see the fire-and-forget tail below):
+  // iOS Safari only keeps the soft keyboard open across the next game if the
+  // next input's autofocus fires while still inside the tap that triggered it,
+  // and RHF's async `handleSubmit` would defer that navigation into a microtask
+  // AFTER the tap — dropping the keyboard between games.
+  function onSubmit() {
+    // A Zod-invalid score, or a locally-legal score the board can't take (the
+    // cross-game overrun: it would leave the match decided before its last
+    // game): surface the messages but write nothing. `revealErrors` bumps
+    // `submitCount`, so `submitted` turns on and the inline Zod / `overrunError`
+    // lines (both `submitCount`-gated) become visible; live re-validation then
+    // clears them as the user fixes the score. No navigation happens here, so
+    // routing it through the async `handleSubmit` is fine.
+    if (!parseResult.success || overrunAt !== null) {
+      void revealErrors()
+      return
+    }
+    // Valid + board-legal: run the sanctioned write path SYNCHRONOUSLY, inside
+    // the tap, so the next game's autofocus keeps the mobile keyboard open
+    // (#567; see the fire-and-forget tail). This path always either navigates
+    // away or surfaces an ungated banner/finalize-error, so it never needs
+    // `submitCount` — which is why only the invalid/overrun branch above bumps
+    // it, and why the navigating path can't set state after it unmounts.
+    //
     // Ignore a second Save while the per-game save is still in flight (#538):
     // a double-tap would otherwise fire a duplicate create that 409s. This
     // synchronous guard is the only protection now — the mutationFn no longer
@@ -662,7 +686,10 @@ function ScoreEntryInner({
     // the network round-trip — is what keeps the mobile soft keyboard open: a
     // browser only honours the next input's autofocus while still inside the
     // tap that triggered it, so deferring to onSettled dropped focus and closed
-    // the keyboard between games (#567).
+    // the keyboard between games (#567). This is also why `onSubmit` runs this
+    // whole path synchronously instead of through RHF's async `handleSubmit`:
+    // awaiting the Zod resolver would push this `navigate` into a microtask
+    // AFTER the tap, dropping the keyboard the exact same way onSettled did.
     saveMutation.mutate(args)
     navigate({ ...next, ignoreBlocker: true })
   }
@@ -774,7 +801,7 @@ function ScoreEntryInner({
         oppRef.current?.focus()
         oppRef.current?.select()
       } else if (side === 'opp') {
-        submit()
+        onSubmit()
       }
     } else if (e.key === 'ArrowRight' && side === 'me') {
       e.preventDefault()
@@ -905,7 +932,7 @@ function ScoreEntryInner({
           // genuine in-flight locks via `inputsLocked` (finalize pending /
           // 409-redirect window), handled inside ScorePad.
           canSubmit
-          onSubmit={submit}
+          onSubmit={onSubmit}
           onClear={isEdit ? onClear : undefined}
           clearDisabled={deleteMutation.isPending}
         />

--- a/web-client/src/components/matches/score-entry.tsx
+++ b/web-client/src/components/matches/score-entry.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useController, useForm, useWatch } from 'react-hook-form'
 import {
   Link,
   Navigate,
@@ -50,13 +52,71 @@ import {
 } from './score-saves'
 import { SaveBanner } from './save-banner'
 import { ScorePad } from './score-pad'
+import { isAcceptableScoreInput } from './score-pad/validate-game-score'
 import {
-  isAcceptableScoreInput,
-  validateGameScore,
-} from './score-pad/validate-game-score'
+  gameScoreSchema,
+  type GameScoreInput,
+} from './score-pad/game-score-schema'
+import { mapGameScoreValidation } from './score-pad/game-score-ui'
 
 /** The non-null persisted score on a game. */
 type PersistedScore = NonNullable<MatchDetails['games'][number]['score']>
+
+/**
+ * The baseline `{ me, opp }` the inputs read with no local typing — the failed
+ * scratch save, else the persisted score, else empty (#624 keeps everything a
+ * clean digit string, or empty). Seeds React Hook Form's `values` (ADR-0018), so
+ * the form is initialised from the same source the dirty baseline below computes.
+ * Computed at the top of the component (before the loading guard) where the
+ * derived `persistedMe`/`failedMe` aren't in scope yet; the render body recomputes
+ * the same baseline for the dirty check and the conflict notice.
+ */
+function seedScoreValues(
+  data: MatchDetails,
+  gameNumber: number,
+  ownSave: ReturnType<typeof useGameSaveState>,
+): GameScoreInput {
+  const mySide = data.sides.find((s) => s.is_current_user_side) ?? null
+  if (!mySide) return { me: '', opp: '' }
+  const mySideNumber: 1 | 2 = mySide.side_number === 2 ? 2 : 1
+  const persistedScore =
+    data.games.find((g) => g.game_number === gameNumber)?.score ?? null
+  const persistedMe = persistedScore
+    ? mySideNumber === 1
+      ? persistedScore.side_1_points
+      : persistedScore.side_2_points
+    : null
+  const persistedOpp = persistedScore
+    ? mySideNumber === 1
+      ? persistedScore.side_2_points
+      : persistedScore.side_1_points
+    : null
+  const failedEntry = ownSave?.status === 'error' ? ownSave.variables : null
+  const failedMe = failedEntry
+    ? mySideNumber === 1
+      ? failedEntry.side_1_points
+      : failedEntry.side_2_points
+    : null
+  const failedOpp = failedEntry
+    ? mySideNumber === 1
+      ? failedEntry.side_2_points
+      : failedEntry.side_1_points
+    : null
+  return {
+    me:
+      failedMe != null
+        ? String(failedMe)
+        : persistedMe != null
+          ? String(persistedMe)
+          : '',
+    opp:
+      failedOpp != null
+        ? String(failedOpp)
+        : persistedOpp != null
+          ? String(persistedOpp)
+          : '',
+  }
+}
 
 // Placeholder for the opponent label on solo matches — mirrors the match
 // details hero. Distinct from `initialsOf('Opponent')` so users can tell
@@ -113,11 +173,41 @@ function ScoreEntryInner({
   // silently overwrite it.
   const failedSaves = useFailedGameSaves(matchId)
 
-  // `null` means "user hasn't typed anything yet" — we fall through to the
-  // persisted score in edit mode. Avoids a state-syncing effect when `data`
-  // arrives after first render.
-  const [meTyped, setMeTyped] = useState<string | null>(null)
-  const [oppTyped, setOppTyped] = useState<string | null>(null)
+  // React Hook Form owns the two score fields and their Zod validation — and
+  // nothing else (ADR-0018). Its `values` are seeded from the same baseline the
+  // render body computes (failed scratch → persisted → empty); `keepDirtyValues`
+  // makes a later refetch (e.g. the conflict re-sync) leave the user's typed
+  // entry alone, exactly like the old `meTyped ?? baseline` fall-through did.
+  // `keepSubmitCount` keeps the errors-after-first-submit gate from silently
+  // resetting when a background refetch changes the baseline mid-edit.
+  //
+  // `mode: 'onSubmit'` + `reValidateMode: 'onChange'`: nothing is red while the
+  // user first types; the first submit surfaces the errors; thereafter they
+  // re-validate live so a fix clears the red. The submit button is NEVER gated
+  // on validity (ADR-0018) — `handleSubmit` is the only gate, an invalid submit
+  // fires nothing.
+  const form = useForm<GameScoreInput>({
+    resolver: zodResolver(gameScoreSchema),
+    mode: 'onSubmit',
+    reValidateMode: 'onChange',
+    defaultValues: { me: '', opp: '' },
+    values: data ? seedScoreValues(data, gameNumber, ownSave) : undefined,
+    resetOptions: {
+      keepDirtyValues: true,
+      keepSubmitCount: true,
+      keepIsSubmitted: true,
+    },
+  })
+  // Each side is driven through a controller so the #624 keystroke filter
+  // (`isAcceptableScoreInput`) can reject a change outright — the value never
+  // updates — while RHF still owns the field. The live values are read back with
+  // `useWatch` and every downstream consumer (dirty tracking, finalize
+  // prediction, `overrunAt`, `toBody`, the copy, the scoreline) reads them.
+  const meField = useController({ control: form.control, name: 'me' })
+  const oppField = useController({ control: form.control, name: 'opp' })
+  const me = useWatch({ control: form.control, name: 'me' }) ?? ''
+  const opp = useWatch({ control: form.control, name: 'opp' }) ?? ''
+  const submitted = form.formState.submitCount > 0
   const meRef = useRef<HTMLInputElement>(null)
   const oppRef = useRef<HTMLInputElement>(null)
   // Set when a per-cell clear is confirmed: the dialog otherwise restores focus
@@ -293,20 +383,6 @@ function ScoreEntryInner({
   // `onError` re-sync primed it). Distinct from a plain failed save, which the
   // scoreline/banner just offer to retry.
   const conflict = ownSave?.status === 'error' && isScoreConflict(ownSave.error)
-  const me =
-    meTyped ??
-    (failedMe != null
-      ? String(failedMe)
-      : persistedMe != null
-        ? String(persistedMe)
-        : '')
-  const opp =
-    oppTyped ??
-    (failedOpp != null
-      ? String(failedOpp)
-      : persistedOpp != null
-        ? String(persistedOpp)
-        : '')
 
   // The baseline is what the inputs read with no local typing — the failed
   // scratch save, else the persisted score, else empty. Input is "dirty"
@@ -339,27 +415,34 @@ function ScoreEntryInner({
   // visible and get flagged inline instead of masquerading as a real score.
   const onMeChange = (value: string) => {
     if (!isAcceptableScoreInput(value)) return
-    setMeTyped(value)
+    meField.field.onChange(value)
     setIsDirty(computeDirty(value, opp))
     if (finalizeMutation.error) finalizeMutation.reset()
   }
   const onOppChange = (value: string) => {
     if (!isAcceptableScoreInput(value)) return
-    setOppTyped(value)
+    oppField.field.onChange(value)
     setIsDirty(computeDirty(me, value))
     if (finalizeMutation.error) finalizeMutation.reset()
   }
 
-  // The shared single-game verdict: 1–3-digit well-formedness, the "exactly one
-  // side filled" hint (#387), and the `illegalScoreReason` table-tennis rule.
-  // Now shared with the propose-a-result correction surface via `score-pad`.
-  const validation = validateGameScore(me, opp)
-  const oneSideFilled = validation.oneSideFilled
-  const meMalformed = validation.meMalformed
-  const oppMalformed = validation.oppMalformed
-  const formatError = meMalformed || oppMalformed ? validation.error : null
-  const localScoreError = validation.error
-  const inputsValid = validation.valid
+  // The shared single-game verdict via the Zod schema (ADR-0018): 1–2-digit
+  // well-formedness, the `illegalScoreReason` table-tennis rule, and the soft
+  // "enter both scores" tier. `inputsValid` (a successful parse — both sides
+  // filled, well-formed, legal) still gates the finalize prediction and the
+  // write; `mapGameScoreValidation` routes the failed-parse issues to ScorePad's
+  // per-side red flags / error line, but ONLY after the first submit
+  // (`submitted`) — nothing is red while the user first types.
+  const parseResult = gameScoreSchema.safeParse({ me, opp })
+  const inputsValid = parseResult.success
+  const ui = mapGameScoreValidation(parseResult, { me, opp })
+  // Gate the local Zod verdict behind the first submit. Before then the fields
+  // stay clean even with an illegal or half-typed score; after, `onChange`
+  // re-validation clears the red as the user fixes it.
+  const localScoreError = submitted ? ui.scoreError : null
+  const localMeInvalid = submitted && ui.meInvalid
+  const localOppInvalid = submitted && ui.oppInvalid
+  const localBothRequired = submitted && ui.showBothRequired
   const finalizeApiError =
     finalizeMutation.error instanceof ApiError ? finalizeMutation.error : null
   // A finalize error that ISN'T an `ApiError` is a transport-level drop:
@@ -444,35 +527,37 @@ function ScoreEntryInner({
   // transport-level drop (`finalizeNetworkError`) is the same story: the entered
   // score is perfectly valid, the POST just never reached the server, so the
   // fields stay clean and only the message line explains the failure (#868).
-  const inputsInvalid =
-    localScoreError !== null || finalizeApiError?.status === 422
-  // The message line, though, surfaces every finalize error (409/500 included),
-  // a transport-level drop, and the cross-game overrun block (a legal score that
-  // the board can't take).
+  const finalize422 = finalizeApiError?.status === 422
+  // The cross-game overrun block (a legal score the board can't take) follows
+  // the same after-first-submit gate as the Zod errors (ADR-0018 §4).
   const overrunError =
-    overrunAt !== null
+    submitted && overrunAt !== null
       ? `The match is already decided at game ${overrunAt} — clear the games after it before saving this score.`
       : null
-  const showScoreError =
-    inputsInvalid ||
-    overrunError !== null ||
-    // A 409 is surfaced as the calm redirect notice below, not the red error.
-    (finalizeApiError !== null && !finalizeRedirecting) ||
-    finalizeNetworkError
-  // The "both scores required" hint is its own, lower-severity line — shown only
-  // when exactly one field is filled and there's no harder error to surface.
-  const showBothRequired = oneSideFilled && !showScoreError
-  // Per-side red flags: a format error paints only the malformed side; a
-  // genuine scoring error (illegal score / 422 drift) paints both inputs; the
-  // both-required hint only flags the empty one.
-  const meInvalid =
-    meMalformed ||
-    (formatError === null && inputsInvalid) ||
-    (showBothRequired && me === '')
-  const oppInvalid =
-    oppMalformed ||
-    (formatError === null && inputsInvalid) ||
-    (showBothRequired && opp === '')
+  // A finalize error's message line, surfaced regardless of `submitted` (a
+  // finalize is inherently post-submit): every finalize error (409/500 included)
+  // and a transport-level drop. The negotiation-conflict 409 is shown as the calm
+  // redirect notice below instead, so it's excluded here.
+  const finalizeErrorText =
+    finalizeApiError !== null && !finalizeRedirecting
+      ? (finalizeApiError.detail ?? finalizeApiError.message)
+      : finalizeNetworkError
+        ? "Couldn't post the result — check your connection and try again."
+        : null
+  // Single `scoreError` slot, in ADR-0018 precedence: local Zod error (after
+  // submit) → overrun (after submit) → finalize API error (409/500) → finalize
+  // network drop.
+  const scoreError = localScoreError ?? overrunError ?? finalizeErrorText
+  // The "both scores required" hint is its own, lower-severity line — the schema
+  // emits it (post-submit) when either side is empty, but only show it when
+  // there's no harder error to surface.
+  const showBothRequired = localBothRequired && scoreError === null
+  // Per-side red flags: the mapper already paints only the malformed side, both
+  // sides for an illegal score, and the empty side for the soft hint (all gated
+  // post-submit via `localMeInvalid`/`localOppInvalid`); a server 422 drift
+  // paints both inputs.
+  const meInvalid = localMeInvalid || finalize422
+  const oppInvalid = localOppInvalid || finalize422
 
   function predictNextScoringRoute() {
     if (!data) return matchDetailRoute(matchId)
@@ -499,11 +584,18 @@ function ScoreEntryInner({
       : { side_1_points: Number(opp), side_2_points: Number(me) }
   }
 
-  function onSubmit() {
-    if (!inputsValid) return
+  // The submit gesture, always live (ADR-0018): `handleSubmit` is the ONLY
+  // gate — it runs Zod validation and calls `onValid` only when the parse
+  // succeeds (an invalid submit fires nothing but bumps `submitCount`, which is
+  // what surfaces the errors). The button is never disabled on validity; the
+  // in-flight/overrun guards below stay inside `onValid`.
+  const submit = form.handleSubmit(onValid)
+
+  function onValid() {
     // The score is legal on its own but the board can't take it (it would leave
     // the match decided before its last game). Block the write — the inline
-    // `overrunError` tells the user to clear the trailing games first.
+    // `overrunError` (now visible, `submitCount > 0`) tells the user to clear the
+    // trailing games first.
     if (overrunAt !== null) return
     // Ignore a second Save while the per-game save is still in flight (#538):
     // a double-tap would otherwise fire a duplicate create that 409s. This
@@ -647,10 +739,15 @@ function ScoreEntryInner({
   // guard forces before any further write to this game.
   function keepCommittedScore() {
     // Drop our rejected scratch save; the inputs fall back to the committed
-    // score and the conflict notice clears.
+    // score and the conflict notice clears. `form.reset` to the committed score
+    // clears RHF's dirty flags so the recomputed `values` (now the persisted
+    // score, with the failed scratch gone) don't get kept as our losing entry by
+    // `keepDirtyValues`, and drops `submitCount` so the fresh state starts clean.
     forgetScoreSaves(queryClient, matchId, gameNumber)
-    setMeTyped(null)
-    setOppTyped(null)
+    form.reset({
+      me: persistedMe != null ? String(persistedMe) : '',
+      opp: persistedOpp != null ? String(persistedOpp) : '',
+    })
     setIsDirty(false)
   }
 
@@ -676,7 +773,7 @@ function ScoreEntryInner({
         oppRef.current?.focus()
         oppRef.current?.select()
       } else if (side === 'opp') {
-        onSubmit()
+        submit()
       }
     } else if (e.key === 'ArrowRight' && side === 'me') {
       e.preventDefault()
@@ -790,30 +887,24 @@ function ScoreEntryInner({
             onKeyDown: (e) => handleKey(e, 'opp'),
           }}
           gamesTally={bestOf > 1 ? `${meWins} – ${oppWins}` : null}
-          // The scratchpad surfaces the local validation error, the cross-game
-          // overrun block, a finalize API rejection (409/500 too), and — last in
-          // precedence — a transport-level drop's connection copy here;
-          // `showScoreError` gates when any of them shows, in that order. The
-          // connection copy is last because an `ApiError` (a real server verdict)
-          // is always the more specific thing to say; a bare transport failure is
-          // the fallback when the POST never reached the server at all (#868).
-          scoreError={
-            showScoreError
-              ? (localScoreError ??
-                overrunError ??
-                finalizeApiError?.detail ??
-                finalizeApiError?.message ??
-                (finalizeNetworkError
-                  ? "Couldn't post the result — check your connection and try again."
-                  : null))
-              : null
-          }
+          // The single error slot, already resolved in ADR-0018 precedence: the
+          // local Zod error (after submit) → the cross-game overrun block (after
+          // submit) → a finalize API rejection (409/500) → a transport-level
+          // drop's connection copy. The connection copy is last because an
+          // `ApiError` (a real server verdict) is always the more specific thing
+          // to say; a bare transport failure is the fallback when the POST never
+          // reached the server at all (#868).
+          scoreError={scoreError}
           showBothRequired={showBothRequired}
           inputsLocked={inputsLocked}
           subtitle={subtitle}
           submitLabel={submitLabel}
-          canSubmit={inputsValid && overrunAt === null}
-          onSubmit={onSubmit}
+          // Never gated on validity (ADR-0018): the button is always live, and
+          // `handleSubmit` (in `submit`) is the only gate. It's disabled only by
+          // genuine in-flight locks via `inputsLocked` (finalize pending /
+          // 409-redirect window), handled inside ScorePad.
+          canSubmit
+          onSubmit={submit}
           onClear={isEdit ? onClear : undefined}
           clearDisabled={deleteMutation.isPending}
         />

--- a/web-client/src/components/matches/score-pad/game-score-schema.test.ts
+++ b/web-client/src/components/matches/score-pad/game-score-schema.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BOTH_REQUIRED_MESSAGE,
+  MALFORMED_SCORE_MESSAGE,
+  gameScoreSchema,
+  type GameScoreTier,
+} from './game-score-schema'
+
+interface FlatIssue {
+  path: (PropertyKey | undefined)[]
+  message: string
+  tier: GameScoreTier | undefined
+}
+
+/** Parse and flatten the issues to the parts the mapper reads (path, message,
+ * tier), so each tier can be asserted precisely. */
+function issuesFor(me: string, opp: string): FlatIssue[] {
+  const result = gameScoreSchema.safeParse({ me, opp })
+  if (result.success) return []
+  return result.error.issues.map((issue) => ({
+    path: [...issue.path],
+    message: issue.message,
+    tier: (issue as { params?: { tier?: GameScoreTier } }).params?.tier,
+  }))
+}
+
+describe('gameScoreSchema', () => {
+  describe('valid — both sides filled, well-formed, legal decided score', () => {
+    it('accepts a legal decided game (11–9) with no issues', () => {
+      const result = gameScoreSchema.safeParse({ me: '11', opp: '9' })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts a losing-but-legal score (9–11)', () => {
+      expect(issuesFor('9', '11')).toEqual([])
+    })
+
+    it('accepts a legal deuce game (12–10)', () => {
+      expect(issuesFor('12', '10')).toEqual([])
+    })
+
+    it('accepts a two-digit zero-loser game (11–0)', () => {
+      expect(issuesFor('11', '0')).toEqual([])
+    })
+  })
+
+  describe('illegal — a cross-field (root) hard error that reddens both sides', () => {
+    it('flags a sub-11 winner (8–5) on the root path with the reason', () => {
+      expect(issuesFor('8', '5')).toEqual([
+        {
+          path: [],
+          message: 'The winning side must reach at least 11 points.',
+          tier: 'illegal',
+        },
+      ])
+    })
+
+    it('flags a tie (11–11) with the tie reason', () => {
+      expect(issuesFor('11', '11')).toEqual([
+        {
+          path: [],
+          message: 'A game cannot end in a tie.',
+          tier: 'illegal',
+        },
+      ])
+    })
+  })
+
+  describe('malformed — a hard error on the offending side only', () => {
+    it('flags a trailing-letter run ("1x") on the me path only', () => {
+      expect(issuesFor('1x', '7')).toEqual([
+        { path: ['me'], message: MALFORMED_SCORE_MESSAGE, tier: 'malformed' },
+      ])
+    })
+
+    it('flags a decimal ("5.") on the me path', () => {
+      expect(issuesFor('5.', '7')).toEqual([
+        { path: ['me'], message: MALFORMED_SCORE_MESSAGE, tier: 'malformed' },
+      ])
+    })
+
+    it('flags a three-digit run ("111") as malformed (1–2 digits only)', () => {
+      expect(issuesFor('111', '7')).toEqual([
+        { path: ['me'], message: MALFORMED_SCORE_MESSAGE, tier: 'malformed' },
+      ])
+    })
+
+    it('flags a leading-letter run ("x1") as malformed (anchored regex)', () => {
+      expect(issuesFor('x1', '7')).toEqual([
+        { path: ['me'], message: MALFORMED_SCORE_MESSAGE, tier: 'malformed' },
+      ])
+    })
+
+    it('flags a malformed opp side on the opp path only', () => {
+      expect(issuesFor('7', '1x')).toEqual([
+        { path: ['opp'], message: MALFORMED_SCORE_MESSAGE, tier: 'malformed' },
+      ])
+    })
+
+    it('flags both sides when both are malformed', () => {
+      expect(issuesFor('1x', '2y')).toEqual([
+        { path: ['me'], message: MALFORMED_SCORE_MESSAGE, tier: 'malformed' },
+        { path: ['opp'], message: MALFORMED_SCORE_MESSAGE, tier: 'malformed' },
+      ])
+    })
+  })
+
+  describe('both-required — the soft hint on the empty side(s)', () => {
+    it('flags only the empty opp side when me is filled', () => {
+      expect(issuesFor('11', '')).toEqual([
+        { path: ['opp'], message: BOTH_REQUIRED_MESSAGE, tier: 'both-required' },
+      ])
+    })
+
+    it('flags only the empty me side when opp is filled', () => {
+      expect(issuesFor('', '11')).toEqual([
+        { path: ['me'], message: BOTH_REQUIRED_MESSAGE, tier: 'both-required' },
+      ])
+    })
+
+    it('flags both sides for a wholly-empty pair', () => {
+      expect(issuesFor('', '')).toEqual([
+        { path: ['me'], message: BOTH_REQUIRED_MESSAGE, tier: 'both-required' },
+        { path: ['opp'], message: BOTH_REQUIRED_MESSAGE, tier: 'both-required' },
+      ])
+    })
+  })
+
+  describe('precedence — hard errors outrank the both-required hint', () => {
+    it('reports only the malformed error when a malformed side sits beside an empty one', () => {
+      expect(issuesFor('1x', '')).toEqual([
+        { path: ['me'], message: MALFORMED_SCORE_MESSAGE, tier: 'malformed' },
+      ])
+    })
+
+    it('reports only the malformed error, never the illegal one, when the other side is a well-formed score', () => {
+      expect(issuesFor('1x', '5')).toEqual([
+        { path: ['me'], message: MALFORMED_SCORE_MESSAGE, tier: 'malformed' },
+      ])
+    })
+  })
+})

--- a/web-client/src/components/matches/score-pad/game-score-schema.ts
+++ b/web-client/src/components/matches/score-pad/game-score-schema.ts
@@ -1,0 +1,124 @@
+import { z } from 'zod'
+
+import { illegalScoreReason } from '@/lib/scoring'
+
+/**
+ * The message shown when a filled side isn't a plain 1–2-digit whole number.
+ * Mirrors the live `validateGameScore` copy (the server caps each side at 99).
+ */
+export const MALFORMED_SCORE_MESSAGE =
+  'Enter each score as a whole number from 0 to 99.'
+
+/**
+ * The soft hint shown when the game is only half-entered (one side filled, or
+ * both still empty). Lower severity than a hard error — matches the ScorePad
+ * `showBothRequired` line.
+ */
+export const BOTH_REQUIRED_MESSAGE = 'Enter both scores to save this game.'
+
+/**
+ * How a single game's two raw inputs failed, carried on each issue's `params`
+ * so the issues→UI mapper can render the three message tiers without re-parsing
+ * the strings:
+ * - `malformed` — a filled side that isn't 1–2 digits (hard error, that side).
+ * - `illegal` — both sides well-formed but the final score breaks the
+ *   table-tennis rule (hard error, cross-field / both sides).
+ * - `both-required` — a side is still empty (soft hint, the empty side only).
+ */
+export type GameScoreTier = 'malformed' | 'illegal' | 'both-required'
+
+/** One filled score side is well-formed only as 1–2 digits (server caps at 99). */
+const SCORE_DIGITS = /^\d{1,2}$/
+
+/**
+ * One game's two raw score-input strings, taken verbatim — no coercion or trim,
+ * so a malformed entry stays visible and gets flagged rather than laundered into
+ * a real score (#624).
+ *
+ * Validation runs on submit (the button is never disabled, ADR-0018), producing
+ * issues the mapper renders as ScorePad's existing three tiers. Precedence
+ * mirrors the live `validateGameScore`: a malformed side or an illegal final
+ * score (both hard) short-circuits before the softer "enter both scores" hint,
+ * so a half-entered game with a malformed side reports the malformed error, not
+ * the hint.
+ *
+ * The tier lives on each issue's `params` (see {@link GameScoreTier}); the path
+ * points at the side(s) to redden — a malformed side's own path, the empty
+ * side's path for the soft hint, and the root (`[]`) for an illegal score,
+ * which reddens both sides.
+ */
+export const gameScoreSchema = z
+  .object({
+    me: z.string(),
+    opp: z.string(),
+  })
+  .superRefine(({ me, opp }, ctx) => {
+    const meFilled = me !== ''
+    const oppFilled = opp !== ''
+    const meMalformed = meFilled && !SCORE_DIGITS.test(me)
+    const oppMalformed = oppFilled && !SCORE_DIGITS.test(opp)
+
+    // Hard tier 1: a malformed digit run on a filled side outranks everything
+    // else — flag each offending side and stop.
+    if (meMalformed || oppMalformed) {
+      if (meMalformed) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['me'],
+          message: MALFORMED_SCORE_MESSAGE,
+          params: { tier: 'malformed' },
+        })
+      }
+      if (oppMalformed) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['opp'],
+          message: MALFORMED_SCORE_MESSAGE,
+          params: { tier: 'malformed' },
+        })
+      }
+      return
+    }
+
+    // Hard tier 2: both sides well-formed but the decided score is illegal. The
+    // whole game is wrong, so this is a cross-field issue on the root path — the
+    // UI reddens both sides.
+    if (meFilled && oppFilled) {
+      const reason = illegalScoreReason(Number(me), Number(opp))
+      if (reason !== null) {
+        ctx.addIssue({
+          code: 'custom',
+          path: [],
+          message: reason,
+          params: { tier: 'illegal' },
+        })
+      }
+      return
+    }
+
+    // Soft tier: the game is only half-entered — a hint on each empty side. A
+    // wholly-empty pair lands here too (both sides flagged), because the submit
+    // button is always enabled and an empty submit must say "enter both scores".
+    if (!meFilled) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['me'],
+        message: BOTH_REQUIRED_MESSAGE,
+        params: { tier: 'both-required' },
+      })
+    }
+    if (!oppFilled) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['opp'],
+        message: BOTH_REQUIRED_MESSAGE,
+        params: { tier: 'both-required' },
+      })
+    }
+  })
+
+/** One game's two raw score strings — `{ me, opp }`, taken verbatim. */
+export type GameScoreInput = z.infer<typeof gameScoreSchema>
+
+/** The `safeParse` result shape for {@link gameScoreSchema}. */
+export type GameScoreParseResult = ReturnType<typeof gameScoreSchema.safeParse>

--- a/web-client/src/components/matches/score-pad/game-score-ui.test.ts
+++ b/web-client/src/components/matches/score-pad/game-score-ui.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BOTH_REQUIRED_MESSAGE,
+  MALFORMED_SCORE_MESSAGE,
+  gameScoreSchema,
+  type GameScoreParseResult,
+} from './game-score-schema'
+import { mapGameScoreValidation, type GameScoreUiState } from './game-score-ui'
+
+/** Parse the raw pair through the schema and map it to ScorePad props — the same
+ * two-step 1b wires into the form. */
+function uiFor(me: string, opp: string): GameScoreUiState {
+  return mapGameScoreValidation(gameScoreSchema.safeParse({ me, opp }), {
+    me,
+    opp,
+  })
+}
+
+/** A hand-built failed parse result carrying one issue with an arbitrary tier —
+ * to prove the mapper only reacts to the tiers it knows, rather than treating
+ * any leftover issue as the soft hint. */
+function failedResultWithTier(tier: string): GameScoreParseResult {
+  return {
+    success: false,
+    error: { issues: [{ code: 'custom', message: 'nope', path: [], params: { tier } }] },
+  } as unknown as GameScoreParseResult
+}
+
+describe('mapGameScoreValidation', () => {
+  it('reports a clean slate for a legal decided game (11–9)', () => {
+    expect(uiFor('11', '9')).toEqual({
+      meInvalid: false,
+      oppInvalid: false,
+      scoreError: null,
+      showBothRequired: false,
+    })
+  })
+
+  it('reports a clean slate for a losing-but-legal score (9–11)', () => {
+    expect(uiFor('9', '11')).toEqual({
+      meInvalid: false,
+      oppInvalid: false,
+      scoreError: null,
+      showBothRequired: false,
+    })
+  })
+
+  it('reddens both sides for an illegal finished score (8–5) with the reason', () => {
+    expect(uiFor('8', '5')).toEqual({
+      meInvalid: true,
+      oppInvalid: true,
+      scoreError: 'The winning side must reach at least 11 points.',
+      showBothRequired: false,
+    })
+  })
+
+  it('reddens only the me side for a malformed me entry ("1x")', () => {
+    expect(uiFor('1x', '7')).toEqual({
+      meInvalid: true,
+      oppInvalid: false,
+      scoreError: MALFORMED_SCORE_MESSAGE,
+      showBothRequired: false,
+    })
+  })
+
+  it('reddens only the opp side for a malformed opp entry ("1x")', () => {
+    expect(uiFor('7', '1x')).toEqual({
+      meInvalid: false,
+      oppInvalid: true,
+      scoreError: MALFORMED_SCORE_MESSAGE,
+      showBothRequired: false,
+    })
+  })
+
+  it('reddens both sides when both entries are malformed', () => {
+    expect(uiFor('1x', '2y')).toEqual({
+      meInvalid: true,
+      oppInvalid: true,
+      scoreError: MALFORMED_SCORE_MESSAGE,
+      showBothRequired: false,
+    })
+  })
+
+  it('shows the soft hint and reddens only the empty opp side when me is filled', () => {
+    expect(uiFor('11', '')).toEqual({
+      meInvalid: false,
+      oppInvalid: true,
+      scoreError: null,
+      showBothRequired: true,
+    })
+  })
+
+  it('shows the soft hint and reddens only the empty me side when opp is filled', () => {
+    expect(uiFor('', '11')).toEqual({
+      meInvalid: true,
+      oppInvalid: false,
+      scoreError: null,
+      showBothRequired: true,
+    })
+  })
+
+  it('shows the soft hint and reddens both sides for a wholly-empty pair', () => {
+    expect(uiFor('', '')).toEqual({
+      meInvalid: true,
+      oppInvalid: true,
+      scoreError: null,
+      showBothRequired: true,
+    })
+  })
+
+  it('surfaces the malformed error (never the hint) when a malformed side sits beside an empty one', () => {
+    expect(uiFor('1x', '')).toEqual({
+      meInvalid: true,
+      oppInvalid: false,
+      scoreError: MALFORMED_SCORE_MESSAGE,
+      showBothRequired: false,
+    })
+  })
+
+  it('ignores an issue whose tier it does not recognize (only both-required raises the hint)', () => {
+    expect(mapGameScoreValidation(failedResultWithTier('mystery'), {
+      me: '',
+      opp: '',
+    })).toEqual({
+      meInvalid: false,
+      oppInvalid: false,
+      scoreError: null,
+      showBothRequired: false,
+    })
+  })
+
+  it('does not use the BOTH_REQUIRED copy as a hard error', () => {
+    // The soft tier never populates scoreError — that line is the hint, not the
+    // red error. Guards against the mapper mis-routing the both-required issue.
+    expect(uiFor('11', '').scoreError).not.toBe(BOTH_REQUIRED_MESSAGE)
+  })
+})

--- a/web-client/src/components/matches/score-pad/game-score-ui.test.ts
+++ b/web-client/src/components/matches/score-pad/game-score-ui.test.ts
@@ -11,19 +11,19 @@ import { mapGameScoreValidation, type GameScoreUiState } from './game-score-ui'
 /** Parse the raw pair through the schema and map it to ScorePad props — the same
  * two-step 1b wires into the form. */
 function uiFor(me: string, opp: string): GameScoreUiState {
-  return mapGameScoreValidation(gameScoreSchema.safeParse({ me, opp }), {
-    me,
-    opp,
-  })
+  return mapGameScoreValidation(gameScoreSchema.safeParse({ me, opp }))
 }
 
-/** A hand-built failed parse result carrying one issue with an arbitrary tier —
- * to prove the mapper only reacts to the tiers it knows, rather than treating
- * any leftover issue as the soft hint. */
-function failedResultWithTier(tier: string): GameScoreParseResult {
+/** A hand-built failed parse result carrying one issue with an arbitrary tier
+ * (and optional side path) — to prove the mapper only reacts to the tiers it
+ * knows, rather than treating any leftover issue as the soft hint. */
+function failedResultWithTier(
+  tier: string,
+  path: PropertyKey[] = [],
+): GameScoreParseResult {
   return {
     success: false,
-    error: { issues: [{ code: 'custom', message: 'nope', path: [], params: { tier } }] },
+    error: { issues: [{ code: 'custom', message: 'nope', path, params: { tier } }] },
   } as unknown as GameScoreParseResult
 }
 
@@ -119,10 +119,22 @@ describe('mapGameScoreValidation', () => {
   })
 
   it('ignores an issue whose tier it does not recognize (only both-required raises the hint)', () => {
-    expect(mapGameScoreValidation(failedResultWithTier('mystery'), {
-      me: '',
-      opp: '',
-    })).toEqual({
+    expect(mapGameScoreValidation(failedResultWithTier('mystery'))).toEqual({
+      meInvalid: false,
+      oppInvalid: false,
+      scoreError: null,
+      showBothRequired: false,
+    })
+  })
+
+  it('ignores an unrecognized tier even when its issue targets a side path', () => {
+    // The `both-required` branch keys off the tier, NOT merely "any leftover
+    // issue on a side path": an unknown tier pointed at `['me']` must not redden
+    // that side or raise the hint. (Kills the `tier === 'both-required'` → `true`
+    // mutant, which would treat this issue as the soft hint.)
+    expect(
+      mapGameScoreValidation(failedResultWithTier('mystery', ['me'])),
+    ).toEqual({
       meInvalid: false,
       oppInvalid: false,
       scoreError: null,

--- a/web-client/src/components/matches/score-pad/game-score-ui.ts
+++ b/web-client/src/components/matches/score-pad/game-score-ui.ts
@@ -1,0 +1,80 @@
+import type {
+  GameScoreInput,
+  GameScoreParseResult,
+  GameScoreTier,
+} from './game-score-schema'
+
+/**
+ * Exactly what {@link mapGameScoreValidation} hands the presentational ScorePad:
+ * which side(s) to redden, the hard-error line, and the soft "enter both scores"
+ * hint. Slots straight into ScorePad's existing `me.invalid` / `opp.invalid`,
+ * `scoreError`, and `showBothRequired` props.
+ */
+export interface GameScoreUiState {
+  /** Redden the `me` field. */
+  meInvalid: boolean
+  /** Redden the `opp` field. */
+  oppInvalid: boolean
+  /** The hard-error message (malformed digits or an illegal score), or null. */
+  scoreError: string | null
+  /** Show the softer "enter both scores to save this game" hint. */
+  showBothRequired: boolean
+}
+
+/**
+ * Turn {@link gameScoreSchema}'s parse result into the ScorePad props for one
+ * game. Pure — the schema owns the rules (and their precedence: it never emits
+ * the soft `both-required` hint alongside a hard error), so this only routes the
+ * issues to fields:
+ * - `malformed` → redden that side and surface its message as the hard error,
+ * - `illegal` → redden both sides and surface the reason as the hard error,
+ * - `both-required` → show the soft hint and redden only the empty side(s).
+ *
+ * The empty-side flag reads the raw `{ me, opp }` (mirroring the live
+ * score-entry logic), so only the field the user hasn't filled goes red.
+ */
+export function mapGameScoreValidation(
+  result: GameScoreParseResult,
+  { me, opp }: GameScoreInput,
+): GameScoreUiState {
+  if (result.success) {
+    return {
+      meInvalid: false,
+      oppInvalid: false,
+      scoreError: null,
+      showBothRequired: false,
+    }
+  }
+
+  let scoreError: string | null = null
+  let malformedMe = false
+  let malformedOpp = false
+  let illegal = false
+  let bothRequired = false
+
+  for (const issue of result.error.issues) {
+    // Every issue the schema emits carries a `tier` on `params` (see
+    // `gameScoreSchema`), so read it straight — no untagged issue reaches here.
+    // Cast through `unknown`: Zod's issue union types `params` as an optional
+    // `Record`, but ours is always this tagged shape.
+    const tier = (issue as unknown as { params: { tier: GameScoreTier } }).params
+      .tier
+    if (tier === 'malformed') {
+      scoreError = issue.message
+      if (issue.path[0] === 'me') malformedMe = true
+      if (issue.path[0] === 'opp') malformedOpp = true
+    } else if (tier === 'illegal') {
+      scoreError = issue.message
+      illegal = true
+    } else if (tier === 'both-required') {
+      bothRequired = true
+    }
+  }
+
+  return {
+    meInvalid: malformedMe || illegal || (bothRequired && me === ''),
+    oppInvalid: malformedOpp || illegal || (bothRequired && opp === ''),
+    scoreError,
+    showBothRequired: bothRequired,
+  }
+}

--- a/web-client/src/components/matches/score-pad/game-score-ui.ts
+++ b/web-client/src/components/matches/score-pad/game-score-ui.ts
@@ -1,5 +1,4 @@
 import type {
-  GameScoreInput,
   GameScoreParseResult,
   GameScoreTier,
 } from './game-score-schema'
@@ -30,12 +29,13 @@ export interface GameScoreUiState {
  * - `illegal` → redden both sides and surface the reason as the hard error,
  * - `both-required` → show the soft hint and redden only the empty side(s).
  *
- * The empty-side flag reads the raw `{ me, opp }` (mirroring the live
- * score-entry logic), so only the field the user hasn't filled goes red.
+ * Pure — a function of the parse result alone. The empty-side flag reads the
+ * `both-required` issue's own `path` (the schema emits it on the empty side, and
+ * on BOTH paths for a wholly-empty pair), exactly like the `malformed` tier, so
+ * only the field the user hasn't filled goes red.
  */
 export function mapGameScoreValidation(
   result: GameScoreParseResult,
-  { me, opp }: GameScoreInput,
 ): GameScoreUiState {
   if (result.success) {
     return {
@@ -50,7 +50,8 @@ export function mapGameScoreValidation(
   let malformedMe = false
   let malformedOpp = false
   let illegal = false
-  let bothRequired = false
+  let bothRequiredMe = false
+  let bothRequiredOpp = false
 
   for (const issue of result.error.issues) {
     // Every issue the schema emits carries a `tier` on `params` (see
@@ -67,14 +68,15 @@ export function mapGameScoreValidation(
       scoreError = issue.message
       illegal = true
     } else if (tier === 'both-required') {
-      bothRequired = true
+      if (issue.path[0] === 'me') bothRequiredMe = true
+      if (issue.path[0] === 'opp') bothRequiredOpp = true
     }
   }
 
   return {
-    meInvalid: malformedMe || illegal || (bothRequired && me === ''),
-    oppInvalid: malformedOpp || illegal || (bothRequired && opp === ''),
+    meInvalid: malformedMe || illegal || bothRequiredMe,
+    oppInvalid: malformedOpp || illegal || bothRequiredOpp,
     scoreError,
-    showBothRequired: bothRequired,
+    showBothRequired: bothRequiredMe || bothRequiredOpp,
   }
 }


### PR DESCRIPTION
## What

Converts the single-game **score-entry** form off its hand-rolled `useState` onto **React Hook Form + Zod**, and changes two behaviors deliberately (per **ADR 0018**, included in this PR):

1. **The submit button is always enabled** — only genuine in-flight locks (finalize pending / 409-redirect) disable it; validity never does. `handleSubmit` is the only gate.
2. **Validation errors appear only after the first submit**, then re-validate live as the user fixes the score. The now-reachable **empty submit** shows a soft "Enter both scores to save this game." on both fields.

RHF owns *only* the two score fields (via `useController`, keeping the #624 keystroke filter); `useWatch` feeds every existing downstream consumer unchanged — the custom dirty-tracking router blocker (ADR-0014), finalize-vs-save prediction, cross-game overrun, save-conflict chooser, offline scratchpad, and the scoreline. Server/finalize error handling (409/422/500/network, #868/#827) stays outside the form.

The reusable single-game **Zod schema + issues→UI mapper** live in `score-pad/` (beside `validate-game-score.ts`, reusing `illegalScoreReason`) so the propose-a-result **correction board can adopt them next**; `validateGameScore` is left untouched for that surface this pass.

## Testing

- **Vitest:** full suite green (2793). The score-entry suite keeps its ~3.4k lines — 5 existing tests rewritten to the submit-gated behavior, 8 new tests for always-enabled submit + errors-after-submit + the empty-submit hint.
- **Mutation (Stryker):** the new schema + mapper at **100% mutants killed** (independently reproduced).
- **Web-client Playwright e2e:** 289 passed (two `score-entry.spec.ts` tests updated to the new behavior).
- **Lint + `tsc` + build:** clean.

## Scope

`web-client/**` only — no API, no OpenAPI schema change, no iOS. `correction-entry.tsx` and `validateGameScore` intentionally untouched (migrated in the follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)