### PR TITLE
Have /grilling ask its interview questions via AskUserQuestion

### DIFF
--- a/.claude/skills/grilling/SKILL.md
+++ b/.claude/skills/grilling/SKILL.md
@@ -5,6 +5,6 @@ description: Interview the user relentlessly about a plan or design. Use when th
 
 Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
 
-Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+Ask the questions one at a time using the AskUserQuestion tool, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering. Put your recommended answer first and label it "(Recommended)"; include the other real options you're weighing as the remaining choices. The user can always free-type something else via "Other", so don't force a fit — if a question is genuinely open-ended (no small set of discrete options), ask it as plain text instead of forcing it into the tool.
 
 If a question can be answered by exploring the codebase, explore the codebase instead.


### PR DESCRIPTION
## Summary
- The /grilling skill (also used by /grill-with-docs) now asks its interview questions with the AskUserQuestion tool instead of plain text, recommended answer first, falling back to plain text for genuinely open-ended questions.

## Test plan
- [x] Docs-only change to a skill markdown file; no code paths affected.