### PR TITLE
Call a tournament match only when its table and players are free (#1106)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -505,6 +505,22 @@ and packs the free ones around them. Before the scheduler, every placement is a 
 one and the distinction is dormant.
 _Avoid_: locked (reserve for other domains), fixed (ambiguous with a *fixture*).
 
+**Call** (scheduler-era):
+**Starting** a tournament **match** — telling both entrants to play and flipping the
+match from *scheduled* (`pending`) to *started* (`in_progress`). Unlike a **placement**,
+which is only a **prediction**, a call is a **promise**: the entrants were told, so the
+solver holds the started match fixed at its actual occupancy. A match is called only when
+its **placement** is *due* **and** its **table** and both its **players** (by **user**,
+so it holds across events) are **free** — i.e. no unfinished started match holds them.
+A match that runs long therefore **stalls** its successors rather than starting a second
+match on the same table or human (which would double-book a physical resource and wedge
+the **schedule** infeasible — #1106, ADR 20260718). Calling is driven by a match
+**completing** (which frees a table and re-solves), not by a clock poll; the pin tick is
+only a backstop for a **Slot** window opening or a tournament's first matches.
+_Avoid_: pin (the call *causes* a pin, but a **manual placement** also pins without a
+call; the pin is the placement's fixedness, the call is the promise to the players),
+notify (the call includes a notification but is the whole state transition, not just it).
+
 ## Dashboard
 
 **First-match**:

--- a/api/app/match_calls.py
+++ b/api/app/match_calls.py
@@ -417,7 +417,7 @@ async def call_due_fixtures(
     # it; the loop mutates these in place (the returned sets are freshly built).
     claimed_tables, claimed_users = await _held_resources(db, tournament.id)
     free: list[TournamentFixture] = []
-    for fixture in sorted(due, key=lambda f: (f.scheduled_start or datetime.max, f.id)):
+    for fixture in sorted(due, key=lambda f: (f.scheduled_start, f.id)):
         user_ids = {
             user.id
             for user in (

--- a/api/app/match_calls.py
+++ b/api/app/match_calls.py
@@ -289,6 +289,67 @@ async def _un_call_pristine_match(db: AsyncSession, match_id: uuid.UUID | None) 
     )
 
 
+async def _held_resources(
+    db: AsyncSession, tournament_id: uuid.UUID
+) -> tuple[set[str], set[uuid.UUID]]:
+    """The tables and **users** an unfinished (``in_progress``) match in this
+    tournament currently holds — the resource-freedom gate's occupancy read
+    (ADR "a tournament match is called only when its table and players are
+    free", #1106). A started match is a fixed interval the solver pins at its
+    *actual* occupancy; calling a second match onto the same table or the same
+    human would hand the next solve two overlapping fixed intervals and wedge
+    it ``infeasible`` — the exact bug this gate exists to prevent.
+
+    "Held" reads *real* state: a ``Match`` with ``status == in_progress`` (not
+    ``completed``/``voided``) whose fixture carries the ``table_id`` /
+    entrants. Players are held at the **user** level, across events — the same
+    human in two events is one person, as the solver's no-double-booking
+    already treats them (``schedule_solves`` maps entrants → ``PlayerId`` via
+    the user). Runs on the caller's already-locked transaction: one occupancy
+    query, plus one entry→user resolution, per batch.
+    """
+    rows = (
+        await db.execute(
+            select(
+                TournamentFixture.table_id,
+                TournamentFixture.entry_a_id,
+                TournamentFixture.entry_b_id,
+            )
+            .join(Match, Match.id == TournamentFixture.match_id)
+            .where(
+                TournamentFixture.event_id.in_(
+                    select(TournamentEvent.id).where(
+                        TournamentEvent.tournament_id == tournament_id
+                    )
+                ),
+                Match.status == MatchStatus.in_progress,
+            )
+        )
+    ).all()
+    held_tables: set[str] = set()
+    held_entry_ids: set[uuid.UUID] = set()
+    for table_id, entry_a_id, entry_b_id in rows:
+        if table_id is not None:
+            held_tables.add(table_id)
+        for entry_id in (entry_a_id, entry_b_id):
+            if entry_id is not None:
+                held_entry_ids.add(entry_id)
+    held_users: set[uuid.UUID] = set()
+    if held_entry_ids:
+        held_users = set(
+            (
+                await db.execute(
+                    select(TournamentEntry.user_id).where(
+                        TournamentEntry.id.in_(held_entry_ids)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    return held_tables, held_users
+
+
 async def call_due_fixtures(
     db: AsyncSession,
     tournament: Tournament,
@@ -342,6 +403,40 @@ async def call_due_fixtures(
 
     if ingredients is None:
         ingredients = await load_copy_ingredients(db, tournament, due)
+
+    # Resource-freedom gate (ADR "…called only when its table and players are
+    # free", #1106). A fixture is *due* by its predicted start, but calling it
+    # onto a table or a human already held by an unfinished in_progress match
+    # would produce two overlapping fixed intervals and wedge the next solve
+    # infeasible. _due_for_call is a per-row predicate blind to cross-row
+    # occupancy, so the gate lives here — one occupancy read under the locks
+    # already held (the authoritative gate, per the ADR). Two due fixtures
+    # contending for the same freshly-free resource within one pass are settled
+    # by earliest predicted start; the loser defers to a later pass.
+    held_tables, held_users = await _held_resources(db, tournament.id)
+    claimed_tables = set(held_tables)
+    claimed_users = set(held_users)
+    free: list[TournamentFixture] = []
+    for fixture in sorted(due, key=lambda f: (f.scheduled_start or datetime.max, f.id)):
+        user_ids = {
+            user.id
+            for user in (
+                ingredients.user_for_entry(fixture.entry_a_id),
+                ingredients.user_for_entry(fixture.entry_b_id),
+            )
+            if user is not None
+        }
+        if fixture.table_id is not None and fixture.table_id in claimed_tables:
+            continue
+        if user_ids & claimed_users:
+            continue
+        if fixture.table_id is not None:
+            claimed_tables.add(fixture.table_id)
+        claimed_users |= user_ids
+        free.append(fixture)
+    due = free
+    if not due:
+        return []
 
     # First pass resolves each due fixture's people, so the whole batch's
     # in-app preferences resolve in one round (the locks are already held).

--- a/api/app/match_calls.py
+++ b/api/app/match_calls.py
@@ -413,9 +413,9 @@ async def call_due_fixtures(
     # already held (the authoritative gate, per the ADR). Two due fixtures
     # contending for the same freshly-free resource within one pass are settled
     # by earliest predicted start; the loser defers to a later pass.
-    held_tables, held_users = await _held_resources(db, tournament.id)
-    claimed_tables = set(held_tables)
-    claimed_users = set(held_users)
+    # Seed the running claim from real held state, then admit due fixtures into
+    # it; the loop mutates these in place (the returned sets are freshly built).
+    claimed_tables, claimed_users = await _held_resources(db, tournament.id)
     free: list[TournamentFixture] = []
     for fixture in sorted(due, key=lambda f: (f.scheduled_start or datetime.max, f.id)):
         user_ids = {

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -823,6 +823,65 @@ class TestResourceFreedomGate:
         # Exactly the earlier fixture's pair was told.
         assert len(await _call_notifications(db_session)) == 2
 
+    async def test_a_full_disjoint_round_is_all_called_in_one_pass(
+        self,
+        db_session: AsyncSession,
+        fake_notifications_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A normal simultaneous round — several due fixtures that are mutually
+        disjoint (distinct tables AND distinct players, nothing yet
+        ``in_progress``) — is called in FULL in one pass: the greedy claim loop
+        admits every fixture, none starved. Guards against a regression where
+        the loop over-claims a free round and under-calls it."""
+        tournament_id, event_id = await _make_tournament(
+            db_session, entrants=6, tables=("t1", "t2", "t3")
+        )
+        fixtures = await _all_fixtures(db_session, event_id)
+        # A perfect matching over the six players: three fixtures whose entrants
+        # are pairwise disjoint (round-robin always yields one).
+        chosen: list[TournamentFixture] = []
+        claimed_entries: set[uuid.UUID | None] = set()
+        for fixture in fixtures:
+            pair = {fixture.entry_a_id, fixture.entry_b_id}
+            if pair & claimed_entries:
+                continue
+            chosen.append(fixture)
+            claimed_entries |= pair
+            if len(chosen) == 3:
+                break
+        assert len(chosen) == 3, "round-robin over 6 players has a disjoint triple"
+        # Each on its own table, all imminent, all untold → a full due round.
+        chosen_ids: list[uuid.UUID] = []
+        for offset, (fixture, table) in enumerate(
+            zip(chosen, ("t1", "t2", "t3"), strict=True)
+        ):
+            fixture.table_id = table
+            fixture.scheduled_start = BASE + timedelta(minutes=offset)
+            chosen_ids.append(fixture.id)
+        expected_users = await _users_for_entries(
+            db_session,
+            [
+                entry_id
+                for fixture in chosen
+                for entry_id in (fixture.entry_a_id, fixture.entry_b_id)
+            ],
+        )
+        await db_session.commit()
+        _freeze_clocks(monkeypatch, BASE)
+
+        run_pin_tick(str(tournament_id))
+
+        db_session.expire_all()
+        for fixture_id in chosen_ids:
+            called = await db_session.get(TournamentFixture, fixture_id)
+            assert called is not None
+            assert called.pinned_at == BASE  # every disjoint fixture called
+            assert called.call_notified_count == 1
+        rows = await _call_notifications(db_session)
+        assert len(rows) == 6  # two entrants per fixture, all three called
+        assert {row.user_id for row in rows} == expected_users
+
 
 async def _hold_user_in_second_event(
     db: AsyncSession,

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -635,6 +635,460 @@ class TestPinTick:
         }
 
 
+class TestResourceFreedomGate:
+    """The #1106 gate (ADR "a tournament match is called only when its table
+    and players are free"): the caller never starts a match onto a table or a
+    human already held by an unfinished ``in_progress`` match — two started
+    matches on one resource are two overlapping fixed intervals that wedge the
+    next solve ``infeasible``. Players are held at the **user** level, across
+    events. Within one pass at most one fixture is called per table and per
+    user, the earliest predicted start winning a contested resource."""
+
+    async def test_a_due_fixture_on_a_held_table_is_not_called(
+        self,
+        db_session: AsyncSession,
+        fake_notifications_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A fixture placed imminently on a table an ``in_progress`` match
+        already occupies is NOT called — even though its own players are free
+        (disjoint from the running match's)."""
+        tournament_id, event_id = await _make_tournament(
+            db_session, entrants=4, tables=("t1", "t2")
+        )
+        fixtures = await _all_fixtures(db_session, event_id)
+        held = fixtures[0]
+        due = next(
+            f
+            for f in fixtures
+            if not ({f.entry_a_id, f.entry_b_id} & {held.entry_a_id, held.entry_b_id})
+        )
+        # The running match: called (told), live, occupying t1.
+        await _pin_directly(
+            db_session,
+            held,
+            table_id="t1",
+            start=BASE - timedelta(minutes=5),
+            pinned_at=BASE - timedelta(minutes=10),
+            notified=1,
+        )
+        await _link_match(
+            db_session, tournament_id, held, status=MatchStatus.in_progress
+        )
+        # The successor: same table, imminent, untold → due, but t1 is held.
+        due.table_id = "t1"
+        due.scheduled_start = BASE + timedelta(minutes=5)
+        due_id = due.id
+        await db_session.commit()
+        _freeze_clocks(monkeypatch, BASE)
+
+        run_pin_tick(str(tournament_id))
+
+        db_session.expire_all()
+        blocked = await db_session.get(TournamentFixture, due_id)
+        assert blocked is not None
+        assert blocked.pinned_at is None  # the table was busy — not called
+        assert blocked.call_notified_count == 0
+        assert await _call_notifications(db_session) == []
+        assert fake_notifications_queue.jobs == []
+
+    async def test_a_due_fixture_whose_player_is_live_in_another_event_is_not_called(
+        self,
+        db_session: AsyncSession,
+        fake_notifications_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A player is one human across events (user-level, like the solver's
+        no-double-booking): a fixture whose entrant is already in an
+        ``in_progress`` match in a *different* event of the same tournament —
+        a different entry, same user — is NOT called, though its own table is
+        free."""
+        tournament_id, event_id = await _make_tournament(
+            db_session, tables=("t1", "t2")
+        )
+        fixture = await _the_fixture(db_session, event_id)
+        fixture.table_id = "t1"
+        fixture.scheduled_start = BASE + timedelta(minutes=5)  # imminent, untold
+        fixture_id = fixture.id
+        await db_session.commit()
+        (shared_user,) = await _users_for_entries(db_session, [fixture.entry_a_id])
+
+        # A second event of the SAME tournament, with an in_progress match on a
+        # different table (t2) whose entrant is the same human.
+        await _hold_user_in_second_event(
+            db_session, tournament_id, held_user=shared_user, table_id="t2"
+        )
+        _freeze_clocks(monkeypatch, BASE)
+
+        run_pin_tick(str(tournament_id))
+
+        db_session.expire_all()
+        blocked = await db_session.get(TournamentFixture, fixture_id)
+        assert blocked is not None
+        assert blocked.pinned_at is None  # the human is mid-match elsewhere
+        assert blocked.call_notified_count == 0
+        assert await _call_notifications(db_session) == []
+        assert fake_notifications_queue.jobs == []
+
+    async def test_a_fixture_with_a_free_table_and_free_players_is_still_called(
+        self,
+        db_session: AsyncSession,
+        fake_notifications_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No over-blocking: even with another match running (a different
+        table, different humans), a fixture whose own table AND both players
+        are free is called normally."""
+        tournament_id, event_id = await _make_tournament(
+            db_session, entrants=4, tables=("t1", "t2")
+        )
+        fixtures = await _all_fixtures(db_session, event_id)
+        held = fixtures[0]
+        free = next(
+            f
+            for f in fixtures
+            if not ({f.entry_a_id, f.entry_b_id} & {held.entry_a_id, held.entry_b_id})
+        )
+        # A running match on t1 with its own (disjoint) players.
+        await _pin_directly(
+            db_session,
+            held,
+            table_id="t1",
+            start=BASE - timedelta(minutes=5),
+            pinned_at=BASE - timedelta(minutes=10),
+            notified=1,
+        )
+        await _link_match(
+            db_session, tournament_id, held, status=MatchStatus.in_progress
+        )
+        # The free fixture: t2, imminent, untold, players free.
+        free.table_id = "t2"
+        free.scheduled_start = BASE + timedelta(minutes=5)
+        free_id = free.id
+        free_users = await _users_for_entries(
+            db_session, [free.entry_a_id, free.entry_b_id]
+        )
+        await db_session.commit()
+        _freeze_clocks(monkeypatch, BASE)
+
+        run_pin_tick(str(tournament_id))
+
+        db_session.expire_all()
+        called = await db_session.get(TournamentFixture, free_id)
+        assert called is not None
+        assert called.pinned_at == BASE  # free of the running match → called
+        assert called.call_notified_count == 1
+        rows = await _call_notifications(db_session)
+        assert {row.user_id for row in rows} == free_users
+        assert len(rows) == 2
+
+    async def test_two_due_fixtures_for_one_player_call_only_the_earlier(
+        self,
+        db_session: AsyncSession,
+        fake_notifications_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Two fixtures come due in one pass for a resource (here a shared
+        human) that started the pass free: only the earlier predicted start is
+        called; the later defers to a later pass. Guards the degenerate case
+        the cross-batch occupancy read can't see."""
+        tournament_id, event_id = await _make_tournament(
+            db_session, entrants=4, tables=("t1", "t2")
+        )
+        fixtures = await _all_fixtures(db_session, event_id)
+        earlier = fixtures[0]
+        shared = {earlier.entry_a_id, earlier.entry_b_id}
+        # A second fixture sharing exactly one entrant (one human) with the first.
+        later = next(
+            f for f in fixtures if len({f.entry_a_id, f.entry_b_id} & shared) == 1
+        )
+        earlier.table_id = "t1"
+        earlier.scheduled_start = BASE  # the earlier predicted start
+        later.table_id = "t2"
+        later.scheduled_start = BASE + timedelta(minutes=2)
+        earlier_id, later_id = earlier.id, later.id
+        await db_session.commit()
+        _freeze_clocks(monkeypatch, BASE)
+
+        run_pin_tick(str(tournament_id))
+
+        db_session.expire_all()
+        won = await db_session.get(TournamentFixture, earlier_id)
+        deferred = await db_session.get(TournamentFixture, later_id)
+        assert won is not None and deferred is not None
+        assert won.pinned_at == BASE  # earliest start wins the shared human
+        assert won.call_notified_count == 1
+        assert deferred.pinned_at is None  # the later one defers
+        assert deferred.call_notified_count == 0
+        # Exactly the earlier fixture's pair was told.
+        assert len(await _call_notifications(db_session)) == 2
+
+
+async def _hold_user_in_second_event(
+    db: AsyncSession,
+    tournament_id: uuid.UUID,
+    *,
+    held_user: uuid.UUID,
+    table_id: str,
+) -> uuid.UUID:
+    """Add a second event to the tournament whose ``in_progress`` match holds
+    ``held_user`` (a different entry, same human) on ``table_id`` — the
+    cross-event occupancy the user-level gate must see. Returns the fixture id."""
+    tournament = await db.get(Tournament, tournament_id)
+    assert tournament is not None
+    event = TournamentEvent(
+        tournament_id=tournament_id,
+        name="Consolation Singles",
+        format=EventFormat.singles,
+        draw_type=DrawType.round_robin,
+        max_players=None,
+        entry_fee=Decimal("0.00"),
+        slot={"date": DATE, "start": "09:00", "end": "17:00"},
+        match_settings={"rated": False, "length_games": 3},
+        pools=[
+            {
+                "id": "pool-b",
+                "name": "Pool B",
+                "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
+                "table_ids": [table_id],
+            }
+        ],
+    )
+    db.add(event)
+    await db.flush()
+    other = await make_user(db, f"other-{uuid.uuid4().hex[:8]}")
+    entry_held = TournamentEntry(event_id=event.id, user_id=held_user)
+    entry_other = TournamentEntry(event_id=event.id, user_id=other.id)
+    db.add_all([entry_held, entry_other])
+    await db.flush()
+    match = Match(
+        match_settings=MatchSettings(team_size=1, best_of=3, affects_rating=False),
+        league_id=tournament.league_id,
+        created_by_user_id=tournament.created_by_user_id,
+        status=MatchStatus.in_progress,
+    )
+    db.add(match)
+    await db.flush()
+    fixture = TournamentFixture(
+        event_id=event.id,
+        round=1,
+        position=1,
+        entry_a_id=entry_held.id,
+        entry_b_id=entry_other.id,
+        table_id=table_id,
+        scheduled_start=BASE - timedelta(minutes=5),
+        pinned_at=BASE - timedelta(minutes=10),
+        call_notified_count=1,
+        match_id=match.id,
+    )
+    db.add(fixture)
+    await db.commit()
+    return fixture.id
+
+
+async def _in_progress_count_by_user(
+    db: AsyncSession, tournament_id: uuid.UUID
+) -> dict[uuid.UUID, int]:
+    """How many ``in_progress`` matches each human currently holds across the
+    tournament's events — the double-booking the #1106 gate exists to prevent.
+    Counts by **user** (the entry→user resolution the gate and the solver both
+    use), so the same human in two events counts twice."""
+    rows = (
+        await db.execute(
+            select(TournamentFixture.entry_a_id, TournamentFixture.entry_b_id)
+            .join(Match, Match.id == TournamentFixture.match_id)
+            .where(
+                TournamentFixture.event_id.in_(
+                    select(TournamentEvent.id).where(
+                        TournamentEvent.tournament_id == tournament_id
+                    )
+                ),
+                Match.status == MatchStatus.in_progress,
+            )
+        )
+    ).all()
+    entry_ids = {e for a, b in rows for e in (a, b) if e is not None}
+    entry_user = {
+        entry_id: user_id
+        for entry_id, user_id in (
+            await db.execute(
+                select(TournamentEntry.id, TournamentEntry.user_id).where(
+                    TournamentEntry.id.in_(entry_ids)
+                )
+            )
+        ).all()
+    }
+    counts: dict[uuid.UUID, int] = {}
+    for entry_a_id, entry_b_id in rows:
+        for entry_id in (entry_a_id, entry_b_id):
+            if entry_id is not None:
+                user_id = entry_user[entry_id]
+                counts[user_id] = counts.get(user_id, 0) + 1
+    return counts
+
+
+async def _complete_linked_match(
+    db: AsyncSession,
+    match_id: uuid.UUID,
+    fixture_id: uuid.UUID,
+    *,
+    winner_entry_id: uuid.UUID,
+    completed_at: datetime,
+) -> None:
+    """Finish a called (``in_progress``) match: flip its status to
+    ``completed`` and record the winner + completion stamp — the real
+    match-completion boundary, which frees the table and both humans for the
+    next call pass (``_held_resources`` reads only ``in_progress``)."""
+    match = await db.get(Match, match_id)
+    assert match is not None
+    match.status = MatchStatus.completed
+    match.completed_at = completed_at
+    fixture = await db.get(TournamentFixture, fixture_id)
+    assert fixture is not None
+    fixture.winner_entry_id = winner_entry_id
+    await db.commit()
+
+
+class TestIdleTournamentWedgeIsGone:
+    """Acceptance test for the #1106 UAT report (ADR "a tournament match is
+    called only when its table and players are free"): a live tournament whose
+    round-1 matches were called but never scored must NOT wedge when round-2
+    fixtures age into the call window. Pre-1a, the caller called a round-2
+    fixture onto a human already ``in_progress`` in round 1 → two overlapping
+    fixed intervals for that human → the next solve returned ``infeasible`` and
+    the tournament sat idle forever. Driven end-to-end through the real caller
+    (``run_pin_tick``), the guarded pin write, and a real snapshot+solve."""
+
+    async def test_the_1106_idle_tournament_wedge_cannot_recur(
+        self,
+        db_session: AsyncSession,
+        fake_notifications_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A live round-robin (5 humans, 3 tables) — enough that a human has a
+        # round-1 match AND a distinct round-2 match, the shape the UAT report
+        # hit.
+        tournament_id, event_id = await _make_tournament(
+            db_session, entrants=5, tables=("t1", "t2", "t3")
+        )
+        fixtures = await _all_fixtures(db_session, event_id)
+
+        # Two disjoint round-1 fixtures, and a round-2 fixture that shares
+        # exactly ONE human with round-1 (the double-booked player) and pairs
+        # them with the fifth, otherwise-idle human.
+        r1a = fixtures[0]
+        r1a_entries = {r1a.entry_a_id, r1a.entry_b_id}
+        r1b = next(
+            f for f in fixtures if not ({f.entry_a_id, f.entry_b_id} & r1a_entries)
+        )
+        r1b_entries = {r1b.entry_a_id, r1b.entry_b_id}
+        all_entries = {e for f in fixtures for e in (f.entry_a_id, f.entry_b_id)}
+        (fifth_entry,) = all_entries - r1a_entries - r1b_entries
+        r2 = next(
+            f
+            for f in fixtures
+            if fifth_entry in {f.entry_a_id, f.entry_b_id}
+            and len({f.entry_a_id, f.entry_b_id} & r1a_entries) == 1
+        )
+        (shared_entry,) = {r2.entry_a_id, r2.entry_b_id} & r1a_entries
+        (shared_user,) = await _users_for_entries(db_session, [shared_entry])
+
+        # Every one of the three carries a materialized match, born pending —
+        # so the caller's go-live flip has something to move to in_progress.
+        r1a_match = await _link_match(
+            db_session, tournament_id, r1a, status=MatchStatus.pending
+        )
+        r1b_match = await _link_match(
+            db_session, tournament_id, r1b, status=MatchStatus.pending
+        )
+        await _link_match(db_session, tournament_id, r2, status=MatchStatus.pending)
+        # Round 1 is due immediately (09:00); round 2 is predicted 20 min out,
+        # beyond the 10-min call-ahead window — not yet due at 09:00.
+        r1a.table_id, r1a.scheduled_start = "t1", BASE
+        r1b.table_id, r1b.scheduled_start = "t2", BASE
+        r2.table_id, r2.scheduled_start = "t3", BASE + timedelta(minutes=20)
+        r1a_id, r1b_id, r2_id = r1a.id, r1b.id, r2.id
+        r1a_winner = r1a.entry_a_id
+        assert r1a_winner is not None
+        await db_session.commit()
+
+        # --- Round 1 is CALLED through the real caller (no hand-set status). --
+        _freeze_clocks(monkeypatch, BASE)
+        run_pin_tick(str(tournament_id))
+
+        db_session.expire_all()
+        called_r1a = await db_session.get(TournamentFixture, r1a_id)
+        called_r1b = await db_session.get(TournamentFixture, r1b_id)
+        stalled_r2 = await db_session.get(TournamentFixture, r2_id)
+        assert called_r1a is not None and called_r1b is not None
+        assert stalled_r2 is not None
+        assert called_r1a.pinned_at == BASE  # round 1 called…
+        assert called_r1b.pinned_at == BASE
+        assert stalled_r2.pinned_at is None  # …round 2 not yet due
+        assert await _match_status(db_session, r1a_match) is MatchStatus.in_progress
+        assert await _match_status(db_session, r1b_match) is MatchStatus.in_progress
+
+        # --- No scores entered; the wall clock advances so round 2 comes due. -
+        now2 = BASE + timedelta(minutes=25)
+        _freeze_clocks(monkeypatch, now2)
+        run_pin_tick(str(tournament_id))
+
+        db_session.expire_all()
+        # 1) The double-booked human is in exactly one in_progress match; nobody
+        #    holds two. Pre-1a the tick would have called round 2 onto the
+        #    shared human → count 2 → this assertion reds.
+        counts = await _in_progress_count_by_user(db_session, tournament_id)
+        assert counts.get(shared_user) == 1
+        assert all(count <= 1 for count in counts.values())
+
+        # 2) The busy round-2 fixture stalled — not called (pre-1a it was).
+        stalled_r2 = await db_session.get(TournamentFixture, r2_id)
+        assert stalled_r2 is not None
+        assert stalled_r2.pinned_at is None
+        assert stalled_r2.call_notified_count == 0
+
+        # 3) A solve over exactly this DB state is FEASIBLE, not infeasible.
+        #    The gate kept round 2 out of the occupancy set (only the two real
+        #    round-1 matches are in_progress), so the solver has one fixed
+        #    interval per human — not the two overlapping ones that wedged it
+        #    infeasible pre-1a.
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=now2, lock=False
+        )
+        assert inputs is not None
+        assert len(inputs.snapshot.in_progress) == 2
+        in_progress_ids = {m.fixture_id for m in inputs.snapshot.in_progress}
+        assert str(r2_id) not in in_progress_ids  # round 2 is not occupancy
+        result = scheduling.solve(inputs.snapshot)
+        assert result.verdict is not scheduling.Verdict.infeasible
+        assert result.verdict in (
+            scheduling.Verdict.optimal,
+            scheduling.Verdict.feasible,
+        )
+
+        # --- Complete ONE round-1 match; its successor becomes callable. ------
+        await _complete_linked_match(
+            db_session,
+            r1a_match,
+            r1a_id,
+            winner_entry_id=r1a_winner,
+            completed_at=(BASE + timedelta(minutes=5)).astimezone(),
+        )
+        _freeze_clocks(monkeypatch, now2)
+        run_pin_tick(str(tournament_id))
+
+        db_session.expire_all()
+        freed_r2 = await db_session.get(TournamentFixture, r2_id)
+        assert freed_r2 is not None
+        assert freed_r2.pinned_at == now2  # table + both humans free → called
+        assert freed_r2.call_notified_count == 1
+        assert freed_r2.match_id is not None
+        assert (
+            await _match_status(db_session, freed_r2.match_id)
+            is MatchStatus.in_progress
+        )
+
+
 class TestConcurrentTickAndApply:
     """THE race: a pin tick fires in the gap between a solve's snapshot and
     its guarded apply, both wanting to call the same imminent fixture."""

--- a/docs/adr/20260718-a-tournament-match-is-called-only-when-its-table-and-players-are-free.md
+++ b/docs/adr/20260718-a-tournament-match-is-called-only-when-its-table-and-players-are-free.md
@@ -1,0 +1,138 @@
+# A tournament match is called only when its table and players are free
+
+Date: 2026-07-18 (date-numbered — sequential numbers collide across concurrent
+worktrees; see ADR-0788's note and the duplicate 0915s in this directory)
+
+## Status
+
+Accepted — fix for issue #1106, decided before implementation. **Amends
+ADR 20260716** ("the schedule is solved, the call is pinned") and **ADR 20260717**
+("a tournament match is born scheduled and goes live when called"). Both assumed
+the call fires when a **placement**'s predicted start enters the ~10-minute
+call-ahead window. This ADR keeps the call the same *event* (tell the entrants,
+flip `pending → in_progress`) but gates *when* it may fire on the fixture's
+physical resources actually being free. Everything else those ADRs decided
+stands.
+
+## Context
+
+The caller (`app.match_calls.call_due_fixtures`, reached from both the guarded
+solve-apply and the pin tick) started a match the moment its **placement**'s
+predicted start entered the call-ahead window (`_due_for_call`:
+`scheduled_start <= now + CALL_AHEAD_MIN`), with **no check that the match's
+table or its players were free**.
+
+But a placement's start is a **prediction, not a promise** (the glossary's
+`Placement`). The prediction is derived from an estimated match length. When a
+match instead runs long — the pathological case is a live tournament that simply
+sits idle, nobody entering a score, so a match stays `in_progress` indefinitely —
+the estimate is wrong, yet the *next* fixture's predicted start still creeps into
+the window on schedule. The caller then starts it. That produces a **second
+`in_progress` match sharing the same table and/or the same human** as the one
+still underway.
+
+A started (`in_progress`) match is a **pinned** placement whose position the
+solver holds at its *actual* occupancy — "a running fixture's pin is superseded
+by its actual occupancy" (`app.scheduling`). Two started matches on one table, or
+two on one human, are therefore **two immovable fixed intervals that overlap**.
+The next solve is over-constrained before search begins and returns `infeasible`
+in ~1 second (observed on UAT: ~20 `in_progress` matches, ~19 players each
+started in two at once). No solver time budget can fix it — the contradiction is
+in the inputs, put there by the caller.
+
+The root trap: **the call-ahead window is priced off a prediction.** The only
+moment we actually *know* a table will be free is when the match on it
+**completes**. And completion already does the right thing — it fires a
+`match_completed` solve (`app.tournament_advancement`), and the guarded apply
+calls due fixtures in that same transaction (`app.schedule_solves`). The pin
+tick's clock-driven polling was the workhorse only because the *old* model made
+matches become due by the clock; an event-driven caller barely needs it.
+
+Fixing this in the solver instead — teaching it to *tolerate* two started
+matches on one resource, or to explain *which* inputs conflict — was rejected as
+the primary fix: two humans cannot be one, and a table cannot host two matches,
+so the contradiction is real, not a modelling artefact. The caller must not
+create it. (Surfacing *why* an infeasible set of pins conflicts is still worth
+doing as diagnostics — left to #1102/#1103. With this fix the caller no longer
+manufactures that infeasibility, so the diagnostic is defence-in-depth, not the
+fix.)
+
+## Decision
+
+### A match is called only when its resources are actually free
+
+The caller flips a fixture `pending → in_progress` (the **call**) only when it
+is **due** *and* its **table** and **both its players** are free of any
+unfinished `in_progress` match — where a player is identified by their **user**,
+so the check holds across events (the same human in two events is one person, as
+the solver's no-double-booking already treats them).
+
+- **Due** reads the *prediction* (`scheduled_start` within the call-ahead
+  window). **Free** reads *real state* (are there unfinished `in_progress`
+  matches on this table / for either user?). **On conflict, real state wins** —
+  the classic conflict *is* the bug: the estimate optimistically predicts your
+  next match at now (assuming your current one ended), but your current match is
+  still `in_progress`, so we do not call.
+
+The guard lives in the shared callability predicate (`_due_for_call` and its SQL
+twin `_due_fixture_clauses`), so **every caller** — the guarded apply and the pin
+tick — enforces it identically.
+
+### The invariant: at most one started match per table and per human
+
+The caller can no longer produce two overlapping started matches on one resource.
+The solver therefore never receives contradictory fixed intervals from the
+caller, and a tournament that sits idle **stalls honestly** — the successor waits
+for the current match to complete — instead of wedging itself `infeasible`.
+
+### Calling is event-driven; the pin tick is a clock-only backstop
+
+A **completion** frees a table and re-solves; that solve's guarded apply calls
+the freed table's successor **immediately** (bounded by the solve's own latency,
+not a poll interval). The call is not made synchronously in the completion
+transaction: the successor's placement still predicts a *future* start until a
+solve pulls it to now, and calling a stale placement would risk committing a
+fixture the fresh solve would not have chosen. The solve remains the single
+source of truth for *where* a match goes and *whether* it may be called.
+
+The **pin tick** is demoted to the one case no event covers: a fixture whose
+resources are already free but whose predicted start arrives by the *clock* — a
+pool **Slot** window opening, or a tournament's very first matches at start time.
+
+### Readiness comes from the estimate, not a speculative pin
+
+The "you're up soon, be near the table" signal is the **soft placement** the
+player already sees ("Up next" / the schedule). A pin is a *hard, irreversible*
+commitment (echoed verbatim, never reschedulable earlier); using it to deliver a
+*provisional* heads-up is the mismatch that caused this bug. We accept a little
+table idle (the next players called when the table frees, not up to 10 minutes
+early on a guess) over risking an infeasible schedule. A genuine call-ahead, if
+ever wanted, must key on *actual match progress* (e.g. the current match is on
+its deciding game), never on the clock.
+
+### What is unchanged
+
+- **The director's manual placement stays a pin** — the one deliberate human
+  commitment to a future slot, exempt from the resource-free gate (the director
+  is deciding, not gambling on a prediction).
+- **`pinned_at` is still stamped at the call** — the "was called" record; the
+  solver ignores it on a started match (actual occupancy supersedes it), so it
+  costs nothing and keeps the two July ADRs' pin/notify machinery intact.
+
+## Consequences
+
+- **The #1106 wedge is structurally impossible.** The caller cannot create
+  overlapping started matches, so the solver never sees the contradictory fixed
+  intervals that produced the bare `infeasible`.
+- **An idle tournament stalls, it does not wedge.** With no scores entered, the
+  next match simply waits — the honest behaviour — and a single score resumes the
+  cascade.
+- **Slightly less call-ahead lead time.** Players are called when their table is
+  free rather than up to ~10 minutes early on a prediction; the "Up next" surface
+  carries the anticipation. This is the deliberate trade — flexibility and
+  correctness over a lead time the prediction could not reliably deliver anyway.
+- **`api/`-only.** No schema change (no new column or status; the guard is a
+  predicate), and no web/iOS change — the client already shows scheduled/"Up
+  next" matches.
+- **The pin tick keeps existing** as a thin clock-only backstop; it is no longer
+  the primary caller.

--- a/docs/adr/20260718-a-tournament-match-is-called-only-when-its-table-and-players-are-free.md
+++ b/docs/adr/20260718-a-tournament-match-is-called-only-when-its-table-and-players-are-free.md
@@ -74,9 +74,18 @@ the solver's no-double-booking already treats them).
   next match at now (assuming your current one ended), but your current match is
   still `in_progress`, so we do not call.
 
-The guard lives in the shared callability predicate (`_due_for_call` and its SQL
-twin `_due_fixture_clauses`), so **every caller** — the guarded apply and the pin
-tick — enforces it identically.
+The guard lives in **`call_due_fixtures`** — the single choke point both the
+guarded apply and the pin tick funnel through — as a **cross-row pass** over the
+due batch, *not* in the per-row `_due_for_call`/`_due_fixture_clauses`. This is
+deliberate and load-bearing: the invariant is inherently cross-row ("at most one
+started match per table/human *across this batch*"), so it cannot be expressed as
+a row-local predicate — `_due_for_call` cannot see a sibling due fixture
+competing for the same freshly-free table. Do not "simplify" the gate by pushing
+it into `_due_for_call`; that reintroduces the bug. (The tick's lock-free
+`_due_fixture_clauses` EXISTS probe stays resource-blind and may therefore take
+the tournament lock on an idle-but-blocked tick only to call nothing — a bounded
+no-op at the 60s backstop cadence, left as-is; the authoritative gate is the
+cross-row pass here.)
 
 ### The invariant: at most one started match per table and per human
 
@@ -121,9 +130,18 @@ its deciding game), never on the clock.
 
 ## Consequences
 
-- **The #1106 wedge is structurally impossible.** The caller cannot create
-  overlapping started matches, so the solver never sees the contradictory fixed
-  intervals that produced the bare `infeasible`.
+- **The #1106 wedge — an *automatically* self-inflicted one — is gone.** The
+  automatic caller can no longer create overlapping started matches, so the idle
+  tournament that motivated this issue never hands the solver the contradictory
+  fixed intervals that produced the bare `infeasible`. This is scoped to the
+  automatic path on purpose: **manual placement stays exempt (see below), so a
+  director *can* still hand-place a fixture onto a busy table or human and
+  recreate the same overlap.** That is a deliberate-human action, not the
+  spontaneous idle-time wedge the issue reported — but it is a live path to the
+  same infeasible state, and if it proves a real hazard the honest fix is to
+  enforce the one-started-match-per-resource invariant at the go-live transition
+  itself (`_go_live_on_call`) with a director-facing override, rather than in the
+  automatic caller alone.
 - **An idle tournament stalls, it does not wedge.** With no scores entered, the
   next match simply waits — the honest behaviour — and a single score resumes the
   cascade.


### PR DESCRIPTION
## What & why

Fixes #1106. In a **live** tournament, the auto-caller (`api/app/match_calls.py`) started a fixture — flipping its match `pending → in_progress` — the moment its *predicted* start entered the ~10-min call-ahead window, with **no check that the fixture's table or players were free**. When a match runs long (the pathological case: an idle tournament where nobody enters a score, so a match stays `in_progress` indefinitely), the caller still called the *next* fixture on schedule, producing a **second `in_progress` match sharing the same table and/or the same human**. Two started matches on one table, or one human, are two immovable fixed intervals for the CP-SAT solver → the next solve returns `infeasible` in ~1s. The schedule wedged itself purely from idle time (UAT: ~20 `in_progress` matches, ~19 players each live in two at once).

## The fix

A **resource-freedom gate** in `call_due_fixtures` — the single choke point both the guarded solve-apply and the pin tick funnel through. Before calling, it reads which **tables** and which **users** (by user, across events — matching the solver's user-level no-double-booking) are held by an unfinished `in_progress` match, and:

- drops any due fixture whose table or either player is held;
- calls **at most one** fixture per table/user per pass (earliest predicted start wins a contested freshly-free resource).

The invariant is now **at most one `in_progress` match per table and per human**, so the caller can never hand the solver contradictory fixed intervals. An idle tournament **stalls honestly** (the successor waits for the current match to complete) instead of wedging, and a single completion resumes the cascade. The pin tick stays as a clock-only backstop (window openings / first matches) — now gated-safe.

A predicated cross-row gate, not a per-row one: the invariant ("at most one per resource *across the batch*") can't be expressed in the row-local `_due_for_call`, so it lives in `call_due_fixtures`.

Decisions captured in **ADR `docs/adr/20260718-...`** and a **CONTEXT "Call"** glossary entry.

### Scope note (surfaced by review)
The gate covers the **automatic** caller. **Manual director placement stays a deliberate exempt path** (per the ADR / the design discussion) — a director *can* still hand-place onto a busy table/human and recreate the same overlap. That's a human action, not the spontaneous idle-time wedge #1106 reported; the ADR documents it as a possible follow-up (enforce the invariant at `_go_live_on_call` with a director-facing override). Not in this PR.

## Testing

- `api`: ruff, `ruff format --check`, `mypy --strict` (118 files, clean), **`pytest` 1347 passed**.
- New unit tests (`TestResourceFreedomGate`): held-table / cross-event-held-player fixtures are not called; a free fixture still is; two same-player fixtures in one pass → only the earlier. Falsified red→green against the ungated caller.
- New acceptance test (`TestIdleTournamentWedgeIsGone`): reproduces the #1106 idle-tournament scenario end-to-end through the real caller + solver — without the gate: two `in_progress` per human, solve `infeasible`; with it: stall, feasible verdict, and a completion resumes the cascade.
- No route/schema/docstring change → `openapi.json` unaffected (no type regen); no web/iOS change. **Not observable via the QA-stack browser** (can't drive tournaments without the director role), so verified by the api acceptance test rather than a browser QA pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)