### PR TITLE
Warm-start CP-SAT with the previous plan via AddHint (#1110)

### DIFF
--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -58,6 +58,18 @@ one makespan minute times the ratio): ``W_stability = 1``,
 ``W_wait = max stability swing + 1``, ``W_makespan = W_wait · (max total wait
 swing) + 1``. All fit comfortably in int64 at any realistic instance size.
 
+**Warm start.** Before solving, every unpinned fixture that has a
+``previous_plan`` entry *whose prior table is still in its pool* seeds its prior
+``(table, start)`` back into the model as a CP-SAT hint (``AddHint`` on the
+bucket, the start, and the table presence bools). A mostly-unchanged re-solve
+therefore begins the search *at* the previous plan and only has to repair the
+local delta, rather than rediscovering the whole board from scratch. Fixtures
+with no prior entry — or whose prior table has left the pool (a forced move) —
+get no hint and solve fresh; the solver derives ``same_start``/``kept``/
+``makespan`` from the hinted values itself and repairs any partial
+infeasibility. Crucially a hint only *orders the search* — it can never change
+which solution is optimal, so correctness is untouched and only speed changes.
+
 **Verdict.** CP-SAT's OPTIMAL/FEASIBLE map directly; INFEASIBLE returns an
 empty placement set and *never raises* — infeasibility is the point of
 pre-live solves, a designed outcome, not an error. UNKNOWN (time cap exhausted
@@ -388,15 +400,36 @@ def _validated(
     return pools, events, active, running
 
 
-def solve(snapshot: ScheduleSnapshot, time_cap_s: float = 10.0) -> SolveResult:
-    """Place every active fixture: pins echoed verbatim, everything else
-    solved onto its pool's tables inside its pool's window, on the
-    :data:`BUCKET_MIN` grid, no earlier than ``now_min``.
+@dataclass(frozen=True, slots=True)
+class _SolverModel:
+    """The built CP-SAT model plus the index a solve needs to read its answer
+    back out. Internal seam between :func:`_build_model` (construction, warm-
+    start hints included) and :func:`solve` (running the solver, shaping the
+    result) — split so a test can build the *real* model, then observe the
+    hint's effect deterministically (single worker, fixed seed) without
+    touching the production solver parameters. ``model`` carries the hints;
+    ``starts``/``presences`` recover each unpinned fixture's chosen start and
+    table, ``durations`` its ``end_min``, and ``pinned_placements`` are echoed
+    verbatim."""
 
-    Never raises for infeasibility — see :class:`Verdict`. Raises
-    :class:`IncoherentSnapshot` for inputs that reference things they do not
-    contain, and :class:`SchedulingError` if CP-SAT rejects the model (a bug
-    here, not a property of the tournament).
+    model: cp_model.CpModel
+    unpinned: tuple[ScheduleFixture, ...]
+    starts: dict[FixtureId, Any]
+    presences: dict[FixtureId, dict[TableId, Any]]
+    durations: dict[FixtureId, int]
+    pinned_placements: tuple[PlacedFixture, ...]
+
+
+def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
+    """Construct the CP-SAT model for one solve, warm-start hints and all.
+
+    Returns a finished :class:`SolveResult` for the cases that need no solver —
+    nothing to place (trivially optimal) or a structural infeasibility a guard
+    can prove without search — and otherwise a :class:`_SolverModel` carrying
+    the model and the index :func:`solve` reads its answer back out of.
+
+    Raises :class:`IncoherentSnapshot` for inputs that reference things they do
+    not contain (via :func:`_validated`).
     """
     pools, events, active, running = _validated(snapshot)
 
@@ -530,6 +563,8 @@ def solve(snapshot: ScheduleSnapshot, time_cap_s: float = 10.0) -> SolveResult:
     # variables.
     starts: dict[FixtureId, Any] = {}
     presences: dict[FixtureId, dict[TableId, Any]] = {}
+    buckets: dict[FixtureId, Any] = {}
+    durations: dict[FixtureId, int] = {}
     wait_terms: list[Any] = []
     for fixture in unpinned:
         pool = pools[fixture.pool_id]
@@ -556,6 +591,8 @@ def solve(snapshot: ScheduleSnapshot, time_cap_s: float = 10.0) -> SolveResult:
             )
         starts[fixture.id] = start
         presences[fixture.id] = by_table
+        buckets[fixture.id] = bucket
+        durations[fixture.id] = duration
         variable_ends.append(start + duration)
         wait_terms.append(start - now)
 
@@ -610,10 +647,55 @@ def solve(snapshot: ScheduleSnapshot, time_cap_s: float = 10.0) -> SolveResult:
     objective = objective + w_stability * forced_moves
     model.Minimize(objective)
 
+    # Warm start: seed each unpinned fixture's prior (table, start) as a hint so
+    # a mostly-unchanged re-solve begins *at* the previous plan and only repairs
+    # the local delta. A hint whose prior table has left the pool (a forced move)
+    # or that has no prior entry is simply omitted — that fixture solves fresh.
+    # Hints never change which solution is optimal; they only order the search.
+    for fixture in unpinned:
+        prior = previous.get(fixture.id)
+        if prior is None:
+            continue
+        prior_present = presences[fixture.id].get(prior.table_id)
+        if prior_present is None:
+            continue
+        model.AddHint(buckets[fixture.id], prior.start_min // BUCKET_MIN)
+        model.AddHint(starts[fixture.id], prior.start_min)
+        model.AddHint(prior_present, 1)
+        for table, present in presences[fixture.id].items():
+            if table != prior.table_id:
+                model.AddHint(present, 0)
+
+    return _SolverModel(
+        model=model,
+        unpinned=tuple(unpinned),
+        starts=starts,
+        presences=presences,
+        durations=durations,
+        pinned_placements=tuple(pinned_placements),
+    )
+
+
+def solve(snapshot: ScheduleSnapshot, time_cap_s: float = 10.0) -> SolveResult:
+    """Place every active fixture: pins echoed verbatim, everything else
+    solved onto its pool's tables inside its pool's window, on the
+    :data:`BUCKET_MIN` grid, no earlier than ``now_min``.
+
+    Never raises for infeasibility — see :class:`Verdict`. Raises
+    :class:`IncoherentSnapshot` for inputs that reference things they do not
+    contain, and :class:`SchedulingError` if CP-SAT rejects the model (a bug
+    here, not a property of the tournament).
+    """
+    built = _build_model(snapshot)
+    if isinstance(built, SolveResult):
+        # Nothing to solve: trivially optimal, or a structural infeasibility a
+        # guard proved without the solver.
+        return built
+
     solver = cp_model.CpSolver()
     solver.parameters.max_time_in_seconds = time_cap_s
     solver.parameters.random_seed = 0
-    status = solver.Solve(model)
+    status = solver.Solve(built.model)
     wall_time_ms = int(solver.WallTime() * 1000)
 
     if status == cp_model.MODEL_INVALID:
@@ -626,16 +708,16 @@ def solve(snapshot: ScheduleSnapshot, time_cap_s: float = 10.0) -> SolveResult:
     if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
         return _no_plan(Verdict.unknown, wall_time_ms)
 
-    placements = list(pinned_placements)
-    for fixture in unpinned:
-        start_value = int(solver.Value(starts[fixture.id]))
-        table = _chosen_table(solver, presences[fixture.id], fixture.id)
+    placements = list(built.pinned_placements)
+    for fixture in built.unpinned:
+        start_value = int(solver.Value(built.starts[fixture.id]))
+        table = _chosen_table(solver, built.presences[fixture.id], fixture.id)
         placements.append(
             PlacedFixture(
                 fixture_id=fixture.id,
                 table_id=table,
                 start_min=start_value,
-                end_min=start_value + duration_of(fixture),
+                end_min=start_value + built.durations[fixture.id],
             )
         )
     placements.sort(key=lambda p: (p.start_min, p.table_id, p.fixture_id))

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -654,17 +654,12 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
     # Hints never change which solution is optimal; they only order the search.
     for fixture in unpinned:
         prior = previous.get(fixture.id)
-        if prior is None:
-            continue
-        prior_present = presences[fixture.id].get(prior.table_id)
-        if prior_present is None:
+        if prior is None or prior.table_id not in presences[fixture.id]:
             continue
         model.AddHint(buckets[fixture.id], prior.start_min // BUCKET_MIN)
         model.AddHint(starts[fixture.id], prior.start_min)
-        model.AddHint(prior_present, 1)
         for table, present in presences[fixture.id].items():
-            if table != prior.table_id:
-                model.AddHint(present, 0)
+            model.AddHint(present, 1 if table == prior.table_id else 0)
 
     return _SolverModel(
         model=model,

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -9,8 +9,10 @@ cap so the suite stays fast and deterministic.
 
 import dataclasses
 import random
+from typing import Any
 
 import pytest
+from ortools.sat.python import cp_model
 
 from app.scheduling import (
     BUCKET_MIN,
@@ -34,6 +36,9 @@ from app.scheduling import (
     TableId,
     Verdict,
     Window,
+    _build_model,
+    _chosen_table,
+    _SolverModel,
     match_minutes,
     solve,
 )
@@ -625,3 +630,153 @@ class TestIncoherentSnapshots:
         placement = PlacedFixture(FixtureId("F1"), TableId("T1"), 0, 25)
         with pytest.raises(dataclasses.FrozenInstanceError):
             placement.start_min = 5  # type: ignore[misc]
+
+
+def _star_chain_snapshot(
+    n_fixtures: int = 4, *, tables: int = 2, with_previous: bool = True
+) -> ScheduleSnapshot:
+    """A *star chain*: one player (``STAR``) is in every fixture, so all matches
+    are mutually exclusive in time no matter which table they land on. The
+    unique optimum chains them back-to-back at ``0, step, 2·step, …`` (``step``
+    = duration + rest), and the ``previous_plan`` puts that chain on the first
+    table. Because every match shares ``STAR``, makespan and wait are fixed by
+    the chain and the only remaining freedom — which fixture takes which slot,
+    on which table — is settled by the stability tier toward the previous plan,
+    making it the *unique* optimum. That uniqueness lets these tests assert an
+    exact board rather than just an objective."""
+    star = PlayerId("STAR")
+    table_ids = _tables(tables)
+    step = match_minutes(3) + REST_MIN
+    fixtures = tuple(
+        _fixture(n, star, PlayerId(f"Q{n}")) for n in range(1, n_fixtures + 1)
+    )
+    previous = tuple(
+        PreviousPlacement(FixtureId(f"F{n}"), table_ids[0], (n - 1) * step)
+        for n in range(1, n_fixtures + 1)
+    )
+    return ScheduleSnapshot(
+        table_ids=table_ids,
+        pools=(SchedulePool(PoolId("A"), table_ids, Window(0, 600)),),
+        events=(EventSettings(EventId("E1"), 3),),
+        fixtures=fixtures,
+        now_min=0,
+        previous_plan=previous if with_previous else (),
+    )
+
+
+def _board(solver: Any, built: _SolverModel) -> set[tuple[str, str, int]]:
+    """The unpinned placements of one solved model as ``(fixture, table, start)``
+    triples — comparable directly against a ``previous_plan``."""
+    return {
+        (
+            str(fixture.id),
+            str(_chosen_table(solver, built.presences[fixture.id], fixture.id)),
+            int(solver.Value(built.starts[fixture.id])),
+        )
+        for fixture in built.unpinned
+    }
+
+
+def _plan_board(
+    placements: tuple[PreviousPlacement, ...] | tuple[PlacedFixture, ...],
+) -> set[tuple[str, str, int]]:
+    return {(str(p.fixture_id), str(p.table_id), p.start_min) for p in placements}
+
+
+def _solve_to_optimal(
+    built: _SolverModel,
+) -> tuple[int, int, set[tuple[str, str, int]]]:
+    """Solve a built model to proven optimality with the production parameters,
+    returning ``(status, objective, board)``. A generous cap: the optimality
+    claim is only meaningful against a proven optimum (a loaded runner can
+    otherwise honestly answer ``feasible`` under a short cap)."""
+    solver = cp_model.CpSolver()
+    solver.parameters.random_seed = 0
+    solver.parameters.max_time_in_seconds = 30.0
+    status = solver.Solve(built.model)
+    return status, int(solver.ObjectiveValue()), _board(solver, built)
+
+
+def _first_solution_board(built: _SolverModel) -> set[tuple[str, str, int]]:
+    """CP-SAT's *first* feasible solution under a single deterministic worker.
+
+    One worker plus a fixed seed makes *which* solution is discovered first
+    reproducible, so the warm-start hint's effect — it seeds the search at the
+    previous plan — is observable. The production ``solve`` deliberately keeps
+    its multi-worker portfolio, whose aggregate branch count and first-solution
+    identity are non-deterministic (a lucky worker can presolve either board in
+    zero branches), so it cannot show this; hence the single-worker probe."""
+    solver = cp_model.CpSolver()
+    solver.parameters.random_seed = 0
+    solver.parameters.num_search_workers = 1
+    solver.parameters.stop_after_first_solution = True
+    solver.parameters.max_time_in_seconds = CAP
+    status = solver.Solve(built.model)
+    assert status in (cp_model.OPTIMAL, cp_model.FEASIBLE)
+    return _board(solver, built)
+
+
+class TestWarmStart:
+    """The solver warm-starts every unpinned fixture's prior ``(table, start)``
+    as a CP-SAT hint. A hint only orders the search; it can never change which
+    solution is optimal — so these tests pin down both halves: correctness is
+    untouched, and the hint is genuinely consumed."""
+
+    def test_warm_started_solve_reproduces_the_previous_plan(self) -> None:
+        """The black-box claim: fed a previous plan that is the unique optimum,
+        the production solve returns exactly it, optimally."""
+        snapshot = _star_chain_snapshot()
+        result = solve(snapshot, time_cap_s=30.0)
+        assert result.verdict is Verdict.optimal
+        assert _plan_board(result.placements) == _plan_board(snapshot.previous_plan)
+
+    def test_warm_start_never_changes_the_optimum(self) -> None:
+        """Correctness guard: the hint can only order the search, never change
+        which board is optimal. Build the real model, solve to optimality, then
+        clear the hints and solve again — identical optimal objective *and*
+        identical board.
+
+        (This deliberately does **not** compare against a ``previous_plan=()``
+        snapshot: the tier weights are computed per instance from the stability
+        span, which is zero without a previous plan, so the two snapshots' raw
+        objectives live on different scales and are never equal. The clean,
+        weight-stable invariant is hinted-vs-hint-cleared on the *same* model.)
+        """
+        snapshot = _star_chain_snapshot()
+        built = _build_model(snapshot)
+        assert isinstance(built, _SolverModel)
+
+        hinted_status, hinted_obj, hinted_board = _solve_to_optimal(built)
+        built.model.ClearHints()
+        cleared_status, cleared_obj, cleared_board = _solve_to_optimal(built)
+
+        assert hinted_status == cp_model.OPTIMAL
+        assert cleared_status == cp_model.OPTIMAL
+        assert hinted_obj == cleared_obj
+        assert hinted_board == cleared_board == _plan_board(snapshot.previous_plan)
+
+    def test_warm_start_hint_is_consumed(self) -> None:
+        """The load-bearing proof that the hint actually drives the search —
+        not merely that the board matches (the stability tier alone forces that
+        even cold, so board equality does not discriminate).
+
+        Take CP-SAT's first feasible solution under one deterministic worker:
+        with the warm-start hints present it is exactly the previous plan (the
+        search begins there); with the hints cleared — which is precisely what
+        the code did before this change — the first solution is a different,
+        stability-suboptimal board. That difference *is* the hint being
+        consumed, and it is why this test goes red if the ``AddHint`` warm start
+        is removed: without it the hinted branch below no longer starts at the
+        previous plan, so ``first == previous`` fails."""
+        snapshot = _star_chain_snapshot()
+        previous = _plan_board(snapshot.previous_plan)
+
+        built = _build_model(snapshot)
+        assert isinstance(built, _SolverModel)
+        # Warm-started: the search starts at — and first reports — the prior plan.
+        assert _first_solution_board(built) == previous
+
+        # Hints cleared (the pre-change behaviour): the first feasible solution
+        # the same deterministic search finds is a *different* board.
+        built.model.ClearHints()
+        assert _first_solution_board(built) != previous

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -654,12 +654,10 @@ def _star_chain_snapshot(
         PreviousPlacement(FixtureId(f"F{n}"), table_ids[0], (n - 1) * step)
         for n in range(1, n_fixtures + 1)
     )
-    return ScheduleSnapshot(
-        table_ids=table_ids,
-        pools=(SchedulePool(PoolId("A"), table_ids, Window(0, 600)),),
-        events=(EventSettings(EventId("E1"), 3),),
-        fixtures=fixtures,
-        now_min=0,
+    return _one_pool_snapshot(
+        fixtures,
+        tables=tables,
+        window=(0, 600),
         previous_plan=previous if with_previous else (),
     )
 


### PR DESCRIPTION
Closes #1110.

## What

Before solving, `scheduling.solve()` now seeds every **unpinned** fixture's prior `(table, start)` back into the CP-SAT model as a hint (`AddHint` on the bucket, the start, and the table-presence bools). A mostly-unchanged re-solve therefore begins the search *at* the previous plan and only repairs the local delta, instead of rediscovering the whole board cold.

- Fixtures with **no** prior placement, or whose prior table has **left the pool** (a forced move), get no hint and solve fresh.
- Pinned / in-progress fixtures aren't decision variables and are never hinted.
- **No solver-parameter changes** (`random_seed`, `num_search_workers`, `max_time_in_seconds` untouched).
- A hint only *orders the search* — it can never change which solution is optimal, so correctness is untouched and only speed changes.

Model construction was extracted into an internal `_build_model()` + a frozen `_SolverModel` seam, so a test can build the *real* model (hints and all) and observe the hint's effect deterministically without touching production solver params.

## Why

A post-game re-solve rebuilds the model and searches from scratch — ~the full time cap — even though ~99% of the board is unchanged. Warm-starting makes those steady-state re-solves incremental/sub-second.

**Re: #1109 (livelock) — partial credit, stated honestly.** This dissolves the *steady-state* re-solve storm once a schedule has applied (there is then a `previous_plan` to warm-start from). It does **not** address the **cold initial go-live solve** — that's a cap-policy / drift-detection concern tracked in #1109 / #1103. This PR does not claim to fully close #1109.

## Tests

- **Correctness guard** — hinted vs. hint-cleared on the *same* model yields an identical optimal objective and board (proves the hint can't corrupt the result).
- **Hint-is-consumed proof** — under a single deterministic worker, CP-SAT's first feasible solution equals the previous plan *with* hints and differs *without* them. This is the load-bearing test: it goes **red** if the `AddHint` block is removed (a cold search first lands on a different, stability-suboptimal board).

## Verification

- `ruff check` + `ruff format --check` + `mypy --strict` — clean
- `pytest` (full api suite) — **1345 passed**
- No OpenAPI drift: the change adds no FastAPI/Pydantic surface (pure internal domain module).

Not observable in the UI — identical schedules come out, only faster on incremental re-solves; no browser QA applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)