### PR TITLE
Make the solver time cap configurable via SOLVER_TIME_CAP_S

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -1,0 +1,32 @@
+"""Shared application configuration.
+
+New configuration belongs here as a field on ``Settings`` rather than another
+ad hoc ``os.environ.get(...)`` call site scattered through the codebase (see
+"Module layout for new code" in ``api/CLAUDE.md``). Existing ad hoc readers
+(``app/db.py``, ``app/captcha.py``, ``app/queue.py``) predate this module and
+are left as-is.
+"""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(extra="ignore")
+
+    #: The CP-SAT wall-clock time cap, in seconds, for a schedule solve
+    #: (``app.scheduling.solve``'s ``time_cap_s``). The ADR's default is a
+    #: hard cap: mid-tournament we want a good answer now, not a proof, and
+    #: FEASIBLE under the cap is accepted. Large one-off solves (e.g. a big
+    #: multi-day tournament with hundreds of fixtures) may need this raised
+    #: well past the default — there is deliberately no upper clamp.
+    solver_time_cap_s: float = 10.0
+
+
+def get_settings() -> Settings:
+    """Read settings from the environment.
+
+    Constructed fresh on every call rather than cached at import time, so
+    tests can override an environment variable (``monkeypatch.setenv(...)``)
+    per test and see it take effect — mirrors ``app.db.get_database_url()``.
+    """
+    return Settings()

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -173,6 +173,15 @@ log = logging.getLogger(__name__)
 #: like ``app.retirement_jobs.RUN_RETIREMENT_SWEEP_JOB``.
 RUN_SCHEDULE_SOLVE_JOB = "app.schedule_solves.run_schedule_solve"
 
+#: Slack, in seconds, added on top of ``get_settings().solver_time_cap_s`` to
+#: get the RQ job's own ``job_timeout``. The job wraps the CP-SAT call with DB
+#: work on both sides (phase (a)'s snapshot + fingerprint, phase (c)'s
+#: row-locked re-read, fingerprint recompute, and fixture writes) — RQ's
+#: watchdog must never be tighter than the solve it is timing, or raising
+#: ``SOLVER_TIME_CAP_S`` to run a large one-off solve (the whole point of the
+#: config) does nothing because RQ kills the job first.
+JOB_TIMEOUT_MARGIN_S = 60
+
 #: What a drift-discarded run records. The run is ``failed`` because it is
 #: honest — this run produced nothing — not because anything broke; the rerun
 #: it requested is the run that will produce something.
@@ -258,7 +267,11 @@ async def request_solve(
     db.add(row)
     await db.flush()
     try:
-        queue_module.get_queue().enqueue(RUN_SCHEDULE_SOLVE_JOB, str(row.id))
+        queue_module.get_queue().enqueue(
+            RUN_SCHEDULE_SOLVE_JOB,
+            str(row.id),
+            job_timeout=int(get_settings().solver_time_cap_s) + JOB_TIMEOUT_MARGIN_S,
+        )
     except RedisError:
         log.exception(
             "Failed to enqueue schedule solve for tournament %s", tournament_id

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -127,6 +127,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app import match_calls, scheduling
 from app import queue as queue_module
+from app.config import get_settings
 from app.match_calls import _wall_now
 from app.models import (
     Match,
@@ -171,10 +172,6 @@ log = logging.getLogger(__name__)
 #: The dotted path RQ resolves in the worker process — enqueued as a string,
 #: like ``app.retirement_jobs.RUN_RETIREMENT_SWEEP_JOB``.
 RUN_SCHEDULE_SOLVE_JOB = "app.schedule_solves.run_schedule_solve"
-
-#: The ADR's hard time cap: mid-tournament we want a good answer now, not a
-#: proof, and FEASIBLE under the cap is accepted.
-SOLVE_TIME_CAP_S = 10.0
 
 #: What a drift-discarded run records. The run is ``failed`` because it is
 #: honest — this run produced nothing — not because anything broke; the rerun
@@ -824,7 +821,7 @@ async def execute_solve(
             await db.commit()
 
         # (b) The solve itself, outside any transaction / open session.
-        result = _solve(inputs.snapshot, time_cap_s=SOLVE_TIME_CAP_S)
+        result = _solve(inputs.snapshot, time_cap_s=get_settings().solver_time_cap_s)
 
         await _apply_result(sessionmaker, solve_id, tournament_id, inputs, result)
     except Exception as exc:  # noqa: BLE001 -- the job's boundary: never leave a row running

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "coolname>=2.2",
     "jsonschema>=4.21",
     "pydantic[email]>=2.0",
+    "pydantic-settings>=2.0",
     "httpx[http2]>=0.27.0",
     "fastapi-limiter>=0.1.6,<0.3",
     "pyjwt[crypto]>=2.9",

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -1,0 +1,46 @@
+"""``app.config.Settings`` — the shared pydantic-settings object.
+
+``get_settings()`` builds a fresh ``Settings`` on every call (never cached at
+import time), so tests can override an env var with ``monkeypatch.setenv``
+per test and see it take effect immediately — mirroring
+``app.db.get_database_url()``.
+"""
+
+import pytest
+
+from app.config import get_settings
+
+
+def test_solver_time_cap_defaults_to_ten_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SOLVER_TIME_CAP_S", raising=False)
+    assert get_settings().solver_time_cap_s == 10.0
+
+
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        ("45.5", 45.5),
+        # A one-off big solve may need up to 1200s (20 min) per the issue;
+        # a large value must pass through untouched — no upper clamp.
+        ("1200", 1200.0),
+    ],
+)
+def test_solver_time_cap_reads_from_env(
+    monkeypatch: pytest.MonkeyPatch, env_value: str, expected: float
+) -> None:
+    monkeypatch.setenv("SOLVER_TIME_CAP_S", env_value)
+    assert get_settings().solver_time_cap_s == expected
+
+
+def test_get_settings_rereads_env_on_every_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Not a module-level constant computed once at import time — each call
+    picks up the current environment."""
+    monkeypatch.delenv("SOLVER_TIME_CAP_S", raising=False)
+    assert get_settings().solver_time_cap_s == 10.0
+
+    monkeypatch.setenv("SOLVER_TIME_CAP_S", "99")
+    assert get_settings().solver_time_cap_s == 99.0

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -548,6 +548,52 @@ class TestSolveJob:
         assert {f.id: (f.table_id, f.scheduled_start) for f in again} == placements
         assert len(await _solve_rows(db_session, tournament_id)) == 1
 
+    @pytest.mark.parametrize(
+        "env_value, expected",
+        [
+            (None, 10.0),
+            # No upper clamp — a large one-off value (per the issue) must
+            # pass through untouched.
+            ("1200", 1200.0),
+        ],
+    )
+    async def test_solve_uses_the_configured_time_cap(
+        self,
+        db_session: AsyncSession,
+        solver_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+        env_value: str | None,
+        expected: float,
+    ) -> None:
+        """``get_settings().solver_time_cap_s`` — default or env-overridden —
+        is what actually reaches ``app.scheduling.solve``."""
+        if env_value is None:
+            monkeypatch.delenv("SOLVER_TIME_CAP_S", raising=False)
+        else:
+            monkeypatch.setenv("SOLVER_TIME_CAP_S", env_value)
+        seen: list[float] = []
+        real = schedule_solves._solve
+
+        def wrapper(snapshot: ScheduleSnapshot, time_cap_s: float) -> SolveResult:
+            seen.append(time_cap_s)
+            # Don't actually run the real solver for the full budget — the
+            # cap value reaching the seam is what's under test.
+            return real(snapshot, time_cap_s=1.0)
+
+        monkeypatch.setattr(schedule_solves, "_solve", wrapper)
+
+        tournament_id, _event_id = await _make_tournament(db_session)
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+        assert row is not None
+        row_id = row.id
+        await db_session.commit()
+
+        _run_recorded_job(solver_queue, row_id)
+
+        assert seen == [expected]
+
     async def test_pinned_fixture_columns_are_untouched_by_apply(
         self, db_session: AsyncSession, solver_queue: Queue
     ) -> None:

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -64,6 +64,7 @@ from app.models import (
     TournamentStatus,
 )
 from app.schedule_solves import (
+    JOB_TIMEOUT_MARGIN_S,
     RUN_SCHEDULE_SOLVE_JOB,
     SUPERSEDED_ERROR,
     TIME_CAP_ERROR,
@@ -474,6 +475,44 @@ class TestRequestSolveCoalescing:
         assert row_a.id != row_b.id
         assert len(await _solve_rows(db_session, tournament_a_id)) == 1
         assert len(await _solve_rows(db_session, tournament_b_id)) == 1
+
+    @pytest.mark.parametrize(
+        "env_value, expected_time_cap_s",
+        [
+            (None, 10.0),
+            # No upper clamp on the solver's own cap (per the issue) — the RQ
+            # job_timeout must track it with margin, not silently stay at
+            # RQ's 180s default and kill the job before the solver's cap.
+            ("1200", 1200.0),
+        ],
+    )
+    async def test_enqueue_passes_a_job_timeout_above_the_time_cap(
+        self,
+        db_session: AsyncSession,
+        solver_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+        env_value: str | None,
+        expected_time_cap_s: float,
+    ) -> None:
+        """The RQ job_timeout must never be tighter than the CP-SAT cap it is
+        timing, or raising ``SOLVER_TIME_CAP_S`` above RQ's ~180s default
+        does nothing — RQ's watchdog kills the job before the solver's own
+        (now-configurable) cap is ever reached."""
+        if env_value is None:
+            monkeypatch.delenv("SOLVER_TIME_CAP_S", raising=False)
+        else:
+            monkeypatch.setenv("SOLVER_TIME_CAP_S", env_value)
+        tournament_id, _event_id = await _make_tournament(db_session)
+
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+
+        assert row is not None
+        (job,) = solver_queue.jobs
+        assert job.func_name == RUN_SCHEDULE_SOLVE_JOB
+        assert job.timeout == int(expected_time_cap_s) + JOB_TIMEOUT_MARGIN_S
+        assert job.timeout > expected_time_cap_s
 
     async def test_enqueue_failure_takes_the_row_back_out(
         self, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch

--- a/deploy/uat/values.yaml
+++ b/deploy/uat/values.yaml
@@ -40,6 +40,11 @@ config:
   SESSION_COOKIE_SECURE: "true"
   # Real client IP for IP-keyed rate limiters behind the proxy — see docs/adr/0008-trust-client-ip-at-the-uvicorn-edge.md
   FORWARDED_ALLOW_IPS: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8"
+  # Wall-clock cap (seconds) on the CP-SAT tournament solve, consumed by the
+  # `worker` (rq "solver" queue) — see api/app/schedule_solves.py (issue #1103).
+  # Only the worker acts on it, but it lives in the shared ConfigMap alongside
+  # the other simple tunables above.
+  SOLVER_TIME_CAP_S: "10"
 
 postgres:
   user: postgres

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,6 +57,8 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
       REDIS_URL: redis://redis:6379/0
+      # Wall-clock cap (seconds) on the CP-SAT tournament solve (issue #1103).
+      SOLVER_TIME_CAP_S: ${SOLVER_TIME_CAP_S:-10}
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,6 +35,10 @@ services:
       SESSION_COOKIE_SECURE: "false"
       # Real client IP for IP-keyed rate limiters behind the proxy — see docs/adr/0008-trust-client-ip-at-the-uvicorn-edge.md
       FORWARDED_ALLOW_IPS: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8
+      # Wall-clock cap (seconds) on the CP-SAT tournament solve (issue #1103).
+      # request_solve() reads this to size the RQ job_timeout, so the api
+      # service needs it too, not just the worker that runs the solve itself.
+      SOLVER_TIME_CAP_S: ${SOLVER_TIME_CAP_S:-10}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -106,6 +106,8 @@ services:
       <<: *mailpit-smtp
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/fortymm
       REDIS_URL: redis://redis:6379/0
+      # Wall-clock cap (seconds) on the CP-SAT tournament solve (issue #1103).
+      SOLVER_TIME_CAP_S: ${SOLVER_TIME_CAP_S:-10}
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -84,6 +84,10 @@ services:
       SESSION_COOKIE_SECURE: "false"
       # Real client IP for IP-keyed rate limiters behind the proxy — see docs/adr/0008-trust-client-ip-at-the-uvicorn-edge.md
       FORWARDED_ALLOW_IPS: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8
+      # Wall-clock cap (seconds) on the CP-SAT tournament solve (issue #1103).
+      # request_solve() reads this to size the RQ job_timeout, so the api
+      # service needs it too, not just the worker that runs the solve itself.
+      SOLVER_TIME_CAP_S: ${SOLVER_TIME_CAP_S:-10}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Fixes #1103 — the CP-SAT schedule-solve time cap was a hardcoded `10.0` constant (`SOLVE_TIME_CAP_S` in `api/app/schedule_solves.py`), so raising it for a large tournament required a code change + redeploy.
- Adds `api/app/config.py`, a `pydantic-settings` `Settings` module (the first of its kind in this codebase — `api/CLAUDE.md`'s documented pattern for new config) exposing `solver_time_cap_s: float = 10.0`, read fresh on every call from the `SOLVER_TIME_CAP_S` env var so tests can override it per-test. No upper clamp, so a one-off large value (e.g. 1200s) passes through untouched.
- Wires the setting into `execute_solve` in place of the old module constant.
- Exposes `SOLVER_TIME_CAP_S` on the `worker` service (the only process that runs the `solver` RQ queue) in `docker-compose.dev.yml` and `docker-compose.qa.yml`, and via the shared `config` map in `deploy/uat/values.yaml` for the UAT Helm chart.
- Existing scattered `os.environ.get(...)` call sites (`app/db.py`, `app/captcha.py`, `app/queue.py`) are deliberately left untouched — out of scope for this ticket.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` / `pytest` (api, full suite — 1357 passed)
- [x] `docker compose -f docker-compose.dev.yml config` / `docker compose -f docker-compose.qa.yml config` render cleanly with the new env var
- [x] `helm lint deploy/uat` + `helm template` render cleanly with `SOLVER_TIME_CAP_S` in the ConfigMap
- [x] `npm run test:run` (web-client vitest — 2804 passed), lint + `tsc -b` + `vite build` clean
- [x] `npm run test:e2e` (web-client Playwright — 289 passed)
- [x] root `e2e` (Playwright + docker compose, incl. `tournament-lifecycle` and `tournament-solver-schedule` specs) — 14 passed
- [x] OpenAPI schema regenerated from the live app object and diffed against the committed `schema.d.ts` — no drift (no routes/schemas changed)