### PR TITLE
Size the solve worker's CPU/memory and align num_search_workers with the CPU limit

### DIFF
--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -114,6 +114,7 @@ import hashlib
 import json
 import logging
 import math
+import os
 import uuid
 from collections import defaultdict
 from collections.abc import Sequence
@@ -175,6 +176,17 @@ RUN_SCHEDULE_SOLVE_JOB = "app.schedule_solves.run_schedule_solve"
 #: The ADR's hard time cap: mid-tournament we want a good answer now, not a
 #: proof, and FEASIBLE under the cap is accepted.
 SOLVE_TIME_CAP_S = 10.0
+
+#: CP-SAT's search-worker portfolio size. Left unset, CP-SAT auto-sizes off
+#: the *node's* core count (``os.cpu_count()``), not the worker container's
+#: cgroup CPU limit, so under a k8s/compose CPU limit it oversubscribes and
+#: gets CFS-throttled (#1115). Defaulting to 1 keeps solves deterministic and
+#: never oversubscribed; deployments with a larger CPU limit raise this via
+#: env to match (the chart keeps the two in step — see
+#: deploy/uat/templates/worker.yaml). Note ``num_search_workers > 1`` makes
+#: CP-SAT non-deterministic — the ``random_seed = 0`` in app.scheduling no
+#: longer pins the result once more than one worker is searching.
+SOLVE_NUM_WORKERS = int(os.environ.get("SOLVE_NUM_WORKERS", "1"))
 
 #: What a drift-discarded run records. The run is ``failed`` because it is
 #: honest — this run produced nothing — not because anything broke; the rerun
@@ -824,7 +836,11 @@ async def execute_solve(
             await db.commit()
 
         # (b) The solve itself, outside any transaction / open session.
-        result = _solve(inputs.snapshot, time_cap_s=SOLVE_TIME_CAP_S)
+        result = _solve(
+            inputs.snapshot,
+            time_cap_s=SOLVE_TIME_CAP_S,
+            num_search_workers=SOLVE_NUM_WORKERS,
+        )
 
         await _apply_result(sessionmaker, solve_id, tournament_id, inputs, result)
     except Exception as exc:  # noqa: BLE001 -- the job's boundary: never leave a row running

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -177,16 +177,22 @@ RUN_SCHEDULE_SOLVE_JOB = "app.schedule_solves.run_schedule_solve"
 #: proof, and FEASIBLE under the cap is accepted.
 SOLVE_TIME_CAP_S = 10.0
 
-#: CP-SAT's search-worker portfolio size. Left unset, CP-SAT auto-sizes off
-#: the *node's* core count (``os.cpu_count()``), not the worker container's
-#: cgroup CPU limit, so under a k8s/compose CPU limit it oversubscribes and
-#: gets CFS-throttled (#1115). Defaulting to 1 keeps solves deterministic and
-#: never oversubscribed; deployments with a larger CPU limit raise this via
-#: env to match (the chart keeps the two in step — see
-#: deploy/uat/templates/worker.yaml). Note ``num_search_workers > 1`` makes
-#: CP-SAT non-deterministic — the ``random_seed = 0`` in app.scheduling no
-#: longer pins the result once more than one worker is searching.
-SOLVE_NUM_WORKERS = int(os.environ.get("SOLVE_NUM_WORKERS", "1"))
+
+def _solve_num_workers() -> int:
+    """CP-SAT's search-worker portfolio size. Left unset, CP-SAT auto-sizes
+    off the *node's* core count (``os.cpu_count()``), not the worker
+    container's cgroup CPU limit, so under a k8s/compose CPU limit it
+    oversubscribes and gets CFS-throttled (#1115). Defaulting to 1 keeps
+    solves deterministic and never oversubscribed; deployments with a larger
+    CPU limit raise this via env to match (the chart keeps the two in step —
+    see deploy/uat/templates/worker.yaml). Note ``num_search_workers > 1``
+    makes CP-SAT non-deterministic — the ``random_seed = 0`` in
+    app.scheduling no longer pins the result once more than one worker is
+    searching. Read lazily (like the rest of this module's env config) so
+    tests can override it with ``monkeypatch.setenv``.
+    """
+    return int(os.environ.get("SOLVE_NUM_WORKERS", "1"))
+
 
 #: What a drift-discarded run records. The run is ``failed`` because it is
 #: honest — this run produced nothing — not because anything broke; the rerun
@@ -839,7 +845,7 @@ async def execute_solve(
         result = _solve(
             inputs.snapshot,
             time_cap_s=SOLVE_TIME_CAP_S,
-            num_search_workers=SOLVE_NUM_WORKERS,
+            num_search_workers=_solve_num_workers(),
         )
 
         await _apply_result(sessionmaker, solve_id, tournament_id, inputs, result)

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -671,7 +671,11 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
     )
 
 
-def solve(snapshot: ScheduleSnapshot, time_cap_s: float = 10.0) -> SolveResult:
+def solve(
+    snapshot: ScheduleSnapshot,
+    time_cap_s: float = 10.0,
+    num_search_workers: int = 1,
+) -> SolveResult:
     """Place every active fixture: pins echoed verbatim, everything else
     solved onto its pool's tables inside its pool's window, on the
     :data:`BUCKET_MIN` grid, no earlier than ``now_min``.
@@ -680,6 +684,12 @@ def solve(snapshot: ScheduleSnapshot, time_cap_s: float = 10.0) -> SolveResult:
     :class:`IncoherentSnapshot` for inputs that reference things they do not
     contain, and :class:`SchedulingError` if CP-SAT rejects the model (a bug
     here, not a property of the tournament).
+
+    ``num_search_workers`` must stay within the caller's CPU budget — CP-SAT
+    spawns that many search threads regardless of how many cores are actually
+    available, and a value above the caller's CPU limit gets CFS-throttled.
+    The default of 1 is also what keeps ``random_seed = 0`` below pinning the
+    result: CP-SAT's parallel portfolio is not deterministic across workers.
     """
     built = _build_model(snapshot)
     if isinstance(built, SolveResult):
@@ -689,6 +699,7 @@ def solve(snapshot: ScheduleSnapshot, time_cap_s: float = 10.0) -> SolveResult:
 
     solver = cp_model.CpSolver()
     solver.parameters.max_time_in_seconds = time_cap_s
+    solver.parameters.num_search_workers = num_search_workers
     solver.parameters.random_seed = 0
     status = solver.Solve(built.model)
     wall_time_ms = int(solver.WallTime() * 1000)

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -4,15 +4,17 @@ The leading underscore keeps pytest from auto-collecting this as a test module;
 fixtures still belong in ``conftest.py``.
 """
 
-from collections.abc import AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
+import pytest
 from httpx import ASGITransport, AsyncClient, Request
 from rq import Queue
 from sqlalchemy import event, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
+from app import schedule_solves, scheduling
 from app.main import app as fastapi_app
 from app.models import (
     League,
@@ -28,8 +30,30 @@ from app.models import (
 from app.notifications.apns import Environment, SendOutcome, SendResult
 from app.notifications.dependencies import get_push_sender
 from app.notifications.jobs import DELIVER_NOTIFICATION_JOB
+from app.scheduling import ScheduleSnapshot, SolveResult
 from app.schemas.notification import NotificationJob
 from app.sessions import CSRF_COOKIE_NAME, CSRF_HEADER_NAME, CSRF_SAFE_METHODS
+
+
+def hijack_solve(
+    monkeypatch: pytest.MonkeyPatch, after_solve: Callable[[], None]
+) -> None:
+    """Interpose on the ``_solve`` seam: run the real solver, then
+    ``after_solve`` — landing work exactly in the gap between a schedule
+    solve job's snapshot and its guarded apply (the drift-guard race
+    window)."""
+    real = scheduling.solve
+
+    def wrapper(
+        snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+    ) -> SolveResult:
+        result = real(
+            snapshot, time_cap_s=time_cap_s, num_search_workers=num_search_workers
+        )
+        after_solve()
+        return result
+
+    monkeypatch.setattr(schedule_solves, "_solve", wrapper)
 
 
 def enqueued_notification_jobs(queue: Queue) -> list[NotificationJob]:

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -244,8 +244,12 @@ def _hijack_solve(
     snapshot and its guarded apply."""
     real = scheduling.solve
 
-    def wrapper(snapshot: ScheduleSnapshot, time_cap_s: float) -> SolveResult:
-        result = real(snapshot, time_cap_s=time_cap_s)
+    def wrapper(
+        snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+    ) -> SolveResult:
+        result = real(
+            snapshot, time_cap_s=time_cap_s, num_search_workers=num_search_workers
+        )
         after_solve()
         return result
 

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -20,7 +20,7 @@ re-check is the ONLY guard — the fingerprint deliberately excludes the count.
 """
 
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 from decimal import Decimal
 
@@ -61,10 +61,9 @@ from app.models import (
     User,
 )
 from app.schedule_solves import RUN_SCHEDULE_SOLVE_JOB, SUPERSEDED_ERROR, request_solve
-from app.scheduling import ScheduleSnapshot, SolveResult
 from app.schemas.notification import NotificationJob
 from app.tournament_draws import cut_draw
-from tests._helpers import make_user
+from tests._helpers import hijack_solve, make_user
 
 DATE = "2030-01-01"
 #: The pool window's start — the tournament's minute-frame origin.
@@ -234,26 +233,6 @@ async def _request_and_run_solve(
     await db.commit()
     _run_recorded_solve(solver_queue, row_id)
     db.expire_all()
-
-
-def _hijack_solve(
-    monkeypatch: pytest.MonkeyPatch, after_solve: Callable[[], None]
-) -> None:
-    """Interpose on the ``_solve`` seam: run the real solver, then
-    ``after_solve`` — landing work exactly in the gap between the job's
-    snapshot and its guarded apply."""
-    real = scheduling.solve
-
-    def wrapper(
-        snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
-    ) -> SolveResult:
-        result = real(
-            snapshot, time_cap_s=time_cap_s, num_search_workers=num_search_workers
-        )
-        after_solve()
-        return result
-
-    monkeypatch.setattr(schedule_solves, "_solve", wrapper)
 
 
 class TestApplyCallEvaluation:
@@ -1175,7 +1154,7 @@ class TestConcurrentTickAndApply:
         assert row is not None
         row_id = row.id
         await db_session.commit()
-        _hijack_solve(monkeypatch, after_solve=lambda: run_pin_tick(str(tournament_id)))
+        hijack_solve(monkeypatch, after_solve=lambda: run_pin_tick(str(tournament_id)))
         return tournament_id, event_id, row_id
 
     async def test_concurrent_tick_and_apply_call_exactly_once(
@@ -1312,7 +1291,7 @@ class TestConcurrentTickAndApply:
         assert row is not None
         row_id = row.id
         await db_session.commit()
-        _hijack_solve(monkeypatch, after_solve=lambda: run_pin_tick(str(tournament_id)))
+        hijack_solve(monkeypatch, after_solve=lambda: run_pin_tick(str(tournament_id)))
         return tournament_id, event_id, row_id
 
     async def test_concurrent_tick_and_apply_notify_a_silent_pin_exactly_once(

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -26,7 +26,6 @@ load-bearing and the green above isn't scheduler luck.
 import asyncio
 import threading
 import uuid
-from collections.abc import Callable
 from datetime import datetime, timedelta
 from decimal import Decimal
 
@@ -77,7 +76,7 @@ from app.scheduling import (
     Verdict,
 )
 from app.tournament_draws import cut_draw
-from tests._helpers import make_user
+from tests._helpers import hijack_solve, make_user
 
 DATE = "2030-01-01"
 #: The tournament's minute-frame origin: the (single) pool window's start.
@@ -235,26 +234,6 @@ def _commit_concurrently(database_url: str, statement: Executable) -> None:
     thread.join()
 
 
-def _hijack_solve(
-    monkeypatch: pytest.MonkeyPatch, after_solve: Callable[[], None]
-) -> None:
-    """Interpose on the ``_solve`` seam: run the real solver, then run
-    ``after_solve`` — landing a committed mutation exactly in the gap between
-    the job's snapshot and its guarded apply (the drift window)."""
-    real = scheduling.solve
-
-    def wrapper(
-        snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
-    ) -> SolveResult:
-        result = real(
-            snapshot, time_cap_s=time_cap_s, num_search_workers=num_search_workers
-        )
-        after_solve()
-        return result
-
-    monkeypatch.setattr(schedule_solves, "_solve", wrapper)
-
-
 async def _fixture_user_ids(
     db: AsyncSession, entry_a_id: uuid.UUID, entry_b_id: uuid.UUID
 ) -> tuple[str, str]:
@@ -319,6 +298,20 @@ async def _mark_completed(
     fixture.winner_entry_id = entry_a_id
     await db.commit()
     return await _fixture_user_ids(db, entry_a_id, entry_b_id)
+
+
+class TestSolveNumWorkers:
+    """``SOLVE_NUM_WORKERS`` (#1115): must stay operator-configurable via env,
+    not baked in at import time, or the chart's per-environment CPU-limit
+    alignment (deploy/uat/templates/worker.yaml) has nothing to actually set."""
+
+    def test_defaults_to_one_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SOLVE_NUM_WORKERS", raising=False)
+        assert schedule_solves._solve_num_workers() == 1
+
+    def test_reads_the_env_var_live(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SOLVE_NUM_WORKERS", "16")
+        assert schedule_solves._solve_num_workers() == 16
 
 
 class TestRestShadows:
@@ -721,7 +714,7 @@ class TestSolveJob:
         row_id = row.id
         await db_session.commit()
 
-        _hijack_solve(
+        hijack_solve(
             monkeypatch,
             after_solve=lambda: _commit_concurrently(
                 postgres_url,
@@ -775,7 +768,7 @@ class TestDriftGuard:
                 .limit(1)
             )
         ).scalar_one()
-        _hijack_solve(
+        hijack_solve(
             monkeypatch,
             after_solve=lambda: _commit_concurrently(
                 postgres_url,

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -243,8 +243,12 @@ def _hijack_solve(
     the job's snapshot and its guarded apply (the drift window)."""
     real = scheduling.solve
 
-    def wrapper(snapshot: ScheduleSnapshot, time_cap_s: float) -> SolveResult:
-        result = real(snapshot, time_cap_s=time_cap_s)
+    def wrapper(
+        snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+    ) -> SolveResult:
+        result = real(
+            snapshot, time_cap_s=time_cap_s, num_search_workers=num_search_workers
+        )
         after_solve()
         return result
 
@@ -651,7 +655,9 @@ class TestSolveJob:
         row_id = row.id
         await db_session.commit()
 
-        def exhausted(snapshot: ScheduleSnapshot, time_cap_s: float) -> SolveResult:
+        def exhausted(
+            snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+        ) -> SolveResult:
             return SolveResult(
                 verdict=Verdict.unknown,
                 placements=(),
@@ -684,7 +690,9 @@ class TestSolveJob:
         row_id = row.id
         await db_session.commit()
 
-        def broken(snapshot: ScheduleSnapshot, time_cap_s: float) -> SolveResult:
+        def broken(
+            snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+        ) -> SolveResult:
             raise RuntimeError("the solver caught fire")
 
         monkeypatch.setattr(schedule_solves, "_solve", broken)

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -700,10 +700,12 @@ def _first_solution_board(built: _SolverModel) -> set[tuple[str, str, int]]:
 
     One worker plus a fixed seed makes *which* solution is discovered first
     reproducible, so the warm-start hint's effect — it seeds the search at the
-    previous plan — is observable. The production ``solve`` deliberately keeps
-    its multi-worker portfolio, whose aggregate branch count and first-solution
-    identity are non-deterministic (a lucky worker can presolve either board in
-    zero branches), so it cannot show this; hence the single-worker probe."""
+    previous plan — is observable. Production ``solve`` defaults to one worker
+    too, but a deployment can raise ``num_search_workers`` (``SOLVE_NUM_WORKERS``,
+    #1115) — under a multi-worker portfolio, aggregate branch count and
+    first-solution identity are non-deterministic (a lucky worker can presolve
+    either board in zero branches), so it cannot show this; hence this test
+    pins a single worker explicitly rather than relying on the default."""
     solver = cp_model.CpSolver()
     solver.parameters.random_seed = 0
     solver.parameters.num_search_workers = 1

--- a/deploy/uat/templates/worker.yaml
+++ b/deploy/uat/templates/worker.yaml
@@ -21,11 +21,18 @@ spec:
           command: ["rq", "worker", "--url", "{{ .Values.config.REDIS_URL }}", {{ range $i, $q := splitList " " .Values.worker.queues }}{{ if $i }}, {{ end }}{{ $q | quote }}{{ end }}]
           resources:
             requests:
-              cpu: 100m
-              memory: 128Mi
+              cpu: {{ .Values.worker.requests.cpu }}
+              memory: {{ .Values.worker.requests.memory }}
             limits:
-              cpu: 2000m
-              memory: 1Gi
+              cpu: {{ .Values.worker.cpu }}
+              memory: {{ .Values.worker.memory }}
+          env:
+            # CP-SAT's search-worker count — kept equal to the CPU limit above
+            # (single source of truth: .Values.worker.cpu) so the solver never
+            # oversubscribes the container's cgroup quota. See #1115 and the
+            # comment on SOLVE_NUM_WORKERS in api/app/schedule_solves.py.
+            - name: SOLVE_NUM_WORKERS
+              value: {{ .Values.worker.cpu | quote }}
           envFrom:
             {{- include "fortymm-uat.appEnvFrom" . | nindent 12 }}
           volumeMounts:

--- a/deploy/uat/values.yaml
+++ b/deploy/uat/values.yaml
@@ -61,6 +61,18 @@ apnsKeyFile: apns_auth_key.p8
 
 worker:
   queues: solver email ratings notifications
+  # CPU/memory for the CP-SAT solve worker. `cpu` is a bare core count (not
+  # "m" millicores) because it doubles as SOLVE_NUM_WORKERS — CP-SAT's
+  # search-worker portfolio must equal the container's CPU limit or it
+  # auto-sizes off the *node's* core count and gets CFS-throttled (#1115).
+  # 16 cores / 8Gi is a UAT stress setting sized for large-model solves
+  # (hundreds of fixtures x many tables), not necessarily the prod default —
+  # right-size per environment by overriding these values.
+  cpu: "16"
+  memory: 8Gi
+  requests:
+    cpu: "2"
+    memory: 512Mi
 
 # Periodic retirement sweep CronJob (task #9 / ADR 0007 O8). Runs
 # `python -m app.retirement_sweep` on this schedule to auto-accept lapsed


### PR DESCRIPTION
## Summary

- Give the schedule-solve worker enough CPU/memory for CP-SAT, and align the solver's parallelism with the actual CPU allocation — configurably, not hardcoded.
- `api/app/scheduling.py`: `solve()` now takes `num_search_workers: int = 1`, applied to `solver.parameters.num_search_workers`. Default of 1 keeps solves deterministic (`random_seed = 0`) and never oversubscribed anywhere the env var isn't set.
- `api/app/schedule_solves.py`: new `_solve_num_workers()` (env `SOLVE_NUM_WORKERS`, default `1`) threaded into the solve call — a lazy accessor matching this module's other env-derived config, so `monkeypatch.setenv` works in tests.
- `deploy/uat/templates/worker.yaml` / `deploy/uat/values.yaml`: worker CPU/memory now come from `.Values.worker.*` instead of being hardcoded (`2000m/1Gi` → `16`/`8Gi`, the UAT stress setting from the issue). `SOLVE_NUM_WORKERS` is set on the worker container from the same `.Values.worker.cpu` that sets the CPU limit — single source of truth, so the two can't drift apart.
- Documented the determinism tradeoff in both the `scheduling.solve()` docstring and the `SOLVE_NUM_WORKERS` comment: `num_search_workers > 1` makes CP-SAT non-deterministic despite `random_seed = 0`.

Fixes #1115.

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy --strict` — clean
- [x] `pytest` (api) — 1353 passed
- [x] `helm lint` / `helm template` — chart renders `SOLVE_NUM_WORKERS="16"` and `limits.cpu: 16` from the same value
- [x] web-client vitest (2804 passed), lint, and build (tsc + vite) — unaffected by this change, run as a safety net since `api/**` changed
- [x] OpenAPI schema regen — no drift (this change touches no routes/schemas)
- [ ] web-client e2e / root e2e / iOS — skipped; this branch touches only `api/` and `deploy/uat/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)