### PR TITLE
Reap a stale running schedule solve on the next read or request

### DIFF
--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -237,21 +237,19 @@ def _is_stale_running(row: ScheduleSolve, *, now: datetime) -> bool:
 
 
 def _reap_stale_running(row: ScheduleSolve, *, now: datetime) -> None:
-    """Mark an already ``FOR UPDATE``-locked ``running`` row as failed because
-    its lease expired (ADR) — the same terminal shape as an ordinary crash's
+    """Mark an already-confirmed-stale, ``FOR UPDATE``-locked ``running`` row
+    as failed (ADR) — the same terminal shape as an ordinary crash's
     best-effort write (:func:`_finish_failed_best_effort`), so a reaped row is
     indistinguishable from a normal one to every other reader.
 
-    Re-checks staleness under the lock before mutating: the caller may have
-    only tested with an earlier or unlocked ``now``, and by the time the lock
-    is held the job may have already finished normally — in which case this is
-    a no-op and the caller's normal flow proceeds against the now-terminal
-    row. Deliberately does not special-case ``rerun_requested`` — it is left
-    exactly as the row already carries it, mirroring
-    :func:`_finish_failed_best_effort`, which already silently drops it on an
-    ordinary crash (ADR)."""
-    if not _is_stale_running(row, now=now):
-        return
+    Callers must confirm :func:`_is_stale_running` themselves, under the lock,
+    immediately before calling — both call sites already do, so this does not
+    re-check (the job may have finished normally in the gap between an
+    earlier, unlocked read and acquiring the lock; that recheck belongs to the
+    caller, not duplicated here). Deliberately does not special-case
+    ``rerun_requested`` — it is left exactly as the row already carries it,
+    mirroring :func:`_finish_failed_best_effort`, which already silently drops
+    it on an ordinary crash (ADR)."""
     row.status = ScheduleSolveStatus.failed
     row.error = STALE_RUNNING_ERROR
     row.finished_at = now
@@ -327,8 +325,9 @@ async def request_solve(
             # terminal state and fall through to the "neither queued nor
             # running" branch below — this trigger gets a fresh row rather
             # than being absorbed by a job that will never run.
+            # Not flushed here: the fall-through below adds a new row and
+            # flushes once, carrying both this UPDATE and that INSERT.
             _reap_stale_running(running, now=now)
-            await db.flush()
         else:
             running.rerun_requested = True
             await db.flush()

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -177,6 +177,20 @@ RUN_SCHEDULE_SOLVE_JOB = "app.schedule_solves.run_schedule_solve"
 #: proof, and FEASIBLE under the cap is accepted.
 SOLVE_TIME_CAP_S = 10.0
 
+#: How long a ``running`` row is allowed to go without a terminal write before
+#: it is presumed dead (worker OOM-killed / SIGKILLed mid-run) rather than
+#: merely slow (ADR). A multiple of ``SOLVE_TIME_CAP_S``, not equal to it:
+#: the cap only bounds the solver's own call in phase (b) — the lease must
+#: also cover phases (a) and (c)'s DB round-trips (snapshot read, apply's
+#: locked re-read and writes, notification fan-out), which run with no cap of
+#: their own. A generous multiple keeps a merely-slow-but-alive run from being
+#: reaped out from under itself.
+STALE_RUNNING_LEASE_S = SOLVE_TIME_CAP_S * 6
+
+#: What a reaped row records — the honest fact that nothing finished it, not
+#: a solver verdict.
+STALE_RUNNING_ERROR = "the solve job stopped responding (worker crashed or was killed)"
+
 
 def _solve_num_workers() -> int:
     """CP-SAT's search-worker portfolio size. Left unset, CP-SAT auto-sizes
@@ -210,6 +224,39 @@ TIME_CAP_ERROR = "time cap exhausted without a solution"
 _solve = scheduling.solve
 
 
+def _is_stale_running(row: ScheduleSolve, *, now: datetime) -> bool:
+    """Whether ``row`` has been ``running`` past its lease — presumed dead
+    rather than merely slow (ADR). ``started_at`` is set in the same
+    transaction the row flips to ``running``, so ``None`` here can only mean
+    the row hasn't actually started running yet."""
+    return (
+        row.status is ScheduleSolveStatus.running
+        and row.started_at is not None
+        and now - row.started_at >= timedelta(seconds=STALE_RUNNING_LEASE_S)
+    )
+
+
+def _reap_stale_running(row: ScheduleSolve, *, now: datetime) -> None:
+    """Mark an already ``FOR UPDATE``-locked ``running`` row as failed because
+    its lease expired (ADR) — the same terminal shape as an ordinary crash's
+    best-effort write (:func:`_finish_failed_best_effort`), so a reaped row is
+    indistinguishable from a normal one to every other reader.
+
+    Re-checks staleness under the lock before mutating: the caller may have
+    only tested with an earlier or unlocked ``now``, and by the time the lock
+    is held the job may have already finished normally — in which case this is
+    a no-op and the caller's normal flow proceeds against the now-terminal
+    row. Deliberately does not special-case ``rerun_requested`` — it is left
+    exactly as the row already carries it, mirroring
+    :func:`_finish_failed_best_effort`, which already silently drops it on an
+    ordinary crash (ADR)."""
+    if not _is_stale_running(row, now=now):
+        return
+    row.status = ScheduleSolveStatus.failed
+    row.error = STALE_RUNNING_ERROR
+    row.finished_at = now
+
+
 async def request_solve(
     db: AsyncSession,
     tournament_id: uuid.UUID,
@@ -221,9 +268,15 @@ async def request_solve(
     * A ``queued`` row exists → return it: the pending run will already see
       whatever state motivated this trigger. The trigger is absorbed — the
       row keeps the trigger that *caused* it.
-    * A ``running`` row exists → set ``rerun_requested`` on it and return it:
-      the job re-queues (trigger ``rerun``) at finish, in the same
+    * A ``running`` row exists and is still within its lease
+      (``STALE_RUNNING_LEASE_S``) → set ``rerun_requested`` on it and return
+      it: the job re-queues (trigger ``rerun``) at finish, in the same
       transaction as its final status.
+    * A ``running`` row exists but has out-lived its lease → its owning
+      worker is presumed dead (OOM/SIGKILL mid-run, ADR): reap it to
+      ``failed``/``STALE_RUNNING_ERROR`` and fall through to the "neither"
+      branch below, so this trigger gets a fresh row rather than being
+      absorbed by a job that will never finish.
     * Neither → insert a ``queued`` row and enqueue the RQ job with its id.
       Returns ``None`` only when the enqueue itself fails (Redis down): the
       row is taken back out rather than left as a zombie that would absorb
@@ -267,9 +320,19 @@ async def request_solve(
         .first()
     )
     if running is not None:
-        running.rerun_requested = True
-        await db.flush()
-        return running
+        now = datetime.now(UTC)
+        if _is_stale_running(running, now=now):
+            # The row is locked (FOR UPDATE, above) and confirmed stale: the
+            # worker that owned it is presumed dead (ADR). Reap it to a
+            # terminal state and fall through to the "neither queued nor
+            # running" branch below — this trigger gets a fresh row rather
+            # than being absorbed by a job that will never run.
+            _reap_stale_running(running, now=now)
+            await db.flush()
+        else:
+            running.rerun_requested = True
+            await db.flush()
+            return running
 
     row = ScheduleSolve(
         tournament_id=tournament_id,
@@ -322,15 +385,33 @@ async def latest_solve(
     db: AsyncSession, tournament_id: uuid.UUID
 ) -> ScheduleSolve | None:
     """The newest row of this tournament's solve ledger, or ``None`` when no solve
-    has ever been requested — what the detail BFF's solve strip renders.
+    has ever been requested — what the detail BFF's solve strip renders, and what
+    gates the "Run scheduler" button.
 
     Newest by ``requested_at``, which is what the composite index
     (``ix_schedule_solves_tournament_id_requested_at``) was built to answer; the id
     tie-break only makes the read deterministic for rows minted in the same
     transaction (a drift-discarded run and the rerun it requested share one
     ``now()``), it carries no chronology of its own.
+
+    A row that looks stale-``running`` (ADR "a stale running solve is reaped by
+    the next reader or request") is reaped in place before it is returned: a
+    worker that was hard-killed mid-solve (OOM/SIGKILL) never gets to write a
+    terminal status, and without this a pre-live tournament's "Run scheduler"
+    button would stay disabled forever with the row wedged ``running`` and no
+    trigger left that would ever call :func:`request_solve` again. The first,
+    unlocked read only *suspects* staleness (this function commits nothing on
+    its own path — see below); a second read re-fetches the same row by id
+    ``FOR UPDATE`` and re-checks staleness under the lock, because the worker may
+    have finished normally in the gap between the two reads. Only if it is
+    *still* stale under the lock is it reaped and the write committed — this is
+    the first GET-triggered commit in this codebase, and it is scoped tightly to
+    exactly this one row's ``running`` → ``failed`` transition, not a general
+    write path for this route. Otherwise (never stale, or no longer stale under
+    the lock) nothing is written and the row — freshly re-read where re-read
+    happened — is returned unchanged.
     """
-    return (
+    row = (
         await db.execute(
             select(ScheduleSolve)
             .where(ScheduleSolve.tournament_id == tournament_id)
@@ -338,6 +419,24 @@ async def latest_solve(
             .limit(1)
         )
     ).scalar_one_or_none()
+    if row is None or not _is_stale_running(row, now=datetime.now(UTC)):
+        return row
+
+    locked = (
+        await db.execute(
+            select(ScheduleSolve).where(ScheduleSolve.id == row.id).with_for_update()
+        )
+    ).scalar_one_or_none()
+    if locked is None:
+        # Cascaded away (tournament deleted) between the two reads: nothing
+        # left to reap or return correctly — fall back to the stale read.
+        return row
+
+    now = datetime.now(UTC)
+    if _is_stale_running(locked, now=now):
+        _reap_stale_running(locked, now=now)
+        await db.commit()
+    return locked
 
 
 @dataclass(frozen=True, slots=True)

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -213,6 +213,29 @@ def _run_recorded_job(queue: Queue, expected_solve_id: uuid.UUID) -> None:
     job.func(*job.args)
 
 
+async def _make_running_solve(
+    db: AsyncSession,
+    tournament_id: uuid.UUID,
+    *,
+    started_at: datetime,
+    rerun_requested: bool = False,
+) -> uuid.UUID:
+    """A ``running`` schedule-solve row backdated to ``started_at`` — the shape
+    every stale-reap test starts from, varying only how far past the lease it
+    is. Returns the id (the `_make_tournament` convention: tests read it back
+    through `_solve_rows`/`latest_solve` rather than off an expired instance)."""
+    running = ScheduleSolve(
+        tournament_id=tournament_id,
+        trigger=ScheduleSolveTrigger.go_live,
+        status=ScheduleSolveStatus.running,
+        started_at=started_at,
+        rerun_requested=rerun_requested,
+    )
+    db.add(running)
+    await db.commit()
+    return running.id
+
+
 def _commit_concurrently(database_url: str, statement: Executable) -> None:
     """Commit ``statement`` through a separate engine on its own loop + thread
     — a genuinely concurrent writer, independent of every session the test or
@@ -486,15 +509,9 @@ class TestRequestSolveCoalescing:
         stale_started_at = datetime.now(UTC) - timedelta(
             seconds=schedule_solves.STALE_RUNNING_LEASE_S + 1
         )
-        running = ScheduleSolve(
-            tournament_id=tournament_id,
-            trigger=ScheduleSolveTrigger.go_live,
-            status=ScheduleSolveStatus.running,
-            started_at=stale_started_at,
+        running_id = await _make_running_solve(
+            db_session, tournament_id, started_at=stale_started_at
         )
-        db_session.add(running)
-        await db_session.commit()
-        running_id = running.id
 
         result = await request_solve(
             db_session, tournament_id, ScheduleSolveTrigger.settings_changed
@@ -525,21 +542,16 @@ class TestRequestSolveCoalescing:
         fresh_started_at = datetime.now(UTC) - timedelta(
             seconds=schedule_solves.STALE_RUNNING_LEASE_S - 1
         )
-        running = ScheduleSolve(
-            tournament_id=tournament_id,
-            trigger=ScheduleSolveTrigger.go_live,
-            status=ScheduleSolveStatus.running,
-            started_at=fresh_started_at,
+        running_id = await _make_running_solve(
+            db_session, tournament_id, started_at=fresh_started_at
         )
-        db_session.add(running)
-        await db_session.commit()
 
         result = await request_solve(
             db_session, tournament_id, ScheduleSolveTrigger.settings_changed
         )
 
         assert result is not None
-        assert result.id == running.id
+        assert result.id == running_id
         assert result.status is ScheduleSolveStatus.running
         assert result.rerun_requested is True
         assert result.error is None
@@ -615,15 +627,9 @@ class TestLatestSolve:
         fresh_started_at = datetime.now(UTC) - timedelta(
             seconds=schedule_solves.STALE_RUNNING_LEASE_S - 1
         )
-        running = ScheduleSolve(
-            tournament_id=tournament_id,
-            trigger=ScheduleSolveTrigger.go_live,
-            status=ScheduleSolveStatus.running,
-            started_at=fresh_started_at,
+        running_id = await _make_running_solve(
+            db_session, tournament_id, started_at=fresh_started_at
         )
-        db_session.add(running)
-        await db_session.commit()
-        running_id = running.id
 
         result = await latest_solve(db_session, tournament_id)
 
@@ -655,16 +661,12 @@ class TestLatestSolve:
         stale_started_at = datetime.now(UTC) - timedelta(
             seconds=schedule_solves.STALE_RUNNING_LEASE_S + 1
         )
-        running = ScheduleSolve(
-            tournament_id=tournament_id,
-            trigger=ScheduleSolveTrigger.go_live,
-            status=ScheduleSolveStatus.running,
+        running_id = await _make_running_solve(
+            db_session,
+            tournament_id,
             started_at=stale_started_at,
             rerun_requested=True,
         )
-        db_session.add(running)
-        await db_session.commit()
-        running_id = running.id
 
         result = await latest_solve(db_session, tournament_id)
 

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -26,7 +26,7 @@ load-bearing and the green above isn't scheduler luck.
 import asyncio
 import threading
 import uuid
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import fakeredis
@@ -35,6 +35,7 @@ from redis.exceptions import RedisError
 from rq import Queue
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
@@ -66,6 +67,7 @@ from app.schedule_solves import (
     RUN_SCHEDULE_SOLVE_JOB,
     SUPERSEDED_ERROR,
     TIME_CAP_ERROR,
+    latest_solve,
     request_solve,
 )
 from app.scheduling import (
@@ -472,6 +474,79 @@ class TestRequestSolveCoalescing:
         assert len(await _solve_rows(db_session, tournament_a_id)) == 1
         assert len(await _solve_rows(db_session, tournament_b_id)) == 1
 
+    async def test_running_past_lease_is_reaped_and_a_fresh_row_is_queued(
+        self, db_session: AsyncSession
+    ) -> None:
+        """A ``running`` row whose worker died mid-run (OOM/SIGKILL) without
+        ever writing a terminal status must not wedge the tournament forever
+        (#1102): once its lease expires, a new trigger reaps it to ``failed``
+        and gets a genuinely new row rather than being absorbed as a
+        ``rerun_requested`` flag on a job that will never run."""
+        tournament_id, _event_id = await _make_tournament(db_session)
+        stale_started_at = datetime.now(UTC) - timedelta(
+            seconds=schedule_solves.STALE_RUNNING_LEASE_S + 1
+        )
+        running = ScheduleSolve(
+            tournament_id=tournament_id,
+            trigger=ScheduleSolveTrigger.go_live,
+            status=ScheduleSolveStatus.running,
+            started_at=stale_started_at,
+        )
+        db_session.add(running)
+        await db_session.commit()
+        running_id = running.id
+
+        result = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.settings_changed
+        )
+        await db_session.commit()
+
+        assert result is not None
+        assert result.id != running_id
+        assert result.status is ScheduleSolveStatus.queued
+        assert result.trigger is ScheduleSolveTrigger.settings_changed
+
+        rows = {row.id: row for row in await _solve_rows(db_session, tournament_id)}
+        assert len(rows) == 2
+        reaped = rows[running_id]
+        assert reaped.status is ScheduleSolveStatus.failed
+        assert reaped.error == schedule_solves.STALE_RUNNING_ERROR
+        assert reaped.finished_at is not None
+        assert reaped.wall_time_ms is None
+
+    async def test_running_within_lease_keeps_todays_behavior(
+        self, db_session: AsyncSession
+    ) -> None:
+        """A ``running`` row that is merely slow — not yet past its lease —
+        must be unaffected by the reaper: the existing coalescing behavior
+        (set ``rerun_requested``, return the same row, enqueue nothing new)
+        stands."""
+        tournament_id, _event_id = await _make_tournament(db_session)
+        fresh_started_at = datetime.now(UTC) - timedelta(
+            seconds=schedule_solves.STALE_RUNNING_LEASE_S - 1
+        )
+        running = ScheduleSolve(
+            tournament_id=tournament_id,
+            trigger=ScheduleSolveTrigger.go_live,
+            status=ScheduleSolveStatus.running,
+            started_at=fresh_started_at,
+        )
+        db_session.add(running)
+        await db_session.commit()
+
+        result = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.settings_changed
+        )
+
+        assert result is not None
+        assert result.id == running.id
+        assert result.status is ScheduleSolveStatus.running
+        assert result.rerun_requested is True
+        assert result.error is None
+        assert result.finished_at is None
+        rows = await _solve_rows(db_session, tournament_id)
+        assert len(rows) == 1
+
     async def test_enqueue_failure_takes_the_row_back_out(
         self, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -492,6 +567,127 @@ class TestRequestSolveCoalescing:
 
         assert result is None
         assert await _solve_rows(db_session, tournament_id) == []
+
+
+class TestLatestSolve:
+    """``latest_solve`` feeds the tournament detail BFF's solve strip and, per
+    the "stale running solve" ADR, is one of the two places (the other is
+    :func:`request_solve`'s coalescer) that reaps a stranded ``running`` row
+    whose worker was hard-killed mid-solve (#1102) — the read path a pre-live
+    tournament actually depends on, since nothing else calls ``request_solve``
+    again until the director acts, and the button that would let them is
+    gated on this exact query."""
+
+    async def test_returns_none_when_no_solve_ever_requested(
+        self, db_session: AsyncSession
+    ) -> None:
+        tournament_id, _event_id = await _make_tournament(db_session)
+
+        assert await latest_solve(db_session, tournament_id) is None
+
+    async def test_returns_a_non_stale_terminal_row_unchanged(
+        self, db_session: AsyncSession
+    ) -> None:
+        tournament_id, _event_id = await _make_tournament(db_session)
+        succeeded = ScheduleSolve(
+            tournament_id=tournament_id,
+            trigger=ScheduleSolveTrigger.manual,
+            status=ScheduleSolveStatus.succeeded,
+            verdict=SolverVerdict.optimal,
+            finished_at=datetime.now(UTC),
+        )
+        db_session.add(succeeded)
+        await db_session.commit()
+
+        result = await latest_solve(db_session, tournament_id)
+
+        assert result is not None
+        assert result.id == succeeded.id
+        assert result.status is ScheduleSolveStatus.succeeded
+
+    async def test_running_within_lease_is_unchanged_and_writes_nothing(
+        self, db_session: AsyncSession, engine: AsyncEngine
+    ) -> None:
+        """A ``running`` row that is merely slow — not yet past its lease —
+        must come back untouched, and no write may have happened at all: a
+        fresh, independent session reading the same row confirms it."""
+        tournament_id, _event_id = await _make_tournament(db_session)
+        fresh_started_at = datetime.now(UTC) - timedelta(
+            seconds=schedule_solves.STALE_RUNNING_LEASE_S - 1
+        )
+        running = ScheduleSolve(
+            tournament_id=tournament_id,
+            trigger=ScheduleSolveTrigger.go_live,
+            status=ScheduleSolveStatus.running,
+            started_at=fresh_started_at,
+        )
+        db_session.add(running)
+        await db_session.commit()
+        running_id = running.id
+
+        result = await latest_solve(db_session, tournament_id)
+
+        assert result is not None
+        assert result.id == running_id
+        assert result.status is ScheduleSolveStatus.running
+        assert result.finished_at is None
+        assert result.error is None
+
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        async with sessionmaker() as fresh_db:
+            fresh = (
+                await fresh_db.execute(
+                    select(ScheduleSolve).where(ScheduleSolve.id == running_id)
+                )
+            ).scalar_one()
+            assert fresh.status is ScheduleSolveStatus.running
+            assert fresh.finished_at is None
+
+    async def test_running_past_lease_is_reaped_and_durably_committed(
+        self, db_session: AsyncSession, engine: AsyncEngine
+    ) -> None:
+        """The stranded-``running`` row (#1102) is reaped by the very next GET
+        of the tournament detail page. Critically, the write must be durably
+        committed, not just patched onto the in-memory row this call returns:
+        a second, independent session reading the same row afterwards (a
+        stand-in for "someone else reads it next") must also see ``failed``."""
+        tournament_id, _event_id = await _make_tournament(db_session)
+        stale_started_at = datetime.now(UTC) - timedelta(
+            seconds=schedule_solves.STALE_RUNNING_LEASE_S + 1
+        )
+        running = ScheduleSolve(
+            tournament_id=tournament_id,
+            trigger=ScheduleSolveTrigger.go_live,
+            status=ScheduleSolveStatus.running,
+            started_at=stale_started_at,
+            rerun_requested=True,
+        )
+        db_session.add(running)
+        await db_session.commit()
+        running_id = running.id
+
+        result = await latest_solve(db_session, tournament_id)
+
+        assert result is not None
+        assert result.id == running_id
+        assert result.status is ScheduleSolveStatus.failed
+        assert result.error == schedule_solves.STALE_RUNNING_ERROR
+        assert result.finished_at is not None
+        assert result.wall_time_ms is None
+        # Mirrors _finish_failed_best_effort: an ordinary crash already drops
+        # rerun_requested silently, and the reaper does not special-case it.
+        assert result.rerun_requested is True
+
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        async with sessionmaker() as fresh_db:
+            fresh = (
+                await fresh_db.execute(
+                    select(ScheduleSolve).where(ScheduleSolve.id == running_id)
+                )
+            ).scalar_one()
+            assert fresh.status is ScheduleSolveStatus.failed
+            assert fresh.error == schedule_solves.STALE_RUNNING_ERROR
+            assert fresh.finished_at is not None
 
 
 class TestSolveJob:

--- a/docs/adr/20260718-a-stale-running-solve-is-reaped-by-the-next-reader-or-request.md
+++ b/docs/adr/20260718-a-stale-running-solve-is-reaped-by-the-next-reader-or-request.md
@@ -1,0 +1,142 @@
+# A stale `running` solve is reaped by the next reader or request
+
+Date: 2026-07-18 (date-numbered — sequential numbers collide across concurrent
+worktrees; see ADR-0788's note and the duplicate 0915s in this directory)
+
+## Status
+
+Accepted — fix for issue #1102, decided before implementation.
+
+## Context
+
+`execute_solve` (`app.schedule_solves`) is written so a row is never left
+`running` forever: whatever breaks, its `except` clause is the job's boundary
+handler, and `_finish_failed_best_effort` writes a terminal `failed` status on a
+fresh session. That guarantee holds for any Python exception — but not for a
+hard kill. An OOM (or any SIGKILL / pod eviction / node restart) terminates the
+worker process instantly; no `except` ever runs, and the row is stranded
+`running`.
+
+The worker is deployed as a single-replica `Deployment` running `rq worker`
+directly in its own container (`deploy/uat/templates/worker.yaml`) — there is
+no separate monitor process that forks a child and can observe an abnormal
+child exit (the pattern RQ's own worker uses when *it* forks the job). A cgroup
+OOM kill takes out the whole container, worker included, so nothing inside the
+app ever gets a chance to record what happened.
+
+The `schedule_solves` row *is* the coalescer's in-progress state
+(`request_solve`'s module docstring): a `running` row makes every subsequent
+trigger set `rerun_requested` and return **without enqueuing** — by design, to
+guarantee one solve in flight per tournament. A stranded `running` row is
+therefore not just a bad ledger entry: it permanently wedges that tournament's
+scheduler, and the "Run scheduler" button (gated on `solveInFlight`, which
+reads `queued`/`running`) stays disabled with no error ever surfaced, because
+nothing ever transitions the row out of `running`.
+
+Observed on UAT (issue #1102): a large tournament's solve exceeded the worker's
+memory limit, the worker was OOMKilled (exit 137), RQ restarted the worker, and
+the in-flight solve row stayed `running` indefinitely. Solver queue depth was
+0 — nothing running or queued — yet the UI showed an eternal disabled
+"Solving…".
+
+Two things this decision does **not** need to build:
+
+- **The frontend's failure state already exists.** `solve-strip.tsx` /
+  `data/solve.ts` already render a fully designed `failed` state (headline,
+  server `error` detail, and the "Run scheduler" button re-enabling the moment
+  status leaves `queued`/`running`) and already poll the tournament detail
+  query every 3s while a solve is in flight (`SOLVE_IN_FLIGHT_POLL_MS`). The
+  only missing piece is something to actually *write* `failed` on a stranded
+  row — the read/rendering side needs no change.
+- **A periodic sweep** (a `schedule-solve-reaper` CronJob/compose loop,
+  mirroring `app.retirement_sweep`'s established pattern) was considered and
+  rejected as the *primary* mechanism: it would add a new deploy artifact for
+  something the read path below already covers, for free, at the cadence the
+  UI already polls at.
+
+## Decision
+
+### A fixed 60-second lease, tied to the solver's own time cap
+
+```python
+SOLVE_TIME_CAP_S = 10.0
+STALE_RUNNING_LEASE_S = SOLVE_TIME_CAP_S * 6  # 60.0
+```
+
+`SOLVE_TIME_CAP_S` bounds only phase (b), the CP-SAT call itself; phases (a)
+and (c) do unbounded (if normally fast) DB work outside that cap. 6× gives
+comfortable headroom for that DB work under load while still being short
+enough that a genuinely wedged tournament self-heals within roughly one
+polling cycle. Not env-configurable (unlike `SOLVE_NUM_WORKERS`, which varies
+by deployment's CPU limit) — this is a correctness constant, not a
+deployment-shape knob.
+
+### Reaping happens at the two places that already look at the `running` row
+
+No new job, queue, or scheduled process. A `running` row past its lease is
+found and terminated at whichever of these happens first:
+
+1. **`request_solve`'s coalescer** — it already takes `FOR UPDATE` on a
+   `running` row before deciding what to do with it. Before setting
+   `rerun_requested`, it now also checks staleness; if stale, it reaps the row
+   in place and falls through to the existing "neither queued nor running"
+   branch, inserting a fresh `queued` row for the trigger that just fired.
+   This alone is not sufficient for a **pre-live** tournament, though: nothing
+   calls `request_solve` again until the director acts, and the button that
+   would let them act is disabled until the row is unstuck.
+
+2. **`latest_solve`** — the one query that feeds the tournament detail BFF's
+   `latest_schedule_solve`, which is what gates the Run-scheduler button and
+   what the frontend already polls every 3s while "in flight". This is a new
+   pattern for the codebase: **no GET route currently commits a write** — this
+   is the first "read repair". It is scoped tightly: `latest_solve` re-fetches
+   only a row it already suspects is stale, re-locks it `FOR UPDATE`,
+   re-confirms it is still `running` and still past its lease (the worker may
+   have finished in the gap between the two reads), and only then writes
+   `failed` and commits — before returning the now-corrected row to its
+   caller. It does not turn the route into a general write path.
+
+Both compare against `datetime.now(UTC)` — matching how `started_at` and
+`finished_at` are already written — never `_wall_now()`, which is a distinct,
+naive-local-time concept used for solver business logic.
+
+A reaped row gets:
+
+```python
+STALE_RUNNING_ERROR = "the solve job stopped responding (worker crashed or was killed)"
+```
+
+— `status = failed`, `error = STALE_RUNNING_ERROR`, `finished_at = now`,
+`wall_time_ms` left `NULL` (the job never produced a result).
+
+### Reaping does not special-case `rerun_requested`
+
+`_finish_failed_best_effort` — the *existing* handler for an ordinary Python
+crash — already does not honor `rerun_requested`; it is silently dropped
+whenever a job dies mid-run rather than finishing normally. The reaper mirrors
+that, rather than introducing a third, inconsistent failure semantics:
+
+- On a **live** tournament, match completions keep calling
+  `request_solve(..., match_completed)` regardless of a stuck row; once
+  reaped, the very next completion inserts a fresh row on its own.
+  `rerun_requested` is redundant there.
+- On a **pre-live** tournament, the director already has to return and click
+  "Run scheduler" to make further progress, same as any other `failed` row —
+  reaping does not change that.
+
+## Consequences
+
+- **`api/`-only.** No schema change (no new column, no migration —
+  `started_at` already exists and is all the lease needs), and no web/iOS
+  change: the frontend's `failed` rendering and polling cadence already do
+  the right thing the moment the row's status changes underneath them.
+- **Self-heals within about one polling cycle plus the lease**, with no new
+  deploy surface. A director watching the page sees "Solving…" flip to an
+  honest "The scheduler hit a problem" instead of an eternal spinner.
+- **A GET route can now commit a write**, for the first time in this
+  codebase. Scoped to exactly one function's one guarded transition; not a
+  precedent for GET routes generally becoming write paths.
+- **`rerun_requested` can be silently dropped on reap**, same as it already is
+  on an ordinary crash. Accepted because a live tournament's own
+  match-completion cadence covers it, and a pre-live tournament requires a
+  director's action to proceed either way.


### PR DESCRIPTION
## Summary

Fixes #1102. A schedule-solve worker that's hard-killed mid-run (OOM/SIGKILL, pod eviction, node restart) leaves its `schedule_solves` row stuck `status='running'` forever, since the row's own exception-handler cleanup never gets a chance to run. That permanently wedges `request_solve`'s coalescer, which treats any `running` row as a job already in flight and refuses to enqueue a new one — the "Run scheduler" button stays disabled forever with no error ever surfaced.

- `request_solve` and `latest_solve` now reap a `running` row past a 60s lease (`STALE_RUNNING_LEASE_S = SOLVE_TIME_CAP_S * 6`), under `FOR UPDATE`, re-confirming staleness under the lock before writing `failed`.
- Self-heals via the coalescer's own callers (any new trigger) and via the tournament detail BFF's existing ~3s poll while a solve is in flight — no new job, queue, migration, or deploy surface.
- No frontend change needed: `solve-strip.tsx` already renders the `failed` state fully (error detail, "Run scheduler" re-enabling) the moment the row's status changes.

Full design rationale: `docs/adr/20260718-a-stale-running-solve-is-reaped-by-the-next-reader-or-request.md`.

## Test plan

- [x] `cd api && ruff check app tests && ruff format --check app tests && mypy && pytest` — 1359 passed
- [x] `cd web-client && npm run test:run` — 2804 passed (281 files)
- [x] `cd web-client && npm run lint && npm run build` — clean
- [x] OpenAPI schema drift check — no drift (no route/schema changed)
- [x] New tests cover: a `running` row past its lease is reaped to `failed` (with `STALE_RUNNING_ERROR`) and durably committed via both `request_solve` and `latest_solve`; a `running` row within its lease is left untouched by both
- Not covered by browser QA — the failure mode (a worker hard-killed mid-solve) isn't reproducible by driving a browser; verified entirely at the API test level (see ADR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)