### PR TITLE
Resolve auth bearer-first so an API token wins over an ambient session cookie

### DIFF
--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -4,7 +4,7 @@ import os
 import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
-from typing import Annotated
+from typing import Annotated, Literal
 
 import redis.exceptions
 from coolname import generate_slug
@@ -582,31 +582,90 @@ def _clear_session_cookie(response: Response) -> None:
     )
 
 
+# Which credential authenticated a request. The session endpoint needs this to
+# decide whether to Set-Cookie: only a cookie-authenticated caller gets a browser
+# session (re)issued — an API-token caller must never be handed one.
+CredentialSource = Literal["bearer", "cookie"]
+
+
+async def _resolve_current_user(
+    db: AsyncSession,
+    *,
+    authorization: str | None,
+    session_cookie: str | None,
+) -> tuple[User, CredentialSource] | None:
+    """Resolve the current user from an ``Authorization: Bearer`` header and/or a
+    session cookie, **bearer-first**, returning ``(user, source)`` or ``None``.
+
+    An explicit bearer credential wins over the ambient session cookie: an API
+    client that presents a personal API token must authenticate as that token's
+    user even when it's also carrying a stray guest cookie (e.g. one minted by an
+    earlier ``GET /v1/session``). The bearer is only skipped when it doesn't
+    resolve a live user — then we fall back to the cookie.
+
+    Preserves the tombstoned-guest handling: a cookie that resolves to a
+    merged-away guest (``merged_into_user_id`` set) raises the structured
+    ``session_merged`` 401 rather than silently falling through. Because the
+    bearer wins, that check is only reached when the bearer did *not* resolve a
+    user — a valid bearer alongside a tombstoned cookie succeeds as the bearer
+    user and never looks at the cookie.
+
+    The single resolver shared by ``get_current_user`` and ``GET /v1/session`` so
+    the two auth entry points can't drift.
+    """
+    if authorization:
+        bearer_user = await _find_api_token_user(db, authorization)
+        if bearer_user is not None:
+            return bearer_user, "bearer"
+    if session_cookie:
+        cookie_user = await _find_session_user(db, session_cookie)
+        if cookie_user is not None:
+            if cookie_user.merged_into_user_id is not None:
+                raise await _merged_session_exception(db, cookie_user)
+            return cookie_user, "cookie"
+    return None
+
+
 @router.get("/v1/session", response_model=SessionResponse)
 async def get_session_endpoint(
     response: Response,
     session_cookie: Annotated[str | None, Cookie(alias=SESSION_COOKIE_NAME)] = None,
     csrf_cookie: Annotated[str | None, Cookie(alias=CSRF_COOKIE_NAME)] = None,
+    authorization: Annotated[str | None, Header()] = None,
     db: AsyncSession = Depends(get_session),
 ) -> SessionResponse:
-    user: User | None = None
-    if session_cookie:
-        user = await _find_session_user(db, session_cookie)
-        if user is not None and user.merged_into_user_id is not None:
-            # The cookie's guest was folded into another account. Don't silently
-            # mint a fresh guest (that would quietly swap identities) — tell the
-            # holder so they sign in. A no-cookie / garbage-cookie request still
-            # mints below, preserving the zero-friction first visit.
-            raise await _merged_session_exception(db, user)
-    if user is None:
+    """Return the current session, resolving the caller **bearer-first**.
+
+    An ``Authorization: Bearer <token>`` header (a personal API token minted at
+    ``POST /v1/api-tokens``) takes precedence over the session cookie: an API
+    client gets *its token's* user back and **no ``Set-Cookie``** — we never hand
+    an external tool a browser session. The session cookie is consulted only when
+    the bearer doesn't resolve a live user.
+
+    For a cookie-authenticated caller the endpoint self-heals a dropped CSRF
+    cookie (reissuing it without rotating the session), and a cookie that resolves
+    to a merged-away guest raises the structured ``session_merged`` 401 instead of
+    silently swapping identities.
+
+    Only when *neither* credential resolves a user (no/garbage cookie and no valid
+    bearer) does it mint a fresh guest and Set-Cookie it — the zero-friction first
+    visit.
+    """
+    resolved = await _resolve_current_user(
+        db, authorization=authorization, session_cookie=session_cookie
+    )
+    if resolved is None:
         user, raw_token = await _create_session(db)
         _set_session_cookie(response, raw_token)
-    elif csrf_cookie is None:
-        # Returning session whose (non-HttpOnly) CSRF cookie was dropped —
-        # reissue it so mutations don't permanently 403. Self-heals on the
-        # bootstrap the client makes on every load, without rotating the cookie
-        # (or re-setting the session cookie) when one is already present.
-        _set_csrf_cookie(response)
+    else:
+        user, source = resolved
+        if source == "cookie" and csrf_cookie is None:
+            # Returning cookie session whose (non-HttpOnly) CSRF cookie was
+            # dropped — reissue it so mutations don't permanently 403. Self-heals
+            # on the bootstrap the client makes on every load, without rotating
+            # the cookie (or re-setting the session cookie) when one is already
+            # present. A bearer-authenticated caller gets no cookie of any kind.
+            _set_csrf_cookie(response)
     return await _build_session_response(db, user)
 
 
@@ -658,7 +717,7 @@ async def get_current_user(
     authorization: Annotated[str | None, Header()] = None,
     db: AsyncSession = Depends(get_session),
 ) -> User:
-    """Resolve the authenticated user, cookie first and then a bearer token.
+    """Resolve the authenticated user, **bearer token first** and then the cookie.
 
     Unlike ``GET /v1/session``, this dependency never mints a new session —
     endpoints that create or mutate data require an already-established
@@ -666,28 +725,30 @@ async def get_current_user(
 
     Two credentials are accepted, in a fixed precedence:
 
-    1. **Session cookie** (the browser flow). Resolved directly (rather than via
+    1. **``Authorization: Bearer <token>``** (external tooling). An explicit
+       bearer credential wins over the ambient cookie: the opaque personal API
+       token minted at ``POST /v1/api-tokens`` is looked up by hash, so an API
+       client authenticates as *its* user even when it's also carrying a stray
+       guest cookie. A bearer token whose user is tombstoned does not resolve.
+    2. **Session cookie** (the browser flow), consulted only when the bearer
+       doesn't resolve a live user. Resolved directly (rather than via
        ``get_optional_user``) so it can tell a *tombstoned* guest — whose cookie
        still resolves — apart from no session at all, raising the structured
-       ``session_merged`` 401 for the former. A valid cookie always wins, even
-       when an ``Authorization`` header is also present.
-    2. **``Authorization: Bearer <token>``** (external tooling), consulted only
-       when no valid session cookie resolves a user. The opaque personal API
-       token minted at ``POST /v1/api-tokens`` is looked up by hash; a bearer
-       token whose user is tombstoned does not resolve.
+       ``session_merged`` 401 for the former. Because the bearer wins, that check
+       is only reached when the bearer didn't resolve: a valid bearer alongside a
+       tombstoned cookie succeeds as the bearer user.
 
-    When neither credential resolves a user — no/invalid cookie and a
-    missing/invalid/unknown bearer token — the structured ``session_ended`` 401
-    is raised so the client redirects to sign in (instead of acting as a
-    merged-away ghost, or silently minting a new guest).
+    When neither credential resolves a user — a missing/invalid/unknown bearer
+    token and no/invalid cookie — the structured ``session_ended`` 401 is raised
+    so the client redirects to sign in (instead of acting as a merged-away ghost,
+    or silently minting a new guest).
     """
-    user = await _find_session_user(db, session_cookie) if session_cookie else None
-    if user is not None and user.merged_into_user_id is not None:
-        raise await _merged_session_exception(db, user)
-    if user is None and authorization:
-        user = await _find_api_token_user(db, authorization)
-    if user is None:
+    resolved = await _resolve_current_user(
+        db, authorization=authorization, session_cookie=session_cookie
+    )
+    if resolved is None:
         raise _session_ended_exception()
+    user, _ = resolved
     return user
 
 

--- a/api/tests/test_session.py
+++ b/api/tests/test_session.py
@@ -602,11 +602,13 @@ async def test_unknown_bearer_token_without_cookie_401s(api_client: AsyncClient)
     assert response.json()["detail"]["code"] == "session_ended"
 
 
-async def test_valid_cookie_wins_over_bearer_token(
+async def test_bearer_token_wins_over_ambient_cookie(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     """With BOTH a valid session cookie and a valid (different-user) bearer token
-    present, the cookie's user wins — the bearer header is never consulted."""
+    present, the **bearer** user wins — an explicit API token beats the ambient
+    guest cookie (the Postman case), so the API client isn't shadowed by a stray
+    session cookie handed out by an earlier ``GET /v1/session``."""
     cookie_user = await start_session(api_client, db_session)
 
     # A second, distinct user who owns the bearer token.
@@ -617,12 +619,12 @@ async def test_valid_cookie_wins_over_bearer_token(
 
     response = await api_client.patch(
         "/v1/me",
-        json={"username": "cookie-wins"},
+        json={"username": "bearer-wins"},
         headers={"Authorization": f"Bearer {raw}"},
     )
     assert response.status_code == 200, response.text
-    # The COOKIE user is the one acted upon, not the bearer token's user.
-    assert response.json()["data"]["user"]["id"] == str(cookie_user.id)
+    # The BEARER token's user is the one acted upon, not the cookie's user.
+    assert response.json()["data"]["user"]["id"] == str(bearer_user.id)
 
 
 async def test_bearer_token_for_tombstoned_user_401s(
@@ -643,6 +645,105 @@ async def test_bearer_token_for_tombstoned_user_401s(
     )
     assert response.status_code == 401, response.text
     assert response.json()["detail"]["code"] == "session_ended"
+
+
+async def test_valid_bearer_with_tombstoned_cookie_succeeds_as_bearer(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A valid bearer token alongside a *tombstoned* (merged-away) session cookie
+    authenticates as the bearer user and does NOT raise ``session_merged`` — the
+    bearer wins, so the cookie (and thus its tombstone) is never consulted."""
+    # The bearer belongs to a second, live user, distinct from the tombstoned
+    # cookie holder.
+    async with make_client() as other_client:
+        bearer_user = await start_session(other_client, db_session)
+    raw = await _mint_api_token(db_session, bearer_user)
+
+    # The api_client's own cookie is for a guest that gets merged away.
+    guest = await start_session(api_client, db_session)
+    await _tombstone(db_session, guest, "owner-bearer-wins@example.com")
+    assert guest.id != bearer_user.id
+
+    response = await api_client.patch(
+        "/v1/me",
+        json={"username": "bearer-over-tombstone"},
+        headers={"Authorization": f"Bearer {raw}"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["user"]["id"] == str(bearer_user.id)
+
+
+# ----- GET /v1/session credential precedence --------------------------------
+
+
+async def test_get_session_with_bearer_no_cookie_returns_token_user_no_cookie(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """GET /v1/session for an API-token caller (valid bearer, no cookie) returns
+    that token's user and sets **no** ``session`` cookie — we never hand an
+    external tool a browser session."""
+    async with make_client() as other_client:
+        bearer_user = await start_session(other_client, db_session)
+    raw = await _mint_api_token(db_session, bearer_user)
+    # Drop the cookies the api_client's own mint set, so the bearer is the only
+    # authenticating credential on the wire.
+    api_client.cookies.clear()
+
+    response = await api_client.get(
+        "/v1/session", headers={"Authorization": f"Bearer {raw}"}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["user"]["id"] == str(bearer_user.id)
+    # No browser session handed to an API client — nothing named `session` is set.
+    set_cookies = [h.lower() for h in response.headers.get_list("set-cookie")]
+    assert not any(h.startswith(f"{SESSION_COOKIE_NAME}=") for h in set_cookies)
+
+
+async def test_get_session_bearer_wins_over_guest_cookie(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """GET /v1/session with a guest ``session`` cookie AND a valid bearer for a
+    different user resolves to the **bearer** user (the Postman case)."""
+    cookie_user = await start_session(api_client, db_session)
+
+    async with make_client() as other_client:
+        bearer_user = await start_session(other_client, db_session)
+    raw = await _mint_api_token(db_session, bearer_user)
+    assert bearer_user.id != cookie_user.id
+
+    response = await api_client.get(
+        "/v1/session", headers={"Authorization": f"Bearer {raw}"}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["user"]["id"] == str(bearer_user.id)
+    # The bearer path never (re)issues a browser session cookie.
+    set_cookies = [h.lower() for h in response.headers.get_list("set-cookie")]
+    assert not any(h.startswith(f"{SESSION_COOKIE_NAME}=") for h in set_cookies)
+
+
+async def test_get_session_cookie_only_still_resolves_cookie_user(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """Browser flow unchanged: with only a session cookie (no bearer),
+    GET /v1/session still resolves the cookie's own user."""
+    cookie_user = await start_session(api_client, db_session)
+
+    response = await api_client.get("/v1/session")
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["user"]["id"] == str(cookie_user.id)
+
+
+async def test_get_session_merged_cookie_with_no_bearer_still_401s(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A tombstoned cookie with NO bearer still raises the ``session_merged`` 401
+    on GET /v1/session — it must not silently mint a fresh guest."""
+    guest = await start_session(api_client, db_session)
+    await _tombstone(db_session, guest, "owner-nobearer@example.com")
+
+    response = await api_client.get("/v1/session")
+    assert response.status_code == 401, response.text
+    assert response.json()["detail"]["code"] == "session_merged"
 
 
 # ----- CSRF double-submit guard ---------------------------------------------

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -13,6 +13,23 @@ import struct Foundation.Date
 internal protocol APIProtocol: Sendable {
     /// Get Session Endpoint
     ///
+    /// Return the current session, resolving the caller **bearer-first**.
+    ///
+    /// An ``Authorization: Bearer <token>`` header (a personal API token minted at
+    /// ``POST /v1/api-tokens``) takes precedence over the session cookie: an API
+    /// client gets *its token's* user back and **no ``Set-Cookie``** — we never hand
+    /// an external tool a browser session. The session cookie is consulted only when
+    /// the bearer doesn't resolve a live user.
+    ///
+    /// For a cookie-authenticated caller the endpoint self-heals a dropped CSRF
+    /// cookie (reissuing it without rotating the session), and a cookie that resolves
+    /// to a merged-away guest raises the structured ``session_merged`` 401 instead of
+    /// silently swapping identities.
+    ///
+    /// Only when *neither* credential resolves a user (no/garbage cookie and no valid
+    /// bearer) does it mint a fresh guest and Set-Cookie it — the zero-friction first
+    /// visit.
+    ///
     /// - Remark: HTTP `GET /v1/session`.
     /// - Remark: Generated from `#/paths//v1/session/get(get_session_endpoint_v1_session_get)`.
     func getSessionEndpointV1SessionGet(_ input: Operations.GetSessionEndpointV1SessionGet.Input) async throws -> Operations.GetSessionEndpointV1SessionGet.Output
@@ -860,6 +877,23 @@ internal protocol APIProtocol: Sendable {
 /// Convenience overloads for operation inputs.
 extension APIProtocol {
     /// Get Session Endpoint
+    ///
+    /// Return the current session, resolving the caller **bearer-first**.
+    ///
+    /// An ``Authorization: Bearer <token>`` header (a personal API token minted at
+    /// ``POST /v1/api-tokens``) takes precedence over the session cookie: an API
+    /// client gets *its token's* user back and **no ``Set-Cookie``** — we never hand
+    /// an external tool a browser session. The session cookie is consulted only when
+    /// the bearer doesn't resolve a live user.
+    ///
+    /// For a cookie-authenticated caller the endpoint self-heals a dropped CSRF
+    /// cookie (reissuing it without rotating the session), and a cookie that resolves
+    /// to a merged-away guest raises the structured ``session_merged`` 401 instead of
+    /// silently swapping identities.
+    ///
+    /// Only when *neither* credential resolves a user (no/garbage cookie and no valid
+    /// bearer) does it mint a fresh guest and Set-Cookie it — the zero-friction first
+    /// visit.
     ///
     /// - Remark: HTTP `GET /v1/session`.
     /// - Remark: Generated from `#/paths//v1/session/get(get_session_endpoint_v1_session_get)`.
@@ -9168,6 +9202,23 @@ internal enum Components {
 /// API operations, with input and output types, generated from `#/paths` in the OpenAPI document.
 internal enum Operations {
     /// Get Session Endpoint
+    ///
+    /// Return the current session, resolving the caller **bearer-first**.
+    ///
+    /// An ``Authorization: Bearer <token>`` header (a personal API token minted at
+    /// ``POST /v1/api-tokens``) takes precedence over the session cookie: an API
+    /// client gets *its token's* user back and **no ``Set-Cookie``** — we never hand
+    /// an external tool a browser session. The session cookie is consulted only when
+    /// the bearer doesn't resolve a live user.
+    ///
+    /// For a cookie-authenticated caller the endpoint self-heals a dropped CSRF
+    /// cookie (reissuing it without rotating the session), and a cookie that resolves
+    /// to a merged-away guest raises the structured ``session_merged`` 401 instead of
+    /// silently swapping identities.
+    ///
+    /// Only when *neither* credential resolves a user (no/garbage cookie and no valid
+    /// bearer) does it mint a fresh guest and Set-Cookie it — the zero-friction first
+    /// visit.
     ///
     /// - Remark: HTTP `GET /v1/session`.
     /// - Remark: Generated from `#/paths//v1/session/get(get_session_endpoint_v1_session_get)`.

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -11,7 +11,25 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get Session Endpoint */
+        /**
+         * Get Session Endpoint
+         * @description Return the current session, resolving the caller **bearer-first**.
+         *
+         *     An ``Authorization: Bearer <token>`` header (a personal API token minted at
+         *     ``POST /v1/api-tokens``) takes precedence over the session cookie: an API
+         *     client gets *its token's* user back and **no ``Set-Cookie``** — we never hand
+         *     an external tool a browser session. The session cookie is consulted only when
+         *     the bearer doesn't resolve a live user.
+         *
+         *     For a cookie-authenticated caller the endpoint self-heals a dropped CSRF
+         *     cookie (reissuing it without rotating the session), and a cookie that resolves
+         *     to a merged-away guest raises the structured ``session_merged`` 401 instead of
+         *     silently swapping identities.
+         *
+         *     Only when *neither* credential resolves a user (no/garbage cookie and no valid
+         *     bearer) does it mint a fresh guest and Set-Cookie it — the zero-friction first
+         *     visit.
+         */
         get: operations["get_session_endpoint_v1_session_get"];
         put?: never;
         post?: never;
@@ -4124,7 +4142,9 @@ export interface operations {
     get_session_endpoint_v1_session_get: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string | null;
+            };
             path?: never;
             cookie?: {
                 session?: string | null;


### PR DESCRIPTION
## Problem

Personal API tokens and browser sessions are the same `user_tokens` rows under different `context`s, and both `get_current_user` and `GET /v1/session` can resolve either credential. But precedence was **cookie-first**, and `GET /v1/session` ignored the `Authorization` header entirely — it only read the cookie and, finding none, minted a guest and `Set-Cookie`'d it.

That's a footgun for any cookie-persisting API client (e.g. **Postman**):

1. Client calls `GET /v1/session` carrying a valid `Authorization: Bearer <api-token>`.
2. `/v1/session` ignores the token, mints a **guest** user, and hands back that guest's session cookie.
3. On every later call, `get_current_user` sees the ambient guest cookie **first** and never consults the bearer → the client authenticates as the permission-less guest → **403 Forbidden**, even though the token's user holds the permission.

Reproduced against UAT: bearer-only `GET /v1/tournaments` → `200`; guest-cookie **+** bearer → `403`.

## Fix

An **explicit bearer credential now wins over the ambient cookie**, and both entry points share one resolver so they can't drift again.

- New `_resolve_current_user(db, *, authorization, session_cookie)` → `(user, "bearer" | "cookie") | None`, bearer-first. Tombstoned-cookie handling is preserved and only reached when the bearer doesn't resolve, so a valid bearer alongside a merged-away cookie succeeds as the bearer user.
- `get_current_user` delegates (401 on `None`).
- `GET /v1/session` delegates too — mints a guest only when **neither** credential resolves, and issues a session/CSRF cookie only on the **cookie** path. An API-token caller now gets its token's user back with **no `Set-Cookie`** (we never hand an external tool a browser session).

## Tests

- `GET /v1/session` with bearer + no cookie → token's user, **no** `session` Set-Cookie.
- `GET /v1/session` guest cookie + different-user bearer → resolves the **bearer** user (the Postman case).
- Authed endpoint, guest cookie + privileged bearer → acts as the bearer user (no 403).
- Valid bearer + tombstoned cookie → 200 as bearer user (no `session_merged`).
- Unchanged: browser cookie-only flow; no-credential guest mint + Set-Cookie; tombstoned cookie w/ no bearer still raises `session_merged`.

Full API suite: **1382 passed**; `ruff` + `mypy --strict` clean.

## Generated types
Regenerated `web-client/src/api/schema.d.ts` and `ios/Fortymm/Generated/Types.swift` for the `/v1/session` docstring + new optional `authorization` header param (no web/iOS behavior change required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrPmGP6EbyRPRSPgS3mtWT