### PR TITLE
Add an MCP server exposing match create/score/approve over shared services

### DIFF
--- a/api/app/api_token_auth.py
+++ b/api/app/api_token_auth.py
@@ -1,0 +1,53 @@
+"""Shared bearer-token → user resolver for personal API tokens (issue #1130).
+
+The single place that turns a raw ``api``-context bearer token into the live
+``User`` behind it: ``hash_token(raw)`` → ``User`` joined to its ``UserToken``
+where ``context == API_TOKEN_CONTEXT`` and the user is not tombstoned. Router-free
+(no FastAPI imports) so both the HTTP bearer path (``app.sessions`` — the
+``Authorization: Bearer`` header) and the FastMCP ``TokenVerifier`` (the ``/mcp``
+transport, see the shared-services ADR) resolve tokens through exactly this
+function and can never drift.
+
+Lives alongside ``app/token_hashing.py`` (the router-free home for the hasher it
+calls) rather than in either router.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import User, UserToken
+from app.token_hashing import hash_token
+
+# Context for personal, opaque API bearer tokens a user mints for external
+# tooling (issue #1130). Namespaced like every other credential type so the
+# api-tokens flow can rotate/resolve its own rows without touching a user's
+# session / login / email-change / merge tokens. Owned here so the mint endpoint
+# (app/api_tokens.py), the bearer-auth path (app/sessions.py), and the MCP
+# verifier all import one definition. ``app.sessions`` re-exports it for callers
+# that historically imported it from there.
+API_TOKEN_CONTEXT = "api"
+
+
+async def find_api_token_user(db: AsyncSession, raw_token: str) -> User | None:
+    """Resolve the live ``api``-context ``User`` behind a raw bearer token, or
+    ``None`` when the token matches no ``api``-context row or that row's user is
+    tombstoned.
+
+    ``raw_token`` is the credential already parsed out of any transport framing
+    (the ``Bearer <token>`` header for HTTP, the token the MCP verifier is
+    handed) — this function owns only the ``hash_token`` → lookup step. The token
+    is compared by sha256 hash, never in plaintext. Tombstoned (merged-away)
+    users are excluded in the query — ``merged_into_user_id IS NOT NULL`` — so a
+    bearer token for a folded-in guest simply doesn't resolve, the same way the
+    auth-layer session queries keep ghosts from surfacing.
+    """
+    result = await db.execute(
+        select(User)
+        .join(UserToken, UserToken.user_id == User.id)
+        .where(
+            UserToken.token == hash_token(raw_token),
+            UserToken.context == API_TOKEN_CONTEXT,
+            User.merged_into_user_id.is_(None),
+        )
+    )
+    return result.scalar_one_or_none()

--- a/api/app/db.py
+++ b/api/app/db.py
@@ -32,9 +32,21 @@ def get_engine() -> AsyncEngine:
     return _engine
 
 
-async def get_session() -> AsyncIterator[AsyncSession]:
+def get_sessionmaker() -> async_sessionmaker[AsyncSession]:
+    """The process-wide async session factory, engine lazily initialised.
+
+    ``get_session`` is the request-scoped FastAPI dependency; this is the raw
+    factory for callers that own the session lifecycle themselves — an MCP tool
+    or verifier, a script, a REPL — outside any FastAPI request (see
+    ``api/CLAUDE.md``: "outside a request you own the session lifecycle
+    yourself").
+    """
     if _sessionmaker is None:
         get_engine()
     assert _sessionmaker is not None
-    async with _sessionmaker() as session:
+    return _sessionmaker
+
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    async with get_sessionmaker()() as session:
         yield session

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -6,7 +6,7 @@ import os
 import secrets
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 
 import redis.asyncio as redis_asyncio
 from fastapi import FastAPI, Request, Response
@@ -23,6 +23,7 @@ from app.api_tokens import router as api_tokens_router
 from app.dashboard import router as dashboard_router
 from app.match_calls import pin_tick_loop
 from app.matches import router as matches_router
+from app.mcp_server import mcp
 from app.notifications.router import router as notifications_router
 from app.players import router as players_router
 from app.rate_limiting import init_rate_limit_redis, shutdown_rate_limit_redis
@@ -43,9 +44,16 @@ from app.tournaments import router as tournaments_router
 # line below surfaces alongside "Application startup complete" in every stack.
 log = logging.getLogger("uvicorn.error")
 
+# The FastMCP Streamable-HTTP ASGI app, mounted at ``/mcp`` below. Built at
+# ``path="/"`` so the endpoint is exactly ``/mcp/`` once mounted (its default
+# ``/mcp`` would nest to ``/mcp/mcp``). It carries its OWN lifespan — the
+# Streamable-HTTP session manager — which MUST run or every MCP call 500s, so
+# ``lifespan`` below enters it alongside the app's own startup.
+mcp_app = mcp.http_app(path="/")
+
 
 @asynccontextmanager
-async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
     connection = redis_asyncio.from_url(redis_url, encoding="utf-8")
     try:
@@ -73,7 +81,13 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         # app.match_calls). Cancelled (and awaited) on shutdown.
         pin_tick_task = asyncio.create_task(pin_tick_loop())
         try:
-            yield
+            # Run the mounted FastMCP app's own lifespan (its Streamable-HTTP
+            # session manager) for the whole of ours — without this the manager
+            # never starts and every /mcp request 500s. AsyncExitStack unwinds
+            # it before the app teardown below.
+            async with AsyncExitStack() as stack:
+                await stack.enter_async_context(mcp_app.lifespan(app))
+                yield
         finally:
             pin_tick_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -191,6 +205,12 @@ app.include_router(dashboard_router)
 app.include_router(notifications_router)
 app.include_router(tournaments_router)
 app.include_router(admin_schedule_solves_router)
+
+# The MCP server (Streamable HTTP) at ``/mcp``. A mounted Starlette sub-app does
+# not contribute to the parent ``openapi.json``, so this endpoint is absent from
+# the generated clients by construction — the mount is additive to the HTTP wire
+# contract. Its lifespan is composed into ``lifespan`` above.
+app.mount("/mcp", mcp_app)
 
 SOLVER_HEALTH_TIMEOUT = 10.0
 

--- a/api/app/match_creation.py
+++ b/api/app/match_creation.py
@@ -24,6 +24,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.leagues import resolve_league
+from app.match_errors import (
+    OpponentNotFoundError,
+    RatedNeedsRegisteredOpponentError,
+    SelfMatchError,
+)
 from app.match_queries import match_eager_options
 from app.models import (
     Match,
@@ -32,11 +37,6 @@ from app.models import (
     MatchSidePlayer,
     MatchStatus,
     User,
-)
-from app.result_acceptance import (
-    OpponentNotFoundError,
-    RatedNeedsRegisteredOpponentError,
-    SelfMatchError,
 )
 
 

--- a/api/app/match_creation.py
+++ b/api/app/match_creation.py
@@ -1,0 +1,144 @@
+"""The transport-neutral core of creating a match.
+
+``create_match`` used to live inline in the ``app.matches`` router handler: it
+resolved the opponent, enforced the rated-needs-registered-opponent rule, built
+the two sides (including the player-less sentinel side a solo match carries),
+committed, and serialised — all in the handler body. It's extracted here as a
+leaf module so a second caller (the MCP server, a script, a worker) can drive
+the same flow without an HTTP request.
+
+Following ``api/CLAUDE.md``'s rule of thumb, creation is a plain module-level
+async function taking ``db`` rather than a class-plus-provider: it has no
+collaborator worth injecting (``resolve_league`` is itself a module-level
+function). It returns the loaded domain :class:`Match`, ready to serialise, and
+signals the three rejection cases with domain exceptions from
+``app.result_acceptance`` — ``SelfMatchError``, ``OpponentNotFoundError``,
+``RatedNeedsRegisteredOpponentError`` — never ``HTTPException``. The HTTP
+handler is a thin adapter that maps each back to the exact status and body it
+produced before.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.leagues import resolve_league
+from app.match_queries import match_eager_options
+from app.models import (
+    Match,
+    MatchSettings,
+    MatchSide,
+    MatchSidePlayer,
+    MatchStatus,
+    User,
+)
+from app.result_acceptance import (
+    OpponentNotFoundError,
+    RatedNeedsRegisteredOpponentError,
+    SelfMatchError,
+)
+
+
+def _add_side(match: Match, side_number: int, player: User | None) -> None:
+    """Attach a side to ``match``. ``player=None`` creates the sentinel
+    "no opponent" side — a real second side carrying no player — so an
+    opponent-less match still has two sides and is therefore scorable. It reads
+    as opponent-less wherever the code inspects ``side.players`` (serialization
+    renders the "No opponent" placeholder; rating updates skip player-less
+    sides).
+
+    Wiring up the ``match`` relationship on both the side and the side-player
+    is what populates their (non-null, denormalized) ``match_id`` columns on
+    flush."""
+    side = MatchSide(match=match, side_number=side_number)
+    if player is not None:
+        side.players.append(MatchSidePlayer(match=match, user=player))
+
+
+async def _load_created_match(db: AsyncSession, match_id: uuid.UUID) -> Match:
+    """Reload the just-committed match with the full read eager-load chain.
+
+    Returns a non-optional :class:`Match`: the row was committed one statement
+    earlier in the same session, so its absence is a genuine invariant
+    violation, not a client-handleable ``None`` — raise loudly rather than hand
+    back an ``assert``-guarded value (``api/CLAUDE.md``)."""
+    match = (
+        await db.execute(
+            select(Match).where(Match.id == match_id).options(*match_eager_options())
+        )
+    ).scalar_one_or_none()
+    if match is None:
+        raise RuntimeError(f"just-created match {match_id} vanished before reload")
+    return match
+
+
+async def create_match(
+    db: AsyncSession,
+    *,
+    creator: User,
+    opponent_user_id: uuid.UUID | None,
+    league_id: uuid.UUID | None,
+    best_of: int,
+    rated: bool,
+) -> Match:
+    """Create a match for ``creator`` and return it loaded and ready to serialise.
+
+    Resolves the opponent (``opponent_user_id`` optional — a solo match gets a
+    player-less sentinel side and is always unrated), enforces the
+    rated-needs-registered-opponent rule, builds both sides, commits, and
+    reloads. Binds to the default league when ``league_id`` is omitted.
+
+    Raises :class:`SelfMatchError` when the opponent is the creator,
+    :class:`OpponentNotFoundError` when the opponent id resolves to no live
+    user, and :class:`RatedNeedsRegisteredOpponentError` when a rated match is
+    requested with no registered opponent. It never raises ``HTTPException`` —
+    it has no HTTP context; the caller adapts these to its transport."""
+    opponent: User | None = None
+    if opponent_user_id is not None:
+        if opponent_user_id == creator.id:
+            raise SelfMatchError
+        opponent = (
+            await db.execute(
+                select(User).where(
+                    User.id == opponent_user_id,
+                    User.merged_into_user_id.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+        if opponent is None:
+            raise OpponentNotFoundError
+
+    if rated and opponent is None:
+        raise RatedNeedsRegisteredOpponentError
+
+    # Solo matches (no opponent picked) get a player-less sentinel opponent
+    # side below, so they're scorable but can never affect ratings regardless
+    # of the requested flag.
+    affects_rating = rated and opponent is not None
+
+    league = await resolve_league(db, league_id)
+
+    settings = MatchSettings(
+        team_size=1,
+        best_of=best_of,
+        affects_rating=affects_rating,
+    )
+    match = Match(
+        match_settings=settings,
+        league=league,
+        created_by_user_id=creator.id,
+        status=MatchStatus.in_progress,
+    )
+    _add_side(match, 1, creator)
+    # Always create side 2. With no opponent it's a player-less sentinel side,
+    # which keeps the match scorable (two sides) while reading as "No opponent".
+    _add_side(match, 2, opponent)
+    # Games are no longer pre-created at match-create time — they're written
+    # lazily by ``POST .../games/{n}/scores/new`` keyed on the game number, so
+    # the FE can deep-link to any 1..best_of without us guessing.
+
+    db.add(match)
+    await db.commit()
+
+    return await _load_created_match(db, match.id)

--- a/api/app/match_creation.py
+++ b/api/app/match_creation.py
@@ -12,7 +12,7 @@ async function taking ``db`` rather than a class-plus-provider: it has no
 collaborator worth injecting (``resolve_league`` is itself a module-level
 function). It returns the loaded domain :class:`Match`, ready to serialise, and
 signals the three rejection cases with domain exceptions from
-``app.result_acceptance`` — ``SelfMatchError``, ``OpponentNotFoundError``,
+``app.match_errors`` — ``SelfMatchError``, ``OpponentNotFoundError``,
 ``RatedNeedsRegisteredOpponentError`` — never ``HTTPException``. The HTTP
 handler is a thin adapter that maps each back to the exact status and body it
 produced before.

--- a/api/app/match_errors.py
+++ b/api/app/match_errors.py
@@ -1,0 +1,173 @@
+"""The match-flow domain exception family.
+
+A neutral leaf that holds every domain exception the match-flow services
+(``match_creation``, ``match_scoring``, ``result_proposal``, ``result_acceptance``)
+raise, so those services don't have to import one another just to share an
+exception type — dissolving the import cycle that pulled them together when the
+family lived on ``result_acceptance``.
+
+None of these is ever an ``HTTPException``: each service is transport-neutral and
+signals a rejection with a plain domain exception, and each adapter (the HTTP
+router, the MCP tools) maps it back to the exact response it produced before.
+
+It imports only ``app.models`` and ``app.schemas.match`` for the two exceptions
+that carry a payload (``NegotiationConflictError`` a :class:`Match`,
+``ScoreConflictError`` a :class:`MatchDetailsScore`) — both leaf modules — so it
+stays cycle-free.
+"""
+
+from app.models import Match
+from app.schemas.match import MatchDetailsScore
+
+
+class SelfMatchError(Exception):
+    """Raised by the match-creation service when the requested opponent is the
+    acting user themselves. The HTTP adapter maps this to the existing 422
+    ``"You cannot start a match against yourself."``."""
+
+
+class OpponentNotFoundError(Exception):
+    """Raised by the match-creation service when the requested opponent id does
+    not resolve to a live (non-tombstoned) user. The HTTP adapter maps this to
+    the existing 404 ``"Opponent not found."``."""
+
+
+class RatedNeedsRegisteredOpponentError(Exception):
+    """Raised by the match-creation service when a rated match is requested
+    without a registered opponent (a solo match cannot be rated). The HTTP
+    adapter maps this to the existing 422
+    ``"A rated match needs a registered opponent."``."""
+
+
+class MatchClosedError(Exception):
+    """Raised by :func:`app.result_proposal.propose_result` when the match has
+    reached a terminal status (``completed``/``voided``) and is closed to new
+    proposals. The HTTP adapter maps this to the existing 409
+    ``"This match is no longer open to results."``. Never an ``HTTPException`` —
+    the caller adapts it to its transport."""
+
+
+class UndecidedBoardError(Exception):
+    """Raised by :func:`app.result_proposal.propose_result` when the proposed
+    board fails the strict finalize validator (empty, gappy-past-decider,
+    duplicate/out-of-range game numbers, or still-undecided) — i.e. it can't be
+    a result. Carries the validator's human-readable ``ValueError`` message; the
+    HTTP adapter maps it to the existing 422 ``str`` body. Never an
+    ``HTTPException``."""
+
+
+class NegotiationConflictError(Exception):
+    """Raised by :func:`app.result_proposal.propose_result` when the propose lost
+    the negotiation race: a first post found a result already exists, a counter
+    targeted a ``supersedes_result_id`` that is no longer the live standing
+    proposal, or the ``uq_match_results_supersedes_result_id`` unique constraint
+    tripped at commit (two concurrent counters superseding the same parent).
+
+    Carries the loaded (or reloaded) :class:`Match` so the HTTP adapter can build
+    the exact viewer-relative negotiation snapshot (``_negotiation_conflict`` /
+    ``_negotiation``) it produced before, letting a client that lost the race
+    re-render from the 409 body without an extra round-trip. Never an
+    ``HTTPException`` — the caller adapts it to its transport."""
+
+    def __init__(self, match: Match) -> None:
+        super().__init__("The standing proposal has moved on.")
+        self.match = match
+
+
+class StandingResultConflictError(Exception):
+    """Raised when the ``result_id`` handed to
+    :func:`app.result_acceptance.accept_standing_result` is no longer the live
+    standing proposal — a concurrent counter superseded it, it was already
+    accepted, or there is no standing proposal at all. The router maps this to
+    the existing 409 carrying the moved-on negotiation state."""
+
+
+class PostedGamesNotDecisiveError(Exception):
+    """Raised when the match's committed games no longer decide a winner at the
+    moment of acceptance. Practically unreachable (a result only stands once its
+    board is decided, and the board is frozen while it stands), but the core
+    stays total rather than silently stamping no winner. The router maps this to
+    the existing 409 ``"The posted games no longer decide this match."``."""
+
+
+class ResultNotFoundError(Exception):
+    """Raised by :func:`app.result_acceptance.accept_result` when the target
+    ``result_id`` is not a result on the loaded match at all (as opposed to being
+    present but no longer the live standing proposal, which is
+    :class:`StandingResultConflictError`). The HTTP adapter maps this to the
+    existing 404 ``"Result not found."``. Never an ``HTTPException`` — the caller
+    adapts it to its transport."""
+
+    def __init__(self) -> None:
+        super().__init__("Result not found.")
+
+
+class CannotAcceptOwnProposalError(Exception):
+    """Raised by :func:`app.result_acceptance.accept_result` when the accepting
+    user is a participant on the *submitter's* side of the standing proposal. The
+    proposing side already consented by proposing, so only a participant on the
+    opposing side may accept (in singles, the submitter themselves can't accept
+    their own proposal). The HTTP adapter maps this to the existing 409
+    ``"You can't accept your own proposal."``. Never an ``HTTPException`` — the
+    caller adapts it to its transport."""
+
+    def __init__(self) -> None:
+        super().__init__("You can't accept your own proposal.")
+
+
+class MatchNotFoundError(Exception):
+    """Raised by the per-game score service (``app.match_scoring``) when the
+    write target can't be resolved — either the match id is absent or the acting
+    user isn't a participant (today's score endpoints collapse both into one
+    opaque 404 so a non-participant can't probe match existence), or, on the
+    update/delete paths, the addressed game score doesn't exist.
+
+    Carries the exact ``message`` the HTTP adapter must reproduce as its 404
+    ``detail``: ``"Match not found."`` for an absent match or non-participant,
+    ``"Score not found."`` for a missing game score. Never an ``HTTPException`` —
+    it has no HTTP context; the caller adapts it to its transport."""
+
+    def __init__(self, message: str = "Match not found.") -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class MatchNotScorableError(Exception):
+    """Raised by the per-game score service when the loaded match can't be
+    scored. It carries the exact ``http_status`` (422 or 409) **and** ``message``
+    for each of ``_enforce_scorable``'s four reason-specific outcomes — no
+    opponent (422), a posted result (409), an uncalled scheduled match (409), or
+    any other non-scorable/terminal state (409) — so the HTTP adapter reproduces
+    the identical response byte-for-byte while the MCP adapter reads the message.
+    Never an ``HTTPException`` — the caller adapts it to its transport."""
+
+    def __init__(self, *, http_status: int, message: str) -> None:
+        super().__init__(message)
+        self.http_status = http_status
+        self.message = message
+
+
+class ScoreNotAllowedError(Exception):
+    """Raised by the per-game score service when a scratchpad write is legal to
+    attempt but disallowed by a cross-game rule — the addressed game exceeds the
+    match's ``best_of`` range, or the prospective board would leave the match
+    decided before its last scored game (overrun). Both map to a 422 carrying
+    this exception's exact message. Never an ``HTTPException``."""
+
+
+class ScoreConflictError(Exception):
+    """Raised by the per-game score service (``app.match_scoring``) when a
+    scratchpad write loses a concurrent-participant race: a create finds the
+    game already scored (or trips the unique constraint at commit), or an
+    update's ``expected_version`` no longer matches the committed row.
+
+    Carries ``committed_score`` — the game's score as it actually stands now,
+    including its ``version`` — so the HTTP adapter can rebuild the exact 409
+    ``MatchGameScoreConflict`` body (``_score_conflict``) and the MCP adapter can
+    point the agent back at ``get_match``. It is ``None`` only when the committed
+    row could not be re-read (the match vanished). Never an ``HTTPException`` —
+    it has no HTTP context; the caller adapts it to its transport."""
+
+    def __init__(self, *, committed_score: MatchDetailsScore | None) -> None:
+        super().__init__("This game was saved by someone else while you were editing.")
+        self.committed_score = committed_score

--- a/api/app/match_errors.py
+++ b/api/app/match_errors.py
@@ -65,7 +65,7 @@ class NegotiationConflictError(Exception):
 
     Carries the loaded (or reloaded) :class:`Match` so the HTTP adapter can build
     the exact viewer-relative negotiation snapshot (``_negotiation_conflict`` /
-    ``_negotiation``) it produced before, letting a client that lost the race
+    ``negotiation``) it produced before, letting a client that lost the race
     re-render from the 409 body without an extra round-trip. Never an
     ``HTTPException`` — the caller adapts it to its transport."""
 
@@ -135,7 +135,7 @@ class MatchNotFoundError(Exception):
 class MatchNotScorableError(Exception):
     """Raised by the per-game score service when the loaded match can't be
     scored. It carries the exact ``http_status`` (422 or 409) **and** ``message``
-    for each of ``_enforce_scorable``'s four reason-specific outcomes — no
+    for each of ``ensure_scorable``'s four reason-specific outcomes — no
     opponent (422), a posted result (409), an uncalled scheduled match (409), or
     any other non-scorable/terminal state (409) — so the HTTP adapter reproduces
     the identical response byte-for-byte while the MCP adapter reads the message.

--- a/api/app/match_result_notifications.py
+++ b/api/app/match_result_notifications.py
@@ -13,7 +13,7 @@ never a router — so it stays cycle-free and is drivable outside an HTTP reques
 import uuid
 
 from app.match_queries import my_side, opponent_side
-from app.match_serialization import _negotiation
+from app.match_serialization import negotiation
 from app.models import Match
 from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
 from app.notifications.service import NotificationService
@@ -109,7 +109,7 @@ async def notify_result_posted(
     if recipient_side is None or not recipient_side.players:
         return
     # Derive counter-vs-first-post from the same viewer-relative negotiation
-    # state the BFF/UI use (``_negotiation``'s ``"corrected"`` vs ``"review"``),
+    # state the BFF/UI use (``negotiation``'s ``"corrected"`` vs ``"review"``),
     # rather than the raw ``supersedes_result_id is not None`` check — that
     # naive check is wrong on a self-edit (poster corrects their own standing
     # proposal before the recipient ever answers): it supersedes a result, but
@@ -117,7 +117,7 @@ async def notify_result_posted(
     # "corrected", so they must get the Accept/Suggest-correction prompt, not
     # Accept/Counter.
     is_counter = (
-        _negotiation(match, recipient_side.players[0].user_id).viewer_state
+        negotiation(match, recipient_side.players[0].user_id).viewer_state
         == "corrected"
     )
     copy = _result_confirmation_copy(match, poster_id, is_counter=is_counter)

--- a/api/app/match_result_notifications.py
+++ b/api/app/match_result_notifications.py
@@ -1,0 +1,144 @@
+"""The result-acceptance push/in-app notification cluster.
+
+Extracted out of the ``app.matches`` router so both the HTTP handler
+(``post_match_result``) and the MCP ``propose_result`` tool can queue the
+"accept or suggest a correction to the result your opponent posted" prompt
+without one adapter importing the other's router internals (``api/CLAUDE.md`` —
+"don't import another router's internals").
+
+FastAPI-free: it imports only domain/query/serializer/notification modules —
+never a router — so it stays cycle-free and is drivable outside an HTTP request.
+"""
+
+import uuid
+
+from app.match_queries import my_side, opponent_side
+from app.match_serialization import _negotiation
+from app.models import Match
+from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
+from app.notifications.service import NotificationService
+from app.notifications.taxonomy import NotificationCategory
+from app.result_acceptance import side_win_counts
+from app.result_chain import standing_result
+from app.schemas.notification import NotificationJob
+
+# En-dash between scores reads better than a hyphen in notification copy.
+_SCORE_DASH = "–"
+
+
+def _game_scores_text(match: Match, poster_side_number: int) -> str:
+    """Compact per-game scores oriented poster-first (e.g. ``"11–7, 9–11"``),
+    so they line up with the games-won headline the recipient sees. Games with
+    no saved score are skipped."""
+    parts: list[str] = []
+    for game in sorted(match.games, key=lambda g: g.game_number):
+        if game.score is None:
+            continue
+        if poster_side_number == 1:
+            poster_pts, recipient_pts = (
+                game.score.side_1_points,
+                game.score.side_2_points,
+            )
+        else:
+            poster_pts, recipient_pts = (
+                game.score.side_2_points,
+                game.score.side_1_points,
+            )
+        parts.append(f"{poster_pts}{_SCORE_DASH}{recipient_pts}")
+    return ", ".join(parts)
+
+
+def _result_confirmation_copy(
+    match: Match, poster_id: uuid.UUID, *, is_counter: bool
+) -> tuple[str, str] | None:
+    """Title + body for the "accept or suggest a correction to the result your
+    opponent posted" push, framed for the *recipient* (the side that didn't
+    post).
+
+    ``is_counter`` picks the closing prompt to match the actual button pair
+    the recipient's in-app callout renders: a first-post shows Accept /
+    Suggest correction (``confirmation-callout-display.tsx``'s ``"review"``
+    case), while a counter shows Accept / Counter (its ``"corrected"`` case,
+    #728). The native iOS push notification itself only ever offers a single,
+    static Approve/Suggest-correction action pair (``PushNotificationManager
+    .swift``) — it doesn't yet grow a counter-specific action — so this body
+    text is the only place a tapped-through counter reads "Counter" until the
+    push actions themselves are split the same way.
+
+    The headline carries the games-won score and, where there's room, the
+    body lists the individual game scores — both oriented so the poster's
+    number comes first. Returns ``None`` when the match isn't a two-human
+    match (nothing to accept)."""
+    poster_side = my_side(match, poster_id)
+    recipient_side = opponent_side(match, poster_id)
+    if poster_side is None or recipient_side is None or not poster_side.players:
+        return None
+
+    poster_name = poster_side.players[0].user.username
+    wins = side_win_counts(match)
+    poster_games = wins.get(poster_side.side_number, 0)
+    recipient_games = wins.get(recipient_side.side_number, 0)
+
+    # Score always reads winner-first; the phrase tells the recipient which
+    # side the poster claims won.
+    if poster_games >= recipient_games:
+        phrase, hi, lo = "beating you", poster_games, recipient_games
+    else:
+        phrase, hi, lo = "losing to you", recipient_games, poster_games
+    headline = f"{poster_name} reported {phrase} {hi}{_SCORE_DASH}{lo}"
+
+    prompt = "Accept or counter?" if is_counter else "Accept or suggest a correction?"
+    games = _game_scores_text(match, poster_side.side_number)
+    body = f"{headline}. Games: {games}. {prompt}" if games else f"{headline}. {prompt}"
+    return "Accept your match result", body
+
+
+async def notify_result_posted(
+    notifications: NotificationService, match: Match, poster_id: uuid.UUID
+) -> None:
+    """Queue an accept/counter (or accept/suggest-correction) prompt to every
+    player on the side that now owes a response. Each enqueued job persists
+    the in-app record (the bell feed) and fans out push/email per the
+    recipient's preferences in the worker. The APNs ``category``/``data``
+    carry the action group, the match id (so a tapped push deep-links to the
+    right match), and the standing result id (so a tapped Approve binds to the
+    exact result the push described, not whatever is standing at tap time — see
+    docs/adr/0007), plus a per-match ``collapse_id`` so a superseding push
+    replaces the stale one on the lock screen."""
+    recipient_side = opponent_side(match, poster_id)
+    if recipient_side is None or not recipient_side.players:
+        return
+    # Derive counter-vs-first-post from the same viewer-relative negotiation
+    # state the BFF/UI use (``_negotiation``'s ``"corrected"`` vs ``"review"``),
+    # rather than the raw ``supersedes_result_id is not None`` check — that
+    # naive check is wrong on a self-edit (poster corrects their own standing
+    # proposal before the recipient ever answers): it supersedes a result, but
+    # the recipient still lands on the first-post "review" view, not
+    # "corrected", so they must get the Accept/Suggest-correction prompt, not
+    # Accept/Counter.
+    is_counter = (
+        _negotiation(match, recipient_side.players[0].user_id).viewer_state
+        == "corrected"
+    )
+    copy = _result_confirmation_copy(match, poster_id, is_counter=is_counter)
+    if copy is None:
+        return
+    title, body = copy
+    result = standing_result(match)
+    push_data = {"match_id": str(match.id)}
+    if result is not None:
+        push_data["result_id"] = str(result.id)
+    for player in recipient_side.players:
+        notifications.enqueue_notification(
+            NotificationJob(
+                user_id=player.user_id,
+                category=NotificationCategory.RESULT_CONFIRM,
+                title=title,
+                body=body,
+                link=f"/matches/{match.id}",
+                action_label="Review",
+                push_category=MATCH_RESULT_CONFIRMATION_CATEGORY,
+                push_data=push_data,
+                collapse_id=f"result-confirm:{match.id}",
+            )
+        )

--- a/api/app/match_scoring.py
+++ b/api/app/match_scoring.py
@@ -1,0 +1,208 @@
+"""The transport-neutral core of the per-game scratchpad score writes.
+
+The three per-game score mutations — create, update, delete — used to live
+inline in the ``app.matches`` router handlers. They're extracted here as a leaf
+module so a second caller (the MCP server, a script, a worker) can drive the
+same "save / clear scratchpad state" flow without an HTTP request.
+
+Following ``api/CLAUDE.md``'s rule of thumb, each is a plain module-level async
+function taking ``db`` rather than a class-plus-provider: none has a collaborator
+worth injecting. Each takes the already-loaded, row-locked, participation-checked
+domain :class:`Match` (the router still owns the ``_load_match_for_scoring`` lock
+and the scorability / overrun guards, exactly as ``accept_standing_result``'s
+router owns its load and pre-guards), mutates the board, and returns the reloaded
+:class:`Match` ready to serialise.
+
+The one race these functions own is the concurrent-participant score conflict:
+they signal it with the domain :class:`ScoreConflictError` (carrying the
+committed score) instead of an ``HTTPException``. The HTTP handler maps it back
+to the exact 409 ``MatchGameScoreConflict`` body it produced before, so the wire
+contract is unchanged.
+"""
+
+import uuid
+from typing import Any, cast
+
+from sqlalchemy import CursorResult, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.match_queries import match_eager_options
+from app.match_serialization import _score_view
+from app.models import Match, MatchGame, MatchGameScore
+from app.result_acceptance import ScoreConflictError
+from app.schemas.match import MatchDetailsScore
+
+
+async def _reload_match(db: AsyncSession, match_id: uuid.UUID) -> Match:
+    """Reload the just-written match with the full read eager-load chain.
+
+    Returns a non-optional :class:`Match`: the row was committed one statement
+    earlier in the same session, so its absence is a genuine invariant
+    violation, not a client-handleable ``None`` (``api/CLAUDE.md``)."""
+    match = (
+        await db.execute(
+            select(Match).where(Match.id == match_id).options(*match_eager_options())
+        )
+    ).scalar_one_or_none()
+    if match is None:
+        raise RuntimeError(f"just-written match {match_id} vanished before reload")
+    return match
+
+
+async def _committed_score(
+    db: AsyncSession, match_id: uuid.UUID, game_number: int
+) -> MatchDetailsScore | None:
+    """The game's score as it actually stands now — for the conflict body after
+    a create lost the unique-constraint race (the committed row belongs to a
+    different transaction, so it isn't on our in-memory ``match``)."""
+    reloaded = (
+        await db.execute(
+            select(Match).where(Match.id == match_id).options(*match_eager_options())
+        )
+    ).scalar_one_or_none()
+    if reloaded is None:
+        return None
+    game = next((g for g in reloaded.games if g.game_number == game_number), None)
+    return _score_view(game.score) if game and game.score else None
+
+
+async def enter_game_score(
+    db: AsyncSession,
+    match: Match,
+    *,
+    game_number: int,
+    side_1_points: int,
+    side_2_points: int,
+) -> Match:
+    """Save the first score for ``game_number`` on ``match`` and return it
+    reloaded. Lazily inserts the ``MatchGame`` row (the FE deeplinks straight
+    into ``/games/N/scores/new`` before the game exists).
+
+    Raises :class:`ScoreConflictError` when a concurrent participant already
+    saved this game — either the in-memory board already carries a committed
+    score (the common case under the router's blocking lock), or the commit
+    trips ``uq_match_games_match_id_game_number`` / ``uq_match_game_scores`` as
+    a residual same-game insert backstop. Both carry the committed score for the
+    conflict body. Never touches ``match.status``, ``side.won``, or ratings.
+
+    Assumes the caller loaded ``match`` under the match row lock and has already
+    enforced scorability, ``game_number <= best_of``, and the no-overrun guard."""
+    game = next((g for g in match.games if g.game_number == game_number), None)
+    if game is None:
+        game = MatchGame(game_number=game_number)
+        match.games.append(game)
+    elif game.score is not None:
+        # A concurrent participant already created this game's score — the same
+        # conflict the update path guards against, just on first write. Hand
+        # back the committed score so the client surfaces it for review instead
+        # of overwriting it.
+        raise ScoreConflictError(committed_score=_score_view(game.score))
+
+    game.score = MatchGameScore(
+        side_1_points=side_1_points,
+        side_2_points=side_2_points,
+    )
+
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        # Two participants on the same game-entry page submitting at once both
+        # lazily insert the same game row (uq_match_games_match_id_game_number)
+        # and/or its score (uq_match_game_scores_match_game_id). The pre-checks
+        # above pass for both before either commits, so the loser of the race
+        # trips a unique constraint. The committed row belongs to the winner's
+        # transaction, so reload to read it for the conflict body.
+        await db.rollback()
+        raise ScoreConflictError(
+            committed_score=await _committed_score(db, match.id, game_number)
+        ) from exc
+
+    return await _reload_match(db, match.id)
+
+
+async def update_game_score(
+    db: AsyncSession,
+    match: Match,
+    *,
+    game_number: int,
+    side_1_points: int,
+    side_2_points: int,
+    expected_version: int,
+) -> Match:
+    """Replace the committed score for ``game_number`` on ``match`` under
+    optimistic concurrency and return it reloaded.
+
+    The ``WHERE version = expected_version`` clause is the whole guard: if a
+    concurrent participant has saved this game since the caller last read it,
+    zero rows match and we raise :class:`ScoreConflictError` (carrying the score
+    as it actually stands now) rather than overwrite their save. Never touches
+    ``match.status``, ``side.won``, or ratings.
+
+    Assumes the caller loaded ``match`` under the match row lock and has already
+    enforced scorability, the score's existence (404), and the no-overrun
+    guard on the prospective board."""
+    game = next((g for g in match.games if g.game_number == game_number), None)
+    if game is None or game.score is None:
+        # The router guards this with a 404 before delegating; reaching here is
+        # an invariant violation, not a client-handleable case.
+        raise RuntimeError(
+            f"update_game_score for match {match.id} game {game_number} "
+            "without a committed score; caller must guard"
+        )
+
+    # Optimistic concurrency: replace the points only while the committed row is
+    # still at the version the caller last read.
+    result = await db.execute(
+        update(MatchGameScore)
+        .where(
+            MatchGameScore.id == game.score.id,
+            MatchGameScore.version == expected_version,
+        )
+        .values(
+            side_1_points=side_1_points,
+            side_2_points=side_2_points,
+            version=MatchGameScore.version + 1,
+        )
+    )
+    if cast(CursorResult[Any], result).rowcount == 0:
+        # Lost the race: a concurrent participant saved this game since the
+        # caller last read it, so the conditional UPDATE matched no row. The
+        # update changed nothing, so there's nothing to undo — refresh the score
+        # to the value as it actually stands now and signal the conflict (the
+        # caller's transaction teardown rolls the no-op transaction back).
+        await db.refresh(game.score)
+        raise ScoreConflictError(committed_score=_score_view(game.score))
+
+    await db.commit()
+
+    return await _reload_match(db, match.id)
+
+
+async def delete_game_score(
+    db: AsyncSession,
+    match: Match,
+    *,
+    game_number: int,
+) -> Match:
+    """Clear the committed score for ``game_number`` on ``match`` and return it
+    reloaded. The ``MatchGame`` row stays so a subsequent
+    ``POST .../scores/new`` for the same number just attaches a fresh score row;
+    delete-orphan on ``MatchGame.score`` removes the score row on flush. Never
+    touches ``match.status``, ``side.won``, or ratings.
+
+    Assumes the caller loaded ``match`` under the match row lock and has already
+    enforced scorability and the score's existence (404)."""
+    game = next((g for g in match.games if g.game_number == game_number), None)
+    if game is None or game.score is None:
+        # The router guards this with a 404 before delegating; reaching here is
+        # an invariant violation, not a client-handleable case.
+        raise RuntimeError(
+            f"delete_game_score for match {match.id} game {game_number} "
+            "without a committed score; caller must guard"
+        )
+
+    game.score = None
+    await db.commit()
+
+    return await _reload_match(db, match.id)

--- a/api/app/match_scoring.py
+++ b/api/app/match_scoring.py
@@ -43,11 +43,11 @@ from app.match_errors import (
 )
 from app.match_queries import match_eager_options
 from app.match_serialization import (
-    _first_decider,
-    _games_payload_from_match,
-    _is_participant,
-    _is_scorable,
-    _score_view,
+    first_decider,
+    games_payload_from_match,
+    is_participant,
+    is_scorable,
+    score_view,
 )
 from app.models import Match, MatchGame, MatchGameScore, MatchStatus
 from app.result_acceptance import _games_to_win
@@ -139,7 +139,7 @@ async def load_match_for_write(
         .options(*(options if options is not None else match_eager_options()))
     )
     match = result.scalar_one_or_none()
-    if match is None or not _is_participant(match, user_id):
+    if match is None or not is_participant(match, user_id):
         raise MatchNotFoundError()
     return match
 
@@ -170,12 +170,12 @@ class _MatchWriteLoader(Protocol):
 
 def ensure_scorable(match: Match) -> None:
     """Raise :class:`MatchNotScorableError` when ``match`` can't be scored.
-    ``_is_scorable`` owns the *decision*; this only picks the reason-specific
+    ``is_scorable`` owns the *decision*; this only picks the reason-specific
     status/message for a rejection, so the write guard can't drift from the
-    ``can_score`` flag — a future gate added to ``_is_scorable`` falls through to
+    ``can_score`` flag — a future gate added to ``is_scorable`` falls through to
     the catch-all 409 rather than being silently accepted. The carried
     status+message reproduce each historical ``_enforce_scorable`` response."""
-    if _is_scorable(match):
+    if is_scorable(match):
         return
     if len(match.sides) < 2:
         raise MatchNotScorableError(
@@ -197,7 +197,7 @@ def ensure_scorable(match: Match) -> None:
             message="This match hasn't been called to a table yet.",
         )
     # Terminal status (``completed``/``voided``) — or any future
-    # ``_is_scorable`` gate without a message of its own.
+    # ``is_scorable`` gate without a message of its own.
     raise MatchNotScorableError(
         http_status=409, message="This match is no longer scorable."
     )
@@ -225,7 +225,7 @@ def _overrun_decided_at(games: list[MatchResultsGameWrite], best_of: int) -> int
     until a side actually clinches *before* the highest-numbered scored game."""
     if not games:
         return None
-    decider = _first_decider(games, _games_to_win(best_of))
+    decider = first_decider(games, _games_to_win(best_of))
     if decider is None:
         return None
     _, decided_at = decider
@@ -283,7 +283,7 @@ async def _committed_score(
     if reloaded is None:
         return None
     game = _game_by_number(reloaded, game_number)
-    return _score_view(game.score) if game and game.score else None
+    return score_view(game.score) if game and game.score else None
 
 
 async def _enter_game_score_locked(
@@ -316,7 +316,7 @@ async def _enter_game_score_locked(
         # conflict the update path guards against, just on first write. Hand
         # back the committed score so the client surfaces it for review instead
         # of overwriting it.
-        raise ScoreConflictError(committed_score=_score_view(game.score))
+        raise ScoreConflictError(committed_score=score_view(game.score))
 
     game.score = MatchGameScore(
         side_1_points=side_1_points,
@@ -391,7 +391,7 @@ async def _update_game_score_locked(
         # to the value as it actually stands now and signal the conflict (the
         # caller's transaction teardown rolls the no-op transaction back).
         await db.refresh(game.score)
-        raise ScoreConflictError(committed_score=_score_view(game.score))
+        raise ScoreConflictError(committed_score=score_view(game.score))
 
     await db.commit()
 
@@ -467,7 +467,7 @@ async def enter_game_score(
     game = _game_by_number(match, game_number)
     if game is None or game.score is None:
         prospective = [
-            g for g in _games_payload_from_match(match) if g.game_number != game_number
+            g for g in games_payload_from_match(match) if g.game_number != game_number
         ] + [
             MatchResultsGameWrite(
                 game_number=game_number,
@@ -524,7 +524,7 @@ async def update_game_score(
             side_1_points=side_1_points,
             side_2_points=side_2_points,
         )
-        for g in _games_payload_from_match(match)
+        for g in games_payload_from_match(match)
     ]
     ensure_no_overrun(prospective, match.match_settings.best_of, game_number)
 

--- a/api/app/match_scoring.py
+++ b/api/app/match_scoring.py
@@ -5,33 +5,252 @@ inline in the ``app.matches`` router handlers. They're extracted here as a leaf
 module so a second caller (the MCP server, a script, a worker) can drive the
 same "save / clear scratchpad state" flow without an HTTP request.
 
+This module owns the **entire FastAPI-free write path**, in two layers:
+
+- The high-level entry points (:func:`enter_game_score`, :func:`update_game_score`,
+  :func:`delete_game_score`) take a ``match_id`` + ``user_id`` and drive the full
+  flow — load+lock+participant (:func:`load_match_for_write`), scorability
+  (:func:`ensure_scorable`), best-of range and no-overrun guards, then the
+  mutation — raising a family of domain exceptions instead of ``HTTPException``.
+  Both the HTTP handlers in ``app.matches`` and the MCP tools call these; each
+  adapts the domain exceptions to its transport (the HTTP adapter reproduces the
+  exact status + body it produced before, so the wire contract is unchanged).
+- The low-level ``_*_locked`` helpers take an already-loaded, row-locked,
+  participation-checked, guard-passed :class:`Match`, mutate the board, and
+  return the reloaded :class:`Match` ready to serialise. They own the one race
+  the guards can't pre-empt: the concurrent-participant score conflict, signalled
+  with the domain :class:`ScoreConflictError` (carrying the committed score).
+
 Following ``api/CLAUDE.md``'s rule of thumb, each is a plain module-level async
 function taking ``db`` rather than a class-plus-provider: none has a collaborator
-worth injecting. Each takes the already-loaded, row-locked, participation-checked
-domain :class:`Match` (the router still owns the ``_load_match_for_scoring`` lock
-and the scorability / overrun guards, exactly as ``accept_standing_result``'s
-router owns its load and pre-guards), mutates the board, and returns the reloaded
-:class:`Match` ready to serialise.
-
-The one race these functions own is the concurrent-participant score conflict:
-they signal it with the domain :class:`ScoreConflictError` (carrying the
-committed score) instead of an ``HTTPException``. The HTTP handler maps it back
-to the exact 409 ``MatchGameScoreConflict`` body it produced before, so the wire
-contract is unchanged.
+worth injecting.
 """
 
 import uuid
-from typing import Any, cast
+from collections.abc import Awaitable
+from typing import Any, Protocol, cast
 
 from sqlalchemy import CursorResult, select, update
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.base import ExecutableOption
 
 from app.match_queries import match_eager_options
-from app.match_serialization import _score_view
-from app.models import Match, MatchGame, MatchGameScore
-from app.result_acceptance import ScoreConflictError
-from app.schemas.match import MatchDetailsScore
+from app.match_serialization import (
+    _first_decider,
+    _games_payload_from_match,
+    _is_participant,
+    _is_scorable,
+    _score_view,
+)
+from app.models import Match, MatchGame, MatchGameScore, MatchStatus
+from app.result_acceptance import (
+    MatchNotFoundError,
+    MatchNotScorableError,
+    ScoreConflictError,
+    ScoreNotAllowedError,
+    _games_to_win,
+)
+from app.schemas.match import MatchDetailsScore, MatchResultsGameWrite
+
+# ----- load + lock ---------------------------------------------------------
+
+
+class MatchLockUnavailable(Exception):
+    """``SELECT ... FOR UPDATE NOWAIT`` found the match row already locked by a
+    concurrent negotiation transaction. Raised by ``_lock_match_row(nowait=True)``
+    so the caller can translate it into a fast, clean 409 instead of blocking
+    on the lock (see ``post_match_result``)."""
+
+
+# Postgres SQLSTATE for a ``NOWAIT`` lock that could not be acquired.
+_LOCK_NOT_AVAILABLE = "55P03"
+
+
+async def _lock_match_row(
+    db: AsyncSession, match_id: uuid.UUID, *, nowait: bool = False
+) -> None:
+    """Take a transaction-scoped row lock on the ``matches`` row so the
+    negotiation transitions (``/results`` propose, ``/results/{id}/acceptance``)
+    and the score writes serialize against each other.
+
+    Without this, a participant firing two acceptances (or a propose racing an
+    acceptance) concurrently lets both transactions pass their standing-result
+    guard on the same pre-image and both commit — finalizing the match twice and
+    applying a rating change more than once (issue #365). The lock forces the
+    second transaction to wait for the first to commit and then re-read the
+    post-image, so its guard returns a clean 409.
+
+    It's a thin ``SELECT matches.id ... FOR UPDATE`` rather than adding
+    ``.with_for_update()`` to the eager load query: a narrow lock-only select is
+    cheaper than re-running ``match_eager_options`` (which fans out into a
+    selectinload query per relationship) just to take the lock, and acquiring it
+    on its own line makes the lock-then-read ordering explicit — the subsequent
+    load sees the serialized state. Locking just the parent row is enough — every
+    negotiation transition reads and writes that match's children under cover of
+    this lock.
+
+    ``nowait=True`` adds ``NOWAIT``: if the row is already locked, Postgres
+    raises immediately instead of blocking, which we surface as
+    ``MatchLockUnavailable``. ``post_match_result`` uses this so a double-tapped
+    finalize doesn't park a request (and its pooled DB connection) on the lock
+    for the full duration of the in-flight post — the pile-up that wedged the
+    whole instance under a stray double-click (issue #641). The blocking form
+    is kept for /results/{id}/acceptance, where a second concurrent caller is a
+    *legitimate* acceptor that must wait, re-read, and proceed."""
+    stmt = select(Match.id).where(Match.id == match_id).with_for_update(nowait=nowait)
+    try:
+        await db.execute(stmt)
+    except DBAPIError as exc:
+        if nowait and getattr(exc.orig, "sqlstate", None) == _LOCK_NOT_AVAILABLE:
+            raise MatchLockUnavailable from exc
+        raise
+
+
+async def load_match_for_write(
+    db: AsyncSession,
+    match_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    lock: bool,
+    nowait: bool = False,
+    options: tuple[ExecutableOption, ...] | None = None,
+) -> Match:
+    """Load the write target for ``user_id``, optionally under the match row lock,
+    and return it — the FastAPI-free core the score write path and the negotiation
+    transitions share.
+
+    ``lock`` callers take the row lock *before* the eager load so the state they
+    read is the serialized one (per ADR-0009 the score endpoints lock too). The
+    finalize paths pass ``options=match_rating_eager_options()`` so the rating
+    hook can read ``league.rating_strategy`` without a mid-request lazy load; the
+    scratchpad score endpoints take the default read chain.
+
+    Raises :class:`MatchNotFoundError` when the match is absent *or* ``user_id``
+    isn't a participant — today's score endpoints collapse both into one opaque
+    404 so a non-participant can't probe existence. May raise
+    :class:`MatchLockUnavailable` when ``lock`` + ``nowait`` and the row is held.
+    Never an ``HTTPException`` — the caller adapts it to its transport."""
+    if lock:
+        await _lock_match_row(db, match_id, nowait=nowait)
+    result = await db.execute(
+        select(Match)
+        .where(Match.id == match_id)
+        .options(*(options if options is not None else match_eager_options()))
+    )
+    match = result.scalar_one_or_none()
+    if match is None or not _is_participant(match, user_id):
+        raise MatchNotFoundError()
+    return match
+
+
+class _MatchWriteLoader(Protocol):
+    """The load seam the high-level entry points accept. Its default is
+    :func:`load_match_for_write` (FastAPI-free, raising domain exceptions), but
+    the HTTP score handlers inject ``matches._load_match_for_scoring`` — a thin
+    wrapper that maps :class:`MatchNotFoundError` to the endpoints' historical
+    ``HTTPException(404)`` — so the router's monkeypatchable load seam (the #835
+    row-lock race test barriers on it) stays the one the endpoints exercise."""
+
+    def __call__(
+        self,
+        db: AsyncSession,
+        match_id: uuid.UUID,
+        user_id: uuid.UUID,
+        /,
+        *,
+        lock: bool,
+        nowait: bool = ...,
+        options: tuple[ExecutableOption, ...] | None = ...,
+    ) -> Awaitable[Match]: ...
+
+
+# ----- FastAPI-free write guards -------------------------------------------
+
+
+def ensure_scorable(match: Match) -> None:
+    """Raise :class:`MatchNotScorableError` when ``match`` can't be scored.
+    ``_is_scorable`` owns the *decision*; this only picks the reason-specific
+    status/message for a rejection, so the write guard can't drift from the
+    ``can_score`` flag — a future gate added to ``_is_scorable`` falls through to
+    the catch-all 409 rather than being silently accepted. The carried
+    status+message reproduce each historical ``_enforce_scorable`` response."""
+    if _is_scorable(match):
+        return
+    if len(match.sides) < 2:
+        raise MatchNotScorableError(
+            http_status=422,
+            message="This match has no opponent and can't be scored.",
+        )
+    # Any posted result freezes the scratchpad (#715); the board now only
+    # changes through propose/accept, not the score endpoints.
+    if match.results:
+        raise MatchNotScorableError(
+            http_status=409,
+            message="This match has a posted result; scores are frozen.",
+        )
+    # Scheduled but not yet called to a table (#1073): the schedule is
+    # authoritative, so an uncalled match can't be played out-of-band.
+    if match.status == MatchStatus.pending:
+        raise MatchNotScorableError(
+            http_status=409,
+            message="This match hasn't been called to a table yet.",
+        )
+    # Terminal status (``completed``/``voided``) — or any future
+    # ``_is_scorable`` gate without a message of its own.
+    raise MatchNotScorableError(
+        http_status=409, message="This match is no longer scorable."
+    )
+
+
+def ensure_game_in_range(match: Match, game_number: int) -> None:
+    """Reject (:class:`ScoreNotAllowedError`, 422-equivalent) a write to a game
+    number the match's ``best_of`` can never reach."""
+    best_of = match.match_settings.best_of
+    if game_number > best_of:
+        raise ScoreNotAllowedError(
+            f"This match is best of {best_of}; game {game_number} can't exist."
+        )
+
+
+def _overrun_decided_at(games: list[MatchResultsGameWrite], best_of: int) -> int | None:
+    """The game number at which the match was already decided when there are
+    scored games numbered *after* it ("overrun"). Returns ``None`` for empty,
+    still-undecided, or exactly-decided-at-the-last-game boards — all legal
+    scratchpad states.
+
+    Gap-tolerant on purpose: it shares the decider core with the finalize
+    validator but does **not** require ``1..N`` contiguity, so legitimate
+    out-of-order / gappy entry (e.g. scoring game 3 first) is allowed right up
+    until a side actually clinches *before* the highest-numbered scored game."""
+    if not games:
+        return None
+    decider = _first_decider(games, _games_to_win(best_of))
+    if decider is None:
+        return None
+    _, decided_at = decider
+    if decided_at < max(g.game_number for g in games):
+        return decided_at
+    return None
+
+
+def ensure_no_overrun(
+    games: list[MatchResultsGameWrite], best_of: int, game_number: int
+) -> None:
+    """Reject a scratchpad write (:class:`ScoreNotAllowedError`, 422-equivalent)
+    when the prospective board ``games`` would leave the match decided before its
+    last scored game. Shared by both score-write paths so the check and message
+    can't drift; each caller builds its own prospective board then hands it here."""
+    decided_at = _overrun_decided_at(games, best_of)
+    if decided_at is not None:
+        raise ScoreNotAllowedError(
+            f"The match was already decided at game {decided_at}; "
+            f"game {game_number} can't be played."
+        )
+
+
+def _game_by_number(match: Match, game_number: int) -> MatchGame | None:
+    return next((g for g in match.games if g.game_number == game_number), None)
 
 
 async def _reload_match(db: AsyncSession, match_id: uuid.UUID) -> Match:
@@ -67,7 +286,7 @@ async def _committed_score(
     return _score_view(game.score) if game and game.score else None
 
 
-async def enter_game_score(
+async def _enter_game_score_locked(
     db: AsyncSession,
     match: Match,
     *,
@@ -121,7 +340,7 @@ async def enter_game_score(
     return await _reload_match(db, match.id)
 
 
-async def update_game_score(
+async def _update_game_score_locked(
     db: AsyncSession,
     match: Match,
     *,
@@ -179,7 +398,7 @@ async def update_game_score(
     return await _reload_match(db, match.id)
 
 
-async def delete_game_score(
+async def _delete_game_score_locked(
     db: AsyncSession,
     match: Match,
     *,
@@ -206,3 +425,139 @@ async def delete_game_score(
     await db.commit()
 
     return await _reload_match(db, match.id)
+
+
+# ----- high-level entry points ---------------------------------------------
+#
+# The full FastAPI-free write path both the HTTP handlers and the MCP tools
+# drive: load+lock+participant, scorability, best-of range, no-overrun, then the
+# mutation — raising the domain exceptions the caller adapts to its transport.
+# ``load_match`` defaults to the FastAPI-free ``load_match_for_write``; the HTTP
+# handlers inject ``matches._load_match_for_scoring`` so the router's
+# monkeypatchable, HTTPException-mapping load seam stays the one they exercise.
+
+
+async def enter_game_score(
+    db: AsyncSession,
+    match_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    game_number: int,
+    side_1_points: int,
+    side_2_points: int,
+    load_match: _MatchWriteLoader = load_match_for_write,
+) -> Match:
+    """Save the first score for ``game_number`` and return the reloaded match.
+
+    Loads under the blocking match row lock, enforces scorability and the
+    best-of range, then — only when this game has no committed score yet — the
+    no-overrun guard against the prospective board (a pre-existing committed
+    score short-circuits to :class:`ScoreConflictError` below without running
+    overrun, preserving the historical conflict-before-overrun ordering). The
+    prospective board is the currently-scored games plus this write.
+
+    Raises :class:`MatchNotFoundError` (absent match / non-participant),
+    :class:`MatchNotScorableError`, :class:`ScoreNotAllowedError` (range or
+    overrun), or :class:`ScoreConflictError` (a concurrent participant already
+    scored this game)."""
+    match = await load_match(db, match_id, user_id, lock=True)
+    ensure_scorable(match)
+    ensure_game_in_range(match, game_number)
+
+    game = _game_by_number(match, game_number)
+    if game is None or game.score is None:
+        prospective = [
+            g for g in _games_payload_from_match(match) if g.game_number != game_number
+        ] + [
+            MatchResultsGameWrite(
+                game_number=game_number,
+                side_1_points=side_1_points,
+                side_2_points=side_2_points,
+            )
+        ]
+        ensure_no_overrun(prospective, match.match_settings.best_of, game_number)
+
+    return await _enter_game_score_locked(
+        db,
+        match,
+        game_number=game_number,
+        side_1_points=side_1_points,
+        side_2_points=side_2_points,
+    )
+
+
+async def update_game_score(
+    db: AsyncSession,
+    match_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    game_number: int,
+    side_1_points: int,
+    side_2_points: int,
+    expected_version: int,
+    load_match: _MatchWriteLoader = load_match_for_write,
+) -> Match:
+    """Replace the committed score for ``game_number`` under optimistic
+    concurrency and return the reloaded match.
+
+    Loads under the blocking match row lock, enforces scorability and the
+    score's existence, then the no-overrun guard on the prospective board built
+    by substituting the payload points for this game (the mutation runs in raw
+    SQL, so in-memory ``match.games`` still holds the OLD score).
+
+    Raises :class:`MatchNotFoundError` — ``"Match not found."`` for an absent
+    match / non-participant, ``"Score not found."`` for a missing game score —
+    plus :class:`MatchNotScorableError`, :class:`ScoreNotAllowedError`, or
+    :class:`ScoreConflictError` (a stale ``expected_version``)."""
+    match = await load_match(db, match_id, user_id, lock=True)
+    ensure_scorable(match)
+
+    game = _game_by_number(match, game_number)
+    if game is None or game.score is None:
+        raise MatchNotFoundError("Score not found.")
+
+    prospective = [
+        g
+        if g.game_number != game_number
+        else MatchResultsGameWrite(
+            game_number=game_number,
+            side_1_points=side_1_points,
+            side_2_points=side_2_points,
+        )
+        for g in _games_payload_from_match(match)
+    ]
+    ensure_no_overrun(prospective, match.match_settings.best_of, game_number)
+
+    return await _update_game_score_locked(
+        db,
+        match,
+        game_number=game_number,
+        side_1_points=side_1_points,
+        side_2_points=side_2_points,
+        expected_version=expected_version,
+    )
+
+
+async def delete_game_score(
+    db: AsyncSession,
+    match_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    game_number: int,
+    load_match: _MatchWriteLoader = load_match_for_write,
+) -> Match:
+    """Clear the committed score for ``game_number`` and return the reloaded
+    match. Loads under the blocking match row lock and enforces scorability and
+    the score's existence.
+
+    Raises :class:`MatchNotFoundError` — ``"Match not found."`` for an absent
+    match / non-participant, ``"Score not found."`` for a missing game score —
+    or :class:`MatchNotScorableError`."""
+    match = await load_match(db, match_id, user_id, lock=True)
+    ensure_scorable(match)
+
+    game = _game_by_number(match, game_number)
+    if game is None or game.score is None:
+        raise MatchNotFoundError("Score not found.")
+
+    return await _delete_game_score_locked(db, match, game_number=game_number)

--- a/api/app/match_scoring.py
+++ b/api/app/match_scoring.py
@@ -35,6 +35,12 @@ from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.base import ExecutableOption
 
+from app.match_errors import (
+    MatchNotFoundError,
+    MatchNotScorableError,
+    ScoreConflictError,
+    ScoreNotAllowedError,
+)
 from app.match_queries import match_eager_options
 from app.match_serialization import (
     _first_decider,
@@ -44,13 +50,7 @@ from app.match_serialization import (
     _score_view,
 )
 from app.models import Match, MatchGame, MatchGameScore, MatchStatus
-from app.result_acceptance import (
-    MatchNotFoundError,
-    MatchNotScorableError,
-    ScoreConflictError,
-    ScoreNotAllowedError,
-    _games_to_win,
-)
+from app.result_acceptance import _games_to_win
 from app.schemas.match import MatchDetailsScore, MatchResultsGameWrite
 
 # ----- load + lock ---------------------------------------------------------
@@ -282,7 +282,7 @@ async def _committed_score(
     ).scalar_one_or_none()
     if reloaded is None:
         return None
-    game = next((g for g in reloaded.games if g.game_number == game_number), None)
+    game = _game_by_number(reloaded, game_number)
     return _score_view(game.score) if game and game.score else None
 
 
@@ -307,7 +307,7 @@ async def _enter_game_score_locked(
 
     Assumes the caller loaded ``match`` under the match row lock and has already
     enforced scorability, ``game_number <= best_of``, and the no-overrun guard."""
-    game = next((g for g in match.games if g.game_number == game_number), None)
+    game = _game_by_number(match, game_number)
     if game is None:
         game = MatchGame(game_number=game_number)
         match.games.append(game)
@@ -361,7 +361,7 @@ async def _update_game_score_locked(
     Assumes the caller loaded ``match`` under the match row lock and has already
     enforced scorability, the score's existence (404), and the no-overrun
     guard on the prospective board."""
-    game = next((g for g in match.games if g.game_number == game_number), None)
+    game = _game_by_number(match, game_number)
     if game is None or game.score is None:
         # The router guards this with a 404 before delegating; reaching here is
         # an invariant violation, not a client-handleable case.
@@ -412,7 +412,7 @@ async def _delete_game_score_locked(
 
     Assumes the caller loaded ``match`` under the match row lock and has already
     enforced scorability and the score's existence (404)."""
-    game = next((g for g in match.games if g.game_number == game_number), None)
+    game = _game_by_number(match, game_number)
     if game is None or game.score is None:
         # The router guards this with a 404 before delegating; reaching here is
         # an invariant violation, not a client-handleable case.

--- a/api/app/match_serialization.py
+++ b/api/app/match_serialization.py
@@ -64,8 +64,28 @@ from app.schemas.match import (
 )
 from app.schemas.rating import RatingChange
 
+# Public shared surface: the serializer/board helpers that both the HTTP router
+# (``matches.py``) and the MCP adapter (``mcp_server.py``), plus the scoring /
+# proposal / notification services, import. Everything not listed is a
+# module-internal helper (leading underscore) and stays private.
+__all__ = [
+    "compact_games",
+    "first_decider",
+    "games_payload_from_match",
+    "is_participant",
+    "is_scorable",
+    "load_match_eager",
+    "negotiation",
+    "score_view",
+    "serialize_details",
+    "side_schema",
+    "status_label",
+    "validate_finalize_games",
+    "view_extras",
+]
 
-def _side_schema(
+
+def side_schema(
     side: MatchSide,
     side_wins: dict[int, int],
     current_user_id: uuid.UUID | None,
@@ -94,11 +114,11 @@ def _side_schema(
     )
 
 
-def _is_participant(match: Match, user_id: uuid.UUID) -> bool:
+def is_participant(match: Match, user_id: uuid.UUID) -> bool:
     return my_side(match, user_id) is not None
 
 
-def _status_label(match: Match) -> str:
+def status_label(match: Match) -> str:
     """User-facing label for a match's lifecycle position. An ``in_progress``
     match with a standing posted result is waiting on the other side — surface
     that distinctly so the FE doesn't need to know about the result model to
@@ -117,7 +137,7 @@ def _status_label(match: Match) -> str:
             return "Voided"
 
 
-def _score_view(score: MatchGameScore) -> MatchDetailsScore:
+def score_view(score: MatchGameScore) -> MatchDetailsScore:
     return MatchDetailsScore(
         id=score.id,
         side_1_points=score.side_1_points,
@@ -193,7 +213,7 @@ def _submitted_on_side(match: Match, result: MatchResult, side: MatchSide) -> bo
     return any(p.user_id == result.submitted_by_user_id for p in side.players)
 
 
-def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegotiation:
+def negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegotiation:
     """Viewer-relative negotiation state for the BFF (#713).
 
     The viewer's "side" is the side the current user is on; the opponent side is
@@ -289,7 +309,7 @@ def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegoti
     )
 
 
-def _is_scorable(match: Match) -> bool:
+def is_scorable(match: Match) -> bool:
     """Whether a match accepts score writes right now (ignoring who's asking).
 
     The saved games are a provisional *scratchpad* until somebody posts the
@@ -307,7 +327,7 @@ def _is_scorable(match: Match) -> bool:
     born ``in_progress`` and so remain scorable at once.
 
     Single source of truth shared by the write-path guard
-    (``_enforce_scorable``) and the BFF ``can_score`` flag, so the flag the
+    (``ensure_scorable``) and the BFF ``can_score`` flag, so the flag the
     clients trust can never disagree with what the score endpoints accept."""
     return (
         len(match.sides) >= 2
@@ -316,7 +336,7 @@ def _is_scorable(match: Match) -> bool:
     )
 
 
-def _first_decider(
+def first_decider(
     games: list[MatchResultsGameWrite], target: int
 ) -> tuple[int, int] | None:
     """Walk ``games`` in game-number order tallying wins; return
@@ -336,7 +356,7 @@ def _first_decider(
     return None
 
 
-def _compact_games(
+def compact_games(
     games: list[MatchResultsGameWrite],
 ) -> list[MatchResultsGameWrite]:
     """Normalize a (possibly gappy) scratchpad board into a canonical one:
@@ -346,7 +366,7 @@ def _compact_games(
     Renumbers by the *rank of each distinct* ``game_number`` (not by list
     position), so a genuine duplicate game_number is preserved as a duplicate
     (two games at original ``1`` both map to new ``1``) and the strict
-    ``_validate_finalize_games`` duplicate check downstream still rejects it.
+    ``validate_finalize_games`` duplicate check downstream still rejects it.
     (Renumbering *does* absorb an out-of-``best_of``-range game_number — e.g.
     ``[1,2,5]`` on best-of-3 → ``[1,2,3]`` — but the real scratchpad never
     produces one: the score endpoints reject ``game_number > best_of`` before a
@@ -377,7 +397,7 @@ def _compact_games(
     ]
 
 
-def _validate_finalize_games(games: list[MatchResultsGameWrite], best_of: int) -> int:
+def validate_finalize_games(games: list[MatchResultsGameWrite], best_of: int) -> int:
     """Cross-game invariants for a finalize payload. Per-game point legality
     is already enforced by ``MatchResultsGameWrite``. Returns the decided side
     number (1 or 2); raises ``ValueError`` with a human-readable detail on any
@@ -394,7 +414,7 @@ def _validate_finalize_games(games: list[MatchResultsGameWrite], best_of: int) -
         raise ValueError("Games must be numbered 1..N consecutively with no gaps.")
 
     target = _games_to_win(best_of)
-    decider = _first_decider(games, target)
+    decider = first_decider(games, target)
     if decider is None:
         raise ValueError(
             f"No side reached {target} game wins — the match isn't decided."
@@ -408,9 +428,9 @@ def _validate_finalize_games(games: list[MatchResultsGameWrite], best_of: int) -
     return decided_side
 
 
-def _games_payload_from_match(match: Match) -> list[MatchResultsGameWrite]:
+def games_payload_from_match(match: Match) -> list[MatchResultsGameWrite]:
     """Recast currently-saved scores as a finalize payload, so ``_can_finalize``
-    can reuse ``_validate_finalize_games`` instead of duplicating its rules.
+    can reuse ``validate_finalize_games`` instead of duplicating its rules.
 
     Returns the board **raw** (scored games at their real ``game_number``, gaps
     and all). The two scratchpad overrun guards depend on this: ``create_game_score``
@@ -448,8 +468,8 @@ def _can_finalize(match: Match) -> bool:
     if match.results:
         return False
     try:
-        _validate_finalize_games(
-            _compact_games(_games_payload_from_match(match)),
+        validate_finalize_games(
+            compact_games(games_payload_from_match(match)),
             match.match_settings.best_of,
         )
     except ValueError:
@@ -457,7 +477,7 @@ def _can_finalize(match: Match) -> bool:
     return True
 
 
-def _serialize_details(
+def serialize_details(
     match: Match,
     current_user_id: uuid.UUID | None,
     extras: MatchDetailsExtras | None = None,
@@ -476,7 +496,7 @@ def _serialize_details(
         MatchDetailsGame(
             id=game.id,
             game_number=game.game_number,
-            score=_score_view(game.score) if game.score else None,
+            score=score_view(game.score) if game.score else None,
         )
         for game in games_sorted
     ]
@@ -490,14 +510,14 @@ def _serialize_details(
 
     sides_sorted = sorted(match.sides, key=lambda s: s.side_number)
     # Anonymous viewers on the public route are never participants.
-    is_participant = current_user_id is not None and _is_participant(
+    viewer_is_participant = current_user_id is not None and is_participant(
         match, current_user_id
     )
 
     return MatchDetails(
         id=match.id,
         status=match.status,
-        status_label=_status_label(match),
+        status_label=status_label(match),
         league=MatchLeague(id=match.league.id, name=match.league.name),
         best_of=match.match_settings.best_of,
         games_to_win=_games_to_win(match.match_settings.best_of),
@@ -505,28 +525,28 @@ def _serialize_details(
         affects_rating=match.match_settings.affects_rating,
         created_at=match.created_at,
         sides=[
-            _side_schema(side, side_wins, current_user_id, extras.rating_changes)
+            side_schema(side, side_wins, current_user_id, extras.rating_changes)
             for side in sides_sorted
         ],
         games=games,
         current_game=current_game,
         # "This participant may edit scores" — true whenever the match is
-        # scorable (no result posted yet; see ``_is_scorable``), *independent*
+        # scorable (no result posted yet; see ``is_scorable``), *independent*
         # of whether there's a next un-played game. A decided-but-unposted
         # board is still editable, so this is True while ``current_game`` is
         # None. Spectators get the read-only view — writes
         # 404 for non-participants in the score endpoints regardless.
-        can_score=(is_participant and _is_scorable(match)),
+        can_score=(viewer_is_participant and is_scorable(match)),
         # True iff the saved games already form a decided, validly-ordered
         # match AND no result is currently posted — the FE flips the scoring
         # page's submit button label to "Post result" when this is true.
         can_finalize=(
-            is_participant and len(match.sides) >= 2 and _can_finalize(match)
+            viewer_is_participant and len(match.sides) >= 2 and _can_finalize(match)
         ),
         # Viewer-relative negotiation state — the standing proposal, whose turn
         # it is, and (when the opponent corrected the viewer's own proposal) the
         # diff. Drives the accept CTA + the negotiation callouts (#713).
-        negotiation=_negotiation(match, current_user_id),
+        negotiation=negotiation(match, current_user_id),
         # ``extras.recent_form`` is a read-only Sequence; the response model owns
         # its own list, so copy rather than alias it.
         recent_form=list(extras.recent_form),

--- a/api/app/match_serialization.py
+++ b/api/app/match_serialization.py
@@ -1,0 +1,518 @@
+"""Router-free serialization of a loaded ``Match`` into the ``MatchDetails``
+view, plus the pure predicates its ``can_score`` / ``can_finalize`` flags derive
+from.
+
+This lives outside ``matches.py`` so that *both* the HTTP handlers and a future
+MCP tool module can produce the identical view object without one adapter
+importing another router's internals (``api/CLAUDE.md`` — "don't import another
+router's internals"; ADR 20260718 "the match flow is a shared service layer
+behind HTTP and MCP adapters"). It imports only domain/query/mapper/schema
+modules — never a router — so it stays cycle-free.
+"""
+
+import uuid
+from collections.abc import Mapping
+
+from app.domain.match.models import Match as MatchModel
+from app.mappers.match_details_mapper import serialize_match_details
+from app.mappers.match_extras_mapper import MatchDetailsExtras, empty_extras
+from app.match_queries import current_game_number, my_side
+from app.models import (
+    Match,
+    MatchGameScore,
+    MatchResult,
+    MatchSide,
+    MatchStatus,
+)
+from app.result_acceptance import (
+    _game_winner_side,
+    _games_to_win,
+    side_win_counts,
+)
+from app.result_chain import accepted_result, standing_result
+from app.retirement import retirement_deadline
+from app.schemas.match import (
+    MatchDetails,
+    MatchDetailsCurrentGame,
+    MatchDetailsGame,
+    MatchDetailsPlayer,
+    MatchDetailsScore,
+    MatchDetailsSide,
+    MatchLeague,
+    MatchNegotiation,
+    MatchResultsGameWrite,
+    NegotiationDiffEntry,
+    NegotiationGame,
+    NegotiationResult,
+)
+from app.schemas.rating import RatingChange
+
+
+def _side_schema(
+    side: MatchSide,
+    side_wins: dict[int, int],
+    current_user_id: uuid.UUID | None,
+    rating_changes: Mapping[uuid.UUID, RatingChange] | None = None,
+) -> MatchDetailsSide:
+    # Singles only for v1: each side has at most one rated player.
+    rating_change = (
+        rating_changes.get(side.players[0].user_id)
+        if rating_changes and side.players
+        else None
+    )
+    return MatchDetailsSide(
+        side_number=side.side_number,
+        players=[
+            MatchDetailsPlayer(
+                user_id=p.user_id,
+                username=p.user.username,
+                is_current_user=p.user_id == current_user_id,
+            )
+            for p in sorted(side.players, key=lambda p: p.user.username)
+        ],
+        games_won=side_wins.get(side.side_number, 0),
+        won=side.won,
+        is_current_user_side=any(p.user_id == current_user_id for p in side.players),
+        rating_change=rating_change,
+    )
+
+
+def _is_participant(match: Match, user_id: uuid.UUID) -> bool:
+    return my_side(match, user_id) is not None
+
+
+def _status_label(match: Match) -> str:
+    """User-facing label for a match's lifecycle position. An ``in_progress``
+    match with a standing posted result is waiting on the other side — surface
+    that distinctly so the FE doesn't need to know about the result model to
+    render it."""
+    if match.status == MatchStatus.in_progress and standing_result(match) is not None:
+        return "Awaiting acceptance"
+    # Exhaustive — adding an enum member is a type error until handled.
+    match match.status:
+        case MatchStatus.pending:
+            return "Scheduled"
+        case MatchStatus.in_progress:
+            return "Live"
+        case MatchStatus.completed:
+            return "Final"
+        case MatchStatus.voided:
+            return "Voided"
+
+
+def _score_view(score: MatchGameScore) -> MatchDetailsScore:
+    return MatchDetailsScore(
+        id=score.id,
+        side_1_points=score.side_1_points,
+        side_2_points=score.side_2_points,
+        winner_side_number=_game_winner_side(score),
+        version=score.version,
+    )
+
+
+def _negotiation_game(snapshot: dict[str, int]) -> NegotiationGame:
+    return NegotiationGame(
+        game_number=snapshot["game_number"],
+        side_1_points=snapshot["side_1_points"],
+        side_2_points=snapshot["side_2_points"],
+    )
+
+
+def _negotiation_result(result: MatchResult) -> NegotiationResult:
+    return NegotiationResult(
+        id=result.id,
+        games=[
+            _negotiation_game(g)
+            for g in sorted(result.games, key=lambda g: g["game_number"])
+        ],
+        submitted_by=result.submitted_by_user_id,
+        submitted_at=result.submitted_at,
+    )
+
+
+def _negotiation_diff(
+    baseline_games: list[dict[str, int]],
+    standing_games: list[dict[str, int]],
+) -> list[NegotiationDiffEntry]:
+    """Viewer-relative diff between the viewer's own last proposal (baseline)
+    and the standing proposal. Emits one entry per game that differs, ordered by
+    game number over the union of both boards. A correction may add, remove, or
+    change games (a decided board can shorten or lengthen — CONTEXT.md
+    "Correction", ADR-0001), so an entry is one of:
+
+    - **added** — the standing board has a game the baseline lacked (``old=None``);
+    - **removed** — the baseline had a game the standing board dropped (``new=None``);
+    - **changed** — both present, points differ.
+
+    Unchanged games are skipped. Computed purely from the two snapshots; the
+    chain walk to pick the baseline is what collapses the opponent's intermediate
+    self-edits."""
+    baseline_by_number = {g["game_number"]: g for g in baseline_games}
+    standing_by_number = {g["game_number"]: g for g in standing_games}
+    entries: list[NegotiationDiffEntry] = []
+    for number in sorted(baseline_by_number.keys() | standing_by_number.keys()):
+        old = baseline_by_number.get(number)
+        new = standing_by_number.get(number)
+        if (
+            old is not None
+            and new is not None
+            and old["side_1_points"] == new["side_1_points"]
+            and old["side_2_points"] == new["side_2_points"]
+        ):
+            continue  # unchanged — omit
+        # ``old``/``new`` null encode removed/added; both-present is a change.
+        entries.append(
+            NegotiationDiffEntry(
+                game_number=number,
+                old=_negotiation_game(old) if old is not None else None,
+                new=_negotiation_game(new) if new is not None else None,
+            )
+        )
+    return entries
+
+
+def _submitted_on_side(match: Match, result: MatchResult, side: MatchSide) -> bool:
+    """True iff the result's submitter is a player on ``side``."""
+    return any(p.user_id == result.submitted_by_user_id for p in side.players)
+
+
+def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegotiation:
+    """Viewer-relative negotiation state for the BFF (#713).
+
+    The viewer's "side" is the side the current user is on; the opponent side is
+    the other. A standing proposal submitted by the viewer's own side is
+    ``awaiting`` (they consented; it's the opponent's move); one submitted by the
+    opponent makes it the viewer's turn — ``review`` if the viewer never
+    proposed, ``corrected`` (with a diff vs the viewer's own last proposal) if
+    they did. ``final`` once a result is accepted; ``live`` before any result.
+
+    Non-participants / anonymous callers get a neutral spectator mapping
+    (``your_turn=False``, no diff/prior)."""
+    accepted = accepted_result(match)
+    if accepted is not None:
+        return MatchNegotiation(
+            viewer_state="final",
+            your_turn=False,
+            standing_result=_negotiation_result(accepted),
+            prior_result=None,
+            diff=None,
+            retirement_deadline=retirement_deadline(match),
+        )
+
+    standing = standing_result(match)
+    if standing is None:
+        return MatchNegotiation(
+            viewer_state="live",
+            your_turn=False,
+            standing_result=None,
+            prior_result=None,
+            diff=None,
+            retirement_deadline=retirement_deadline(match),
+        )
+
+    standing_view = _negotiation_result(standing)
+    viewer_side = (
+        my_side(match, current_user_id) if current_user_id is not None else None
+    )
+    # Spectators / anonymous: neutral mapping — there is a standing proposal but
+    # the viewer has no side, so treat as a read-only "review" view.
+    if viewer_side is None:
+        return MatchNegotiation(
+            viewer_state="review",
+            your_turn=False,
+            standing_result=standing_view,
+            prior_result=None,
+            diff=None,
+            retirement_deadline=retirement_deadline(match),
+        )
+
+    if _submitted_on_side(match, standing, viewer_side):
+        # The viewer's own side proposed the standing result; await the opponent.
+        return MatchNegotiation(
+            viewer_state="awaiting",
+            your_turn=False,
+            standing_result=standing_view,
+            prior_result=None,
+            diff=None,
+            retirement_deadline=retirement_deadline(match),
+        )
+
+    # The opponent submitted the standing result → the viewer must act. Walk the
+    # supersede chain back from the standing result to the viewer's own last
+    # proposal (the baseline that collapses the opponent's intermediate edits).
+    by_id = {r.id: r for r in match.results}
+    prior: MatchResult | None = None
+    cursor = standing.supersedes_result_id
+    while cursor is not None:
+        candidate = by_id.get(cursor)
+        if candidate is None:
+            break
+        if _submitted_on_side(match, candidate, viewer_side):
+            prior = candidate
+            break
+        cursor = candidate.supersedes_result_id
+
+    if prior is None:
+        return MatchNegotiation(
+            viewer_state="review",
+            your_turn=True,
+            standing_result=standing_view,
+            prior_result=None,
+            diff=None,
+            retirement_deadline=retirement_deadline(match),
+        )
+
+    return MatchNegotiation(
+        viewer_state="corrected",
+        your_turn=True,
+        standing_result=standing_view,
+        prior_result=_negotiation_result(prior),
+        diff=_negotiation_diff(prior.games, standing.games),
+        retirement_deadline=retirement_deadline(match),
+    )
+
+
+def _is_scorable(match: Match) -> bool:
+    """Whether a match accepts score writes right now (ignoring who's asking).
+
+    The saved games are a provisional *scratchpad* until somebody posts the
+    first result: editable regardless of whether they already decide the match.
+    So the gates are structural — two sides, a **live** (``in_progress``)
+    status, and **no result row at all**. The scratchpad freezes the instant
+    the first result is proposed (#715); from there the board only changes via
+    the propose/accept negotiation, not the score endpoints.
+
+    ``in_progress`` (not merely non-terminal) is the status gate: a tournament
+    match is born ``pending`` (scheduled) and is not scorable until the
+    scheduler *calls* it to a table — playing an uncalled match out-of-band
+    would corrupt the solver's table model (#1073). This aligns scoring with
+    ``can_finalize``, which already required ``in_progress``. Casual matches are
+    born ``in_progress`` and so remain scorable at once.
+
+    Single source of truth shared by the write-path guard
+    (``_enforce_scorable``) and the BFF ``can_score`` flag, so the flag the
+    clients trust can never disagree with what the score endpoints accept."""
+    return (
+        len(match.sides) >= 2
+        and match.status == MatchStatus.in_progress
+        and not match.results
+    )
+
+
+def _first_decider(
+    games: list[MatchResultsGameWrite], target: int
+) -> tuple[int, int] | None:
+    """Walk ``games`` in game-number order tallying wins; return
+    ``(decided_side, decided_game_number)`` for the first game at which a side
+    reaches ``target`` wins, else ``None``.
+
+    Gap-tolerant: it does not care whether the numbers are contiguous — callers
+    that require ``1..N`` numbering check that separately. The single source of
+    truth for "who clinched, and when" shared by the finalize validator and the
+    scratchpad overrun guard, so the two can never drift."""
+    wins: dict[int, int] = {1: 0, 2: 0}
+    for g in sorted(games, key=lambda g: g.game_number):
+        winner = 1 if g.side_1_points > g.side_2_points else 2
+        wins[winner] += 1
+        if wins[winner] >= target:
+            return winner, g.game_number
+    return None
+
+
+def _compact_games(
+    games: list[MatchResultsGameWrite],
+) -> list[MatchResultsGameWrite]:
+    """Normalize a (possibly gappy) scratchpad board into a canonical one:
+    close empty slots so the surviving scored games are numbered ``1..N`` with
+    no holes. Pure — returns fresh models, doesn't mutate input.
+
+    Renumbers by the *rank of each distinct* ``game_number`` (not by list
+    position), so a genuine duplicate game_number is preserved as a duplicate
+    (two games at original ``1`` both map to new ``1``) and the strict
+    ``_validate_finalize_games`` duplicate check downstream still rejects it.
+    (Renumbering *does* absorb an out-of-``best_of``-range game_number — e.g.
+    ``[1,2,5]`` on best-of-3 → ``[1,2,3]`` — but the real scratchpad never
+    produces one: the score endpoints reject ``game_number > best_of`` before a
+    score is ever saved, and a finalize payload's out-of-range numbers only
+    reach here via a hand-crafted API call, where relabeling three legal scored
+    games into a legal 3-game board is harmless.)
+
+    Provably outcome-invariant: an empty (unscored) slot contributes 0 wins to
+    either side, so dropping it and relabeling can never change the winner or
+    the game score — only the cosmetic slot numbers. It heals the out-of-order
+    clinch (score game 5 while game 4 is blank → ``[1,2,3,5]`` compacts to
+    ``[1,2,3,4]`` and finalizes) without touching a real overrun (a fully-scored
+    ``[1,2,3,4,5]`` compacts to itself and stays rejected).
+    See ``docs/adr/0002-decided-board-is-compacted-at-propose.md``."""
+    rank = {
+        original: compacted
+        for compacted, original in enumerate(
+            sorted({g.game_number for g in games}), start=1
+        )
+    }
+    return [
+        MatchResultsGameWrite(
+            game_number=rank[g.game_number],
+            side_1_points=g.side_1_points,
+            side_2_points=g.side_2_points,
+        )
+        for g in sorted(games, key=lambda g: g.game_number)
+    ]
+
+
+def _validate_finalize_games(games: list[MatchResultsGameWrite], best_of: int) -> int:
+    """Cross-game invariants for a finalize payload. Per-game point legality
+    is already enforced by ``MatchResultsGameWrite``. Returns the decided side
+    number (1 or 2); raises ``ValueError`` with a human-readable detail on any
+    failure (the route handler maps that to 422)."""
+    if not games:
+        raise ValueError("A match needs at least one game to finalize.")
+
+    numbers = [g.game_number for g in games]
+    if any(n > best_of for n in numbers):
+        raise ValueError(f"Each game_number must be ≤ best_of ({best_of}).")
+    if len(set(numbers)) != len(numbers):
+        raise ValueError("Duplicate game_number in payload.")
+    if sorted(numbers) != list(range(1, len(numbers) + 1)):
+        raise ValueError("Games must be numbered 1..N consecutively with no gaps.")
+
+    target = _games_to_win(best_of)
+    decider = _first_decider(games, target)
+    if decider is None:
+        raise ValueError(
+            f"No side reached {target} game wins — the match isn't decided."
+        )
+    decided_side, decided_at = decider
+    if decided_at != max(numbers):
+        raise ValueError(
+            "Scored games extend past the deciding game; "
+            "drop any games after the decider."
+        )
+    return decided_side
+
+
+def _games_payload_from_match(match: Match) -> list[MatchResultsGameWrite]:
+    """Recast currently-saved scores as a finalize payload, so ``_can_finalize``
+    can reuse ``_validate_finalize_games`` instead of duplicating its rules.
+
+    Returns the board **raw** (scored games at their real ``game_number``, gaps
+    and all). The two scratchpad overrun guards depend on this: ``create_game_score``
+    reports the tapped game in its 422 detail, and ``update_game_score`` substitutes
+    the edited game by matching the raw ``game_number`` — both would break on a
+    renumbered board. Compaction is applied by ``_can_finalize`` alone, at its own
+    call site, since only the finalize predicate wants a canonical board."""
+    return [
+        MatchResultsGameWrite(
+            game_number=g.game_number,
+            side_1_points=g.score.side_1_points,
+            side_2_points=g.score.side_2_points,
+        )
+        for g in match.games
+        if g.score is not None
+    ]
+
+
+def _can_finalize(match: Match) -> bool:
+    """Whether ``POST /v1/matches/{id}/results`` would succeed on the
+    currently-saved scores (ignoring authorization). Drives the FE's
+    ``can_finalize`` flag and the submit button's adaptive label.
+
+    Returns False once any result exists — the FE drives this flag only for the
+    FIRST proposal; subsequent counters/acceptances flow through the negotiation
+    surface, not /results-as-finalize.
+
+    Compacts the saved board before validating, mirroring the write path: a
+    gappy-but-decided board (an out-of-order clinch that left a hole) reports
+    ``can_finalize = true`` so the finalize-callout / SaveBanner offers "Post
+    result" and the user self-heals with one tap — this also heals already-stuck
+    matches with no migration."""
+    if match.status != MatchStatus.in_progress:
+        return False
+    if match.results:
+        return False
+    try:
+        _validate_finalize_games(
+            _compact_games(_games_payload_from_match(match)),
+            match.match_settings.best_of,
+        )
+    except ValueError:
+        return False
+    return True
+
+
+def _serialize_details(
+    match: Match,
+    current_user_id: uuid.UUID | None,
+    extras: MatchDetailsExtras | None = None,
+    domain_match: MatchModel | None = None,
+) -> MatchDetails:
+    extras = extras or empty_extras()
+    # The ``data`` view is built from the domain model. The match-details
+    # endpoint loads it through MatchService/MatchRepository and passes it in;
+    # the other serialize call sites already hold the full ORM row, so they
+    # derive it directly rather than firing a second query.
+    domain_match = domain_match or MatchModel.from_row(match)
+    side_wins = side_win_counts(match)
+
+    games_sorted = sorted(match.games, key=lambda g: g.game_number)
+    games = [
+        MatchDetailsGame(
+            id=game.id,
+            game_number=game.game_number,
+            score=_score_view(game.score) if game.score else None,
+        )
+        for game in games_sorted
+    ]
+
+    next_number = current_game_number(match)
+    current_game = (
+        MatchDetailsCurrentGame(game_number=next_number)
+        if next_number is not None
+        else None
+    )
+
+    sides_sorted = sorted(match.sides, key=lambda s: s.side_number)
+    # Anonymous viewers on the public route are never participants.
+    is_participant = current_user_id is not None and _is_participant(
+        match, current_user_id
+    )
+
+    return MatchDetails(
+        id=match.id,
+        status=match.status,
+        status_label=_status_label(match),
+        league=MatchLeague(id=match.league.id, name=match.league.name),
+        best_of=match.match_settings.best_of,
+        games_to_win=_games_to_win(match.match_settings.best_of),
+        team_size=match.match_settings.team_size,
+        affects_rating=match.match_settings.affects_rating,
+        created_at=match.created_at,
+        sides=[
+            _side_schema(side, side_wins, current_user_id, extras.rating_changes)
+            for side in sides_sorted
+        ],
+        games=games,
+        current_game=current_game,
+        # "This participant may edit scores" — true whenever the match is
+        # scorable (no result posted yet; see ``_is_scorable``), *independent*
+        # of whether there's a next un-played game. A decided-but-unposted
+        # board is still editable, so this is True while ``current_game`` is
+        # None. Spectators get the read-only view — writes
+        # 404 for non-participants in the score endpoints regardless.
+        can_score=(is_participant and _is_scorable(match)),
+        # True iff the saved games already form a decided, validly-ordered
+        # match AND no result is currently posted — the FE flips the scoring
+        # page's submit button label to "Post result" when this is true.
+        can_finalize=(
+            is_participant and len(match.sides) >= 2 and _can_finalize(match)
+        ),
+        # Viewer-relative negotiation state — the standing proposal, whose turn
+        # it is, and (when the opponent corrected the viewer's own proposal) the
+        # diff. Drives the accept CTA + the negotiation callouts (#713).
+        negotiation=_negotiation(match, current_user_id),
+        # ``extras.recent_form`` is a read-only Sequence; the response model owns
+        # its own list, so copy rather than alias it.
+        recent_form=list(extras.recent_form),
+        head_to_head=extras.head_to_head,
+        data=serialize_match_details(domain_match),
+    )

--- a/api/app/match_serialization.py
+++ b/api/app/match_serialization.py
@@ -12,11 +12,25 @@ modules — never a router — so it stays cycle-free.
 
 import uuid
 from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.base import ExecutableOption
 
 from app.domain.match.models import Match as MatchModel
 from app.mappers.match_details_mapper import serialize_match_details
-from app.mappers.match_extras_mapper import MatchDetailsExtras, empty_extras
-from app.match_queries import current_game_number, my_side
+from app.mappers.match_extras_mapper import (
+    MatchDetailsExtras,
+    empty_extras,
+    serialize_match_extras,
+)
+from app.match_queries import (
+    current_game_number,
+    match_eager_options,
+    my_side,
+    singles_user_ids,
+)
 from app.models import (
     Match,
     MatchGameScore,
@@ -24,6 +38,9 @@ from app.models import (
     MatchSide,
     MatchStatus,
 )
+
+if TYPE_CHECKING:
+    from app.services.match_service import MatchService
 from app.result_acceptance import (
     _game_winner_side,
     _games_to_win,
@@ -515,4 +532,48 @@ def _serialize_details(
         recent_form=list(extras.recent_form),
         head_to_head=extras.head_to_head,
         data=serialize_match_details(domain_match),
+    )
+
+
+async def load_match_eager(
+    db: AsyncSession,
+    match_id: uuid.UUID,
+    *,
+    options: tuple[ExecutableOption, ...] | None = None,
+) -> Match | None:
+    """Load the eager ``Match`` ORM row the serializer needs (nullable — the
+    read path 404s / raises a ``ToolError`` on absence).
+
+    The canonical read-path loader shared by the HTTP ``GET /v1/matches/{id}``
+    handler and the MCP ``get_match`` tool so the two can't drift on the
+    eager-load chain. ``options`` overrides the default ``match_eager_options()``
+    chain (the router's public-details read passes it through)."""
+    result = await db.execute(
+        select(Match)
+        .where(Match.id == match_id)
+        .options(*(options if options is not None else match_eager_options()))
+    )
+    return result.scalar_one_or_none()
+
+
+async def view_extras(
+    match_service: "MatchService", match: Match
+) -> MatchDetailsExtras:
+    """The participant-only extras block (rating changes, recent form,
+    head-to-head) for an already-loaded ``match``.
+
+    The caller hands the service the primitives it already holds and gets back a
+    domain model; the SQL lives in ``MatchDetailsRepository`` and the wire shapes
+    are built by the extras mapper. Callers gate on participation *before* calling
+    this — a non-participant gets ``empty_extras()`` (see #515). Shared by the
+    HTTP GET and the MCP ``get_match`` tool so the two produce the identical
+    extras assembly."""
+    return serialize_match_extras(
+        await match_service.load_view_extras(
+            match_id=match.id,
+            league_id=match.league_id,
+            status=match.status,
+            created_at=match.created_at,
+            user_ids=singles_user_ids(match),
+        )
     )

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -17,7 +17,7 @@ from fastapi import (
 )
 from pyrate_limiter import Duration, Rate
 from sqlalchemy import Select, func, select
-from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.base import ExecutableOption
@@ -45,18 +45,18 @@ from app.match_queries import (
     singles_user_ids,
 )
 from app.match_scoring import (
-    delete_game_score as delete_game_score_core,
+    MatchLockUnavailable,
+    enter_game_score,
+    load_match_for_write,
 )
 from app.match_scoring import (
-    enter_game_score,
+    delete_game_score as delete_game_score_core,
 )
 from app.match_scoring import (
     update_game_score as update_game_score_core,
 )
 from app.match_serialization import (
     _compact_games,
-    _first_decider,
-    _games_payload_from_match,
     _is_participant,
     _is_scorable,
     _negotiation,
@@ -80,13 +80,15 @@ from app.notifications.service import NotificationService
 from app.notifications.taxonomy import NotificationCategory
 from app.rate_limiting import RedisRateLimiter
 from app.result_acceptance import (
+    MatchNotFoundError,
+    MatchNotScorableError,
     OpponentNotFoundError,
     PostedGamesNotDecisiveError,
     RatedNeedsRegisteredOpponentError,
     ScoreConflictError,
+    ScoreNotAllowedError,
     SelfMatchError,
     StandingResultConflictError,
-    _games_to_win,
     accept_standing_result,
     finalize_match,
     side_win_counts,
@@ -104,7 +106,6 @@ from app.schemas.match import (
     MatchListFilter,
     MatchListResponse,
     MatchListRow,
-    MatchResultsGameWrite,
     MatchResultsWrite,
 )
 from app.schemas.notification import NotificationJob
@@ -608,38 +609,6 @@ _TERMINAL_STATUSES = {
 }
 
 
-def _enforce_scorable(match: Match) -> None:
-    """Raise when a match can't be scored. ``_is_scorable`` owns the *decision*;
-    this only picks the reason-specific status/message for a rejection, so the
-    write guard can't drift from the ``can_score`` flag — a future gate added to
-    ``_is_scorable`` falls through to the catch-all 409 rather than being
-    silently accepted."""
-    if _is_scorable(match):
-        return
-    if len(match.sides) < 2:
-        raise HTTPException(
-            status_code=422,
-            detail="This match has no opponent and can't be scored.",
-        )
-    # Any posted result freezes the scratchpad (#715); the board now only
-    # changes through propose/accept, not the score endpoints.
-    if match.results:
-        raise HTTPException(
-            status_code=409,
-            detail="This match has a posted result; scores are frozen.",
-        )
-    # Scheduled but not yet called to a table (#1073): the schedule is
-    # authoritative, so an uncalled match can't be played out-of-band.
-    if match.status == MatchStatus.pending:
-        raise HTTPException(
-            status_code=409,
-            detail="This match hasn't been called to a table yet.",
-        )
-    # Terminal status (``completed``/``voided``) — or any future
-    # ``_is_scorable`` gate without a message of its own.
-    raise HTTPException(status_code=409, detail="This match is no longer scorable.")
-
-
 # ----- result-acceptance push ---------------------------------------------
 
 # En-dash between scores reads better than a hyphen in notification copy.
@@ -767,49 +736,6 @@ async def _notify_result_posted(
 # ----- finalize-payload validation + apply --------------------------------
 
 
-def _overrun_decider(games: list[MatchResultsGameWrite], best_of: int) -> int | None:
-    """The game number at which the match was already decided when there are
-    scored games numbered *after* it ("overrun"). Returns ``None`` for empty,
-    still-undecided, or exactly-decided-at-the-last-game boards — all legal
-    scratchpad states.
-
-    Gap-tolerant on purpose: it shares the decider core with the finalize
-    validator but does **not** require ``1..N`` contiguity, so legitimate
-    out-of-order / gappy entry (e.g. scoring game 3 first) is allowed right up
-    until a side actually clinches *before* the highest-numbered scored game.
-    That is the impossible state — games can't have been played after the match
-    was already won — so the scratchpad write path rejects it."""
-    if not games:
-        return None
-    decider = _first_decider(games, _games_to_win(best_of))
-    if decider is None:
-        return None
-    _, decided_at = decider
-    if decided_at < max(g.game_number for g in games):
-        return decided_at
-    return None
-
-
-def _enforce_no_overrun(
-    games: list[MatchResultsGameWrite], best_of: int, game_number: int
-) -> None:
-    """Reject a scratchpad write (422) when the prospective board ``games`` would
-    leave the match decided before its last scored game. Shared by both
-    score-write paths so the check, status, and message can't drift; each caller
-    builds its own prospective board (the create path mutates the ORM then reads
-    it back, the update path substitutes the payload because its write is raw
-    SQL), then hands it here."""
-    decided_at = _overrun_decider(games, best_of)
-    if decided_at is not None:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"The match was already decided at game {decided_at}; "
-                f"game {game_number} can't be played."
-            ),
-        )
-
-
 def _result_games_snapshot(payload: MatchResultsWrite) -> list[dict[str, int]]:
     """The immutable JSONB snapshot stored on a ``MatchResult`` — the claimed
     board frozen at post time, ordered by game number. (A typed read-side decode
@@ -873,57 +799,6 @@ def _requires_confirmation(match: Match) -> bool:
 # ----- scoring endpoints ---------------------------------------------------
 
 
-class MatchLockUnavailable(Exception):
-    """``SELECT ... FOR UPDATE NOWAIT`` found the match row already locked by a
-    concurrent negotiation transaction. Raised by ``_lock_match_row(nowait=True)``
-    so the caller can translate it into a fast, clean 409 instead of blocking
-    on the lock (see ``post_match_result``)."""
-
-
-# Postgres SQLSTATE for a ``NOWAIT`` lock that could not be acquired.
-_LOCK_NOT_AVAILABLE = "55P03"
-
-
-async def _lock_match_row(
-    db: AsyncSession, match_id: uuid.UUID, *, nowait: bool = False
-) -> None:
-    """Take a transaction-scoped row lock on the ``matches`` row so the
-    negotiation transitions (``/results`` propose, ``/results/{id}/acceptance``)
-    serialize against each other.
-
-    Without this, a participant firing two acceptances (or a propose racing an
-    acceptance) concurrently lets both transactions pass their standing-result
-    guard on the same pre-image and both commit — finalizing the match twice and
-    applying a rating change more than once (issue #365). The lock forces the
-    second transaction to wait for the first to commit and then re-read the
-    post-image, so its guard returns a clean 409.
-
-    It's a thin ``SELECT matches.id ... FOR UPDATE`` rather than adding
-    ``.with_for_update()`` to the eager ``_load_match`` query: a narrow
-    lock-only select is cheaper than re-running ``match_eager_options`` (which
-    fans out into a selectinload query per relationship) just to take the lock,
-    and acquiring it on its own line makes the lock-then-read ordering explicit
-    — the subsequent load sees the serialized state. Locking just the parent
-    row is enough — every negotiation transition reads and writes that match's
-    children under cover of this lock.
-
-    ``nowait=True`` adds ``NOWAIT``: if the row is already locked, Postgres
-    raises immediately instead of blocking, which we surface as
-    ``MatchLockUnavailable``. ``post_match_result`` uses this so a double-tapped
-    finalize doesn't park a request (and its pooled DB connection) on the lock
-    for the full duration of the in-flight post — the pile-up that wedged the
-    whole instance under a stray double-click (issue #641). The blocking form
-    is kept for /results/{id}/acceptance, where a second concurrent caller is a
-    *legitimate* acceptor that must wait, re-read, and proceed."""
-    stmt = select(Match.id).where(Match.id == match_id).with_for_update(nowait=nowait)
-    try:
-        await db.execute(stmt)
-    except DBAPIError as exc:
-        if nowait and getattr(exc.orig, "sqlstate", None) == _LOCK_NOT_AVAILABLE:
-            raise MatchLockUnavailable from exc
-        raise
-
-
 async def _load_match_for_scoring(
     db: AsyncSession,
     match_id: uuid.UUID,
@@ -933,20 +808,27 @@ async def _load_match_for_scoring(
     nowait: bool = False,
     options: tuple[ExecutableOption, ...] | None = None,
 ) -> Match:
-    # ``lock`` callers (the negotiation transitions, and per ADR-0009 the score
-    # endpoints) take the row lock *before* the eager load so the match state
-    # they read is the serialized one.
-    #
-    # The finalize paths (``post_match_result`` self-accept, ``accept_match_result``)
-    # pass ``options=match_rating_eager_options()`` so ``_apply_rating_update`` can
-    # read ``league.rating_strategy`` without a mid-request lazy load; the scratchpad
-    # score endpoints never finalize, so they take the default read chain.
-    if lock:
-        await _lock_match_row(db, match_id, nowait=nowait)
-    match = await _load_match(db, match_id, options=options)
-    if match is None or not _is_participant(match, current_user_id):
-        raise HTTPException(status_code=404, detail="Match not found.")
-    return match
+    """The HTTP adapter over the FastAPI-free ``load_match_for_write``: it maps
+    the service's :class:`MatchNotFoundError` (absent match *or* non-participant)
+    to the endpoints' historical ``HTTPException(404, "Match not found.")`` and
+    lets :class:`MatchLockUnavailable` propagate so ``post_match_result`` can
+    translate a held ``NOWAIT`` lock into its fast 409.
+
+    Both the negotiation transitions (``post_match_result``,
+    ``accept_match_result``) and — as the injected load seam — the score handlers
+    call this, so it stays the single monkeypatchable load the #835 row-lock race
+    tests barrier on."""
+    try:
+        return await load_match_for_write(
+            db,
+            match_id,
+            current_user_id,
+            lock=lock,
+            nowait=nowait,
+            options=options,
+        )
+    except MatchNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Match not found.") from exc
 
 
 # Per-game endpoints are addressed by ``game_number``: a game row may not
@@ -955,6 +837,39 @@ async def _load_match_for_scoring(
 # on an existing score. All three are pure "save / clear scratchpad state" —
 # they never touch match.status, side wins, side.won, or ratings. The single
 # canonical commit happens in ``finalize_match`` below.
+
+
+# The FastAPI-free score write path (``app.match_scoring``) raises this closed
+# family of domain exceptions; ``_map_score_write_error`` reproduces the exact
+# status + body each endpoint produced before the guards moved into the service.
+# ``_SCORE_WRITE_ERRORS`` is the ``except`` tuple; the alias types the mapper.
+_ScoreWriteError = (
+    MatchNotFoundError
+    | MatchNotScorableError
+    | ScoreNotAllowedError
+    | ScoreConflictError
+)
+_SCORE_WRITE_ERRORS = (
+    MatchNotFoundError,
+    MatchNotScorableError,
+    ScoreNotAllowedError,
+    ScoreConflictError,
+)
+
+
+def _map_score_write_error(exc: _ScoreWriteError) -> HTTPException:
+    """Adapt a score-write domain exception to its historical HTTP response:
+    ``MatchNotFoundError`` → 404 with the carried message (``"Match not found."``
+    / ``"Score not found."``), ``MatchNotScorableError`` → its carried 422/409 +
+    message, ``ScoreNotAllowedError`` → 422 (best-of range / overrun), and
+    ``ScoreConflictError`` → the structured 409 ``MatchGameScoreConflict`` body."""
+    if isinstance(exc, MatchNotFoundError):
+        return HTTPException(status_code=404, detail=exc.message)
+    if isinstance(exc, MatchNotScorableError):
+        return HTTPException(status_code=exc.http_status, detail=exc.message)
+    if isinstance(exc, ScoreNotAllowedError):
+        return HTTPException(status_code=422, detail=str(exc))
+    return _score_conflict(exc.committed_score)
 
 
 @router.post(
@@ -971,56 +886,24 @@ async def create_game_score(
     db: AsyncSession = Depends(get_session),
     match_service: MatchService = Depends(get_match_service),
 ) -> MatchDetails:
-    # Take the blocking match row lock so this score write serializes against a
-    # concurrent first ``post_match_result`` (which locks the same row NOWAIT).
-    # The lock is acquired *before* the eager load, so the ``_enforce_scorable``
-    # recheck below runs on the serialized (post-freeze) state — a score can no
-    # longer commit atop a result the propose already froze (#835, ADR-0009).
-    # Blocking (not NOWAIT): the common score-vs-score contention resolves via
-    # the uq_match_games / version guards and must not spuriously 409.
-    match = await _load_match_for_scoring(db, match_id, current_user.id, lock=True)
-    _enforce_scorable(match)
-    if game_number > match.match_settings.best_of:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"This match is best of {match.match_settings.best_of}; "
-                f"game {game_number} can't exist."
-            ),
-        )
-
-    # The board can't have games after the match was already decided. Reject
-    # before delegating (request teardown rolls back the uncommitted session),
-    # gap-tolerant — only a clinch *before* the last scored game trips. An
-    # existing committed score at this game short-circuits to the service's 409
-    # below without running overrun, preserving the historical ordering (the
-    # pre-existing-score conflict was raised before the overrun 422). Because
-    # this game has no committed score in that branch, the prospective board is
-    # the currently-scored games plus this new write — identical to the ORM the
-    # old handler mutated then read back.
-    game = next((g for g in match.games if g.game_number == game_number), None)
-    if game is None or game.score is None:
-        prospective = [
-            g for g in _games_payload_from_match(match) if g.game_number != game_number
-        ] + [
-            MatchResultsGameWrite(
-                game_number=game_number,
-                side_1_points=payload.side_1_points,
-                side_2_points=payload.side_2_points,
-            )
-        ]
-        _enforce_no_overrun(prospective, match.match_settings.best_of, game_number)
-
+    # The whole write path — the blocking match row lock (serializing against a
+    # concurrent first ``post_match_result`` NOWAIT lock, #835/ADR-0009), the
+    # scorability / best-of-range / no-overrun guards, and the mutation — is
+    # owned by the service. ``load_match=_load_match_for_scoring`` injects the
+    # router's monkeypatchable load seam (mapping a missing/foreign match to its
+    # 404) so the row-lock race tests still barrier on it.
     try:
         reloaded = await enter_game_score(
             db,
-            match,
+            match_id,
+            current_user.id,
             game_number=game_number,
             side_1_points=payload.side_1_points,
             side_2_points=payload.side_2_points,
+            load_match=_load_match_for_scoring,
         )
-    except ScoreConflictError as exc:
-        raise _score_conflict(exc.committed_score) from exc
+    except _SCORE_WRITE_ERRORS as exc:
+        raise _map_score_write_error(exc) from exc
 
     extras = await _view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
@@ -1039,46 +922,23 @@ async def update_game_score(
     db: AsyncSession = Depends(get_session),
     match_service: MatchService = Depends(get_match_service),
 ) -> MatchDetails:
-    # Blocking match row lock (see ``create_game_score``): serializes this update
-    # against a concurrent first ``post_match_result`` so ``_enforce_scorable``
-    # rechecks the serialized state and the conditional UPDATE below can't race a
-    # board freeze that deletes the target score row (#835, ADR-0009). Blocking,
-    # not NOWAIT, so the common score-vs-score edit isn't spuriously 409'd.
-    match = await _load_match_for_scoring(db, match_id, current_user.id, lock=True)
-    _enforce_scorable(match)
-
-    game = next((g for g in match.games if g.game_number == game_number), None)
-    if game is None or game.score is None:
-        raise HTTPException(status_code=404, detail="Score not found.")
-
-    # Editing a game's winner can move the decider earlier, so the same
-    # "no games past the decider" guard the create path enforces applies here.
-    # The service's UPDATE runs in raw SQL, so in-memory ``match.games`` still
-    # holds the OLD score — build the prospective board by substituting the
-    # payload points for this game before delegating.
-    prospective = [
-        g
-        if g.game_number != game_number
-        else MatchResultsGameWrite(
-            game_number=game_number,
-            side_1_points=payload.side_1_points,
-            side_2_points=payload.side_2_points,
-        )
-        for g in _games_payload_from_match(match)
-    ]
-    _enforce_no_overrun(prospective, match.match_settings.best_of, game_number)
-
+    # Whole write path owned by the service (blocking row lock, scorability, the
+    # score's existence 404, the no-overrun guard on the payload-substituted
+    # prospective board, then the optimistic-concurrency UPDATE — #835/ADR-0009).
+    # ``load_match=_load_match_for_scoring`` keeps the barrier-patchable load seam.
     try:
         reloaded = await update_game_score_core(
             db,
-            match,
+            match_id,
+            current_user.id,
             game_number=game_number,
             side_1_points=payload.side_1_points,
             side_2_points=payload.side_2_points,
             expected_version=payload.expected_version,
+            load_match=_load_match_for_scoring,
         )
-    except ScoreConflictError as exc:
-        raise _score_conflict(exc.committed_score) from exc
+    except _SCORE_WRITE_ERRORS as exc:
+        raise _map_score_write_error(exc) from exc
 
     extras = await _view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
@@ -1095,19 +955,22 @@ async def delete_game_score(
     db: AsyncSession = Depends(get_session),
     match_service: MatchService = Depends(get_match_service),
 ) -> MatchDetails:
-    # Blocking match row lock (see ``create_game_score``): serializes this delete
-    # against a concurrent first ``post_match_result`` so ``_enforce_scorable``
-    # rechecks the serialized state, and two racing clears re-read under the lock
-    # — the loser sees the already-cleared score and 404s instead of a lying 200
-    # (#835, ADR-0009). Blocking, not NOWAIT, to match the other score paths.
-    match = await _load_match_for_scoring(db, match_id, current_user.id, lock=True)
-    _enforce_scorable(match)
+    # Whole write path owned by the service (blocking row lock, scorability, the
+    # score's existence 404, then the clear — #835/ADR-0009). Two racing clears
+    # re-read under the lock, so the loser sees the already-cleared score and
+    # 404s. ``load_match=_load_match_for_scoring`` keeps the barrier-patchable
+    # load seam.
+    try:
+        reloaded = await delete_game_score_core(
+            db,
+            match_id,
+            current_user.id,
+            game_number=game_number,
+            load_match=_load_match_for_scoring,
+        )
+    except _SCORE_WRITE_ERRORS as exc:
+        raise _map_score_write_error(exc) from exc
 
-    game = next((g for g in match.games if g.game_number == game_number), None)
-    if game is None or game.score is None:
-        raise HTTPException(status_code=404, detail="Score not found.")
-
-    reloaded = await delete_game_score_core(db, match, game_number=game_number)
     extras = await _view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
 

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -79,6 +79,7 @@ from app.notifications.service import NotificationService
 from app.notifications.taxonomy import NotificationCategory
 from app.rate_limiting import RedisRateLimiter
 from app.result_acceptance import (
+    CannotAcceptOwnProposalError,
     MatchClosedError,
     MatchNotFoundError,
     MatchNotScorableError,
@@ -86,17 +87,22 @@ from app.result_acceptance import (
     OpponentNotFoundError,
     PostedGamesNotDecisiveError,
     RatedNeedsRegisteredOpponentError,
+    ResultNotFoundError,
     ScoreConflictError,
     ScoreNotAllowedError,
     SelfMatchError,
-    StandingResultConflictError,
     UndecidedBoardError,
-    accept_standing_result,
+    accept_result,
     side_win_counts,
 )
 from app.result_chain import standing_result
+
+# Re-exported for ``tests/test_ratings.py``, which loads the finalize eager-load
+# superset via ``app.matches.match_rating_eager_options`` (the propose/accept
+# paths that consume it now live in the services). Redundant alias marks the
+# intentional re-export so ruff doesn't flag it as unused.
+from app.result_proposal import match_rating_eager_options as match_rating_eager_options
 from app.result_proposal import (
-    match_rating_eager_options,
     propose_result,
 )
 from app.schemas.match import (
@@ -1019,52 +1025,38 @@ async def accept_match_result(
     negotiation state (or a 404 if no result with that id exists on the match).
     The proposing side already consented by proposing, so only a participant on
     the *opposing* side may accept."""
-    match = await _load_match_for_scoring(
-        db,
-        match_id,
-        current_user.id,
-        lock=True,
-        options=match_rating_eager_options(),
-    )
-
-    # The path ``result_id`` must exist on this match at all (404); the live
-    # standing-proposal check (409 with the moved-on state) is owned by
-    # ``accept_standing_result`` so it runs identically from a worker.
-    if not any(r.id == result_id for r in match.results):
-        raise HTTPException(status_code=404, detail="Result not found.")
-
-    # The proposing side already consented by proposing; only the opposing side
-    # accepts. A participant on the submitter's side (in singles, the submitter
-    # themselves) can't accept their own proposal. Only meaningful while the
-    # targeted result is still standing — a superseded/absent one falls through
-    # to the core's conflict signal below.
-    standing = standing_result(match)
-    if standing is not None and standing.id == result_id:
-        submitter_side = my_side(match, standing.submitted_by_user_id)
-        if submitter_side is not None and any(
-            p.user_id == current_user.id for p in submitter_side.players
-        ):
-            raise HTTPException(
-                status_code=409, detail="You can't accept your own proposal."
-            )
-
+    # The whole accept path — the blocking row lock (serializing against a
+    # concurrent transition, #365), the result-exists 404 gate, the submitter-side
+    # self-accept guard, the live standing-proposal check, ``finalize_match`` (mark
+    # completed, stamp ``side.won``, apply ratings, advance any tournament draw),
+    # and the commit — is owned by the service. ``load_match=_load_match_for_scoring``
+    # injects the router's monkeypatchable load seam (mapping a missing/foreign
+    # match to its 404) so the #835 row-lock race tests still barrier on it.
     try:
-        await accept_standing_result(
+        reloaded = await accept_result(
             db,
-            match,
+            match_id,
+            current_user.id,
             result_id=result_id,
-            accepted_by_user_id=current_user.id,
+            load_match=_load_match_for_scoring,
         )
-    except StandingResultConflictError:
-        raise _negotiation_conflict(match, current_user.id) from None
-    except PostedGamesNotDecisiveError:
+    except ResultNotFoundError as exc:
+        # The path ``result_id`` isn't a result on this match at all.
+        raise HTTPException(status_code=404, detail="Result not found.") from exc
+    except CannotAcceptOwnProposalError as exc:
+        # A participant on the submitter's side can't accept their own proposal.
+        raise HTTPException(
+            status_code=409, detail="You can't accept your own proposal."
+        ) from exc
+    except NegotiationConflictError as exc:
+        # The targeted result is no longer the live standing proposal (superseded,
+        # already accepted, or none standing). The 409 carries the viewer-relative
+        # moved-on state from the loaded match.
+        raise _negotiation_conflict(exc.match, current_user.id) from exc
+    except PostedGamesNotDecisiveError as exc:
         raise HTTPException(
             status_code=409, detail="The posted games no longer decide this match."
-        ) from None
+        ) from exc
 
-    await db.commit()
-
-    reloaded = await _load_match(db, match.id)
-    assert reloaded is not None
     extras = await _view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -17,9 +17,7 @@ from fastapi import (
 )
 from pyrate_limiter import Duration, Rate
 from sqlalchemy import Select, func, select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.base import ExecutableOption
 
 from app.attention import (
@@ -55,21 +53,22 @@ from app.match_scoring import (
 from app.match_scoring import (
     update_game_score as update_game_score_core,
 )
+
+# Re-exported for ``tests/test_matches.py``, which unit-tests the compaction
+# helper via ``app.matches._compact_games`` (the propose path that consumes it
+# now lives in ``app.result_proposal``). Redundant alias marks the intentional
+# re-export so ruff doesn't flag it as unused.
+from app.match_serialization import _compact_games as _compact_games
 from app.match_serialization import (
-    _compact_games,
     _is_participant,
     _is_scorable,
     _negotiation,
     _serialize_details,
     _side_schema,
     _status_label,
-    _validate_finalize_games,
 )
 from app.models import (
-    League,
     Match,
-    MatchGame,
-    MatchGameScore,
     MatchResult,
     MatchStatus,
     User,
@@ -80,8 +79,10 @@ from app.notifications.service import NotificationService
 from app.notifications.taxonomy import NotificationCategory
 from app.rate_limiting import RedisRateLimiter
 from app.result_acceptance import (
+    MatchClosedError,
     MatchNotFoundError,
     MatchNotScorableError,
+    NegotiationConflictError,
     OpponentNotFoundError,
     PostedGamesNotDecisiveError,
     RatedNeedsRegisteredOpponentError,
@@ -89,11 +90,15 @@ from app.result_acceptance import (
     ScoreNotAllowedError,
     SelfMatchError,
     StandingResultConflictError,
+    UndecidedBoardError,
     accept_standing_result,
-    finalize_match,
     side_win_counts,
 )
 from app.result_chain import standing_result
+from app.result_proposal import (
+    match_rating_eager_options,
+    propose_result,
+)
 from app.schemas.match import (
     MatchCreate,
     MatchDetails,
@@ -123,19 +128,6 @@ MAX_PAGE_SIZE = 100
 # ----- helpers -------------------------------------------------------------
 
 
-# The finalize/score-write superset: everything a read needs, plus the league's
-# rating strategy that ``_apply_rating_update`` reads when a completing match
-# applies ratings. Under async SQLAlchemy a lazy access on the unloaded
-# ``league.rating_strategy`` would raise ``MissingGreenlet`` mid-request, so the
-# two paths that finalize a match must load it up front rather than rely on the
-# shared read chain.
-def match_rating_eager_options() -> tuple[ExecutableOption, ...]:
-    return (
-        *match_eager_options(),
-        selectinload(Match.league).selectinload(League.rating_strategy),
-    )
-
-
 async def _load_match(
     db: AsyncSession,
     match_id: uuid.UUID,
@@ -148,13 +140,6 @@ async def _load_match(
         .options(*(options if options is not None else match_eager_options()))
     )
     return result.scalar_one_or_none()
-
-
-def _all_sides_have_players(match: Match) -> bool:
-    """Solo matches (no opponent picked) carry one player-less sentinel side.
-    The acceptance flow needs a second human, so solo matches skip
-    it entirely; this is the predicate that detects that case."""
-    return len(match.sides) >= 2 and all(side.players for side in match.sides)
 
 
 # One message for every score-write conflict — a concurrent participant already
@@ -599,16 +584,6 @@ async def get_match(
     )
 
 
-# ----- score writes --------------------------------------------------------
-
-
-# A match that has reached one of these states is read-only — never scorable.
-_TERMINAL_STATUSES = {
-    MatchStatus.completed,
-    MatchStatus.voided,
-}
-
-
 # ----- result-acceptance push ---------------------------------------------
 
 # En-dash between scores reads better than a hyphen in notification copy.
@@ -731,69 +706,6 @@ async def _notify_result_posted(
                 collapse_id=f"result-confirm:{match.id}",
             )
         )
-
-
-# ----- finalize-payload validation + apply --------------------------------
-
-
-def _result_games_snapshot(payload: MatchResultsWrite) -> list[dict[str, int]]:
-    """The immutable JSONB snapshot stored on a ``MatchResult`` — the claimed
-    board frozen at post time, ordered by game number. (A typed read-side decode
-    lands with #366, the first consumer of the snapshot.)"""
-    return [
-        {
-            "game_number": g.game_number,
-            "side_1_points": g.side_1_points,
-            "side_2_points": g.side_2_points,
-        }
-        for g in sorted(payload.games, key=lambda g: g.game_number)
-    ]
-
-
-async def _commit_canonical_games(
-    db: AsyncSession,
-    match: Match,
-    payload: MatchResultsWrite,
-) -> None:
-    """Replace ``match.games`` (and the attached score rows) with the canonical
-    payload and set ``side.score`` from it. **Does not change ``match.status``
-    or ``side.won``** — the caller picks whether the result is final
-    (solo/unrated: immediately at /results) or awaiting acceptance (rated),
-    and stamps ``side.won`` via ``_set_side_won`` only at that final moment."""
-    # ``Match.games`` cascades ``all, delete-orphan``; clearing the collection
-    # marks each existing MatchGame (and via MatchGame.score's own cascade,
-    # the MatchGameScore) for delete. We must flush the deletes before
-    # inserting new games at the same numbers, otherwise the
-    # ``uq_match_games_match_id_game_number`` constraint trips during
-    # autoflush.
-    match.games.clear()
-    await db.flush()
-
-    for game in sorted(payload.games, key=lambda g: g.game_number):
-        match.games.append(
-            MatchGame(
-                game_number=game.game_number,
-                score=MatchGameScore(
-                    side_1_points=game.side_1_points,
-                    side_2_points=game.side_2_points,
-                ),
-            )
-        )
-
-    new_wins: dict[int, int] = {1: 0, 2: 0}
-    for g in payload.games:
-        new_wins[1 if g.side_1_points > g.side_2_points else 2] += 1
-    for side in match.sides:
-        side.score = new_wins.get(side.side_number, 0)
-
-
-def _requires_confirmation(match: Match) -> bool:
-    """Only rated matches go through the accept round-trip. Acceptance
-    exists to protect ratings from one-sided claims; an unrated match has no
-    stakes worth a second party's consent, and a solo match has no second
-    human to accept anyway (rated already implies a registered opponent at
-    creation — the player check is defensive)."""
-    return match.match_settings.affects_rating and _all_sides_have_players(match)
 
 
 # ----- scoring endpoints ---------------------------------------------------
@@ -1015,14 +927,24 @@ async def post_match_result(
     fire here. Rated two-human matches leave the result *standing* (unaccepted)
     for the opposing side to accept via
     ``POST /results/{result_id}/acceptance``."""
+    # The whole propose path — the NOWAIT row lock (serializing against a
+    # concurrent transition, #641/#835), the terminal-status gate, board
+    # compaction + the decided-board validator, the first-post-vs-counter
+    # negotiation gates, the canonical-board commit, the self-accept/finalize
+    # (solo/unrated) vs. leave-standing (rated) fork, and the concurrent-counter
+    # IntegrityError race — is owned by the service. ``load_match=
+    # _load_match_for_scoring`` injects the router's monkeypatchable load seam
+    # (mapping a missing/foreign match to its 404) so the row-lock race tests
+    # still barrier on it, and a held ``NOWAIT`` lock surfaces as
+    # ``MatchLockUnavailable`` below.
     try:
-        match = await _load_match_for_scoring(
+        outcome = await propose_result(
             db,
             match_id,
             current_user.id,
-            lock=True,
-            nowait=True,
-            options=match_rating_eager_options(),
+            games=payload.games,
+            supersedes_result_id=payload.supersedes_result_id,
+            load_match=_load_match_for_scoring,
         )
     except MatchLockUnavailable as exc:
         # A concurrent propose is mid-flight (a double-tapped submit). Bail out
@@ -1035,99 +957,25 @@ async def post_match_result(
             detail="A result is already being posted for this match. "
             "Refresh to see the latest.",
         ) from exc
-
-    # A terminal match (completed/voided) is closed to new proposals. A completed
-    # match has an accepted head, so the result-existence gates below would 409 a
-    # first-post against it anyway; but a match voided *before* any result was
-    # posted has no results to gate on — so guard the status explicitly here, or a
-    # first-post would silently un-void it.
-    if match.status in _TERMINAL_STATUSES:
+    except MatchClosedError as exc:
+        # A terminal match (completed/voided) is closed to new proposals.
         raise HTTPException(
             status_code=409, detail="This match is no longer open to results."
-        )
-
-    # NOTE: no ``_enforce_scorable`` here. The scratchpad-scorable guard is now
-    # false the instant any result exists (#715), so a counter — which by design
-    # supersedes an existing result — would 409 before it could supersede.
-    # Propose has its OWN gates below (first-post vs counter) instead.
-
-    # Compact once, upstream of every consumer below (_validate_finalize_games,
-    # _commit_canonical_games, and the immutable _result_games_snapshot), so the
-    # minted board is contiguous (see `_compact_games`). Covers both the first
-    # proposal and the counter — they share this endpoint.
-    payload = payload.model_copy(update={"games": _compact_games(payload.games)})
-
-    # Decided-board hard gate — the strict precondition: an undecided board can't
-    # be a result.
-    try:
-        decided_side = _validate_finalize_games(
-            payload.games, match.match_settings.best_of
-        )
-    except ValueError as exc:
+        ) from exc
+    except UndecidedBoardError as exc:
+        # The strict decided-board precondition failed — an undecided/invalid
+        # board can't be a result.
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except NegotiationConflictError as exc:
+        # The propose lost the negotiation race (a result already exists, the
+        # counter targeted a stale standing id, or the unique constraint tripped).
+        # The 409 carries the viewer-relative moved-on state from the loaded match.
+        raise _negotiation_conflict(exc.match, current_user.id) from exc
+    except MatchNotFoundError as exc:
+        # The concurrent-counter reload found the match gone — today's 404.
+        raise HTTPException(status_code=404, detail="Match not found.") from exc
 
-    if payload.supersedes_result_id is None:
-        # First proposal: only valid when no result exists yet. A concurrent
-        # first-post (or any existing chain) loses here with the current state.
-        if match.results:
-            raise _negotiation_conflict(match, current_user.id)
-    else:
-        # Counter: must target the live standing proposal. If it was already
-        # accepted or superseded by a concurrent counter, the id won't match —
-        # 409 with the moved-on state.
-        standing = standing_result(match)
-        if standing is None or payload.supersedes_result_id != standing.id:
-            raise _negotiation_conflict(match, current_user.id)
-
-    # Sync the canonical ``match_games`` to the proposed board so the scoreboard
-    # ``games``/``can_score`` rendering stays correct. After the first post the
-    # scratchpad is frozen, so ``match_games`` stays == the standing snapshot.
-    await _commit_canonical_games(db, match, payload)
-
-    result = MatchResult(
-        submitted_by_user_id=current_user.id,
-        games=_result_games_snapshot(payload),
-        supersedes_result_id=payload.supersedes_result_id,
-    )
-    match.results.append(result)
-
-    # Drives the post-commit push: only a rated two-human match leaves the other
-    # side owing an acceptance. Computed before commit; the recipient gets pinged
-    # once the result is durably saved.
-    awaiting_acceptance = _requires_confirmation(match)
-    if not awaiting_acceptance:
-        # Solo / unrated path: no second acceptance needed — the proposer
-        # self-accepts and the match finalizes immediately (stamping
-        # ``completed_at``). A solo match has no second human to accept, so the
-        # proposer's own id is recorded as the acceptor.
-        result.accepted_by_user_id = current_user.id
-        result.accepted_at = datetime.now(UTC)
-        # The one completion path shared with the rated accept (``finalize_match``):
-        # mark completed, stamp ``side.won``, run the rating update, and advance any
-        # tournament draw this match belongs to (#789). Funnelling both sites through
-        # it is what keeps a tournament match's draw from being left un-advanced when
-        # its unrated result self-accepts here instead of at acceptance.
-        await finalize_match(db, match, decided_side)
-    else:
-        # Rated path: the result stays standing (unaccepted) and ``side.won``
-        # stays unset until the opposing side accepts. Status is (re)set to
-        # in_progress.
-        match.status = MatchStatus.in_progress
-
-    try:
-        await db.commit()
-    except IntegrityError as exc:
-        # ``uq_match_results_supersedes_result_id``: two concurrent counters
-        # raced to supersede the same parent and the other one won. Reload and
-        # surface the moved-on negotiation state.
-        await db.rollback()
-        reloaded = await _load_match(db, match_id)
-        if reloaded is None:
-            raise HTTPException(status_code=404, detail="Match not found.") from exc
-        raise _negotiation_conflict(reloaded, current_user.id) from exc
-
-    reloaded = await _load_match(db, match.id)
-    assert reloaded is not None
+    reloaded = outcome.match
     extras = await _view_extras(match_service, reloaded)
     details = _serialize_details(reloaded, current_user.id, extras)
     # Record + notify the side that now owes an acceptance. Built after the
@@ -1137,14 +985,14 @@ async def post_match_result(
     # blanket catch, mirroring the fire-and-forget enqueue guards in
     # app.sessions. The session is rolled back so the request's teardown is
     # clean even when the failure was the in-app persist commit.
-    if awaiting_acceptance:
+    if outcome.awaiting_acceptance:
         try:
             await _notify_result_posted(notifications, reloaded, current_user.id)
         except Exception:
             await db.rollback()
             log.exception(
                 "Failed to record result-acceptance notification",
-                extra={"match_id": str(match.id)},
+                extra={"match_id": str(match_id)},
             )
     return details
 

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -62,20 +62,15 @@ from app.match_scoring import (
 from app.match_scoring import (
     update_game_score as update_game_score_core,
 )
-
-# Re-exported for ``tests/test_matches.py``, which unit-tests the compaction
-# helper via ``app.matches._compact_games`` (the propose path that consumes it
-# now lives in ``app.result_proposal``). Redundant alias marks the intentional
-# re-export so ruff doesn't flag it as unused.
-from app.match_serialization import _compact_games as _compact_games
 from app.match_serialization import (
-    _is_participant,
-    _is_scorable,
-    _negotiation,
-    _serialize_details,
-    _side_schema,
-    _status_label,
+    compact_games,
+    is_participant,
+    is_scorable,
     load_match_eager,
+    negotiation,
+    serialize_details,
+    side_schema,
+    status_label,
     view_extras,
 )
 from app.models import (
@@ -118,6 +113,13 @@ from app.services.dependencies import get_match_service
 from app.services.match_service import MatchService
 from app.sessions import get_current_user, get_optional_user
 
+# Re-exported for ``tests/test_matches.py``, which unit-tests the compaction
+# helper via ``app.matches._compact_games`` (the propose path that consumes it
+# now lives in ``app.result_proposal``). The helper is now the public
+# ``compact_games``; this module-level alias keeps the test's import line
+# resolving (and counts as a use, so ruff doesn't flag the import as unused).
+_compact_games = compact_games
+
 router = APIRouter(prefix="/v1")
 
 log = logging.getLogger(__name__)
@@ -159,7 +161,7 @@ def _has_result_exists() -> Any:
     ``in_progress`` match the presence of any result means a standing proposal
     exists (acceptance moves the match to ``completed``, so the head of the
     chain is necessarily unaccepted) — making "has a result" the derived
-    "Awaiting acceptance" bucket (see ``_status_label``). Pulled into a helper
+    "Awaiting acceptance" bucket (see ``status_label``). Pulled into a helper
     so the list filter and the status-count aggregate split the Live vs awaiting
     buckets identically (issue #381)."""
     return select(MatchResult.id).where(MatchResult.match_id == Match.id).exists()
@@ -202,7 +204,7 @@ async def create_match(
             status_code=422,
             detail="A rated match needs a registered opponent.",
         ) from err
-    return _serialize_details(created, current_user.id)
+    return serialize_details(created, current_user.id)
 
 
 def _apply_list_filter[SelectT: Select[Any]](
@@ -327,7 +329,7 @@ async def list_matches(
     status_counts[MatchStatus.in_progress] -= awaiting_count
 
     # The list is open to every signed-in user. Writes still gate on
-    # `_is_participant` downstream.
+    # `is_participant` downstream.
     if attention:
         # The Attention set is bounded by the caller's *actionable* open matches
         # (issue #729) — a handful even for an active player — so we load them
@@ -409,25 +411,25 @@ def _list_row(match: Match, current_user_id: uuid.UUID) -> MatchListRow:
     side_wins = side_win_counts(match)
     sides_sorted = sorted(match.sides, key=lambda s: s.side_number)
     next_number = current_game_number(match)
-    is_participant = _is_participant(match, current_user_id)
-    # Editability follows the no-result scratchpad rule (``_is_scorable``),
+    viewer_is_participant = is_participant(match, current_user_id)
+    # Editability follows the no-result scratchpad rule (``is_scorable``),
     # not whether a next game exists — so a decided-but-unposted row still reads
     # as scorable. ``current_game_number`` stays the next-playable-game
     # deep-link target (None when decided or signed); suppressed for spectators.
-    can_score = is_participant and _is_scorable(match)
+    can_score = viewer_is_participant and is_scorable(match)
 
     return MatchListRow(
         id=match.id,
         status=match.status,
-        status_label=_status_label(match),
+        status_label=status_label(match),
         league=MatchLeague(id=match.league.id, name=match.league.name),
-        sides=[_side_schema(side, side_wins, current_user_id) for side in sides_sorted],
+        sides=[side_schema(side, side_wins, current_user_id) for side in sides_sorted],
         best_of=match.match_settings.best_of,
         affects_rating=match.match_settings.affects_rating,
         created_at=match.created_at,
-        current_game_number=next_number if is_participant else None,
+        current_game_number=next_number if viewer_is_participant else None,
         can_score=can_score,
-        negotiation=_negotiation(match, current_user_id),
+        negotiation=negotiation(match, current_user_id),
         attention=list_attention_kind(match, current_user_id),
     )
 
@@ -537,13 +539,15 @@ async def get_match(
     # Gate the history/rivalry/rating payload on participation. Anonymous and
     # spectator callers never see another player's form or rating trajectory —
     # they get the scorecard with empty extras (see #515).
-    is_participant = current_user is not None and _is_participant(
+    viewer_is_participant = current_user is not None and is_participant(
         match, current_user.id
     )
     extras = (
-        await view_extras(match_service, match) if is_participant else empty_extras()
+        await view_extras(match_service, match)
+        if viewer_is_participant
+        else empty_extras()
     )
-    return _serialize_details(
+    return serialize_details(
         match,
         current_user.id if current_user else None,
         extras,
@@ -591,7 +595,8 @@ async def _load_match_for_scoring(
 # create handler lookups-or-inserts the MatchGame; update and delete operate
 # on an existing score. All three are pure "save / clear scratchpad state" —
 # they never touch match.status, side wins, side.won, or ratings. The single
-# canonical commit happens in ``finalize_match`` below.
+# canonical commit happens in ``finalize_match`` (now in ``app.result_acceptance``,
+# reached via the propose/accept services), not here.
 
 
 # The FastAPI-free score write path (``app.match_scoring``) raises this closed
@@ -661,7 +666,7 @@ async def create_game_score(
         raise _map_score_write_error(exc) from exc
 
     extras = await view_extras(match_service, reloaded)
-    return _serialize_details(reloaded, current_user.id, extras)
+    return serialize_details(reloaded, current_user.id, extras)
 
 
 @router.put(
@@ -696,7 +701,7 @@ async def update_game_score(
         raise _map_score_write_error(exc) from exc
 
     extras = await view_extras(match_service, reloaded)
-    return _serialize_details(reloaded, current_user.id, extras)
+    return serialize_details(reloaded, current_user.id, extras)
 
 
 @router.delete(
@@ -727,7 +732,7 @@ async def delete_game_score(
         raise _map_score_write_error(exc) from exc
 
     extras = await view_extras(match_service, reloaded)
-    return _serialize_details(reloaded, current_user.id, extras)
+    return serialize_details(reloaded, current_user.id, extras)
 
 
 def _negotiation_conflict(match: Match, current_user_id: uuid.UUID) -> HTTPException:
@@ -738,7 +743,7 @@ def _negotiation_conflict(match: Match, current_user_id: uuid.UUID) -> HTTPExcep
     result already exists); the FE reconciles against this snapshot."""
     return HTTPException(
         status_code=409,
-        detail=_negotiation(match, current_user_id).model_dump(mode="json"),
+        detail=negotiation(match, current_user_id).model_dump(mode="json"),
     )
 
 
@@ -820,7 +825,7 @@ async def post_match_result(
 
     reloaded = outcome.match
     extras = await view_extras(match_service, reloaded)
-    details = _serialize_details(reloaded, current_user.id, extras)
+    details = serialize_details(reloaded, current_user.id, extras)
     # Record + notify the side that now owes an acceptance. Built after the
     # response and best-effort: the result is already committed, so *nothing*
     # here may turn the 201 into a 500 — not a DB error, and not a delivery-side
@@ -896,4 +901,4 @@ async def accept_match_result(
         ) from exc
 
     extras = await view_extras(match_service, reloaded)
-    return _serialize_details(reloaded, current_user.id, extras)
+    return serialize_details(reloaded, current_user.id, extras)

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -3,7 +3,7 @@ import io
 import logging
 import uuid
 from datetime import UTC, datetime
-from typing import Annotated, Any, cast
+from typing import Annotated, Any
 
 from fastapi import (
     APIRouter,
@@ -16,7 +16,7 @@ from fastapi import (
     status,
 )
 from pyrate_limiter import Duration, Rate
-from sqlalchemy import CursorResult, Select, func, select, update
+from sqlalchemy import Select, func, select
 from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -44,6 +44,15 @@ from app.match_queries import (
     participant_filter,
     singles_user_ids,
 )
+from app.match_scoring import (
+    delete_game_score as delete_game_score_core,
+)
+from app.match_scoring import (
+    enter_game_score,
+)
+from app.match_scoring import (
+    update_game_score as update_game_score_core,
+)
 from app.match_serialization import (
     _compact_games,
     _first_decider,
@@ -51,7 +60,6 @@ from app.match_serialization import (
     _is_participant,
     _is_scorable,
     _negotiation,
-    _score_view,
     _serialize_details,
     _side_schema,
     _status_label,
@@ -75,6 +83,7 @@ from app.result_acceptance import (
     OpponentNotFoundError,
     PostedGamesNotDecisiveError,
     RatedNeedsRegisteredOpponentError,
+    ScoreConflictError,
     SelfMatchError,
     StandingResultConflictError,
     _games_to_win,
@@ -168,19 +177,6 @@ def _score_conflict(committed: MatchDetailsScore | None) -> HTTPException:
             committed_score=committed,
         ).model_dump(mode="json"),
     )
-
-
-async def _committed_score(
-    db: AsyncSession, match_id: uuid.UUID, game_number: int
-) -> MatchDetailsScore | None:
-    """The game's score as it actually stands now — for the conflict body after
-    a create lost the unique-constraint race (the committed row belongs to a
-    different transaction, so it isn't on our in-memory ``match``)."""
-    reloaded = await _load_match(db, match_id)
-    if reloaded is None:
-        return None
-    game = next((g for g in reloaded.games if g.game_number == game_number), None)
-    return _score_view(game.score) if game and game.score else None
 
 
 async def _view_extras(match_service: MatchService, match: Match) -> MatchDetailsExtras:
@@ -993,46 +989,39 @@ async def create_game_score(
             ),
         )
 
+    # The board can't have games after the match was already decided. Reject
+    # before delegating (request teardown rolls back the uncommitted session),
+    # gap-tolerant — only a clinch *before* the last scored game trips. An
+    # existing committed score at this game short-circuits to the service's 409
+    # below without running overrun, preserving the historical ordering (the
+    # pre-existing-score conflict was raised before the overrun 422). Because
+    # this game has no committed score in that branch, the prospective board is
+    # the currently-scored games plus this new write — identical to the ORM the
+    # old handler mutated then read back.
     game = next((g for g in match.games if g.game_number == game_number), None)
-    if game is None:
-        game = MatchGame(game_number=game_number)
-        match.games.append(game)
-    elif game.score is not None:
-        # A concurrent participant already created this game's score — the same
-        # conflict the update path guards against, just on first write. Hand
-        # back the committed score so the client surfaces it for review instead
-        # of overwriting it.
-        raise _score_conflict(_score_view(game.score))
-
-    game.score = MatchGameScore(
-        side_1_points=payload.side_1_points,
-        side_2_points=payload.side_2_points,
-    )
-
-    # The board can't have games after the match was already decided. The ORM
-    # is mutated above, so ``_games_payload_from_match`` already reflects this
-    # write; reject before commit (request teardown rolls back the uncommitted
-    # session). Gap-tolerant — only a clinch *before* the last scored game trips.
-    _enforce_no_overrun(
-        _games_payload_from_match(match), match.match_settings.best_of, game_number
-    )
+    if game is None or game.score is None:
+        prospective = [
+            g for g in _games_payload_from_match(match) if g.game_number != game_number
+        ] + [
+            MatchResultsGameWrite(
+                game_number=game_number,
+                side_1_points=payload.side_1_points,
+                side_2_points=payload.side_2_points,
+            )
+        ]
+        _enforce_no_overrun(prospective, match.match_settings.best_of, game_number)
 
     try:
-        await db.commit()
-    except IntegrityError as exc:
-        # Two participants on the same game-entry page submitting at once both
-        # lazily insert the same game row (uq_match_games_match_id_game_number)
-        # and/or its score (uq_match_game_scores_match_game_id). The pre-checks
-        # above pass for both before either commits, so the loser of the race
-        # trips a unique constraint. The committed row belongs to the winner's
-        # transaction, so reload to read it for the conflict body.
-        await db.rollback()
-        raise _score_conflict(
-            await _committed_score(db, match_id, game_number)
-        ) from exc
+        reloaded = await enter_game_score(
+            db,
+            match,
+            game_number=game_number,
+            side_1_points=payload.side_1_points,
+            side_2_points=payload.side_2_points,
+        )
+    except ScoreConflictError as exc:
+        raise _score_conflict(exc.committed_score) from exc
 
-    reloaded = await _load_match(db, match.id)
-    assert reloaded is not None
     extras = await _view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
 
@@ -1064,9 +1053,9 @@ async def update_game_score(
 
     # Editing a game's winner can move the decider earlier, so the same
     # "no games past the decider" guard the create path enforces applies here.
-    # The UPDATE below runs in raw SQL, so in-memory ``match.games`` still holds
-    # the OLD score — build the prospective board by substituting the payload
-    # points for this game before checking.
+    # The service's UPDATE runs in raw SQL, so in-memory ``match.games`` still
+    # holds the OLD score — build the prospective board by substituting the
+    # payload points for this game before delegating.
     prospective = [
         g
         if g.game_number != game_number
@@ -1079,37 +1068,18 @@ async def update_game_score(
     ]
     _enforce_no_overrun(prospective, match.match_settings.best_of, game_number)
 
-    # Optimistic concurrency: replace the points only while the committed row is
-    # still at the version the caller last read. The ``WHERE version =`` clause
-    # is the whole guard — if a concurrent participant has saved this game since,
-    # zero rows match and we reject the write rather than overwrite their result
-    # (the data-loss the client used to walk into by re-issuing as a blind PUT).
-    result = await db.execute(
-        update(MatchGameScore)
-        .where(
-            MatchGameScore.id == game.score.id,
-            MatchGameScore.version == payload.expected_version,
-        )
-        .values(
+    try:
+        reloaded = await update_game_score_core(
+            db,
+            match,
+            game_number=game_number,
             side_1_points=payload.side_1_points,
             side_2_points=payload.side_2_points,
-            version=MatchGameScore.version + 1,
+            expected_version=payload.expected_version,
         )
-    )
-    if cast(CursorResult[Any], result).rowcount == 0:
-        # Lost the race: a concurrent participant saved this game since the
-        # caller last read it, so the conditional UPDATE matched no row. The
-        # update changed nothing, so there's nothing to undo — we just refresh
-        # the score to the value as it actually stands now and 409 (the request
-        # teardown rolls the no-op transaction back). The client shows "your
-        # stale entry vs. what's committed" rather than overwriting their save.
-        await db.refresh(game.score)
-        raise _score_conflict(_score_view(game.score))
+    except ScoreConflictError as exc:
+        raise _score_conflict(exc.committed_score) from exc
 
-    await db.commit()
-
-    reloaded = await _load_match(db, match.id)
-    assert reloaded is not None
     extras = await _view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
 
@@ -1137,15 +1107,7 @@ async def delete_game_score(
     if game is None or game.score is None:
         raise HTTPException(status_code=404, detail="Score not found.")
 
-    # Drop the score; the MatchGame stays so a subsequent POST .../scores/new
-    # for the same number just attaches a fresh score row to the existing game.
-    # delete-orphan on ``MatchGame.score`` removes the row on flush.
-    game.score = None
-
-    await db.commit()
-
-    reloaded = await _load_match(db, match.id)
-    assert reloaded is not None
+    reloaded = await delete_game_score_core(db, match, game_number=game_number)
     extras = await _view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
 

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -2,7 +2,6 @@ import csv
 import io
 import logging
 import uuid
-from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Annotated, Any, cast
 
@@ -28,14 +27,12 @@ from app.attention import (
     list_attention_kind,
 )
 from app.db import get_session
-from app.domain.match.models import Match as MatchModel
-from app.leagues import resolve_league
-from app.mappers.match_details_mapper import serialize_match_details
 from app.mappers.match_extras_mapper import (
     MatchDetailsExtras,
     empty_extras,
     serialize_match_extras,
 )
+from app.match_creation import create_match as create_match_core
 from app.match_queries import (
     _actionable_attention_filter,
     _attention_matches_query,
@@ -47,15 +44,25 @@ from app.match_queries import (
     participant_filter,
     singles_user_ids,
 )
+from app.match_serialization import (
+    _compact_games,
+    _first_decider,
+    _games_payload_from_match,
+    _is_participant,
+    _is_scorable,
+    _negotiation,
+    _score_view,
+    _serialize_details,
+    _side_schema,
+    _status_label,
+    _validate_finalize_games,
+)
 from app.models import (
     League,
     Match,
     MatchGame,
     MatchGameScore,
     MatchResult,
-    MatchSettings,
-    MatchSide,
-    MatchSidePlayer,
     MatchStatus,
     User,
 )
@@ -65,22 +72,20 @@ from app.notifications.service import NotificationService
 from app.notifications.taxonomy import NotificationCategory
 from app.rate_limiting import RedisRateLimiter
 from app.result_acceptance import (
+    OpponentNotFoundError,
     PostedGamesNotDecisiveError,
+    RatedNeedsRegisteredOpponentError,
+    SelfMatchError,
     StandingResultConflictError,
-    _game_winner_side,
     _games_to_win,
     accept_standing_result,
     finalize_match,
     side_win_counts,
 )
-from app.result_chain import accepted_result, standing_result
-from app.retirement import retirement_deadline
+from app.result_chain import standing_result
 from app.schemas.match import (
     MatchCreate,
     MatchDetails,
-    MatchDetailsCurrentGame,
-    MatchDetailsGame,
-    MatchDetailsPlayer,
     MatchDetailsScore,
     MatchDetailsSide,
     MatchGameScoreConflict,
@@ -90,15 +95,10 @@ from app.schemas.match import (
     MatchListFilter,
     MatchListResponse,
     MatchListRow,
-    MatchNegotiation,
     MatchResultsGameWrite,
     MatchResultsWrite,
-    NegotiationDiffEntry,
-    NegotiationGame,
-    NegotiationResult,
 )
 from app.schemas.notification import NotificationJob
-from app.schemas.rating import RatingChange
 from app.services.dependencies import get_match_service
 from app.services.match_service import MatchService
 from app.sessions import get_current_user, get_optional_user
@@ -111,35 +111,6 @@ MAX_PAGE_SIZE = 100
 
 
 # ----- helpers -------------------------------------------------------------
-
-
-def _side_schema(
-    side: MatchSide,
-    side_wins: dict[int, int],
-    current_user_id: uuid.UUID | None,
-    rating_changes: Mapping[uuid.UUID, RatingChange] | None = None,
-) -> MatchDetailsSide:
-    # Singles only for v1: each side has at most one rated player.
-    rating_change = (
-        rating_changes.get(side.players[0].user_id)
-        if rating_changes and side.players
-        else None
-    )
-    return MatchDetailsSide(
-        side_number=side.side_number,
-        players=[
-            MatchDetailsPlayer(
-                user_id=p.user_id,
-                username=p.user.username,
-                is_current_user=p.user_id == current_user_id,
-            )
-            for p in sorted(side.players, key=lambda p: p.user.username)
-        ],
-        games_won=side_wins.get(side.side_number, 0),
-        won=side.won,
-        is_current_user_side=any(p.user_id == current_user_id for p in side.players),
-        rating_change=rating_change,
-    )
 
 
 # The finalize/score-write superset: everything a read needs, plus the league's
@@ -169,44 +140,11 @@ async def _load_match(
     return result.scalar_one_or_none()
 
 
-def _is_participant(match: Match, user_id: uuid.UUID) -> bool:
-    return my_side(match, user_id) is not None
-
-
 def _all_sides_have_players(match: Match) -> bool:
     """Solo matches (no opponent picked) carry one player-less sentinel side.
     The acceptance flow needs a second human, so solo matches skip
     it entirely; this is the predicate that detects that case."""
     return len(match.sides) >= 2 and all(side.players for side in match.sides)
-
-
-def _status_label(match: Match) -> str:
-    """User-facing label for a match's lifecycle position. An ``in_progress``
-    match with a standing posted result is waiting on the other side — surface
-    that distinctly so the FE doesn't need to know about the result model to
-    render it."""
-    if match.status == MatchStatus.in_progress and standing_result(match) is not None:
-        return "Awaiting acceptance"
-    # Exhaustive — adding an enum member is a type error until handled.
-    match match.status:
-        case MatchStatus.pending:
-            return "Scheduled"
-        case MatchStatus.in_progress:
-            return "Live"
-        case MatchStatus.completed:
-            return "Final"
-        case MatchStatus.voided:
-            return "Voided"
-
-
-def _score_view(score: MatchGameScore) -> MatchDetailsScore:
-    return MatchDetailsScore(
-        id=score.id,
-        side_1_points=score.side_1_points,
-        side_2_points=score.side_2_points,
-        winner_side_number=_game_winner_side(score),
-        version=score.version,
-    )
 
 
 # One message for every score-write conflict — a concurrent participant already
@@ -245,168 +183,6 @@ async def _committed_score(
     return _score_view(game.score) if game and game.score else None
 
 
-def _negotiation_game(snapshot: dict[str, int]) -> NegotiationGame:
-    return NegotiationGame(
-        game_number=snapshot["game_number"],
-        side_1_points=snapshot["side_1_points"],
-        side_2_points=snapshot["side_2_points"],
-    )
-
-
-def _negotiation_result(result: MatchResult) -> NegotiationResult:
-    return NegotiationResult(
-        id=result.id,
-        games=[
-            _negotiation_game(g)
-            for g in sorted(result.games, key=lambda g: g["game_number"])
-        ],
-        submitted_by=result.submitted_by_user_id,
-        submitted_at=result.submitted_at,
-    )
-
-
-def _negotiation_diff(
-    baseline_games: list[dict[str, int]],
-    standing_games: list[dict[str, int]],
-) -> list[NegotiationDiffEntry]:
-    """Viewer-relative diff between the viewer's own last proposal (baseline)
-    and the standing proposal. Emits one entry per game that differs, ordered by
-    game number over the union of both boards. A correction may add, remove, or
-    change games (a decided board can shorten or lengthen — CONTEXT.md
-    "Correction", ADR-0001), so an entry is one of:
-
-    - **added** — the standing board has a game the baseline lacked (``old=None``);
-    - **removed** — the baseline had a game the standing board dropped (``new=None``);
-    - **changed** — both present, points differ.
-
-    Unchanged games are skipped. Computed purely from the two snapshots; the
-    chain walk to pick the baseline is what collapses the opponent's intermediate
-    self-edits."""
-    baseline_by_number = {g["game_number"]: g for g in baseline_games}
-    standing_by_number = {g["game_number"]: g for g in standing_games}
-    entries: list[NegotiationDiffEntry] = []
-    for number in sorted(baseline_by_number.keys() | standing_by_number.keys()):
-        old = baseline_by_number.get(number)
-        new = standing_by_number.get(number)
-        if (
-            old is not None
-            and new is not None
-            and old["side_1_points"] == new["side_1_points"]
-            and old["side_2_points"] == new["side_2_points"]
-        ):
-            continue  # unchanged — omit
-        # ``old``/``new`` null encode removed/added; both-present is a change.
-        entries.append(
-            NegotiationDiffEntry(
-                game_number=number,
-                old=_negotiation_game(old) if old is not None else None,
-                new=_negotiation_game(new) if new is not None else None,
-            )
-        )
-    return entries
-
-
-def _submitted_on_side(match: Match, result: MatchResult, side: MatchSide) -> bool:
-    """True iff the result's submitter is a player on ``side``."""
-    return any(p.user_id == result.submitted_by_user_id for p in side.players)
-
-
-def _negotiation(match: Match, current_user_id: uuid.UUID | None) -> MatchNegotiation:
-    """Viewer-relative negotiation state for the BFF (#713).
-
-    The viewer's "side" is the side the current user is on; the opponent side is
-    the other. A standing proposal submitted by the viewer's own side is
-    ``awaiting`` (they consented; it's the opponent's move); one submitted by the
-    opponent makes it the viewer's turn — ``review`` if the viewer never
-    proposed, ``corrected`` (with a diff vs the viewer's own last proposal) if
-    they did. ``final`` once a result is accepted; ``live`` before any result.
-
-    Non-participants / anonymous callers get a neutral spectator mapping
-    (``your_turn=False``, no diff/prior)."""
-    accepted = accepted_result(match)
-    if accepted is not None:
-        return MatchNegotiation(
-            viewer_state="final",
-            your_turn=False,
-            standing_result=_negotiation_result(accepted),
-            prior_result=None,
-            diff=None,
-            retirement_deadline=retirement_deadline(match),
-        )
-
-    standing = standing_result(match)
-    if standing is None:
-        return MatchNegotiation(
-            viewer_state="live",
-            your_turn=False,
-            standing_result=None,
-            prior_result=None,
-            diff=None,
-            retirement_deadline=retirement_deadline(match),
-        )
-
-    standing_view = _negotiation_result(standing)
-    viewer_side = (
-        my_side(match, current_user_id) if current_user_id is not None else None
-    )
-    # Spectators / anonymous: neutral mapping — there is a standing proposal but
-    # the viewer has no side, so treat as a read-only "review" view.
-    if viewer_side is None:
-        return MatchNegotiation(
-            viewer_state="review",
-            your_turn=False,
-            standing_result=standing_view,
-            prior_result=None,
-            diff=None,
-            retirement_deadline=retirement_deadline(match),
-        )
-
-    if _submitted_on_side(match, standing, viewer_side):
-        # The viewer's own side proposed the standing result; await the opponent.
-        return MatchNegotiation(
-            viewer_state="awaiting",
-            your_turn=False,
-            standing_result=standing_view,
-            prior_result=None,
-            diff=None,
-            retirement_deadline=retirement_deadline(match),
-        )
-
-    # The opponent submitted the standing result → the viewer must act. Walk the
-    # supersede chain back from the standing result to the viewer's own last
-    # proposal (the baseline that collapses the opponent's intermediate edits).
-    by_id = {r.id: r for r in match.results}
-    prior: MatchResult | None = None
-    cursor = standing.supersedes_result_id
-    while cursor is not None:
-        candidate = by_id.get(cursor)
-        if candidate is None:
-            break
-        if _submitted_on_side(match, candidate, viewer_side):
-            prior = candidate
-            break
-        cursor = candidate.supersedes_result_id
-
-    if prior is None:
-        return MatchNegotiation(
-            viewer_state="review",
-            your_turn=True,
-            standing_result=standing_view,
-            prior_result=None,
-            diff=None,
-            retirement_deadline=retirement_deadline(match),
-        )
-
-    return MatchNegotiation(
-        viewer_state="corrected",
-        your_turn=True,
-        standing_result=standing_view,
-        prior_result=_negotiation_result(prior),
-        diff=_negotiation_diff(prior.games, standing.games),
-        retirement_deadline=retirement_deadline(match),
-    )
-
-
 async def _view_extras(match_service: MatchService, match: Match) -> MatchDetailsExtras:
     """The participant-only extras block (rating changes, recent form,
     head-to-head) for an already-loaded ``match``.
@@ -424,100 +200,6 @@ async def _view_extras(match_service: MatchService, match: Match) -> MatchDetail
             user_ids=singles_user_ids(match),
         )
     )
-
-
-def _serialize_details(
-    match: Match,
-    current_user_id: uuid.UUID | None,
-    extras: MatchDetailsExtras | None = None,
-    domain_match: MatchModel | None = None,
-) -> MatchDetails:
-    extras = extras or empty_extras()
-    # The ``data`` view is built from the domain model. The match-details
-    # endpoint loads it through MatchService/MatchRepository and passes it in;
-    # the other serialize call sites already hold the full ORM row, so they
-    # derive it directly rather than firing a second query.
-    domain_match = domain_match or MatchModel.from_row(match)
-    side_wins = side_win_counts(match)
-
-    games_sorted = sorted(match.games, key=lambda g: g.game_number)
-    games = [
-        MatchDetailsGame(
-            id=game.id,
-            game_number=game.game_number,
-            score=_score_view(game.score) if game.score else None,
-        )
-        for game in games_sorted
-    ]
-
-    next_number = current_game_number(match)
-    current_game = (
-        MatchDetailsCurrentGame(game_number=next_number)
-        if next_number is not None
-        else None
-    )
-
-    sides_sorted = sorted(match.sides, key=lambda s: s.side_number)
-    # Anonymous viewers on the public route are never participants.
-    is_participant = current_user_id is not None and _is_participant(
-        match, current_user_id
-    )
-
-    return MatchDetails(
-        id=match.id,
-        status=match.status,
-        status_label=_status_label(match),
-        league=MatchLeague(id=match.league.id, name=match.league.name),
-        best_of=match.match_settings.best_of,
-        games_to_win=_games_to_win(match.match_settings.best_of),
-        team_size=match.match_settings.team_size,
-        affects_rating=match.match_settings.affects_rating,
-        created_at=match.created_at,
-        sides=[
-            _side_schema(side, side_wins, current_user_id, extras.rating_changes)
-            for side in sides_sorted
-        ],
-        games=games,
-        current_game=current_game,
-        # "This participant may edit scores" — true whenever the match is
-        # scorable (no result posted yet; see ``_is_scorable``), *independent*
-        # of whether there's a next un-played game. A decided-but-unposted
-        # board is still editable, so this is True while ``current_game`` is
-        # None. Spectators get the read-only view — writes
-        # 404 for non-participants in the score endpoints regardless.
-        can_score=(is_participant and _is_scorable(match)),
-        # True iff the saved games already form a decided, validly-ordered
-        # match AND no result is currently posted — the FE flips the scoring
-        # page's submit button label to "Post result" when this is true.
-        can_finalize=(
-            is_participant and len(match.sides) >= 2 and _can_finalize(match)
-        ),
-        # Viewer-relative negotiation state — the standing proposal, whose turn
-        # it is, and (when the opponent corrected the viewer's own proposal) the
-        # diff. Drives the accept CTA + the negotiation callouts (#713).
-        negotiation=_negotiation(match, current_user_id),
-        # ``extras.recent_form`` is a read-only Sequence; the response model owns
-        # its own list, so copy rather than alias it.
-        recent_form=list(extras.recent_form),
-        head_to_head=extras.head_to_head,
-        data=serialize_match_details(domain_match),
-    )
-
-
-def _add_side(match: Match, side_number: int, player: User | None) -> None:
-    """Attach a side to ``match``. ``player=None`` creates the sentinel
-    "no opponent" side — a real second side carrying no player — so an
-    opponent-less match still has two sides and is therefore scorable. It reads
-    as opponent-less wherever the code inspects ``side.players`` (serialization
-    renders the "No opponent" placeholder; rating updates skip player-less
-    sides).
-
-    Wiring up the ``match`` relationship on both the side and the side-player
-    is what populates their (non-null, denormalized) ``match_id`` columns on
-    flush."""
-    side = MatchSide(match=match, side_number=side_number)
-    if player is not None:
-        side.players.append(MatchSidePlayer(match=match, user=player))
 
 
 # ----- list helpers --------------------------------------------------------
@@ -547,61 +229,30 @@ async def create_match(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
 ) -> MatchDetails:
-    opponent: User | None = None
-    if payload.opponent_user_id is not None:
-        if payload.opponent_user_id == current_user.id:
-            raise HTTPException(
-                status_code=422,
-                detail="You cannot start a match against yourself.",
-            )
-        opponent = (
-            await db.execute(
-                select(User).where(
-                    User.id == payload.opponent_user_id,
-                    User.merged_into_user_id.is_(None),
-                )
-            )
-        ).scalar_one_or_none()
-        if opponent is None:
-            raise HTTPException(status_code=404, detail="Opponent not found.")
-
-    if payload.rated and opponent is None:
+    # Thin HTTP adapter over the transport-neutral creation service: it raises
+    # domain exceptions, which we map back to the exact status + body this
+    # endpoint has always produced.
+    try:
+        created = await create_match_core(
+            db,
+            creator=current_user,
+            opponent_user_id=payload.opponent_user_id,
+            league_id=payload.league_id,
+            best_of=payload.best_of,
+            rated=payload.rated,
+        )
+    except SelfMatchError as err:
+        raise HTTPException(
+            status_code=422,
+            detail="You cannot start a match against yourself.",
+        ) from err
+    except OpponentNotFoundError as err:
+        raise HTTPException(status_code=404, detail="Opponent not found.") from err
+    except RatedNeedsRegisteredOpponentError as err:
         raise HTTPException(
             status_code=422,
             detail="A rated match needs a registered opponent.",
-        )
-
-    # Solo matches (no opponent picked) get a player-less sentinel opponent
-    # side below, so they're scorable but can never affect ratings regardless
-    # of the requested flag.
-    affects_rating = payload.rated and opponent is not None
-
-    league = await resolve_league(db, payload.league_id)
-
-    settings = MatchSettings(
-        team_size=1,
-        best_of=payload.best_of,
-        affects_rating=affects_rating,
-    )
-    match = Match(
-        match_settings=settings,
-        league=league,
-        created_by_user_id=current_user.id,
-        status=MatchStatus.in_progress,
-    )
-    _add_side(match, 1, current_user)
-    # Always create side 2. With no opponent it's a player-less sentinel side,
-    # which keeps the match scorable (two sides) while reading as "No opponent".
-    _add_side(match, 2, opponent)
-    # Games are no longer pre-created at match-create time — they're written
-    # lazily by ``POST .../games/{n}/scores/new`` keyed on the game number, so
-    # the FE can deep-link to any 1..best_of without us guessing.
-
-    db.add(match)
-    await db.commit()
-
-    created = await _load_match(db, match.id)
-    assert created is not None
+        ) from err
     return _serialize_details(created, current_user.id)
 
 
@@ -961,33 +612,6 @@ _TERMINAL_STATUSES = {
 }
 
 
-def _is_scorable(match: Match) -> bool:
-    """Whether a match accepts score writes right now (ignoring who's asking).
-
-    The saved games are a provisional *scratchpad* until somebody posts the
-    first result: editable regardless of whether they already decide the match.
-    So the gates are structural — two sides, a **live** (``in_progress``)
-    status, and **no result row at all**. The scratchpad freezes the instant
-    the first result is proposed (#715); from there the board only changes via
-    the propose/accept negotiation, not the score endpoints.
-
-    ``in_progress`` (not merely non-terminal) is the status gate: a tournament
-    match is born ``pending`` (scheduled) and is not scorable until the
-    scheduler *calls* it to a table — playing an uncalled match out-of-band
-    would corrupt the solver's table model (#1073). This aligns scoring with
-    ``can_finalize``, which already required ``in_progress``. Casual matches are
-    born ``in_progress`` and so remain scorable at once.
-
-    Single source of truth shared by the write-path guard
-    (``_enforce_scorable``) and the BFF ``can_score`` flag, so the flag the
-    clients trust can never disagree with what the score endpoints accept."""
-    return (
-        len(match.sides) >= 2
-        and match.status == MatchStatus.in_progress
-        and not match.results
-    )
-
-
 def _enforce_scorable(match: Match) -> None:
     """Raise when a match can't be scored. ``_is_scorable`` owns the *decision*;
     this only picks the reason-specific status/message for a rejection, so the
@@ -1147,26 +771,6 @@ async def _notify_result_posted(
 # ----- finalize-payload validation + apply --------------------------------
 
 
-def _first_decider(
-    games: list[MatchResultsGameWrite], target: int
-) -> tuple[int, int] | None:
-    """Walk ``games`` in game-number order tallying wins; return
-    ``(decided_side, decided_game_number)`` for the first game at which a side
-    reaches ``target`` wins, else ``None``.
-
-    Gap-tolerant: it does not care whether the numbers are contiguous — callers
-    that require ``1..N`` numbering check that separately. The single source of
-    truth for "who clinched, and when" shared by the finalize validator and the
-    scratchpad overrun guard, so the two can never drift."""
-    wins: dict[int, int] = {1: 0, 2: 0}
-    for g in sorted(games, key=lambda g: g.game_number):
-        winner = 1 if g.side_1_points > g.side_2_points else 2
-        wins[winner] += 1
-        if wins[winner] >= target:
-            return winner, g.game_number
-    return None
-
-
 def _overrun_decider(games: list[MatchResultsGameWrite], best_of: int) -> int | None:
     """The game number at which the match was already decided when there are
     scored games numbered *after* it ("overrun"). Returns ``None`` for empty,
@@ -1208,127 +812,6 @@ def _enforce_no_overrun(
                 f"game {game_number} can't be played."
             ),
         )
-
-
-def _compact_games(
-    games: list[MatchResultsGameWrite],
-) -> list[MatchResultsGameWrite]:
-    """Normalize a (possibly gappy) scratchpad board into a canonical one:
-    close empty slots so the surviving scored games are numbered ``1..N`` with
-    no holes. Pure — returns fresh models, doesn't mutate input.
-
-    Renumbers by the *rank of each distinct* ``game_number`` (not by list
-    position), so a genuine duplicate game_number is preserved as a duplicate
-    (two games at original ``1`` both map to new ``1``) and the strict
-    ``_validate_finalize_games`` duplicate check downstream still rejects it.
-    (Renumbering *does* absorb an out-of-``best_of``-range game_number — e.g.
-    ``[1,2,5]`` on best-of-3 → ``[1,2,3]`` — but the real scratchpad never
-    produces one: the score endpoints reject ``game_number > best_of`` before a
-    score is ever saved, and a finalize payload's out-of-range numbers only
-    reach here via a hand-crafted API call, where relabeling three legal scored
-    games into a legal 3-game board is harmless.)
-
-    Provably outcome-invariant: an empty (unscored) slot contributes 0 wins to
-    either side, so dropping it and relabeling can never change the winner or
-    the game score — only the cosmetic slot numbers. It heals the out-of-order
-    clinch (score game 5 while game 4 is blank → ``[1,2,3,5]`` compacts to
-    ``[1,2,3,4]`` and finalizes) without touching a real overrun (a fully-scored
-    ``[1,2,3,4,5]`` compacts to itself and stays rejected).
-    See ``docs/adr/0002-decided-board-is-compacted-at-propose.md``."""
-    rank = {
-        original: compacted
-        for compacted, original in enumerate(
-            sorted({g.game_number for g in games}), start=1
-        )
-    }
-    return [
-        MatchResultsGameWrite(
-            game_number=rank[g.game_number],
-            side_1_points=g.side_1_points,
-            side_2_points=g.side_2_points,
-        )
-        for g in sorted(games, key=lambda g: g.game_number)
-    ]
-
-
-def _validate_finalize_games(games: list[MatchResultsGameWrite], best_of: int) -> int:
-    """Cross-game invariants for a finalize payload. Per-game point legality
-    is already enforced by ``MatchResultsGameWrite``. Returns the decided side
-    number (1 or 2); raises ``ValueError`` with a human-readable detail on any
-    failure (the route handler maps that to 422)."""
-    if not games:
-        raise ValueError("A match needs at least one game to finalize.")
-
-    numbers = [g.game_number for g in games]
-    if any(n > best_of for n in numbers):
-        raise ValueError(f"Each game_number must be ≤ best_of ({best_of}).")
-    if len(set(numbers)) != len(numbers):
-        raise ValueError("Duplicate game_number in payload.")
-    if sorted(numbers) != list(range(1, len(numbers) + 1)):
-        raise ValueError("Games must be numbered 1..N consecutively with no gaps.")
-
-    target = _games_to_win(best_of)
-    decider = _first_decider(games, target)
-    if decider is None:
-        raise ValueError(
-            f"No side reached {target} game wins — the match isn't decided."
-        )
-    decided_side, decided_at = decider
-    if decided_at != max(numbers):
-        raise ValueError(
-            "Scored games extend past the deciding game; "
-            "drop any games after the decider."
-        )
-    return decided_side
-
-
-def _games_payload_from_match(match: Match) -> list[MatchResultsGameWrite]:
-    """Recast currently-saved scores as a finalize payload, so ``_can_finalize``
-    can reuse ``_validate_finalize_games`` instead of duplicating its rules.
-
-    Returns the board **raw** (scored games at their real ``game_number``, gaps
-    and all). The two scratchpad overrun guards depend on this: ``create_game_score``
-    reports the tapped game in its 422 detail, and ``update_game_score`` substitutes
-    the edited game by matching the raw ``game_number`` — both would break on a
-    renumbered board. Compaction is applied by ``_can_finalize`` alone, at its own
-    call site, since only the finalize predicate wants a canonical board."""
-    return [
-        MatchResultsGameWrite(
-            game_number=g.game_number,
-            side_1_points=g.score.side_1_points,
-            side_2_points=g.score.side_2_points,
-        )
-        for g in match.games
-        if g.score is not None
-    ]
-
-
-def _can_finalize(match: Match) -> bool:
-    """Whether ``POST /v1/matches/{id}/results`` would succeed on the
-    currently-saved scores (ignoring authorization). Drives the FE's
-    ``can_finalize`` flag and the submit button's adaptive label.
-
-    Returns False once any result exists — the FE drives this flag only for the
-    FIRST proposal; subsequent counters/acceptances flow through the negotiation
-    surface, not /results-as-finalize.
-
-    Compacts the saved board before validating, mirroring the write path: a
-    gappy-but-decided board (an out-of-order clinch that left a hole) reports
-    ``can_finalize = true`` so the finalize-callout / SaveBanner offers "Post
-    result" and the user self-heals with one tap — this also heals already-stuck
-    matches with no migration."""
-    if match.status != MatchStatus.in_progress:
-        return False
-    if match.results:
-        return False
-    try:
-        _validate_finalize_games(
-            _compact_games(_games_payload_from_match(match)),
-            match.match_settings.best_of,
-        )
-    except ValueError:
-        return False
-    return True
 
 
 def _result_games_snapshot(payload: MatchResultsWrite) -> list[dict[str, int]]:

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -25,23 +25,32 @@ from app.attention import (
     list_attention_kind,
 )
 from app.db import get_session
-from app.mappers.match_extras_mapper import (
-    MatchDetailsExtras,
-    empty_extras,
-    serialize_match_extras,
-)
+from app.mappers.match_extras_mapper import empty_extras
 from app.match_creation import create_match as create_match_core
+from app.match_errors import (
+    CannotAcceptOwnProposalError,
+    MatchClosedError,
+    MatchNotFoundError,
+    MatchNotScorableError,
+    NegotiationConflictError,
+    OpponentNotFoundError,
+    PostedGamesNotDecisiveError,
+    RatedNeedsRegisteredOpponentError,
+    ResultNotFoundError,
+    ScoreConflictError,
+    ScoreNotAllowedError,
+    SelfMatchError,
+    UndecidedBoardError,
+)
 from app.match_queries import (
     _actionable_attention_filter,
     _attention_matches_query,
     _player_username_filter,
     current_game_number,
     match_eager_options,
-    my_side,
-    opponent_side,
     participant_filter,
-    singles_user_ids,
 )
+from app.match_result_notifications import notify_result_posted
 from app.match_scoring import (
     MatchLockUnavailable,
     enter_game_score,
@@ -66,6 +75,8 @@ from app.match_serialization import (
     _serialize_details,
     _side_schema,
     _status_label,
+    load_match_eager,
+    view_extras,
 )
 from app.models import (
     Match,
@@ -73,29 +84,13 @@ from app.models import (
     MatchStatus,
     User,
 )
-from app.notifications.apns import MATCH_RESULT_CONFIRMATION_CATEGORY
 from app.notifications.dependencies import get_notification_service
 from app.notifications.service import NotificationService
-from app.notifications.taxonomy import NotificationCategory
 from app.rate_limiting import RedisRateLimiter
 from app.result_acceptance import (
-    CannotAcceptOwnProposalError,
-    MatchClosedError,
-    MatchNotFoundError,
-    MatchNotScorableError,
-    NegotiationConflictError,
-    OpponentNotFoundError,
-    PostedGamesNotDecisiveError,
-    RatedNeedsRegisteredOpponentError,
-    ResultNotFoundError,
-    ScoreConflictError,
-    ScoreNotAllowedError,
-    SelfMatchError,
-    UndecidedBoardError,
     accept_result,
     side_win_counts,
 )
-from app.result_chain import standing_result
 
 # Re-exported for ``tests/test_ratings.py``, which loads the finalize eager-load
 # superset via ``app.matches.match_rating_eager_options`` (the propose/accept
@@ -119,7 +114,6 @@ from app.schemas.match import (
     MatchListRow,
     MatchResultsWrite,
 )
-from app.schemas.notification import NotificationJob
 from app.services.dependencies import get_match_service
 from app.services.match_service import MatchService
 from app.sessions import get_current_user, get_optional_user
@@ -132,20 +126,6 @@ MAX_PAGE_SIZE = 100
 
 
 # ----- helpers -------------------------------------------------------------
-
-
-async def _load_match(
-    db: AsyncSession,
-    match_id: uuid.UUID,
-    *,
-    options: tuple[ExecutableOption, ...] | None = None,
-) -> Match | None:
-    result = await db.execute(
-        select(Match)
-        .where(Match.id == match_id)
-        .options(*(options if options is not None else match_eager_options()))
-    )
-    return result.scalar_one_or_none()
 
 
 # One message for every score-write conflict — a concurrent participant already
@@ -168,25 +148,6 @@ def _score_conflict(committed: MatchDetailsScore | None) -> HTTPException:
             message=_SCORE_CONFLICT_MESSAGE,
             committed_score=committed,
         ).model_dump(mode="json"),
-    )
-
-
-async def _view_extras(match_service: MatchService, match: Match) -> MatchDetailsExtras:
-    """The participant-only extras block (rating changes, recent form,
-    head-to-head) for an already-loaded ``match``.
-
-    The router hands the service the primitives it already holds and gets back a
-    domain model; the SQL lives in ``MatchDetailsRepository`` and the wire shapes
-    are built by the extras mapper. Callers gate on participation *before* calling
-    this — a non-participant gets ``empty_extras()`` (see #515)."""
-    return serialize_match_extras(
-        await match_service.load_view_extras(
-            match_id=match.id,
-            league_id=match.league_id,
-            status=match.status,
-            created_at=match.created_at,
-            user_ids=singles_user_ids(match),
-        )
     )
 
 
@@ -567,7 +528,7 @@ async def get_match(
 
     The serializer flags whether the current user is on a side; write paths
     below still gate on participation via `get_current_user`."""
-    match = await _load_match(db, match_id)
+    match = await load_match_eager(db, match_id)
     if match is None:
         raise HTTPException(status_code=404, detail="Match not found.")
     domain_match = await match_service.get_match(match_id)
@@ -580,7 +541,7 @@ async def get_match(
         match, current_user.id
     )
     extras = (
-        await _view_extras(match_service, match) if is_participant else empty_extras()
+        await view_extras(match_service, match) if is_participant else empty_extras()
     )
     return _serialize_details(
         match,
@@ -588,130 +549,6 @@ async def get_match(
         extras,
         domain_match,
     )
-
-
-# ----- result-acceptance push ---------------------------------------------
-
-# En-dash between scores reads better than a hyphen in notification copy.
-_SCORE_DASH = "–"
-
-
-def _game_scores_text(match: Match, poster_side_number: int) -> str:
-    """Compact per-game scores oriented poster-first (e.g. ``"11–7, 9–11"``),
-    so they line up with the games-won headline the recipient sees. Games with
-    no saved score are skipped."""
-    parts: list[str] = []
-    for game in sorted(match.games, key=lambda g: g.game_number):
-        if game.score is None:
-            continue
-        if poster_side_number == 1:
-            poster_pts, recipient_pts = (
-                game.score.side_1_points,
-                game.score.side_2_points,
-            )
-        else:
-            poster_pts, recipient_pts = (
-                game.score.side_2_points,
-                game.score.side_1_points,
-            )
-        parts.append(f"{poster_pts}{_SCORE_DASH}{recipient_pts}")
-    return ", ".join(parts)
-
-
-def _result_confirmation_copy(
-    match: Match, poster_id: uuid.UUID, *, is_counter: bool
-) -> tuple[str, str] | None:
-    """Title + body for the "accept or suggest a correction to the result your
-    opponent posted" push, framed for the *recipient* (the side that didn't
-    post).
-
-    ``is_counter`` picks the closing prompt to match the actual button pair
-    the recipient's in-app callout renders: a first-post shows Accept /
-    Suggest correction (``confirmation-callout-display.tsx``'s ``"review"``
-    case), while a counter shows Accept / Counter (its ``"corrected"`` case,
-    #728). The native iOS push notification itself only ever offers a single,
-    static Approve/Suggest-correction action pair (``PushNotificationManager
-    .swift``) — it doesn't yet grow a counter-specific action — so this body
-    text is the only place a tapped-through counter reads "Counter" until the
-    push actions themselves are split the same way.
-
-    The headline carries the games-won score and, where there's room, the
-    body lists the individual game scores — both oriented so the poster's
-    number comes first. Returns ``None`` when the match isn't a two-human
-    match (nothing to accept)."""
-    poster_side = my_side(match, poster_id)
-    recipient_side = opponent_side(match, poster_id)
-    if poster_side is None or recipient_side is None or not poster_side.players:
-        return None
-
-    poster_name = poster_side.players[0].user.username
-    wins = side_win_counts(match)
-    poster_games = wins.get(poster_side.side_number, 0)
-    recipient_games = wins.get(recipient_side.side_number, 0)
-
-    # Score always reads winner-first; the phrase tells the recipient which
-    # side the poster claims won.
-    if poster_games >= recipient_games:
-        phrase, hi, lo = "beating you", poster_games, recipient_games
-    else:
-        phrase, hi, lo = "losing to you", recipient_games, poster_games
-    headline = f"{poster_name} reported {phrase} {hi}{_SCORE_DASH}{lo}"
-
-    prompt = "Accept or counter?" if is_counter else "Accept or suggest a correction?"
-    games = _game_scores_text(match, poster_side.side_number)
-    body = f"{headline}. Games: {games}. {prompt}" if games else f"{headline}. {prompt}"
-    return "Accept your match result", body
-
-
-async def _notify_result_posted(
-    notifications: NotificationService, match: Match, poster_id: uuid.UUID
-) -> None:
-    """Queue an accept/counter (or accept/suggest-correction) prompt to every
-    player on the side that now owes a response. Each enqueued job persists
-    the in-app record (the bell feed) and fans out push/email per the
-    recipient's preferences in the worker. The APNs ``category``/``data``
-    carry the action group, the match id (so a tapped push deep-links to the
-    right match), and the standing result id (so a tapped Approve binds to the
-    exact result the push described, not whatever is standing at tap time — see
-    docs/adr/0007), plus a per-match ``collapse_id`` so a superseding push
-    replaces the stale one on the lock screen."""
-    recipient_side = opponent_side(match, poster_id)
-    if recipient_side is None or not recipient_side.players:
-        return
-    # Derive counter-vs-first-post from the same viewer-relative negotiation
-    # state the BFF/UI use (``_negotiation``'s ``"corrected"`` vs ``"review"``),
-    # rather than the raw ``supersedes_result_id is not None`` check — that
-    # naive check is wrong on a self-edit (poster corrects their own standing
-    # proposal before the recipient ever answers): it supersedes a result, but
-    # the recipient still lands on the first-post "review" view, not
-    # "corrected", so they must get the Accept/Suggest-correction prompt, not
-    # Accept/Counter.
-    is_counter = (
-        _negotiation(match, recipient_side.players[0].user_id).viewer_state
-        == "corrected"
-    )
-    copy = _result_confirmation_copy(match, poster_id, is_counter=is_counter)
-    if copy is None:
-        return
-    title, body = copy
-    result = standing_result(match)
-    push_data = {"match_id": str(match.id)}
-    if result is not None:
-        push_data["result_id"] = str(result.id)
-    for player in recipient_side.players:
-        notifications.enqueue_notification(
-            NotificationJob(
-                user_id=player.user_id,
-                category=NotificationCategory.RESULT_CONFIRM,
-                title=title,
-                body=body,
-                link=f"/matches/{match.id}",
-                action_label="Review",
-                push_category=MATCH_RESULT_CONFIRMATION_CATEGORY,
-                push_data=push_data,
-                collapse_id=f"result-confirm:{match.id}",
-            )
-        )
 
 
 # ----- scoring endpoints ---------------------------------------------------
@@ -823,7 +660,7 @@ async def create_game_score(
     except _SCORE_WRITE_ERRORS as exc:
         raise _map_score_write_error(exc) from exc
 
-    extras = await _view_extras(match_service, reloaded)
+    extras = await view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
 
 
@@ -858,7 +695,7 @@ async def update_game_score(
     except _SCORE_WRITE_ERRORS as exc:
         raise _map_score_write_error(exc) from exc
 
-    extras = await _view_extras(match_service, reloaded)
+    extras = await view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
 
 
@@ -889,7 +726,7 @@ async def delete_game_score(
     except _SCORE_WRITE_ERRORS as exc:
         raise _map_score_write_error(exc) from exc
 
-    extras = await _view_extras(match_service, reloaded)
+    extras = await view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)
 
 
@@ -982,7 +819,7 @@ async def post_match_result(
         raise HTTPException(status_code=404, detail="Match not found.") from exc
 
     reloaded = outcome.match
-    extras = await _view_extras(match_service, reloaded)
+    extras = await view_extras(match_service, reloaded)
     details = _serialize_details(reloaded, current_user.id, extras)
     # Record + notify the side that now owes an acceptance. Built after the
     # response and best-effort: the result is already committed, so *nothing*
@@ -993,7 +830,7 @@ async def post_match_result(
     # clean even when the failure was the in-app persist commit.
     if outcome.awaiting_acceptance:
         try:
-            await _notify_result_posted(notifications, reloaded, current_user.id)
+            await notify_result_posted(notifications, reloaded, current_user.id)
         except Exception:
             await db.rollback()
             log.exception(
@@ -1058,5 +895,5 @@ async def accept_match_result(
             status_code=409, detail="The posted games no longer decide this match."
         ) from exc
 
-    extras = await _view_extras(match_service, reloaded)
+    extras = await view_extras(match_service, reloaded)
     return _serialize_details(reloaded, current_user.id, extras)

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -1,0 +1,166 @@
+"""The FortyMM MCP server: a FastMCP app mounted at ``/mcp`` on the FastAPI app.
+
+Router-free (no FastAPI imports); it owns a configured :data:`mcp` ``FastMCP``
+instance whose transport authentication is a :class:`FortymmTokenVerifier`. The
+curated match-flow verbs are registered here as tools (starting with the
+:func:`get_match` read); each reuses the shared match service + serializer so the
+MCP and HTTP surfaces can never drift.
+
+Auth reuses the exact same resolver as the HTTP bearer path
+(:func:`app.api_token_auth.find_api_token_user`), wrapped in a FastMCP
+``TokenVerifier`` so an unauthenticated MCP call fails **at the transport**, not
+inside a tool, and the two surfaces can never drift (see the shared-services
+ADR). Every tool authenticates before it runs.
+
+Tools run outside a FastAPI request, so they cannot use the request-scoped
+``get_session`` dependency — they own the session lifecycle themselves via
+:func:`mcp_session` (``api/CLAUDE.md``: "outside a request you own the session
+lifecycle yourself"). The verifier does the same.
+"""
+
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.server.auth import AccessToken, TokenVerifier
+from fastmcp.server.dependencies import get_access_token
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api_token_auth import find_api_token_user
+from app.db import get_sessionmaker
+from app.mappers.match_extras_mapper import (
+    MatchDetailsExtras,
+    empty_extras,
+    serialize_match_extras,
+)
+from app.match_queries import match_eager_options, singles_user_ids
+from app.match_serialization import _is_participant, _serialize_details
+from app.models import Match
+from app.repositories.match_details_repository import MatchDetailsRepository
+from app.repositories.match_repository import MatchRepository
+from app.schemas.match import MatchDetails
+from app.services.match_service import MatchService
+
+
+@asynccontextmanager
+async def mcp_session() -> AsyncIterator[AsyncSession]:
+    """An owned ``AsyncSession`` for code running outside a FastAPI request.
+
+    The shared helper every MCP tool (and the token verifier) uses to get a
+    session, since ``get_session`` — the request-scoped FastAPI dependency —
+    isn't available off the request path. Opens a session from the process-wide
+    factory and closes it on exit.
+    """
+    async with get_sessionmaker()() as session:
+        yield session
+
+
+class FortymmTokenVerifier(TokenVerifier):
+    """Authenticates every MCP request against a ``context="api"`` bearer token.
+
+    FastMCP hands us the raw token parsed out of the ``Authorization: Bearer``
+    header; we resolve it through the one shared
+    :func:`~app.api_token_auth.find_api_token_user` lookup (sha256 hash → live,
+    non-tombstoned ``User``). On success we return an ``AccessToken`` carrying
+    the resolved user id as ``subject``/``client_id`` (and under a ``user_id``
+    claim) so tools can identify the caller without re-resolving. On any failure
+    — missing, unknown, or tombstoned-user token — we return ``None``, which
+    FastMCP turns into a 401 at the transport before any tool body runs.
+    """
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        async with mcp_session() as db:
+            user = await find_api_token_user(db, token)
+        if user is None:
+            return None
+        user_id = str(user.id)
+        return AccessToken(
+            token=token,
+            client_id=user_id,
+            subject=user_id,
+            scopes=[],
+            claims={"user_id": user_id},
+        )
+
+
+# The mounted MCP server. ``auth`` wires the verifier so authentication happens
+# at the transport for every request; each tool below reads the resolved caller
+# from the FastMCP auth context rather than re-parsing the bearer token.
+mcp: FastMCP[None] = FastMCP("FortyMM", auth=FortymmTokenVerifier())
+
+
+def _authenticated_user_id() -> uuid.UUID:
+    """The resolved caller's ``users.id`` from the FastMCP auth context.
+
+    The transport already authenticated the request (``FortymmTokenVerifier``);
+    that minted an :class:`AccessToken` carrying the resolved user id under a
+    ``user_id`` claim (and as ``subject``). We read it back here rather than
+    re-resolving the token, so a tool body can identify its caller. A tool only
+    runs after the verifier returned a token, so an absent token / claim is an
+    internal invariant break, not a client error — surface it loudly as a
+    ``ToolError``.
+    """
+    token = get_access_token()
+    raw_user_id = token.claims.get("user_id") if token is not None else None
+    if raw_user_id is None:
+        raise ToolError("Not authenticated.")
+    return uuid.UUID(raw_user_id)
+
+
+async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
+    """Load the eager ``Match`` ORM row the serializer needs, mirroring the HTTP
+    ``GET /v1/matches/{match_id}`` read path's eager-load chain."""
+    result = await db.execute(
+        select(Match).where(Match.id == match_id).options(*match_eager_options())
+    )
+    return result.scalar_one_or_none()
+
+
+async def _view_extras(match_service: MatchService, match: Match) -> MatchDetailsExtras:
+    """Participant-only extras (rating changes, recent form, head-to-head) for an
+    already-loaded ``match`` — the same assembly the HTTP GET uses for a
+    participant caller (#515)."""
+    return serialize_match_extras(
+        await match_service.load_view_extras(
+            match_id=match.id,
+            league_id=match.league_id,
+            status=match.status,
+            created_at=match.created_at,
+            user_ids=singles_user_ids(match),
+        )
+    )
+
+
+@mcp.tool
+async def get_match(match_id: uuid.UUID) -> MatchDetails:
+    """Read a single match as the authenticated API-token caller.
+
+    Returns the same ``MatchDetails`` view the HTTP ``GET /v1/matches/{match_id}``
+    endpoint returns for that user: viewer-relative perspective flags
+    (``is_current_user_side``, ``can_score``, ``can_finalize``, the negotiation
+    block) plus — only when the caller is a participant on the match — the
+    history/rivalry/rating extras (recent form, head-to-head, per-side rating
+    changes; a non-participant gets those empty, per #515).
+
+    Raises a ``ToolError`` when no match has that id.
+    """
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        match = await _load_match(db, match_id)
+        if match is None:
+            raise ToolError(f"No match found with id {match_id}.")
+        service = MatchService(MatchRepository(db), MatchDetailsRepository(db))
+        domain_match = await service.get_match(match_id)
+        if domain_match is None:
+            raise ToolError(f"No match found with id {match_id}.")
+        # Gate the history/rivalry/rating payload on participation, exactly as the
+        # HTTP GET does — a non-participant (spectator) still sees the scorecard,
+        # but with empty extras (#515).
+        is_participant = _is_participant(match, user_id)
+        extras = (
+            await _view_extras(service, match) if is_participant else empty_extras()
+        )
+        return _serialize_details(match, user_id, extras, domain_match)

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -21,6 +21,7 @@ lifecycle yourself"). The verifier does the same.
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Literal
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
@@ -36,11 +37,17 @@ from app.mappers.match_extras_mapper import (
     empty_extras,
     serialize_match_extras,
 )
+from app.match_creation import create_match as create_match_core
 from app.match_queries import match_eager_options, singles_user_ids
 from app.match_serialization import _is_participant, _serialize_details
-from app.models import Match
+from app.models import Match, User
 from app.repositories.match_details_repository import MatchDetailsRepository
 from app.repositories.match_repository import MatchRepository
+from app.result_acceptance import (
+    OpponentNotFoundError,
+    RatedNeedsRegisteredOpponentError,
+    SelfMatchError,
+)
 from app.schemas.match import MatchDetails
 from app.services.match_service import MatchService
 
@@ -110,6 +117,17 @@ def _authenticated_user_id() -> uuid.UUID:
     return uuid.UUID(raw_user_id)
 
 
+async def _load_user(db: AsyncSession, user_id: uuid.UUID) -> User | None:
+    """Load the live ``User`` the caller authenticated as, so the creation
+    service has the ``creator`` row it needs. The transport already resolved
+    this id from a live, non-tombstoned token, so a missing row is an internal
+    invariant break — the tool surfaces it as a ``ToolError`` rather than a
+    silent ``None``."""
+    return (
+        await db.execute(select(User).where(User.id == user_id))
+    ).scalar_one_or_none()
+
+
 async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
     """Load the eager ``Match`` ORM row the serializer needs, mirroring the HTTP
     ``GET /v1/matches/{match_id}`` read path's eager-load chain."""
@@ -164,3 +182,53 @@ async def get_match(match_id: uuid.UUID) -> MatchDetails:
             await _view_extras(service, match) if is_participant else empty_extras()
         )
         return _serialize_details(match, user_id, extras, domain_match)
+
+
+@mcp.tool
+async def create_match(
+    best_of: Literal[1, 3, 5, 7],
+    opponent_user_id: uuid.UUID | None = None,
+    league_id: uuid.UUID | None = None,
+    rated: bool = True,
+) -> MatchDetails:
+    """Start a match as the authenticated API-token caller and return it.
+
+    Mirrors ``POST /v1/matches``: it reuses the shared creation service and
+    serializer, so the MCP and HTTP surfaces can never drift. ``best_of`` is the
+    total games to play and must be one of 1, 3, 5, or 7. ``opponent_user_id`` is
+    optional — omit it for a solo match, which gets a player-less "No opponent"
+    sentinel side (still scorable) and is always unrated, so it must be created
+    with ``rated=False``. ``league_id`` is optional; when omitted the match binds
+    to the default league. Returns the created ``MatchDetails`` from the
+    creator's perspective (the same view ``get_match`` reads back).
+
+    Raises a ``ToolError`` when the opponent is yourself, when
+    ``opponent_user_id`` matches no live registered player, or when a rated match
+    is requested with no registered opponent.
+    """
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        creator = await _load_user(db, user_id)
+        if creator is None:
+            raise ToolError("Not authenticated.")
+        try:
+            created = await create_match_core(
+                db,
+                creator=creator,
+                opponent_user_id=opponent_user_id,
+                league_id=league_id,
+                best_of=best_of,
+                rated=rated,
+            )
+        except SelfMatchError as err:
+            raise ToolError("You cannot start a match against yourself.") from err
+        except OpponentNotFoundError as err:
+            raise ToolError(
+                f"No live registered player found with id {opponent_user_id}."
+            ) from err
+        except RatedNeedsRegisteredOpponentError as err:
+            raise ToolError(
+                "A rated match needs a registered opponent. Pass an "
+                "opponent_user_id, or set rated=False for a solo match."
+            ) from err
+        return _serialize_details(created, creator.id)

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -50,6 +50,8 @@ from app.matches import _notify_result_posted
 from app.models import Match, User
 from app.notifications.dependencies import get_push_sender
 from app.notifications.service import NotificationService
+from app.player_matches import paginated_player_matches
+from app.player_search import SEARCH_DEFAULT_LIMIT, search_players_by_username
 from app.repositories.match_details_repository import MatchDetailsRepository
 from app.repositories.match_repository import MatchRepository
 from app.result_acceptance import (
@@ -72,6 +74,7 @@ from app.result_acceptance import (
 )
 from app.result_proposal import propose_result as propose_result_core
 from app.schemas.match import MatchDetails, MatchResultsGameWrite
+from app.schemas.player import PlayerMatchListResponse, PlayerRead
 from app.services.match_service import MatchService
 
 log = logging.getLogger(__name__)
@@ -81,6 +84,19 @@ log = logging.getLogger(__name__)
 # ``ToolError``. The per-match ``best_of`` range is still enforced inside the
 # ``match_scoring`` entry points (``ScoreNotAllowedError``).
 GameNumber = Annotated[int, Field(ge=1, le=7)]
+
+# Argument bounds for the read tools, mirroring the HTTP query-param caps so the
+# two surfaces can't drift on what a valid page/limit is (``app.players``:
+# ``MAX_LIMIT`` = 50 for the typeahead, ``LIST_MAX_PAGE_SIZE`` = 100 for the
+# per-player match list). An out-of-range value is a schema-level validation
+# error at the transport, not a tool-body ``ToolError``.
+SearchLimit = Annotated[int, Field(ge=1, le=50)]
+MatchPage = Annotated[int, Field(ge=1)]
+MatchPageSize = Annotated[int, Field(ge=1, le=100)]
+
+# The default page size ``list_my_matches`` uses when the caller names none,
+# matching the HTTP per-player list default (``app.players.LIST_DEFAULT_PAGE_SIZE``).
+MY_MATCHES_DEFAULT_PAGE_SIZE = 25
 
 
 @asynccontextmanager
@@ -357,6 +373,55 @@ async def enter_game_score(
         except _SCORE_WRITE_ERRORS as exc:
             raise _map_score_write_tool_error(exc) from exc
         return await _serialize_written_match(db, reloaded, user_id)
+
+
+@mcp.tool
+async def search_players(
+    query: str,
+    limit: SearchLimit = SEARCH_DEFAULT_LIMIT,
+) -> list[PlayerRead]:
+    """Search registered players by username as the authenticated API-token
+    caller — the opponent picker's typeahead.
+
+    Mirrors ``GET /v1/players/search``: it reuses the shared
+    ``search_players_by_username`` query so the MCP and HTTP surfaces can never
+    drift. ``query`` is matched as a case-insensitive substring; the caller is
+    always excluded, as are tombstoned (merged-away) users, and results are
+    ordered alphabetically and capped at ``limit`` (default 10). A blank
+    ``query`` matches nothing and returns an empty list. Each hit carries the
+    player's rating in the default league (``null`` for an unrated player). Use a
+    hit's ``id`` as ``create_match``'s ``opponent_user_id``.
+    """
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        return await search_players_by_username(
+            db, query=query, current_user_id=user_id, limit=limit
+        )
+
+
+@mcp.tool
+async def list_my_matches(
+    page: MatchPage = 1,
+    page_size: MatchPageSize = MY_MATCHES_DEFAULT_PAGE_SIZE,
+) -> PlayerMatchListResponse:
+    """List the authenticated API-token caller's OWN match history, newest first.
+
+    Reuses the same ``paginated_player_matches`` read the HTTP
+    ``GET /v1/players/{id}/matches`` endpoint serves — scoped to the caller — so
+    the MCP and HTTP surfaces can never drift. Unlike the global
+    ``GET /v1/matches`` feed (every platform match, by design), this returns only
+    matches the CALLER is a side of. The history is all-inclusive (ADR-0008):
+    any status, rated or not, solo "No opponent" matches included. Each row is
+    projected onto the caller's side — ``games`` read ``mine``/``theirs``,
+    ``result`` is ``W``/``L`` only once a match is decided (``null`` while it is
+    pending / in play / awaiting acceptance / voided), and ``rating_change`` is
+    the delta the match moved for the caller (``null`` unless decided and rated).
+    ``page`` (1-based) and ``page_size`` (default 25) page through the history;
+    ``total`` is the all-inclusive count.
+    """
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        return await paginated_player_matches(db, user_id, page, page_size)
 
 
 @mcp.tool

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -18,6 +18,7 @@ Tools run outside a FastAPI request, so they cannot use the request-scoped
 lifecycle yourself"). The verifier does the same.
 """
 
+import logging
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -45,20 +46,35 @@ from app.match_scoring import delete_game_score as delete_game_score_core
 from app.match_scoring import enter_game_score as enter_game_score_core
 from app.match_scoring import update_game_score as update_game_score_core
 from app.match_serialization import _is_participant, _serialize_details
+from app.matches import _notify_result_posted
 from app.models import Match, User
+from app.notifications.dependencies import get_push_sender
+from app.notifications.service import NotificationService
 from app.repositories.match_details_repository import MatchDetailsRepository
 from app.repositories.match_repository import MatchRepository
 from app.result_acceptance import (
+    CannotAcceptOwnProposalError,
+    MatchClosedError,
     MatchNotFoundError,
     MatchNotScorableError,
+    NegotiationConflictError,
     OpponentNotFoundError,
+    PostedGamesNotDecisiveError,
     RatedNeedsRegisteredOpponentError,
+    ResultNotFoundError,
     ScoreConflictError,
     ScoreNotAllowedError,
     SelfMatchError,
+    UndecidedBoardError,
 )
-from app.schemas.match import MatchDetails
+from app.result_acceptance import (
+    accept_result as accept_result_core,
+)
+from app.result_proposal import propose_result as propose_result_core
+from app.schemas.match import MatchDetails, MatchResultsGameWrite
 from app.services.match_service import MatchService
+
+log = logging.getLogger(__name__)
 
 # A game number bounded to the widest ``best_of`` (7), so an out-of-range value
 # is a schema-level validation error at the transport rather than a tool-body
@@ -381,6 +397,145 @@ async def update_game_score(
             )
         except _SCORE_WRITE_ERRORS as exc:
             raise _map_score_write_tool_error(exc) from exc
+        return await _serialize_written_match(db, reloaded, user_id)
+
+
+# The recovery message every lost-negotiation race shares: the caller's view of
+# the standing result is stale, so it must re-read before it can act again. Names
+# ``get_match`` explicitly so an agent knows exactly which verb re-syncs it.
+_NEGOTIATION_CONFLICT_MESSAGE = (
+    "The standing result changed — call get_match to see the current standing "
+    "result, then accept it or counter again."
+)
+
+
+async def _fire_result_notification(
+    db: AsyncSession, match: Match, poster_id: uuid.UUID
+) -> None:
+    """Best-effort accept/counter notification to the side that now owes a
+    response, mirroring the HTTP ``post_match_result`` handler.
+
+    The result is already committed by :func:`propose_result`, so *nothing* here
+    may fail the tool — not a DB error, not a delivery-side failure. Hence the
+    blanket catch (the same fire-and-forget guard the HTTP handler uses): a
+    notify failure is logged and swallowed, and the session is rolled back so a
+    failed in-app persist leaves the session clean. The ``NotificationService``
+    is constructed exactly as ``get_notification_service`` does (the owned
+    session plus the process-wide push-sender singleton)."""
+    notifications = NotificationService(db, get_push_sender())
+    try:
+        await _notify_result_posted(notifications, match, poster_id)
+    except Exception:
+        await db.rollback()
+        log.exception(
+            "Failed to record result-acceptance notification",
+            extra={"match_id": str(match.id)},
+        )
+
+
+@mcp.tool
+async def propose_result(
+    match_id: uuid.UUID,
+    games: list[MatchResultsGameWrite],
+    supersedes_result_id: uuid.UUID | None = None,
+) -> MatchDetails:
+    """Propose a result for a match as the authenticated API-token caller — the
+    first verb of the propose/accept negotiation — and return the updated match.
+
+    Mirrors ``POST /v1/matches/{match_id}/results``: it reuses the shared
+    ``result_proposal`` core (the NOWAIT row lock, the terminal-status gate, the
+    decided-board validator, the first-post-vs-counter negotiation gates, the
+    canonical-board commit, and the self-accept/finalize vs leave-standing fork)
+    so the MCP and HTTP surfaces can never drift. ``games`` is the canonical board
+    (each game's per-point legality is validated); this one tool serves both the
+    FIRST proposal (omit ``supersedes_result_id``) and a COUNTER/correction (set
+    ``supersedes_result_id`` to the current standing result's id). A solo/unrated
+    match self-accepts and finalizes immediately; a rated two-human match leaves
+    the result *standing* for the opponent to ``accept_result``, and — only then —
+    fires a best-effort accept/counter notification to the opponent (a notify
+    failure never fails this tool). Returns the ``MatchDetails`` from the
+    proposer's perspective (the same view ``get_match`` reads back).
+
+    Raises a ``ToolError`` when the match doesn't exist or you're not a
+    participant, when the match is closed to new results (completed/voided), when
+    the board is undecided/invalid, when another proposal is mid-flight (retry),
+    or when the standing result moved on under you — the last names ``get_match``
+    as the recovery path (re-read the standing result, then accept or counter)."""
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        try:
+            outcome = await propose_result_core(
+                db,
+                match_id,
+                user_id,
+                games=games,
+                supersedes_result_id=supersedes_result_id,
+            )
+        except MatchNotFoundError as exc:
+            raise ToolError("Match not found, or you are not a participant.") from exc
+        except MatchClosedError as exc:
+            raise ToolError(str(exc)) from exc
+        except UndecidedBoardError as exc:
+            raise ToolError(str(exc)) from exc
+        except MatchLockUnavailable as exc:
+            raise ToolError(
+                "Another proposal is in progress for this match, retry."
+            ) from exc
+        except NegotiationConflictError as exc:
+            raise ToolError(_NEGOTIATION_CONFLICT_MESSAGE) from exc
+
+        # Record + notify the side that now owes an acceptance — only for a rated
+        # two-human match that left the result standing, exactly as the HTTP
+        # handler does, and only after the result is committed. Best-effort: a
+        # notify failure can never fail the tool.
+        if outcome.awaiting_acceptance:
+            await _fire_result_notification(db, outcome.match, user_id)
+        return await _serialize_written_match(db, outcome.match, user_id)
+
+
+@mcp.tool
+async def accept_result(
+    match_id: uuid.UUID,
+    result_id: uuid.UUID,
+) -> MatchDetails:
+    """Accept a standing proposal as the authenticated API-token caller — the
+    second verb of the propose/accept negotiation — and return the completed
+    match.
+
+    Mirrors ``POST /v1/matches/{match_id}/results/{result_id}/acceptance``: it
+    reuses the shared ``result_acceptance`` core (the blocking row lock, the
+    result-exists gate, the submitter-side self-accept guard, the live
+    standing-proposal check, and ``finalize_match`` — mark completed, stamp
+    ``side.won``, apply ratings, advance any tournament draw) so the MCP and HTTP
+    surfaces can never drift. ``result_id`` is the concurrency token: it must be
+    the current standing proposal's id (from ``get_match``). Returns the finalized
+    ``MatchDetails`` from the accepting caller's perspective.
+
+    Raises a ``ToolError`` when no result with that id exists on the match, when
+    the match doesn't exist or you're not a participant, when you try to accept
+    your own proposal (only the opposing side may accept), when the agreed board
+    no longer decides a winner, or when the standing result moved on under you
+    (superseded by a counter or already accepted) — the last names ``get_match``
+    as the recovery path (re-read the standing result, then accept or counter)."""
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        try:
+            reloaded = await accept_result_core(
+                db,
+                match_id,
+                user_id,
+                result_id=result_id,
+            )
+        except MatchNotFoundError as exc:
+            raise ToolError("Match not found, or you are not a participant.") from exc
+        except ResultNotFoundError as exc:
+            raise ToolError("No result with that id exists on this match.") from exc
+        except CannotAcceptOwnProposalError as exc:
+            raise ToolError("You can't accept your own proposal.") from exc
+        except PostedGamesNotDecisiveError as exc:
+            raise ToolError("The posted games no longer decide this match.") from exc
+        except NegotiationConflictError as exc:
+            raise ToolError(_NEGOTIATION_CONFLICT_MESSAGE) from exc
         return await _serialize_written_match(db, reloaded, user_id)
 
 

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -57,9 +57,9 @@ from app.match_scoring import delete_game_score as delete_game_score_core
 from app.match_scoring import enter_game_score as enter_game_score_core
 from app.match_scoring import update_game_score as update_game_score_core
 from app.match_serialization import (
-    _is_participant,
-    _serialize_details,
+    is_participant,
     load_match_eager,
+    serialize_details,
     view_extras,
 )
 from app.models import Match, User
@@ -200,9 +200,13 @@ async def get_match(match_id: uuid.UUID) -> MatchDetails:
         # Gate the history/rivalry/rating payload on participation, exactly as the
         # HTTP GET does — a non-participant (spectator) still sees the scorecard,
         # but with empty extras (#515).
-        is_participant = _is_participant(match, user_id)
-        extras = await view_extras(service, match) if is_participant else empty_extras()
-        return _serialize_details(match, user_id, extras, domain_match)
+        viewer_is_participant = is_participant(match, user_id)
+        extras = (
+            await view_extras(service, match)
+            if viewer_is_participant
+            else empty_extras()
+        )
+        return serialize_details(match, user_id, extras, domain_match)
 
 
 @mcp.tool
@@ -252,7 +256,7 @@ async def create_match(
                 "A rated match needs a registered opponent. Pass an "
                 "opponent_user_id, or set rated=False for a solo match."
             ) from err
-        return _serialize_details(created, creator.id)
+        return serialize_details(created, creator.id)
 
 
 # The per-game score-write domain family the ``match_scoring`` entry points
@@ -304,7 +308,7 @@ async def _serialize_written_match(
     score handlers return for the acting user."""
     service = MatchService(MatchRepository(db), MatchDetailsRepository(db))
     extras = await view_extras(service, match)
-    return _serialize_details(match, user_id, extras)
+    return serialize_details(match, user_id, extras)
 
 
 @mcp.tool

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -34,27 +34,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api_token_auth import find_api_token_user
 from app.db import get_sessionmaker
-from app.mappers.match_extras_mapper import (
-    MatchDetailsExtras,
-    empty_extras,
-    serialize_match_extras,
-)
+from app.mappers.match_extras_mapper import empty_extras
 from app.match_creation import create_match as create_match_core
-from app.match_queries import match_eager_options, singles_user_ids
-from app.match_scoring import MatchLockUnavailable
-from app.match_scoring import delete_game_score as delete_game_score_core
-from app.match_scoring import enter_game_score as enter_game_score_core
-from app.match_scoring import update_game_score as update_game_score_core
-from app.match_serialization import _is_participant, _serialize_details
-from app.matches import _notify_result_posted
-from app.models import Match, User
-from app.notifications.dependencies import get_push_sender
-from app.notifications.service import NotificationService
-from app.player_matches import paginated_player_matches
-from app.player_search import SEARCH_DEFAULT_LIMIT, search_players_by_username
-from app.repositories.match_details_repository import MatchDetailsRepository
-from app.repositories.match_repository import MatchRepository
-from app.result_acceptance import (
+from app.match_errors import (
     CannotAcceptOwnProposalError,
     MatchClosedError,
     MatchNotFoundError,
@@ -69,6 +51,24 @@ from app.result_acceptance import (
     SelfMatchError,
     UndecidedBoardError,
 )
+from app.match_result_notifications import notify_result_posted
+from app.match_scoring import MatchLockUnavailable
+from app.match_scoring import delete_game_score as delete_game_score_core
+from app.match_scoring import enter_game_score as enter_game_score_core
+from app.match_scoring import update_game_score as update_game_score_core
+from app.match_serialization import (
+    _is_participant,
+    _serialize_details,
+    load_match_eager,
+    view_extras,
+)
+from app.models import Match, User
+from app.notifications.dependencies import get_push_sender
+from app.notifications.service import NotificationService
+from app.player_matches import paginated_player_matches
+from app.player_search import SEARCH_DEFAULT_LIMIT, search_players_by_username
+from app.repositories.match_details_repository import MatchDetailsRepository
+from app.repositories.match_repository import MatchRepository
 from app.result_acceptance import (
     accept_result as accept_result_core,
 )
@@ -175,30 +175,6 @@ async def _load_user(db: AsyncSession, user_id: uuid.UUID) -> User | None:
     ).scalar_one_or_none()
 
 
-async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
-    """Load the eager ``Match`` ORM row the serializer needs, mirroring the HTTP
-    ``GET /v1/matches/{match_id}`` read path's eager-load chain."""
-    result = await db.execute(
-        select(Match).where(Match.id == match_id).options(*match_eager_options())
-    )
-    return result.scalar_one_or_none()
-
-
-async def _view_extras(match_service: MatchService, match: Match) -> MatchDetailsExtras:
-    """Participant-only extras (rating changes, recent form, head-to-head) for an
-    already-loaded ``match`` — the same assembly the HTTP GET uses for a
-    participant caller (#515)."""
-    return serialize_match_extras(
-        await match_service.load_view_extras(
-            match_id=match.id,
-            league_id=match.league_id,
-            status=match.status,
-            created_at=match.created_at,
-            user_ids=singles_user_ids(match),
-        )
-    )
-
-
 @mcp.tool
 async def get_match(match_id: uuid.UUID) -> MatchDetails:
     """Read a single match as the authenticated API-token caller.
@@ -214,7 +190,7 @@ async def get_match(match_id: uuid.UUID) -> MatchDetails:
     """
     user_id = _authenticated_user_id()
     async with mcp_session() as db:
-        match = await _load_match(db, match_id)
+        match = await load_match_eager(db, match_id)
         if match is None:
             raise ToolError(f"No match found with id {match_id}.")
         service = MatchService(MatchRepository(db), MatchDetailsRepository(db))
@@ -225,9 +201,7 @@ async def get_match(match_id: uuid.UUID) -> MatchDetails:
         # HTTP GET does — a non-participant (spectator) still sees the scorecard,
         # but with empty extras (#515).
         is_participant = _is_participant(match, user_id)
-        extras = (
-            await _view_extras(service, match) if is_participant else empty_extras()
-        )
+        extras = await view_extras(service, match) if is_participant else empty_extras()
         return _serialize_details(match, user_id, extras, domain_match)
 
 
@@ -309,10 +283,6 @@ def _map_score_write_tool_error(exc: Exception) -> ToolError:
         if exc.message == "Match not found.":
             return ToolError("Match not found, or you are not a participant.")
         return ToolError(exc.message)
-    if isinstance(exc, MatchNotScorableError):
-        return ToolError(exc.message)
-    if isinstance(exc, ScoreNotAllowedError):
-        return ToolError(str(exc))
     if isinstance(exc, ScoreConflictError):
         return ToolError(
             "This game's score changed under you — call get_match to see the "
@@ -333,7 +303,7 @@ async def _serialize_written_match(
     history/rivalry/rating extras are always assembled — the same view the HTTP
     score handlers return for the acting user."""
     service = MatchService(MatchRepository(db), MatchDetailsRepository(db))
-    extras = await _view_extras(service, match)
+    extras = await view_extras(service, match)
     return _serialize_details(match, user_id, extras)
 
 
@@ -489,7 +459,7 @@ async def _fire_result_notification(
     session plus the process-wide push-sender singleton)."""
     notifications = NotificationService(db, get_push_sender())
     try:
-        await _notify_result_posted(notifications, match, poster_id)
+        await notify_result_posted(notifications, match, poster_id)
     except Exception:
         await db.rollback()
         log.exception(

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -21,12 +21,13 @@ lifecycle yourself"). The verifier does the same.
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.auth import AccessToken, TokenVerifier
 from fastmcp.server.dependencies import get_access_token
+from pydantic import Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,17 +40,31 @@ from app.mappers.match_extras_mapper import (
 )
 from app.match_creation import create_match as create_match_core
 from app.match_queries import match_eager_options, singles_user_ids
+from app.match_scoring import MatchLockUnavailable
+from app.match_scoring import delete_game_score as delete_game_score_core
+from app.match_scoring import enter_game_score as enter_game_score_core
+from app.match_scoring import update_game_score as update_game_score_core
 from app.match_serialization import _is_participant, _serialize_details
 from app.models import Match, User
 from app.repositories.match_details_repository import MatchDetailsRepository
 from app.repositories.match_repository import MatchRepository
 from app.result_acceptance import (
+    MatchNotFoundError,
+    MatchNotScorableError,
     OpponentNotFoundError,
     RatedNeedsRegisteredOpponentError,
+    ScoreConflictError,
+    ScoreNotAllowedError,
     SelfMatchError,
 )
 from app.schemas.match import MatchDetails
 from app.services.match_service import MatchService
+
+# A game number bounded to the widest ``best_of`` (7), so an out-of-range value
+# is a schema-level validation error at the transport rather than a tool-body
+# ``ToolError``. The per-match ``best_of`` range is still enforced inside the
+# ``match_scoring`` entry points (``ScoreNotAllowedError``).
+GameNumber = Annotated[int, Field(ge=1, le=7)]
 
 
 @asynccontextmanager
@@ -232,3 +247,170 @@ async def create_match(
                 "opponent_user_id, or set rated=False for a solo match."
             ) from err
         return _serialize_details(created, creator.id)
+
+
+# The per-game score-write domain family the ``match_scoring`` entry points
+# raise. ``MatchLockUnavailable`` is included defensively — the entry points take
+# the *blocking* row lock, so it won't fire today, but mapping it keeps the
+# adapter honest if a caller ever drives them with ``nowait``.
+_SCORE_WRITE_ERRORS = (
+    MatchNotFoundError,
+    MatchNotScorableError,
+    ScoreNotAllowedError,
+    ScoreConflictError,
+    MatchLockUnavailable,
+)
+
+
+def _map_score_write_tool_error(exc: Exception) -> ToolError:
+    """Adapt a score-write domain exception to an actionable ``ToolError``.
+
+    Mirrors the HTTP adapter (``matches._map_score_write_error``) but speaks the
+    agent's language instead of HTTP status codes: a lost optimistic-concurrency
+    race names ``get_match`` as the recovery path (re-read the committed score,
+    then retry with the current version), and a held lock asks for a retry."""
+    if isinstance(exc, MatchNotFoundError):
+        # "Match not found." collapses absent-match and non-participant into one
+        # opaque reason (a non-participant can't probe existence); "Score not
+        # found." is the update/delete missing-score case — surface each as-is,
+        # naming participation for the former.
+        if exc.message == "Match not found.":
+            return ToolError("Match not found, or you are not a participant.")
+        return ToolError(exc.message)
+    if isinstance(exc, MatchNotScorableError):
+        return ToolError(exc.message)
+    if isinstance(exc, ScoreNotAllowedError):
+        return ToolError(str(exc))
+    if isinstance(exc, ScoreConflictError):
+        return ToolError(
+            "This game's score changed under you — call get_match to see the "
+            "committed score, then retry with the current version."
+        )
+    if isinstance(exc, MatchLockUnavailable):
+        return ToolError("Another write is in progress for this match, retry.")
+    return ToolError(str(exc))
+
+
+async def _serialize_written_match(
+    db: AsyncSession, match: Match, user_id: uuid.UUID
+) -> MatchDetails:
+    """Serialize a just-written match from the participant caller's perspective.
+
+    The ``match_scoring`` entry points only return to a participant (a
+    non-participant is rejected at load with ``MatchNotFoundError``), so the
+    history/rivalry/rating extras are always assembled — the same view the HTTP
+    score handlers return for the acting user."""
+    service = MatchService(MatchRepository(db), MatchDetailsRepository(db))
+    extras = await _view_extras(service, match)
+    return _serialize_details(match, user_id, extras)
+
+
+@mcp.tool
+async def enter_game_score(
+    match_id: uuid.UUID,
+    game_number: GameNumber,
+    side_1_points: int,
+    side_2_points: int,
+) -> MatchDetails:
+    """Save the first score for a game as the authenticated API-token caller and
+    return the updated match.
+
+    Mirrors ``POST /v1/matches/{match_id}/games/{game_number}/scores/new``: it
+    reuses the shared ``match_scoring`` write path (blocking row lock,
+    scorability + best-of-range + no-overrun guards, then the insert) so the MCP
+    and HTTP surfaces can never drift. ``game_number`` is 1-based and at most 7.
+    Returns the reloaded ``MatchDetails`` from the caller's perspective (the same
+    view ``get_match`` reads back).
+
+    Raises a ``ToolError`` when the match doesn't exist or you're not a
+    participant, when the match isn't scorable (no opponent, a posted result, not
+    yet called to a table, or terminal), when the game is out of the ``best_of``
+    range or would overrun a decided match, or when a concurrent participant
+    already scored this game (call ``get_match``, then retry)."""
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        try:
+            reloaded = await enter_game_score_core(
+                db,
+                match_id,
+                user_id,
+                game_number=game_number,
+                side_1_points=side_1_points,
+                side_2_points=side_2_points,
+            )
+        except _SCORE_WRITE_ERRORS as exc:
+            raise _map_score_write_tool_error(exc) from exc
+        return await _serialize_written_match(db, reloaded, user_id)
+
+
+@mcp.tool
+async def update_game_score(
+    match_id: uuid.UUID,
+    game_number: GameNumber,
+    side_1_points: int,
+    side_2_points: int,
+    expected_version: int,
+) -> MatchDetails:
+    """Replace a game's committed score under optimistic concurrency as the
+    authenticated API-token caller and return the updated match.
+
+    Mirrors ``PUT /v1/matches/{match_id}/games/{game_number}/scores``: it reuses
+    the shared ``match_scoring`` write path (blocking row lock, scorability + the
+    score's existence + no-overrun guards, then the version-guarded UPDATE) so
+    the MCP and HTTP surfaces can never drift. ``expected_version`` is the
+    ``version`` the caller last read for this game's score (from ``get_match``);
+    the write only commits while the committed row is still at that version.
+
+    Raises a ``ToolError`` when the match doesn't exist or you're not a
+    participant, when the game score doesn't exist, when the match isn't
+    scorable, when the write would overrun a decided match, or when
+    ``expected_version`` is stale — a concurrent participant saved this game since
+    you read it (call ``get_match`` for the committed score, then retry with the
+    current version)."""
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        try:
+            reloaded = await update_game_score_core(
+                db,
+                match_id,
+                user_id,
+                game_number=game_number,
+                side_1_points=side_1_points,
+                side_2_points=side_2_points,
+                expected_version=expected_version,
+            )
+        except _SCORE_WRITE_ERRORS as exc:
+            raise _map_score_write_tool_error(exc) from exc
+        return await _serialize_written_match(db, reloaded, user_id)
+
+
+@mcp.tool
+async def delete_game_score(
+    match_id: uuid.UUID,
+    game_number: GameNumber,
+) -> MatchDetails:
+    """Clear a game's committed score as the authenticated API-token caller and
+    return the updated match.
+
+    Mirrors ``DELETE /v1/matches/{match_id}/games/{game_number}/scores``: it
+    reuses the shared ``match_scoring`` write path (blocking row lock,
+    scorability + the score's existence guards, then the clear) so the MCP and
+    HTTP surfaces can never drift. The game row stays so a later
+    ``enter_game_score`` for the same number attaches a fresh score. Returns the
+    reloaded ``MatchDetails`` from the caller's perspective.
+
+    Raises a ``ToolError`` when the match doesn't exist or you're not a
+    participant, when the game score doesn't exist, or when the match isn't
+    scorable."""
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        try:
+            reloaded = await delete_game_score_core(
+                db,
+                match_id,
+                user_id,
+                game_number=game_number,
+            )
+        except _SCORE_WRITE_ERRORS as exc:
+            raise _map_score_write_tool_error(exc) from exc
+        return await _serialize_written_match(db, reloaded, user_id)

--- a/api/app/player_matches.py
+++ b/api/app/player_matches.py
@@ -175,7 +175,7 @@ def _serialize_player_match(
         result = "L"
 
     # A result has been proposed but the opponent hasn't accepted it yet — the
-    # same predicate matches.py's ``_status_label`` buckets as "Awaiting
+    # same predicate the ``status_label`` serializer helper buckets as "Awaiting
     # acceptance", read from the one place that defines it (``app.result_chain``,
     # a shared domain module — not the matches router). The FE uses this to
     # render a distinct chip instead of the green "LIVE" one a genuinely-live

--- a/api/app/player_search.py
+++ b/api/app/player_search.py
@@ -1,0 +1,65 @@
+"""Username substring search backing the opponent typeahead.
+
+FastAPI-free (no routers, no ``Depends``) so both the HTTP endpoint
+(`app.players`) and the MCP ``search_players`` tool can call the SAME query
+logic and never drift — the shared-services rule in ``api/CLAUDE.md``. A
+stateless query, so it is a module-level function taking ``db`` rather than a
+class-plus-provider.
+"""
+
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.leagues import resolve_league
+from app.models import User
+from app.player_summary import load_player_ratings
+from app.schemas.player import PlayerRead
+from app.sql import escape_like
+
+# The typeahead caps its dropdown well below the full roster.
+SEARCH_DEFAULT_LIMIT = 10
+
+
+async def search_players_by_username(
+    db: AsyncSession,
+    *,
+    query: str,
+    current_user_id: uuid.UUID,
+    league_id: uuid.UUID | None = None,
+    limit: int = SEARCH_DEFAULT_LIMIT,
+) -> list[PlayerRead]:
+    """Candidate opponents whose username matches ``query`` (substring,
+    case-insensitive, LIKE-escaped).
+
+    Excludes the caller and tombstoned (merged-away) users, orders
+    alphabetically, and caps at ``limit`` so no caller has to fetch and filter
+    the whole roster. A blank ``query`` matches nothing. ``rating`` is each
+    candidate's rating in the resolved league (defaulting to the default
+    league), ``None`` for an Unrated player.
+    """
+    term = query.strip()
+    if not term:
+        return []
+
+    pattern = f"%{escape_like(term)}%"
+    result = await db.execute(
+        select(User)
+        .where(
+            User.id != current_user_id,
+            # Exclude tombstoned (merged-away) guests so ghosts never surface.
+            User.merged_into_user_id.is_(None),
+            User.username.ilike(pattern, escape="\\"),
+        )
+        .order_by(User.username)
+        .limit(limit)
+    )
+    users: Sequence[User] = result.scalars().all()
+    league = await resolve_league(db, league_id)
+    ratings = await load_player_ratings(db, league.id, (user.id for user in users))
+    return [
+        PlayerRead(id=user.id, username=user.username, rating=ratings.get(user.id))
+        for user in users
+    ]

--- a/api/app/players.py
+++ b/api/app/players.py
@@ -18,6 +18,7 @@ from app.models import (
     UserLeagueRating,
 )
 from app.player_matches import paginated_player_matches
+from app.player_search import SEARCH_DEFAULT_LIMIT, search_players_by_username
 from app.player_summary import (
     load_player_ratings,
     summarize_one_player,
@@ -42,10 +43,9 @@ from app.sql import escape_like
 
 router = APIRouter(prefix="/v1")
 
-# Sizes for the two opponent-picker endpoints. The recent grid shows six
-# chips; the typeahead caps its dropdown well below the full roster.
+# Sizes for the opponent-picker endpoints. The recent grid shows six chips; the
+# typeahead's cap (SEARCH_DEFAULT_LIMIT) lives with its query in app.player_search.
 RECENT_DEFAULT_LIMIT = 6
-SEARCH_DEFAULT_LIMIT = 10
 MAX_LIMIT = 50
 
 # Pagination caps for the `/players` list + per-player matches endpoint.
@@ -138,26 +138,13 @@ async def search_players(
     client never has to fetch and filter the whole roster. An empty query
     matches nothing.
     """
-    term = q.strip()
-    if not term:
-        return []
-
-    pattern = f"%{escape_like(term)}%"
-    result = await db.execute(
-        select(User)
-        .where(
-            User.id != current_user.id,
-            # Exclude tombstoned (merged-away) guests so ghosts never surface.
-            User.merged_into_user_id.is_(None),
-            User.username.ilike(pattern, escape="\\"),
-        )
-        .order_by(User.username)
-        .limit(limit)
+    return await search_players_by_username(
+        db,
+        query=q,
+        current_user_id=current_user.id,
+        league_id=league_id,
+        limit=limit,
     )
-    users = result.scalars().all()
-    league = await resolve_league(db, league_id)
-    ratings = await load_player_ratings(db, league.id, (user.id for user in users))
-    return _serialize(users, ratings)
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/result_acceptance.py
+++ b/api/app/result_acceptance.py
@@ -121,7 +121,7 @@ def side_win_counts(match: Match) -> dict[int, int]:
 def _posted_decided_side(match: Match) -> int:
     """Winner side number per the committed canonical games. Only meaningful
     once a result has been posted: /results validated the games as decided,
-    and ``_enforce_scorable`` freezes them while a result is pending, so exactly
+    and ``ensure_scorable`` freezes them while a result is pending, so exactly
     one side has clinched by the time acceptance reads this."""
     target = _games_to_win(match.match_settings.best_of)
     for side_number, count in sorted(side_win_counts(match).items()):
@@ -397,7 +397,8 @@ async def finalize_match(db: AsyncSession, match: Match, decided_side: int) -> N
 
     **The one place a match becomes ``completed``.** Both completion sites funnel
     through here — the rated accept/retire path (:func:`accept_standing_result`) and the
-    unrated immediate-self-accept path (``app.matches``) — so the four things a
+    unrated immediate-self-accept path (``app.result_proposal``'s ``propose_result``,
+    which calls ``finalize_match``) — so the four things a
     completion must do happen together and in one order, and a future third completion
     path cannot do three of them and forget the fourth. ``decided_side`` is the winning
     side number, computed by the caller from the agreed board (``_posted_decided_side``

--- a/api/app/result_acceptance.py
+++ b/api/app/result_acceptance.py
@@ -90,6 +90,46 @@ class PostedGamesNotDecisiveError(Exception):
     the existing 409 ``"The posted games no longer decide this match."``."""
 
 
+class MatchNotFoundError(Exception):
+    """Raised by the per-game score service (``app.match_scoring``) when the
+    write target can't be resolved — either the match id is absent or the acting
+    user isn't a participant (today's score endpoints collapse both into one
+    opaque 404 so a non-participant can't probe match existence), or, on the
+    update/delete paths, the addressed game score doesn't exist.
+
+    Carries the exact ``message`` the HTTP adapter must reproduce as its 404
+    ``detail``: ``"Match not found."`` for an absent match or non-participant,
+    ``"Score not found."`` for a missing game score. Never an ``HTTPException`` —
+    it has no HTTP context; the caller adapts it to its transport."""
+
+    def __init__(self, message: str = "Match not found.") -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class MatchNotScorableError(Exception):
+    """Raised by the per-game score service when the loaded match can't be
+    scored. It carries the exact ``http_status`` (422 or 409) **and** ``message``
+    for each of ``_enforce_scorable``'s four reason-specific outcomes — no
+    opponent (422), a posted result (409), an uncalled scheduled match (409), or
+    any other non-scorable/terminal state (409) — so the HTTP adapter reproduces
+    the identical response byte-for-byte while the MCP adapter reads the message.
+    Never an ``HTTPException`` — the caller adapts it to its transport."""
+
+    def __init__(self, *, http_status: int, message: str) -> None:
+        super().__init__(message)
+        self.http_status = http_status
+        self.message = message
+
+
+class ScoreNotAllowedError(Exception):
+    """Raised by the per-game score service when a scratchpad write is legal to
+    attempt but disallowed by a cross-game rule — the addressed game exceeds the
+    match's ``best_of`` range, or the prospective board would leave the match
+    decided before its last scored game (overrun). Both map to a 422 carrying
+    this exception's exact message. Never an ``HTTPException``."""
+
+
 class ScoreConflictError(Exception):
     """Raised by the per-game score service (``app.match_scoring``) when a
     scratchpad write loses a concurrent-participant race: a create finds the

--- a/api/app/result_acceptance.py
+++ b/api/app/result_acceptance.py
@@ -36,6 +36,22 @@ from sqlalchemy.ext.asyncio import AsyncSession
 if TYPE_CHECKING:
     from app.match_scoring import _MatchWriteLoader
 
+from app.match_errors import (
+    CannotAcceptOwnProposalError,
+    MatchClosedError,
+    MatchNotFoundError,
+    MatchNotScorableError,
+    NegotiationConflictError,
+    OpponentNotFoundError,
+    PostedGamesNotDecisiveError,
+    RatedNeedsRegisteredOpponentError,
+    ResultNotFoundError,
+    ScoreConflictError,
+    ScoreNotAllowedError,
+    SelfMatchError,
+    StandingResultConflictError,
+    UndecidedBoardError,
+)
 from app.models import (
     Match,
     MatchGameScore,
@@ -55,160 +71,32 @@ from app.ratings import (
     validate_state,
 )
 from app.result_chain import standing_result
-from app.schemas.match import MatchDetailsScore
 from app.tournament_advancement import on_match_completed
 
-
-class SelfMatchError(Exception):
-    """Raised by the match-creation service when the requested opponent is the
-    acting user themselves. The HTTP adapter maps this to the existing 422
-    ``"You cannot start a match against yourself."``."""
-
-
-class OpponentNotFoundError(Exception):
-    """Raised by the match-creation service when the requested opponent id does
-    not resolve to a live (non-tombstoned) user. The HTTP adapter maps this to
-    the existing 404 ``"Opponent not found."``."""
-
-
-class RatedNeedsRegisteredOpponentError(Exception):
-    """Raised by the match-creation service when a rated match is requested
-    without a registered opponent (a solo match cannot be rated). The HTTP
-    adapter maps this to the existing 422
-    ``"A rated match needs a registered opponent."``."""
-
-
-class MatchClosedError(Exception):
-    """Raised by :func:`app.result_proposal.propose_result` when the match has
-    reached a terminal status (``completed``/``voided``) and is closed to new
-    proposals. The HTTP adapter maps this to the existing 409
-    ``"This match is no longer open to results."``. Never an ``HTTPException`` —
-    the caller adapts it to its transport."""
-
-
-class UndecidedBoardError(Exception):
-    """Raised by :func:`app.result_proposal.propose_result` when the proposed
-    board fails the strict finalize validator (empty, gappy-past-decider,
-    duplicate/out-of-range game numbers, or still-undecided) — i.e. it can't be
-    a result. Carries the validator's human-readable ``ValueError`` message; the
-    HTTP adapter maps it to the existing 422 ``str`` body. Never an
-    ``HTTPException``."""
-
-
-class NegotiationConflictError(Exception):
-    """Raised by :func:`app.result_proposal.propose_result` when the propose lost
-    the negotiation race: a first post found a result already exists, a counter
-    targeted a ``supersedes_result_id`` that is no longer the live standing
-    proposal, or the ``uq_match_results_supersedes_result_id`` unique constraint
-    tripped at commit (two concurrent counters superseding the same parent).
-
-    Carries the loaded (or reloaded) :class:`Match` so the HTTP adapter can build
-    the exact viewer-relative negotiation snapshot (``_negotiation_conflict`` /
-    ``_negotiation``) it produced before, letting a client that lost the race
-    re-render from the 409 body without an extra round-trip. Never an
-    ``HTTPException`` — the caller adapts it to its transport."""
-
-    def __init__(self, match: Match) -> None:
-        super().__init__("The standing proposal has moved on.")
-        self.match = match
-
-
-class StandingResultConflictError(Exception):
-    """Raised when the ``result_id`` handed to :func:`accept_standing_result` is
-    no longer the live standing proposal — a concurrent counter superseded it,
-    it was already accepted, or there is no standing proposal at all. The router
-    maps this to the existing 409 carrying the moved-on negotiation state."""
-
-
-class PostedGamesNotDecisiveError(Exception):
-    """Raised when the match's committed games no longer decide a winner at the
-    moment of acceptance. Practically unreachable (a result only stands once its
-    board is decided, and the board is frozen while it stands), but the core
-    stays total rather than silently stamping no winner. The router maps this to
-    the existing 409 ``"The posted games no longer decide this match."``."""
-
-
-class ResultNotFoundError(Exception):
-    """Raised by :func:`accept_result` when the target ``result_id`` is not a
-    result on the loaded match at all (as opposed to being present but no longer
-    the live standing proposal, which is :class:`StandingResultConflictError`).
-    The HTTP adapter maps this to the existing 404 ``"Result not found."``. Never
-    an ``HTTPException`` — the caller adapts it to its transport."""
-
-    def __init__(self) -> None:
-        super().__init__("Result not found.")
-
-
-class CannotAcceptOwnProposalError(Exception):
-    """Raised by :func:`accept_result` when the accepting user is a participant on
-    the *submitter's* side of the standing proposal. The proposing side already
-    consented by proposing, so only a participant on the opposing side may accept
-    (in singles, the submitter themselves can't accept their own proposal). The
-    HTTP adapter maps this to the existing 409 ``"You can't accept your own
-    proposal."``. Never an ``HTTPException`` — the caller adapts it to its
-    transport."""
-
-    def __init__(self) -> None:
-        super().__init__("You can't accept your own proposal.")
-
-
-class MatchNotFoundError(Exception):
-    """Raised by the per-game score service (``app.match_scoring``) when the
-    write target can't be resolved — either the match id is absent or the acting
-    user isn't a participant (today's score endpoints collapse both into one
-    opaque 404 so a non-participant can't probe match existence), or, on the
-    update/delete paths, the addressed game score doesn't exist.
-
-    Carries the exact ``message`` the HTTP adapter must reproduce as its 404
-    ``detail``: ``"Match not found."`` for an absent match or non-participant,
-    ``"Score not found."`` for a missing game score. Never an ``HTTPException`` —
-    it has no HTTP context; the caller adapts it to its transport."""
-
-    def __init__(self, message: str = "Match not found.") -> None:
-        super().__init__(message)
-        self.message = message
-
-
-class MatchNotScorableError(Exception):
-    """Raised by the per-game score service when the loaded match can't be
-    scored. It carries the exact ``http_status`` (422 or 409) **and** ``message``
-    for each of ``_enforce_scorable``'s four reason-specific outcomes — no
-    opponent (422), a posted result (409), an uncalled scheduled match (409), or
-    any other non-scorable/terminal state (409) — so the HTTP adapter reproduces
-    the identical response byte-for-byte while the MCP adapter reads the message.
-    Never an ``HTTPException`` — the caller adapts it to its transport."""
-
-    def __init__(self, *, http_status: int, message: str) -> None:
-        super().__init__(message)
-        self.http_status = http_status
-        self.message = message
-
-
-class ScoreNotAllowedError(Exception):
-    """Raised by the per-game score service when a scratchpad write is legal to
-    attempt but disallowed by a cross-game rule — the addressed game exceeds the
-    match's ``best_of`` range, or the prospective board would leave the match
-    decided before its last scored game (overrun). Both map to a 422 carrying
-    this exception's exact message. Never an ``HTTPException``."""
-
-
-class ScoreConflictError(Exception):
-    """Raised by the per-game score service (``app.match_scoring``) when a
-    scratchpad write loses a concurrent-participant race: a create finds the
-    game already scored (or trips the unique constraint at commit), or an
-    update's ``expected_version`` no longer matches the committed row.
-
-    Carries ``committed_score`` — the game's score as it actually stands now,
-    including its ``version`` — so the HTTP adapter can rebuild the exact 409
-    ``MatchGameScoreConflict`` body (``_score_conflict``) and a future MCP
-    adapter can point the agent back at ``get_match``. It is ``None`` only when
-    the committed row could not be re-read (the match vanished). Never an
-    ``HTTPException`` — it has no HTTP context; the caller adapts it to its
-    transport."""
-
-    def __init__(self, *, committed_score: MatchDetailsScore | None) -> None:
-        super().__init__("This game was saved by someone else while you were editing.")
-        self.committed_score = committed_score
+# The match-flow domain exception family lives in ``app.match_errors`` (a neutral
+# leaf) so the services can share it without importing one another. Re-exported
+# here because the module's own body raises several of them and because the
+# service-unit tests import them from this module.
+__all__ = [
+    "CannotAcceptOwnProposalError",
+    "MatchClosedError",
+    "MatchNotFoundError",
+    "MatchNotScorableError",
+    "NegotiationConflictError",
+    "OpponentNotFoundError",
+    "PostedGamesNotDecisiveError",
+    "RatedNeedsRegisteredOpponentError",
+    "ResultNotFoundError",
+    "ScoreConflictError",
+    "ScoreNotAllowedError",
+    "SelfMatchError",
+    "StandingResultConflictError",
+    "UndecidedBoardError",
+    "accept_result",
+    "accept_standing_result",
+    "finalize_match",
+    "side_win_counts",
+]
 
 
 def _games_to_win(best_of: int) -> int:
@@ -577,10 +465,12 @@ async def accept_result(
     monkeypatchable, ``HTTPException``-mapping load seam (the #835 row-lock race
     test barriers on it) stays the one it exercises. Never raises
     ``HTTPException`` — the caller adapts it to its transport."""
-    # Lazy imports: ``app.match_scoring`` and ``app.result_proposal`` both import
-    # this module at their top, and ``app.match_queries`` does too, so
-    # module-level imports of their symbols here would be cycles. These are only
-    # needed at call time, so this leaf stays importable ahead of them.
+    # Lazy imports: ``app.match_scoring``, ``app.result_proposal`` and
+    # ``app.match_queries`` all import this module at their top (``match_scoring``
+    # and ``match_queries`` for the scoring primitives ``_games_to_win`` /
+    # ``side_win_counts`` defined here), so module-level imports of their symbols
+    # here would be cycles. These are only needed at call time, so this leaf
+    # stays importable ahead of them.
     from app.match_queries import my_side
     from app.match_scoring import load_match_for_write
     from app.result_proposal import match_rating_eager_options

--- a/api/app/result_acceptance.py
+++ b/api/app/result_acceptance.py
@@ -52,6 +52,7 @@ from app.ratings import (
     validate_state,
 )
 from app.result_chain import standing_result
+from app.schemas.match import MatchDetailsScore
 from app.tournament_advancement import on_match_completed
 
 
@@ -87,6 +88,25 @@ class PostedGamesNotDecisiveError(Exception):
     board is decided, and the board is frozen while it stands), but the core
     stays total rather than silently stamping no winner. The router maps this to
     the existing 409 ``"The posted games no longer decide this match."``."""
+
+
+class ScoreConflictError(Exception):
+    """Raised by the per-game score service (``app.match_scoring``) when a
+    scratchpad write loses a concurrent-participant race: a create finds the
+    game already scored (or trips the unique constraint at commit), or an
+    update's ``expected_version`` no longer matches the committed row.
+
+    Carries ``committed_score`` — the game's score as it actually stands now,
+    including its ``version`` — so the HTTP adapter can rebuild the exact 409
+    ``MatchGameScoreConflict`` body (``_score_conflict``) and a future MCP
+    adapter can point the agent back at ``get_match``. It is ``None`` only when
+    the committed row could not be re-read (the match vanished). Never an
+    ``HTTPException`` — it has no HTTP context; the caller adapts it to its
+    transport."""
+
+    def __init__(self, *, committed_score: MatchDetailsScore | None) -> None:
+        super().__init__("This game was saved by someone else while you were editing.")
+        self.committed_score = committed_score
 
 
 def _games_to_win(best_of: int) -> int:

--- a/api/app/result_acceptance.py
+++ b/api/app/result_acceptance.py
@@ -55,6 +55,25 @@ from app.result_chain import standing_result
 from app.tournament_advancement import on_match_completed
 
 
+class SelfMatchError(Exception):
+    """Raised by the match-creation service when the requested opponent is the
+    acting user themselves. The HTTP adapter maps this to the existing 422
+    ``"You cannot start a match against yourself."``."""
+
+
+class OpponentNotFoundError(Exception):
+    """Raised by the match-creation service when the requested opponent id does
+    not resolve to a live (non-tombstoned) user. The HTTP adapter maps this to
+    the existing 404 ``"Opponent not found."``."""
+
+
+class RatedNeedsRegisteredOpponentError(Exception):
+    """Raised by the match-creation service when a rated match is requested
+    without a registered opponent (a solo match cannot be rated). The HTTP
+    adapter maps this to the existing 422
+    ``"A rated match needs a registered opponent."``."""
+
+
 class StandingResultConflictError(Exception):
     """Raised when the ``result_id`` handed to :func:`accept_standing_result` is
     no longer the live standing proposal — a concurrent counter superseded it,

--- a/api/app/result_acceptance.py
+++ b/api/app/result_acceptance.py
@@ -75,6 +75,41 @@ class RatedNeedsRegisteredOpponentError(Exception):
     ``"A rated match needs a registered opponent."``."""
 
 
+class MatchClosedError(Exception):
+    """Raised by :func:`app.result_proposal.propose_result` when the match has
+    reached a terminal status (``completed``/``voided``) and is closed to new
+    proposals. The HTTP adapter maps this to the existing 409
+    ``"This match is no longer open to results."``. Never an ``HTTPException`` —
+    the caller adapts it to its transport."""
+
+
+class UndecidedBoardError(Exception):
+    """Raised by :func:`app.result_proposal.propose_result` when the proposed
+    board fails the strict finalize validator (empty, gappy-past-decider,
+    duplicate/out-of-range game numbers, or still-undecided) — i.e. it can't be
+    a result. Carries the validator's human-readable ``ValueError`` message; the
+    HTTP adapter maps it to the existing 422 ``str`` body. Never an
+    ``HTTPException``."""
+
+
+class NegotiationConflictError(Exception):
+    """Raised by :func:`app.result_proposal.propose_result` when the propose lost
+    the negotiation race: a first post found a result already exists, a counter
+    targeted a ``supersedes_result_id`` that is no longer the live standing
+    proposal, or the ``uq_match_results_supersedes_result_id`` unique constraint
+    tripped at commit (two concurrent counters superseding the same parent).
+
+    Carries the loaded (or reloaded) :class:`Match` so the HTTP adapter can build
+    the exact viewer-relative negotiation snapshot (``_negotiation_conflict`` /
+    ``_negotiation``) it produced before, letting a client that lost the race
+    re-render from the 409 body without an extra round-trip. Never an
+    ``HTTPException`` — the caller adapts it to its transport."""
+
+    def __init__(self, match: Match) -> None:
+        super().__init__("The standing proposal has moved on.")
+        self.match = match
+
+
 class StandingResultConflictError(Exception):
     """Raised when the ``result_id`` handed to :func:`accept_standing_result` is
     no longer the live standing proposal — a concurrent counter superseded it,

--- a/api/app/result_acceptance.py
+++ b/api/app/result_acceptance.py
@@ -28,10 +28,13 @@ import math
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from app.match_scoring import _MatchWriteLoader
 
 from app.models import (
     Match,
@@ -123,6 +126,30 @@ class PostedGamesNotDecisiveError(Exception):
     board is decided, and the board is frozen while it stands), but the core
     stays total rather than silently stamping no winner. The router maps this to
     the existing 409 ``"The posted games no longer decide this match."``."""
+
+
+class ResultNotFoundError(Exception):
+    """Raised by :func:`accept_result` when the target ``result_id`` is not a
+    result on the loaded match at all (as opposed to being present but no longer
+    the live standing proposal, which is :class:`StandingResultConflictError`).
+    The HTTP adapter maps this to the existing 404 ``"Result not found."``. Never
+    an ``HTTPException`` — the caller adapts it to its transport."""
+
+    def __init__(self) -> None:
+        super().__init__("Result not found.")
+
+
+class CannotAcceptOwnProposalError(Exception):
+    """Raised by :func:`accept_result` when the accepting user is a participant on
+    the *submitter's* side of the standing proposal. The proposing side already
+    consented by proposing, so only a participant on the opposing side may accept
+    (in singles, the submitter themselves can't accept their own proposal). The
+    HTTP adapter maps this to the existing 409 ``"You can't accept your own
+    proposal."``. Never an ``HTTPException`` — the caller adapts it to its
+    transport."""
+
+    def __init__(self) -> None:
+        super().__init__("You can't accept your own proposal.")
 
 
 class MatchNotFoundError(Exception):
@@ -496,3 +523,107 @@ async def finalize_match(db: AsyncSession, match: Match, decided_side: int) -> N
     _set_side_won(match, decided_side)
     await _apply_rating_update(db, match)
     await on_match_completed(db, match)
+
+
+async def _reload_accepted_match(db: AsyncSession, match_id: uuid.UUID) -> Match:
+    """Reload the just-accepted match with the full read eager-load chain.
+
+    Returns a non-optional :class:`Match`: the row was committed one statement
+    earlier in the same session, so its absence is a genuine invariant violation,
+    not a client-handleable ``None`` (``api/CLAUDE.md``)."""
+    # Imported lazily: ``app.match_queries`` imports this module at its top
+    # (``_games_to_win`` / ``side_win_counts``), so a module-level import here
+    # would be a cycle. This leaf stays importable before its higher-level
+    # collaborators finish loading.
+    from app.match_queries import match_eager_options
+
+    match = (
+        await db.execute(
+            select(Match).where(Match.id == match_id).options(*match_eager_options())
+        )
+    ).scalar_one_or_none()
+    if match is None:
+        raise RuntimeError(f"just-accepted match {match_id} vanished before reload")
+    return match
+
+
+async def accept_result(
+    db: AsyncSession,
+    match_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    result_id: uuid.UUID,
+    load_match: "_MatchWriteLoader | None" = None,
+) -> Match:
+    """Accept a standing proposal — the second verb of the propose/accept
+    negotiation — and return the reloaded, finalized domain :class:`Match`.
+
+    Loads under the blocking match row lock (so this serializes against a
+    concurrent propose/accept transition, #365) with the finalize eager-load
+    superset, then runs the two adapter-independent guards the router used to run
+    inline: the target ``result_id`` must be a result on the match at all
+    (:class:`ResultNotFoundError` → the historical 404), and — while it's still
+    the live standing proposal — the accepting user must not be on the submitter's
+    side (:class:`CannotAcceptOwnProposalError` → the historical 409; the
+    proposing side already consented by proposing). It then delegates to
+    :func:`accept_standing_result`, translating its
+    :class:`StandingResultConflictError` into :class:`NegotiationConflictError`
+    (carrying the loaded ``match`` so an adapter can rebuild the viewer-relative
+    moved-on snapshot) and letting :class:`PostedGamesNotDecisiveError` propagate.
+    Finally it commits and returns the reloaded match.
+
+    ``load_match`` defaults to the FastAPI-free :func:`load_match_for_write`; the
+    HTTP handler injects ``matches._load_match_for_scoring`` so the router's
+    monkeypatchable, ``HTTPException``-mapping load seam (the #835 row-lock race
+    test barriers on it) stays the one it exercises. Never raises
+    ``HTTPException`` — the caller adapts it to its transport."""
+    # Lazy imports: ``app.match_scoring`` and ``app.result_proposal`` both import
+    # this module at their top, and ``app.match_queries`` does too, so
+    # module-level imports of their symbols here would be cycles. These are only
+    # needed at call time, so this leaf stays importable ahead of them.
+    from app.match_queries import my_side
+    from app.match_scoring import load_match_for_write
+    from app.result_proposal import match_rating_eager_options
+
+    if load_match is None:
+        load_match = load_match_for_write
+
+    match = await load_match(
+        db,
+        match_id,
+        user_id,
+        lock=True,
+        options=match_rating_eager_options(),
+    )
+
+    # The path ``result_id`` must exist on this match at all (404); the live
+    # standing-proposal check (409 with the moved-on state) is owned by
+    # ``accept_standing_result`` below so it runs identically from a worker.
+    if not any(r.id == result_id for r in match.results):
+        raise ResultNotFoundError
+
+    # The proposing side already consented by proposing; only the opposing side
+    # accepts. A participant on the submitter's side (in singles, the submitter
+    # themselves) can't accept their own proposal. Only meaningful while the
+    # targeted result is still standing — a superseded/absent one falls through
+    # to the core's conflict signal below.
+    standing = standing_result(match)
+    if standing is not None and standing.id == result_id:
+        submitter_side = my_side(match, standing.submitted_by_user_id)
+        if submitter_side is not None and any(
+            p.user_id == user_id for p in submitter_side.players
+        ):
+            raise CannotAcceptOwnProposalError
+
+    try:
+        await accept_standing_result(
+            db,
+            match,
+            result_id=result_id,
+            accepted_by_user_id=user_id,
+        )
+    except StandingResultConflictError as exc:
+        raise NegotiationConflictError(match) from exc
+
+    await db.commit()
+    return await _reload_accepted_match(db, match_id)

--- a/api/app/result_proposal.py
+++ b/api/app/result_proposal.py
@@ -38,6 +38,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.base import ExecutableOption
 
+from app.match_errors import (
+    MatchClosedError,
+    MatchNotFoundError,
+    NegotiationConflictError,
+    UndecidedBoardError,
+)
 from app.match_queries import match_eager_options
 from app.match_scoring import (
     MatchLockUnavailable,  # re-exported for the router adapter
@@ -53,13 +59,7 @@ from app.models import (
     MatchResult,
     MatchStatus,
 )
-from app.result_acceptance import (
-    MatchClosedError,
-    MatchNotFoundError,
-    NegotiationConflictError,
-    UndecidedBoardError,
-    finalize_match,
-)
+from app.result_acceptance import finalize_match
 from app.result_chain import standing_result
 from app.schemas.match import MatchResultsGameWrite
 

--- a/api/app/result_proposal.py
+++ b/api/app/result_proposal.py
@@ -12,11 +12,12 @@ Following ``api/CLAUDE.md``'s rule of thumb, propose is a plain module-level
 async function taking ``db`` rather than a class-plus-provider: none of its
 collaborators is worth injecting. It returns the reloaded domain :class:`Match`
 plus whether acceptance is now awaited (:class:`ProposedResult`), and signals
-every rejection with a domain exception from ``app.result_acceptance`` —
+every rejection with a domain exception from ``app.match_errors`` —
 :class:`MatchClosedError`, :class:`UndecidedBoardError`,
 :class:`NegotiationConflictError` (carrying the loaded ``Match`` so an adapter
 can rebuild the viewer-relative snapshot), and the already-existing
-:class:`MatchLockUnavailable` — never ``HTTPException``. The HTTP handler is a
+:class:`MatchLockUnavailable` (from ``app.match_scoring``) — never
+``HTTPException``. The HTTP handler is a
 thin adapter that maps each back to the exact status and body it produced
 before; the MCP adapter maps the same exceptions to ``ToolError``s.
 
@@ -50,7 +51,7 @@ from app.match_scoring import (
     _MatchWriteLoader,
     load_match_for_write,
 )
-from app.match_serialization import _compact_games, _validate_finalize_games
+from app.match_serialization import compact_games, validate_finalize_games
 from app.models import (
     League,
     Match,
@@ -244,16 +245,16 @@ async def propose_result(
     # an existing result — would be rejected before it could supersede. Propose
     # has its OWN gates below (first-post vs counter) instead.
 
-    # Compact once, upstream of every consumer below (_validate_finalize_games,
+    # Compact once, upstream of every consumer below (validate_finalize_games,
     # _commit_canonical_games, and the immutable _result_games_snapshot), so the
-    # minted board is contiguous (see ``_compact_games``). Covers both the first
+    # minted board is contiguous (see ``compact_games``). Covers both the first
     # proposal and the counter.
-    compacted = _compact_games(games)
+    compacted = compact_games(games)
 
     # Decided-board hard gate — the strict precondition: an undecided board can't
     # be a result.
     try:
-        decided_side = _validate_finalize_games(compacted, match.match_settings.best_of)
+        decided_side = validate_finalize_games(compacted, match.match_settings.best_of)
     except ValueError as exc:
         raise UndecidedBoardError(str(exc)) from exc
 

--- a/api/app/result_proposal.py
+++ b/api/app/result_proposal.py
@@ -1,0 +1,317 @@
+"""The transport-neutral core of proposing a match result (first + counter).
+
+The first verb of the two-verb negotiation (propose → accept) used to live
+inline in the ``app.matches`` router handler (``post_match_result``): ~130 lines
+of row-locking, board compaction, the first-post-vs-counter negotiation gates,
+``finalize_match``, and fire-and-forget notifications. It's extracted here as a
+leaf module — the propose counterpart of ``app.result_acceptance``'s
+``accept_standing_result`` — so a second caller (the MCP server, a script, a
+worker) can drive the same flow without an HTTP request.
+
+Following ``api/CLAUDE.md``'s rule of thumb, propose is a plain module-level
+async function taking ``db`` rather than a class-plus-provider: none of its
+collaborators is worth injecting. It returns the reloaded domain :class:`Match`
+plus whether acceptance is now awaited (:class:`ProposedResult`), and signals
+every rejection with a domain exception from ``app.result_acceptance`` —
+:class:`MatchClosedError`, :class:`UndecidedBoardError`,
+:class:`NegotiationConflictError` (carrying the loaded ``Match`` so an adapter
+can rebuild the viewer-relative snapshot), and the already-existing
+:class:`MatchLockUnavailable` — never ``HTTPException``. The HTTP handler is a
+thin adapter that maps each back to the exact status and body it produced
+before; the MCP adapter maps the same exceptions to ``ToolError``s.
+
+This module also hosts the small pure helpers the propose path owns — the
+finalize-superset eager-load (:func:`match_rating_eager_options`), the canonical
+board commit + snapshot (:func:`_commit_canonical_games` /
+:func:`_result_games_snapshot`), and the rated-round-trip predicate
+(:func:`_requires_confirmation`) — so both the service and the router import them
+from one place rather than the router owning them.
+"""
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlalchemy.sql.base import ExecutableOption
+
+from app.match_queries import match_eager_options
+from app.match_scoring import (
+    MatchLockUnavailable,  # re-exported for the router adapter
+    _MatchWriteLoader,
+    load_match_for_write,
+)
+from app.match_serialization import _compact_games, _validate_finalize_games
+from app.models import (
+    League,
+    Match,
+    MatchGame,
+    MatchGameScore,
+    MatchResult,
+    MatchStatus,
+)
+from app.result_acceptance import (
+    MatchClosedError,
+    MatchNotFoundError,
+    NegotiationConflictError,
+    UndecidedBoardError,
+    finalize_match,
+)
+from app.result_chain import standing_result
+from app.schemas.match import MatchResultsGameWrite
+
+__all__ = [
+    "MatchLockUnavailable",
+    "ProposedResult",
+    "match_rating_eager_options",
+    "propose_result",
+]
+
+
+# A match that has reached one of these states is read-only — closed to new
+# proposals. A completed match has an accepted head, so the result-existence
+# gates would 409 a first-post against it anyway; but a match voided *before* any
+# result was posted has no results to gate on, so the status guard is what keeps
+# a first-post from silently un-voiding it.
+_TERMINAL_STATUSES = {
+    MatchStatus.completed,
+    MatchStatus.voided,
+}
+
+
+# The finalize/score-write superset: everything a read needs, plus the league's
+# rating strategy that ``_apply_rating_update`` reads when a completing match
+# applies ratings. Under async SQLAlchemy a lazy access on the unloaded
+# ``league.rating_strategy`` would raise ``MissingGreenlet`` mid-request, so the
+# two paths that finalize a match must load it up front rather than rely on the
+# shared read chain.
+def match_rating_eager_options() -> tuple[ExecutableOption, ...]:
+    return (
+        *match_eager_options(),
+        selectinload(Match.league).selectinload(League.rating_strategy),
+    )
+
+
+def _all_sides_have_players(match: Match) -> bool:
+    """Solo matches (no opponent picked) carry one player-less sentinel side.
+    The acceptance flow needs a second human, so solo matches skip it entirely;
+    this is the predicate that detects that case."""
+    return len(match.sides) >= 2 and all(side.players for side in match.sides)
+
+
+def _requires_confirmation(match: Match) -> bool:
+    """Only rated matches go through the accept round-trip. Acceptance exists to
+    protect ratings from one-sided claims; an unrated match has no stakes worth a
+    second party's consent, and a solo match has no second human to accept anyway
+    (rated already implies a registered opponent at creation — the player check
+    is defensive)."""
+    return match.match_settings.affects_rating and _all_sides_have_players(match)
+
+
+def _result_games_snapshot(
+    games: list[MatchResultsGameWrite],
+) -> list[dict[str, int]]:
+    """The immutable JSONB snapshot stored on a ``MatchResult`` — the claimed
+    board frozen at post time, ordered by game number."""
+    return [
+        {
+            "game_number": g.game_number,
+            "side_1_points": g.side_1_points,
+            "side_2_points": g.side_2_points,
+        }
+        for g in sorted(games, key=lambda g: g.game_number)
+    ]
+
+
+async def _commit_canonical_games(
+    db: AsyncSession,
+    match: Match,
+    games: list[MatchResultsGameWrite],
+) -> None:
+    """Replace ``match.games`` (and the attached score rows) with the canonical
+    board and set ``side.score`` from it. **Does not change ``match.status`` or
+    ``side.won``** — the caller picks whether the result is final (solo/unrated:
+    immediately at propose) or awaiting acceptance (rated), and stamps
+    ``side.won`` via ``_set_side_won`` only at that final moment."""
+    # ``Match.games`` cascades ``all, delete-orphan``; clearing the collection
+    # marks each existing MatchGame (and via MatchGame.score's own cascade, the
+    # MatchGameScore) for delete. We must flush the deletes before inserting new
+    # games at the same numbers, otherwise the
+    # ``uq_match_games_match_id_game_number`` constraint trips during autoflush.
+    match.games.clear()
+    await db.flush()
+
+    for game in sorted(games, key=lambda g: g.game_number):
+        match.games.append(
+            MatchGame(
+                game_number=game.game_number,
+                score=MatchGameScore(
+                    side_1_points=game.side_1_points,
+                    side_2_points=game.side_2_points,
+                ),
+            )
+        )
+
+    new_wins: dict[int, int] = {1: 0, 2: 0}
+    for g in games:
+        new_wins[1 if g.side_1_points > g.side_2_points else 2] += 1
+    for side in match.sides:
+        side.score = new_wins.get(side.side_number, 0)
+
+
+async def _load_match(db: AsyncSession, match_id: uuid.UUID) -> Match | None:
+    """Reload a match with the full read eager-load chain (nullable — used for
+    the concurrent-counter conflict reload, where the match's absence collapses
+    to today's 404)."""
+    result = await db.execute(
+        select(Match).where(Match.id == match_id).options(*match_eager_options())
+    )
+    return result.scalar_one_or_none()
+
+
+async def _reload_proposed_match(db: AsyncSession, match_id: uuid.UUID) -> Match:
+    """Reload the just-committed match with the full read eager-load chain.
+
+    Returns a non-optional :class:`Match`: the row was committed one statement
+    earlier in the same session, so its absence is a genuine invariant violation,
+    not a client-handleable ``None`` (``api/CLAUDE.md``)."""
+    match = await _load_match(db, match_id)
+    if match is None:
+        raise RuntimeError(f"just-proposed match {match_id} vanished before reload")
+    return match
+
+
+@dataclass(frozen=True)
+class ProposedResult:
+    """The outcome of :func:`propose_result`: the reloaded domain ``match``
+    (ready to serialise) and ``awaiting_acceptance`` — ``True`` only for a rated
+    two-human match that now leaves the opposing side owing an acceptance, so the
+    adapter knows whether to fire the accept/counter notification."""
+
+    match: Match
+    awaiting_acceptance: bool
+
+
+async def propose_result(
+    db: AsyncSession,
+    match_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    games: list[MatchResultsGameWrite],
+    supersedes_result_id: uuid.UUID | None,
+    load_match: _MatchWriteLoader = load_match_for_write,
+) -> ProposedResult:
+    """Propose a result for a match — the first verb of the propose/accept
+    negotiation — and return the reloaded match plus whether acceptance is now
+    awaited.
+
+    Loads under the ``NOWAIT`` match row lock (a held lock surfaces as
+    :class:`MatchLockUnavailable`, which propagates), rejects a terminal match
+    (:class:`MatchClosedError`), compacts + validates the board
+    (:class:`UndecidedBoardError` on an undecided/invalid board), then runs the
+    first-post-vs-counter gates: a first proposal (``supersedes_result_id`` None)
+    requires no result exists; a counter must target the live standing proposal —
+    either miss raises :class:`NegotiationConflictError` carrying the loaded
+    ``Match``. It commits the canonical board and appends the ``MatchResult``,
+    self-accepting + finalizing solo/unrated matches immediately (``side.won`` and
+    the rating update fire here) or leaving the result *standing* (status
+    ``in_progress``) for a rated two-human match. On the
+    ``uq_match_results_supersedes_result_id`` race it reloads and raises
+    :class:`NegotiationConflictError` with the moved-on state.
+
+    ``load_match`` defaults to the FastAPI-free :func:`load_match_for_write`; the
+    HTTP handler injects ``matches._load_match_for_scoring`` so the router's
+    monkeypatchable, ``HTTPException``-mapping load seam stays the one it
+    exercises. Never raises ``HTTPException`` — the caller adapts it to its
+    transport."""
+    match = await load_match(
+        db,
+        match_id,
+        user_id,
+        lock=True,
+        nowait=True,
+        options=match_rating_eager_options(),
+    )
+
+    if match.status in _TERMINAL_STATUSES:
+        raise MatchClosedError("This match is no longer open to results.")
+
+    # NOTE: no scorability guard here. The scratchpad-scorable guard is false the
+    # instant any result exists (#715), so a counter — which by design supersedes
+    # an existing result — would be rejected before it could supersede. Propose
+    # has its OWN gates below (first-post vs counter) instead.
+
+    # Compact once, upstream of every consumer below (_validate_finalize_games,
+    # _commit_canonical_games, and the immutable _result_games_snapshot), so the
+    # minted board is contiguous (see ``_compact_games``). Covers both the first
+    # proposal and the counter.
+    compacted = _compact_games(games)
+
+    # Decided-board hard gate — the strict precondition: an undecided board can't
+    # be a result.
+    try:
+        decided_side = _validate_finalize_games(compacted, match.match_settings.best_of)
+    except ValueError as exc:
+        raise UndecidedBoardError(str(exc)) from exc
+
+    if supersedes_result_id is None:
+        # First proposal: only valid when no result exists yet. A concurrent
+        # first-post (or any existing chain) loses here with the current state.
+        if match.results:
+            raise NegotiationConflictError(match)
+    else:
+        # Counter: must target the live standing proposal. If it was already
+        # accepted or superseded by a concurrent counter, the id won't match.
+        standing = standing_result(match)
+        if standing is None or supersedes_result_id != standing.id:
+            raise NegotiationConflictError(match)
+
+    # Sync the canonical ``match_games`` to the proposed board so the scoreboard
+    # ``games``/``can_score`` rendering stays correct. After the first post the
+    # scratchpad is frozen, so ``match_games`` stays == the standing snapshot.
+    await _commit_canonical_games(db, match, compacted)
+
+    result = MatchResult(
+        submitted_by_user_id=user_id,
+        games=_result_games_snapshot(compacted),
+        supersedes_result_id=supersedes_result_id,
+    )
+    match.results.append(result)
+
+    # Only a rated two-human match leaves the other side owing an acceptance.
+    awaiting_acceptance = _requires_confirmation(match)
+    if not awaiting_acceptance:
+        # Solo / unrated path: no second acceptance needed — the proposer
+        # self-accepts and the match finalizes immediately (stamping
+        # ``completed_at``). A solo match has no second human to accept, so the
+        # proposer's own id is recorded as the acceptor.
+        result.accepted_by_user_id = user_id
+        result.accepted_at = datetime.now(UTC)
+        # The one completion path shared with the rated accept (``finalize_match``):
+        # mark completed, stamp ``side.won``, run the rating update, and advance
+        # any tournament draw this match belongs to (#789).
+        await finalize_match(db, match, decided_side)
+    else:
+        # Rated path: the result stays standing (unaccepted) and ``side.won``
+        # stays unset until the opposing side accepts. Status is (re)set to
+        # in_progress.
+        match.status = MatchStatus.in_progress
+
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        # ``uq_match_results_supersedes_result_id``: two concurrent counters
+        # raced to supersede the same parent and the other one won. Reload and
+        # surface the moved-on negotiation state (a vanished match collapses to
+        # today's 404 via :class:`MatchNotFoundError`).
+        await db.rollback()
+        reloaded = await _load_match(db, match_id)
+        if reloaded is None:
+            raise MatchNotFoundError() from exc
+        raise NegotiationConflictError(reloaded) from exc
+
+    reloaded = await _reload_proposed_match(db, match_id)
+    return ProposedResult(match=reloaded, awaiting_acceptance=awaiting_acceptance)

--- a/api/app/schemas/player.py
+++ b/api/app/schemas/player.py
@@ -98,7 +98,7 @@ class PlayerMatchRow(BaseModel):
     # True when a result has been proposed but not yet accepted by the
     # opponent — i.e. ``status`` is still ``in_progress`` *and* the match has a
     # standing proposed result. This is the same "Awaiting acceptance" bucket
-    # matches.py derives via ``_status_label``; it's surfaced as a boolean here
+    # the ``status_label`` serializer helper derives; it's surfaced as a boolean here
     # so the profile chip can distinguish a posted-but-unaccepted result from a
     # genuinely-live match (both sit at ``in_progress``) without the FE having
     # to re-derive the negotiation state (#364).

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -24,6 +24,7 @@ from sqlalchemy import ColumnElement, delete, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app import api_token_auth
 from app import captcha as captcha_module
 from app import queue as queue_module
 from app.account_merge import merge_user
@@ -81,12 +82,11 @@ CSRF_HEADER_NAME = "x-csrf-token"
 CSRF_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 SESSION_TOKEN_CONTEXT = "session"
 # Context for personal, opaque API bearer tokens a user mints for external
-# tooling (issue #1130). Namespaced like every other credential type so the
-# api-tokens flow can rotate/resolve its own rows without touching a user's
-# session / login / email-change / merge tokens. Defined here alongside the
-# other context constants so both the mint endpoint (app/api_tokens.py) and the
-# bearer-auth path in get_current_user import the same value.
-API_TOKEN_CONTEXT = "api"
+# tooling (issue #1130). Owned by ``app.api_token_auth`` (router-free, so the
+# HTTP bearer path here and a future MCP TokenVerifier share one resolver);
+# re-exported here so callers that historically imported
+# ``app.sessions.API_TOKEN_CONTEXT`` keep working.
+API_TOKEN_CONTEXT = api_token_auth.API_TOKEN_CONTEXT
 # Stable `code` on the 401 we raise when a cookie resolves to a tombstoned
 # (merged-away) guest, so clients can tell "your session was merged, sign in"
 # apart from an ordinary auth failure and redirect to login (with the owner's
@@ -377,28 +377,19 @@ async def _find_api_token_user(db: AsyncSession, authorization: str) -> User | N
     ``None`` when the header isn't a well-formed bearer credential, its token
     matches no live ``api``-context row, or that row's user is tombstoned.
 
-    Mirrors ``_find_session_user`` for the opaque personal API tokens minted at
+    Owns only the header framing for the opaque personal API tokens minted at
     ``POST /v1/api-tokens`` (issue #1130): the scheme is matched
-    case-insensitively (``Bearer``/``bearer``) and the token is compared by
-    sha256 hash, never in plaintext. Tombstoned (merged-away) users are excluded
-    in the query — ``merged_into_user_id IS NOT NULL`` — so a bearer token for a
-    folded-in guest simply doesn't resolve, the same way the auth-layer session
-    queries keep ghosts from surfacing; the caller then falls through to the
-    ordinary ``session_ended`` 401.
+    case-insensitively (``Bearer``/``bearer``) and split off the raw token, which
+    is then resolved by the shared ``api_token_auth.find_api_token_user`` — the
+    single place the ``hash_token`` → live-user lookup lives, so this HTTP bearer
+    path and the MCP ``TokenVerifier`` can't drift. An unresolved token (unknown
+    or tombstoned) returns ``None`` and the caller falls through to the ordinary
+    ``session_ended`` 401.
     """
     scheme, _, raw_token = authorization.partition(" ")
     if scheme.lower() != "bearer" or not raw_token:
         return None
-    result = await db.execute(
-        select(User)
-        .join(UserToken, UserToken.user_id == User.id)
-        .where(
-            UserToken.token == hash_token(raw_token),
-            UserToken.context == API_TOKEN_CONTEXT,
-            User.merged_into_user_id.is_(None),
-        )
-    )
-    return result.scalar_one_or_none()
+    return await api_token_auth.find_api_token_user(db, raw_token)
 
 
 def _clear_cookie_header() -> dict[str, str]:

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "httpx[http2]>=0.27.0",
     "fastapi-limiter>=0.1.6,<0.3",
     "pyjwt[crypto]>=2.9",
+    "fastmcp>=3.4,<4",
 ]
 
 [project.optional-dependencies]

--- a/api/tests/test_accept_result_service.py
+++ b/api/tests/test_accept_result_service.py
@@ -1,0 +1,194 @@
+"""Unit tests for the transport-neutral result-acceptance service
+(``app.result_acceptance.accept_result``) — the second verb of the propose/accept
+negotiation. Constructed directly with a ``db_session`` (no FastAPI, no HTTP
+client): the HTTP wire contract is covered by ``test_matches.py``; here we prove
+the service finalizes on the opposing side's acceptance (completing the match,
+stamping ``side.won``, applying the rating), and raises the domain exceptions
+(never ``HTTPException``) the adapters map — the submitter-side self-accept guard,
+the unknown-``result_id`` 404 gate, and the moved-on negotiation conflict."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.match_creation import create_match
+from app.models import MatchStatus, RatingHistory
+from app.result_acceptance import (
+    CannotAcceptOwnProposalError,
+    NegotiationConflictError,
+    ResultNotFoundError,
+    accept_result,
+)
+from app.result_chain import standing_result
+from app.result_proposal import propose_result
+from app.schemas.match import MatchResultsGameWrite
+from tests._helpers import make_user
+
+
+def _decisive_board(winner_side: int = 1) -> list[MatchResultsGameWrite]:
+    """A single decided game for a best-of-1 board (``winner_side`` takes it)."""
+    if winner_side == 1:
+        return [MatchResultsGameWrite(game_number=1, side_1_points=11, side_2_points=4)]
+    return [MatchResultsGameWrite(game_number=1, side_1_points=4, side_2_points=11)]
+
+
+async def _propose_standing(
+    db_session: AsyncSession, *, creator_name: str, opponent_name: str
+) -> tuple[uuid.UUID, uuid.UUID, uuid.UUID]:
+    """Create a rated two-human best-of-1 match and post a first proposal by the
+    creator, leaving it standing. Returns ``(match_id, standing_result_id,
+    opponent_id)``."""
+    creator = await make_user(db_session, creator_name)
+    opponent = await make_user(db_session, opponent_name)
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=opponent.id,
+        league_id=None,
+        best_of=1,
+        rated=True,
+    )
+    outcome = await propose_result(
+        db_session,
+        match.id,
+        creator.id,
+        games=_decisive_board(winner_side=1),
+        supersedes_result_id=None,
+    )
+    standing = standing_result(outcome.match)
+    assert standing is not None
+    return match.id, standing.id, opponent.id
+
+
+async def test_opposing_side_accept_completes_and_applies_rating(
+    db_session: AsyncSession,
+) -> None:
+    match_id, result_id, opponent_id = await _propose_standing(
+        db_session, creator_name="accept-svc-proposer", opponent_name="accept-svc-opp"
+    )
+
+    reloaded = await accept_result(
+        db_session,
+        match_id,
+        opponent_id,
+        result_id=result_id,
+    )
+
+    # The match completes and the agreed board stamps the W/L (creator's side 1
+    # won on the 11-4 board).
+    assert reloaded.status is MatchStatus.completed
+    sides = sorted(reloaded.sides, key=lambda s: s.side_number)
+    assert sides[0].won is True
+    assert sides[1].won is False
+    # The accepted head records the acceptor.
+    standing = standing_result(reloaded)
+    assert standing is None  # accepted, no longer "standing"
+
+    # The rating update ran: one glicko2 rating_history row per side.
+    history = (
+        (
+            await db_session.execute(
+                select(RatingHistory).where(RatingHistory.match_id == match_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(history) == 2
+
+
+async def test_submitter_side_self_accept_raises_cannot_accept_own(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "self-accept-proposer")
+    opponent = await make_user(db_session, "self-accept-opp")
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=opponent.id,
+        league_id=None,
+        best_of=1,
+        rated=True,
+    )
+    outcome = await propose_result(
+        db_session,
+        match.id,
+        creator.id,
+        games=_decisive_board(winner_side=1),
+        supersedes_result_id=None,
+    )
+    standing = standing_result(outcome.match)
+    assert standing is not None
+
+    # The proposer accepting their own standing proposal is the self-accept guard.
+    with pytest.raises(CannotAcceptOwnProposalError):
+        await accept_result(
+            db_session,
+            match.id,
+            creator.id,
+            result_id=standing.id,
+        )
+
+
+async def test_unknown_result_id_raises_result_not_found(
+    db_session: AsyncSession,
+) -> None:
+    match_id, _result_id, opponent_id = await _propose_standing(
+        db_session, creator_name="unknown-proposer", opponent_name="unknown-opp"
+    )
+
+    # A ``result_id`` that isn't a result on the match at all is the 404 gate.
+    with pytest.raises(ResultNotFoundError):
+        await accept_result(
+            db_session,
+            match_id,
+            opponent_id,
+            result_id=uuid.uuid4(),
+        )
+
+
+async def test_superseded_result_id_raises_negotiation_conflict(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "superseded-proposer")
+    opponent = await make_user(db_session, "superseded-opp")
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=opponent.id,
+        league_id=None,
+        best_of=1,
+        rated=True,
+    )
+    first = await propose_result(
+        db_session,
+        match.id,
+        creator.id,
+        games=_decisive_board(winner_side=1),
+        supersedes_result_id=None,
+    )
+    first_result = standing_result(first.match)
+    assert first_result is not None
+
+    # A counter moves the standing head off ``first_result`` — it's still a result
+    # on the match (so it passes the 404 gate) but no longer the live proposal.
+    await propose_result(
+        db_session,
+        match.id,
+        opponent.id,
+        games=_decisive_board(winner_side=2),
+        supersedes_result_id=first_result.id,
+    )
+
+    # Accepting the now-superseded id is the moved-on negotiation conflict; the
+    # error carries the loaded match so an adapter can rebuild the snapshot.
+    with pytest.raises(NegotiationConflictError) as excinfo:
+        await accept_result(
+            db_session,
+            match.id,
+            creator.id,
+            result_id=first_result.id,
+        )
+    assert excinfo.value.match.id == match.id

--- a/api/tests/test_api_token_auth.py
+++ b/api/tests/test_api_token_auth.py
@@ -1,0 +1,76 @@
+"""Unit tests for the shared ``find_api_token_user`` resolver.
+
+The bare ``hash_token(raw)`` → live ``api``-context ``User`` lookup that both the
+HTTP bearer path (``app.sessions._find_api_token_user``) and a future FastMCP
+``TokenVerifier`` call, so the two can't drift. Exercised directly against a real
+``db_session`` — no HTTP framing — since that framing lives in the callers.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api_token_auth import API_TOKEN_CONTEXT, find_api_token_user
+from app.models import User, UserToken
+from app.token_hashing import hash_token
+from tests._helpers import make_user
+
+
+async def _mint(db_session: AsyncSession, user: User) -> str:
+    """Store an ``api``-context token for ``user`` the way production does (only
+    the sha256 hash lands in the DB) and return the raw token."""
+    raw = "api-raw-" + uuid.uuid4().hex
+    db_session.add(
+        UserToken(user_id=user.id, context=API_TOKEN_CONTEXT, token=hash_token(raw))
+    )
+    await db_session.commit()
+    return raw
+
+
+async def test_valid_token_resolves_to_its_user(db_session: AsyncSession) -> None:
+    user = await make_user(db_session, "token-owner")
+    raw = await _mint(db_session, user)
+
+    resolved = await find_api_token_user(db_session, raw)
+
+    assert resolved is not None
+    assert resolved.id == user.id
+
+
+async def test_unknown_token_resolves_to_none(db_session: AsyncSession) -> None:
+    # A well-formed but never-minted token matches no api-context row.
+    resolved = await find_api_token_user(db_session, "api-raw-" + uuid.uuid4().hex)
+
+    assert resolved is None
+
+
+async def test_wrong_context_token_resolves_to_none(db_session: AsyncSession) -> None:
+    """A token stored under a different context (e.g. a session token) must not
+    resolve through the api-token lookup, even for a live user."""
+    user = await make_user(db_session, "session-token-owner")
+    raw = "sess-raw-" + uuid.uuid4().hex
+    db_session.add(UserToken(user_id=user.id, context="session", token=hash_token(raw)))
+    await db_session.commit()
+
+    resolved = await find_api_token_user(db_session, raw)
+
+    assert resolved is None
+
+
+async def test_tombstoned_users_token_resolves_to_none(
+    db_session: AsyncSession,
+) -> None:
+    """A valid api token whose user was merged away (``merged_into_user_id`` set)
+    does not resolve — the folded-in ghost never authenticates."""
+    owner = await make_user(db_session, "merge-owner")
+    guest = await make_user(db_session, "merged-guest")
+    raw = await _mint(db_session, guest)
+
+    guest.merged_into_user_id = owner.id
+    guest.merged_at = datetime.now(UTC)
+    await db_session.commit()
+
+    resolved = await find_api_token_user(db_session, raw)
+
+    assert resolved is None

--- a/api/tests/test_match_creation.py
+++ b/api/tests/test_match_creation.py
@@ -1,0 +1,113 @@
+"""Unit tests for the transport-neutral match-creation service
+(``app.match_creation.create_match``), constructed directly with a
+``db_session`` — no FastAPI, no HTTP client. The HTTP wire contract is covered
+separately by ``test_matches.py``; here we prove the service returns the loaded
+domain ``Match`` on the happy paths and raises the domain exceptions (never
+``HTTPException``) on the three rejection cases the HTTP adapter maps."""
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.match_creation import create_match
+from app.models import Match, MatchStatus
+from app.result_acceptance import (
+    OpponentNotFoundError,
+    RatedNeedsRegisteredOpponentError,
+    SelfMatchError,
+)
+from tests._helpers import make_user
+
+
+async def test_create_solo_match_returns_loaded_match(db_session: AsyncSession) -> None:
+    creator = await make_user(db_session, "solo-creator")
+
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=None,
+        league_id=None,
+        best_of=5,
+        rated=False,
+    )
+
+    assert isinstance(match, Match)
+    assert match.status is MatchStatus.in_progress
+    assert match.created_by_user_id == creator.id
+    assert match.match_settings.best_of == 5
+    # A solo match is never rated (a rated one without an opponent is rejected).
+    assert match.match_settings.affects_rating is False
+    # Two sides: the creator, plus a player-less sentinel "No opponent" side.
+    sides = sorted(match.sides, key=lambda s: s.side_number)
+    assert len(sides) == 2
+    assert [p.user_id for p in sides[0].players] == [creator.id]
+    assert sides[1].players == []
+
+
+async def test_create_rated_match_against_registered_opponent(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "rated-creator")
+    opponent = await make_user(db_session, "rated-opponent")
+
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=opponent.id,
+        league_id=None,
+        best_of=3,
+        rated=True,
+    )
+
+    assert match.match_settings.best_of == 3
+    assert match.match_settings.affects_rating is True
+    sides = sorted(match.sides, key=lambda s: s.side_number)
+    assert [p.user_id for p in sides[0].players] == [creator.id]
+    assert [p.user_id for p in sides[1].players] == [opponent.id]
+
+
+async def test_self_match_raises_self_match_error(db_session: AsyncSession) -> None:
+    creator = await make_user(db_session, "self-player")
+
+    with pytest.raises(SelfMatchError):
+        await create_match(
+            db_session,
+            creator=creator,
+            opponent_user_id=creator.id,
+            league_id=None,
+            best_of=5,
+            rated=True,
+        )
+
+
+async def test_unknown_opponent_raises_opponent_not_found(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "seeking-creator")
+
+    with pytest.raises(OpponentNotFoundError):
+        await create_match(
+            db_session,
+            creator=creator,
+            opponent_user_id=uuid.uuid4(),
+            league_id=None,
+            best_of=5,
+            rated=True,
+        )
+
+
+async def test_rated_without_opponent_raises_needs_registered_opponent(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "rated-solo-creator")
+
+    with pytest.raises(RatedNeedsRegisteredOpponentError):
+        await create_match(
+            db_session,
+            creator=creator,
+            opponent_user_id=None,
+            league_id=None,
+            best_of=5,
+            rated=True,
+        )

--- a/api/tests/test_match_scoring.py
+++ b/api/tests/test_match_scoring.py
@@ -1,10 +1,16 @@
 """Unit tests for the transport-neutral per-game score service
 (``app.match_scoring``), constructed directly with a ``db_session`` — no
-FastAPI, no HTTP client. The HTTP wire contract (the 201/409 bodies) is covered
-separately by ``test_matches.py``; here we prove each service function returns
-the reloaded domain ``Match`` on the happy paths and raises the domain
-``ScoreConflictError`` (carrying the committed score, never ``HTTPException``)
-on the concurrent-participant races the HTTP adapter maps to its 409."""
+FastAPI, no HTTP client.
+
+The high-level entry points (:func:`enter_game_score`, :func:`update_game_score`,
+:func:`delete_game_score`) drive the full FastAPI-free write path from a
+``match_id`` + ``user_id``: load+lock+participant, scorability, best-of range,
+no-overrun, then the mutation. They trade in the domain ``Match`` and the domain
+exception family (``MatchNotFoundError`` / ``MatchNotScorableError`` /
+``ScoreNotAllowedError`` / ``ScoreConflictError``), never ``HTTPException`` — the
+HTTP adapter maps each back to its exact status + body, and ``test_matches.py``
+covers that wire contract separately.
+"""
 
 import uuid
 
@@ -14,15 +20,26 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.match_creation import create_match
 from app.match_queries import match_eager_options
-from app.match_scoring import delete_game_score, enter_game_score, update_game_score
-from app.models import Match
-from app.result_acceptance import ScoreConflictError
+from app.match_scoring import (
+    delete_game_score,
+    ensure_scorable,
+    enter_game_score,
+    update_game_score,
+)
+from app.models import Match, MatchResult, MatchStatus
+from app.result_acceptance import (
+    MatchNotFoundError,
+    MatchNotScorableError,
+    ScoreConflictError,
+    ScoreNotAllowedError,
+)
 from tests._helpers import make_user
 
 
 async def _rated_match(db_session: AsyncSession, tag: str) -> Match:
     """A fresh rated best-of-5 match between two registered users, loaded with
-    the read eager-load chain the score service expects."""
+    the read eager-load chain. ``match.created_by_user_id`` is the side-1
+    participant every write test acts as."""
     creator = await make_user(db_session, f"{tag}-creator")
     opponent = await make_user(db_session, f"{tag}-opponent")
     return await create_match(
@@ -51,13 +68,21 @@ def _score_for(match: Match, game_number: int) -> object:
     return game.score
 
 
+# ----- happy paths ---------------------------------------------------------
+
+
 async def test_enter_game_score_saves_the_first_score(
     db_session: AsyncSession,
 ) -> None:
     match = await _rated_match(db_session, "enter")
 
     updated = await enter_game_score(
-        db_session, match, game_number=1, side_1_points=11, side_2_points=4
+        db_session,
+        match.id,
+        match.created_by_user_id,
+        game_number=1,
+        side_1_points=11,
+        side_2_points=4,
     )
 
     assert isinstance(updated, Match)
@@ -72,13 +97,19 @@ async def test_update_game_score_with_the_right_version_replaces_it(
     db_session: AsyncSession,
 ) -> None:
     match = await _rated_match(db_session, "update-ok")
-    match = await enter_game_score(
-        db_session, match, game_number=1, side_1_points=11, side_2_points=4
+    await enter_game_score(
+        db_session,
+        match.id,
+        match.created_by_user_id,
+        game_number=1,
+        side_1_points=11,
+        side_2_points=4,
     )
 
     updated = await update_game_score(
         db_session,
-        match,
+        match.id,
+        match.created_by_user_id,
         game_number=1,
         side_1_points=11,
         side_2_points=9,
@@ -92,17 +123,246 @@ async def test_update_game_score_with_the_right_version_replaces_it(
     assert score.version == 2
 
 
+async def test_delete_game_score_clears_the_score_and_keeps_the_game(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "delete")
+    await enter_game_score(
+        db_session,
+        match.id,
+        match.created_by_user_id,
+        game_number=1,
+        side_1_points=11,
+        side_2_points=4,
+    )
+
+    updated = await delete_game_score(
+        db_session, match.id, match.created_by_user_id, game_number=1
+    )
+
+    game = next(g for g in updated.games if g.game_number == 1)
+    # The score row is gone but the MatchGame stays so a fresh score can attach.
+    assert game.score is None
+
+
+# ----- load + participation (MatchNotFoundError) ---------------------------
+
+
+async def test_enter_game_score_for_a_non_participant_raises_match_not_found(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "enter-outsider")
+    outsider = await make_user(db_session, "enter-outsider-3p")
+
+    with pytest.raises(MatchNotFoundError) as excinfo:
+        await enter_game_score(
+            db_session,
+            match.id,
+            outsider.id,
+            game_number=1,
+            side_1_points=11,
+            side_2_points=4,
+        )
+
+    # A non-participant is opaque-404'd exactly like an absent match, so they
+    # can't probe existence.
+    assert excinfo.value.message == "Match not found."
+
+
+async def test_enter_game_score_for_an_absent_match_raises_match_not_found(
+    db_session: AsyncSession,
+) -> None:
+    with pytest.raises(MatchNotFoundError) as excinfo:
+        await enter_game_score(
+            db_session,
+            uuid.uuid4(),
+            uuid.uuid4(),
+            game_number=1,
+            side_1_points=11,
+            side_2_points=4,
+        )
+
+    assert excinfo.value.message == "Match not found."
+
+
+async def test_update_game_score_without_a_committed_score_raises_score_not_found(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "update-missing")
+
+    with pytest.raises(MatchNotFoundError) as excinfo:
+        await update_game_score(
+            db_session,
+            match.id,
+            match.created_by_user_id,
+            game_number=1,
+            side_1_points=11,
+            side_2_points=9,
+            expected_version=1,
+        )
+
+    # Distinct 404 copy from match-not-found: the match resolved, the game score
+    # didn't.
+    assert excinfo.value.message == "Score not found."
+
+
+async def test_delete_game_score_without_a_committed_score_raises_score_not_found(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "delete-missing")
+
+    with pytest.raises(MatchNotFoundError) as excinfo:
+        await delete_game_score(
+            db_session, match.id, match.created_by_user_id, game_number=1
+        )
+
+    assert excinfo.value.message == "Score not found."
+
+
+# ----- scorability (MatchNotScorableError) ---------------------------------
+
+
+async def test_enter_game_score_on_a_pending_match_raises_not_scorable(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "pending")
+    # A scheduled-but-uncalled match: the schedule is authoritative, so an
+    # out-of-band score is refused. Commit so the high-level reload sees it.
+    match.status = MatchStatus.pending
+    await db_session.commit()
+
+    with pytest.raises(MatchNotScorableError) as excinfo:
+        await enter_game_score(
+            db_session,
+            match.id,
+            match.created_by_user_id,
+            game_number=1,
+            side_1_points=11,
+            side_2_points=4,
+        )
+
+    assert excinfo.value.http_status == 409
+    assert excinfo.value.message == "This match hasn't been called to a table yet."
+
+
+def test_ensure_scorable_no_opponent_is_422() -> None:
+    # A one-sided match (defensive: creation always builds a sentinel side 2).
+    match = Match()
+    match.status = MatchStatus.in_progress
+    with pytest.raises(MatchNotScorableError) as excinfo:
+        ensure_scorable(match)
+    assert excinfo.value.http_status == 422
+    assert excinfo.value.message == "This match has no opponent and can't be scored."
+
+
+async def test_ensure_scorable_posted_result_is_409(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "posted")
+    # A posted result freezes the scratchpad (#715); the board now only moves
+    # via propose/accept. Appended in memory — the truthiness of ``results`` is
+    # the whole gate.
+    match.results.append(
+        MatchResult(submitted_by_user_id=match.created_by_user_id, games=[])
+    )
+    with pytest.raises(MatchNotScorableError) as excinfo:
+        ensure_scorable(match)
+    assert excinfo.value.http_status == 409
+    assert excinfo.value.message == "This match has a posted result; scores are frozen."
+
+
+async def test_ensure_scorable_pending_is_409(db_session: AsyncSession) -> None:
+    match = await _rated_match(db_session, "pending-direct")
+    match.status = MatchStatus.pending
+    with pytest.raises(MatchNotScorableError) as excinfo:
+        ensure_scorable(match)
+    assert excinfo.value.http_status == 409
+    assert excinfo.value.message == "This match hasn't been called to a table yet."
+
+
+async def test_ensure_scorable_completed_is_409(db_session: AsyncSession) -> None:
+    match = await _rated_match(db_session, "completed")
+    match.status = MatchStatus.completed
+    with pytest.raises(MatchNotScorableError) as excinfo:
+        ensure_scorable(match)
+    assert excinfo.value.http_status == 409
+    assert excinfo.value.message == "This match is no longer scorable."
+
+
+# ----- range + overrun (ScoreNotAllowedError) ------------------------------
+
+
+async def test_enter_game_score_past_best_of_raises_not_allowed(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "range")
+
+    with pytest.raises(ScoreNotAllowedError) as excinfo:
+        # best_of is 5; game 6 can never exist.
+        await enter_game_score(
+            db_session,
+            match.id,
+            match.created_by_user_id,
+            game_number=6,
+            side_1_points=11,
+            side_2_points=4,
+        )
+
+    assert str(excinfo.value) == "This match is best of 5; game 6 can't exist."
+
+
+async def test_enter_game_score_overrunning_the_decider_raises_not_allowed(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "overrun")
+    # Side 1 clinches best-of-5 by sweeping games 1-3 (3 wins = target).
+    for game_number in (1, 2, 3):
+        await enter_game_score(
+            db_session,
+            match.id,
+            match.created_by_user_id,
+            game_number=game_number,
+            side_1_points=11,
+            side_2_points=4,
+        )
+
+    with pytest.raises(ScoreNotAllowedError) as excinfo:
+        # Game 4 can't have been played — the match was already decided at 3.
+        await enter_game_score(
+            db_session,
+            match.id,
+            match.created_by_user_id,
+            game_number=4,
+            side_1_points=11,
+            side_2_points=4,
+        )
+
+    assert (
+        str(excinfo.value)
+        == "The match was already decided at game 3; game 4 can't be played."
+    )
+
+
+# ----- concurrent-participant conflicts (ScoreConflictError) ---------------
+
+
 async def test_update_game_score_with_a_stale_version_raises_score_conflict(
     db_session: AsyncSession,
 ) -> None:
     match = await _rated_match(db_session, "update-stale")
-    match = await enter_game_score(
-        db_session, match, game_number=1, side_1_points=11, side_2_points=4
+    await enter_game_score(
+        db_session,
+        match.id,
+        match.created_by_user_id,
+        game_number=1,
+        side_1_points=11,
+        side_2_points=4,
     )
     # A first participant's edit advances the committed row to version 2.
-    match = await update_game_score(
+    await update_game_score(
         db_session,
-        match,
+        match.id,
+        match.created_by_user_id,
         game_number=1,
         side_1_points=11,
         side_2_points=8,
@@ -113,7 +373,8 @@ async def test_update_game_score_with_a_stale_version_raises_score_conflict(
     with pytest.raises(ScoreConflictError) as excinfo:
         await update_game_score(
             db_session,
-            match,
+            match.id,
+            match.created_by_user_id,
             game_number=1,
             side_1_points=5,
             side_2_points=11,
@@ -133,38 +394,31 @@ async def test_enter_game_score_on_an_already_scored_game_raises_score_conflict(
     db_session: AsyncSession,
 ) -> None:
     match = await _rated_match(db_session, "concurrent-create")
-    match = await enter_game_score(
-        db_session, match, game_number=1, side_1_points=11, side_2_points=4
+    await enter_game_score(
+        db_session,
+        match.id,
+        match.created_by_user_id,
+        game_number=1,
+        side_1_points=11,
+        side_2_points=4,
     )
-    # Re-read the committed state a second participant would be holding, then
-    # try to create the same game again — the in-memory pre-check the router's
-    # blocking lock funnels the concurrent create into.
-    match = await _reload(db_session, match.id)
 
+    # A concurrent participant tries to create the same game again — the
+    # in-memory pre-check the router's blocking lock funnels the race into.
     with pytest.raises(ScoreConflictError) as excinfo:
         await enter_game_score(
-            db_session, match, game_number=1, side_1_points=11, side_2_points=6
+            db_session,
+            match.id,
+            match.created_by_user_id,
+            game_number=1,
+            side_1_points=11,
+            side_2_points=6,
         )
 
     committed = excinfo.value.committed_score
     assert committed is not None
-    # The conflict hands back the winner's committed score (11–4), not the
-    # loser's attempted overwrite.
+    # The conflict hands back the winner's committed score (11-4), not the
+    # loser's attempted overwrite, and runs *before* any overrun check.
     assert committed.side_1_points == 11
     assert committed.side_2_points == 4
     assert committed.version == 1
-
-
-async def test_delete_game_score_clears_the_score_and_keeps_the_game(
-    db_session: AsyncSession,
-) -> None:
-    match = await _rated_match(db_session, "delete")
-    match = await enter_game_score(
-        db_session, match, game_number=1, side_1_points=11, side_2_points=4
-    )
-
-    updated = await delete_game_score(db_session, match, game_number=1)
-
-    game = next(g for g in updated.games if g.game_number == 1)
-    # The score row is gone but the MatchGame stays so a fresh score can attach.
-    assert game.score is None

--- a/api/tests/test_match_scoring.py
+++ b/api/tests/test_match_scoring.py
@@ -1,0 +1,170 @@
+"""Unit tests for the transport-neutral per-game score service
+(``app.match_scoring``), constructed directly with a ``db_session`` — no
+FastAPI, no HTTP client. The HTTP wire contract (the 201/409 bodies) is covered
+separately by ``test_matches.py``; here we prove each service function returns
+the reloaded domain ``Match`` on the happy paths and raises the domain
+``ScoreConflictError`` (carrying the committed score, never ``HTTPException``)
+on the concurrent-participant races the HTTP adapter maps to its 409."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.match_creation import create_match
+from app.match_queries import match_eager_options
+from app.match_scoring import delete_game_score, enter_game_score, update_game_score
+from app.models import Match
+from app.result_acceptance import ScoreConflictError
+from tests._helpers import make_user
+
+
+async def _rated_match(db_session: AsyncSession, tag: str) -> Match:
+    """A fresh rated best-of-5 match between two registered users, loaded with
+    the read eager-load chain the score service expects."""
+    creator = await make_user(db_session, f"{tag}-creator")
+    opponent = await make_user(db_session, f"{tag}-opponent")
+    return await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=opponent.id,
+        league_id=None,
+        best_of=5,
+        rated=True,
+    )
+
+
+async def _reload(db_session: AsyncSession, match_id: uuid.UUID) -> Match:
+    match = (
+        await db_session.execute(
+            select(Match).where(Match.id == match_id).options(*match_eager_options())
+        )
+    ).scalar_one_or_none()
+    assert match is not None
+    return match
+
+
+def _score_for(match: Match, game_number: int) -> object:
+    game = next(g for g in match.games if g.game_number == game_number)
+    assert game.score is not None
+    return game.score
+
+
+async def test_enter_game_score_saves_the_first_score(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "enter")
+
+    updated = await enter_game_score(
+        db_session, match, game_number=1, side_1_points=11, side_2_points=4
+    )
+
+    assert isinstance(updated, Match)
+    score = _score_for(updated, 1)
+    assert score.side_1_points == 11
+    assert score.side_2_points == 4
+    # A freshly created score is version 1.
+    assert score.version == 1
+
+
+async def test_update_game_score_with_the_right_version_replaces_it(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "update-ok")
+    match = await enter_game_score(
+        db_session, match, game_number=1, side_1_points=11, side_2_points=4
+    )
+
+    updated = await update_game_score(
+        db_session,
+        match,
+        game_number=1,
+        side_1_points=11,
+        side_2_points=9,
+        expected_version=1,
+    )
+
+    score = _score_for(updated, 1)
+    assert score.side_1_points == 11
+    assert score.side_2_points == 9
+    # The optimistic-concurrency token advances on a successful write.
+    assert score.version == 2
+
+
+async def test_update_game_score_with_a_stale_version_raises_score_conflict(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "update-stale")
+    match = await enter_game_score(
+        db_session, match, game_number=1, side_1_points=11, side_2_points=4
+    )
+    # A first participant's edit advances the committed row to version 2.
+    match = await update_game_score(
+        db_session,
+        match,
+        game_number=1,
+        side_1_points=11,
+        side_2_points=8,
+        expected_version=1,
+    )
+
+    # A second participant still holding version 1 loses the race.
+    with pytest.raises(ScoreConflictError) as excinfo:
+        await update_game_score(
+            db_session,
+            match,
+            game_number=1,
+            side_1_points=5,
+            side_2_points=11,
+            expected_version=1,
+        )
+
+    committed = excinfo.value.committed_score
+    assert committed is not None
+    # The conflict carries the score as it actually stands now (version 2),
+    # not the stale write, so the adapter can surface "yours vs. committed".
+    assert committed.version == 2
+    assert committed.side_1_points == 11
+    assert committed.side_2_points == 8
+
+
+async def test_enter_game_score_on_an_already_scored_game_raises_score_conflict(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "concurrent-create")
+    match = await enter_game_score(
+        db_session, match, game_number=1, side_1_points=11, side_2_points=4
+    )
+    # Re-read the committed state a second participant would be holding, then
+    # try to create the same game again — the in-memory pre-check the router's
+    # blocking lock funnels the concurrent create into.
+    match = await _reload(db_session, match.id)
+
+    with pytest.raises(ScoreConflictError) as excinfo:
+        await enter_game_score(
+            db_session, match, game_number=1, side_1_points=11, side_2_points=6
+        )
+
+    committed = excinfo.value.committed_score
+    assert committed is not None
+    # The conflict hands back the winner's committed score (11–4), not the
+    # loser's attempted overwrite.
+    assert committed.side_1_points == 11
+    assert committed.side_2_points == 4
+    assert committed.version == 1
+
+
+async def test_delete_game_score_clears_the_score_and_keeps_the_game(
+    db_session: AsyncSession,
+) -> None:
+    match = await _rated_match(db_session, "delete")
+    match = await enter_game_score(
+        db_session, match, game_number=1, side_1_points=11, side_2_points=4
+    )
+
+    updated = await delete_game_score(db_session, match, game_number=1)
+
+    game = next(g for g in updated.games if g.game_number == 1)
+    # The score row is gone but the MatchGame stays so a fresh score can attach.
+    assert game.score is None

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -26,6 +26,7 @@ import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
 from fastmcp.exceptions import ToolError
+from rq import Queue
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api_token_auth import API_TOKEN_CONTEXT
@@ -33,7 +34,7 @@ from app.main import app as fastapi_app
 from app.main import mcp_app
 from app.models import User, UserToken
 from app.token_hashing import hash_token
-from tests._helpers import make_user, start_session
+from tests._helpers import enqueued_notification_jobs, make_user, start_session
 
 MCP_URL = "http://testserver/mcp/"
 
@@ -531,5 +532,254 @@ async def test_enter_game_score_on_frozen_match_raises_scorable_reason(
                     "game_number": 1,
                     "side_1_points": 11,
                     "side_2_points": 7,
+                },
+            )
+
+
+# ----- propose_result / accept_result tools --------------------------------
+
+# A decided best-of-3 board — side 1 clinches 2–0 — for the first proposal, and a
+# different-but-still-decided board (also 2–0 to side 1, different points) for the
+# counter that supersedes it.
+_DECISIVE_BOARD = [
+    {"game_number": 1, "side_1_points": 11, "side_2_points": 7},
+    {"game_number": 2, "side_1_points": 11, "side_2_points": 8},
+]
+_COUNTER_BOARD = [
+    {"game_number": 1, "side_1_points": 11, "side_2_points": 9},
+    {"game_number": 2, "side_1_points": 11, "side_2_points": 6},
+]
+
+
+async def test_propose_and_accept_result_tools_are_registered(
+    db_session: AsyncSession,
+) -> None:
+    """Both negotiation verbs are exposed over the transport."""
+    user = await make_user(db_session, "mcp-negotiation-listed")
+    raw = await _mint(db_session, user)
+
+    async with _mcp_client(raw) as client, client:
+        names = {tool.name for tool in await client.list_tools()}
+
+    assert {"propose_result", "accept_result"} <= names
+
+
+async def test_propose_awaits_acceptance_notifies_and_accept_completes(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
+) -> None:
+    """The headline flow: A proposes a decided board on a rated two-human match →
+    a standing result awaiting B, and B is sent one accept/counter notification.
+    B reads the standing result id via get_match, then accept_result completes the
+    match."""
+    a = await start_session(api_client, db_session)
+    b = await make_user(db_session, "mcp-accept-rival")
+    token_a = await _mint(db_session, a)
+    token_b = await _mint(db_session, b)
+    match_id = await _create_match(api_client, b, best_of=3)
+
+    async with _mcp_client(token_a) as client_a, client_a:
+        proposed = await client_a.call_tool_mcp(
+            "propose_result", {"match_id": match_id, "games": _DECISIVE_BOARD}
+        )
+
+    assert proposed.isError is False
+    body = proposed.structuredContent
+    assert body is not None
+    # A's own view after proposing: the standing result is theirs and awaits B.
+    assert body["status"] == "in_progress"
+    negotiation = body["negotiation"]
+    assert negotiation["viewer_state"] == "awaiting"
+    standing = negotiation["standing_result"]
+    assert standing is not None
+    assert standing["submitted_by"] == str(a.id)
+    standing_id = standing["id"]
+
+    # B (the opposing side) got exactly one accept/counter notification.
+    jobs = enqueued_notification_jobs(fake_notifications_queue)
+    assert [job.user_id for job in jobs] == [b.id]
+    assert jobs[0].link == f"/matches/{match_id}"
+
+    async with _mcp_client(token_b) as client_b, client_b:
+        # B sees the same standing result id through get_match, then accepts it.
+        seen = await client_b.call_tool_mcp("get_match", {"match_id": match_id})
+        assert seen.structuredContent is not None
+        assert seen.structuredContent["negotiation"]["standing_result"]["id"] == (
+            standing_id
+        )
+
+        accepted = await client_b.call_tool_mcp(
+            "accept_result", {"match_id": match_id, "result_id": standing_id}
+        )
+
+    assert accepted.isError is False
+    assert accepted.structuredContent is not None
+    assert accepted.structuredContent["status"] == "completed"
+    assert accepted.structuredContent["negotiation"]["viewer_state"] == "final"
+
+
+async def test_counter_supersedes_standing_proposal(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """After A proposes, B counters with a different decided board targeting the
+    standing id — the counter becomes the new standing result, superseding A's."""
+    a = await start_session(api_client, db_session)
+    b = await make_user(db_session, "mcp-counter-rival")
+    token_a = await _mint(db_session, a)
+    token_b = await _mint(db_session, b)
+    match_id = await _create_match(api_client, b, best_of=3)
+
+    async with _mcp_client(token_a) as client_a, client_a:
+        proposed = await client_a.call_tool_mcp(
+            "propose_result", {"match_id": match_id, "games": _DECISIVE_BOARD}
+        )
+    assert proposed.structuredContent is not None
+    first_id = proposed.structuredContent["negotiation"]["standing_result"]["id"]
+
+    async with _mcp_client(token_b) as client_b, client_b:
+        countered = await client_b.call_tool_mcp(
+            "propose_result",
+            {
+                "match_id": match_id,
+                "games": _COUNTER_BOARD,
+                "supersedes_result_id": first_id,
+            },
+        )
+
+    assert countered.isError is False
+    body = countered.structuredContent
+    assert body is not None
+    standing = body["negotiation"]["standing_result"]
+    assert standing is not None
+    # A new standing result, submitted by B, that supersedes A's first proposal.
+    assert standing["id"] != first_id
+    assert standing["submitted_by"] == str(b.id)
+
+
+async def test_accept_own_proposal_raises_tool_error(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The proposing side already consented by proposing; A accepting their own
+    standing proposal is a ``ToolError``."""
+    a = await start_session(api_client, db_session)
+    b = await make_user(db_session, "mcp-own-rival")
+    token_a = await _mint(db_session, a)
+    match_id = await _create_match(api_client, b, best_of=3)
+
+    async with _mcp_client(token_a) as client_a, client_a:
+        proposed = await client_a.call_tool_mcp(
+            "propose_result", {"match_id": match_id, "games": _DECISIVE_BOARD}
+        )
+        assert proposed.structuredContent is not None
+        standing_id = proposed.structuredContent["negotiation"]["standing_result"]["id"]
+
+        with pytest.raises(ToolError, match="your own proposal"):
+            await client_a.call_tool(
+                "accept_result", {"match_id": match_id, "result_id": standing_id}
+            )
+
+
+async def test_accept_stale_result_id_raises_tool_error_naming_get_match(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Accepting a superseded result id (A's first proposal, after B countered)
+    surfaces the moved-on conflict as a ``ToolError`` naming get_match."""
+    a = await start_session(api_client, db_session)
+    b = await make_user(db_session, "mcp-stale-rival")
+    token_a = await _mint(db_session, a)
+    token_b = await _mint(db_session, b)
+    match_id = await _create_match(api_client, b, best_of=3)
+
+    async with _mcp_client(token_a) as client_a, client_a:
+        proposed = await client_a.call_tool_mcp(
+            "propose_result", {"match_id": match_id, "games": _DECISIVE_BOARD}
+        )
+    assert proposed.structuredContent is not None
+    first_id = proposed.structuredContent["negotiation"]["standing_result"]["id"]
+
+    async with _mcp_client(token_b) as client_b, client_b:
+        # B counters, superseding A's first proposal ...
+        await client_b.call_tool_mcp(
+            "propose_result",
+            {
+                "match_id": match_id,
+                "games": _COUNTER_BOARD,
+                "supersedes_result_id": first_id,
+            },
+        )
+        # ... so accepting the now-stale first id loses the negotiation race.
+        with pytest.raises(ToolError, match="get_match"):
+            await client_b.call_tool(
+                "accept_result", {"match_id": match_id, "result_id": first_id}
+            )
+
+
+async def test_countering_stale_result_id_raises_tool_error_naming_get_match(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A counter that supersedes an id no longer standing (B already countered
+    A's first proposal) surfaces the conflict as a ``ToolError`` naming
+    get_match."""
+    a = await start_session(api_client, db_session)
+    b = await make_user(db_session, "mcp-counter-stale-rival")
+    token_a = await _mint(db_session, a)
+    token_b = await _mint(db_session, b)
+    match_id = await _create_match(api_client, b, best_of=3)
+
+    async with _mcp_client(token_a) as client_a, client_a:
+        proposed = await client_a.call_tool_mcp(
+            "propose_result", {"match_id": match_id, "games": _DECISIVE_BOARD}
+        )
+        assert proposed.structuredContent is not None
+        first_id = proposed.structuredContent["negotiation"]["standing_result"]["id"]
+
+    async with _mcp_client(token_b) as client_b, client_b:
+        await client_b.call_tool_mcp(
+            "propose_result",
+            {
+                "match_id": match_id,
+                "games": _COUNTER_BOARD,
+                "supersedes_result_id": first_id,
+            },
+        )
+
+    # A now tries to counter targeting the stale first id.
+    async with _mcp_client(token_a) as client_a, client_a:
+        with pytest.raises(ToolError, match="get_match"):
+            await client_a.call_tool(
+                "propose_result",
+                {
+                    "match_id": match_id,
+                    "games": _DECISIVE_BOARD,
+                    "supersedes_result_id": first_id,
+                },
+            )
+
+
+async def test_propose_undecided_board_raises_tool_error(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """A board that doesn't decide the match (one game on a best-of-3) can't be a
+    result — surfaced as a ``ToolError``."""
+    a = await start_session(api_client, db_session)
+    b = await make_user(db_session, "mcp-undecided-rival")
+    token_a = await _mint(db_session, a)
+    match_id = await _create_match(api_client, b, best_of=3)
+
+    async with _mcp_client(token_a) as client_a, client_a:
+        with pytest.raises(ToolError):
+            await client_a.call_tool(
+                "propose_result",
+                {
+                    "match_id": match_id,
+                    "games": [
+                        {"game_number": 1, "side_1_points": 11, "side_2_points": 7}
+                    ],
                 },
             )

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -783,3 +783,156 @@ async def test_propose_undecided_board_raises_tool_error(
                     ],
                 },
             )
+
+
+# ----- search_players / list_my_matches read tools -------------------------
+
+
+async def test_search_and_list_my_matches_tools_are_registered(
+    db_session: AsyncSession,
+) -> None:
+    """Both read verbs are exposed over the transport."""
+    user = await make_user(db_session, "mcp-reads-listed")
+    raw = await _mint(db_session, user)
+
+    async with _mcp_client(raw) as client, client:
+        names = {tool.name for tool in await client.list_tools()}
+
+    assert {"search_players", "list_my_matches"} <= names
+
+
+async def test_search_players_finds_opponent_and_excludes_caller(
+    db_session: AsyncSession,
+) -> None:
+    """A username-fragment search returns matching players and never the caller
+    themselves, mirroring ``GET /v1/players/search``."""
+    me = await make_user(db_session, "mcp-search-zephyr-self")
+    rival = await make_user(db_session, "mcp-search-zephyr-rival")
+    raw = await _mint(db_session, me)
+
+    async with _mcp_client(raw) as client, client:
+        found = await client.call_tool_mcp("search_players", {"query": "zephyr-rival"})
+
+    assert found.isError is False
+    assert found.structuredContent is not None
+    players = found.structuredContent["result"]
+    ids = {p["id"] for p in players}
+    assert str(rival.id) in ids
+    assert str(me.id) not in ids
+
+
+async def test_search_players_blank_query_returns_empty(
+    db_session: AsyncSession,
+) -> None:
+    """A blank query matches nothing — the same as the underlying service."""
+    me = await make_user(db_session, "mcp-search-blank")
+    await make_user(db_session, "mcp-search-blank-other")
+    raw = await _mint(db_session, me)
+
+    async with _mcp_client(raw) as client, client:
+        found = await client.call_tool_mcp("search_players", {"query": "   "})
+
+    assert found.isError is False
+    assert found.structuredContent is not None
+    assert found.structuredContent["result"] == []
+
+
+async def test_search_create_score_negotiate_then_list_my_matches(
+    db_session: AsyncSession,
+) -> None:
+    """The whole match flow over MCP ONLY: A searches for B, creates a rated
+    best-of-3, scores a decisive board, proposes it; B accepts → completed;
+    finally A's ``list_my_matches`` shows the completed match, won, against B."""
+    a = await make_user(db_session, "mcp-flow-alice")
+    b = await make_user(db_session, "mcp-flow-bob-quartz")
+    token_a = await _mint(db_session, a)
+    token_b = await _mint(db_session, b)
+
+    async with _mcp_client(token_a) as client_a, client_a:
+        # A finds B by a username fragment; A is excluded from her own search.
+        found = await client_a.call_tool_mcp("search_players", {"query": "bob-quartz"})
+        assert found.isError is False
+        assert found.structuredContent is not None
+        hit_ids = {p["id"] for p in found.structuredContent["result"]}
+        assert str(b.id) in hit_ids
+        assert str(a.id) not in hit_ids
+
+        # A creates a rated best-of-3 against B via the tool.
+        created = await client_a.call_tool_mcp(
+            "create_match",
+            {"best_of": 3, "rated": True, "opponent_user_id": str(b.id)},
+        )
+        assert created.isError is False
+        assert created.structuredContent is not None
+        match_id = created.structuredContent["id"]
+
+        # A scores a decisive 2-0 board, then proposes it.
+        for game in _DECISIVE_BOARD:
+            entered = await client_a.call_tool_mcp(
+                "enter_game_score",
+                {
+                    "match_id": match_id,
+                    "game_number": game["game_number"],
+                    "side_1_points": game["side_1_points"],
+                    "side_2_points": game["side_2_points"],
+                },
+            )
+            assert entered.isError is False
+        proposed = await client_a.call_tool_mcp(
+            "propose_result", {"match_id": match_id, "games": _DECISIVE_BOARD}
+        )
+        assert proposed.structuredContent is not None
+        standing_id = proposed.structuredContent["negotiation"]["standing_result"]["id"]
+
+    # B accepts the standing proposal → the match completes.
+    async with _mcp_client(token_b) as client_b, client_b:
+        accepted = await client_b.call_tool_mcp(
+            "accept_result", {"match_id": match_id, "result_id": standing_id}
+        )
+        assert accepted.isError is False
+        assert accepted.structuredContent is not None
+        assert accepted.structuredContent["status"] == "completed"
+
+    # A's own match list now shows the completed match, projected onto her side.
+    async with _mcp_client(token_a) as client_a, client_a:
+        listed = await client_a.call_tool_mcp("list_my_matches", {})
+
+    assert listed.isError is False
+    assert listed.structuredContent is not None
+    rows = {row["id"]: row for row in listed.structuredContent["items"]}
+    assert match_id in rows
+    assert rows[match_id]["status"] == "completed"
+    assert rows[match_id]["result"] == "W"
+    assert rows[match_id]["opponent"]["id"] == str(b.id)
+
+
+async def test_list_my_matches_returns_only_the_callers_matches(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """``list_my_matches`` is scoped to the caller — a match the caller is NOT a
+    side of (unlike the global ``GET /v1/matches`` feed) never appears."""
+    me = await make_user(db_session, "mcp-mine-owner")
+    raw = await _mint(db_session, me)
+
+    # A match the caller owns (created via the tool), and a wholly-separate match
+    # between two other players seeded over HTTP that the caller is absent from.
+    other = await start_session(api_client, db_session)
+    other_opponent = await make_user(db_session, "mcp-mine-other-rival")
+    foreign_match_id = await _create_match(api_client, other_opponent)
+
+    async with _mcp_client(raw) as client, client:
+        created = await client.call_tool_mcp(
+            "create_match",
+            {"best_of": 3, "rated": True, "opponent_user_id": str(other.id)},
+        )
+        assert created.structuredContent is not None
+        mine_match_id = created.structuredContent["id"]
+
+        listed = await client.call_tool_mcp("list_my_matches", {})
+
+    assert listed.isError is False
+    assert listed.structuredContent is not None
+    listed_ids = {row["id"] for row in listed.structuredContent["items"]}
+    assert mine_match_id in listed_ids
+    assert foreign_match_id not in listed_ids

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -232,3 +232,120 @@ async def test_get_match_non_participant_sees_scorecard_without_extras(
     )
     assert body["recent_form"] == []
     assert body["head_to_head"] is None
+
+
+# ----- create_match tool ---------------------------------------------------
+
+
+async def test_create_match_is_registered(db_session: AsyncSession) -> None:
+    """The write verb is exposed alongside the read verb over the transport."""
+    user = await make_user(db_session, "mcp-create-listed")
+    raw = await _mint(db_session, user)
+
+    async with _mcp_client(raw) as client, client:
+        tools = await client.list_tools()
+
+    assert "create_match" in {tool.name for tool in tools}
+
+
+async def test_create_solo_match_is_retrievable_via_get_match(
+    db_session: AsyncSession,
+) -> None:
+    """A solo ``create_match`` (no opponent, ``rated=False``) returns a
+    ``MatchDetails`` with two sides — side 2 the player-less sentinel — and the
+    created match is then readable back through ``get_match``."""
+    me = await make_user(db_session, "mcp-solo-creator")
+    raw = await _mint(db_session, me)
+
+    async with _mcp_client(raw) as client, client:
+        created = await client.call_tool_mcp(
+            "create_match", {"best_of": 3, "rated": False}
+        )
+        assert created.isError is False
+        body = created.structuredContent
+        assert body is not None
+        match_id = body["id"]
+
+        read_back = await client.call_tool_mcp("get_match", {"match_id": match_id})
+
+    # Creator's perspective: side 1 is mine, side 2 is the player-less sentinel.
+    my_side, opp_side = body["sides"]
+    assert my_side["is_current_user_side"] is True
+    assert my_side["players"][0]["user_id"] == str(me.id)
+    assert opp_side["is_current_user_side"] is False
+    assert opp_side["players"] == []
+    assert body["best_of"] == 3
+    assert body["affects_rating"] is False
+    # get_match reads the same match back.
+    assert read_back.isError is False
+    assert read_back.structuredContent is not None
+    assert read_back.structuredContent["id"] == match_id
+
+
+async def test_create_rated_without_opponent_raises_tool_error(
+    db_session: AsyncSession,
+) -> None:
+    """A rated match with no opponent surfaces the domain rule as a ``ToolError``
+    with an actionable message."""
+    me = await make_user(db_session, "mcp-rated-noopp")
+    raw = await _mint(db_session, me)
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="registered opponent"):
+            await client.call_tool("create_match", {"best_of": 3, "rated": True})
+
+
+async def test_create_self_match_raises_tool_error(
+    db_session: AsyncSession,
+) -> None:
+    """Passing your own id as the opponent surfaces ``SelfMatchError`` as a
+    ``ToolError``."""
+    me = await make_user(db_session, "mcp-self-match")
+    raw = await _mint(db_session, me)
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="against yourself"):
+            await client.call_tool(
+                "create_match",
+                {"best_of": 3, "rated": False, "opponent_user_id": str(me.id)},
+            )
+
+
+async def test_create_match_unknown_opponent_raises_tool_error(
+    db_session: AsyncSession,
+) -> None:
+    """A rated match against an id that matches no live player surfaces
+    ``OpponentNotFoundError`` as a ``ToolError``."""
+    me = await make_user(db_session, "mcp-unknown-opp")
+    raw = await _mint(db_session, me)
+    ghost = str(uuid.uuid4())
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match=ghost):
+            await client.call_tool(
+                "create_match",
+                {"best_of": 5, "rated": True, "opponent_user_id": ghost},
+            )
+
+
+async def test_create_rated_match_against_registered_opponent(
+    db_session: AsyncSession,
+) -> None:
+    """A rated match against a real registered opponent is created and rated."""
+    me = await make_user(db_session, "mcp-rated-creator")
+    opponent = await make_user(db_session, "mcp-rated-rival")
+    raw = await _mint(db_session, me)
+
+    async with _mcp_client(raw) as client, client:
+        created = await client.call_tool_mcp(
+            "create_match",
+            {"best_of": 5, "rated": True, "opponent_user_id": str(opponent.id)},
+        )
+
+    assert created.isError is False
+    body = created.structuredContent
+    assert body is not None
+    assert body["affects_rating"] is True
+    my_side, opp_side = body["sides"]
+    assert my_side["players"][0]["user_id"] == str(me.id)
+    assert opp_side["players"][0]["user_id"] == str(opponent.id)

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -1,0 +1,234 @@
+"""Transport-auth tests for the mounted FastMCP server (chore 1c).
+
+These drive the **mounted** app over HTTP (httpx ``ASGITransport`` against the
+FastAPI app, wrapped in a FastMCP ``Client`` speaking Streamable HTTP) so the
+``FortymmTokenVerifier`` actually runs at the transport — an in-memory
+``Client(mcp)`` would bypass it. The server exposes **zero tools** for now, so a
+valid token proves only that ``list_tools`` succeeds (empty is fine); the point
+is that missing / invalid / tombstoned-user tokens are rejected **before** any
+tool body, at the transport.
+
+The MCP app carries its own lifespan (the Streamable-HTTP session manager);
+``ASGITransport`` does not fire it, so each test enters ``mcp_app.lifespan``
+explicitly. The verifier resolves tokens against the process-wide engine
+(``DATABASE_URL`` is pointed at the test Postgres by the autouse
+``_solver_job_database`` fixture), so tokens are committed via ``db_session``
+first — the verifier's own connection only sees committed rows.
+"""
+
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+from fastmcp.exceptions import ToolError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api_token_auth import API_TOKEN_CONTEXT
+from app.main import app as fastapi_app
+from app.main import mcp_app
+from app.models import User, UserToken
+from app.token_hashing import hash_token
+from tests._helpers import make_user, start_session
+
+MCP_URL = "http://testserver/mcp/"
+
+
+async def _mint(db_session: AsyncSession, user: User) -> str:
+    """Store an ``api``-context token for ``user`` (only the sha256 hash lands in
+    the DB, as production does) and return the raw token."""
+    raw = "api-raw-" + uuid.uuid4().hex
+    db_session.add(
+        UserToken(user_id=user.id, context=API_TOKEN_CONTEXT, token=hash_token(raw))
+    )
+    await db_session.commit()
+    return raw
+
+
+@asynccontextmanager
+async def _mcp_client(token: str | None) -> AsyncIterator[Client]:
+    """A FastMCP ``Client`` bound to the mounted app over ``ASGITransport``.
+
+    Enters ``mcp_app.lifespan`` so the Streamable-HTTP session manager is
+    running (``ASGITransport`` skips the app lifespan). ``token`` becomes the
+    ``Authorization: Bearer`` header, or is omitted entirely when ``None``.
+    """
+    transport = httpx.ASGITransport(app=fastapi_app)
+
+    def _factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+        **kwargs: object,
+    ) -> httpx.AsyncClient:
+        # fastmcp's factory call passes extra kwargs (e.g. follow_redirects)
+        # beyond the McpHttpClientFactory protocol's three; forward them, but
+        # keep our ASGITransport + base_url so the client hits the mounted app.
+        kwargs.pop("transport", None)
+        kwargs.pop("base_url", None)
+        return httpx.AsyncClient(
+            transport=transport,
+            headers=headers,
+            timeout=timeout if timeout is not None else httpx.Timeout(30.0),
+            auth=auth,
+            base_url="http://testserver",
+            **kwargs,  # type: ignore[arg-type]  # httpx kwargs are heterogeneous
+        )
+
+    headers = {"Authorization": f"Bearer {token}"} if token is not None else None
+    client = Client(
+        StreamableHttpTransport(MCP_URL, headers=headers, httpx_client_factory=_factory)
+    )
+    async with mcp_app.lifespan(fastapi_app):
+        yield client
+
+
+async def _assert_rejected(client: Client) -> None:
+    """Connecting/listing tools fails at the transport with a 401.
+
+    The ``pytest.raises`` is held here — inside the ``mcp_app.lifespan`` block —
+    so the 401 is caught before it would otherwise unwind through the session
+    manager's task group and be re-wrapped in an ``ExceptionGroup``.
+    """
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        async with client:
+            await client.list_tools()
+    assert exc_info.value.response.status_code == 401
+
+
+async def test_valid_api_token_can_list_tools(db_session: AsyncSession) -> None:
+    """A live ``context="api"`` bearer token authenticates at the transport and
+    can complete the initialize + ``list_tools`` handshake. The curated
+    match-flow verbs are exposed — ``get_match`` is registered."""
+    user = await make_user(db_session, "mcp-token-owner")
+    raw = await _mint(db_session, user)
+
+    async with _mcp_client(raw) as client, client:
+        tools = await client.list_tools()
+
+    assert "get_match" in {tool.name for tool in tools}
+
+
+async def test_missing_token_is_rejected(db_session: AsyncSession) -> None:
+    """No ``Authorization`` header → rejected at the transport (401), before any
+    tool body."""
+    async with _mcp_client(None) as client:
+        await _assert_rejected(client)
+
+
+async def test_invalid_token_is_rejected(db_session: AsyncSession) -> None:
+    """A well-formed but never-minted token resolves to no user → 401."""
+    async with _mcp_client("api-raw-" + uuid.uuid4().hex) as client:
+        await _assert_rejected(client)
+
+
+async def test_tombstoned_users_token_is_rejected(db_session: AsyncSession) -> None:
+    """A valid token whose user was merged away (``merged_into_user_id`` set) is
+    rejected — the folded-in ghost never authenticates through MCP either."""
+    owner = await make_user(db_session, "mcp-merge-owner")
+    guest = await make_user(db_session, "mcp-merged-guest")
+    raw = await _mint(db_session, guest)
+
+    guest.merged_into_user_id = owner.id
+    guest.merged_at = datetime.now(UTC)
+    await db_session.commit()
+
+    async with _mcp_client(raw) as client:
+        await _assert_rejected(client)
+
+
+# ----- get_match tool ------------------------------------------------------
+
+
+async def _create_match(
+    api_client: httpx.AsyncClient, opponent: User, *, best_of: int = 5
+) -> str:
+    """Create a rated match against ``opponent`` as the client's session user via
+    the HTTP endpoint (committed), returning the new match id."""
+    response = await api_client.post(
+        "/v1/matches",
+        json={
+            "opponent_user_id": str(opponent.id),
+            "best_of": best_of,
+            "rated": True,
+        },
+    )
+    assert response.status_code == 201, response.text
+    return str(response.json()["id"])
+
+
+async def test_get_match_returns_same_details_as_http_get(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """The ``get_match`` tool returns the identical ``MatchDetails`` view the HTTP
+    ``GET /v1/matches/{id}`` returns for the same authenticated user — same id,
+    sides, negotiation, and viewer-relative perspective flags."""
+    me = await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "mcp-get-rival")
+    raw = await _mint(db_session, me)
+    match_id = await _create_match(api_client, opponent)
+
+    http_body = (await api_client.get(f"/v1/matches/{match_id}")).json()
+
+    async with _mcp_client(raw) as client, client:
+        result = await client.call_tool_mcp("get_match", {"match_id": match_id})
+
+    assert result.isError is False
+    assert result.structuredContent == http_body
+    # Spot-check the load-bearing fields the tool is meant to preserve.
+    assert result.structuredContent is not None
+    assert result.structuredContent["id"] == match_id
+    my_side, opp_side = result.structuredContent["sides"]
+    assert my_side["is_current_user_side"] is True
+    assert my_side["players"][0]["user_id"] == str(me.id)
+    assert opp_side["is_current_user_side"] is False
+    assert result.structuredContent["negotiation"]["viewer_state"] == "live"
+    assert result.structuredContent["can_score"] is True
+
+
+async def test_get_match_unknown_id_raises_tool_error(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """An id that matches no match surfaces as a ``ToolError`` at the caller."""
+    me = await start_session(api_client, db_session)
+    raw = await _mint(db_session, me)
+    unknown = str(uuid.uuid4())
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match=unknown):
+            await client.call_tool("get_match", {"match_id": unknown})
+
+
+async def test_get_match_non_participant_sees_scorecard_without_extras(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """Mirroring the public HTTP GET (#515): a caller who is not on the match
+    still reads the scorecard, but with no current-user side and the
+    history/rivalry extras empty — not a ``ToolError``."""
+    await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "mcp-nonpart-rival")
+    match_id = await _create_match(api_client, opponent)
+
+    outsider = await make_user(db_session, "mcp-outsider")
+    outsider_token = await _mint(db_session, outsider)
+
+    async with _mcp_client(outsider_token) as client, client:
+        result = await client.call_tool_mcp("get_match", {"match_id": match_id})
+
+    assert result.isError is False
+    body = result.structuredContent
+    assert body is not None
+    assert body["id"] == match_id
+    # No side is the outsider's, and the participant-only extras are empty (#515).
+    assert all(side["is_current_user_side"] is False for side in body["sides"])
+    assert all(
+        player["is_current_user"] is False
+        for side in body["sides"]
+        for player in side["players"]
+    )
+    assert body["recent_form"] == []
+    assert body["head_to_head"] is None

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -349,3 +349,187 @@ async def test_create_rated_match_against_registered_opponent(
     my_side, opp_side = body["sides"]
     assert my_side["players"][0]["user_id"] == str(me.id)
     assert opp_side["players"][0]["user_id"] == str(opponent.id)
+
+
+# ----- score-write tools (enter / update / delete) -------------------------
+
+
+def _game_score(body: dict[str, object] | None, game_number: int) -> dict[str, int]:
+    """The committed score dict for ``game_number`` in a ``MatchDetails`` body,
+    asserting one exists."""
+    assert body is not None
+    games = body["games"]
+    assert isinstance(games, list)
+    game = next(g for g in games if g["game_number"] == game_number)
+    score = game["score"]
+    assert score is not None
+    return score
+
+
+async def test_score_write_tools_are_registered(db_session: AsyncSession) -> None:
+    """The three per-game score verbs are exposed over the transport."""
+    user = await make_user(db_session, "mcp-score-listed")
+    raw = await _mint(db_session, user)
+
+    async with _mcp_client(raw) as client, client:
+        names = {tool.name for tool in await client.list_tools()}
+
+    assert {"enter_game_score", "update_game_score", "delete_game_score"} <= names
+
+
+async def test_enter_update_delete_game_score_round_trip(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """enter → get_match reflects it; update with the current version replaces
+    it; a STALE version conflicts (naming get_match); delete clears it."""
+    me = await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "mcp-score-rival")
+    raw = await _mint(db_session, me)
+    match_id = await _create_match(api_client, opponent, best_of=5)
+
+    async with _mcp_client(raw) as client, client:
+        entered = await client.call_tool_mcp(
+            "enter_game_score",
+            {
+                "match_id": match_id,
+                "game_number": 1,
+                "side_1_points": 11,
+                "side_2_points": 5,
+            },
+        )
+        assert entered.isError is False
+        score = _game_score(entered.structuredContent, 1)
+        assert (score["side_1_points"], score["side_2_points"], score["version"]) == (
+            11,
+            5,
+            1,
+        )
+
+        # get_match reads the committed score back.
+        read_back = await client.call_tool_mcp("get_match", {"match_id": match_id})
+        assert _game_score(read_back.structuredContent, 1)["side_1_points"] == 11
+
+        # Update with the current version succeeds and bumps the version.
+        updated = await client.call_tool_mcp(
+            "update_game_score",
+            {
+                "match_id": match_id,
+                "game_number": 1,
+                "side_1_points": 11,
+                "side_2_points": 7,
+                "expected_version": 1,
+            },
+        )
+        assert updated.isError is False
+        score = _game_score(updated.structuredContent, 1)
+        assert (score["side_1_points"], score["side_2_points"], score["version"]) == (
+            11,
+            7,
+            2,
+        )
+
+        # A stale expected_version loses the optimistic-concurrency check; the
+        # ToolError must name get_match as the recovery path.
+        with pytest.raises(ToolError, match="get_match"):
+            await client.call_tool(
+                "update_game_score",
+                {
+                    "match_id": match_id,
+                    "game_number": 1,
+                    "side_1_points": 11,
+                    "side_2_points": 9,
+                    "expected_version": 1,
+                },
+            )
+
+        # Delete clears the committed score (the game row stays, score is null).
+        deleted = await client.call_tool_mcp(
+            "delete_game_score",
+            {"match_id": match_id, "game_number": 1},
+        )
+        assert deleted.isError is False
+        assert deleted.structuredContent is not None
+        game = next(
+            g for g in deleted.structuredContent["games"] if g["game_number"] == 1
+        )
+        assert game["score"] is None
+
+
+async def test_enter_game_score_out_of_range_is_schema_error(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """A ``game_number`` outside 1..7 is rejected as a validation error before the
+    tool body — the bounded ``Field(ge=1, le=7)`` on the argument."""
+    me = await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "mcp-score-range-rival")
+    raw = await _mint(db_session, me)
+    match_id = await _create_match(api_client, opponent, best_of=5)
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError):
+            await client.call_tool(
+                "enter_game_score",
+                {
+                    "match_id": match_id,
+                    "game_number": 8,
+                    "side_1_points": 11,
+                    "side_2_points": 5,
+                },
+            )
+
+
+async def test_enter_game_score_non_participant_raises_tool_error(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """A caller who isn't on the match can't score it — the load collapses
+    non-participation into the same opaque not-found ToolError (naming
+    participation), so existence can't be probed."""
+    await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "mcp-score-outsider-rival")
+    match_id = await _create_match(api_client, opponent, best_of=5)
+
+    outsider = await make_user(db_session, "mcp-score-outsider")
+    outsider_token = await _mint(db_session, outsider)
+
+    async with _mcp_client(outsider_token) as client, client:
+        with pytest.raises(ToolError, match="participant"):
+            await client.call_tool(
+                "enter_game_score",
+                {
+                    "match_id": match_id,
+                    "game_number": 1,
+                    "side_1_points": 11,
+                    "side_2_points": 5,
+                },
+            )
+
+
+async def test_enter_game_score_on_frozen_match_raises_scorable_reason(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """A match with a posted (standing) result has a frozen scratchpad; scoring
+    it surfaces the carried scorability reason as the ToolError."""
+    me = await start_session(api_client, db_session)
+    opponent = await make_user(db_session, "mcp-score-frozen-rival")
+    raw = await _mint(db_session, me)
+    match_id = await _create_match(api_client, opponent, best_of=1)
+
+    # Post a complete, decided result via HTTP — a rated two-human match leaves
+    # it standing and freezes the score endpoints (#715).
+    posted = await api_client.post(
+        f"/v1/matches/{match_id}/results",
+        json={"games": [{"game_number": 1, "side_1_points": 11, "side_2_points": 5}]},
+    )
+    assert posted.status_code == 201, posted.text
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="posted result"):
+            await client.call_tool(
+                "enter_game_score",
+                {
+                    "match_id": match_id,
+                    "game_number": 1,
+                    "side_1_points": 11,
+                    "side_2_points": 7,
+                },
+            )

--- a/api/tests/test_player_search.py
+++ b/api/tests/test_player_search.py
@@ -1,0 +1,136 @@
+"""Unit tests for the FastAPI-free player-search service.
+
+Constructs `search_players_by_username` directly against `db_session`, so the
+shared query the MCP tool and HTTP endpoint both call is covered without a
+request. The HTTP wire contract is tested separately in `test_players.py`.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.leagues import get_default_league, seed_user_league_rating
+from app.models import (
+    League,
+    RatingHistory,
+    RatingHistorySource,
+    User,
+    UserLeagueRating,
+)
+from app.player_search import search_players_by_username
+from tests._helpers import make_user
+
+
+def _provenance(user: User, league: League, rating_value: float) -> RatingHistory:
+    """A ``manual`` rating-history row — the cheapest production shape that
+    carries provenance, so ``is_rated_member()`` treats the seeded number as an
+    actual rating (see ``test_players._provenance``)."""
+    return RatingHistory(
+        league_id=league.id,
+        user_id=user.id,
+        match_id=None,
+        rating_strategy_id=league.rating_strategy_id,
+        rating_value=rating_value,
+        rating_state={"rating": rating_value, "rd": 200.0, "volatility": 0.06},
+        previous_rating_value=None,
+        source=RatingHistorySource.manual,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+
+async def test_finds_a_registered_player_by_a_name_fragment(db_session: AsyncSession):
+    caller = await make_user(db_session, "caller")
+    await make_user(db_session, "Ada.Lovelace")
+    await make_user(db_session, "grace.hopper")
+
+    results = await search_players_by_username(
+        db_session, query="ADA", current_user_id=caller.id
+    )
+
+    assert [player.username for player in results] == ["Ada.Lovelace"]
+
+
+async def test_excludes_the_caller(db_session: AsyncSession):
+    caller = await make_user(db_session, "ada.caller")
+    await make_user(db_session, "ada.other")
+
+    results = await search_players_by_username(
+        db_session, query="ada", current_user_id=caller.id
+    )
+
+    usernames = [player.username for player in results]
+    assert "ada.caller" not in usernames
+    assert usernames == ["ada.other"]
+
+
+async def test_excludes_tombstoned_users(db_session: AsyncSession):
+    caller = await make_user(db_session, "caller")
+    survivor = await make_user(db_session, "match.survivor")
+    ghost = await make_user(db_session, "match.ghost")
+    ghost.merged_into_user_id = survivor.id
+    await db_session.commit()
+
+    results = await search_players_by_username(
+        db_session, query="match.", current_user_id=caller.id
+    )
+
+    assert [player.username for player in results] == ["match.survivor"]
+
+
+async def test_respects_the_limit(db_session: AsyncSession):
+    caller = await make_user(db_session, "caller")
+    for i in range(15):
+        await make_user(db_session, f"player{i:02d}")
+
+    capped = await search_players_by_username(
+        db_session, query="player", current_user_id=caller.id, limit=3
+    )
+
+    assert len(capped) == 3
+    # Alphabetical order, so the cap takes the first three.
+    assert [player.username for player in capped] == [
+        "player00",
+        "player01",
+        "player02",
+    ]
+
+
+async def test_blank_query_matches_nothing(db_session: AsyncSession):
+    caller = await make_user(db_session, "caller")
+    await make_user(db_session, "ada.lovelace")
+
+    results = await search_players_by_username(
+        db_session, query="   ", current_user_id=caller.id
+    )
+
+    assert results == []
+
+
+async def test_surfaces_the_default_league_rating(db_session: AsyncSession):
+    caller = await make_user(db_session, "caller")
+    rival = await make_user(db_session, "ratedrival")
+    freshface = await make_user(db_session, "freshface")
+
+    league = await get_default_league(db_session)
+    db_session.add(
+        UserLeagueRating(
+            league_id=league.id,
+            user_id=rival.id,
+            rating_strategy_id=league.rating_strategy_id,
+            rating_value=1750.0,
+            rating_state={"rating": 1750.0, "rd": 200.0, "volatility": 0.06},
+        )
+    )
+    db_session.add(_provenance(rival, league, 1750.0))
+    # A brand-new member is seeded a 1500 row; the service must still report them
+    # Unrated rather than handing back the league's prior.
+    seed_user_league_rating(db_session, league.id, freshface.id, league.rating_strategy)
+    await db_session.commit()
+
+    results = await search_players_by_username(
+        db_session, query="a", current_user_id=caller.id
+    )
+    by_name = {player.username: player.rating for player in results}
+
+    assert by_name["ratedrival"] == 1750.0
+    assert by_name["freshface"] is None

--- a/api/tests/test_ratings.py
+++ b/api/tests/test_ratings.py
@@ -12,8 +12,8 @@ from sqlalchemy import event, select
 from sqlalchemy.exc import IntegrityError, MissingGreenlet
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
+from app.match_serialization import load_match_eager as _load_match
 from app.matches import (
-    _load_match,
     match_eager_options,
     match_rating_eager_options,
 )

--- a/api/tests/test_result_proposal.py
+++ b/api/tests/test_result_proposal.py
@@ -1,0 +1,280 @@
+"""Unit tests for the transport-neutral result-proposal service
+(``app.result_proposal.propose_result``) — the first verb of the propose/accept
+negotiation, covering both a first proposal and a counter. Constructed directly
+with a ``db_session`` (no FastAPI, no HTTP client): the HTTP wire contract is
+covered by ``test_matches.py``; here we prove the service self-accepts +
+finalizes solo/unrated matches, leaves a rated two-human match standing, honours
+the counter chain, and raises the domain exceptions (never ``HTTPException``)
+the adapters map."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.match_creation import create_match
+from app.models import MatchStatus
+from app.result_acceptance import (
+    MatchClosedError,
+    NegotiationConflictError,
+    UndecidedBoardError,
+)
+from app.result_chain import accepted_result, standing_result
+from app.result_proposal import propose_result
+from app.schemas.match import MatchResultsGameWrite
+from tests._helpers import make_user
+
+
+def _decisive_board(winner_side: int = 1) -> list[MatchResultsGameWrite]:
+    """A single decided game for a best-of-1 board (``winner_side`` takes it)."""
+    if winner_side == 1:
+        return [MatchResultsGameWrite(game_number=1, side_1_points=11, side_2_points=4)]
+    return [MatchResultsGameWrite(game_number=1, side_1_points=4, side_2_points=11)]
+
+
+async def test_first_proposal_on_solo_match_self_accepts_and_finalizes(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "solo-proposer")
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=None,
+        league_id=None,
+        best_of=1,
+        rated=False,
+    )
+
+    outcome = await propose_result(
+        db_session,
+        match.id,
+        creator.id,
+        games=_decisive_board(winner_side=1),
+        supersedes_result_id=None,
+    )
+
+    # No second human to accept — the proposer self-accepts and the match
+    # finalizes immediately.
+    assert outcome.awaiting_acceptance is False
+    assert outcome.match.status is MatchStatus.completed
+    sides = sorted(outcome.match.sides, key=lambda s: s.side_number)
+    assert sides[0].won is True
+    assert sides[1].won is False
+    # A finalized result is accepted (not "standing"): the proposer self-accepts.
+    assert standing_result(outcome.match) is None
+    result = accepted_result(outcome.match)
+    assert result is not None
+    assert result.accepted_by_user_id == creator.id
+    assert result.accepted_at is not None
+
+
+async def test_first_proposal_on_rated_match_stays_standing(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "rated-proposer")
+    opponent = await make_user(db_session, "rated-recipient")
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=opponent.id,
+        league_id=None,
+        best_of=1,
+        rated=True,
+    )
+
+    outcome = await propose_result(
+        db_session,
+        match.id,
+        creator.id,
+        games=_decisive_board(winner_side=1),
+        supersedes_result_id=None,
+    )
+
+    # A rated two-human match leaves the result standing for the opposing side.
+    assert outcome.awaiting_acceptance is True
+    assert outcome.match.status is MatchStatus.in_progress
+    standing = standing_result(outcome.match)
+    assert standing is not None
+    assert standing.submitted_by_user_id == creator.id
+    assert standing.accepted_by_user_id is None
+    # No W/L stamped until acceptance.
+    assert all(side.won is None for side in outcome.match.sides)
+
+
+async def test_counter_supersedes_the_standing_result(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "counter-proposer")
+    opponent = await make_user(db_session, "counter-recipient")
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=opponent.id,
+        league_id=None,
+        best_of=1,
+        rated=True,
+    )
+
+    first = await propose_result(
+        db_session,
+        match.id,
+        creator.id,
+        games=_decisive_board(winner_side=1),
+        supersedes_result_id=None,
+    )
+    first_id = standing_result(first.match)
+    assert first_id is not None
+
+    countered = await propose_result(
+        db_session,
+        match.id,
+        opponent.id,
+        games=_decisive_board(winner_side=2),
+        supersedes_result_id=first_id.id,
+    )
+
+    # The counter mints a superseding result; still standing (rated), chain length 2.
+    assert countered.awaiting_acceptance is True
+    assert countered.match.status is MatchStatus.in_progress
+    assert len(countered.match.results) == 2
+    new_standing = standing_result(countered.match)
+    assert new_standing is not None
+    assert new_standing.supersedes_result_id == first_id.id
+    assert new_standing.submitted_by_user_id == opponent.id
+
+
+async def test_counter_targeting_a_stale_id_raises_negotiation_conflict(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "stale-proposer")
+    opponent = await make_user(db_session, "stale-recipient")
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=opponent.id,
+        league_id=None,
+        best_of=1,
+        rated=True,
+    )
+
+    first = await propose_result(
+        db_session,
+        match.id,
+        creator.id,
+        games=_decisive_board(winner_side=1),
+        supersedes_result_id=None,
+    )
+    first_result = standing_result(first.match)
+    assert first_result is not None
+
+    # A counter moves the head off ``first_result``.
+    await propose_result(
+        db_session,
+        match.id,
+        opponent.id,
+        games=_decisive_board(winner_side=2),
+        supersedes_result_id=first_result.id,
+    )
+
+    # Superseding the now-stale (already-superseded) id is the lost-race case.
+    with pytest.raises(NegotiationConflictError) as excinfo:
+        await propose_result(
+            db_session,
+            match.id,
+            creator.id,
+            games=_decisive_board(winner_side=1),
+            supersedes_result_id=first_result.id,
+        )
+    # It carries the loaded match so the adapter can build the moved-on snapshot.
+    assert excinfo.value.match.id == match.id
+
+
+async def test_first_proposal_colliding_with_existing_result_conflicts(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "collide-proposer")
+    opponent = await make_user(db_session, "collide-recipient")
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=opponent.id,
+        league_id=None,
+        best_of=1,
+        rated=True,
+    )
+
+    await propose_result(
+        db_session,
+        match.id,
+        creator.id,
+        games=_decisive_board(winner_side=1),
+        supersedes_result_id=None,
+    )
+
+    # A second first-post (no supersedes) against an existing chain loses.
+    with pytest.raises(NegotiationConflictError):
+        await propose_result(
+            db_session,
+            match.id,
+            opponent.id,
+            games=_decisive_board(winner_side=2),
+            supersedes_result_id=None,
+        )
+
+
+async def test_undecided_board_raises_undecided_board_error(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "undecided-proposer")
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=None,
+        league_id=None,
+        best_of=3,
+        rated=False,
+    )
+
+    # Best-of-3 needs two game wins; one game is undecided.
+    with pytest.raises(UndecidedBoardError):
+        await propose_result(
+            db_session,
+            match.id,
+            creator.id,
+            games=[
+                MatchResultsGameWrite(game_number=1, side_1_points=11, side_2_points=4)
+            ],
+            supersedes_result_id=None,
+        )
+
+
+async def test_terminal_match_raises_match_closed_error(
+    db_session: AsyncSession,
+) -> None:
+    creator = await make_user(db_session, "terminal-proposer")
+    match = await create_match(
+        db_session,
+        creator=creator,
+        opponent_user_id=None,
+        league_id=None,
+        best_of=1,
+        rated=False,
+    )
+
+    # First proposal finalizes the solo match (completed).
+    first = await propose_result(
+        db_session,
+        match.id,
+        creator.id,
+        games=_decisive_board(winner_side=1),
+        supersedes_result_id=None,
+    )
+    assert first.match.status is MatchStatus.completed
+
+    # A completed match is closed to new proposals.
+    with pytest.raises(MatchClosedError):
+        await propose_result(
+            db_session,
+            match.id,
+            creator.id,
+            games=_decisive_board(winner_side=1),
+            supersedes_result_id=None,
+        )

--- a/docs/adr/20260718-the-match-flow-is-shared-services-behind-http-and-mcp-adapters.md
+++ b/docs/adr/20260718-the-match-flow-is-shared-services-behind-http-and-mcp-adapters.md
@@ -76,8 +76,11 @@ object without one router depending on another's internals.
 
 ### The MCP server is FastMCP, mounted on the same app at `/mcp`
 
-FastMCP 2.x, hand-written tools (not OpenAPI-generated — we curate agent-shaped
-verbs), Streamable HTTP transport, mounted `app.mount("/mcp", mcp.http_app())`.
+FastMCP 3.x (`fastmcp>=3.4,<4`, 3.4.4 at implementation — the current PyPI major;
+the earlier "2.x" note was superseded), hand-written tools (not OpenAPI-generated
+— we curate agent-shaped verbs), Streamable HTTP transport, mounted
+`app.mount("/mcp", mcp.http_app(path="/"))` (the `path="/"` form yields the
+intended `/mcp` endpoint rather than a nested `/mcp/mcp`).
 The FastMCP ASGI app has **its own lifespan** (the Streamable-HTTP session
 manager) which **must be combined** into the FastAPI lifespan, or every MCP call
 500s. Always mounted; **no env flag**. It is one new dependency (`fastmcp`).

--- a/docs/adr/20260718-the-match-flow-is-shared-services-behind-http-and-mcp-adapters.md
+++ b/docs/adr/20260718-the-match-flow-is-shared-services-behind-http-and-mcp-adapters.md
@@ -1,0 +1,154 @@
+# The match flow is a shared service layer behind HTTP and MCP adapters
+
+Date: 2026-07-18 (date-numbered — sequential numbers collide across concurrent
+worktrees; see ADR-0788's note and the duplicate 0915s in this directory)
+
+## Status
+
+Accepted — decided before implementation, from a described goal ("add an MCP
+server to the API that uses the normal auth method and exposes match creation,
+score entry, and the approval/correction flow"). No issue number yet. Builds
+directly on **PR #1130/#1131** ("Opaque API tokens (`context="api"`) for
+programmatic bearer auth"), which is the auth mechanism this ADR reuses.
+
+## Context
+
+The match-flow write logic — create a match, enter/update/delete a per-game
+score, propose a result, accept a standing result (and counter it) — lives
+**inline in the `matches.py` route handlers**. `create_match`
+(`matches.py:545`) resolves the opponent, enforces the rated-needs-opponent
+rule, builds the sides, commits, and serialises, all in the handler body.
+`post_match_result` (`matches.py:1687`) is ~130 lines of row-locking, board
+compaction, the first-post-vs-counter negotiation gates, `finalize_match`, and
+fire-and-forget notifications — inline. Only `accept_match_result` already
+delegates its core to `accept_standing_result` in `result_acceptance.py`, and
+that seam is the one that works: the handler maps two **domain exceptions**
+(`StandingResultConflictError`, `PostedGamesNotDecisiveError`) to 409s.
+
+We want a second caller of this logic — an **MCP server** so an agent can drive
+the same flow — without duplicating the negotiation rules or letting the two
+callers drift. An MCP tool cannot catch an `HTTPException`, and `api/CLAUDE.md`
+forbids FastAPI imports in the service layer. So the logic must speak a
+transport-neutral contract that both an HTTP handler and an MCP tool can adapt.
+
+The auth mechanism already exists: `POST /v1/api-tokens` mints an opaque,
+sha256-hashed `context="api"` bearer token, and `get_current_user` resolves
+`Authorization: Bearer <token>` via `_find_api_token_user` (`sessions.py:375`),
+excluding tombstoned users. We reuse it rather than inventing MCP-specific auth.
+
+## Decision
+
+### Match-flow write logic moves into a shared service layer
+
+Following `api/CLAUDE.md`'s three-layer rule (handler → provider → plain
+service class), the create/score/propose/accept logic is extracted into service
+object(s) with plain `__init__`s and no FastAPI imports, constructible in a REPL
+or test with a raw session. Player search — the web opponent typeahead's
+existing endpoint logic — is factored the same way so MCP and HTTP share it.
+
+### Services return the domain `Match` and raise domain exceptions; adapters map
+
+The service trades in the domain `Match` and a family of **domain exceptions**,
+extending the pair that already exists in `result_acceptance.py`. New members
+cover every case currently raised inline as an `HTTPException` in these
+handlers: e.g. `SelfMatchError`, `OpponentNotFoundError`,
+`RatedNeedsRegisteredOpponentError`, `MatchClosedError`,
+`NegotiationConflictError` (carries the loaded `Match` so an adapter can rebuild
+the viewer-relative snapshot), `ScoreConflictError` (carries the committed
+score). `MatchLockUnavailable` already exists.
+
+- The **HTTP adapter** maps each domain exception to the **exact status code and
+  body it produces today** — the wire contract does not move a byte — and
+  serialises via the shared serializer.
+- The **MCP adapter** maps the same exceptions to FastMCP `ToolError`s with
+  **actionable messages** (see below) and returns `MatchDetails` as structured
+  content on success.
+
+Rejected: services returning the already-serialised `MatchDetails` DTO. That
+drags viewer-relative response-shaping into the service and couples the MCP
+payload to the web BFF view — the coupling the split exists to avoid.
+
+### The `MatchDetails` serializer moves to a shared module both adapters import
+
+`_serialize_details` (today private to `matches.py`) moves to a module both the
+HTTP handlers and the MCP tools import, so both surfaces produce the same view
+object without one router depending on another's internals.
+
+### The MCP server is FastMCP, mounted on the same app at `/mcp`
+
+FastMCP 2.x, hand-written tools (not OpenAPI-generated — we curate agent-shaped
+verbs), Streamable HTTP transport, mounted `app.mount("/mcp", mcp.http_app())`.
+The FastMCP ASGI app has **its own lifespan** (the Streamable-HTTP session
+manager) which **must be combined** into the FastAPI lifespan, or every MCP call
+500s. Always mounted; **no env flag**. It is one new dependency (`fastmcp`).
+
+The CSRF middleware (`main.py:149`) **only engages when a session cookie is
+present**, so cookieless bearer MCP requests bypass it by construction — no
+exemption needed. A mounted Starlette sub-app does **not** contribute to the
+parent `openapi.json`, so the MCP endpoint does not appear in `schema.d.ts` /
+`Types.swift`; the regen step is run as a drift safety-check and is expected to
+be a no-op.
+
+### Auth is one shared token→user resolver wrapped in a FastMCP `TokenVerifier`
+
+The bare lookup — `hash_token(raw)` → live `context="api"` `User`, tombstoned
+excluded — is extracted into one function that **both** `_find_api_token_user`
+(the HTTP bearer path) and a FastMCP `TokenVerifier` call, so MCP auth and
+API-token auth can never drift. The verifier authenticates *every* tool at the
+transport; unauthenticated calls fail there, not inside a tool. Each tool owns
+its own DB session via a shared helper (`api/CLAUDE.md`: "outside a request you
+own the session lifecycle yourself").
+
+### The tool surface is nine curated verbs
+
+Reads: `get_match`, `list_my_matches`, `search_players`. Writes: `create_match`,
+`enter_game_score`, `update_game_score`, `delete_game_score`, `propose_result`
+(one tool for both the first proposal and a counter/correction, via
+`supersedes_result_id`), `accept_result`. The reads exist because an agent
+cannot drive the negotiation blind — it re-reads state with `get_match` to learn
+whose turn it is and the `result_id` to accept or supersede.
+
+### Errors surface as actionable `ToolError`s; the agent recovers via `get_match`
+
+Reconcilable conflicts (`NegotiationConflictError`, `ScoreConflictError`) map to
+a `ToolError` whose message names the recovery (*"this proposal was superseded;
+call `get_match` for the current standing result, then counter or accept"*).
+Tool return schemas stay clean — happy path is always `MatchDetails`, errors are
+errors — because the reconciliation state is always one `get_match` away.
+Rejected for v1: bespoke structured conflict payloads (a discriminated
+`{ok, conflict, match}` union on every tool) — a nicety to add later if agents
+thrash, not warranted now.
+
+### Access is inherited from who-can-mint; no MCP-specific RBAC
+
+An MCP call is authorized exactly like the equivalent HTTP endpoint — a valid
+`context="api"` token identifies the user; authorization is the same in-domain
+participant check the services enforce. Minting stays gated on `api_token.manage`
+(operator-only, per #1130), so the MCP server is **operator-only for now**. This
+is a **known, accepted limitation**, not fixed here — broadening self-serve token
+minting is #1130's surface, orthogonal to adding the server.
+
+### Testing is three-tiered
+
+The **service layer** carries the branch matrix (create/score/propose/accept/
+counter/conflicts/search) via direct construction with a real `db_session`. The
+existing **HTTP endpoint tests stay green and unchanged** as a regression net
+proving the wire contract held. **MCP tests are thin**: a valid bearer token
+drives one happy-path round-trip (create → score → propose → accept), an
+invalid/missing/tombstoned token is rejected at the transport, and one
+representative conflict surfaces as a `ToolError`.
+
+## Consequences
+
+- **One source of truth for the match flow.** The negotiation rules live once,
+  in services; the HTTP handler and the MCP tools are thin adapters. A future
+  third caller (a worker, a script) reuses the same services.
+- **The HTTP wire contract is unchanged.** Every current status code and body is
+  reproduced by the HTTP adapter; the endpoint tests are the proof. If one has
+  to change, that is a red flag the refactor altered behavior.
+- **`fastmcp` is a new dependency** in `api/pyproject.toml`, and the FastAPI
+  lifespan gains the FastMCP session-manager lifespan.
+- **The MCP server is operator-only** until token minting is broadened — an
+  inherited limitation, documented, not a bug.
+- **`api/`-only, no schema change** (reuses `UserToken`; no new column or
+  migration). No web/iOS change; regen is a drift check expected to no-op.


### PR DESCRIPTION
## What

Adds an **MCP server** to the API (mounted at `/mcp`, FastMCP over streamable-HTTP) that exposes the match-flow — **create, score, and the approval/correction (propose/accept) negotiation** — to agents, authenticated with the existing opaque `context="api"` bearer tokens (#1130). To do it without duplicating logic, the match-flow write path is first **extracted into shared, FastAPI-free service objects** that both the existing HTTP handlers and the new MCP tools drive as thin adapters.

Decisions are captured in `docs/adr/20260718-the-match-flow-is-shared-services-behind-http-and-mcp-adapters.md`.

## The core invariant: the REST API does not change

This is an internal refactor + an *additive* `/mcp` mount. Every existing route keeps its path, method, schema, status codes, and docstring — only internals move (handler-inline → shared services). Proof:

- **Every existing endpoint test passes unedited** (`test_matches.py`, `test_api_tokens.py`, `test_session.py`, `test_players.py`, …) — the endpoint tests were a hard invariant on every chore.
- **Zero OpenAPI drift**: `app.openapi()` is byte-identical to the base branch, and the `/mcp` mount (a Starlette sub-app) is excluded from `openapi.json` — so `schema.d.ts` and `Types.swift` regenerate to an empty diff. **Web and iOS clients see an identical surface.**

## The shared service layer

Write logic lifted out of the `matches.py` router into FastAPI-free services returning the domain `Match` and raising **domain exceptions** (adapters map them — HTTP to its exact status/body, MCP to `ToolError`):

- `app/match_creation.py` — `create_match`
- `app/match_scoring.py` — per-game `enter/update/delete_game_score` incl. the load+lock+scorable+overrun guards
- `app/result_proposal.py` — `propose_result` (first + counter negotiation)
- `app/result_acceptance.py` — `accept_result` (+ the existing `accept_standing_result`)
- `app/player_search.py` — the opponent-typeahead query
- `app/api_token_auth.py` — the shared `token → context="api" User` resolver (reused by the HTTP bearer path **and** the MCP `TokenVerifier`, so they can't drift)
- `app/match_serialization.py` — the shared `MatchDetails` serializer

## The MCP surface (9 tools)

Reads: `get_match`, `list_my_matches` (caller-scoped, **not** the global feed), `search_players`.
Writes: `create_match`, `enter_game_score`, `update_game_score`, `delete_game_score`, `propose_result` (first + counter via `supersedes_result_id`), `accept_result`.

Auth is a FastMCP `TokenVerifier` over the shared resolver — every tool is authenticated at the transport; a missing/invalid/tombstoned token is rejected there. Reconcilable conflicts (superseded proposal, stale score version) surface as `ToolError`s that name `get_match` as the recovery.

## Known limitation (by design, documented)

Minting a `context="api"` token stays gated on `api_token.manage` (operator-only, per #1130), so **the MCP server is operator-only for now** — an inherited property of who-can-mint, not changed here.

## Deferred cleanup (for review)

`app/mcp_server.py` imports `_notify_result_posted` from the `app.matches` router (cycle-free, functionally correct); per `api/CLAUDE.md` it should be relocated to a shared module. Flagged for the `/simplify` pass.

## Tests

Service-layer branch coverage (direct construction) + the existing HTTP endpoint tests unchanged as a regression net + thin MCP integration tests over the real mounted transport (auth, one happy round-trip per surface, representative conflicts). Full api suite: **1449 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
