### PR TITLE
Solver returns specific, actionable feedback on failure (#1100)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -521,6 +521,48 @@ _Avoid_: pin (the call *causes* a pin, but a **manual placement** also pins with
 call; the pin is the placement's fixedness, the call is the promise to the players),
 notify (the call includes a notification but is the whole state transition, not just it).
 
+**Infeasible** (scheduler-era):
+A **solve** outcome: the **scheduler** *proved* the day's matches cannot all be placed
+on their tables inside their windows. A **designed outcome, not a failure** — proving a
+day does not fit is the point of a pre-live solve — kept distinct from *failed* (the job
+itself broke) and from *unknown* (the time cap ran out before any answer). An infeasible
+solve changes nothing: the last accepted **placements** stand.
+_Avoid_: failed (a broken job, not a proven non-fit), impossible, error.
+
+**Infeasibility reason** (scheduler-era):
+Why an **infeasible** solve does not fit, carried as a small closed set of causes rather
+than the bare verdict. Each is either a **structural cause** (certain, and it names the
+offending **pool** or **fixture**) or the single residual **timing conflict** (best-effort).
+The reason is computed in ids and minutes by the pure solver, then **resolved to the pool's
+display name and wall-clock window at the moment the solve is applied** — so the ledger row
+records what the director saw then and stays legible even if that pool is later renamed or
+removed. All structural causes are reported together, so a director fixes them in one pass.
+_Avoid_: error message (it is structured data the client renders, not a server sentence),
+diagnostic.
+
+**Structural cause** (scheduler-era):
+An **infeasibility reason** the scheduler is *certain* of, provable by arithmetic before
+CP-SAT runs, and that **names an entity**: a **pool** with no tables, a **fixture** whose
+window is too short to hold even one of its matches, or a pool over **per-pool capacity**.
+Contrast the **timing conflict**, which is the residual best-effort case.
+_Avoid_: hard failure, constraint violation.
+
+**Per-pool capacity** (scheduler-era):
+A **pool**'s ceiling on match time: its window length times its table count. Because a
+pool's **fixtures** can run only on that pool's tables in that pool's window, aggregate
+match-time exceeding this ceiling is a *proof* the pool cannot fit (sharing tables across
+pools only lowers real capacity, never raises it) — one of the **structural causes**.
+_Avoid_: table-time budget (reserve for the whole-day figure the **timing conflict** cites).
+
+**Timing conflict** (scheduler-era):
+The single residual **infeasibility reason**: CP-SAT proved the day infeasible, yet every
+**structural cause** passed — so there *is* enough total table-time and the obstacle is
+*arrangement*, not capacity (a **player** in too many matches too close together, or tables
+contended across overlapping windows). Reported best-effort, telling the director not to add
+tables; naming the exact fixtures/players is deferred (#1129).
+_Avoid_: over capacity (the opposite — capacity is sufficient here), unknown (that is the
+time-cap verdict, which carries no reason at all).
+
 ## Dashboard
 
 **First-match**:

--- a/api/app/admin_schedule_solves.py
+++ b/api/app/admin_schedule_solves.py
@@ -21,6 +21,7 @@ from app.db import get_session
 from app.models import ScheduleSolve, Tournament
 from app.rbac import require_permission
 from app.schemas.admin import AdminScheduleSolveListResponse, AdminScheduleSolveRead
+from app.schemas.schedule_solve import parse_infeasibility_reasons
 
 # Gates the Administration area's solve-ledger page. Seeded (scripts/seed_rbac.py)
 # and granted to the Administrator role, like the other admin-tool permissions.
@@ -49,6 +50,7 @@ def _serialize(solve: ScheduleSolve, tournament_name: str) -> AdminScheduleSolve
         fixtures_placed=solve.fixtures_placed,
         fixtures_pinned=solve.fixtures_pinned,
         error=solve.error,
+        infeasibility_reasons=parse_infeasibility_reasons(solve.infeasibility_reasons),
         input_fingerprint=solve.input_fingerprint,
         rerun_requested=solve.rerun_requested,
         tournament_id=solve.tournament_id,

--- a/api/app/models/schedule_solve.py
+++ b/api/app/models/schedule_solve.py
@@ -1,6 +1,7 @@
 import enum
 import uuid
 from datetime import datetime
+from typing import Any
 
 from sqlalchemy import (
     Boolean,
@@ -13,7 +14,7 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db import Base
@@ -139,6 +140,12 @@ class ScheduleSolve(Base):
     input_fingerprint: Mapped[str | None] = mapped_column(Text, nullable=True)
     #: Why a ``failed`` run failed. ``NULL`` on every other status.
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    #: Structured reasons an ``infeasible`` solve did not fit, kept raw here; a
+    #: later boundary parses this into Pydantic models. ``NULL`` on every other
+    #: status.
+    infeasibility_reasons: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        JSONB, nullable=True
+    )
     #: The coalesced enqueue's second arm: a trigger that lands while this row is
     #: ``running`` cannot be absorbed by a queued row (there isn't one) and must
     #: not enqueue a second job (one solve in flight per tournament) — so it sets

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -722,9 +722,6 @@ async def _load_solver_inputs(
                 window_start=pool.slot.start,
                 window_end=pool.slot.end,
             )
-    for event, settings, _pools in parsed_events:
-        for fixture in fixtures_by_event[event.id]:
-            fixture_best_of[str(fixture.id)] = settings.length_games
 
     # The minute frame's origin: the earliest pool window start. Everything —
     # windows, pins, previous placements, ``now`` itself — is offset from it,
@@ -755,7 +752,7 @@ async def _load_solver_inputs(
     rest_shadows: list[RestShadow] = []
     broken_pin_moves: set[uuid.UUID] = set()
     broken_pin_voids: set[uuid.UUID] = set()
-    for event, _settings, _pools in parsed_events:
+    for event, settings, _pools in parsed_events:
         for fixture in fixtures_by_event[event.id]:
             if fixture.pool_id is None:
                 # Un-pooled (single-elim / a KO stage): no pool, no window —
@@ -809,6 +806,10 @@ async def _load_solver_inputs(
                         start_min=to_min(fixture.scheduled_start),
                     )
             fixture_id = FixtureId(str(fixture.id))
+            # Only placeable (pooled, both-sides-known) fixtures reach here, and
+            # only such a fixture can surface in a WindowTooShortForMatch reason —
+            # so this is exactly the set the apply resolves best_of for.
+            fixture_best_of[fixture_id] = settings.length_games
             schedule_fixtures.append(
                 ScheduleFixture(
                     id=fixture_id,

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -118,9 +118,9 @@ import os
 import uuid
 from collections import defaultdict
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Literal, assert_never
 
 from redis.exceptions import RedisError
 from sqlalchemy import exists, select, update
@@ -150,10 +150,14 @@ from app.scheduling import (
     EventId,
     EventSettings,
     FixtureId,
+    InfeasibilityReason,
     InProgressMatch,
+    NoSingleCause,
     Pin,
     PlayerId,
+    PoolHasNoTables,
     PoolId,
+    PoolOverCapacity,
     PreviousPlacement,
     RestShadow,
     ScheduleFixture,
@@ -162,8 +166,16 @@ from app.scheduling import (
     SolveResult,
     TableId,
     Window,
+    WindowTooShortForMatch,
 )
 from app.schemas.notification import NotificationJob
+from app.schemas.schedule_solve import (
+    NoSingleCauseRead,
+    PoolHasNoTablesRead,
+    PoolOverCapacityRead,
+    ResolvedReason,
+    WindowTooShortForMatchRead,
+)
 from app.schemas.tournament import MatchSettings as EventMatchSettings
 from app.schemas.tournament import Pool, Slot, TournamentTable
 from app.tournament_draws import event_pools
@@ -458,6 +470,17 @@ async def latest_solve(
 
 
 @dataclass(frozen=True, slots=True)
+class _PoolResolution:
+    """The DB-side facts an infeasibility reason needs to name a pool a human
+    can act on: its display ``name`` and the ``HH:MM`` clock bounds of its
+    window (already strings on the pool's ``Slot`` — no minute→clock math)."""
+
+    name: str
+    window_start: str
+    window_end: str
+
+
+@dataclass(frozen=True, slots=True)
 class SolveInputs:
     """One transactional read of everything a solve consumes: the pure
     snapshot, its fingerprint, the wall-clock origin of the snapshot's minute
@@ -471,7 +494,15 @@ class SolveInputs:
     ``withdrawn_entry_ids`` lets the cancelled correction pick the *remaining*
     entrant. Everything these sets derive from is fingerprinted, so a
     fingerprint match between snapshot and apply guarantees the fresh read's
-    sets are the ones the solve was computed against."""
+    sets are the ones the solve was computed against.
+
+    ``pool_resolutions`` (keyed by the solver's namespaced ``PoolId`` string
+    ``f"{event.id}:{pool.id}"``) and ``fixture_best_of`` (keyed by
+    ``str(fixture.id)``) are the resolution lookups the apply humanizes an
+    *infeasible* solve's structured reasons through — pool id → name+clock,
+    fixture id → its event's ``length_games``. They derive from the same
+    fingerprinted inputs, so the fresh read's maps match the ones the reasons
+    were computed against."""
 
     snapshot: ScheduleSnapshot
     fingerprint: str
@@ -480,6 +511,8 @@ class SolveInputs:
     broken_pin_moves: frozenset[uuid.UUID] = frozenset()
     broken_pin_voids: frozenset[uuid.UUID] = frozenset()
     withdrawn_entry_ids: frozenset[uuid.UUID] = frozenset()
+    pool_resolutions: dict[str, _PoolResolution] = field(default_factory=dict)
+    fixture_best_of: dict[str, Literal[1, 3, 5, 7]] = field(default_factory=dict)
 
 
 def _fingerprint(payload: dict[str, Any]) -> str:
@@ -667,6 +700,13 @@ async def _load_solver_inputs(
     # ``SchedulePool``s are built from these same specs below (only ``base``
     # — which needs every window start first — stands between the two).
     pool_specs: list[tuple[str, tuple[TableId, ...], datetime, datetime]] = []
+    # Resolution lookups the apply humanizes an infeasible solve's reasons
+    # through: solver ``PoolId`` → the pool's display name + ``HH:MM`` bounds,
+    # and fixture id → its event's ``length_games`` (``best_of``). Built off the
+    # same parsed inputs the snapshot is, so they resolve exactly the ids the
+    # reasons carry.
+    pool_resolutions: dict[str, _PoolResolution] = {}
+    fixture_best_of: dict[str, Literal[1, 3, 5, 7]] = {}
     for event, _settings, pools in parsed_events:
         for pool in pools:
             key = f"{event.id}:{pool.id}"
@@ -677,6 +717,14 @@ async def _load_solver_inputs(
                 if TableId(table_id) in catalogue_ids
             )
             pool_specs.append((key, tables, start, end))
+            pool_resolutions[key] = _PoolResolution(
+                name=pool.name,
+                window_start=pool.slot.start,
+                window_end=pool.slot.end,
+            )
+    for event, settings, _pools in parsed_events:
+        for fixture in fixtures_by_event[event.id]:
+            fixture_best_of[str(fixture.id)] = settings.length_games
 
     # The minute frame's origin: the earliest pool window start. Everything —
     # windows, pins, previous placements, ``now`` itself — is offset from it,
@@ -892,11 +940,61 @@ async def _load_solver_inputs(
         broken_pin_moves=frozenset(broken_pin_moves),
         broken_pin_voids=frozenset(broken_pin_voids),
         withdrawn_entry_ids=frozenset(withdrawn_entry_ids),
+        pool_resolutions=pool_resolutions,
+        fixture_best_of=fixture_best_of,
     )
 
 
 def _opt(value: uuid.UUID | None) -> str | None:
     return str(value) if value is not None else None
+
+
+def _resolve_reason(reason: InfeasibilityReason, inputs: SolveInputs) -> ResolvedReason:
+    """Humanize one pure, id-and-minute reason into its resolved read form
+    (ADR "structured data, not prose"): the pool's display name and ``HH:MM``
+    window come from ``inputs.pool_resolutions``, ``best_of`` from
+    ``inputs.fixture_best_of``; the integer minutes pass through untouched for
+    the client to format. Direct id lookups are safe here — the apply resolves
+    only after the drift guard proved this read's inputs fingerprint-identical
+    to the ones the reasons were computed against, so every pool/fixture id a
+    reason carries is present in these maps (the same guarantee the placement
+    write relies on when it indexes ``fresh.fixtures``).
+
+    An exhaustive ``match`` with an ``assert_never`` floor, no catch-all: adding
+    an arm to :data:`app.scheduling.InfeasibilityReason` is a type error here
+    until it is handled."""
+    match reason:
+        case PoolHasNoTables():
+            return PoolHasNoTablesRead(
+                pool_name=inputs.pool_resolutions[reason.pool_id].name
+            )
+        case WindowTooShortForMatch():
+            pool = inputs.pool_resolutions[reason.pool_id]
+            return WindowTooShortForMatchRead(
+                pool_name=pool.name,
+                window_start=pool.window_start,
+                window_end=pool.window_end,
+                best_of=inputs.fixture_best_of[reason.fixture_id],
+                needed_min=reason.needed_min,
+                window_span_min=reason.window_span_min,
+            )
+        case PoolOverCapacity():
+            pool = inputs.pool_resolutions[reason.pool_id]
+            return PoolOverCapacityRead(
+                pool_name=pool.name,
+                window_start=pool.window_start,
+                window_end=pool.window_end,
+                required_min=reason.required_min,
+                capacity_min=reason.capacity_min,
+                table_count=reason.table_count,
+            )
+        case NoSingleCause():
+            return NoSingleCauseRead(
+                required_min=reason.required_min,
+                available_min=reason.available_min,
+            )
+        case _:
+            assert_never(reason)
 
 
 def run_schedule_solve(schedule_solve_id: str) -> None:
@@ -1113,10 +1211,20 @@ async def _apply_result(
                 )
             case scheduling.Verdict.infeasible:
                 # A designed outcome, not a failure: the solver *proved* the
-                # day does not fit. Nothing is written; existing placements
-                # (the last accepted plan) stand.
+                # day does not fit. No *placement* is written (the last accepted
+                # plan stands) — but the run records *why*: each structured,
+                # id-and-minute reason is resolved to its humanized read form
+                # (pool name + HH:MM window + best_of, minutes passed through)
+                # against ``fresh``'s maps and stored as JSONB. Only this branch
+                # writes ``infeasibility_reasons``; every other status leaves it
+                # NULL (parsed back at read via
+                # ``schemas.schedule_solve.parse_infeasibility_reasons``).
                 row.status = ScheduleSolveStatus.infeasible
                 row.verdict = SolverVerdict.infeasible
+                resolved: list[ResolvedReason] = [
+                    _resolve_reason(reason, fresh) for reason in result.reasons
+                ]
+                row.infeasibility_reasons = [reason.model_dump() for reason in resolved]
             case scheduling.Verdict.unknown:
                 # The cap ran out before any answer. No verdict — the DB enum
                 # has no ``unknown``, and a run that proved nothing has none.

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -335,14 +335,19 @@ class WindowTooShortForMatch:
 
 @dataclass(frozen=True, slots=True)
 class PoolOverCapacity:
-    """A pool whose aggregate active-fixture match-time (``required_min``)
+    """A pool whose aggregate *unpinned*-fixture match-time (``required_min``)
     exceeds the table-minutes its window offers (``capacity_min`` =
     ``window_span × table_count``). A pigeonhole bound: it is a *necessary*
     condition for the pool to fit, so a violation proves the day cannot —
     without naming which fixtures collide (that is the CP-SAT conflict core,
-    out of scope here). Deliberately conservative: it undercounts demand
-    (ignores rest padding) rather than ever overcounting, so it never *falsely*
-    reports over-capacity."""
+    out of scope here). Scoped to unpinned fixtures only: pins/in-progress are
+    not constrained to this pool's tables or window (ADR-0790), so counting them
+    could invent a false over-capacity. Deliberately conservative — it excludes
+    pins and undercounts demand (ignores rest padding) rather than ever
+    overcounting, so it never *falsely* reports over-capacity. The trade-off is
+    completeness: a pool that fits its unpinned fixtures but only overflows once
+    in-window pins are layered in is left to CP-SAT and surfaces as
+    ``NoSingleCause``."""
 
     pool_id: PoolId
     required_min: int
@@ -570,17 +575,25 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
     # A day that cannot possibly be placed should explain every certain cause at
     # once (the director fixes them together), not just the first one hit. Three
     # certain, per-structure causes need no solver to prove:
-    #   * PoolHasNoTables — a pool with active fixtures but no tables to use,
+    #   * PoolHasNoTables — a pool with unpinned fixtures but no tables to use,
     #   * WindowTooShortForMatch — a single fixture whose window can't hold it,
-    #   * PoolOverCapacity — a pool's demand exceeds window_span × table_count.
+    #   * PoolOverCapacity — a pool's unpinned demand exceeds window × tables.
     # We dedupe to the *most specific* cause per pool: a no-tables or window-too-
     # short pool is already unplaceable, so we don't also pile on over-capacity
     # for it. Bucket bounds for the pools that *do* fit are recorded on the way,
     # so the window is walked once; they are only consumed when no reason fires
     # (the clean case populates every unpinned fixture).
-    active_by_pool: defaultdict[PoolId, list[ScheduleFixture]] = defaultdict(list)
-    for fixture in active:
-        active_by_pool[fixture.pool_id].append(fixture)
+    #
+    # Every arm scopes to *unpinned* demand only. Pins and in-progress fixtures
+    # are deliberately not constrained to their pool's tables or window (ADR-0790:
+    # an off-pool or out-of-window pin is a supported director action), so
+    # counting them against a pool's window×tables would invent false
+    # infeasibility. Only unpinned fixtures are constrained to their pool's tables
+    # inside its window by construction, so only they can prove a certain
+    # structural cause that can never false-fire.
+    unpinned_by_pool: defaultdict[PoolId, list[ScheduleFixture]] = defaultdict(list)
+    for fixture in unpinned:
+        unpinned_by_pool[fixture.pool_id].append(fixture)
 
     reasons: list[InfeasibilityReason] = []
     bucket_bounds: dict[FixtureId, tuple[int, int]] = {}
@@ -613,20 +626,30 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
 
     # Per-pool (in snapshot order for determinism), most-specific cause wins.
     for pool in snapshot.pools:
-        pool_fixtures = active_by_pool.get(pool.id)
-        if not pool_fixtures:
-            continue  # a pool with no demand cannot be a cause
+        pool_unpinned = unpinned_by_pool.get(pool.id)
+        if not pool_unpinned:
+            continue  # no unpinned demand: no arm can prove a cause here
         if not pool.table_ids:
+            # A no-tables pool with ≥1 unpinned fixture: that fixture has nowhere
+            # to go. A no-tables pool whose only fixtures are pinned/in-progress
+            # (placed off-pool by the director) is fine — it never reaches here.
             reasons.append(PoolHasNoTables(pool_id=pool.id))
             continue  # dominates any capacity claim for this pool
         if pool.id in pools_short_window:
             continue  # window-too-short already dominates this pool
-        # Capacity is a pigeonhole *necessary* condition: sum the match-time of
-        # every active (non-completed) fixture on this pool — pinned included,
-        # since a pin occupies table-time too — against the table-minutes the
-        # window offers. Undercounting (we ignore rest padding) keeps it
-        # conservative, so it never *falsely* reports over-capacity.
-        required_min = sum(duration_of(f) for f in pool_fixtures)
+        # Capacity is a pigeonhole *necessary* condition over *unpinned* demand:
+        # sum the match-time of this pool's unpinned fixtures (the only ones
+        # constrained to its tables inside its window) against the table-minutes
+        # the window offers. Pins/in-progress are excluded — they are not bound
+        # to this pool's tables or window (ADR-0790), so counting them could
+        # invent a false over-capacity. Dropping them keeps the bound truly
+        # conservative: a pin only ever adds contention, so unpinned-alone
+        # overflowing is a genuine, necessary infeasibility, while unpinned-alone
+        # fitting is never falsely flagged. Completeness trade-off: a pool that
+        # fits its unpinned fixtures but tips over only once in-window pins are
+        # layered in is not reported here — that case is infeasible only if
+        # CP-SAT proves it, surfacing as the honest NoSingleCause residual.
+        required_min = sum(duration_of(f) for f in pool_unpinned)
         table_count = len(pool.table_ids)
         capacity_min = (pool.window.end_min - pool.window.start_min) * table_count
         if required_min > capacity_min:

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -310,23 +310,124 @@ class SolveStats:
 
 
 @dataclass(frozen=True, slots=True)
+class PoolHasNoTables:
+    """A pool that carries active fixtures but no tables at all — its unpinned
+    fixtures have nowhere to be placed. The most specific, most certain cause a
+    pool can have: no search is needed to know it cannot run."""
+
+    pool_id: PoolId
+    kind: Literal["pool_has_no_tables"] = "pool_has_no_tables"
+
+
+@dataclass(frozen=True, slots=True)
+class WindowTooShortForMatch:
+    """A single unpinned fixture whose pool window cannot hold even one match
+    contiguously (the ``lo > hi`` case): its match needs ``needed_min`` minutes
+    but the pool's playable span is only ``window_span_min``. Certain and
+    per-fixture — no other fixture's placement can rescue it."""
+
+    pool_id: PoolId
+    fixture_id: FixtureId
+    needed_min: int
+    window_span_min: int
+    kind: Literal["window_too_short_for_match"] = "window_too_short_for_match"
+
+
+@dataclass(frozen=True, slots=True)
+class PoolOverCapacity:
+    """A pool whose aggregate active-fixture match-time (``required_min``)
+    exceeds the table-minutes its window offers (``capacity_min`` =
+    ``window_span × table_count``). A pigeonhole bound: it is a *necessary*
+    condition for the pool to fit, so a violation proves the day cannot —
+    without naming which fixtures collide (that is the CP-SAT conflict core,
+    out of scope here). Deliberately conservative: it undercounts demand
+    (ignores rest padding) rather than ever overcounting, so it never *falsely*
+    reports over-capacity."""
+
+    pool_id: PoolId
+    required_min: int
+    capacity_min: int
+    table_count: int
+    kind: Literal["pool_over_capacity"] = "pool_over_capacity"
+
+
+@dataclass(frozen=True, slots=True)
+class NoSingleCause:
+    """The honest residual: CP-SAT *proved* the day infeasible, yet no certain
+    structural cause (arms above) explains it — the infeasibility lives in the
+    combinatorial interaction of windows, rest, and no-double-booking that only
+    search sees. Carries the whole-day aggregate for context: ``required_min``
+    (Σ every active fixture's duration) against ``available_min`` (Σ over pools
+    of ``window_span × table_count``). Typically ``required_min ≤ available_min``
+    here — aggregate room exists, but it cannot be packed."""
+
+    required_min: int
+    available_min: int
+    kind: Literal["no_single_cause"] = "no_single_cause"
+
+
+#: The closed set of reasons an infeasible solve can carry. A discriminated
+#: union over ``kind``: the first three arms are *certain* structural causes a
+#: guard proves without the solver (and are collected exhaustively — every one
+#: that holds, not just the first), the last is the best-effort residual when
+#: CP-SAT refuses but no structure does. Frozen dataclasses + a ``kind``
+#: discriminator so a downstream humanizer can ``match`` exhaustively with no
+#: catch-all. Ids + minute-ints only: turning these into names and wall-clock
+#: is a later, DB-aware layer's job, not this pure module's.
+InfeasibilityReason = (
+    PoolHasNoTables | WindowTooShortForMatch | PoolOverCapacity | NoSingleCause
+)
+
+
+@dataclass(frozen=True, slots=True)
 class SolveResult:
     """A solve's whole answer. Placements cover every active fixture that is
     not in progress — pins echoed verbatim, unpinned fixtures solved — or are
     empty when ``verdict`` produced no plan. Deterministically ordered by
-    ``(start, table, fixture)``."""
+    ``(start, table, fixture)``.
+
+    ``reasons`` is non-empty exactly when ``verdict`` is
+    :attr:`Verdict.infeasible` and empty (``()``) for every other verdict
+    (optimal / feasible / unknown, including the trivial no-active-fixtures
+    optimal). It carries the structured, id-and-minute-only explanation of
+    *why* the day does not fit — see :data:`InfeasibilityReason`."""
 
     verdict: Verdict
     placements: tuple[PlacedFixture, ...]
     stats: SolveStats
+    reasons: tuple[InfeasibilityReason, ...] = ()
 
 
-def _no_plan(verdict: Verdict, wall_time_ms: int = 0) -> SolveResult:
+def _no_plan(
+    verdict: Verdict,
+    wall_time_ms: int = 0,
+    reasons: tuple[InfeasibilityReason, ...] = (),
+) -> SolveResult:
     return SolveResult(
         verdict=verdict,
         placements=(),
         stats=SolveStats(wall_time_ms=wall_time_ms, objective=None),
+        reasons=reasons,
     )
+
+
+def _aggregate_capacity(snapshot: ScheduleSnapshot) -> tuple[int, int]:
+    """``(required_min, available_min)`` for the whole day: Σ every active
+    fixture's duration against Σ over pools of ``window_span × table_count``.
+    The rough aggregate behind :class:`NoSingleCause`. Reads the event map
+    directly — a solve only reaches this on a *built* model, so the snapshot's
+    cross-references have already passed :func:`_validated`."""
+    events = {e.id: e for e in snapshot.events}
+    required = sum(
+        match_minutes(events[f.event_id].length_games)
+        for f in snapshot.fixtures
+        if not f.completed
+    )
+    available = sum(
+        (p.window.end_min - p.window.start_min) * len(p.table_ids)
+        for p in snapshot.pools
+    )
+    return required, available
 
 
 def _validated(
@@ -465,21 +566,83 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
     for end in occupancy_ends.values():
         horizon = max(horizon, end)
 
-    # Structural feasibility first: a fixture whose window cannot hold its
-    # duration at all needs no solver to refuse. (Whole-or-nothing: one
-    # unplaceable fixture makes the entire day infeasible, by design.)
+    # Structural feasibility first — but gathered *exhaustively*, not first-fail.
+    # A day that cannot possibly be placed should explain every certain cause at
+    # once (the director fixes them together), not just the first one hit. Three
+    # certain, per-structure causes need no solver to prove:
+    #   * PoolHasNoTables — a pool with active fixtures but no tables to use,
+    #   * WindowTooShortForMatch — a single fixture whose window can't hold it,
+    #   * PoolOverCapacity — a pool's demand exceeds window_span × table_count.
+    # We dedupe to the *most specific* cause per pool: a no-tables or window-too-
+    # short pool is already unplaceable, so we don't also pile on over-capacity
+    # for it. Bucket bounds for the pools that *do* fit are recorded on the way,
+    # so the window is walked once; they are only consumed when no reason fires
+    # (the clean case populates every unpinned fixture).
+    active_by_pool: defaultdict[PoolId, list[ScheduleFixture]] = defaultdict(list)
+    for fixture in active:
+        active_by_pool[fixture.pool_id].append(fixture)
+
+    reasons: list[InfeasibilityReason] = []
     bucket_bounds: dict[FixtureId, tuple[int, int]] = {}
+    pools_short_window: set[PoolId] = set()
+
+    # Per-fixture: does this unpinned fixture's window hold even one match
+    # contiguously? (Pinned fixtures outrank windows, so they never apply here.)
+    # A no-tables pool is covered by PoolHasNoTables below, so skip its fixtures.
     for fixture in unpinned:
         pool = pools[fixture.pool_id]
         if not pool.table_ids:
-            return _no_plan(Verdict.infeasible)
+            continue
+        needed = duration_of(fixture)
         earliest = max(now, pool.window.start_min)
-        latest = pool.window.end_min - duration_of(fixture)
+        latest = pool.window.end_min - needed
         lo = -(-earliest // BUCKET_MIN)  # ceil: first grid start not in the past
         hi = latest // BUCKET_MIN  # floor: last grid start that still fits
         if lo > hi:
-            return _no_plan(Verdict.infeasible)
+            reasons.append(
+                WindowTooShortForMatch(
+                    pool_id=pool.id,
+                    fixture_id=fixture.id,
+                    needed_min=needed,
+                    window_span_min=pool.window.end_min - pool.window.start_min,
+                )
+            )
+            pools_short_window.add(pool.id)
+            continue
         bucket_bounds[fixture.id] = (lo, hi)
+
+    # Per-pool (in snapshot order for determinism), most-specific cause wins.
+    for pool in snapshot.pools:
+        pool_fixtures = active_by_pool.get(pool.id)
+        if not pool_fixtures:
+            continue  # a pool with no demand cannot be a cause
+        if not pool.table_ids:
+            reasons.append(PoolHasNoTables(pool_id=pool.id))
+            continue  # dominates any capacity claim for this pool
+        if pool.id in pools_short_window:
+            continue  # window-too-short already dominates this pool
+        # Capacity is a pigeonhole *necessary* condition: sum the match-time of
+        # every active (non-completed) fixture on this pool — pinned included,
+        # since a pin occupies table-time too — against the table-minutes the
+        # window offers. Undercounting (we ignore rest padding) keeps it
+        # conservative, so it never *falsely* reports over-capacity.
+        required_min = sum(duration_of(f) for f in pool_fixtures)
+        table_count = len(pool.table_ids)
+        capacity_min = (pool.window.end_min - pool.window.start_min) * table_count
+        if required_min > capacity_min:
+            reasons.append(
+                PoolOverCapacity(
+                    pool_id=pool.id,
+                    required_min=required_min,
+                    capacity_min=capacity_min,
+                    table_count=table_count,
+                )
+            )
+
+    if reasons:
+        # A certain structural infeasibility: refuse without building or running
+        # CP-SAT, but carry every cause we found rather than a bare verdict.
+        return _no_plan(Verdict.infeasible, reasons=tuple(reasons))
 
     model = cp_model.CpModel()
     table_intervals: defaultdict[TableId, list[Any]] = defaultdict(list)
@@ -710,7 +873,17 @@ def solve(
             "in app.scheduling, not a property of the tournament."
         )
     if status == cp_model.INFEASIBLE:
-        return _no_plan(Verdict.infeasible, wall_time_ms)
+        # CP-SAT proved it, but the structural pre-check found no certain cause
+        # (by construction: it returns before we ever build the model). Attach
+        # the honest residual — the whole-day aggregate, no single blamed pool.
+        required_min, available_min = _aggregate_capacity(snapshot)
+        return _no_plan(
+            Verdict.infeasible,
+            wall_time_ms,
+            reasons=(
+                NoSingleCause(required_min=required_min, available_min=available_min),
+            ),
+        )
     if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
         return _no_plan(Verdict.unknown, wall_time_ms)
 

--- a/api/app/schemas/schedule_solve.py
+++ b/api/app/schemas/schedule_solve.py
@@ -1,0 +1,101 @@
+"""The read boundary for a schedule solve's *resolved* infeasibility reasons.
+
+``app.scheduling`` proves a day infeasible and emits structured, id-and-minute
+only reasons (:data:`app.scheduling.InfeasibilityReason`) — pure and DB-blind on
+purpose. This module is the DB-aware humanizer: it carries the *resolved* form a
+client can render without any further lookup — the pool's display **name**, the
+window's ``HH:MM`` clock bounds, the event's ``best_of`` — while leaving the raw
+integer minutes (needed / span / required / capacity / available) untouched so
+the client formats hours itself.
+
+Structured, not prose (ADR "an infeasible solve explains itself with a resolved
+reason"): a discriminated union over ``kind`` — the *same* discriminator strings
+the pure module stamps — so a downstream renderer ``match``es it exhaustively
+with no catch-all, and OpenAPI describes each arm precisely. The union is the
+one importable alias :data:`ResolvedReason`, reused wherever a solve's reasons
+are read (the ledger's persisted JSONB, and :class:`ScheduleSolveRead`).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, TypeAdapter
+
+
+class PoolHasNoTablesRead(BaseModel):
+    """A pool with active fixtures but no tables at all — nowhere to place them.
+    Resolved: the pool's display ``name`` (never the namespaced solver id)."""
+
+    kind: Literal["pool_has_no_tables"] = "pool_has_no_tables"
+    pool_name: str
+
+
+class WindowTooShortForMatchRead(BaseModel):
+    """A single fixture whose pool window cannot hold even one match: its
+    ``best_of`` match needs ``needed_min`` minutes but the window spans only
+    ``window_span_min``. Resolved: the pool ``name`` and its ``HH:MM`` window
+    bounds; the minutes pass through as integers for the client to format."""
+
+    kind: Literal["window_too_short_for_match"] = "window_too_short_for_match"
+    pool_name: str
+    window_start: str
+    window_end: str
+    best_of: Literal[1, 3, 5, 7]
+    needed_min: int
+    window_span_min: int
+
+
+class PoolOverCapacityRead(BaseModel):
+    """A pool whose aggregate match-time (``required_min``) exceeds the
+    table-minutes its window offers (``capacity_min`` = window span ×
+    ``table_count``). Resolved: the pool ``name`` and its ``HH:MM`` bounds; the
+    minutes stay integers."""
+
+    kind: Literal["pool_over_capacity"] = "pool_over_capacity"
+    pool_name: str
+    window_start: str
+    window_end: str
+    required_min: int
+    capacity_min: int
+    table_count: int
+
+
+class NoSingleCauseRead(BaseModel):
+    """CP-SAT proved the day infeasible yet no structural arm explains it — the
+    whole-day residual. No pool: it carries only the day aggregate,
+    ``required_min`` against ``available_min``, as integer minutes."""
+
+    kind: Literal["no_single_cause"] = "no_single_cause"
+    required_min: int
+    available_min: int
+
+
+#: The closed set of *resolved* reasons an infeasible solve carries — the
+#: DB-aware mirror of :data:`app.scheduling.InfeasibilityReason`, humanized once
+#: at apply and parsed back here at every read. Discriminated on ``kind`` so a
+#: renderer is a total function of it (add an arm → a type error until handled).
+ResolvedReason = Annotated[
+    PoolHasNoTablesRead
+    | WindowTooShortForMatchRead
+    | PoolOverCapacityRead
+    | NoSingleCauseRead,
+    Field(discriminator="kind"),
+]
+
+#: Parses the ledger's raw JSONB (``list[dict]``) back into the typed union in
+#: one place, so no read path downstream ever touches a raw dict (parse, don't
+#: validate). Built once at import — a ``TypeAdapter`` is reusable and cached.
+_REASONS_ADAPTER: TypeAdapter[list[ResolvedReason]] = TypeAdapter(list[ResolvedReason])
+
+
+def parse_infeasibility_reasons(
+    raw: list[dict[str, Any]] | None,
+) -> list[ResolvedReason]:
+    """Turn the ledger's ``infeasibility_reasons`` JSONB into typed reasons.
+
+    ``None`` (every non-``infeasible`` status leaves the column NULL) parses to
+    the empty list — a solve with no reasons to explain, not an error."""
+    if raw is None:
+        return []
+    return _REASONS_ADAPTER.validate_python(raw)

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -21,6 +21,7 @@ from app.models.schedule_solve import (
     SolverVerdict,
 )
 from app.models.tournament import DrawType, EventFormat, TournamentStatus
+from app.schemas.schedule_solve import ResolvedReason, parse_infeasibility_reasons
 
 # ----- bounded numerics (the column is a constraint too) ---------------------
 
@@ -597,6 +598,13 @@ class ScheduleSolveRead(BaseModel):
       was discarded for drift re-runs rather than reporting partial counts — the
       apply is whole-or-nothing.
     * ``error`` — why a ``failed`` run failed; ``null`` on every other status.
+
+    ``infeasibility_reasons`` is **never null** — it is always a list, empty on
+    every row that is not ``infeasible`` (so a client never null-checks it). An
+    ``infeasible`` verdict carries the resolved, DB-humanized reasons the day
+    could not be scheduled (pool names, ``HH:MM`` window bounds, the integer
+    minutes to format); every other row carries ``[]``. Parsed from the ledger's
+    raw JSONB at this boundary so no downstream reader touches a bare dict.
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -612,6 +620,18 @@ class ScheduleSolveRead(BaseModel):
     fixtures_placed: int | None
     fixtures_pinned: int | None
     error: str | None
+    infeasibility_reasons: list[ResolvedReason]
+
+    @field_validator("infeasibility_reasons", mode="before")
+    @classmethod
+    def _parse_infeasibility_reasons(cls, value: Any) -> list[ResolvedReason]:
+        """Parse the ledger's raw ``infeasibility_reasons`` JSONB
+        (``list[dict] | None``) into the typed union at the boundary, mapping the
+        NULL of a non-``infeasible`` row to ``[]`` — so ``model_validate`` on a
+        ``ScheduleSolve`` row never fails on a null column and no raw dict leaks
+        inward. A value already parsed to typed reasons passes back through
+        unchanged."""
+        return parse_infeasibility_reasons(value)
 
 
 class StandingRowRead(BaseModel):

--- a/api/migrations/versions/20260716_0000_0013_create_schedule_solves_table.py
+++ b/api/migrations/versions/20260716_0000_0013_create_schedule_solves_table.py
@@ -107,6 +107,10 @@ def upgrade() -> None:
         sa.Column("input_fingerprint", sa.Text(), nullable=True),
         # Why a ``failed`` run failed. NULL on every other status.
         sa.Column("error", sa.Text(), nullable=True),
+        # Structured reasons an ``infeasible`` solve did not fit — raw JSONB
+        # here, parsed into Pydantic at a later boundary. NULL on every other
+        # status.
+        sa.Column("infeasibility_reasons", postgresql.JSONB(), nullable=True),
     )
     # The admin page's one read: "this tournament's solves, newest first".
     op.create_index(

--- a/api/tests/test_admin_schedule_solves.py
+++ b/api/tests/test_admin_schedule_solves.py
@@ -7,6 +7,7 @@ deliberately omits."""
 
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -73,6 +74,7 @@ async def _add_solve(
     started_at: datetime | None = None,
     input_fingerprint: str | None = None,
     rerun_requested: bool = False,
+    infeasibility_reasons: list[dict[str, Any]] | None = None,
 ) -> uuid.UUID:
     row = ScheduleSolve(
         tournament_id=tournament_id,
@@ -83,6 +85,7 @@ async def _add_solve(
         started_at=started_at,
         input_fingerprint=input_fingerprint,
         rerun_requested=rerun_requested,
+        infeasibility_reasons=infeasibility_reasons,
     )
     db.add(row)
     await db.flush()
@@ -172,6 +175,57 @@ async def test_rows_carry_the_operator_only_facts(
     assert item["rerun_requested"] is True
     assert item["tournament_id"] == str(tournament_id)
     assert item["tournament_name"] == "Winter Masters"
+    # A non-infeasible row carries an empty list, never a null.
+    assert item["infeasibility_reasons"] == []
+
+
+async def test_infeasible_row_carries_resolved_reasons(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """An ``infeasible`` ledger row's admin read carries the resolved reasons,
+    parsed from the raw JSONB into the typed union at the boundary — the same
+    ``ScheduleSolveRead`` field the detail BFF exposes."""
+    admin = await _admin_session(api_client, db_session)
+    tournament_id = await _make_tournament(db_session, admin, "Spring Open")
+    await _add_solve(
+        db_session,
+        tournament_id,
+        requested_at=T0,
+        status=ScheduleSolveStatus.infeasible,
+        verdict=SolverVerdict.infeasible,
+        infeasibility_reasons=[
+            {
+                "kind": "window_too_short_for_match",
+                "pool_name": "Pool A",
+                "window_start": "09:00",
+                "window_end": "09:10",
+                "best_of": 5,
+                "needed_min": 45,
+                "window_span_min": 10,
+            },
+            {"kind": "no_single_cause", "required_min": 600, "available_min": 480},
+        ],
+    )
+    await db_session.commit()
+
+    response = await api_client.get(URL)
+    assert response.status_code == 200
+    (item,) = response.json()["items"]
+    reasons = item["infeasibility_reasons"]
+    assert [r["kind"] for r in reasons] == [
+        "window_too_short_for_match",
+        "no_single_cause",
+    ]
+    window = reasons[0]
+    assert window["pool_name"] == "Pool A"
+    assert window["best_of"] == 5
+    assert window["needed_min"] == 45
+    assert window["window_span_min"] == 10
+    assert reasons[1] == {
+        "kind": "no_single_cause",
+        "required_min": 600,
+        "available_min": 480,
+    }
 
 
 async def test_tournament_id_filter_narrows_rows_and_total(

--- a/api/tests/test_schedule_solve_models.py
+++ b/api/tests/test_schedule_solve_models.py
@@ -213,6 +213,7 @@ async def test_schedule_solve_read_refuses_an_unknown_enum_value(
         "fixtures_placed": None,
         "fixtures_pinned": None,
         "error": None,
+        "infeasibility_reasons": [],
     }
     assert ScheduleSolveRead.model_validate(payload).trigger is (
         ScheduleSolveTrigger.manual

--- a/api/tests/test_schedule_solve_route.py
+++ b/api/tests/test_schedule_solve_route.py
@@ -382,6 +382,63 @@ async def test_solve_strip_carries_the_newest_row_by_requested_at(
     assert strip["status"] == "failed"
     assert strip["trigger"] == "manual"
     assert strip["error"] == "the solver caught fire"
+    # Never-infeasible rows carry an empty list, never a null — the client never
+    # null-checks ``infeasibility_reasons``.
+    assert strip["infeasibility_reasons"] == []
+
+
+async def test_solve_strip_carries_resolved_infeasibility_reasons(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """An ``infeasible`` solve's strip carries the resolved, DB-humanized reasons
+    the day did not fit — parsed from the ledger's raw JSONB into the typed union
+    at the read boundary, so a client renders the pool name / window / minutes
+    without any further lookup."""
+    client, owner = authed_client
+    tournament_id, _ = await _make_tournament(db_session, owner)
+    solve = ScheduleSolve(
+        tournament_id=tournament_id,
+        trigger=ScheduleSolveTrigger.manual,
+        status=ScheduleSolveStatus.infeasible,
+        verdict=SolverVerdict.infeasible,
+        requested_at=datetime(2030, 1, 1, 9, 0, tzinfo=UTC),
+        infeasibility_reasons=[
+            {"kind": "pool_has_no_tables", "pool_name": "Pool A"},
+            {
+                "kind": "pool_over_capacity",
+                "pool_name": "Pool A",
+                "window_start": "09:00",
+                "window_end": "17:00",
+                "required_min": 600,
+                "capacity_min": 480,
+                "table_count": 1,
+            },
+        ],
+    )
+    db_session.add(solve)
+    await db_session.commit()
+
+    strip = (await client.get(_detail_url(tournament_id))).json()[
+        "latest_schedule_solve"
+    ]
+
+    assert strip["id"] == str(solve.id)
+    assert strip["status"] == "infeasible"
+    assert strip["verdict"] == "infeasible"
+    reasons = strip["infeasibility_reasons"]
+    assert [r["kind"] for r in reasons] == [
+        "pool_has_no_tables",
+        "pool_over_capacity",
+    ]
+    assert reasons[0]["pool_name"] == "Pool A"
+    over_capacity = reasons[1]
+    assert over_capacity["pool_name"] == "Pool A"
+    assert over_capacity["window_start"] == "09:00"
+    assert over_capacity["window_end"] == "17:00"
+    assert over_capacity["required_min"] == 600
+    assert over_capacity["capacity_min"] == 480
+    assert over_capacity["table_count"] == 1
 
 
 async def test_after_the_drained_job_the_solve_strip_and_pin_facts_reach_the_page(

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -73,10 +73,18 @@ from app.schedule_solves import (
 )
 from app.scheduling import (
     REST_MIN,
+    PoolHasNoTables,
+    PoolId,
+    PoolOverCapacity,
     ScheduleSnapshot,
     SolveResult,
     SolveStats,
     Verdict,
+)
+from app.schemas.schedule_solve import (
+    PoolHasNoTablesRead,
+    PoolOverCapacityRead,
+    parse_infeasibility_reasons,
 )
 from app.tournament_draws import cut_draw
 from tests._helpers import hijack_solve, make_user
@@ -1020,6 +1028,121 @@ class TestSolveJob:
         assert rerun.status is ScheduleSolveStatus.queued
         assert rerun.trigger is ScheduleSolveTrigger.rerun
         assert len(solver_queue.jobs) == 2
+
+    async def test_infeasible_reasons_are_resolved_to_names_and_clock(
+        self,
+        db_session: AsyncSession,
+        solver_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An infeasible verdict's structured, id-and-minute reasons are
+        humanized at apply: the persisted ``infeasibility_reasons`` carry the
+        pool's DISPLAY NAME (not the namespaced solver id) and, for the capacity
+        arm, the ``HH:MM`` window and the integer minutes verbatim."""
+        tournament_id, event_id = await _make_tournament(
+            db_session, window=("09:00", "17:00")
+        )
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+        assert row is not None
+        row_id = row.id
+        await db_session.commit()
+
+        pool_id = PoolId(f"{event_id}:pool-a")
+
+        def infeasible(
+            snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+        ) -> SolveResult:
+            return SolveResult(
+                verdict=Verdict.infeasible,
+                placements=(),
+                stats=SolveStats(wall_time_ms=77, objective=None),
+                reasons=(
+                    PoolHasNoTables(pool_id=pool_id),
+                    PoolOverCapacity(
+                        pool_id=pool_id,
+                        required_min=600,
+                        capacity_min=480,
+                        table_count=2,
+                    ),
+                ),
+            )
+
+        monkeypatch.setattr(schedule_solves, "_solve", infeasible)
+        _run_recorded_job(solver_queue, row_id)
+
+        db_session.expire_all()
+        (ledger,) = await _solve_rows(db_session, tournament_id)
+        assert ledger.status is ScheduleSolveStatus.infeasible
+        assert ledger.verdict is SolverVerdict.infeasible
+
+        reasons = parse_infeasibility_reasons(ledger.infeasibility_reasons)
+        no_tables, over_capacity = reasons
+        assert isinstance(no_tables, PoolHasNoTablesRead)
+        # The DISPLAY name, never the namespaced ``{event_id}:pool-a`` id.
+        assert no_tables.pool_name == "Pool A"
+
+        assert isinstance(over_capacity, PoolOverCapacityRead)
+        assert over_capacity.pool_name == "Pool A"
+        assert over_capacity.window_start == "09:00"
+        assert over_capacity.window_end == "17:00"
+        assert over_capacity.required_min == 600
+        assert over_capacity.capacity_min == 480
+        assert over_capacity.table_count == 2
+
+    async def test_succeeded_apply_leaves_infeasibility_reasons_null(
+        self, db_session: AsyncSession, solver_queue: Queue
+    ) -> None:
+        """Only the infeasible branch writes ``infeasibility_reasons``; a real
+        (optimal/feasible) solve leaves the column NULL."""
+        tournament_id, _event_id = await _make_tournament(db_session)
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+        assert row is not None
+        row_id = row.id
+        await db_session.commit()
+        _run_recorded_job(solver_queue, row_id)
+
+        db_session.expire_all()
+        (ledger,) = await _solve_rows(db_session, tournament_id)
+        assert ledger.status is ScheduleSolveStatus.succeeded
+        assert ledger.infeasibility_reasons is None
+        assert parse_infeasibility_reasons(ledger.infeasibility_reasons) == []
+
+    async def test_failed_apply_leaves_infeasibility_reasons_null(
+        self,
+        db_session: AsyncSession,
+        solver_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An ``unknown`` verdict fails the row (cap exhausted) and never
+        touches ``infeasibility_reasons`` — it stays NULL."""
+        tournament_id, _event_id = await _make_tournament(db_session)
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+        assert row is not None
+        row_id = row.id
+        await db_session.commit()
+
+        def exhausted(
+            snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+        ) -> SolveResult:
+            return SolveResult(
+                verdict=Verdict.unknown,
+                placements=(),
+                stats=SolveStats(wall_time_ms=5, objective=None),
+            )
+
+        monkeypatch.setattr(schedule_solves, "_solve", exhausted)
+        _run_recorded_job(solver_queue, row_id)
+
+        db_session.expire_all()
+        (ledger,) = await _solve_rows(db_session, tournament_id)
+        assert ledger.status is ScheduleSolveStatus.failed
+        assert ledger.infeasibility_reasons is None
 
 
 class TestDriftGuard:

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -429,27 +429,84 @@ class TestInfeasibility:
             ),
         )
 
-    def test_over_capacity_counts_pinned_fixtures_too(self) -> None:
-        """Capacity is about *all* demand on the pool's tables: a pin occupies
-        table-time like anything else, so a pool that is only over capacity once
-        the pin is counted still reports it."""
+    def test_over_capacity_excludes_pinned_fixtures(self) -> None:
+        """Capacity is scoped to *unpinned* demand only: a pin is not constrained
+        to its pool's tables or window (ADR-0790), so it must not be summed into
+        the pigeonhole bound. Here the lone unpinned fixture fits the window on
+        its own (25 <= 45), so the pool is never reported as over capacity even
+        though pinned + unpinned would exceed it. This is the completeness
+        trade-off: with a single shared table the pin's occupancy genuinely does
+        leave no room, so CP-SAT proves it infeasible and it surfaces as the
+        honest NoSingleCause residual, never a false PoolOverCapacity."""
         p1, p2, p3, p4 = _players(4)
         fixtures = (
-            _fixture(1, p1, p2, pin=Pin(TableId("T1"), 0)),  # 25 min pinned
+            _fixture(1, p1, p2, pin=Pin(TableId("T1"), 0)),  # 25 min pinned [0,25]
             _fixture(2, p3, p4),  # 25 min unpinned
         )
-        # One table, a 40-minute window: two 25-minute matches (50) can't fit 40.
-        snapshot = _one_pool_snapshot(fixtures, tables=1, window=(0, 40))
+        # One table, a 45-minute window. Unpinned alone (25) fits 45, so no
+        # PoolOverCapacity — but with the pin holding T1 for [0,25] the unpinned
+        # 25-min match can't also fit before 45, so CP-SAT proves infeasibility.
+        snapshot = _one_pool_snapshot(fixtures, tables=1, window=(0, 45))
         result = solve(snapshot, time_cap_s=CAP)
         assert result.verdict is Verdict.infeasible
-        assert result.reasons == (
-            PoolOverCapacity(
-                pool_id=PoolId("A"),
-                required_min=50,  # pinned 25 + unpinned 25
-                capacity_min=40,
-                table_count=1,
+        by_kind = _reasons_by_kind(result)
+        assert "pool_over_capacity" not in by_kind
+        assert result.reasons == (NoSingleCause(required_min=50, available_min=45),)
+
+    def test_no_tables_pool_with_only_a_pinned_fixture_is_not_flagged(self) -> None:
+        """Regression: a pool with no tables whose only fixture is *pinned* to a
+        catalogue table owned by another pool (a supported off-pool director
+        placement, ADR-0790) must not fire PoolHasNoTables — that arm is about a
+        pool's *unpinned* fixtures having nowhere to go, and this pool has none.
+        The pinned fixture is honored on its table and the day solves."""
+        p1, p2, p3, p4 = _players(4)
+        catalogue = _tables(1)  # T1 belongs to pool B; pool A owns no tables
+        snapshot = ScheduleSnapshot(
+            table_ids=catalogue,
+            pools=(
+                SchedulePool(PoolId("A"), (), Window(0, 480)),  # no tables
+                SchedulePool(PoolId("B"), catalogue, Window(0, 480)),
             ),
+            events=(EventSettings(EventId("E1"), 3),),
+            fixtures=(
+                # F1 lives in the no-tables pool A but is pinned onto T1 (pool B's
+                # table) — an off-pool placement the director is allowed to make.
+                _fixture(1, p1, p2, pool="A", pin=Pin(TableId("T1"), 0)),
+                _fixture(2, p3, p4, pool="B"),  # unpinned, plenty of room
+            ),
+            now_min=0,
         )
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict in SOLVED
+        by_kind = _reasons_by_kind(result)
+        assert "pool_has_no_tables" not in by_kind
+        assert result.reasons == ()
+
+    def test_off_pool_pin_does_not_push_a_pool_over_capacity(self) -> None:
+        """Regression: a pool owning one table with a comfortable window and a
+        single unpinned fixture that fits (25 <= 60) must not be reported over
+        capacity just because it *also* owns a fixture pinned to an outside table
+        whose duration would overflow the window if naively summed in
+        (25 + 45 = 70 > 60). Pins are not bound to the pool's tables/window, so
+        only the unpinned demand counts — and it fits, so the day solves."""
+        p1, p2, p3, p4 = _players(4)
+        catalogue = _tables(2)  # T1 is pool A's; T2 is the outside table
+        snapshot = ScheduleSnapshot(
+            table_ids=catalogue,
+            pools=(SchedulePool(PoolId("A"), (TableId("T1"),), Window(0, 60)),),
+            events=(EventSettings(EventId("E1"), 3),),
+            fixtures=(
+                _fixture(1, p1, p2, pool="A"),  # 25 min unpinned, fits T1 in [0,60]
+                # F2 is pool A's but pinned onto T2 (outside A's tables); 45 min.
+                _fixture(2, p3, p4, pool="A", pin=Pin(TableId("T2"), 0)),
+            ),
+            now_min=0,
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict in SOLVED
+        by_kind = _reasons_by_kind(result)
+        assert "pool_over_capacity" not in by_kind
+        assert result.reasons == ()
 
     def test_tight_shared_window_is_no_single_cause(self) -> None:
         """Every certain guard passes — each match fits its window, two tables

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -21,12 +21,16 @@ from app.scheduling import (
     EventSettings,
     FixtureId,
     IncoherentSnapshot,
+    InfeasibilityReason,
     InProgressMatch,
     MatchLength,
+    NoSingleCause,
     Pin,
     PlacedFixture,
     PlayerId,
+    PoolHasNoTables,
     PoolId,
+    PoolOverCapacity,
     PreviousPlacement,
     RestShadow,
     ScheduleFixture,
@@ -36,6 +40,7 @@ from app.scheduling import (
     TableId,
     Verdict,
     Window,
+    WindowTooShortForMatch,
     _build_model,
     _chosen_table,
     _SolverModel,
@@ -373,6 +378,15 @@ class TestPinsArePromises:
         assert placed[FixtureId("F2")].start_min >= 40
 
 
+def _reasons_by_kind(
+    result: SolveResult,
+) -> dict[str, list[InfeasibilityReason]]:
+    by_kind: dict[str, list[InfeasibilityReason]] = {}
+    for reason in result.reasons:
+        by_kind.setdefault(reason.kind, []).append(reason)
+    return by_kind
+
+
 class TestInfeasibility:
     def test_window_too_small_for_one_match_is_infeasible(self) -> None:
         p1, p2 = _players(2)
@@ -384,10 +398,20 @@ class TestInfeasibility:
         assert result.verdict is Verdict.infeasible
         assert result.placements == ()
         assert result.stats.objective is None
+        assert result.reasons == (
+            WindowTooShortForMatch(
+                pool_id=PoolId("A"),
+                fixture_id=FixtureId("F1"),
+                needed_min=25,
+                window_span_min=20,
+            ),
+        )
 
-    def test_combinatorially_overfull_day_is_infeasible(self) -> None:
-        """Each match fits its window alone; three of them cannot share the
-        single table — infeasibility proven by the solver, not the guard."""
+    def test_pool_over_capacity_is_reported_without_the_solver(self) -> None:
+        """Three back-to-back-impossible matches on one table in a 60-minute
+        window: aggregate demand (75) exceeds table-minutes (60), so the
+        pigeonhole guard proves it infeasible — no CP-SAT run, and it blames the
+        pool by id with the raw minute arithmetic."""
         players = _players(6)
         fixtures = tuple(
             _fixture(n, players[2 * (n - 1)], players[2 * n - 1]) for n in (1, 2, 3)
@@ -396,6 +420,56 @@ class TestInfeasibility:
         result = solve(snapshot, time_cap_s=CAP)
         assert result.verdict is Verdict.infeasible
         assert result.placements == ()
+        assert result.reasons == (
+            PoolOverCapacity(
+                pool_id=PoolId("A"),
+                required_min=75,  # 3 * 25
+                capacity_min=60,  # 60-minute window * 1 table
+                table_count=1,
+            ),
+        )
+
+    def test_over_capacity_counts_pinned_fixtures_too(self) -> None:
+        """Capacity is about *all* demand on the pool's tables: a pin occupies
+        table-time like anything else, so a pool that is only over capacity once
+        the pin is counted still reports it."""
+        p1, p2, p3, p4 = _players(4)
+        fixtures = (
+            _fixture(1, p1, p2, pin=Pin(TableId("T1"), 0)),  # 25 min pinned
+            _fixture(2, p3, p4),  # 25 min unpinned
+        )
+        # One table, a 40-minute window: two 25-minute matches (50) can't fit 40.
+        snapshot = _one_pool_snapshot(fixtures, tables=1, window=(0, 40))
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict is Verdict.infeasible
+        assert result.reasons == (
+            PoolOverCapacity(
+                pool_id=PoolId("A"),
+                required_min=50,  # pinned 25 + unpinned 25
+                capacity_min=40,
+                table_count=1,
+            ),
+        )
+
+    def test_tight_shared_window_is_no_single_cause(self) -> None:
+        """Every certain guard passes — each match fits its window, two tables
+        give room to spare, the pool is well under aggregate capacity — yet the
+        two matches share a player and cannot both fit with the rest floor in the
+        tight window, so CP-SAT proves it infeasible. No single structural cause
+        explains that, so the residual :class:`NoSingleCause` is attached, with
+        aggregate room to spare (``required_min <= available_min``)."""
+        p1, p2, p3 = _players(3)
+        fixtures = (_fixture(1, p1, p2), _fixture(2, p1, p3))  # share P1
+        # 55-minute window, 2 tables. Each 25-min match starts by 30 (fits), and
+        # 2*25=50 <= 55*2=110 (under capacity) — but P1's chain needs 25+10+25=60.
+        snapshot = _one_pool_snapshot(fixtures, tables=2, window=(0, 55))
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict is Verdict.infeasible
+        assert result.placements == ()
+        assert result.reasons == (NoSingleCause(required_min=50, available_min=110),)
+        (only,) = result.reasons
+        assert isinstance(only, NoSingleCause)
+        assert only.required_min <= only.available_min
 
     def test_pool_with_no_tables_is_infeasible(self) -> None:
         p1, p2 = _players(2)
@@ -409,6 +483,69 @@ class TestInfeasibility:
         result = solve(snapshot, time_cap_s=CAP)
         assert result.verdict is Verdict.infeasible
         assert result.placements == ()
+        assert result.reasons == (PoolHasNoTables(pool_id=PoolId("A")),)
+
+    def test_no_tables_dominates_over_capacity_for_the_same_pool(self) -> None:
+        """A no-tables pool is trivially over capacity too (capacity 0), but the
+        more specific PoolHasNoTables wins — a pool reports exactly one cause."""
+        p1, p2 = _players(2)
+        snapshot = ScheduleSnapshot(
+            table_ids=(),
+            pools=(SchedulePool(PoolId("A"), (), Window(0, 480)),),
+            events=(EventSettings(EventId("E1"), 3),),
+            fixtures=(_fixture(1, p1, p2),),
+            now_min=0,
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.reasons == (PoolHasNoTables(pool_id=PoolId("A")),)
+
+    def test_all_structural_causes_are_collected_at_once(self) -> None:
+        """Two independently-broken pools: one has no tables, the other is over
+        capacity. Both causes are reported in a single solve (not first-fail),
+        each blaming its own pool."""
+        p1, p2, p3, p4 = _players(4)
+        table_ids = _tables(1)  # the single table belongs to pool B only
+        snapshot = ScheduleSnapshot(
+            table_ids=table_ids,
+            pools=(
+                SchedulePool(PoolId("A"), (), Window(0, 480)),  # no tables
+                SchedulePool(PoolId("B"), table_ids, Window(0, 40)),  # over cap
+            ),
+            events=(EventSettings(EventId("E1"), 3),),
+            fixtures=(
+                _fixture(1, p1, p2, pool="A"),
+                _fixture(2, p3, p4, pool="B"),
+                _fixture(3, p1, p3, pool="B"),  # 2 * 25 = 50 > 40 * 1
+            ),
+            now_min=0,
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict is Verdict.infeasible
+        by_kind = _reasons_by_kind(result)
+        assert by_kind["pool_has_no_tables"] == [PoolHasNoTables(pool_id=PoolId("A"))]
+        assert by_kind["pool_over_capacity"] == [
+            PoolOverCapacity(
+                pool_id=PoolId("B"),
+                required_min=50,
+                capacity_min=40,
+                table_count=1,
+            )
+        ]
+        assert len(result.reasons) == 2
+
+    def test_solvable_snapshot_carries_no_reasons(self) -> None:
+        """The contract's other half: every non-infeasible verdict — here a
+        comfortably solvable day — carries an empty reason tuple."""
+        p1, p2, p3, p4 = _players(4)
+        fixtures = (_fixture(1, p1, p2), _fixture(2, p3, p4))
+        result = solve(_one_pool_snapshot(fixtures), time_cap_s=CAP)
+        assert result.verdict in SOLVED
+        assert result.reasons == ()
+
+    def test_trivial_optimal_carries_no_reasons(self) -> None:
+        result = solve(_one_pool_snapshot(()), time_cap_s=CAP)
+        assert result.verdict is Verdict.optimal
+        assert result.reasons == ()
 
 
 class TestInProgress:

--- a/docs/adr/20260718-an-infeasible-solve-explains-itself-with-a-resolved-reason.md
+++ b/docs/adr/20260718-an-infeasible-solve-explains-itself-with-a-resolved-reason.md
@@ -1,0 +1,158 @@
+# An infeasible solve explains itself with a resolved, structured reason
+
+Date: 2026-07-18 (date-numbered — sequential numbers collide across concurrent
+worktrees; see ADR-0788's note and the duplicate 0915s in this directory)
+
+## Status
+
+Accepted — fix for issue #1100, decided before implementation. Bounds against
+its follow-up #1129 (a real CP-SAT conflict core), which this ADR explicitly
+scopes out.
+
+## Context
+
+When a schedule solve fails, the director gets a single opaque verdict —
+**"Doesn't fit"** — with no explanation of *why* or *what to change*. The
+information exists at the point of failure and is thrown away:
+
+- `app.scheduling._build_model` detects a **pool with no tables**
+  (`if not pool.table_ids: return _no_plan(Verdict.infeasible)`) and a
+  **fixture whose window cannot hold even one match of its duration**
+  (`if lo > hi: ...`) — both know the exact `PoolId`/`FixtureId`, both discard
+  it into a bare `Verdict.infeasible`.
+- A CP-SAT-proven `INFEASIBLE` (`solve()`) returns the same bare verdict with
+  no reason at all.
+
+`SolveResult` carries only `verdict / placements / stats`; `schedule_solves`
+maps `Verdict.infeasible` → `ScheduleSolveStatus.infeasible` +
+`SolverVerdict.infeasible` and stores nothing else; the wire
+(`ScheduleSolveRead`) and both UI surfaces (the Schedule-tab **solve strip** and
+the admin **solve ledger**) therefore have nothing specific to say and fall back
+to one static generic sentence.
+
+The pure solver speaks only in ids and minute-ints (`PoolId` is the namespaced
+`"{event.id}:{pool.id}"`; `FixtureId` is a uuid string) and holds no human
+names or wall-clock times — those live in the DB/BFF layer. So *where* a reason
+is computed and *where* it becomes words is the crux of the design.
+
+### What a plain CP-SAT `INFEASIBLE` can and cannot tell us
+
+A bare `solver.Solve()` returning `INFEASIBLE` proves no solution exists and
+says **nothing** about why. CP-SAT can produce an unsat core, but only over
+**assumption literals** we deliberately add (`SufficientAssumptionsForInfeasibility`),
+and our hardest constraints are `AddNoOverlap` over intervals, which CP-SAT
+cannot reify behind an enforcement literal. A faithful core needs a
+soft/optional-placement remodel of the objective (maximize placed fixtures; the
+dropped set is the diagnostic) — a real change with its own correctness risk.
+**That remodel is out of scope here and is issue #1129.** This ADR ships what is
+*certain* plus one *honestly-labelled* best-effort residual.
+
+## Decision
+
+### Infeasibility carries a closed sum type of reasons on `SolveResult`
+
+`SolveResult` gains `reasons: tuple[InfeasibilityReason, ...]` — non-empty on
+any `infeasible` verdict, empty on every other verdict. `InfeasibilityReason` is
+a closed discriminated union (frozen dataclasses, exhaustive `match` with no
+catch-all — the codebase's "make illegal states unrepresentable" idiom), with
+four arms carrying **ids and minute-ints only** (the pure module stays pure and
+REPL-runnable):
+
+1. **`PoolHasNoTables(pool_id)`** — certain.
+2. **`WindowTooShortForMatch(pool_id, fixture_id, needed_min, window_span_min)`**
+   — certain; a single match cannot fit its window *contiguously* (e.g. a 35-min
+   best-of-5 in a 20-min window, whatever the table count). Distinct from #3.
+3. **`PoolOverCapacity(pool_id, required_min, capacity_min, table_count)`** —
+   certain; the pool's aggregate matches cannot fit `window_span × tables`.
+4. **`NoSingleCause(required_min, available_min)`** — the residual: CP-SAT proved
+   `INFEASIBLE` but arms 1–3 all passed. Carries the whole-day figures for
+   framing, not as a deficit (see below).
+
+`unknown` (time cap exhausted, no solution found) carries **no** reasons — it is
+"did not finish", not "does not fit", and stays `failed`/`TIME_CAP_ERROR`.
+
+### Per-pool capacity is a *certain pre-check*, not a post-INFEASIBLE heuristic
+
+A pool's fixtures can run only on *that pool's* tables inside *that pool's*
+window, so `Σ(match durations in pool P) > window_span_P × table_count_P` is a
+**valid necessary condition** for infeasibility — sharing tables across pools
+only lowers real capacity, never raises it, and counting only unpinned demand
+only makes the test more conservative. It names the exact pool, and it is pure
+arithmetic on the snapshot the solver already holds. So it runs in the same
+cheap pre-check pass as arms 1–2, **before CP-SAT is built** (arm 3), rather
+than being reverse-engineered from CP-SAT's proof. This is precisely the issue's
+own headline example — "the 09:00–13:00 window can't hold 40 best-of-5 matches
+on 5 tables."
+
+**Consequence that shapes the residual.** If every pool passes arm 3, then
+`Σ required ≤ Σ available` necessarily. So the residual case (arm 4) can *never*
+be a raw-capacity shortfall — a whole-day "required vs available" number will
+always show a surplus. Arm 4 therefore reports **"there is enough total
+table-time (needs ≈Xh, has ≈Yh), so this is a *timing* conflict — a player in
+too many matches close together, or tables shared across overlapping windows —
+not a capacity shortfall"**, which tells the director *not* to add tables. The
+precise "which fixtures/players" is #1129.
+
+All structural causes are **collected**, not first-fail: three no-tables pools
+report all three, so the director fixes them in one pass instead of re-running
+into the next. In practice the set is either "≥1 structural cause (arms 1–3)"
+**or** "exactly one arm-4 finding", never mixed (arm 4 is only reached when 1–3
+found nothing).
+
+### The reason is *resolved to names/numbers at apply time* and stored as JSONB
+
+A new JSONB column `schedule_solves.infeasibility_reasons` holds the reasons in
+**resolved** form: phase (c) of `execute_solve` already holds the fixtures and
+tournament under lock, so it maps `pool_id → pool.name` ("Pool B"),
+`fixture_id → its pairing/format`, and minute-ints → the pool's `Slot`
+`HH:MM`–`HH:MM` strings and whole-hours, then stores a structured object per
+reason (`{kind, pool_name, needed_min, window_span_min, …}`). `ScheduleSolveStatus.infeasible`
+is unchanged — the column is purely additive; the existing `error: Text` column
+stays `failed`-only (single-prose, cannot hold a structured multi-cause list).
+
+Resolved-at-write, not resolved-at-read, because the solve ledger is a
+**historical log** ("append-mostly, never rewritten — the history of the day's
+solves is the table itself"). A row should record what the director saw *then*,
+be self-contained, and never lose its story because a pool was later renamed or
+**deleted** (which would make a raw-id reason unresolvable on read). The one
+thing this gives up — names auto-updating on rename — is the wrong behaviour for
+a historical record.
+
+**"Resolved" means structured data, not prose.** The stored object and the wire
+carry `{kind, pool_name: "Pool B", needed_min: 35, …}` — names and numbers, which
+are *data* (like a username), never a finished sentence. The client still owns
+the sentence template (below), so the invariant "raw API strings never reach the
+UI" holds.
+
+### The client owns one shared reason→copy module; both surfaces render all reasons
+
+The wire (`ScheduleSolveRead`) gains `infeasibility_reasons`, Zod-parsed at the
+`data/solve.ts` boundary into a client sum type. **One** copy module (extending
+`data/solve.ts`, the way the admin ledger already reuses `VERDICT_LABEL`) maps
+each arm `kind` → a headline + specific sentence + a **user-facing remedy**
+(no `#1099`/`#1129` issue numbers on screen), interpolating the resolved
+names/numbers. Both surfaces consume it and render the **full** list:
+
+- the solve strip's `infeasible` arm replaces its static
+  "Add tables, widen a pool window…" sentence with the per-reason list;
+- the admin ledger shows the same reasons under its existing headline.
+
+Sharing the copy guarantees the two surfaces tell one story and cannot drift.
+
+## Consequences
+
+- **Cross-layer.** Pure solver (`SolveResult.reasons` + the pre-check arm 3),
+  a DB migration (new JSONB column — edited in place pre-deploy per
+  `api/CLAUDE.md`), the apply's id→name resolution, `ScheduleSolveRead`, the
+  OpenAPI/type regen (`schema.d.ts` **and** `Types.swift`), and both web
+  surfaces. iOS gets the regenerated `Types.swift` reference only — no UI.
+- **The pure module stays pure.** Reasons are ids + ints; every human name and
+  wall-clock string is added at apply. `app.scheduling` remains re-runnable in a
+  REPL with no database.
+- **`over_capacity` is a real proof, not a guess.** Only arm 4 is best-effort,
+  and it is labelled as such and never claims a capacity deficit.
+- **Determinism is untouched.** Arms 1–3 are pre-CP-SAT arithmetic; the solver
+  parameters (`num_search_workers`, `random_seed = 0`) are unchanged.
+- **Bounds #1129.** The "which fixtures/players" core is explicitly deferred;
+  arm 4 is the honest placeholder until it lands, and #1129 adds a richer arm to
+  this same sum type rather than re-plumbing.

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -2362,6 +2362,59 @@ internal enum Components {
             internal var fixturesPinned: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/error`.
             internal var error: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload`.
+            internal enum InfeasibilityReasonsPayloadPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload/NoSingleCauseRead`.
+                case noSingleCause(Components.Schemas.NoSingleCauseRead)
+                /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload/PoolHasNoTablesRead`.
+                case poolHasNoTables(Components.Schemas.PoolHasNoTablesRead)
+                /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload/PoolOverCapacityRead`.
+                case poolOverCapacity(Components.Schemas.PoolOverCapacityRead)
+                /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload/WindowTooShortForMatchRead`.
+                case windowTooShortForMatch(Components.Schemas.WindowTooShortForMatchRead)
+                internal enum CodingKeys: String, CodingKey {
+                    case kind
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    let discriminator = try container.decode(
+                        Swift.String.self,
+                        forKey: .kind
+                    )
+                    switch discriminator {
+                    case "no_single_cause":
+                        self = .noSingleCause(try .init(from: decoder))
+                    case "pool_has_no_tables":
+                        self = .poolHasNoTables(try .init(from: decoder))
+                    case "pool_over_capacity":
+                        self = .poolOverCapacity(try .init(from: decoder))
+                    case "window_too_short_for_match":
+                        self = .windowTooShortForMatch(try .init(from: decoder))
+                    default:
+                        throw Swift.DecodingError.unknownOneOfDiscriminator(
+                            discriminatorKey: CodingKeys.kind,
+                            discriminatorValue: discriminator,
+                            codingPath: decoder.codingPath
+                        )
+                    }
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    switch self {
+                    case let .noSingleCause(value):
+                        try value.encode(to: encoder)
+                    case let .poolHasNoTables(value):
+                        try value.encode(to: encoder)
+                    case let .poolOverCapacity(value):
+                        try value.encode(to: encoder)
+                    case let .windowTooShortForMatch(value):
+                        try value.encode(to: encoder)
+                    }
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/infeasibility_reasons`.
+            internal typealias InfeasibilityReasonsPayload = [Components.Schemas.AdminScheduleSolveRead.InfeasibilityReasonsPayloadPayload]
+            /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/infeasibility_reasons`.
+            internal var infeasibilityReasons: Components.Schemas.AdminScheduleSolveRead.InfeasibilityReasonsPayload
             /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/input_fingerprint`.
             internal var inputFingerprint: Swift.String?
             /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/rerun_requested`.
@@ -2384,6 +2437,7 @@ internal enum Components {
             ///   - fixturesPlaced:
             ///   - fixturesPinned:
             ///   - error:
+            ///   - infeasibilityReasons:
             ///   - inputFingerprint:
             ///   - rerunRequested:
             ///   - tournamentId:
@@ -2400,6 +2454,7 @@ internal enum Components {
                 fixturesPlaced: Swift.Int? = nil,
                 fixturesPinned: Swift.Int? = nil,
                 error: Swift.String? = nil,
+                infeasibilityReasons: Components.Schemas.AdminScheduleSolveRead.InfeasibilityReasonsPayload,
                 inputFingerprint: Swift.String? = nil,
                 rerunRequested: Swift.Bool,
                 tournamentId: Swift.String,
@@ -2416,6 +2471,7 @@ internal enum Components {
                 self.fixturesPlaced = fixturesPlaced
                 self.fixturesPinned = fixturesPinned
                 self.error = error
+                self.infeasibilityReasons = infeasibilityReasons
                 self.inputFingerprint = inputFingerprint
                 self.rerunRequested = rerunRequested
                 self.tournamentId = tournamentId
@@ -2433,6 +2489,7 @@ internal enum Components {
                 case fixturesPlaced = "fixtures_placed"
                 case fixturesPinned = "fixtures_pinned"
                 case error
+                case infeasibilityReasons = "infeasibility_reasons"
                 case inputFingerprint = "input_fingerprint"
                 case rerunRequested = "rerun_requested"
                 case tournamentId = "tournament_id"
@@ -4754,6 +4811,43 @@ internal enum Components {
                 case submittedAt = "submitted_at"
             }
         }
+        /// CP-SAT proved the day infeasible yet no structural arm explains it — the
+        /// whole-day residual. No pool: it carries only the day aggregate,
+        /// ``required_min`` against ``available_min``, as integer minutes.
+        ///
+        /// - Remark: Generated from `#/components/schemas/NoSingleCauseRead`.
+        internal struct NoSingleCauseRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/NoSingleCauseRead/kind`.
+            internal enum KindPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case noSingleCause = "no_single_cause"
+            }
+            /// - Remark: Generated from `#/components/schemas/NoSingleCauseRead/kind`.
+            internal var kind: Components.Schemas.NoSingleCauseRead.KindPayload?
+            /// - Remark: Generated from `#/components/schemas/NoSingleCauseRead/required_min`.
+            internal var requiredMin: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/NoSingleCauseRead/available_min`.
+            internal var availableMin: Swift.Int
+            /// Creates a new `NoSingleCauseRead`.
+            ///
+            /// - Parameters:
+            ///   - kind:
+            ///   - requiredMin:
+            ///   - availableMin:
+            internal init(
+                kind: Components.Schemas.NoSingleCauseRead.KindPayload? = nil,
+                requiredMin: Swift.Int,
+                availableMin: Swift.Int
+            ) {
+                self.kind = kind
+                self.requiredMin = requiredMin
+                self.availableMin = availableMin
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case kind
+                case requiredMin = "required_min"
+                case availableMin = "available_min"
+            }
+        }
         /// What a notification is about. Mirrors the product's notification kinds;
         /// a user can mute each category independently per channel.
         ///
@@ -6134,6 +6228,98 @@ internal enum Components {
                 ])
             }
         }
+        /// A pool with active fixtures but no tables at all — nowhere to place them.
+        /// Resolved: the pool's display ``name`` (never the namespaced solver id).
+        ///
+        /// - Remark: Generated from `#/components/schemas/PoolHasNoTablesRead`.
+        internal struct PoolHasNoTablesRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/PoolHasNoTablesRead/kind`.
+            internal enum KindPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case poolHasNoTables = "pool_has_no_tables"
+            }
+            /// - Remark: Generated from `#/components/schemas/PoolHasNoTablesRead/kind`.
+            internal var kind: Components.Schemas.PoolHasNoTablesRead.KindPayload?
+            /// - Remark: Generated from `#/components/schemas/PoolHasNoTablesRead/pool_name`.
+            internal var poolName: Swift.String
+            /// Creates a new `PoolHasNoTablesRead`.
+            ///
+            /// - Parameters:
+            ///   - kind:
+            ///   - poolName:
+            internal init(
+                kind: Components.Schemas.PoolHasNoTablesRead.KindPayload? = nil,
+                poolName: Swift.String
+            ) {
+                self.kind = kind
+                self.poolName = poolName
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case kind
+                case poolName = "pool_name"
+            }
+        }
+        /// A pool whose aggregate match-time (``required_min``) exceeds the
+        /// table-minutes its window offers (``capacity_min`` = window span ×
+        /// ``table_count``). Resolved: the pool ``name`` and its ``HH:MM`` bounds; the
+        /// minutes stay integers.
+        ///
+        /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead`.
+        internal struct PoolOverCapacityRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/kind`.
+            internal enum KindPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case poolOverCapacity = "pool_over_capacity"
+            }
+            /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/kind`.
+            internal var kind: Components.Schemas.PoolOverCapacityRead.KindPayload?
+            /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/pool_name`.
+            internal var poolName: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/window_start`.
+            internal var windowStart: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/window_end`.
+            internal var windowEnd: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/required_min`.
+            internal var requiredMin: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/capacity_min`.
+            internal var capacityMin: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/table_count`.
+            internal var tableCount: Swift.Int
+            /// Creates a new `PoolOverCapacityRead`.
+            ///
+            /// - Parameters:
+            ///   - kind:
+            ///   - poolName:
+            ///   - windowStart:
+            ///   - windowEnd:
+            ///   - requiredMin:
+            ///   - capacityMin:
+            ///   - tableCount:
+            internal init(
+                kind: Components.Schemas.PoolOverCapacityRead.KindPayload? = nil,
+                poolName: Swift.String,
+                windowStart: Swift.String,
+                windowEnd: Swift.String,
+                requiredMin: Swift.Int,
+                capacityMin: Swift.Int,
+                tableCount: Swift.Int
+            ) {
+                self.kind = kind
+                self.poolName = poolName
+                self.windowStart = windowStart
+                self.windowEnd = windowEnd
+                self.requiredMin = requiredMin
+                self.capacityMin = capacityMin
+                self.tableCount = tableCount
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case kind
+                case poolName = "pool_name"
+                case windowStart = "window_start"
+                case windowEnd = "window_end"
+                case requiredMin = "required_min"
+                case capacityMin = "capacity_min"
+                case tableCount = "table_count"
+            }
+        }
         /// One pool's standings: its rows in finishing order, and whether every one of its
         /// fixtures has been decided.
         ///
@@ -6910,6 +7096,13 @@ internal enum Components {
         ///   apply is whole-or-nothing.
         /// * ``error`` — why a ``failed`` run failed; ``null`` on every other status.
         ///
+        /// ``infeasibility_reasons`` is **never null** — it is always a list, empty on
+        /// every row that is not ``infeasible`` (so a client never null-checks it). An
+        /// ``infeasible`` verdict carries the resolved, DB-humanized reasons the day
+        /// could not be scheduled (pool names, ``HH:MM`` window bounds, the integer
+        /// minutes to format); every other row carries ``[]``. Parsed from the ledger's
+        /// raw JSONB at this boundary so no downstream reader touches a bare dict.
+        ///
         /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead`.
         internal struct ScheduleSolveRead: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/id`.
@@ -6952,6 +7145,59 @@ internal enum Components {
             internal var fixturesPinned: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/error`.
             internal var error: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload`.
+            internal enum InfeasibilityReasonsPayloadPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload/NoSingleCauseRead`.
+                case noSingleCause(Components.Schemas.NoSingleCauseRead)
+                /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload/PoolHasNoTablesRead`.
+                case poolHasNoTables(Components.Schemas.PoolHasNoTablesRead)
+                /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload/PoolOverCapacityRead`.
+                case poolOverCapacity(Components.Schemas.PoolOverCapacityRead)
+                /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload/WindowTooShortForMatchRead`.
+                case windowTooShortForMatch(Components.Schemas.WindowTooShortForMatchRead)
+                internal enum CodingKeys: String, CodingKey {
+                    case kind
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    let discriminator = try container.decode(
+                        Swift.String.self,
+                        forKey: .kind
+                    )
+                    switch discriminator {
+                    case "no_single_cause":
+                        self = .noSingleCause(try .init(from: decoder))
+                    case "pool_has_no_tables":
+                        self = .poolHasNoTables(try .init(from: decoder))
+                    case "pool_over_capacity":
+                        self = .poolOverCapacity(try .init(from: decoder))
+                    case "window_too_short_for_match":
+                        self = .windowTooShortForMatch(try .init(from: decoder))
+                    default:
+                        throw Swift.DecodingError.unknownOneOfDiscriminator(
+                            discriminatorKey: CodingKeys.kind,
+                            discriminatorValue: discriminator,
+                            codingPath: decoder.codingPath
+                        )
+                    }
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    switch self {
+                    case let .noSingleCause(value):
+                        try value.encode(to: encoder)
+                    case let .poolHasNoTables(value):
+                        try value.encode(to: encoder)
+                    case let .poolOverCapacity(value):
+                        try value.encode(to: encoder)
+                    case let .windowTooShortForMatch(value):
+                        try value.encode(to: encoder)
+                    }
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/infeasibility_reasons`.
+            internal typealias InfeasibilityReasonsPayload = [Components.Schemas.ScheduleSolveRead.InfeasibilityReasonsPayloadPayload]
+            /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/infeasibility_reasons`.
+            internal var infeasibilityReasons: Components.Schemas.ScheduleSolveRead.InfeasibilityReasonsPayload
             /// Creates a new `ScheduleSolveRead`.
             ///
             /// - Parameters:
@@ -6966,6 +7212,7 @@ internal enum Components {
             ///   - fixturesPlaced:
             ///   - fixturesPinned:
             ///   - error:
+            ///   - infeasibilityReasons:
             internal init(
                 id: Swift.String,
                 trigger: Components.Schemas.ScheduleSolveTrigger,
@@ -6977,7 +7224,8 @@ internal enum Components {
                 wallTimeMs: Swift.Int? = nil,
                 fixturesPlaced: Swift.Int? = nil,
                 fixturesPinned: Swift.Int? = nil,
-                error: Swift.String? = nil
+                error: Swift.String? = nil,
+                infeasibilityReasons: Components.Schemas.ScheduleSolveRead.InfeasibilityReasonsPayload
             ) {
                 self.id = id
                 self.trigger = trigger
@@ -6990,6 +7238,7 @@ internal enum Components {
                 self.fixturesPlaced = fixturesPlaced
                 self.fixturesPinned = fixturesPinned
                 self.error = error
+                self.infeasibilityReasons = infeasibilityReasons
             }
             internal enum CodingKeys: String, CodingKey {
                 case id
@@ -7003,6 +7252,7 @@ internal enum Components {
                 case fixturesPlaced = "fixtures_placed"
                 case fixturesPinned = "fixtures_pinned"
                 case error
+                case infeasibilityReasons = "infeasibility_reasons"
             }
         }
         /// The run's lifecycle. ``infeasible`` is a *terminal outcome*, not a failure:
@@ -8937,6 +9187,75 @@ internal enum Components {
                 case losses
                 case lastMeeting = "last_meeting"
                 case meetings
+            }
+        }
+        /// A single fixture whose pool window cannot hold even one match: its
+        /// ``best_of`` match needs ``needed_min`` minutes but the window spans only
+        /// ``window_span_min``. Resolved: the pool ``name`` and its ``HH:MM`` window
+        /// bounds; the minutes pass through as integers for the client to format.
+        ///
+        /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead`.
+        internal struct WindowTooShortForMatchRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/kind`.
+            internal enum KindPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case windowTooShortForMatch = "window_too_short_for_match"
+            }
+            /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/kind`.
+            internal var kind: Components.Schemas.WindowTooShortForMatchRead.KindPayload?
+            /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/pool_name`.
+            internal var poolName: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/window_start`.
+            internal var windowStart: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/window_end`.
+            internal var windowEnd: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/best_of`.
+            internal enum BestOfPayload: Int, Codable, Hashable, Sendable, CaseIterable {
+                case _1 = 1
+                case _3 = 3
+                case _5 = 5
+                case _7 = 7
+            }
+            /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/best_of`.
+            internal var bestOf: Components.Schemas.WindowTooShortForMatchRead.BestOfPayload
+            /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/needed_min`.
+            internal var neededMin: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/window_span_min`.
+            internal var windowSpanMin: Swift.Int
+            /// Creates a new `WindowTooShortForMatchRead`.
+            ///
+            /// - Parameters:
+            ///   - kind:
+            ///   - poolName:
+            ///   - windowStart:
+            ///   - windowEnd:
+            ///   - bestOf:
+            ///   - neededMin:
+            ///   - windowSpanMin:
+            internal init(
+                kind: Components.Schemas.WindowTooShortForMatchRead.KindPayload? = nil,
+                poolName: Swift.String,
+                windowStart: Swift.String,
+                windowEnd: Swift.String,
+                bestOf: Components.Schemas.WindowTooShortForMatchRead.BestOfPayload,
+                neededMin: Swift.Int,
+                windowSpanMin: Swift.Int
+            ) {
+                self.kind = kind
+                self.poolName = poolName
+                self.windowStart = windowStart
+                self.windowEnd = windowEnd
+                self.bestOf = bestOf
+                self.neededMin = neededMin
+                self.windowSpanMin = windowSpanMin
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case kind
+                case poolName = "pool_name"
+                case windowStart = "window_start"
+                case windowEnd = "window_end"
+                case bestOf = "best_of"
+                case neededMin = "needed_min"
+                case windowSpanMin = "window_span_min"
             }
         }
         /// - Remark: Generated from `#/components/schemas/app__schemas__match__MatchDetails`.

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1502,6 +1502,8 @@ export interface components {
             fixtures_pinned: number | null;
             /** Error */
             error: string | null;
+            /** Infeasibility Reasons */
+            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["NoSingleCauseRead"])[];
             /** Input Fingerprint */
             input_fingerprint: string | null;
             /** Rerun Requested */
@@ -2414,6 +2416,23 @@ export interface components {
             submitted_at: string;
         };
         /**
+         * NoSingleCauseRead
+         * @description CP-SAT proved the day infeasible yet no structural arm explains it — the
+         *     whole-day residual. No pool: it carries only the day aggregate,
+         *     ``required_min`` against ``available_min``, as integer minutes.
+         */
+        NoSingleCauseRead: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "no_single_cause";
+            /** Required Min */
+            required_min: number;
+            /** Available Min */
+            available_min: number;
+        };
+        /**
          * NotificationCategory
          * @description What a notification is about. Mirrors the product's notification kinds;
          *     a user can mute each category independently per channel.
@@ -2962,6 +2981,46 @@ export interface components {
             table_ids: string[];
         };
         /**
+         * PoolHasNoTablesRead
+         * @description A pool with active fixtures but no tables at all — nowhere to place them.
+         *     Resolved: the pool's display ``name`` (never the namespaced solver id).
+         */
+        PoolHasNoTablesRead: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "pool_has_no_tables";
+            /** Pool Name */
+            pool_name: string;
+        };
+        /**
+         * PoolOverCapacityRead
+         * @description A pool whose aggregate match-time (``required_min``) exceeds the
+         *     table-minutes its window offers (``capacity_min`` = window span ×
+         *     ``table_count``). Resolved: the pool ``name`` and its ``HH:MM`` bounds; the
+         *     minutes stay integers.
+         */
+        PoolOverCapacityRead: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "pool_over_capacity";
+            /** Pool Name */
+            pool_name: string;
+            /** Window Start */
+            window_start: string;
+            /** Window End */
+            window_end: string;
+            /** Required Min */
+            required_min: number;
+            /** Capacity Min */
+            capacity_min: number;
+            /** Table Count */
+            table_count: number;
+        };
+        /**
          * PoolStandingsRead
          * @description One pool's standings: its rows in finishing order, and whether every one of its
          *     fixtures has been decided.
@@ -3297,6 +3356,13 @@ export interface components {
          *       was discarded for drift re-runs rather than reporting partial counts — the
          *       apply is whole-or-nothing.
          *     * ``error`` — why a ``failed`` run failed; ``null`` on every other status.
+         *
+         *     ``infeasibility_reasons`` is **never null** — it is always a list, empty on
+         *     every row that is not ``infeasible`` (so a client never null-checks it). An
+         *     ``infeasible`` verdict carries the resolved, DB-humanized reasons the day
+         *     could not be scheduled (pool names, ``HH:MM`` window bounds, the integer
+         *     minutes to format); every other row carries ``[]``. Parsed from the ledger's
+         *     raw JSONB at this boundary so no downstream reader touches a bare dict.
          */
         ScheduleSolveRead: {
             /**
@@ -3324,6 +3390,8 @@ export interface components {
             fixtures_pinned: number | null;
             /** Error */
             error: string | null;
+            /** Infeasibility Reasons */
+            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["NoSingleCauseRead"])[];
         };
         /**
          * ScheduleSolveStatus
@@ -4034,6 +4102,35 @@ export interface components {
              *     drift (api/CLAUDE.md, "don't carry a field and its own derivation").
              */
             readonly meetings: number;
+        };
+        /**
+         * WindowTooShortForMatchRead
+         * @description A single fixture whose pool window cannot hold even one match: its
+         *     ``best_of`` match needs ``needed_min`` minutes but the window spans only
+         *     ``window_span_min``. Resolved: the pool ``name`` and its ``HH:MM`` window
+         *     bounds; the minutes pass through as integers for the client to format.
+         */
+        WindowTooShortForMatchRead: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "window_too_short_for_match";
+            /** Pool Name */
+            pool_name: string;
+            /** Window Start */
+            window_start: string;
+            /** Window End */
+            window_end: string;
+            /**
+             * Best Of
+             * @enum {integer}
+             */
+            best_of: 1 | 3 | 5 | 7;
+            /** Needed Min */
+            needed_min: number;
+            /** Window Span Min */
+            window_span_min: number;
         };
         /** MatchDetails */
         app__schemas__match__MatchDetails: {

--- a/web-client/src/components/scheduling/solve-ledger-page.factory.ts
+++ b/web-client/src/components/scheduling/solve-ledger-page.factory.ts
@@ -60,6 +60,25 @@ export function buildLedgerVariety(): AdminScheduleSolveRead[] {
       fixtures_pinned: null,
       tournament_id: 'summer-slam-2026',
       tournament_name: 'Summer Slam 2026',
+      // The resolved causes the day doesn't fit — two arms, so the expansion
+      // proves it renders each reason's sentence + remedy (the same list the
+      // Schedule-tab strip shows).
+      infeasibility_reasons: [
+        {
+          kind: 'window_too_short_for_match',
+          pool_name: 'Pool A',
+          window_start: '09:00',
+          window_end: '10:00',
+          best_of: 5,
+          needed_min: 75,
+          window_span_min: 60,
+        },
+        {
+          kind: 'no_single_cause',
+          required_min: 420,
+          available_min: 480,
+        },
+      ],
     }),
     buildAdminScheduleSolveRead({
       id: 'sv-succeeded',

--- a/web-client/src/components/scheduling/solve-ledger-page.test.tsx
+++ b/web-client/src/components/scheduling/solve-ledger-page.test.tsx
@@ -1,12 +1,32 @@
 import { describe, expect, it } from 'vitest'
 import { screen, waitFor, within } from '@/test/utilities'
 
+import { infeasibilityReasonCopy } from '@/components/tournaments/data/solve'
+
 import {
   buildAdminScheduleSolveRead,
   buildLedgerRows,
   buildLedgerVariety,
 } from './solve-ledger-page.factory'
 import { solveLedgerPage } from './solve-ledger-page.page'
+
+// The exact copy the two surfaces share — reused (not re-hardcoded) so the test
+// pins the admin ledger to the ONE `infeasibilityReasonCopy`, exactly as the
+// factory's `sv-infeasible` row carries these two reasons.
+const windowReasonCopy = infeasibilityReasonCopy({
+  kind: 'window_too_short_for_match',
+  poolName: 'Pool A',
+  windowStart: '09:00',
+  windowEnd: '10:00',
+  bestOf: 5,
+  neededMin: 75,
+  windowSpanMin: 60,
+})
+const noSingleCauseCopy = infeasibilityReasonCopy({
+  kind: 'no_single_cause',
+  requiredMin: 420,
+  availableMin: 480,
+})
 
 describe('SolveLedgerPage', () => {
   it('renders a ledger row per run with every column in the designed vocabulary', async () => {
@@ -78,6 +98,10 @@ describe('SolveLedgerPage', () => {
       'worker crashed: out of memory in CP-SAT presolve',
     )
     expect(detail).toHaveTextContent('deadbeef'.repeat(8))
+    // A failed run carries NO infeasibility reasons — the expansion never bleeds
+    // the infeasible surface's "day doesn't fit" wording into a broken run.
+    expect(detail).not.toHaveTextContent(windowReasonCopy.sentence)
+    expect(detail).not.toHaveTextContent(noSingleCauseCopy.sentence)
     expect(
       within(failed).getByRole('button', { name: 'Hide run details' }),
     ).toHaveAttribute('aria-expanded', 'true')
@@ -100,11 +124,43 @@ describe('SolveLedgerPage', () => {
     expect(detail).toHaveTextContent("The day doesn't fit")
     expect(detail).toHaveTextContent('Input fingerprint')
 
+    // Both resolved reasons render their sentence AND remedy — the SAME copy the
+    // Schedule-tab strip shows (reused from `infeasibilityReasonCopy`, so the two
+    // surfaces cannot drift).
+    expect(detail).toHaveTextContent(windowReasonCopy.sentence)
+    expect(detail).toHaveTextContent(windowReasonCopy.remedy)
+    expect(detail).toHaveTextContent(noSingleCauseCopy.sentence)
+    expect(detail).toHaveTextContent(noSingleCauseCopy.remedy)
+    // An infeasible run carries no failed `error` sentence.
+    expect(detail).not.toHaveTextContent('worker crashed')
+
     // A succeeded (or in-flight) run has no story to expand.
     const succeeded = await solveLedgerPage.findRow('sv-succeeded')
     expect(
       within(succeeded).queryByRole('button', { name: /run details/i }),
     ).not.toBeInTheDocument()
+  })
+
+  it('keeps the headline-only expansion for an infeasible row with no resolved reasons', async () => {
+    solveLedgerPage.render([
+      buildAdminScheduleSolveRead({
+        id: 'sv-bare',
+        status: 'infeasible',
+        verdict: 'infeasible',
+        infeasibility_reasons: [],
+      }),
+    ])
+    const user = solveLedgerPage.user()
+
+    const bare = await solveLedgerPage.findRow('sv-bare')
+    await user.click(
+      within(bare).getByRole('button', { name: 'Show run details' }),
+    )
+    const detail = solveLedgerPage.queryDetail('sv-bare')
+    expect(detail).toHaveTextContent("The day doesn't fit")
+    expect(detail).toHaveTextContent('Input fingerprint')
+    // No reason list is rendered when the (normally ≥1) list is somehow empty.
+    expect(detail?.querySelector('.solve-ledger-detail-reasons')).toBeNull()
   })
 
   it('renders the designed empty state when no solver has ever run', async () => {

--- a/web-client/src/components/scheduling/solve-ledger-page.tsx
+++ b/web-client/src/components/scheduling/solve-ledger-page.tsx
@@ -10,7 +10,7 @@ import {
   TRIGGER_LABEL,
   fmtWallTime,
   infeasibilityReasonCopy,
-  type InfeasibilityReason,
+  infeasibilityReasonKey,
 } from '@/components/tournaments/data/solve'
 import { fmtDateTimeShort } from '@/lib/dates'
 
@@ -35,14 +35,6 @@ import '@/components/matches/match-list/match-list.css'
 import './solve-ledger.css'
 
 const COLUMN_COUNT = 8
-
-/** A stable-enough React key for one infeasibility reason (the solve strip's own
- * rule, so the two surfaces key the list the same way): its `kind`, the pool it
- * names when it has one, and the list index. */
-const reasonKey = (reason: InfeasibilityReason, i: number) =>
-  'poolName' in reason
-    ? `${reason.kind}:${reason.poolName}:${i}`
-    : `${reason.kind}:${i}`
 
 /** The strip's tints, as the match-list pill tone classes this table borrows.
  * Keyed over the sum type so a new tone is a compile error until it has a
@@ -371,7 +363,7 @@ function LedgerRow({
                   {solve.infeasibilityReasons.map((reason, i) => {
                     const copy = infeasibilityReasonCopy(reason)
                     return (
-                      <li key={reasonKey(reason, i)}>
+                      <li key={infeasibilityReasonKey(reason, i)}>
                         <span className="solve-ledger-detail-reason-sentence">
                           {copy.sentence}
                         </span>{' '}

--- a/web-client/src/components/scheduling/solve-ledger-page.tsx
+++ b/web-client/src/components/scheduling/solve-ledger-page.tsx
@@ -6,8 +6,12 @@ import { ChevronDown, ChevronUp, ListFilter, X } from 'lucide-react'
 import { PaginationFooter } from '@/components/pagination-footer'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { TRIGGER_LABEL } from '@/components/tournaments/data/solve'
-import { fmtWallTime } from '@/components/tournaments/data/solve'
+import {
+  TRIGGER_LABEL,
+  fmtWallTime,
+  infeasibilityReasonCopy,
+  type InfeasibilityReason,
+} from '@/components/tournaments/data/solve'
 import { fmtDateTimeShort } from '@/lib/dates'
 
 import {
@@ -31,6 +35,14 @@ import '@/components/matches/match-list/match-list.css'
 import './solve-ledger.css'
 
 const COLUMN_COUNT = 8
+
+/** A stable-enough React key for one infeasibility reason (the solve strip's own
+ * rule, so the two surfaces key the list the same way): its `kind`, the pool it
+ * names when it has one, and the list index. */
+const reasonKey = (reason: InfeasibilityReason, i: number) =>
+  'poolName' in reason
+    ? `${reason.kind}:${reason.poolName}:${i}`
+    : `${reason.kind}:${i}`
 
 /** The strip's tints, as the match-list pill tone classes this table borrows.
  * Keyed over the sum type so a new tone is a compile error until it has a
@@ -348,6 +360,28 @@ function LedgerRow({
                   content (the solve strip's precedent). */}
               {solve.error && (
                 <div className="solve-ledger-detail-error mono">{solve.error}</div>
+              )}
+              {/* Why the day doesn't fit — the SAME resolved reasons the Schedule
+                  tab's strip shows, rendered through the one shared
+                  `infeasibilityReasonCopy` so the two surfaces cannot drift.
+                  Only the `infeasible` arm carries reasons (`[]` off that path);
+                  an unexpectedly empty list keeps the headline-only expansion. */}
+              {status === 'infeasible' && solve.infeasibilityReasons.length > 0 && (
+                <ul className="solve-ledger-detail-reasons">
+                  {solve.infeasibilityReasons.map((reason, i) => {
+                    const copy = infeasibilityReasonCopy(reason)
+                    return (
+                      <li key={reasonKey(reason, i)}>
+                        <span className="solve-ledger-detail-reason-sentence">
+                          {copy.sentence}
+                        </span>{' '}
+                        <span className="solve-ledger-detail-reason-remedy">
+                          {copy.remedy}
+                        </span>
+                      </li>
+                    )
+                  })}
+                </ul>
               )}
               <div className="solve-ledger-detail-fingerprint">
                 <span className="solve-ledger-detail-label">

--- a/web-client/src/components/scheduling/solve-ledger.css
+++ b/web-client/src/components/scheduling/solve-ledger.css
@@ -119,6 +119,17 @@
   list-style: none;
   font-size: 12px;
 }
+/* Wrap a long sentence + remedy inside the panel instead of overflowing it.
+   The reasons live in a `.matches` table cell, whose `white-space: nowrap`
+   (match-list.css) is inherited here — so a long reason line stays on one line,
+   pushing the colSpan cell's max-content wider than the 100% table and
+   clipping the remedy at the panel edge. Restore normal wrapping and, like the
+   `.solve-ledger-detail-error` sibling's `word-break: break-word`, also break a
+   pathological unbreakable token rather than overflow. */
+.match-list-page .solve-ledger-detail-reasons li {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
 .match-list-page .solve-ledger-detail-reason-sentence {
   color: var(--fg-2);
 }

--- a/web-client/src/components/scheduling/solve-ledger.css
+++ b/web-client/src/components/scheduling/solve-ledger.css
@@ -107,6 +107,24 @@
   color: var(--loss);
   word-break: break-word;
 }
+/* The resolved infeasibility reasons — one quiet line per cause, the sentence
+ * in the reading tone and the remedy a notch quieter, mirroring the Schedule
+ * tab's strip. */
+.match-list-page .solve-ledger-detail-reasons {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 12px;
+}
+.match-list-page .solve-ledger-detail-reason-sentence {
+  color: var(--fg-2);
+}
+.match-list-page .solve-ledger-detail-reason-remedy {
+  color: var(--fg-3);
+}
 .match-list-page .solve-ledger-detail-label {
   font-size: 11px;
   font-weight: 600;

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -280,6 +280,9 @@ export function buildScheduleSolve(
     fixturesPlaced: 9,
     fixturesPinned: 0,
     error: null,
+    // A succeeded run has no infeasibility reasons; the list is always present
+    // (`[]` off the infeasible path). An infeasible fixture overrides this.
+    infeasibilityReasons: [],
     ...overrides,
   }
 }

--- a/web-client/src/components/tournaments/data/solve.test.ts
+++ b/web-client/src/components/tournaments/data/solve.test.ts
@@ -7,13 +7,18 @@ import { buildScheduleSolve } from './seed.factory'
 import {
   LIVE_POLL_MS,
   SOLVE_IN_FLIGHT_POLL_MS,
+  fmtTableTime,
+  fmtTables,
   fmtWallTime,
+  infeasibilityReasonCopy,
+  infeasibilityReasonSchema,
   parseLatestScheduleSolve,
   parseScheduleSolve,
   runSchedulerNotice,
   scheduleRefetchInterval,
   solveInFlight,
   solveStripState,
+  type InfeasibilityReason,
 } from './solve'
 
 // ----- the parse boundary ----------------------------------------------------
@@ -61,6 +66,235 @@ describe('parseLatestScheduleSolve', () => {
     const { verdict, ...missing } = buildScheduleSolveRead()
     void verdict
     expect(() => parseLatestScheduleSolve(missing)).toThrow()
+  })
+})
+
+// ----- the infeasibility reasons: parse boundary ------------------------------
+
+describe('infeasibilityReasonSchema (the parse boundary)', () => {
+  it('parses pool_has_no_tables into its client arm', () => {
+    expect(
+      infeasibilityReasonSchema.parse({
+        kind: 'pool_has_no_tables',
+        pool_name: 'Pool B',
+      }),
+    ).toEqual({ kind: 'pool_has_no_tables', poolName: 'Pool B' })
+  })
+
+  it('parses window_too_short_for_match, mapping snake→camel and keeping best_of narrow', () => {
+    expect(
+      infeasibilityReasonSchema.parse({
+        kind: 'window_too_short_for_match',
+        pool_name: 'Pool A',
+        window_start: '09:00',
+        window_end: '09:20',
+        best_of: 5,
+        needed_min: 35,
+        window_span_min: 20,
+      }),
+    ).toEqual({
+      kind: 'window_too_short_for_match',
+      poolName: 'Pool A',
+      windowStart: '09:00',
+      windowEnd: '09:20',
+      bestOf: 5,
+      neededMin: 35,
+      windowSpanMin: 20,
+    })
+  })
+
+  it('parses pool_over_capacity', () => {
+    expect(
+      infeasibilityReasonSchema.parse({
+        kind: 'pool_over_capacity',
+        pool_name: 'Pool C',
+        window_start: '09:00',
+        window_end: '13:00',
+        required_min: 480,
+        capacity_min: 450,
+        table_count: 5,
+      }),
+    ).toEqual({
+      kind: 'pool_over_capacity',
+      poolName: 'Pool C',
+      windowStart: '09:00',
+      windowEnd: '13:00',
+      requiredMin: 480,
+      capacityMin: 450,
+      tableCount: 5,
+    })
+  })
+
+  it('parses no_single_cause (the residual, no pool)', () => {
+    expect(
+      infeasibilityReasonSchema.parse({
+        kind: 'no_single_cause',
+        required_min: 360,
+        available_min: 480,
+      }),
+    ).toEqual({ kind: 'no_single_cause', requiredMin: 360, availableMin: 480 })
+  })
+
+  it('refuses an arm kind this client has no words for — an unknown reason must fail the parse, not blank the row', () => {
+    expect(() =>
+      infeasibilityReasonSchema.parse({ kind: 'sunspots', pool_name: 'Pool B' }),
+    ).toThrow()
+  })
+
+  it('fails the whole solve row when one reason arm is unknown — the boundary rejects, the query fails', () => {
+    expect(() =>
+      parseLatestScheduleSolve(
+        buildScheduleSolveRead({
+          status: 'infeasible',
+          verdict: 'infeasible',
+          infeasibility_reasons: [
+            { kind: 'pool_has_no_tables', pool_name: 'Pool B' },
+            { kind: 'gremlins' },
+          ] as never,
+        }),
+      ),
+    ).toThrow()
+  })
+
+  it('carries the reasons through onto the domain row, snake→camel-mapped', () => {
+    const parsed = parseLatestScheduleSolve(
+      buildScheduleSolveRead({
+        status: 'infeasible',
+        verdict: 'infeasible',
+        infeasibility_reasons: [{ kind: 'pool_has_no_tables', pool_name: 'Pool B' }],
+      }),
+    )
+    expect(parsed?.infeasibilityReasons).toEqual([
+      { kind: 'pool_has_no_tables', poolName: 'Pool B' },
+    ])
+  })
+
+  it('defaults to an empty list off the infeasible path', () => {
+    expect(parseLatestScheduleSolve(buildScheduleSolveRead())?.infeasibilityReasons).toEqual([])
+  })
+})
+
+// ----- the infeasibility reasons: shared copy ---------------------------------
+
+describe('infeasibilityReasonCopy', () => {
+  it('words pool_has_no_tables with the pool name interpolated into both lines', () => {
+    expect(
+      infeasibilityReasonCopy({ kind: 'pool_has_no_tables', poolName: 'Pool B' }),
+    ).toEqual({
+      sentence: 'Pool B has no tables assigned.',
+      remedy: 'Assign at least one table to Pool B, then run the scheduler again.',
+    })
+  })
+
+  it('words window_too_short_for_match with the window, format and minutes', () => {
+    expect(
+      infeasibilityReasonCopy({
+        kind: 'window_too_short_for_match',
+        poolName: 'Pool A',
+        windowStart: '09:00',
+        windowEnd: '09:20',
+        bestOf: 5,
+        neededMin: 35,
+        windowSpanMin: 20,
+      }),
+    ).toEqual({
+      sentence:
+        "Pool A's 09:00–09:20 window is too short for a best-of-5 match — it needs 35 min but the window is only 20.",
+      remedy: "Widen Pool A's window, or use a shorter match format.",
+    })
+  })
+
+  it('words pool_over_capacity, formatting the minutes as hours and pluralising tables', () => {
+    expect(
+      infeasibilityReasonCopy({
+        kind: 'pool_over_capacity',
+        poolName: 'Pool C',
+        windowStart: '09:00',
+        windowEnd: '13:00',
+        requiredMin: 480,
+        capacityMin: 450,
+        tableCount: 5,
+      }),
+    ).toEqual({
+      sentence:
+        "Pool C can't fit all its matches: they need about 8h of table-time, but its 09:00–13:00 window on 5 tables only holds about 7.5h.",
+      remedy: 'Add a table to Pool C, widen its window, or trim the field.',
+    })
+  })
+
+  it('pluralises a single table as "1 table"', () => {
+    expect(
+      infeasibilityReasonCopy({
+        kind: 'pool_over_capacity',
+        poolName: 'Pool D',
+        windowStart: '09:00',
+        windowEnd: '10:15',
+        requiredMin: 90,
+        capacityMin: 75,
+        tableCount: 1,
+      }).sentence,
+    ).toContain('on 1 table only')
+  })
+
+  it('words no_single_cause as a timing conflict that steers away from adding tables', () => {
+    const copy = infeasibilityReasonCopy({
+      kind: 'no_single_cause',
+      requiredMin: 360,
+      availableMin: 480,
+    })
+    expect(copy.sentence).toBe(
+      "There's enough total table-time (about 8h available for about 6h of matches), so this is a timing conflict — a player is in too many matches too close together, or tables are shared across overlapping windows.",
+    )
+    expect(copy.remedy).toContain("adding tables won't help here")
+  })
+
+  it('gives each arm a distinct sentence and remedy', () => {
+    const arms: InfeasibilityReason[] = [
+      { kind: 'pool_has_no_tables', poolName: 'Pool B' },
+      {
+        kind: 'window_too_short_for_match',
+        poolName: 'Pool A',
+        windowStart: '09:00',
+        windowEnd: '09:20',
+        bestOf: 3,
+        neededMin: 30,
+        windowSpanMin: 20,
+      },
+      {
+        kind: 'pool_over_capacity',
+        poolName: 'Pool C',
+        windowStart: '09:00',
+        windowEnd: '13:00',
+        requiredMin: 480,
+        capacityMin: 450,
+        tableCount: 5,
+      },
+      { kind: 'no_single_cause', requiredMin: 360, availableMin: 480 },
+    ]
+    const sentences = arms.map((a) => infeasibilityReasonCopy(a).sentence)
+    expect(new Set(sentences).size).toBe(arms.length)
+  })
+})
+
+describe('fmtTableTime', () => {
+  it('renders sub-hour spans in whole minutes, no leading "about"', () => {
+    expect(fmtTableTime(45)).toBe('45 min')
+  })
+
+  it('renders whole hours without a decimal', () => {
+    expect(fmtTableTime(480)).toBe('8h')
+  })
+
+  it('renders fractional hours to one decimal (75 min → 1.3h)', () => {
+    expect(fmtTableTime(75)).toBe('1.3h')
+    expect(fmtTableTime(450)).toBe('7.5h')
+  })
+})
+
+describe('fmtTables', () => {
+  it('pluralises', () => {
+    expect(fmtTables(1)).toBe('1 table')
+    expect(fmtTables(5)).toBe('5 tables')
   })
 })
 

--- a/web-client/src/components/tournaments/data/solve.ts
+++ b/web-client/src/components/tournaments/data/solve.ts
@@ -68,6 +68,160 @@ export type ScheduleSolveTrigger = z.infer<typeof scheduleSolveTriggerSchema>
 export type ScheduleSolveStatus = z.infer<typeof scheduleSolveStatusSchema>
 export type SolverVerdict = z.infer<typeof solverVerdictSchema>
 
+// ----- why the day doesn't fit: the resolved infeasibility reasons ------------
+//
+// An `infeasible` solve no longer speaks in one opaque "Doesn't fit" — the API
+// resolves the causes to names/numbers at apply time (the ADR
+// "an-infeasible-solve-explains-itself-with-a-resolved-reason") and ships them
+// as a closed sum type on `ScheduleSolveRead.infeasibility_reasons`: always a
+// list, `[]` off the infeasible path. The `kind` discriminant is *data* the
+// client switches on, so — like `status`/`trigger`/`verdict` — an arm this
+// client has no words for must FAIL the parse here, in the queryFn, not fall
+// out of a `switch` two components later as a blank row (`z.discriminatedUnion`
+// rejects an unknown discriminator). Names + numbers are data (a `pool_name` is
+// like a username); the *sentence* is still the client's, minted in
+// `infeasibilityReasonCopy` below, so "raw API strings never reach the UI" holds.
+
+type PoolHasNoTablesWire =
+  components['schemas']['PoolHasNoTablesRead']
+type WindowTooShortForMatchWire =
+  components['schemas']['WindowTooShortForMatchRead']
+type PoolOverCapacityWire =
+  components['schemas']['PoolOverCapacityRead']
+type NoSingleCauseWire =
+  components['schemas']['NoSingleCauseRead']
+
+/**
+ * One resolved reason an `infeasible` solve carries, in the domain's camelCase
+ * spelling — a discriminated union over `kind`, one arm per structural cause the
+ * solver can name, plus the honestly-labelled residual (`no_single_cause`). The
+ * `kind` string stays snake_case (it is the wire's discriminant, and the copy
+ * module + admin ledger switch on it); every other field is mapped snake→camel
+ * like the rest of this module.
+ *
+ * - **`pool_has_no_tables`** — a pool with fixtures but nowhere to place them.
+ * - **`window_too_short_for_match`** — a single match cannot fit its pool window
+ *   contiguously, whatever the table count.
+ * - **`pool_over_capacity`** — a pool's aggregate match-time exceeds what its
+ *   window × tables can hold (a *certain* pre-check, not a CP-SAT guess).
+ * - **`no_single_cause`** — CP-SAT proved infeasible but arms 1–3 all passed: a
+ *   *timing* conflict, never a raw-capacity shortfall (so: don't add tables).
+ */
+export type InfeasibilityReason =
+  | { kind: 'pool_has_no_tables'; poolName: string }
+  | {
+      kind: 'window_too_short_for_match'
+      poolName: string
+      windowStart: string
+      windowEnd: string
+      bestOf: 1 | 3 | 5 | 7
+      neededMin: number
+      windowSpanMin: number
+    }
+  | {
+      kind: 'pool_over_capacity'
+      poolName: string
+      windowStart: string
+      windowEnd: string
+      requiredMin: number
+      capacityMin: number
+      tableCount: number
+    }
+  | { kind: 'no_single_cause'; requiredMin: number; availableMin: number }
+
+/** The wire arms, as they really arrive: snake_case, `kind` a literal so the
+ * union below can discriminate on it. `satisfies` each against the generated
+ * schema so a field renamed in the API is a compile error here, not a silent
+ * `undefined` at render. */
+const poolHasNoTablesWireSchema = z.object({
+  kind: z.literal('pool_has_no_tables'),
+  pool_name: z.string(),
+}) satisfies z.ZodType<PoolHasNoTablesWire>
+
+const windowTooShortForMatchWireSchema = z.object({
+  kind: z.literal('window_too_short_for_match'),
+  pool_name: z.string(),
+  window_start: z.string(),
+  window_end: z.string(),
+  best_of: z.union([z.literal(1), z.literal(3), z.literal(5), z.literal(7)]),
+  needed_min: z.number().int(),
+  window_span_min: z.number().int(),
+}) satisfies z.ZodType<WindowTooShortForMatchWire>
+
+const poolOverCapacityWireSchema = z.object({
+  kind: z.literal('pool_over_capacity'),
+  pool_name: z.string(),
+  window_start: z.string(),
+  window_end: z.string(),
+  required_min: z.number().int(),
+  capacity_min: z.number().int(),
+  table_count: z.number().int(),
+}) satisfies z.ZodType<PoolOverCapacityWire>
+
+const noSingleCauseWireSchema = z.object({
+  kind: z.literal('no_single_cause'),
+  required_min: z.number().int(),
+  available_min: z.number().int(),
+}) satisfies z.ZodType<NoSingleCauseWire>
+
+/** The four arms as one `z.discriminatedUnion('kind', …)` — an unknown `kind`
+ * has no arm and throws, which is exactly the boundary rule: a reason this
+ * client cannot render must fail the parse, not blank the row. */
+export const infeasibilityReasonWireSchema = z.discriminatedUnion('kind', [
+  poolHasNoTablesWireSchema,
+  windowTooShortForMatchWireSchema,
+  poolOverCapacityWireSchema,
+  noSingleCauseWireSchema,
+])
+
+/** One wire arm → one domain `InfeasibilityReason`. Annotated `: InfeasibilityReason`
+ * so the union above and the wire arms are one thing — drop or rename a field on
+ * either and this is a compile error. Exhaustive over `kind` (a `never` default),
+ * so a fifth arm added to the API cannot slip through unmapped. */
+export function infeasibilityReasonFromWire(
+  r: z.infer<typeof infeasibilityReasonWireSchema>,
+): InfeasibilityReason {
+  switch (r.kind) {
+    case 'pool_has_no_tables':
+      return { kind: r.kind, poolName: r.pool_name }
+    case 'window_too_short_for_match':
+      return {
+        kind: r.kind,
+        poolName: r.pool_name,
+        windowStart: r.window_start,
+        windowEnd: r.window_end,
+        bestOf: r.best_of,
+        neededMin: r.needed_min,
+        windowSpanMin: r.window_span_min,
+      }
+    case 'pool_over_capacity':
+      return {
+        kind: r.kind,
+        poolName: r.pool_name,
+        windowStart: r.window_start,
+        windowEnd: r.window_end,
+        requiredMin: r.required_min,
+        capacityMin: r.capacity_min,
+        tableCount: r.table_count,
+      }
+    case 'no_single_cause':
+      return {
+        kind: r.kind,
+        requiredMin: r.required_min,
+        availableMin: r.available_min,
+      }
+    default: {
+      const exhaustive: never = r
+      return exhaustive
+    }
+  }
+}
+
+/** The per-reason parser: the wire arm plus the snake→camel mapping, one Zod
+ * pipeline. Exported so the admin ledger's wire schema reuses the same arm set. */
+export const infeasibilityReasonSchema =
+  infeasibilityReasonWireSchema.transform(infeasibilityReasonFromWire)
+
 /**
  * One row of the tournament's **solve ledger**, in the domain's spelling — the
  * latest run of the placement solver, as the detail payload carries it.
@@ -90,6 +244,11 @@ export interface ScheduleSolve {
   fixturesPlaced: number | null
   fixturesPinned: number | null
   error: string | null
+  /** Why the day doesn't fit — **always a list**, never null (`[]` off the
+   * infeasible path; one or more resolved causes on an `infeasible` row). Not a
+   * nullable stage marker like the fields above: the API guarantees the array is
+   * present, and an absent key is a payload we reject rather than read as `[]`. */
+  infeasibilityReasons: InfeasibilityReason[]
 }
 
 /** The wire shape (`ScheduleSolveRead`), as it really arrives: snake_case, every
@@ -109,6 +268,9 @@ export const scheduleSolveWireSchema = z.object({
   fixtures_placed: z.number().int().nullable(),
   fixtures_pinned: z.number().int().nullable(),
   error: z.string().nullable(),
+  // Always present (a non-nullable list); each element is parsed through the
+  // discriminated union, so an unknown arm `kind` fails the whole row.
+  infeasibility_reasons: z.array(infeasibilityReasonSchema),
 })
 
 /** The snake→camel mapping, one wire row → one domain `ScheduleSolve`. Annotated
@@ -131,6 +293,8 @@ export function scheduleSolveFromWire(
     fixturesPlaced: s.fixtures_placed,
     fixturesPinned: s.fixtures_pinned,
     error: s.error,
+    // Already snake→camel-mapped by `infeasibilityReasonSchema`'s transform.
+    infeasibilityReasons: s.infeasibility_reasons,
   }
 }
 
@@ -176,7 +340,15 @@ export type SolveStripState =
       finishedAt: string | null
       trigger: ScheduleSolveTrigger
     }
-  | { kind: 'infeasible'; finishedAt: string | null; trigger: ScheduleSolveTrigger }
+  | {
+      kind: 'infeasible'
+      finishedAt: string | null
+      trigger: ScheduleSolveTrigger
+      /** The resolved causes the day doesn't fit — the same list the ledger row
+       * carries (`≥1` on an infeasible row; the strip renders each via
+       * `infeasibilityReasonCopy`, falling back to its generic sentence if empty). */
+      reasons: InfeasibilityReason[]
+    }
   | {
       kind: 'failed'
       /** The server's own account of why the job broke, or `null`. Shown as
@@ -218,6 +390,7 @@ export function solveStripState(solve: ScheduleSolve | null): SolveStripState {
         kind: 'infeasible',
         finishedAt: solve.finishedAt,
         trigger: solve.trigger,
+        reasons: solve.infeasibilityReasons,
       }
     case 'failed':
       return { kind: 'failed', error: solve.error, trigger: solve.trigger }
@@ -264,6 +437,77 @@ export function fmtWallTime(ms: number | null): string | null {
   if (ms === null) return null
   if (ms < 1000) return `${Math.round(ms)} ms`
   return `${(ms / 1000).toFixed(1)}s`
+}
+
+// ----- copy: the infeasibility reasons → the director's words -----------------
+//
+// ONE shared module, in the spirit of `VERDICT_LABEL`: both the Schedule-tab
+// solve strip (chore 4b) and the admin solve ledger (chore 4c) import
+// `infeasibilityReasonCopy` and render the SAME `sentence` + `remedy`, so the two
+// surfaces cannot drift on how a reason reads. Pure functions, unit-tested here.
+
+/** A pool's table-time, human-sized in the *prose*' spirit of `fmtWallTime`:
+ * a bare `8h` / `1.3h` / `45 min`, WITHOUT a leading "about" — the sentences
+ * below own that word ("… need about {…}"), so the formatter must not double it.
+ * Hours to one decimal when not whole (`75 min → 1.3h`), a whole number when it
+ * is (`480 min → 8h`), and plain minutes under the hour (`45 min`). */
+export function fmtTableTime(min: number): string {
+  if (min < 60) return `${Math.round(min)} min`
+  const hours = Math.round((min / 60) * 10) / 10
+  return Number.isInteger(hours) ? `${hours}h` : `${hours.toFixed(1)}h`
+}
+
+/** `1 table` / `5 tables` — sane pluralisation for the reason sentences. */
+export function fmtTables(count: number): string {
+  return `${count} ${count === 1 ? 'table' : 'tables'}`
+}
+
+/** What a caller renders for one reason: the client's own sentence naming the
+ * cause, and a user-facing remedy. Both interpolate the resolved names/numbers;
+ * neither carries a GitHub issue number (the ADR's rule). */
+export interface InfeasibilityReasonCopy {
+  sentence: string
+  remedy: string
+}
+
+/**
+ * Map one resolved reason to its designed copy. Exhaustive over `kind` — a `never`
+ * default makes a fifth arm added to the API a compile error here until it is
+ * given words, so a reason can never reach the UI as a blank line.
+ *
+ * The residual (`no_single_cause`) is deliberately worded to steer the director
+ * *away* from adding tables: by construction there is a table-time surplus, so the
+ * problem is timing, not capacity (the ADR's "don't add tables here").
+ */
+export function infeasibilityReasonCopy(
+  reason: InfeasibilityReason,
+): InfeasibilityReasonCopy {
+  switch (reason.kind) {
+    case 'pool_has_no_tables':
+      return {
+        sentence: `${reason.poolName} has no tables assigned.`,
+        remedy: `Assign at least one table to ${reason.poolName}, then run the scheduler again.`,
+      }
+    case 'window_too_short_for_match':
+      return {
+        sentence: `${reason.poolName}'s ${reason.windowStart}–${reason.windowEnd} window is too short for a best-of-${reason.bestOf} match — it needs ${reason.neededMin} min but the window is only ${reason.windowSpanMin}.`,
+        remedy: `Widen ${reason.poolName}'s window, or use a shorter match format.`,
+      }
+    case 'pool_over_capacity':
+      return {
+        sentence: `${reason.poolName} can't fit all its matches: they need about ${fmtTableTime(reason.requiredMin)} of table-time, but its ${reason.windowStart}–${reason.windowEnd} window on ${fmtTables(reason.tableCount)} only holds about ${fmtTableTime(reason.capacityMin)}.`,
+        remedy: `Add a table to ${reason.poolName}, widen its window, or trim the field.`,
+      }
+    case 'no_single_cause':
+      return {
+        sentence: `There's enough total table-time (about ${fmtTableTime(reason.availableMin)} available for about ${fmtTableTime(reason.requiredMin)} of matches), so this is a timing conflict — a player is in too many matches too close together, or tables are shared across overlapping windows.`,
+        remedy: `Trim a field, widen a window, or split the event across days — adding tables won't help here.`,
+      }
+    default: {
+      const exhaustive: never = reason
+      return exhaustive
+    }
+  }
 }
 
 // ----- polling ----------------------------------------------------------------

--- a/web-client/src/components/tournaments/data/solve.ts
+++ b/web-client/src/components/tournaments/data/solve.ts
@@ -218,7 +218,8 @@ export function infeasibilityReasonFromWire(
 }
 
 /** The per-reason parser: the wire arm plus the snake→camel mapping, one Zod
- * pipeline. Exported so the admin ledger's wire schema reuses the same arm set. */
+ * pipeline. Embedded in `scheduleSolveWireSchema` below, which the admin ledger's
+ * wire schema `.extend()`s — so both surfaces parse reasons through this one arm. */
 export const infeasibilityReasonSchema =
   infeasibilityReasonWireSchema.transform(infeasibilityReasonFromWire)
 
@@ -508,6 +509,16 @@ export function infeasibilityReasonCopy(
       return exhaustive
     }
   }
+}
+
+/** A stable-enough React key for one infeasibility reason: its `kind`, the pool
+ * it names when it has one, and the list index (two `no_single_cause`s never
+ * coexist, but the index keeps the key total). Shared so every surface that
+ * lists the reasons keys them the same way by import, not by convention. */
+export function infeasibilityReasonKey(reason: InfeasibilityReason, i: number): string {
+  return 'poolName' in reason
+    ? `${reason.kind}:${reason.poolName}:${i}`
+    : `${reason.kind}:${i}`
 }
 
 // ----- polling ----------------------------------------------------------------

--- a/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
@@ -90,22 +90,56 @@ describe('SolveStrip', () => {
     )
   })
 
-  it('renders infeasible as a DESIGNED state in the director\'s terms — the day does not fit — not an error banner', () => {
+  it('renders infeasible as a DESIGNED state in the director\'s terms — the day does not fit — not an error banner, naming EACH resolved cause', () => {
     solveStripPage.render({
       solve: buildScheduleSolve({
         status: 'infeasible',
         verdict: 'infeasible',
         fixturesPlaced: null,
         fixturesPinned: null,
+        infeasibilityReasons: [
+          { kind: 'pool_has_no_tables', poolName: 'Pool B' },
+          {
+            kind: 'pool_over_capacity',
+            poolName: 'Pool A',
+            windowStart: '09:00',
+            windowEnd: '12:30',
+            requiredMin: 480,
+            capacityMin: 420,
+            tableCount: 4,
+          },
+        ],
       }),
     })
     const text = solveStripPage.getStateText('infeasible')
     expect(text).toContain("The day doesn't fit")
-    // Actionable, in venue vocabulary — never the solver's.
-    expect(text).toContain('Add tables, widen a pool window')
+    // BOTH reasons' sentences, named specifically…
+    expect(text).toContain('Pool B has no tables assigned.')
+    expect(text).toContain("Pool A can't fit all its matches")
+    // …AND both remedies.
+    expect(text).toContain('Assign at least one table to Pool B')
+    expect(text).toContain('Add a table to Pool A, widen its window, or trim the field.')
+    // The specific list REPLACES the generic sentence.
+    expect(text).not.toContain('The matches can\'t all fit inside their windows')
+    // The raw enum never reaches the UI.
     expect(text).not.toContain('infeasible')
     // And it is a state, not a refusal: no notice rings.
     expect(solveStripPage.queryNotice()).toBeNull()
+  })
+
+  it('falls back to the generic sentence if an infeasible row carries no reasons — the strip never renders bodyless', () => {
+    solveStripPage.render({
+      solve: buildScheduleSolve({
+        status: 'infeasible',
+        verdict: 'infeasible',
+        fixturesPlaced: null,
+        fixturesPinned: null,
+        infeasibilityReasons: [],
+      }),
+    })
+    const text = solveStripPage.getStateText('infeasible')
+    expect(text).toContain("The day doesn't fit")
+    expect(text).toContain('Add tables, widen a pool window')
   })
 
   it('renders a failed run under our headline, with the server\'s account as detail', () => {
@@ -122,6 +156,9 @@ describe('SolveStrip', () => {
     const text = solveStripPage.getStateText('failed')
     expect(text).toContain('The scheduler hit a problem')
     expect(text).toContain('worker crashed: OOM')
+    // A broken job is NOT the infeasible outcome — no resolved reason leaks in.
+    expect(text).not.toContain('has no tables assigned')
+    expect(text).not.toContain("The day doesn't fit")
   })
 
   // ----- the Run-scheduler button --------------------------------------------

--- a/web-client/src/components/tournaments/tournament-detail-page/solve-strip.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/solve-strip.tsx
@@ -18,10 +18,10 @@ import {
   VERDICT_LABEL,
   fmtWallTime,
   infeasibilityReasonCopy,
+  infeasibilityReasonKey,
   runSchedulerNotice,
   solveInFlight,
   solveStripState,
-  type InfeasibilityReason,
   type RunSchedulerNotice,
   type ScheduleSolve,
 } from '../data/solve'
@@ -66,12 +66,6 @@ const Line = ({
     </div>
   </div>
 )
-
-/** A stable-enough React key for one infeasibility reason: its `kind`, the pool
- * it names when it has one, and the list index (two `no_single_cause`s never
- * coexist, but the index keeps the key total). */
-const reasonKey = (reason: InfeasibilityReason, i: number) =>
-  'poolName' in reason ? `${reason.kind}:${reason.poolName}:${i}` : `${reason.kind}:${i}`
 
 /** The latest solve, rendered as its designed state. Split from the strip so the
  * strip's `switch` reads as the sum type it renders. */
@@ -141,7 +135,7 @@ const SolveState = ({ solve, canEdit }: { solve: ScheduleSolve | null; canEdit: 
                 {state.reasons.map((reason, i) => {
                   const copy = infeasibilityReasonCopy(reason)
                   return (
-                    <li key={reasonKey(reason, i)}>
+                    <li key={infeasibilityReasonKey(reason, i)}>
                       <span className="text-[color:var(--fg-2)]">
                         {copy.sentence}
                       </span>{' '}

--- a/web-client/src/components/tournaments/tournament-detail-page/solve-strip.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/solve-strip.tsx
@@ -17,9 +17,11 @@ import {
   TRIGGER_LABEL,
   VERDICT_LABEL,
   fmtWallTime,
+  infeasibilityReasonCopy,
   runSchedulerNotice,
   solveInFlight,
   solveStripState,
+  type InfeasibilityReason,
   type RunSchedulerNotice,
   type ScheduleSolve,
 } from '../data/solve'
@@ -64,6 +66,12 @@ const Line = ({
     </div>
   </div>
 )
+
+/** A stable-enough React key for one infeasibility reason: its `kind`, the pool
+ * it names when it has one, and the list index (two `no_single_cause`s never
+ * coexist, but the index keeps the key total). */
+const reasonKey = (reason: InfeasibilityReason, i: number) =>
+  'poolName' in reason ? `${reason.kind}:${reason.poolName}:${i}` : `${reason.kind}:${i}`
 
 /** The latest solve, rendered as its designed state. Split from the strip so the
  * strip's `switch` reads as the sum type it renders. */
@@ -117,7 +125,10 @@ const SolveState = ({ solve, canEdit }: { solve: ScheduleSolve | null; canEdit: 
     }
     case 'infeasible':
       // A DESIGNED outcome, not an error banner: the solver *proved* the plan
-      // impossible, which is exactly what a pre-live run is for.
+      // impossible, which is exactly what a pre-live run is for. The API resolves
+      // the causes to names/numbers, so the strip names each specifically —
+      // falling back to the generic sentence only if the (guaranteed ≥1) list is
+      // somehow empty, so the strip never renders bodyless.
       return (
         <div data-testid="solve-strip-infeasible">
           <Line
@@ -125,9 +136,27 @@ const SolveState = ({ solve, canEdit }: { solve: ScheduleSolve | null; canEdit: 
             tint="text-[color:var(--warn)]"
             title="The day doesn't fit"
           >
-            The matches can't all fit inside their windows on the tables
-            available. Add tables, widen a pool window, or trim an event's field —
-            then run the scheduler again.
+            {state.reasons.length > 0 ? (
+              <ul className="space-y-1.5">
+                {state.reasons.map((reason, i) => {
+                  const copy = infeasibilityReasonCopy(reason)
+                  return (
+                    <li key={reasonKey(reason, i)}>
+                      <span className="text-[color:var(--fg-2)]">
+                        {copy.sentence}
+                      </span>{' '}
+                      {copy.remedy}
+                    </li>
+                  )
+                })}
+              </ul>
+            ) : (
+              <>
+                The matches can't all fit inside their windows on the tables
+                available. Add tables, widen a pool window, or trim an event's
+                field — then run the scheduler again.
+              </>
+            )}
           </Line>
         </div>
       )

--- a/web-client/src/mocks/factories/tournaments/solver-sim.ts
+++ b/web-client/src/mocks/factories/tournaments/solver-sim.ts
@@ -57,6 +57,8 @@ export function queuedSolveRow(id: string): ScheduleSolveRead {
     fixtures_placed: null,
     fixtures_pinned: null,
     error: null,
+    // Always a list; a queued run has reached no infeasibility.
+    infeasibility_reasons: [],
   }
 }
 

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -123,6 +123,9 @@ export function buildScheduleSolveRead(
     fixtures_placed: 9,
     fixtures_pinned: 0,
     error: null,
+    // A succeeded run has no infeasibility reasons; the field is always a list
+    // (`[]` off the infeasible path). Infeasible fixtures override this.
+    infeasibility_reasons: [],
     ...overrides,
   }
 }


### PR DESCRIPTION
## What

When a schedule solve fails, the director no longer gets a single opaque **"Doesn't fit"** — the solver now returns a **structured set of reasons**, and both the Schedule-tab solve strip and the admin solve-ledger name the offending pool / show the figures / give a concrete next step.

Closes #1100. The real CP-SAT conflict core (which fixtures/players) is deliberately out of scope and filed as **#1129**.

## How (per [ADR](docs/adr/20260718-an-infeasible-solve-explains-itself-with-a-resolved-reason.md))

- **Pure solver** (`app/scheduling.py`): `SolveResult.reasons` — a closed 4-arm union carrying ids + minute-ints only:
  - `PoolHasNoTables` · `WindowTooShortForMatch` · `PoolOverCapacity` — **certain** structural causes, *collected* (not first-fail) and deduped most-specific-per-pool, returned **without running CP-SAT**. Per-pool capacity is a provable necessary condition, so the "40 best-of-5 in a 4h window on 5 tables" case is named precisely.
  - `NoSingleCause` — the honest best-effort residual on a CP-SAT-proven `INFEASIBLE` that survived the structural checks: "there's enough total table-time, so this is a *timing* conflict — don't add tables."
- **Persistence** (`app/schedule_solves.py`): new JSONB `schedule_solves.infeasibility_reasons`, **resolved at apply time** (pool id→display name, `Slot` `HH:MM`, minutes) into a self-contained historical row. Non-infeasible verdicts leave it NULL.
- **Wire**: `ScheduleSolveRead.infeasibility_reasons: list[ResolvedReason]` (always a list, `[]` off the infeasible path), parsed at the boundary; `schema.d.ts` + `Types.swift` regenerated.
- **Web**: one shared reason→copy module (sentence + user-facing remedy per kind); the solve strip and admin ledger both render the full list through it, so the two surfaces cannot drift.

## Testing

- API: ruff + `mypy --strict` (120 files) + **pytest 1378 passed**
- Web: **vitest 2824 passed**, eslint + `tsc`/`vite build` clean, **Playwright e2e 289 passed** (MSW off)
- OpenAPI: **no drift**; iOS: **BUILD SUCCEEDED** (regenerated types compile)
- Root compose e2e skipped — pre-live director surface + solver refactor; the happy path is covered by api pytest + web e2e.

Each slice was implemented by a domain-expert agent and independently reproduced by a fresh verifier (fail-before restores, real CP-SAT infeasibility traces, empty no-drift diffs, full-suite re-runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8ZC75JHjtQmHnhJGF9zda