### PR TITLE
Make MCP transport stateless + streaming /mcp nginx block

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -49,7 +49,16 @@ log = logging.getLogger("uvicorn.error")
 # ``/mcp`` would nest to ``/mcp/mcp``). It carries its OWN lifespan — the
 # Streamable-HTTP session manager — which MUST run or every MCP call 500s, so
 # ``lifespan`` below enters it alongside the app's own startup.
-mcp_app = mcp.http_app(path="/")
+#
+# ``stateless_http=True`` is load-balancer-safety, not an optimization: UAT runs
+# 2 api replicas behind a round-robin Service with no session affinity. In the
+# default *stateful* mode the transport mints an ``Mcp-Session-Id`` on
+# ``initialize`` and keeps that session's state in the pod's memory; the next
+# tool call round-robins to the other pod, which 404s the unknown session, and
+# the client tears down and re-initializes ("session expired"). Stateless mode
+# makes every request self-contained, so it survives landing on any replica (or
+# a rolling redeploy) — the correct shape for a horizontally-scaled deployment.
+mcp_app = mcp.http_app(path="/", stateless_http=True)
 
 
 @asynccontextmanager

--- a/deploy/uat/templates/_helpers.tpl
+++ b/deploy/uat/templates/_helpers.tpl
@@ -86,6 +86,37 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # MCP (FastMCP Streamable-HTTP mount at /mcp) — served to clients via
+    # /api/mcp/. This longer, more-specific prefix wins over /api/ above, so the
+    # streaming-friendly settings apply: buffering OFF so SSE frames aren't held,
+    # and a long read timeout so an idle stream isn't cut at nginx's default 60s
+    # (that timeout is a second, independent cause of "session expired" churn).
+    # The api transport is stateless (main.py), so no session affinity is needed.
+    location /api/mcp/ {
+        rewrite ^/api/(.*)$ /$1 break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # A bare /mcp/ hit (not via /api/) reaches the same FastMCP mount directly —
+    # without this it would fall through to `location /` and land on the SPA.
+    location /mcp/ {
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Browser telemetry (Grafana Faro) -> Alloy faro.receiver in the
     # `monitoring` namespace (deploy/observability). resolver + variable
     # upstream so this nginx starts even before the observability release

--- a/nginx/dev.conf
+++ b/nginx/dev.conf
@@ -22,6 +22,33 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # MCP (FastMCP Streamable-HTTP mount at /mcp), reached via /api/mcp/. Longer,
+    # more-specific prefix than /api/, so buffering OFF + a long read timeout keep
+    # a streamed/idle connection alive past nginx's default 60s.
+    location /api/mcp/ {
+        rewrite ^/api/(.*)$ /$1 break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # A bare /mcp/ hit (not via /api/) reaches the same FastMCP mount directly.
+    location /mcp/ {
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         proxy_pass http://web_upstream;
         proxy_http_version 1.1;

--- a/nginx/uat.conf
+++ b/nginx/uat.conf
@@ -25,6 +25,36 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # MCP (FastMCP Streamable-HTTP mount at /mcp), reached via /api/mcp/. This
+    # longer, more-specific prefix wins over /api/ above so the streaming-friendly
+    # settings apply: buffering OFF and a long read timeout so an idle stream
+    # isn't cut at nginx's default 60s. The api transport is stateless, so no
+    # session affinity is needed across replicas.
+    location /api/mcp/ {
+        rewrite ^/api/(.*)$ /$1 break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # A bare /mcp/ hit (not via /api/) reaches the same FastMCP mount directly —
+    # without this it would fall through to `location /` and land on the SPA.
+    location /mcp/ {
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Direct API paths — FastAPI mounts routes at /v1/*; /openapi.json,
     # /docs, /redoc are FastAPI's defaults. Useful for curl / API docs.
     location ~ ^/(v1|openapi\.json|docs|redoc)(/|$) {


### PR DESCRIPTION
## Why

The `session expired during the check; I'm reconnecting` churn on the FortyMM MCP server (#1135) is a **stateful-session-behind-a-load-balancer** bug, not a transient.

UAT runs `api.replicas: 2` behind a round-robin Service with **no session affinity**. FastMCP's Streamable-HTTP transport defaults to **stateful**: it mints an `Mcp-Session-Id` on `initialize` and keeps that session's state **in one pod's memory**. The next tool call round-robins to the *other* pod, which 404s the unknown session → the client tears down and re-initializes. It recurs on roughly every other request.

## Changes

1. **api — stateless transport** (`api/app/main.py`): mount FastMCP with `stateless_http=True`. Every request becomes self-contained, so it survives landing on any replica or a rolling redeploy — the correct shape for a horizontally-scaled deploy, no affinity needed.
2. **nginx `/mcp` streaming block** (UAT Helm helper `deploy/uat/templates/_helpers.tpl`, plus the dev/QA compose confs `nginx/dev.conf` + `nginx/uat.conf`): a dedicated, more-specific `location /api/mcp/` (nginx longest-prefix wins over `/api/`) and a bare `location /mcp/`, both with `proxy_buffering off` + `proxy_read_timeout 3600s`. This kills the *second, independent* drop cause — nginx's default 60s read timeout cutting an idle/streamed MCP connection — and the bare `/mcp/` block stops a direct hit from falling through to the SPA.

## Verification

- `pytest tests/test_mcp_server.py` — **30 passed** (drives the real mounted Streamable-HTTP transport with bearer auth).
- `mypy` + `ruff check`/`ruff format --check` on `app/main.py` — clean.
- `nginx -t` on all three rendered configs (helm ConfigMap + both compose confs) — syntax OK.

## Deploy note

Not live until merged + `mise run redeploy-uat` (the nginx ConfigMap checksum annotation rolls the nginx pod; the api change rolls the api pods). The live MCP host is `uat.fortymm.com` — there is no prod/`www.fortymm.com` stack in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdT7s4u3qs1PY87oN7t96m