### PR TITLE
Called match holds its table, slides later (fix overrun-overlap infeasibility) (#1141)

### DIFF
--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -1045,39 +1045,24 @@ async def _apply_result(
                         # A called match holds its table, but its start can be
                         # pushed LATER on a re-solve when a predecessor overruns
                         # (ADR "a called match holds its table and slides
-                        # later"). Compare the solver's returned start to the
-                        # stored one on the SAME floored-minute basis the
-                        # snapshot pinned it at (``to_min`` floors), so a
-                        # genuinely-unchanged pin — off-grid start included — is
-                        # byte-stable and moves no one.
-                        stored_start = fixture.scheduled_start
-                        stored_start_min = (
-                            None
-                            if stored_start is None
-                            else int((stored_start - fresh.base).total_seconds() // 60)
-                        )
+                        # later"). The solver floors a pin at its stored start,
+                        # so it can only echo that start or return a strictly
+                        # later minute. An unchanged pin — off-grid start
+                        # included — is byte-stable and moves no one; a slid pin
+                        # falls through to the shared moved-repair path below,
+                        # which persists the later start, renews ``pinned_at``,
+                        # and fires the SAME "moved" correction (its
+                        # ``table_id`` write is a no-op, since the solver never
+                        # re-tables a pin).
+                        new_start = fresh.base + timedelta(minutes=placement.start_min)
                         if (
-                            stored_start_min is None
-                            or placement.start_min <= stored_start_min
+                            fixture.scheduled_start is None
+                            or new_start <= fixture.scheduled_start
                         ):
-                            # Unchanged: the solver floors a pin at its stored
-                            # start, so it can only echo it or slide later. A
-                            # promise's columns are never rewritten, not even
-                            # with their own bytes, and nobody is told.
+                            # Unchanged: a promise's columns are never rewritten,
+                            # not even with their own bytes, and nobody is told.
                             pinned += 1
                             continue
-                        # Slid later on its (invariant) table — the solver never
-                        # re-tables a pin, so ``table_id`` is left untouched.
-                        # Persist the new start, renew ``pinned_at``, and route
-                        # it through the SAME "moved" correction a broken-pin
-                        # move fires: every persisted pin change carries one.
-                        fixture.scheduled_start = fresh.base + timedelta(
-                            minutes=placement.start_min
-                        )
-                        fixture.pinned_at = apply_now
-                        moved_repairs.append(fixture)
-                        placed += 1
-                        continue
                     repaired_pin = fixture.pinned_at is not None
                     fixture.table_id = str(placement.table_id)
                     fixture.scheduled_start = fresh.base + timedelta(

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -32,9 +32,13 @@ lock or Redis key to drift from it.
     ``rerun`` solve is requested in the same transaction. That is honest (this
     run produced nothing) and keeps the status enum closed. On a match, every
     returned placement for an *unpinned* fixture is written back as wall-clock
-    (``base + minutes``); pinned fixtures' columns are never touched — the
-    solver echoes pins verbatim, and a promise is not rewritten even with its
-    own bytes. (The one exception is a pin *physics* broke — see the
+    (``base + minutes``); a pinned fixture's **table** is never rewritten, and
+    its start is left byte-identical when the solver echoes it unchanged (a
+    promise is not rewritten even with its own bytes) — but a called match the
+    solver slid **later** on its (unchanged) table has that later start
+    persisted with ``pinned_at`` refreshed and fires the same "moved"
+    correction as a broken-pin move (ADR "a called match holds its table and
+    slides later"). (Physics moving a pin is the other exception — see the
     broken-pins section below.) No per-fixture merging, ever: the output is
     taken whole or not at all.
 
@@ -1038,9 +1042,41 @@ async def _apply_result(
                         fixture.pinned_at is not None
                         and fixture.id not in fresh.broken_pin_moves
                     ):
-                        # The solver echoes pins verbatim; a promise's columns
-                        # are never rewritten, not even with their own bytes.
-                        pinned += 1
+                        # A called match holds its table, but its start can be
+                        # pushed LATER on a re-solve when a predecessor overruns
+                        # (ADR "a called match holds its table and slides
+                        # later"). Compare the solver's returned start to the
+                        # stored one on the SAME floored-minute basis the
+                        # snapshot pinned it at (``to_min`` floors), so a
+                        # genuinely-unchanged pin — off-grid start included — is
+                        # byte-stable and moves no one.
+                        stored_start = fixture.scheduled_start
+                        stored_start_min = (
+                            None
+                            if stored_start is None
+                            else int((stored_start - fresh.base).total_seconds() // 60)
+                        )
+                        if (
+                            stored_start_min is None
+                            or placement.start_min <= stored_start_min
+                        ):
+                            # Unchanged: the solver floors a pin at its stored
+                            # start, so it can only echo it or slide later. A
+                            # promise's columns are never rewritten, not even
+                            # with their own bytes, and nobody is told.
+                            pinned += 1
+                            continue
+                        # Slid later on its (invariant) table — the solver never
+                        # re-tables a pin, so ``table_id`` is left untouched.
+                        # Persist the new start, renew ``pinned_at``, and route
+                        # it through the SAME "moved" correction a broken-pin
+                        # move fires: every persisted pin change carries one.
+                        fixture.scheduled_start = fresh.base + timedelta(
+                            minutes=placement.start_min
+                        )
+                        fixture.pinned_at = apply_now
+                        moved_repairs.append(fixture)
+                        placed += 1
                         continue
                     repaired_pin = fixture.pinned_at is not None
                     fixture.table_id = str(placement.table_id)

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -13,18 +13,28 @@ offsets used throughout is the *snapshot builder's* job (a later slice), not
 this module's: every time here is an ``int`` minute offset in one shared frame.
 
 **Two tiers: a plan is an estimate, a call is a promise.** Unpinned fixtures
-are decision variables. Pinned fixtures are **constants**: their
-``(table, start)`` is echoed into the output verbatim and their occupancy is a
-fixed interval every variable must schedule around. A pin is deliberately not
-modeled as "start ≥ pinned start" — a variable the objective is indifferent to
-could drift between solves, and the whole point of a pin is that what we told
-the players never changes. Pins also outrank windows: a pin pushed past its
-pool window by overrun keeps its promised slot (no window constraint is applied
-to pins). The flip side of pins-as-constants is honest: promises that
-physically contradict each other (two pins overlapping on one table, or a pin
-under an in-progress overrun) make the day **infeasible**, which the solve
-reports rather than papering over — the correction path (re-place / void, ADR)
-is the fix, and it runs *before* the next solve, not inside it.
+are free decision variables in both dimensions. A **called** (pinned, not-yet-
+started) fixture holds its *table* as a hard constant — it can never be re-placed
+onto another court — but its *start* is a free variable that can only be pushed
+**later** (``start ≥ pin.start_min``, the promised time as a floor). The start is
+anchored downward at the same weight as an unpinned fixture's wait (see the
+objective below): with no contention it sits exactly at the floor — the promised
+time, no drift — and under contention it slides to the *minimum* legal later
+value, just past the obstruction. The start is deliberately **not** snapped to
+the :data:`BUCKET_MIN` grid: ``pin.start_min`` may itself be off-grid (a manual
+director PATCH, a call tick), and snapping would both re-introduce drift and
+over-delay the slide. Pins still outrank windows: a called match pushed past its
+pool window by overrun keeps running (no window constraint is applied to it).
+
+Because a called match's start can always slide to the horizon, pins essentially
+**stop being a source of infeasibility**: the two promise contradictions that
+used to make a day infeasible — *two called matches promised the same table at
+overlapping times* and *a called match under an in-progress overrun* — now
+auto-resolve by sliding one later on the same table (the apply path notifies the
+player, a separate concern). Infeasibility becomes almost entirely a property of
+*unpinned* fixtures that cannot fit their pool window. A **genuinely in-progress**
+(being-played) match is different: it stays fully fixed in both dimensions —
+reality is not a variable, and a match underway must never move.
 
 **Rest across the completion boundary.** A player's 10-minute rest floor
 (:data:`REST_MIN`) is a hard constraint, and it must survive a match *ending*,
@@ -42,9 +52,11 @@ the floor stays this one module's single source of truth.
 
 1. **Makespan** — the max end over every active fixture. The day finishes as
    early as possible.
-2. **Player wait**, proxied as the sum of ``start − now`` over unpinned
-   fixtures. The true quantity ("wait beyond the rest floor between a player's
-   consecutive matches") needs per-player sequencing variables; total
+2. **Player wait**, proxied as the sum of ``start − now`` over every fixture
+   with a start variable — unpinned *and* called (a called match's slide is
+   anchored down here, at the same weight, so its start bottoms out at the
+   promised floor). The true quantity ("wait beyond the rest floor between a
+   player's consecutive matches") needs per-player sequencing variables; total
    start-lateness is monotone with aggregate waiting around, is linear, and
    keeps the model small. Documented trade-off: it also rewards starting the
    whole day promptly, which is indistinguishable from the real goal on the
@@ -56,7 +68,13 @@ The weights are computed **per instance** so the tiers provably never trade
 (the fixed "10000/10/1" style breaks once total wait can swing by more than
 one makespan minute times the ratio): ``W_stability = 1``,
 ``W_wait = max stability swing + 1``, ``W_makespan = W_wait · (max total wait
-swing) + 1``. All fit comfortably in int64 at any realistic instance size.
+swing) + 1``. The max total wait swing is bounded by the *count* of wait terms
+times the span — and that count is now ``len(unpinned) + len(pinned)``, since a
+called match contributes a wait term too. A called match's ``start − now`` can
+be *negative* when its promised floor is before ``now`` (a call already ticked
+past); a negative term only lowers the total, so bounding the positive swing by
+``count · span`` still holds. All fit comfortably in int64 at any realistic
+instance size.
 
 **Warm start.** Before solving, every unpinned fixture that has a
 ``previous_plan`` entry *whose prior table is still in its pool* seeds its prior
@@ -191,8 +209,11 @@ class EventSettings:
 
 @dataclass(frozen=True, slots=True)
 class Pin:
-    """A called placement — a promise. The solve echoes it back verbatim and
-    schedules everything else around it."""
+    """A called placement — a promise. ``table_id`` is a hard constant the
+    solve never changes; ``start_min`` is the promised time, which the solve
+    treats as a *floor* — a called match may be pushed later on a re-solve (and
+    the apply path then notifies the player), but never moved to another table
+    and never started earlier than promised."""
 
     table_id: TableId
     start_min: int
@@ -289,8 +310,9 @@ class ScheduleSnapshot:
 class PlacedFixture:
     """One line of the output plan. ``end_min`` is always
     ``start_min + match_minutes(...)`` — carried so consumers never re-derive
-    durations. For a pinned fixture, ``(table_id, start_min)`` is the pin,
-    byte for byte."""
+    durations. For a called fixture, ``table_id`` is the pin's table (always)
+    and ``start_min`` is the pin's promised time or a later slid value the
+    solver chose — never earlier than promised."""
 
     fixture_id: FixtureId
     table_id: TableId
@@ -312,8 +334,9 @@ class SolveStats:
 @dataclass(frozen=True, slots=True)
 class SolveResult:
     """A solve's whole answer. Placements cover every active fixture that is
-    not in progress — pins echoed verbatim, unpinned fixtures solved — or are
-    empty when ``verdict`` produced no plan. Deterministically ordered by
+    not in progress — called fixtures on their fixed table at the promised or a
+    slid-later start, unpinned fixtures solved in both dimensions — or are empty
+    when ``verdict`` produced no plan. Deterministically ordered by
     ``(start, table, fixture)``."""
 
     verdict: Verdict
@@ -409,15 +432,20 @@ class _SolverModel:
     hint's effect deterministically (single worker, fixed seed) without
     touching the production solver parameters. ``model`` carries the hints;
     ``starts``/``presences`` recover each unpinned fixture's chosen start and
-    table, ``durations`` its ``end_min``, and ``pinned_placements`` are echoed
-    verbatim."""
+    table, ``durations`` its ``end_min``. A called fixture's start is *also* a
+    variable now (it can slide later on its fixed table), so its solved start is
+    read back from ``pin_starts``; ``pin_tables`` holds its immovable table and
+    ``pin_durations`` its length."""
 
     model: cp_model.CpModel
     unpinned: tuple[ScheduleFixture, ...]
     starts: dict[FixtureId, Any]
     presences: dict[FixtureId, dict[TableId, Any]]
     durations: dict[FixtureId, int]
-    pinned_placements: tuple[PlacedFixture, ...]
+    pinned: tuple[ScheduleFixture, ...]
+    pin_starts: dict[FixtureId, Any]
+    pin_tables: dict[FixtureId, TableId]
+    pin_durations: dict[FixtureId, int]
 
 
 def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
@@ -456,14 +484,26 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
         for f in in_progress
     }
 
-    # The latest minute anything can end — start-variable and makespan bounds.
+    # The latest minute anything can end — the domain ceiling for every start
+    # variable (a called match's included, since it can now slide) and for the
+    # makespan var. A called match's start is no longer a constant: per-table
+    # no-overlap can force it to slide behind every fixed obstruction on its
+    # table (an in-progress occupancy end) and behind every other called match
+    # promised the same table. The safe worst case is *all* pins stacked end to
+    # end just after the latest fixed obstruction, so fold the total pin duration
+    # on top of the latest occupancy end and the latest pin floor. The old bound
+    # (the largest single ``pin.start_min + duration``) could be too tight for a
+    # pin forced past a *later* obstruction — an artificial INFEASIBLE.
     horizon = now + BUCKET_MIN
     for pool in snapshot.pools:
         horizon = max(horizon, pool.window.end_min)
-    for fixture, pin in pinned:
-        horizon = max(horizon, pin.start_min + duration_of(fixture))
+    latest_obstruction = now
     for end in occupancy_ends.values():
-        horizon = max(horizon, end)
+        latest_obstruction = max(latest_obstruction, end)
+    for _fixture, pin in pinned:
+        latest_obstruction = max(latest_obstruction, pin.start_min)
+    total_pin_duration = sum(duration_of(fixture) for fixture, _ in pinned)
+    horizon = max(horizon, latest_obstruction + total_pin_duration)
 
     # Structural feasibility first: a fixture whose window cannot hold its
     # duration at all needs no solver to refuse. (Whole-or-nothing: one
@@ -486,6 +526,9 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
     player_intervals: defaultdict[PlayerId, list[Any]] = defaultdict(list)
     fixed_ends: list[int] = []
     variable_ends: list[Any] = []
+    # start − now, summed as the player-wait objective tier. Both unpinned and
+    # called fixtures contribute (a called match's slide is anchored here).
+    wait_terms: list[Any] = []
 
     # In-progress matches: fixed occupancy from their *actual* start. Their
     # players rest for REST_MIN after the occupancy end, like everyone else.
@@ -527,33 +570,42 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
             )
         )
 
-    # Pins: constants. No window constraint (pins outrank windows), no start
-    # variable (a promise does not drift), occupancy every variable respects.
-    pinned_placements: list[PlacedFixture] = []
+    # Called matches: table hard-fixed, start a free variable pushable only
+    # later. The start lives on `table_intervals[pin.table_id]` alone — no
+    # table-choice presence bools, so a promise can never be re-placed onto
+    # another court — with lower bound `pin.start_min` (never earlier than
+    # promised) and no window constraint (pins outrank windows). It is NOT
+    # snapped to the BUCKET_MIN grid: `pin.start_min` may itself be off-grid,
+    # and snapping would re-introduce drift and over-delay the slide. Occupancy
+    # and the rest-padded per-player interval both key off the start variable,
+    # exactly like an in-progress or unpinned interval; the end is a *variable*
+    # end folded into the makespan bound, not a fixed constant.
+    pin_starts: dict[FixtureId, Any] = {}
+    pin_tables: dict[FixtureId, TableId] = {}
+    pin_durations: dict[FixtureId, int] = {}
     for fixture, pin in pinned:
         duration = duration_of(fixture)
-        end = pin.start_min + duration
+        pin_start = model.NewIntVar(
+            pin.start_min, horizon - duration, f"pin_start_{fixture.id}"
+        )
         table_intervals[pin.table_id].append(
-            model.NewIntervalVar(pin.start_min, duration, end, f"pin_{fixture.id}")
+            model.NewFixedSizeIntervalVar(pin_start, duration, f"pin_{fixture.id}")
         )
         for player in (fixture.player_a_id, fixture.player_b_id):
             player_intervals[player].append(
-                model.NewIntervalVar(
-                    pin.start_min,
-                    duration + REST_MIN,
-                    end + REST_MIN,
-                    f"pin_{fixture.id}_{player}",
+                model.NewFixedSizeIntervalVar(
+                    pin_start, duration + REST_MIN, f"pin_{fixture.id}_{player}"
                 )
             )
-        fixed_ends.append(end)
-        pinned_placements.append(
-            PlacedFixture(
-                fixture_id=fixture.id,
-                table_id=pin.table_id,
-                start_min=pin.start_min,
-                end_min=end,
-            )
-        )
+        variable_ends.append(pin_start + duration)
+        # Anchor the start downward at the *same* weight as an unpinned fixture:
+        # since `pin.start_min` is the variable's floor, this wait term bottoms
+        # out at the promised time (no drift, uncontended) and slides to the
+        # minimum legal later value under contention. No new objective tier.
+        wait_terms.append(pin_start - now)
+        pin_starts[fixture.id] = pin_start
+        pin_tables[fixture.id] = pin.table_id
+        pin_durations[fixture.id] = duration
 
     # Unpinned fixtures: one start variable on the 5-minute grid, one optional
     # interval per candidate table (exactly one present), and a mandatory
@@ -565,7 +617,6 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
     presences: dict[FixtureId, dict[TableId, Any]] = {}
     buckets: dict[FixtureId, Any] = {}
     durations: dict[FixtureId, int] = {}
-    wait_terms: list[Any] = []
     for fixture in unpinned:
         pool = pools[fixture.pool_id]
         duration = duration_of(fixture)
@@ -634,10 +685,15 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
         kept_literals.append(kept)
 
     # Instance-computed strictly-lexicographic weights — see module docstring.
+    # The wait tier now has one term per unpinned *and* per called fixture, so
+    # the count bounding the max total wait swing is len(unpinned) + len(pinned).
+    # A called match's `pin_start - now` can be negative (a floor before now),
+    # which only lowers the total, so `count * span` still bounds the positive
+    # swing and the tiers provably never trade.
     span = max(1, horizon - now)
     w_stability = 1
     w_wait = w_stability * stability_span + 1
-    w_makespan = w_wait * max(1, len(unpinned)) * span + 1
+    w_makespan = w_wait * max(1, len(unpinned) + len(pinned)) * span + 1
 
     objective = w_makespan * makespan
     for term in wait_terms:
@@ -661,13 +717,21 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
         for table, present in presences[fixture.id].items():
             model.AddHint(present, 1 if table == prior.table_id else 0)
 
+    # Warm start each called match's slide variable at its promised time so a
+    # re-solve begins at what the player was told and only slides if forced.
+    for fixture, pin in pinned:
+        model.AddHint(pin_starts[fixture.id], pin.start_min)
+
     return _SolverModel(
         model=model,
         unpinned=tuple(unpinned),
         starts=starts,
         presences=presences,
         durations=durations,
-        pinned_placements=tuple(pinned_placements),
+        pinned=tuple(fixture for fixture, _ in pinned),
+        pin_starts=pin_starts,
+        pin_tables=pin_tables,
+        pin_durations=pin_durations,
     )
 
 
@@ -676,9 +740,10 @@ def solve(
     time_cap_s: float = 10.0,
     num_search_workers: int = 1,
 ) -> SolveResult:
-    """Place every active fixture: pins echoed verbatim, everything else
-    solved onto its pool's tables inside its pool's window, on the
-    :data:`BUCKET_MIN` grid, no earlier than ``now_min``.
+    """Place every active fixture: a called match on its fixed table at the
+    promised start or a slid-later one (never earlier), everything else solved
+    onto its pool's tables inside its pool's window, on the :data:`BUCKET_MIN`
+    grid, no earlier than ``now_min``.
 
     Never raises for infeasibility — see :class:`Verdict`. Raises
     :class:`IncoherentSnapshot` for inputs that reference things they do not
@@ -714,7 +779,20 @@ def solve(
     if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
         return _no_plan(Verdict.unknown, wall_time_ms)
 
-    placements = list(built.pinned_placements)
+    placements: list[PlacedFixture] = []
+    # Called matches: table is the pin's fixed table; start is read back from
+    # the solver (it slid later if forced, else sits at the promised floor).
+    for fixture in built.pinned:
+        pin_start = int(solver.Value(built.pin_starts[fixture.id]))
+        duration = built.pin_durations[fixture.id]
+        placements.append(
+            PlacedFixture(
+                fixture_id=fixture.id,
+                table_id=built.pin_tables[fixture.id],
+                start_min=pin_start,
+                end_min=pin_start + duration,
+            )
+        )
     for fixture in built.unpinned:
         start_value = int(solver.Value(built.starts[fixture.id]))
         table = _chosen_table(solver, built.presences[fixture.id], fixture.id)

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -1537,6 +1537,13 @@ class TestBrokenPinRepair:
             )
         )
         original_pin_time = BASE - timedelta(minutes=15)
+        # The control sits late on t2, after every other fixture packs in, so
+        # it is uncontended and the solver leaves it byte-for-byte. A called
+        # match's start is a floor, not a constant (ADR "a called match holds
+        # its table and slides later") — an EARLY pin sharing a player with the
+        # rest of the round-robin gets legitimately bumped later, which is not
+        # the "untouched" case this control is here to demonstrate.
+        control_start = BASE + timedelta(minutes=300)
         await _pin_directly(
             db_session,
             target,
@@ -1548,7 +1555,7 @@ class TestBrokenPinRepair:
             db_session,
             control,
             table_id="t2",
-            start=BASE,
+            start=control_start,
             pinned_at=original_pin_time,
         )
         await _remove_table(db_session, tournament_id, event_id, "t1")
@@ -1567,7 +1574,7 @@ class TestBrokenPinRepair:
 
         # The untouched pin: byte-identical, no re-notification.
         assert control.table_id == "t2"
-        assert control.scheduled_start == BASE
+        assert control.scheduled_start == control_start
         assert control.pinned_at == original_pin_time
         assert control.call_notified_count == 1
 
@@ -2188,7 +2195,11 @@ class TestManualPlacementPin:
         )
         target = fixtures[0]
         target_id = target.id
-        pin_start = BASE + timedelta(minutes=60)
+        # Late on the shared table, after the other two pack in: a called
+        # match's start is a floor, not a constant (ADR "a called match holds
+        # its table and slides later"), so an uncontended pin is the one the
+        # solver leaves byte-for-byte — the "does not undo it" point here.
+        pin_start = BASE + timedelta(minutes=200)
         fanout = await match_calls.apply_manual_placement(
             db_session, tournament, target, table_id="t1", scheduled_start=pin_start
         )

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -392,12 +392,11 @@ def _slide_pin_later(
             PlacedFixture(
                 fixture_id=placement.fixture_id,
                 table_id=placement.table_id,
-                start_min=placement.start_min
-                + (extra_min if placement.fixture_id == target_id else 0),
-                end_min=placement.end_min
-                + (extra_min if placement.fixture_id == target_id else 0),
+                start_min=placement.start_min + bump,
+                end_min=placement.end_min + bump,
             )
             for placement in result.placements
+            for bump in (extra_min if placement.fixture_id == target_id else 0,)
         )
         return SolveResult(
             verdict=result.verdict, placements=placements, stats=result.stats

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -26,6 +26,7 @@ load-bearing and the green above isn't scheduler luck.
 import asyncio
 import threading
 import uuid
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
@@ -52,6 +53,7 @@ from app.models import (
     Match,
     MatchSettings,
     MatchStatus,
+    Notification,
     ScheduleSolve,
     ScheduleSolveStatus,
     ScheduleSolveTrigger,
@@ -73,11 +75,13 @@ from app.schedule_solves import (
 )
 from app.scheduling import (
     REST_MIN,
+    PlacedFixture,
     ScheduleSnapshot,
     SolveResult,
     SolveStats,
     Verdict,
 )
+from app.schemas.notification import NotificationJob
 from app.tournament_draws import cut_draw
 from tests._helpers import hijack_solve, make_user
 
@@ -107,6 +111,7 @@ def solver_queue(monkeypatch: pytest.MonkeyPatch) -> Queue:
 async def _make_tournament(
     db: AsyncSession,
     *,
+    status: TournamentStatus = TournamentStatus.published,
     entrants: int = 4,
     tables: tuple[str, ...] = ("t1", "t2"),
     window: tuple[str, str] = ("09:00", "17:00"),
@@ -124,7 +129,7 @@ async def _make_tournament(
 
     tournament = Tournament(
         name="Scheduled Open",
-        status=TournamentStatus.published,
+        status=status,
         address={
             "venue": "Berkeley TT Club",
             "street": "1 Shattuck Ave",
@@ -324,6 +329,81 @@ async def _mark_completed(
     fixture.winner_entry_id = entry_a_id
     await db.commit()
     return await _fixture_user_ids(db, entry_a_id, entry_b_id)
+
+
+async def _pin_fixture(
+    db: AsyncSession,
+    fixture: TournamentFixture,
+    *,
+    table_id: str,
+    start: datetime,
+    pinned_at: datetime,
+    notified: int = 1,
+) -> None:
+    """Stage an already-called fixture directly on the row — table, promised
+    start, ``pinned_at`` and the told-count — the pre-state the slide/echo
+    apply paths read."""
+    fixture.table_id = table_id
+    fixture.scheduled_start = start
+    fixture.pinned_at = pinned_at
+    fixture.call_notified_count = notified
+    await db.commit()
+
+
+async def _match_call_notifications(db: AsyncSession) -> list[Notification]:
+    return list(
+        (
+            await db.execute(
+                select(Notification)
+                .where(Notification.category == "match_calls")
+                .order_by(Notification.created_at, Notification.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+def _fanout_jobs(notifications_queue: Queue) -> list[NotificationJob]:
+    return [
+        NotificationJob.model_validate_json(job.args[0])
+        for job in notifications_queue.jobs
+    ]
+
+
+def _slide_pin_later(
+    target_fixture_id: uuid.UUID, extra_min: int
+) -> Callable[[ScheduleSnapshot, float, int], SolveResult]:
+    """Interpose on the ``_solve`` seam: run the real solver, then push only
+    the target pin's placement ``extra_min`` minutes later on its (unchanged)
+    table — exactly the "predecessor overran" outcome 1a's solver produces
+    under contention, staged deterministically so the apply path is what's
+    under test."""
+    real = scheduling.solve
+    target_id = str(target_fixture_id)
+
+    def wrapper(
+        snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+    ) -> SolveResult:
+        result = real(
+            snapshot, time_cap_s=time_cap_s, num_search_workers=num_search_workers
+        )
+        placements = tuple(
+            PlacedFixture(
+                fixture_id=placement.fixture_id,
+                table_id=placement.table_id,
+                start_min=placement.start_min
+                + (extra_min if placement.fixture_id == target_id else 0),
+                end_min=placement.end_min
+                + (extra_min if placement.fixture_id == target_id else 0),
+            )
+            for placement in result.placements
+        )
+        return SolveResult(
+            verdict=result.verdict, placements=placements, stats=result.stats
+        )
+
+    return wrapper
 
 
 class TestSolveNumWorkers:
@@ -833,14 +913,19 @@ class TestSolveJob:
     async def test_pinned_fixture_columns_are_untouched_by_apply(
         self, db_session: AsyncSession, solver_queue: Queue
     ) -> None:
-        """The solver echoes pins verbatim; the apply must not rewrite a
-        promise's columns even with identical values — so a deliberately
-        off-grid pin survives byte for byte."""
+        """When the solver returns a called match UNCHANGED (its start is a
+        floor with nothing competing for that slot — 1a's no-drift guarantee),
+        the apply must not rewrite the promise's columns even with identical
+        values, so a deliberately off-grid pin survives byte for byte. The pin
+        sits late enough that no other fixture wants its slot, so the floor is
+        the minimum and it never slides (contrast the slide path below)."""
         tournament_id, event_id = await _make_tournament(db_session)
         fixtures = await _fixtures_of(db_session, event_id)
         pinned = fixtures[0]
         pinned_id = pinned.id
-        pinned_start = BASE + timedelta(minutes=62)  # off the 5-minute grid
+        # Late + off the 5-minute grid: every other fixture packs earlier, so
+        # this pin is uncontended and the solver leaves it exactly here.
+        pinned_start = BASE + timedelta(minutes=302)
         pinned_at = BASE - timedelta(minutes=30)
         pinned.table_id = "t1"
         pinned.scheduled_start = pinned_start
@@ -1123,3 +1208,129 @@ class TestDriftGuard:
             if fixture.table_id is not None
         ]
         assert len(placed) == 6
+
+
+class TestCalledMatchSlides:
+    """Chore 2a (ADR "a called match holds its table and slides later"): the
+    guarded apply persists a called match the solver pushed LATER on its
+    (unchanged) table and fires the same "moved" correction a broken-pin move
+    does — while a pin the solver echoes unchanged is still byte-stable and
+    tells no one."""
+
+    async def test_a_slid_called_match_is_persisted_and_moved_notified(
+        self,
+        db_session: AsyncSession,
+        solver_queue: Queue,
+        fake_notifications_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A predecessor overran: the solver returns the called match 20
+        minutes later on the SAME table. The apply persists the slid start,
+        refreshes ``pinned_at``, and sends exactly one *moved* correction per
+        entrant — the pin counts as placed, not pinned."""
+        tournament_id, event_id = await _make_tournament(
+            db_session, status=TournamentStatus.live, entrants=2, tables=("t1",)
+        )
+        fixture = (await _fixtures_of(db_session, event_id))[0]
+        fixture_id = fixture.id
+        entry_a_id, entry_b_id = fixture.entry_a_id, fixture.entry_b_id
+        assert entry_a_id is not None and entry_b_id is not None
+        original_pin_time = BASE - timedelta(minutes=15)
+        await _pin_fixture(
+            db_session,
+            fixture,
+            table_id="t1",
+            start=BASE,
+            pinned_at=original_pin_time,
+            notified=1,
+        )
+        user_a, user_b = await _fixture_user_ids(db_session, entry_a_id, entry_b_id)
+
+        apply_now = BASE - timedelta(minutes=60)
+        monkeypatch.setattr(schedule_solves, "_wall_now", lambda: apply_now)
+        monkeypatch.setattr(
+            schedule_solves, "_solve", _slide_pin_later(fixture_id, extra_min=20)
+        )
+
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+        assert row is not None
+        row_id = row.id
+        await db_session.commit()
+        _run_recorded_job(solver_queue, row_id)
+
+        db_session.expire_all()
+        slid = (await _fixtures_of(db_session, event_id))[0]
+        assert slid.table_id == "t1"  # the table is invariant
+        assert slid.scheduled_start == BASE + timedelta(minutes=20)  # slid later
+        assert slid.pinned_at == apply_now  # the promise is renewed, not demoted
+        assert slid.call_notified_count == 2  # the call, then the moved correction
+
+        rows = await _match_call_notifications(db_session)
+        assert len(rows) == 2  # exactly one per entrant, nobody else
+        assert {str(row.user_id) for row in rows} == {user_a, user_b}
+        for notification in rows:
+            assert notification.title == "Your match moved to T1"
+            assert "09:20" in notification.body  # BASE + 20 minutes
+        jobs = _fanout_jobs(fake_notifications_queue)
+        assert {str(job.user_id) for job in jobs} == {user_a, user_b}
+        assert all(job.collapse_id == f"match-call:{fixture_id}" for job in jobs)
+
+        (ledger,) = await _solve_rows(db_session, tournament_id)
+        assert ledger.status is ScheduleSolveStatus.succeeded
+        assert ledger.fixtures_placed == 1  # the slid pin moved → placed
+        assert ledger.fixtures_pinned == 0
+
+    async def test_an_unchanged_called_match_is_echoed_verbatim_and_silent(
+        self,
+        db_session: AsyncSession,
+        solver_queue: Queue,
+        fake_notifications_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No contention: the real solver returns the (off-grid) pin exactly at
+        its promised start. The apply rewrites not a byte and notifies no one —
+        the pin counts as pinned, not placed."""
+        tournament_id, event_id = await _make_tournament(
+            db_session, status=TournamentStatus.live, entrants=2, tables=("t1",)
+        )
+        fixture = (await _fixtures_of(db_session, event_id))[0]
+        fixture_id = fixture.id
+        original_pin_time = BASE - timedelta(minutes=15)
+        pinned_start = BASE + timedelta(minutes=7)  # off the 5-minute grid
+        await _pin_fixture(
+            db_session,
+            fixture,
+            table_id="t1",
+            start=pinned_start,
+            pinned_at=original_pin_time,
+            notified=1,
+        )
+
+        apply_now = BASE - timedelta(minutes=60)
+        monkeypatch.setattr(schedule_solves, "_wall_now", lambda: apply_now)
+
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+        assert row is not None
+        row_id = row.id
+        await db_session.commit()
+        _run_recorded_job(solver_queue, row_id)
+
+        db_session.expire_all()
+        survivor = (await _fixtures_of(db_session, event_id))[0]
+        assert survivor.id == fixture_id
+        assert survivor.table_id == "t1"
+        assert survivor.scheduled_start == pinned_start  # byte-identical
+        assert survivor.pinned_at == original_pin_time  # not refreshed
+        assert survivor.call_notified_count == 1  # never re-told
+
+        assert await _match_call_notifications(db_session) == []
+        assert fake_notifications_queue.jobs == []
+
+        (ledger,) = await _solve_rows(db_session, tournament_id)
+        assert ledger.status is ScheduleSolveStatus.succeeded
+        assert ledger.fixtures_placed == 0  # nothing moved
+        assert ledger.fixtures_pinned == 1  # the verbatim echo

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -174,9 +174,10 @@ def _assert_hard_constraints(snapshot: ScheduleSnapshot, result: SolveResult) ->
                 (placement.start_min, placement.end_min)
             )
         if fixture.pin is not None:
-            # Pins echoed byte for byte; windows do not apply to them.
+            # A called match holds its table as a hard constant; its start can
+            # slide later but never earlier than promised. Windows do not apply.
             assert placement.table_id == fixture.pin.table_id
-            assert placement.start_min == fixture.pin.start_min
+            assert placement.start_min >= fixture.pin.start_min
         else:
             pool = pools[fixture.pool_id]
             assert placement.table_id in pool.table_ids
@@ -267,10 +268,15 @@ class TestHardConstraints:
 
 class TestPinsArePromises:
     def test_pinned_placements_survive_arbitrary_resolves(self) -> None:
-        """THE invariant: a pin's (table, start) is byte-identical in the
-        output across re-solves with mutated unpinned inputs — added and
-        removed fixtures, junk previous plans, shrunk capacity elsewhere,
-        and a later clock."""
+        """THE invariant, post-ADR "a called match holds its table and slides
+        later": across re-solves with mutated unpinned inputs — added and
+        removed fixtures, junk previous plans, shrunk capacity elsewhere, and a
+        later clock — a called match's *table* is byte-identical and its *start*
+        never precedes the promise. (The stronger "start is byte-identical too"
+        no longer holds: a called match's start is now a variable that can slide
+        later under contention; the no-drift-when-uncontended case is proven
+        exactly, against a proven optimum, in
+        ``TestCalledMatchesSlideNotBreak``.)"""
         base = _random_snapshot(seed=7)
         first = solve(base, time_cap_s=CAP)
         assert first.verdict in SOLVED
@@ -324,7 +330,7 @@ class TestPinsArePromises:
             placed = {p.fixture_id: p for p in result.placements}
             for fixture_id, promise in called.items():
                 assert placed[fixture_id].table_id == promise.table_id
-                assert placed[fixture_id].start_min == promise.start_min
+                assert placed[fixture_id].start_min >= promise.start_min
 
     def test_hard_constraints_hold_around_pins(self) -> None:
         """Run the full hard-constraint check over a plan that CONTAINS a pin
@@ -371,6 +377,130 @@ class TestPinsArePromises:
         placed = {p.fixture_id: p for p in result.placements}
         assert placed[FixtureId("F1")].start_min == 30
         assert placed[FixtureId("F2")].start_min >= 40
+
+
+class TestCalledMatchesSlideNotBreak:
+    """A called match holds its *table* as a hard constant but its *start* is a
+    variable that can only be pushed later (ADR "a called match holds its table
+    and slides later", #1141). The promise contradictions that used to make a
+    day INFEASIBLE — a called match under an in-progress overrun, two called
+    matches promised the same table at overlapping times — now auto-resolve by
+    sliding one later on the same table. Each test here goes red before that
+    change: the old fully-rigid pin overlapped a fixed interval and the solve
+    answered INFEASIBLE."""
+
+    def test_called_match_slides_behind_an_overrunning_predecessor(self) -> None:
+        """The motivating bug: a match ahead of a called one on the *same*
+        shared table overruns its estimate, so the called match's promised slot
+        overlaps the still-busy court. Old model (pin a rigid constant): the two
+        fixed intervals overlap on the table -> INFEASIBLE, the whole board
+        frozen. New model: the called match slides later on the *same* table,
+        just past the occupancy, and the day is feasible.
+
+        Proves: overrun predecessor behind a same-table pin -> feasible/optimal
+        with the called fixture slid later ON THE SAME TABLE."""
+        p1, p2, p3, p4 = _players(4)
+        # F1 started at 0 (a 25-minute best-of-3) but now is 60 — 35 minutes
+        # over. Its occupancy blocks T1 through max(0 + 25, 60 + 5) = 65. F2 is
+        # called to that same T1 at 30, which overlaps [0, 65). It must slide.
+        fixtures = (
+            _fixture(1, p1, p2),
+            _fixture(2, p3, p4, pin=Pin(TableId("T1"), 30)),
+        )
+        snapshot = _one_pool_snapshot(
+            fixtures,
+            tables=1,
+            now_min=60,
+            in_progress=(InProgressMatch(FixtureId("F1"), TableId("T1"), 0),),
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        _assert_hard_constraints(snapshot, result)
+        called = {p.fixture_id: p for p in result.placements}[FixtureId("F2")]
+        assert called.table_id == TableId("T1")  # never a different court
+        # Slid just past the overrunning occupancy end (65), off-grid-friendly.
+        assert called.start_min == 65
+
+    def test_uncontended_called_match_holds_its_off_grid_start_exactly(
+        self,
+    ) -> None:
+        """With no contention the slide bottoms out at the promised floor: the
+        solved start equals ``pin.start_min`` exactly, with zero drift. The
+        promised time is deliberately *off* the 5-minute grid to prove the
+        start is not snapped (snapping would both drift and over-delay).
+
+        Proves: no contention -> solved start == pin.start_min exactly, off
+        grid, no grid-snap and no drift."""
+        p1, p2 = _players(2)
+        off_grid = 63  # not a multiple of BUCKET_MIN
+        assert off_grid % BUCKET_MIN != 0
+        snapshot = _one_pool_snapshot(
+            (_fixture(1, p1, p2, pin=Pin(TableId("T1"), off_grid)),),
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict in SOLVED
+        placed = {p.fixture_id: p for p in result.placements}[FixtureId("F1")]
+        assert placed.table_id == TableId("T1")
+        assert placed.start_min == off_grid  # no snap, no drift
+        assert placed.end_min == off_grid + match_minutes(3)
+
+    def test_called_matchs_table_is_invariant_across_a_resolve(self) -> None:
+        """The one-line rule: a called match may be pushed later on a re-solve
+        but never moved to a different table. Solve twice — once uncontended,
+        once with an overrun on the pinned table that forces a slide — and the
+        table is identical both times even as the start moves.
+
+        Proves: a called fixture's ``table_id`` is invariant across a re-solve."""
+        p1, p2, p3, p4 = _players(4)
+        pin = Pin(TableId("T2"), 100)
+        base = _one_pool_snapshot(
+            (_fixture(1, p1, p2, pin=pin), _fixture(2, p3, p4)),
+            tables=3,
+        )
+        first = solve(base, time_cap_s=CAP)
+        assert first.verdict in SOLVED
+        first_called = {p.fixture_id: p for p in first.placements}[FixtureId("F1")]
+        assert first_called.table_id == TableId("T2")
+        assert first_called.start_min == 100  # uncontended: at the floor
+
+        # Re-solve with an overrun on T2 that overlaps the promise, forcing a
+        # slide — but never a table change.
+        contended = dataclasses.replace(
+            base,
+            now_min=110,
+            in_progress=(InProgressMatch(FixtureId("F2"), TableId("T2"), 100),),
+        )
+        # F2 becomes the running match; drop its unpinned duplicate placement by
+        # keeping it as the in-progress fixture (already in `fixtures`).
+        second = solve(contended, time_cap_s=CAP)
+        assert second.verdict in SOLVED
+        second_called = {p.fixture_id: p for p in second.placements}[FixtureId("F1")]
+        assert second_called.table_id == TableId("T2")  # table never varies
+        assert second_called.start_min > 100  # but the start slid later
+
+    def test_two_called_matches_same_table_overlap_resolves_by_sliding(
+        self,
+    ) -> None:
+        """Two promises to the same table at overlapping times. Old model: two
+        rigid fixed intervals overlap on T1 -> INFEASIBLE. New model: one holds
+        its floor and the other slides just past it — feasible, both still on
+        T1, non-overlapping.
+
+        Proves: two called fixtures promised the same table at overlapping times
+        resolve to one sliding later (feasible), not INFEASIBLE."""
+        p1, p2, p3, p4 = _players(4)
+        fixtures = (
+            _fixture(1, p1, p2, pin=Pin(TableId("T1"), 0)),  # [0, 25)
+            _fixture(2, p3, p4, pin=Pin(TableId("T1"), 10)),  # promised [10, 35)
+        )
+        snapshot = _one_pool_snapshot(fixtures, tables=1)
+        result = solve(snapshot, time_cap_s=CAP)
+        _assert_hard_constraints(snapshot, result)
+        placed = {p.fixture_id: p for p in result.placements}
+        assert placed[FixtureId("F1")].table_id == TableId("T1")
+        assert placed[FixtureId("F2")].table_id == TableId("T1")
+        # F1 holds its 0 floor; F2 slides from 10 to just past F1's end (25).
+        starts = sorted(p.start_min for p in result.placements)
+        assert starts == [0, 25]
 
 
 class TestInfeasibility:

--- a/docs/adr/20260716-the-schedule-is-solved-the-call-is-pinned.md
+++ b/docs/adr/20260716-the-schedule-is-solved-the-call-is-pinned.md
@@ -1,8 +1,18 @@
 # The schedule is solved; the call is pinned
 
 Date: 2026-07-16
-Status: accepted
+Status: accepted (amended 2026-07-19)
 (Number this ADR by its PR at land time; date-prefixed until then.)
+
+> **Amendment (2026-07-19, #1141):** a pin is no longer a *fully* rigid `(table, start)`
+> interval. A called match's **table** is still a hard constant it can never leave, but its
+> **start can be pushed later** when a predecessor overruns — the solver slides it on the same
+> table and the persisted change fires the same "moved" correction. Read "pins are fixed
+> intervals" and "we never rearrange what we told a player" below as: *a called match's table
+> never changes; its start can slide later, always with a correction.* The whole-or-nothing
+> invariant in Consequences still holds — no pinned placement changes except through a capacity
+> break (an overrun now among them), and every such break still carries a correction. See
+> [ADR "A called match holds its table and slides later"](20260719-a-called-match-holds-its-table-and-slides-later.md).
 
 ## Context
 

--- a/docs/adr/20260719-a-called-match-holds-its-table-and-slides-later.md
+++ b/docs/adr/20260719-a-called-match-holds-its-table-and-slides-later.md
@@ -1,0 +1,91 @@
+# A called match holds its table and slides later
+
+Date: 2026-07-19
+Status: accepted
+(Number this ADR by its PR at land time; date-prefixed until then.)
+
+Amends ["The schedule is solved; the call is pinned"](20260716-the-schedule-is-solved-the-call-is-pinned.md).
+Fixes the intermittent infeasibility caught in the UAT soak (#1114); closes #1141.
+
+## Context
+
+The original pin model (the ADR above) makes a **called** (pinned, not-yet-started) match a
+**fully rigid `(table, start)` constant**: both dimensions frozen, echoed back verbatim, an
+immovable interval every other fixture schedules around. The stated reason a pin was *not*
+modeled as "start ≥ pinned start" was drift: a variable the objective is indifferent to could
+wander between solves, and the whole point of a pin is that what we told the player never
+changes.
+
+That rigidity is the root cause of an intermittent infeasibility. A match ahead of a called
+one on the **same shared table** overruns its duration estimate; the called match is frozen at
+a constant start; the two fixed intervals overlap on that table → a structurally **INFEASIBLE**
+solve. Nothing is applied, so the whole board is stuck (no reflow for anyone) until the
+overrunning match completes and frees the court. With shared table pools and long matches this
+fires under live churn.
+
+A human control desk never hits this: it says "a few more minutes on Table 3" and slides the
+called match later on the **same** table. It never tells a player to switch tables, and it
+never contradicts the physical reality that the court is still busy.
+
+## Decision
+
+**A called match's *table* stays a hard constant; its *start* becomes a variable that can only
+be pushed later.** Rule in one line: **a called match may be pushed later on a re-solve, but
+never moved to a different table.**
+
+### In the solver (`api/app/scheduling.py`)
+
+- A pinned fixture's start is a **free integer-minute CP-SAT variable** with
+  `start ≥ pin.start_min`, on `table_intervals[pin.table_id]` only — the table never varies, so
+  the pin can never be re-placed onto another court. Its occupancy and rest-padded player
+  interval both key off that variable. It is **not** snapped to the 5-minute bucket grid the
+  unpinned fixtures use: `pin.start_min` may itself be off-grid (a manual director PATCH, a call
+  tick), and snapping would both break "no drift" and over-delay the slide.
+- **The start is anchored downward in the objective** by folding the called match's `start − now`
+  into the **existing player-wait term**, at the same weight as an unpinned fixture. The current
+  strict tier order is unchanged: `makespan ≫ player-wait ≫ stability`. Because `pin.start_min`
+  is the variable's floor, the wait term is minimized *at the floor* — so with no contention the
+  start sits exactly at the promised time (no drift), and under contention it slides to the
+  **minimum** legal later value (just past the obstruction).
+- **Genuinely in-progress (being-played) matches stay fully fixed** in both dimensions. This
+  change is only about *called-but-not-yet-started* fixtures. A match underway must never move.
+- Calling is unchanged: `run_pin_tick` / the pin writers in `app/match_calls.py` still call
+  matches on the same schedule. This only changes how the solver treats an already-called
+  fixture.
+
+### At apply (`api/app/schedule_solves.py`)
+
+- The apply loop no longer blindly echoes a pin verbatim. When the solver returns a called
+  match at a **later** start than its stored placement (same table, always), that slid start is
+  **persisted** and the existing **"moved" correction** (`notify_pin_repairs`) fires — the
+  player is told, same as any other pin repair. When the solver returns it **unchanged** (the
+  common, no-contention case), it is still echoed verbatim and notifies no one.
+- Reusing the existing table-changed "moved" correction (rather than a distinct gentler
+  "same table, a few minutes later" message) is deliberate for now — least new surface, and it
+  honors the amended ADR's invariant that *every* persisted pin change carries a correction.
+
+## Consequences
+
+- **The intermittent overrun-overlap infeasibility is gone.** A called match behind an
+  overrunning predecessor slides later on the same table and the day stays feasible and applies —
+  early finishes visibly compact instead of the board freezing.
+- **Pins essentially stop being a source of infeasibility.** With no window ceiling and a start
+  that can always slide to the horizon, the two former pin contradictions — *two called matches
+  promised the same table at overlapping times* and *a called match under an in-progress overrun*
+  — now **auto-resolve** by sliding one later plus a correction, rather than surfacing as
+  INFEASIBLE. Infeasibility becomes almost entirely a property of *unpinned* fixtures that cannot
+  fit their pool window. This is broader than the single-overrun scenario that motivated the fix,
+  and it is accepted: a self-healing slide beats a stuck day.
+- **A called match is not specially shielded from being bumped.** Folded into player-wait at
+  equal weight, the called match's start is interchangeable with an unpinned match's when they
+  compete for the same freed slot — so an unpinned match can occasionally jump the queue and push
+  a *called, already-promised* match later. The stronger guarantee (a dedicated, higher-weighted
+  "called-delay" tier so a promise is never bumped, and ultimately a **configurable** tier
+  ordering) is a deliberate **follow-up**, not built here. Because the tier weights are computed
+  symmetrically (each tier's weight is "1 more than the max cost of every tier below it"),
+  reordering or inserting a tier later is a localized change to the weight formulas.
+  **Revisit trigger:** measure how often an unpinned match actually bumps a called one in
+  practice (UAT soak / production) before deciding whether the dedicated tier is worth its cost.
+- The module docstring's infeasibility discussion and the amended ADR's "pins are fixed
+  intervals / we never rearrange what we told a player" language are updated to: *a called
+  match's **table** never changes; its **start** can be pushed later, always with a correction.*


### PR DESCRIPTION
## Summary

A **called** (pinned, not-yet-started) match was a fully rigid `(table, start)` constant in the CP-SAT solver. When a match ahead of it on a **shared table** overran its duration estimate, the frozen pin overlapped the fixed occupancy → a structurally **INFEASIBLE** solve, so nothing applied and the whole board froze until the overrun finished. This was the root cause of the intermittent infeasibility from the UAT soak (#1114).

This change makes a called match's **table a hard constant** but its **start a variable that can only be pushed later**, anchored at its promised floor. Rule in one line: *a called match may be pushed later on a re-solve, but never moved to a different table* — exactly what a human control desk does ("a few more minutes on Table 3").

Closes #1141.

## What changed

**Solver (`app/scheduling.py`):** a pinned fixture's start is now a free integer-minute variable `start ≥ pin.start_min` on its fixed table (no table-choice bools, not grid-snapped so an off-grid promise holds exactly). It's anchored downward by folding `start − now` into the existing player-wait term — so with no contention it sits at the promised time (no drift), and under contention it slides to the minimum legal later value behind the overrun. Horizon, lexicographic weight bound, and makespan updated to cover the now-variable pin ends; pin starts read back from the solver.

**Apply (`app/schedule_solves.py`):** `_apply_result` no longer blindly echoes a pin. A called match returned at a later start (same table) has its `scheduled_start` persisted, `pinned_at` renewed, and fires the existing "moved" correction — honoring the ADR invariant that every persisted pin change carries a correction. An unchanged pin is still echoed verbatim and notifies no one.

## Consequence (recorded, deliberately deferred)

Folded into player-wait at equal weight, a called match is **not** specially shielded from being bumped later by an unpinned match competing for the same freed slot. A dedicated higher-priority "called-delay" tier + configurable tier ordering is a follow-up; revisit once we can measure how often bumping happens in practice. See ADR `docs/adr/20260719-a-called-match-holds-its-table-and-slides-later.md` (amends the 2026-07-16 pinned-call ADR).

## Testing

- `api/` gate green: `ruff check` + `ruff format --check` + `mypy --strict` clean, **1460 pytest passed**.
- New solver tests: overrun-behind-a-pin is now feasible with the pin slid later on the same table (was INFEASIBLE); uncontended off-grid pin holds its exact start (no drift); `table_id` invariant across re-solves; two pins on one table auto-slide.
- New apply tests: a slid pin persists its later start + emits exactly one moved correction to its two players; an unchanged pin (real solver, off-grid) writes nothing and notifies no one.
- No route/schema/OpenAPI surface — no type regen. Not observable in the web UI; the real acceptance check is the director-facing UAT soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)