### PR TITLE
Tournament MCP tools: get/edit/list, build-cut/uncut, get-schedule, run-scheduler

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -521,6 +521,20 @@ _Avoid_: pin (the call *causes* a pin, but a **manual placement** also pins with
 call; the pin is the placement's fixedness, the call is the promise to the players),
 notify (the call includes a notification but is the whole state transition, not just it).
 
+**Solve**:
+One run of the **scheduler** over a tournament: the CP-SAT job that packs the
+event's unplayed, **free** **placements** onto **tables** within each **pool**'s
+**Slot**, holding **pinned** ones fixed, and writes the resulting placements back.
+A solve is **requested** (queued), **running**, then reaches a **verdict** —
+`succeeded`, `infeasible`, or `failed` — recorded on the tournament's **solve
+ledger**; at most one is in flight per tournament at a time (a fresh request
+coalesces onto the running one), and a **stale running** solve is reaped by the
+next reader or request. Requesting a solve is what "run the scheduler" means; it
+is **not** a hypothetical or Monte-Carlo projection of who will win — it computes
+*when and where* the real matches play, not their outcomes.
+_Avoid_: simulation, run (a solve computes the real schedule, never a
+what-if), optimization pass, recalculation.
+
 ## Dashboard
 
 **First-match**:

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -99,7 +99,9 @@ from app.tournament_errors import (
     EventNotFoundError,
     LeagueNotEditableError,
     LeagueNotFoundError,
+    NoDrawnEventsError,
     NotTournamentOwnerError,
+    ScheduleQueueUnavailableError,
     TournamentNotFoundError,
 )
 from app.tournament_list import list_tournament_details
@@ -112,6 +114,9 @@ from app.tournament_queries import (
     visible_to,
 )
 from app.tournament_serialization import serialize, serialize_detail
+from app.tournament_solve_service import (
+    request_schedule_solve as request_schedule_solve_core,
+)
 
 log = logging.getLogger(__name__)
 
@@ -885,6 +890,75 @@ async def uncut(event_id: uuid.UUID) -> DrawUncutConfirmation:
             event_id=event_id,
             fixtures_remaining=fixtures_remaining,
         )
+
+
+@mcp.tool
+async def request_schedule_solve(tournament_id: uuid.UUID) -> ScheduleSolveRead:
+    """Run the SCHEDULER for a tournament you OWN as the authenticated API-token
+    caller — queue a solve that places its cut draws' fixtures onto tables and
+    times — and return the ledger row that will carry the outcome.
+
+    This is NOT a match-outcome simulation: it does not play games or predict
+    winners. It runs the CP-SAT placement SOLVER, which decides *when and where*
+    each already-drawn fixture is played (its ``table_id`` and predicted
+    ``scheduled_start``), the same run the tournament page's "Run scheduler" button
+    triggers.
+
+    It is **ASYNC**: the solve runs on a background worker, so this tool returns the
+    freshly queued (or already in-flight) ``ScheduleSolveRead`` immediately — a
+    ledger row whose ``status`` is ``queued`` or ``running`` and whose ``verdict`` /
+    placement counts are still ``null``. Read the verdict back later via
+    ``get_schedule`` (or ``get_tournament``) — its ``latest_schedule_solve`` carries
+    the run's final ``status`` and CP-SAT ``verdict`` (``optimal`` / ``feasible`` /
+    ``infeasible``) once the worker finishes. Poll it; do not expect the answer in
+    this return value.
+
+    Mirrors ``POST /v1/tournaments/{tournament_id}/schedule/solves``: it reuses the
+    shared ``request_schedule_solve`` verb (the ``FOR UPDATE`` tournament row lock,
+    the owner gate, the has-a-drawn-event gate, and the one coalesced enqueue every
+    trigger funnels into) so the MCP and HTTP surfaces can never drift. **One solve
+    is in flight per tournament**: if a run is already ``queued`` this request is
+    absorbed by it and that row comes back; if one is ``running`` its re-run flag is
+    set and the running row comes back; only when neither exists is a fresh run
+    queued. Allowed in ANY tournament status, from the moment any event has a cut
+    draw — pre-live solves are the point (an ``infeasible`` verdict before going live
+    is how a director learns the day does not fit while there is still time).
+
+    Raises a ``ToolError`` when no tournament with that id exists, when you are not
+    the tournament's owner (only the creator may run the scheduler), when no event of
+    the tournament has a cut draw yet (there is nothing to schedule — ``build_cut`` an
+    event's draw first, then retry), or when the scheduler queue itself is
+    unreachable (nothing was queued; the same request is safe to retry)."""
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        actor = await _load_user(db, user_id)
+        if actor is None:
+            raise ToolError("Not authenticated.")
+        try:
+            row = await request_schedule_solve_core(
+                db, tournament_id=tournament_id, actor=actor
+            )
+        except TournamentNotFoundError as exc:
+            raise ToolError(f"No tournament found with id {tournament_id}.") from exc
+        except NotTournamentOwnerError as exc:
+            raise ToolError(
+                "You can only run the scheduler for tournaments you created."
+            ) from exc
+        except NoDrawnEventsError as exc:
+            raise ToolError(
+                "There is nothing to schedule yet: no event of this tournament has a "
+                "cut draw. The scheduler places a draw's fixtures, so build_cut at "
+                "least one event's draw first, then run it again."
+            ) from exc
+        except ScheduleQueueUnavailableError as exc:
+            raise ToolError(
+                "The scheduler queue is unavailable, so the solve was not queued. "
+                "Try again in a moment."
+            ) from exc
+        # The core committed and refreshed the queued/running ledger row — serialize
+        # it into the same ``ScheduleSolveRead`` the HTTP route and the schedule
+        # projection carry, so the agent reads the run's status back off it.
+        return ScheduleSolveRead.model_validate(row)
 
 
 @mcp.tool

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -34,6 +34,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api_token_auth import find_api_token_user
 from app.db import get_sessionmaker
+from app.draws import (
+    DegenerateDraw,
+    DrawError,
+    NonSinglesDraw,
+    UnsupportedDrawType,
+)
 from app.mappers.match_extras_mapper import empty_extras
 from app.match_creation import create_match as create_match_core
 from app.match_errors import (
@@ -85,8 +91,12 @@ from app.schemas.tournament import (
     TournamentUpdate,
 )
 from app.services.match_service import MatchService
+from app.tournament_draw_service import cut_event_draw as cut_event_draw_core
+from app.tournament_draw_service import uncut_event_draw as uncut_event_draw_core
 from app.tournament_edit import edit_tournament as edit_tournament_core
 from app.tournament_errors import (
+    DrawUnderWayError,
+    EventNotFoundError,
     LeagueNotEditableError,
     LeagueNotFoundError,
     NotTournamentOwnerError,
@@ -677,6 +687,203 @@ async def edit_tournament(
             tournament,
             created_by_username=actor.username,
             current_user_id=actor.id,
+        )
+
+
+# The domain-exception family the two draw-write verbs raise for a refusal that is
+# NOT a ``DrawError`` — an absent event, a non-owner, or a draw already under way. The
+# ``app.draws.DrawError`` family (an un-cuttable field) is a separate hierarchy that
+# only ``build_cut`` can hit, and is mapped by ``_map_draw_refusal_tool_error`` below.
+_DRAW_WRITE_ERRORS = (
+    TournamentNotFoundError,
+    EventNotFoundError,
+    NotTournamentOwnerError,
+    DrawUnderWayError,
+)
+
+
+class DrawUncutConfirmation(BaseModel):
+    """The result of tearing an event's draw down (``uncut``) — a small, agent-shaped
+    confirmation rather than the HTTP route's bodiless ``204``.
+
+    An MCP tool should answer with a meaningful value, so this names *what* was un-cut
+    (the resolved ``tournament_id`` + the ``event_id``) and asserts the outcome:
+    ``fixtures_remaining`` is read back through the same ``fixtures_by_event`` loader
+    the detail page uses and is ``0`` after a successful un-cut (the event now has no
+    draw). Un-cutting a never-cut draw is an idempotent success too — it deletes
+    nothing and still confirms ``0`` remaining (ADR-0786).
+
+    This schema is **MCP-only** and is attached to no FastAPI route, so it does not
+    reach ``openapi.json`` (a mounted MCP sub-app does not contribute to the parent
+    schema — see the tournament-verbs ADR).
+    """
+
+    tournament_id: uuid.UUID
+    event_id: uuid.UUID
+    fixtures_remaining: int
+
+
+async def _tournament_id_for_event(db: AsyncSession, event_id: uuid.UUID) -> uuid.UUID:
+    """Resolve the tournament that owns ``event_id`` — the id the shared draw cores
+    need alongside the event id.
+
+    An event id is globally unique, so a draw tool can take just the event and recover
+    its tournament from the ``TournamentEvent.tournament_id`` foreign key, keeping a
+    clean agent-facing signature. A missing event is a not-found ``ToolError`` here,
+    before the core is called; because the resolved id comes straight off the event's
+    own FK, the core's later event-under-tournament load always matches, so the owner
+    gate inside the core is what actually refuses a stranger."""
+    tournament_id = (
+        await db.execute(
+            select(TournamentEvent.tournament_id).where(TournamentEvent.id == event_id)
+        )
+    ).scalar_one_or_none()
+    if tournament_id is None:
+        raise ToolError(f"No event found with id {event_id}.")
+    return tournament_id
+
+
+def _map_draw_write_tool_error(exc: Exception, event_id: uuid.UUID) -> ToolError:
+    """Adapt a non-``DrawError`` draw-write refusal to an actionable ``ToolError``.
+
+    Mirrors the HTTP adapters (``tournaments.cut_event_draw`` /
+    ``uncut_event_draw``) but speaks the agent's language instead of HTTP status
+    codes: a tournament/event that does not resolve is one opaque not-found (the tool
+    is addressed by event id), a non-owner is told the write is owner-gated, and a draw
+    already under way passes through its own domain-authored sentence
+    (``DrawUnderWayError`` carries the exact copy)."""
+    if isinstance(exc, TournamentNotFoundError | EventNotFoundError):
+        return ToolError(f"No event found with id {event_id}.")
+    if isinstance(exc, NotTournamentOwnerError):
+        return ToolError(
+            "You can only cut or remove draws for tournaments you created."
+        )
+    return ToolError(str(exc))
+
+
+def _map_draw_refusal_tool_error(error: DrawError) -> ToolError:
+    """Adapt a ``DrawError`` — the domain refusing to produce a draw from this event —
+    to an actionable ``ToolError``, mirroring the intent of the HTTP route's
+    ``_draw_refusal`` but in the agent's language.
+
+    A ``match`` over the error, not ``str(error)`` over whatever arrives, so each arm
+    tells an agent which of *their* events cannot be cut and why:
+
+    * ``UnsupportedDrawType`` carries its ``draw_type`` structurally — the event's draw
+      type has no generator yet (only round-robin does today), a fact to change on the
+      event, not a transient one to retry.
+    * ``NonSinglesDraw`` carries its ``event_format`` structurally — a doubles/teams
+      event can never be given a draw (an entry is one row per player, with nowhere to
+      seat a partner or a team, ADR-0788), so the refusal names the event and is
+      permanent.
+    * ``DegenerateDraw``'s message is **domain-authored copy** (the strategy alone knows
+      which degeneracy it hit and the numbers the director must change — "5 entrants
+      across 3 pool(s)"), passed through so the agent reads exactly what a director
+      would.
+    * The fallback arm is a generic sentence, never a future subclass's own message —
+      refusing vaguely is a bug report, leaking internals is a defect."""
+    match error:
+        case UnsupportedDrawType():
+            return ToolError(
+                f"This event's {error.draw_type.value} draw can't be cut yet — only "
+                "round-robin draws are supported. Change the event's draw type to one "
+                "that can, or wait for support."
+            )
+        case NonSinglesDraw():
+            return ToolError(
+                f"A {error.event_format.value} event can't be given a draw — only "
+                "singles events can. A fixture seats one entrant on each side, and "
+                "there's nowhere to record a doubles pairing or a team."
+            )
+        case DegenerateDraw():
+            return ToolError(str(error))
+        case _:
+            return ToolError("This event's draw can't be cut as the event stands.")
+
+
+@mcp.tool
+async def build_cut(event_id: uuid.UUID) -> list[TournamentFixtureRead]:
+    """Cut (or re-cut) an event's DRAW as the authenticated API-token caller — generate
+    its fixtures from its entrants — and return them.
+
+    Mirrors ``POST /v1/tournaments/{tournament_id}/events/{event_id}/draw``: it reuses
+    the shared ``cut_event_draw`` verb (the ``FOR UPDATE`` tournament row lock, the
+    owner gate, the event-under-tournament load, the play-evidence gate, the
+    ``cut_draw`` domain core and the re-solve trigger) so the MCP and HTTP surfaces can
+    never drift. You address the event by its globally-unique ``event_id`` alone; the
+    owning tournament is resolved from it. Cutting is owner-gated (only the
+    tournament's creator may cut), and it is NOT tied to status — a draw may be cut and
+    re-cut freely while a director inspects the pools and the seeding. **Re-cutting
+    replaces the draw wholesale**: the previous fixtures are deleted and a fresh set is
+    planned from the event's current active entrants (their ids do not survive).
+    Returns the created
+    fixtures in **pool → round → position** order — the same ``TournamentFixtureRead``
+    the detail page and ``get_schedule`` carry.
+
+    Raises a ``ToolError`` when no event has that id, when you are not the owner of the
+    event's tournament, when the draw already shows evidence of play (a fixture with a
+    recorded winner or a linked match — it can no longer be cut), or when the event
+    cannot produce a draw at all: its draw type has no generator yet (only round-robin
+    does today), it has no pools configured for a pooled draw type, or its field is too
+    small for its pools (a pool of fewer than two has nobody to play). The message names
+    what to change."""
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        actor = await _load_user(db, user_id)
+        if actor is None:
+            raise ToolError("Not authenticated.")
+        tournament_id = await _tournament_id_for_event(db, event_id)
+        try:
+            return await cut_event_draw_core(
+                db, tournament_id=tournament_id, event_id=event_id, actor=actor
+            )
+        except _DRAW_WRITE_ERRORS as exc:
+            raise _map_draw_write_tool_error(exc, event_id) from exc
+        except DrawError as error:
+            # The domain refusing to produce a draw is not a bug — it is an answer, and
+            # the verb already rolled back, so nothing was written. Compose the agent's
+            # sentence and surface it as a ``ToolError``.
+            raise _map_draw_refusal_tool_error(error) from error
+
+
+@mcp.tool
+async def uncut(event_id: uuid.UUID) -> DrawUncutConfirmation:
+    """Un-cut an event's DRAW as the authenticated API-token caller: delete its
+    fixtures, leaving the event with no draw. Returns a confirmation carrying the
+    resolved tournament, the event, and the fixtures now remaining (``0`` on success).
+
+    Mirrors ``DELETE /v1/tournaments/{tournament_id}/events/{event_id}/draw`` (which
+    answers a bodiless ``204``): it reuses the shared ``uncut_event_draw`` verb (the
+    ``FOR UPDATE`` tournament row lock, the owner gate, the event-under-tournament load,
+    the play-evidence gate, the ``uncut_draw`` core and the ``had_draw``-gated re-solve
+    trigger) so the MCP and HTTP surfaces can never drift. You address the event by its
+    globally-unique ``event_id`` alone; the owning tournament is resolved from it.
+    Un-cutting is owner-gated (only the tournament's creator may). An event with **no
+    draw is already in the state this asks for**, so un-cutting a never-cut draw deletes
+    nothing and is still a success (``fixtures_remaining`` = ``0``) — it is idempotent.
+
+    Raises a ``ToolError`` when no event has that id, when you are not the owner of the
+    event's tournament, or when the draw already shows evidence of play (a fixture with
+    a recorded winner or a linked match — it can no longer be removed)."""
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        actor = await _load_user(db, user_id)
+        if actor is None:
+            raise ToolError("Not authenticated.")
+        tournament_id = await _tournament_id_for_event(db, event_id)
+        try:
+            await uncut_event_draw_core(
+                db, tournament_id=tournament_id, event_id=event_id, actor=actor
+            )
+        except _DRAW_WRITE_ERRORS as exc:
+            raise _map_draw_write_tool_error(exc, event_id) from exc
+        # Read the draw back through the same loader the detail page uses — after a
+        # successful un-cut the event maps to ``[]``, so this confirms the teardown.
+        fixtures_remaining = len((await fixtures_by_event(db, [event_id]))[event_id])
+        return DrawUncutConfirmation(
+            tournament_id=tournament_id,
+            event_id=event_id,
+            fixtures_remaining=fixtures_remaining,
         )
 
 

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -28,7 +28,7 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.auth import AccessToken, TokenVerifier
 from fastmcp.server.dependencies import get_access_token
-from pydantic import Field
+from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -62,20 +62,37 @@ from app.match_serialization import (
     serialize_details,
     view_extras,
 )
-from app.models import Match, User
+from app.models import Match, Tournament, TournamentEvent, User
 from app.notifications.dependencies import get_push_sender
 from app.notifications.service import NotificationService
 from app.player_matches import paginated_player_matches
 from app.player_search import SEARCH_DEFAULT_LIMIT, search_players_by_username
+from app.rbac import user_has_permission
 from app.repositories.match_details_repository import MatchDetailsRepository
 from app.repositories.match_repository import MatchRepository
 from app.result_acceptance import (
     accept_result as accept_result_core,
 )
 from app.result_proposal import propose_result as propose_result_core
+from app.schedule_solves import latest_solve
 from app.schemas.match import MatchDetails, MatchResultsGameWrite
 from app.schemas.player import PlayerMatchListResponse, PlayerRead
+from app.schemas.tournament import (
+    ScheduleSolveRead,
+    TournamentDetailRead,
+    TournamentFixtureRead,
+)
 from app.services.match_service import MatchService
+from app.tournament_list import list_tournament_details
+from app.tournament_queries import (
+    active_entrants_by_event,
+    completed_match_ids,
+    entrant_rating,
+    fixtures_by_event,
+    game_counts_by_match,
+    visible_to,
+)
+from app.tournament_serialization import serialize_detail
 
 log = logging.getLogger(__name__)
 
@@ -97,6 +114,13 @@ MatchPageSize = Annotated[int, Field(ge=1, le=100)]
 # The default page size ``list_my_matches`` uses when the caller names none,
 # matching the HTTP per-player list default (``app.players.LIST_DEFAULT_PAGE_SIZE``).
 MY_MATCHES_DEFAULT_PAGE_SIZE = 25
+
+# The permission the tournament reads gate on — the same seeded RBAC name the HTTP
+# router's ``require_view`` dependency enforces (``app.tournaments.TOURNAMENT_VIEW``,
+# ``scripts/seed_rbac.py``). Held as a literal rather than imported from the router so
+# the MCP adapter stays router-free; ``get_tournament`` asks it through the one shared
+# ``user_has_permission`` (``app.rbac``), so the two surfaces gate on the same grant.
+TOURNAMENT_VIEW_PERMISSION = "tournament.view"
 
 
 @asynccontextmanager
@@ -347,6 +371,243 @@ async def enter_game_score(
         except _SCORE_WRITE_ERRORS as exc:
             raise _map_score_write_tool_error(exc) from exc
         return await _serialize_written_match(db, reloaded, user_id)
+
+
+@mcp.tool
+async def get_tournament(tournament_id: uuid.UUID) -> TournamentDetailRead:
+    """Read a single tournament as the authenticated API-token caller.
+
+    Returns the same ``TournamentDetailRead`` view the HTTP
+    ``GET /v1/tournaments/{tournament_id}`` endpoint returns for that user: the
+    tournament's fields (with the caller's ``can_edit``), its events in creation
+    order — each carrying its active entrants, its draw (fixtures), the caller's
+    ``entry_state``, and its round-robin standings once played — plus the newest
+    row of the schedule-solve ledger. It reuses the exact same shared read queries
+    (``tournament_queries``, ``latest_solve``) and the shared ``serialize_detail``
+    serializer the HTTP route composes, so the two surfaces can never drift.
+
+    Gated on the same ``tournament.view`` permission the HTTP route requires, and
+    scoped by the same visibility rule: a draft you do not own is not yours to see,
+    so it surfaces as a not-found ``ToolError`` — the same way the HTTP route hides
+    it behind a 404 rather than confirming it exists.
+
+    Raises a ``ToolError`` when you lack ``tournament.view``, and when no tournament
+    with that id is visible to you (absent, or an unannounced draft you do not own).
+    """
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        # Permission first, then visibility — the order the HTTP route keeps: the
+        # ``require_view`` dependency (403) runs before the handler, and only then
+        # does ``_visible_to`` scope the row so a hidden draft leaves by not-found.
+        if not await user_has_permission(db, user_id, TOURNAMENT_VIEW_PERMISSION):
+            raise ToolError("You don't have permission to view tournaments.")
+        # ``visible_to`` rides in the same WHERE as the id lookup, so a tournament
+        # the caller can't see leaves by the same not-found path as an absent one —
+        # existence is never confirmed for an unannounced draft (see visible_to).
+        row = (
+            await db.execute(
+                select(Tournament, User.username)
+                .join(User, User.id == Tournament.created_by_user_id)
+                .where(Tournament.id == tournament_id, visible_to(user_id))
+            )
+        ).one_or_none()
+        if row is None:
+            raise ToolError(f"No tournament found with id {tournament_id}.")
+        tournament, username = row
+        # Mirror the HTTP route's batched read shape exactly — events, then their
+        # active entrants, their draws, the games of every completed match (for
+        # standings), the caller's one rating on the tournament's league, and the
+        # newest solve — feeding the identical shared ``serialize_detail``.
+        events = list(
+            (
+                await db.execute(
+                    select(TournamentEvent)
+                    .where(TournamentEvent.tournament_id == tournament_id)
+                    .order_by(TournamentEvent.created_at)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        event_ids = [e.id for e in events]
+        entrants_by_event = await active_entrants_by_event(db, event_ids)
+        event_fixtures = await fixtures_by_event(db, event_ids)
+        game_counts = await game_counts_by_match(
+            db, completed_match_ids(event_fixtures)
+        )
+        rating = await entrant_rating(db, tournament.league_id, user_id)
+        latest_schedule_solve = await latest_solve(db, tournament.id)
+        return serialize_detail(
+            tournament,
+            created_by_username=username,
+            current_user_id=user_id,
+            events=events,
+            entrants_by_event=entrants_by_event,
+            fixtures_by_event=event_fixtures,
+            game_counts=game_counts,
+            rating=rating,
+            latest_schedule_solve=latest_schedule_solve,
+        )
+
+
+class ScheduleEventGroup(BaseModel):
+    """One event's slice of the schedule projection: the event's identity and its
+    draw's fixtures, each carrying its placement (``table_id`` +
+    ``scheduled_start``) and its pool/round/position.
+
+    The fixtures are the exact ``TournamentFixtureRead`` the detail BFF composes —
+    same fields, same **pool → round → position** order (``fixtures_by_event``) —
+    reused whole rather than reshaped, so this agent-facing schedule and the
+    detail page cannot disagree about a slot. Empty is the designed state of an
+    event whose draw has not been cut (ADR-0786), not an error.
+    """
+
+    event_id: uuid.UUID
+    name: str
+    fixtures: list[TournamentFixtureRead]
+
+
+class TournamentScheduleRead(BaseModel):
+    """A narrow, agent-shaped SCHEDULE projection of a tournament — each event's
+    placed fixtures grouped for reading, plus the tournament's latest solve.
+
+    Deliberately NOT the whole ``TournamentDetailRead``: it drops entrants,
+    standings, eligibility and the per-event write metadata an agent reading a
+    schedule does not need, and keeps only what answers "what plays where and
+    when, and how is the current solve doing". It is composed entirely from the
+    existing detail-BFF reads — ``fixtures_by_event`` for each event's placed
+    fixtures and ``latest_solve`` for the ledger's newest row — wrapping the
+    unchanged ``TournamentFixtureRead`` / ``ScheduleSolveRead`` shapes so the MCP
+    and HTTP surfaces read the same placement and solve facts.
+
+    This schema is **MCP-only** and is attached to no FastAPI route, so it does
+    not reach ``openapi.json`` (a mounted MCP sub-app does not contribute to the
+    parent schema — see the tournament-verbs ADR).
+    """
+
+    tournament_id: uuid.UUID
+    events: list[ScheduleEventGroup]
+    # The newest row of the tournament's solve ledger (status + CP-SAT verdict),
+    # or ``null`` when no solve has ever been requested — the same ``latest_solve``
+    # read, and the same ``ScheduleSolveRead`` shape, the detail BFF's solve strip
+    # renders.
+    latest_schedule_solve: ScheduleSolveRead | None
+
+
+@mcp.tool
+async def get_schedule(tournament_id: uuid.UUID) -> TournamentScheduleRead:
+    """Read a tournament's SCHEDULE as the authenticated API-token caller — a
+    narrow, agent-shaped projection, not the whole tournament detail.
+
+    Returns each event's draw fixtures with their placement (``table_id`` and the
+    predicted ``scheduled_start``) and pool/round/position — grouped by event, in
+    the same **pool → round → position** order the detail page uses — plus the
+    tournament's latest schedule solve (its ``status`` and CP-SAT ``verdict``). It
+    reuses the exact same shared reads the detail BFF composes (``fixtures_by_event``
+    for the placed fixtures, ``latest_solve`` for the ledger's newest row) and the
+    identical ``TournamentFixtureRead`` / ``ScheduleSolveRead`` shapes, so this
+    schedule and the tournament page can never drift.
+
+    An event whose draw has not been cut carries ``[]`` fixtures (the designed
+    state, not an error), and a tournament for which no solve has ever been
+    requested has ``latest_schedule_solve = null``.
+
+    Gated on the same ``tournament.view`` permission the HTTP detail read requires,
+    and scoped by the same visibility rule: a draft you do not own is not yours to
+    see, so it surfaces as a not-found ``ToolError`` — existence is never confirmed
+    for an unannounced draft you do not own.
+
+    Raises a ``ToolError`` when you lack ``tournament.view``, and when no tournament
+    with that id is visible to you (absent, or an unannounced draft you do not own).
+    """
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        # Permission first, then visibility — the same order ``get_tournament``
+        # keeps: the HTTP detail route's ``require_view`` dependency (403) runs
+        # before the handler, and only then does ``visible_to`` scope the row so a
+        # hidden draft leaves by not-found.
+        if not await user_has_permission(db, user_id, TOURNAMENT_VIEW_PERMISSION):
+            raise ToolError("You don't have permission to view tournaments.")
+        tournament = (
+            await db.execute(
+                select(Tournament).where(
+                    Tournament.id == tournament_id, visible_to(user_id)
+                )
+            )
+        ).scalar_one_or_none()
+        if tournament is None:
+            raise ToolError(f"No tournament found with id {tournament_id}.")
+        # Events in creation order (as the detail read lists them), then their
+        # draws in one batched read (``fixtures_by_event`` — pool → round →
+        # position ordered, every event id keyed so an un-cut event maps to ``[]``)
+        # and the ledger's newest row — the same shared reads the detail BFF uses.
+        events = list(
+            (
+                await db.execute(
+                    select(TournamentEvent)
+                    .where(TournamentEvent.tournament_id == tournament_id)
+                    .order_by(TournamentEvent.created_at)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        event_fixtures = await fixtures_by_event(db, [event.id for event in events])
+        latest_schedule_solve = await latest_solve(db, tournament.id)
+        return TournamentScheduleRead(
+            tournament_id=tournament.id,
+            events=[
+                ScheduleEventGroup(
+                    event_id=event.id,
+                    name=event.name,
+                    fixtures=event_fixtures[event.id],
+                )
+                for event in events
+            ],
+            latest_schedule_solve=(
+                ScheduleSolveRead.model_validate(latest_schedule_solve)
+                if latest_schedule_solve is not None
+                else None
+            ),
+        )
+
+
+@mcp.tool
+async def list_my_tournaments() -> list[TournamentDetailRead]:
+    """List the tournaments the authenticated API-token caller OWNS, newest first.
+
+    Returns the same ``TournamentDetailRead`` aggregate the HTTP
+    ``GET /v1/tournaments`` list serves — each tournament with its events, their
+    active entrants and their draws, the caller's ``can_edit`` / per-event
+    ``entry_state`` / ladder ``rating`` — by reusing that list's exact five-query
+    batched read (``list_tournament_details``), so the MCP and HTTP surfaces can
+    never drift and neither runs an N+1.
+
+    Unlike the HTTP list, which is VISIBILITY-scoped (every announced tournament
+    plus your own drafts), this is OWNER-scoped: only tournaments you created
+    (``created_by_user_id == you``), in ANY status. That is deliberate — the
+    tournament write verbs are owner-gated, so the tournaments an agent can act on
+    are exactly the ones it owns, and this is the discovery read that hands the
+    agent a ``tournament_id`` to drive them (see the tournament-verbs ADR). A
+    tournament you can merely *see* but do not own is excluded.
+
+    Gated on the same ``tournament.view`` permission the HTTP list requires.
+
+    Raises a ``ToolError`` when you lack ``tournament.view``.
+    """
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        # Permission first, mirroring the HTTP list's ``require_view`` dependency;
+        # only then the owner-scoped read. Owner-scoping is by construction (the
+        # WHERE selects only the caller's own rows), so there is no separate
+        # visibility gate to run — an owner always sees their own tournaments.
+        if not await user_has_permission(db, user_id, TOURNAMENT_VIEW_PERMISSION):
+            raise ToolError("You don't have permission to view tournaments.")
+        return await list_tournament_details(
+            db,
+            where=Tournament.created_by_user_id == user_id,
+            current_user_id=user_id,
+        )
 
 
 @mcp.tool

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -104,16 +104,12 @@ from app.tournament_errors import (
     ScheduleQueueUnavailableError,
     TournamentNotFoundError,
 )
-from app.tournament_list import list_tournament_details
+from app.tournament_list import list_tournament_details, tournament_detail
 from app.tournament_queries import (
-    active_entrants_by_event,
-    completed_match_ids,
-    entrant_rating,
     fixtures_by_event,
-    game_counts_by_match,
     visible_to,
 )
-from app.tournament_serialization import serialize, serialize_detail
+from app.tournament_serialization import serialize
 from app.tournament_solve_service import (
     request_schedule_solve as request_schedule_solve_core,
 )
@@ -221,6 +217,44 @@ async def _load_user(db: AsyncSession, user_id: uuid.UUID) -> User | None:
     return (
         await db.execute(select(User).where(User.id == user_id))
     ).scalar_one_or_none()
+
+
+async def _require_tournament_view(db: AsyncSession, user_id: uuid.UUID) -> None:
+    """The tournament-read gate every read tool shares: refuse unless the caller
+    holds ``tournament.view``.
+
+    Byte-for-byte the ``ToolError`` the three read tools each raised inline, asked
+    through the one shared ``user_has_permission`` the HTTP ``require_view``
+    dependency asks — so the MCP and HTTP surfaces gate reads on the same grant, and
+    a fourth read tool cannot grow a different message or a different permission
+    name. Permission is checked first (before any visibility load), the order the
+    HTTP route keeps: ``require_view`` (403) runs before the handler."""
+    if not await user_has_permission(db, user_id, TOURNAMENT_VIEW_PERMISSION):
+        raise ToolError("You don't have permission to view tournaments.")
+
+
+async def _load_visible_tournament(
+    db: AsyncSession, user_id: uuid.UUID, tournament_id: uuid.UUID
+) -> Tournament:
+    """The tournament ``tournament_id`` names, scoped to what ``user_id`` may see,
+    or a not-found ``ToolError`` — the visibility-scoped load ``get_tournament`` and
+    ``get_schedule`` share.
+
+    ``visible_to`` rides in the same WHERE as the id lookup, so a tournament the
+    caller can't see leaves by the same not-found path as an absent one — existence
+    is never confirmed for an unannounced draft the caller does not own, exactly as
+    the HTTP route hides it behind a 404. The ``ToolError`` message is byte-for-byte
+    the one both tools raised inline."""
+    tournament = (
+        await db.execute(
+            select(Tournament).where(
+                Tournament.id == tournament_id, visible_to(user_id)
+            )
+        )
+    ).scalar_one_or_none()
+    if tournament is None:
+        raise ToolError(f"No tournament found with id {tournament_id}.")
+    return tournament
 
 
 @mcp.tool
@@ -406,9 +440,9 @@ async def get_tournament(tournament_id: uuid.UUID) -> TournamentDetailRead:
     tournament's fields (with the caller's ``can_edit``), its events in creation
     order — each carrying its active entrants, its draw (fixtures), the caller's
     ``entry_state``, and its round-robin standings once played — plus the newest
-    row of the schedule-solve ledger. It reuses the exact same shared read queries
-    (``tournament_queries``, ``latest_solve``) and the shared ``serialize_detail``
-    serializer the HTTP route composes, so the two surfaces can never drift.
+    row of the schedule-solve ledger. It composes the exact same shared
+    ``tournament_detail`` reader the HTTP route composes, so the two surfaces can
+    never drift.
 
     Gated on the same ``tournament.view`` permission the HTTP route requires, and
     scoped by the same visibility rule: a draft you do not own is not yours to see,
@@ -420,57 +454,26 @@ async def get_tournament(tournament_id: uuid.UUID) -> TournamentDetailRead:
     """
     user_id = _authenticated_user_id()
     async with mcp_session() as db:
-        # Permission first, then visibility — the order the HTTP route keeps: the
-        # ``require_view`` dependency (403) runs before the handler, and only then
-        # does ``_visible_to`` scope the row so a hidden draft leaves by not-found.
-        if not await user_has_permission(db, user_id, TOURNAMENT_VIEW_PERMISSION):
-            raise ToolError("You don't have permission to view tournaments.")
-        # ``visible_to`` rides in the same WHERE as the id lookup, so a tournament
-        # the caller can't see leaves by the same not-found path as an absent one —
-        # existence is never confirmed for an unannounced draft (see visible_to).
-        row = (
+        # Permission first, then the visibility-scoped load — the order the HTTP
+        # route keeps (``require_view`` (403) runs before the handler, then
+        # ``_visible_to`` scopes the row so a hidden draft leaves by not-found).
+        await _require_tournament_view(db, user_id)
+        tournament = await _load_visible_tournament(db, user_id, tournament_id)
+        # The creator's username the shared reader needs for the aggregate. The
+        # RESTRICT FK guarantees the creator row exists, so ``scalar_one`` is total.
+        username = (
             await db.execute(
-                select(Tournament, User.username)
-                .join(User, User.id == Tournament.created_by_user_id)
-                .where(Tournament.id == tournament_id, visible_to(user_id))
+                select(User.username).where(User.id == tournament.created_by_user_id)
             )
-        ).one_or_none()
-        if row is None:
-            raise ToolError(f"No tournament found with id {tournament_id}.")
-        tournament, username = row
-        # Mirror the HTTP route's batched read shape exactly — events, then their
-        # active entrants, their draws, the games of every completed match (for
-        # standings), the caller's one rating on the tournament's league, and the
-        # newest solve — feeding the identical shared ``serialize_detail``.
-        events = list(
-            (
-                await db.execute(
-                    select(TournamentEvent)
-                    .where(TournamentEvent.tournament_id == tournament_id)
-                    .order_by(TournamentEvent.created_at)
-                )
-            )
-            .scalars()
-            .all()
-        )
-        event_ids = [e.id for e in events]
-        entrants_by_event = await active_entrants_by_event(db, event_ids)
-        event_fixtures = await fixtures_by_event(db, event_ids)
-        game_counts = await game_counts_by_match(
-            db, completed_match_ids(event_fixtures)
-        )
-        rating = await entrant_rating(db, tournament.league_id, user_id)
-        latest_schedule_solve = await latest_solve(db, tournament.id)
-        return serialize_detail(
+        ).scalar_one()
+        # The identical six-statement batched composition + ``serialize_detail`` the
+        # HTTP route runs — extracted into the shared ``tournament_detail`` reader,
+        # so this tool and the page can never drift on how a tournament is read.
+        return await tournament_detail(
+            db,
             tournament,
             created_by_username=username,
             current_user_id=user_id,
-            events=events,
-            entrants_by_event=entrants_by_event,
-            fixtures_by_event=event_fixtures,
-            game_counts=game_counts,
-            rating=rating,
-            latest_schedule_solve=latest_schedule_solve,
         )
 
 
@@ -546,21 +549,12 @@ async def get_schedule(tournament_id: uuid.UUID) -> TournamentScheduleRead:
     """
     user_id = _authenticated_user_id()
     async with mcp_session() as db:
-        # Permission first, then visibility — the same order ``get_tournament``
-        # keeps: the HTTP detail route's ``require_view`` dependency (403) runs
-        # before the handler, and only then does ``visible_to`` scope the row so a
-        # hidden draft leaves by not-found.
-        if not await user_has_permission(db, user_id, TOURNAMENT_VIEW_PERMISSION):
-            raise ToolError("You don't have permission to view tournaments.")
-        tournament = (
-            await db.execute(
-                select(Tournament).where(
-                    Tournament.id == tournament_id, visible_to(user_id)
-                )
-            )
-        ).scalar_one_or_none()
-        if tournament is None:
-            raise ToolError(f"No tournament found with id {tournament_id}.")
+        # Permission first, then the visibility-scoped load — the same shared gate
+        # and loader ``get_tournament`` uses, keeping the order the HTTP detail
+        # route keeps (``require_view`` (403) before the handler, then ``visible_to``
+        # scoping the row so a hidden draft leaves by not-found).
+        await _require_tournament_view(db, user_id)
+        tournament = await _load_visible_tournament(db, user_id, tournament_id)
         # Events in creation order (as the detail read lists them), then their
         # draws in one batched read (``fixtures_by_event`` — pool → round →
         # position ordered, every event id keyed so an un-cut event maps to ``[]``)
@@ -621,12 +615,12 @@ async def list_my_tournaments() -> list[TournamentDetailRead]:
     """
     user_id = _authenticated_user_id()
     async with mcp_session() as db:
-        # Permission first, mirroring the HTTP list's ``require_view`` dependency;
-        # only then the owner-scoped read. Owner-scoping is by construction (the
-        # WHERE selects only the caller's own rows), so there is no separate
-        # visibility gate to run — an owner always sees their own tournaments.
-        if not await user_has_permission(db, user_id, TOURNAMENT_VIEW_PERMISSION):
-            raise ToolError("You don't have permission to view tournaments.")
+        # Permission first, through the same shared gate the detail reads use
+        # (mirroring the HTTP list's ``require_view`` dependency); only then the
+        # owner-scoped read. Owner-scoping is by construction (the WHERE selects only
+        # the caller's own rows), so there is no separate visibility gate to run — an
+        # owner always sees their own tournaments.
+        await _require_tournament_view(db, user_id)
         return await list_tournament_details(
             db,
             where=Tournament.created_by_user_id == user_id,
@@ -713,10 +707,10 @@ class DrawUncutConfirmation(BaseModel):
 
     An MCP tool should answer with a meaningful value, so this names *what* was un-cut
     (the resolved ``tournament_id`` + the ``event_id``) and asserts the outcome:
-    ``fixtures_remaining`` is read back through the same ``fixtures_by_event`` loader
-    the detail page uses and is ``0`` after a successful un-cut (the event now has no
-    draw). Un-cutting a never-cut draw is an idempotent success too — it deletes
-    nothing and still confirms ``0`` remaining (ADR-0786).
+    ``fixtures_remaining`` is ``0`` after a successful un-cut — the core deleted the
+    draw wholesale, so the event provably has no fixtures left. Un-cutting a never-cut
+    draw is an idempotent success too — it deletes nothing and still confirms ``0``
+    remaining (ADR-0786).
 
     This schema is **MCP-only** and is attached to no FastAPI route, so it does not
     reach ``openapi.json`` (a mounted MCP sub-app does not contribute to the parent
@@ -882,13 +876,15 @@ async def uncut(event_id: uuid.UUID) -> DrawUncutConfirmation:
             )
         except _DRAW_WRITE_ERRORS as exc:
             raise _map_draw_write_tool_error(exc, event_id) from exc
-        # Read the draw back through the same loader the detail page uses — after a
-        # successful un-cut the event maps to ``[]``, so this confirms the teardown.
-        fixtures_remaining = len((await fixtures_by_event(db, [event_id]))[event_id])
+        # A successful ``uncut_event_draw`` deleted the draw wholesale (or there was
+        # never one), so the event provably has no fixtures — ``fixtures_remaining``
+        # is ``0`` by construction, no confirming re-read of ``fixtures_by_event``
+        # needed. The idempotent un-cut of a never-cut draw lands here too, and it is
+        # ``0`` for it as well (ADR-0786).
         return DrawUncutConfirmation(
             tournament_id=tournament_id,
             event_id=event_id,
-            fixtures_remaining=fixtures_remaining,
+            fixtures_remaining=0,
         )
 
 

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -81,8 +81,17 @@ from app.schemas.tournament import (
     ScheduleSolveRead,
     TournamentDetailRead,
     TournamentFixtureRead,
+    TournamentRead,
+    TournamentUpdate,
 )
 from app.services.match_service import MatchService
+from app.tournament_edit import edit_tournament as edit_tournament_core
+from app.tournament_errors import (
+    LeagueNotEditableError,
+    LeagueNotFoundError,
+    NotTournamentOwnerError,
+    TournamentNotFoundError,
+)
 from app.tournament_list import list_tournament_details
 from app.tournament_queries import (
     active_entrants_by_event,
@@ -92,7 +101,7 @@ from app.tournament_queries import (
     game_counts_by_match,
     visible_to,
 )
-from app.tournament_serialization import serialize_detail
+from app.tournament_serialization import serialize, serialize_detail
 
 log = logging.getLogger(__name__)
 
@@ -607,6 +616,67 @@ async def list_my_tournaments() -> list[TournamentDetailRead]:
             db,
             where=Tournament.created_by_user_id == user_id,
             current_user_id=user_id,
+        )
+
+
+@mcp.tool
+async def edit_tournament(
+    tournament_id: uuid.UUID,
+    updates: TournamentUpdate,
+) -> TournamentRead:
+    """Edit a tournament you OWN as the authenticated API-token caller, and return
+    the updated tournament.
+
+    Mirrors ``PATCH /v1/tournaments/{tournament_id}``: it reuses the shared
+    ``edit_tournament`` verb (the ``FOR UPDATE`` load-lock, the owner gate, the
+    league-editable-only-while-draft state rule, the STRICT league lookup, the
+    partial apply, and the table-catalogue-change → re-solve trigger) and the same
+    ``TournamentUpdate`` schema the HTTP route validates, so the MCP and HTTP
+    surfaces can never drift on what a valid edit is.
+
+    ``updates`` is a PARTIAL patch: an OMITTED field is left unchanged; a supplied
+    field replaces the current value. ``name``, ``address``, ``table_catalogue``
+    and ``league_id`` back NOT NULL columns, so an explicit ``null`` for any of
+    them is rejected (send them only to set a real value);
+    ``description`` / ``start_date`` / ``end_date`` are nullable and may be cleared
+    with ``null``. ``table_catalogue`` replaces wholesale when present.
+    ``league_id`` is editable ONLY while the tournament is a ``draft`` — once it is
+    published the ladder is settled. ``status`` is not editable here (it moves only
+    across the guarded lifecycle transitions). Returns the updated
+    ``TournamentRead`` from the owner's perspective (``can_edit`` is always true).
+
+    Raises a ``ToolError`` when no tournament with that id exists, when you are not
+    the tournament's owner (only the creator may edit it), when you try to change
+    the league of a tournament that has left ``draft``, or when ``league_id`` names
+    no league.
+    """
+    user_id = _authenticated_user_id()
+    async with mcp_session() as db:
+        actor = await _load_user(db, user_id)
+        if actor is None:
+            raise ToolError("Not authenticated.")
+        try:
+            tournament = await edit_tournament_core(
+                db,
+                tournament_id=tournament_id,
+                actor=actor,
+                updates=updates,
+            )
+        except TournamentNotFoundError as exc:
+            raise ToolError(f"No tournament found with id {tournament_id}.") from exc
+        except NotTournamentOwnerError as exc:
+            raise ToolError("You can only edit tournaments you created.") from exc
+        except LeagueNotEditableError as exc:
+            raise ToolError(str(exc)) from exc
+        except LeagueNotFoundError as exc:
+            raise ToolError("No league found with that id.") from exc
+        # The core raised ``NotTournamentOwnerError`` unless the caller is the owner,
+        # so here the actor is the creator — the owner's perspective the HTTP PATCH
+        # serializes from (``created_by_username`` known, ``can_edit`` true).
+        return serialize(
+            tournament,
+            created_by_username=actor.username,
+            current_user_id=actor.id,
         )
 
 

--- a/api/app/tournament_draw_service.py
+++ b/api/app/tournament_draw_service.py
@@ -1,0 +1,213 @@
+"""The transport-neutral cut / un-cut draw write verbs (ADR-0786).
+
+The orchestration behind ``POST`` and ``DELETE
+/v1/tournaments/{id}/events/{id}/draw`` — the ``FOR UPDATE`` load-lock on the
+tournament, the owner gate, the event-under-tournament load, the play-evidence
+gate, and the ``cut_draw`` / ``uncut_draw`` domain core — extracted out of the
+router so it can run without FastAPI: from the HTTP adapters
+(``app.tournaments.cut_event_draw`` / ``uncut_event_draw``) and, later, from an
+MCP tool alike, and be constructed in a plain REPL with a raw session.
+
+Per the tournament-verbs ADR (mirroring the match-flow ADR and the edit verb in
+``app.tournament_edit``), it signals every refusal with a **domain exception** from
+``app.tournament_errors`` — never an ``HTTPException`` — and each adapter maps it
+back to the exact response it produced before:
+
+* an absent tournament → :class:`TournamentNotFoundError` (404);
+* an event that is not under it → :class:`EventNotFoundError` (404);
+* a non-owner → :class:`NotTournamentOwnerError` (403);
+* a draw with evidence of play → :class:`DrawUnderWayError` (409).
+
+The :class:`~app.draws.DrawError` family (``UnsupportedDrawType`` /
+``NonSinglesDraw`` / ``DegenerateDraw``) is **already** a FastAPI-free domain
+family; :func:`cut_draw` raises it and this verb lets it propagate **unchanged**,
+for the adapter to turn into the 422 ``_draw_refusal`` composes. A cut refused
+that way rolls back first, so a 422 destroys nothing — the same rollback the
+router used to do inline.
+
+The tournament is loaded through the same ``FOR UPDATE`` loader the edit verb
+uses (``app.tournament_edit._load_tournament_for_update``): the lock is not
+decoration. A cut reads the event's active field and writes fixtures derived from
+it, and Postgres runs READ COMMITTED, so an unlocked read would answer from its
+own statement's snapshot and an entry (or a withdrawal) committing between the
+read and the INSERT would leave a persisted draw that never matched any real field
+of players. Every writer of the entrant field already queues on this row, so
+taking it here is what puts the cut in that queue.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.draws import DrawError
+from app.models import ScheduleSolveTrigger, TournamentEvent, User
+from app.schedule_solves import request_solve, tournament_has_drawn_event
+from app.schemas.tournament import TournamentFixtureRead
+from app.tournament_draws import (
+    cut_draw,
+    draw_has_play,
+    event_has_draw,
+    uncut_draw,
+)
+from app.tournament_edit import _load_tournament_for_update
+from app.tournament_errors import (
+    DrawUnderWayError,
+    EventNotFoundError,
+    NotTournamentOwnerError,
+)
+from app.tournament_queries import fixtures_by_event
+
+
+async def _load_owned_event_for_draw(
+    db: AsyncSession,
+    *,
+    tournament_id: uuid.UUID,
+    event_id: uuid.UUID,
+    actor: User,
+) -> TournamentEvent:
+    """The event whose draw is about to be written, loaded under the tournament's row
+    lock and the owner check — the refusal ordering both draw verbs share.
+
+    **404 → 403 → 409**, the ordering ADR-0017 fixed and every tournament write
+    keeps: a tournament that does not exist (:class:`TournamentNotFoundError`) or an
+    event that is not under it (:class:`EventNotFoundError`) is a 404 before
+    ownership is considered, so a stranger probing ids learns nothing; a non-owner
+    (:class:`NotTournamentOwnerError`) is a 403 before the draw's *state* is looked
+    at, so the refusal never leaks whether an event has been played. The play-evidence
+    409 (:func:`_enforce_unplayed`) is the caller's own, and comes last.
+
+    The tournament is loaded through the **locking** loader the edit, entry,
+    withdrawal and transition paths all share — the same lock, on the same row, taken
+    first — which is what keeps them free of a deadlock cycle. The FastAPI-free
+    equivalent of the router's ``_get_owned_event_for_draw_or_404``.
+    """
+    tournament = await _load_tournament_for_update(db, tournament_id)
+    if tournament.created_by_user_id != actor.id:
+        raise NotTournamentOwnerError()
+    # The event must belong to the named tournament — scoped by both ids so a
+    # mismatched pair is a miss, not a cross-tournament draw.
+    event = (
+        await db.execute(
+            select(TournamentEvent).where(
+                TournamentEvent.id == event_id,
+                TournamentEvent.tournament_id == tournament_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if event is None:
+        raise EventNotFoundError()
+    return event
+
+
+async def _enforce_unplayed(db: AsyncSession, event: TournamentEvent) -> None:
+    """Raise :class:`DrawUnderWayError` once an event's draw shows **evidence of
+    play** — the single gate on both cutting and un-cutting a draw (ADR-0786).
+
+    It is what makes a re-cut safe. A cut replaces the draw wholesale, so a draw with
+    a decided fixture (a recorded winner) or a materialized one (a linked match, which
+    may already carry games) cannot be re-cut without throwing away results players
+    actually produced. The refusal is on the *evidence*, not on the tournament's
+    status: a director may cut and re-cut right up until the first fixture becomes
+    real. Read under the tournament's row lock, like every other judge-then-write
+    guard, so the evidence it reads is the evidence the write below is authorized by.
+
+    One exception for both verbs, because it is one fact — a re-cut and an un-cut are
+    refused for the same reason.
+    """
+    if await draw_has_play(db, event.id):
+        raise DrawUnderWayError()
+
+
+async def cut_event_draw(
+    db: AsyncSession,
+    *,
+    tournament_id: uuid.UUID,
+    event_id: uuid.UUID,
+    actor: User,
+) -> list[TournamentFixtureRead]:
+    """Cut (or re-cut) the draw of the event ``actor`` owns, and return its fixtures
+    in the page's canonical **pool → round → position** order.
+
+    Runs the same orchestration the HTTP handler used to run inline, under the
+    tournament row lock (:func:`_load_owned_event_for_draw`):
+
+    * **404 / 403** — absent tournament, event not under it, or a non-owner, judged
+      first so the draw's own state is never the reason a stranger's request is
+      refused.
+    * **409** — a draw with evidence of play raises :class:`DrawUnderWayError`, asked
+      before anything is planned or deleted, so a refused re-cut leaves the standing
+      draw exactly as it was.
+    * **the DrawError family** — :func:`cut_draw` plans, deletes and re-inserts inside
+      *this* transaction (the lock still held, so the field cannot move under it and
+      the DELETE and INSERTs land together). When it refuses — an unsupported draw
+      type, a non-singles event, a degenerate field — it raises
+      :class:`~app.draws.DrawError` **before** the DELETE, so nothing is written; this
+      verb rolls back and lets the error propagate **unchanged** for the adapter to map
+      to the existing 422. It is deliberately *not* converted to an ``HTTPException``
+      here.
+
+    On success it requests a ``settings_changed`` solve in the same transaction under
+    the row lock (the order ``request_solve`` requires): the fixtures just changed
+    wholesale — a re-cut deleted the old rows (any pins died with them) and a first cut
+    minted the day's inputs. The cut *is* the drawn event, so no drawn-event gate is
+    needed; a ``None`` return (Redis down) deliberately costs the solve, never the cut.
+
+    Commits, then reads the draw back through :func:`fixtures_by_event` — the same
+    loader the detail page reads it through — so the fixtures this answers with are
+    byte-for-byte the ones the page will show. Never raises ``HTTPException``.
+    """
+    event = await _load_owned_event_for_draw(
+        db, tournament_id=tournament_id, event_id=event_id, actor=actor
+    )
+    await _enforce_unplayed(db, event)
+    try:
+        await cut_draw(db, event)
+    except DrawError:
+        # The domain refusing to produce a draw is not a bug — it is an answer, and it
+        # is the caller's to act on. Roll back (a DrawError is raised before the DELETE,
+        # so nothing is written, but the rollback clears the session and preserves the
+        # router's inline behaviour) and let the error propagate: the adapter composes
+        # the 422 sentence, the core stays FastAPI-free.
+        await db.rollback()
+        raise
+    await request_solve(db, tournament_id, ScheduleSolveTrigger.settings_changed)
+    await db.commit()
+    return (await fixtures_by_event(db, [event.id]))[event.id]
+
+
+async def uncut_event_draw(
+    db: AsyncSession,
+    *,
+    tournament_id: uuid.UUID,
+    event_id: uuid.UUID,
+    actor: User,
+) -> None:
+    """Un-cut the draw of the event ``actor`` owns: delete its fixtures, leaving the
+    event with no draw.
+
+    The same 404 → 403 → 409 ordering, and the same row lock, as
+    :func:`cut_event_draw`: this verb deletes what that verb writes, and the guard that
+    protects the fixtures cannot depend on which caller is asking. An event with **no
+    draw is already in the state this asks for**, so un-cutting a never-cut draw
+    deletes nothing and is a success (the router answers 204 either way) — which is
+    why the solve trigger is read off ``had_draw`` below, not assumed.
+
+    On a real un-cut of a draw it requests a ``settings_changed`` solve in the same
+    transaction under the row lock, gated on a drawn event **surviving** the un-cut
+    (``tournament_has_drawn_event``): un-cutting the only draw leaves nothing to place,
+    and a solve over an empty board is a no-op ledger entry. A ``None`` return (Redis
+    down) deliberately costs the solve, never the un-cut. Never raises an
+    ``HTTPException``.
+    """
+    event = await _load_owned_event_for_draw(
+        db, tournament_id=tournament_id, event_id=event_id, actor=actor
+    )
+    await _enforce_unplayed(db, event)
+    # Read before the DELETE: whether this verb is about to change anything at all. The
+    # idempotent un-cut of a never-cut draw deletes nothing and must trigger nothing.
+    had_draw = await event_has_draw(db, event.id)
+    await uncut_draw(db, [event.id])
+    if had_draw and await tournament_has_drawn_event(db, tournament_id):
+        await request_solve(db, tournament_id, ScheduleSolveTrigger.settings_changed)
+    await db.commit()

--- a/api/app/tournament_draw_service.py
+++ b/api/app/tournament_draw_service.py
@@ -50,11 +50,10 @@ from app.tournament_draws import (
     event_has_draw,
     uncut_draw,
 )
-from app.tournament_edit import _load_tournament_for_update
+from app.tournament_edit import _load_owned_tournament_for_update
 from app.tournament_errors import (
     DrawUnderWayError,
     EventNotFoundError,
-    NotTournamentOwnerError,
 )
 from app.tournament_queries import fixtures_by_event
 
@@ -82,9 +81,7 @@ async def _load_owned_event_for_draw(
     first — which is what keeps them free of a deadlock cycle. The FastAPI-free
     equivalent of the router's ``_get_owned_event_for_draw_or_404``.
     """
-    tournament = await _load_tournament_for_update(db, tournament_id)
-    if tournament.created_by_user_id != actor.id:
-        raise NotTournamentOwnerError()
+    await _load_owned_tournament_for_update(db, tournament_id, actor)
     # The event must belong to the named tournament — scoped by both ids so a
     # mismatched pair is a miss, not a cross-tournament draw.
     event = (

--- a/api/app/tournament_edit.py
+++ b/api/app/tournament_edit.py
@@ -1,0 +1,152 @@
+"""The transport-neutral edit-tournament write verb.
+
+The orchestration behind ``PATCH /v1/tournaments/{id}`` — the ``FOR UPDATE``
+load-lock, the owner gate, the league-editable-only-while-draft state rule
+(ADR-0783), the STRICT league resolution, the partial apply, and the
+table-catalogue-change → re-solve trigger — extracted out of the router so it can
+run without FastAPI: from the HTTP adapter (``app.tournaments.update_tournament``)
+and from the MCP ``edit_tournament`` tool alike, and be constructed in a plain
+REPL with a raw session.
+
+Per the tournament-verbs ADR (mirroring the match-flow ADR), it signals every
+refusal with a **domain exception** from ``app.tournament_errors`` — never an
+``HTTPException`` — and each adapter maps it back to the exact response it
+produced before. In particular the league lookup does NOT reuse ``resolve_league``
+(``app.leagues``), which raises an ``HTTPException`` a FastAPI-free verb must not
+let escape: it resolves through the FastAPI-free ``_load_league`` and raises
+:class:`LeagueNotFoundError` on a miss, the transport-neutral equivalent of that
+resolver's strict 404.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.leagues import _load_league
+from app.models import ScheduleSolveTrigger, Tournament, TournamentStatus, User
+from app.schedule_solves import request_solve, tournament_has_drawn_event
+from app.schemas.tournament import TournamentTable, TournamentUpdate
+from app.tournament_errors import (
+    LeagueNotEditableError,
+    LeagueNotFoundError,
+    NotTournamentOwnerError,
+    TournamentNotFoundError,
+)
+
+
+async def _load_tournament_for_update(
+    db: AsyncSession, tournament_id: uuid.UUID
+) -> Tournament:
+    """Load the tournament row with ``FOR UPDATE`` held for the rest of the
+    transaction, or raise :class:`TournamentNotFoundError`.
+
+    The FastAPI-free twin of the router's ``_get_tournament_for_update_or_404``:
+    the edit path *judges the status and then writes* (the league guard reads
+    ``status``, ADR-0783), so it takes the tournament row lock — on the same row,
+    in the same order the transition and entry routes take it — before any read
+    the write depends on. Postgres runs READ COMMITTED, so without the lock a
+    league change could pass the ``draft`` check, a concurrent publish could
+    commit, and the UPDATE could land behind it, moving the ladder under a
+    tournament whose registration is already open. The lock is taken
+    unconditionally though the status is only *judged* when the payload carries a
+    ``league_id``: one loader is simpler than a branch, and a name-only edit that
+    queues behind a publish is harmless.
+    """
+    tournament = (
+        await db.execute(
+            select(Tournament).where(Tournament.id == tournament_id).with_for_update()
+        )
+    ).scalar_one_or_none()
+    if tournament is None:
+        raise TournamentNotFoundError()
+    return tournament
+
+
+def _catalogue_ids(tournament: Tournament) -> list[str]:
+    """The table catalogue reduced to its ``id`` list — the only slice of it the
+    solver reads (``_load_solver_inputs`` reduces the catalogue to ``TableId``s;
+    labels and courts are display). Parsed with the same model the write boundary
+    validated it with, so the before/after comparison is over what actually feeds
+    a solve: a rename/address/date edit and a label-only re-word trigger nothing,
+    adding/removing/re-identifying a table triggers a re-solve."""
+    return [
+        TournamentTable.model_validate(table).id for table in tournament.table_catalogue
+    ]
+
+
+async def edit_tournament(
+    db: AsyncSession,
+    *,
+    tournament_id: uuid.UUID,
+    actor: User,
+    updates: TournamentUpdate,
+) -> Tournament:
+    """Apply the partial ``updates`` to the tournament ``actor`` owns, and return
+    the refreshed :class:`Tournament`.
+
+    Loads under the tournament row lock (:func:`_load_tournament_for_update`) and
+    runs the same orchestration the HTTP handler used to run inline:
+
+    * **404** — an absent tournament id raises :class:`TournamentNotFoundError`.
+      Loaded first, so ownership is judged only once the row exists.
+    * **403** — a caller who is not the tournament's creator raises
+      :class:`NotTournamentOwnerError`. Tournament mutations are owner-gated
+      (``created_by_user_id == actor.id``), not RBAC-gated.
+    * **409** — a ``league_id`` in the payload on a tournament that has left
+      ``draft`` raises :class:`LeagueNotEditableError` (carrying the current
+      status): once published, registration is open and eligibility is live, so
+      the ladder is settled (ADR-0783). Judged *before* the league is looked up,
+      so a caller who cannot change it learns nothing about which leagues exist.
+    * **404** — a ``league_id`` that names no league raises
+      :class:`LeagueNotFoundError` (the STRICT resolution, via the FastAPI-free
+      ``_load_league``): a director's typo must not silently swap to the default.
+
+    Then it applies the remaining fields (``model_dump(exclude_unset=True)``
+    already serialized the nested value-objects to plain dicts/lists, so one
+    ``setattr`` loop covers the JSONB and scalar columns alike) and, when the
+    table-catalogue ids changed AND at least one event is drawn, requests a
+    ``settings_changed`` solve inside this transaction under the row lock (the
+    lock order ``request_solve`` requires). A ``None`` return from
+    ``request_solve`` (Redis down) is deliberately ignored: the edit is what the
+    owner asked for, and the missing solve is recovered by the pin tick or the
+    Run-scheduler button.
+
+    Commits and refreshes before returning. Never raises ``HTTPException`` — the
+    caller adapts each domain exception to its transport.
+    """
+    tournament = await _load_tournament_for_update(db, tournament_id)
+    if tournament.created_by_user_id != actor.id:
+        raise NotTournamentOwnerError()
+
+    fields = updates.model_dump(exclude_unset=True)
+
+    # The league is the one field with a *state* rule (ADR-0783), so it comes out
+    # of the generic loop and is judged before anything is written — and the
+    # refusal is raised before the league is looked up, so a caller who cannot
+    # change it learns nothing about whether the league they named exists.
+    if "league_id" in fields:
+        if tournament.status is not TournamentStatus.draft:
+            raise LeagueNotEditableError(tournament.status.value)
+        # STRICT resolution, exactly as on create — but via the FastAPI-free
+        # ``_load_league`` rather than ``resolve_league`` (which raises an
+        # ``HTTPException`` this verb must not let escape). The schema rejects an
+        # explicit ``null`` for ``league_id``, so it is always a real id here.
+        league = await _load_league(db, fields.pop("league_id"))
+        if league is None:
+            raise LeagueNotFoundError()
+        tournament.league_id = league.id
+
+    catalogue_ids_before = _catalogue_ids(tournament)
+    for key, value in fields.items():
+        setattr(tournament, key, value)
+    catalogue_ids_after = _catalogue_ids(tournament)
+
+    if catalogue_ids_after != catalogue_ids_before and await tournament_has_drawn_event(
+        db, tournament_id
+    ):
+        await request_solve(db, tournament_id, ScheduleSolveTrigger.settings_changed)
+
+    await db.commit()
+    await db.refresh(tournament)
+    return tournament

--- a/api/app/tournament_edit.py
+++ b/api/app/tournament_edit.py
@@ -63,6 +63,26 @@ async def _load_tournament_for_update(
     return tournament
 
 
+async def _load_owned_tournament_for_update(
+    db: AsyncSession, tournament_id: uuid.UUID, actor: User
+) -> Tournament:
+    """Load the tournament ``actor`` owns under ``FOR UPDATE``, or raise — the
+    lock-then-owner-gate pair every owner-only tournament write shares.
+
+    Composes :func:`_load_tournament_for_update` (the row lock, raising
+    :class:`TournamentNotFoundError`) with the owner gate (raising
+    :class:`NotTournamentOwnerError`), in that order: the 404 is judged before the
+    403, so a caller who is not the owner never learns whether an absent id existed.
+    The single home for the two lines the edit, solve and draw write cores each ran
+    inline — same exceptions, same order — so a fourth write core cannot grow a
+    fifth opinion about what "the owner's locked tournament" means.
+    """
+    tournament = await _load_tournament_for_update(db, tournament_id)
+    if tournament.created_by_user_id != actor.id:
+        raise NotTournamentOwnerError()
+    return tournament
+
+
 def _catalogue_ids(tournament: Tournament) -> list[str]:
     """The table catalogue reduced to its ``id`` list — the only slice of it the
     solver reads (``_load_solver_inputs`` reduces the catalogue to ``TableId``s;
@@ -115,9 +135,7 @@ async def edit_tournament(
     Commits and refreshes before returning. Never raises ``HTTPException`` — the
     caller adapts each domain exception to its transport.
     """
-    tournament = await _load_tournament_for_update(db, tournament_id)
-    if tournament.created_by_user_id != actor.id:
-        raise NotTournamentOwnerError()
+    tournament = await _load_owned_tournament_for_update(db, tournament_id, actor)
 
     fields = updates.model_dump(exclude_unset=True)
 

--- a/api/app/tournament_errors.py
+++ b/api/app/tournament_errors.py
@@ -78,3 +78,27 @@ class LeagueNotFoundError(Exception):
     ``resolve_league`` 404 (``app.leagues``), which raises an ``HTTPException``
     the FastAPI-free verb must not. The HTTP adapter maps this to the existing
     404 ``"League not found."``. Never an ``HTTPException``."""
+
+
+class NoDrawnEventsError(Exception):
+    """Raised by the request-schedule-solve verb when no event of the addressed
+    tournament has a **cut draw** — nothing the solver can place, so a run would
+    succeed at placing zero fixtures (a green ledger row that answers a question
+    nobody asked). The HTTP adapter maps this to the existing 422 with the
+    machine-readable ``{"code": "no_drawn_events", "message": ...}`` body
+    (``app.tournaments._no_drawn_events_refusal``): a bare marker like
+    :class:`TournamentNotFoundError`, its transport copy lives in the adapter,
+    not here. Never an ``HTTPException``."""
+
+
+class ScheduleQueueUnavailableError(Exception):
+    """Raised by the request-schedule-solve verb when the enqueue itself could
+    not be placed on the queue (Redis down): :func:`app.schedule_solves.request_solve`
+    catches the ``RedisError`` internally, takes its just-inserted row back out
+    (a zombie row would absorb every later trigger while no job ever runs) and
+    returns ``None``. This verb turns that ``None`` into this exception so its
+    own return type stays a non-optional :class:`~app.models.ScheduleSolve` —
+    the caller gets a real ledger row or a refusal, never an ambiguous ``None``.
+    The HTTP adapter maps this to the existing 503 ``"The scheduling queue is
+    unavailable, …"``; nothing was queued and the same request is safe to retry.
+    Never an ``HTTPException``."""

--- a/api/app/tournament_errors.py
+++ b/api/app/tournament_errors.py
@@ -1,8 +1,9 @@
 """The tournament-flow domain exception family.
 
 A neutral leaf holding the domain exceptions the transport-neutral tournament
-verbs (``tournament_edit`` today; cut/uncut and solve as they are extracted)
-raise, mirroring ``app.match_errors``.
+verbs (``tournament_edit`` and the cut/uncut draw verbs in
+``tournament_draw_service`` today; solve as it is extracted) raise, mirroring
+``app.match_errors``.
 
 None of these is ever an ``HTTPException``: each verb is transport-neutral and
 signals a refusal with a plain domain exception, and each adapter (the HTTP
@@ -25,6 +26,34 @@ class NotTournamentOwnerError(Exception):
     actor``), not RBAC-gated. The HTTP adapter maps this to the existing 403
     ``"You can only modify tournaments you created."``. Never an
     ``HTTPException``."""
+
+
+class EventNotFoundError(Exception):
+    """Raised by the draw verbs when the addressed event id does not resolve to a
+    row **under the named tournament** — a well-formed pair that names no
+    addressable event (a right event id under the wrong tournament id included, so
+    a cross-tournament draw is a miss, not an edit). The HTTP adapter maps this to
+    the existing 404 ``"Event not found."``. Never an ``HTTPException`` — the caller
+    adapts it to its transport."""
+
+
+class DrawUnderWayError(Exception):
+    """Raised by the draw verbs when an event's draw shows **evidence of play** — a
+    fixture with a recorded winner or a linked match — the single gate on both
+    cutting and un-cutting a draw (ADR-0786). A cut replaces the draw wholesale and
+    an un-cut destroys it, so either one over a played fixture would throw away a
+    result a player produced.
+
+    Carries the exact sentence the HTTP handler used to compose inline, so the
+    adapter can rebuild the existing 409 body verbatim with ``str(exc)``. It is a
+    409, not a 403: the caller is the owner and the draw is theirs — it is the draw
+    that is past the point where a re-cut means anything. Never an ``HTTPException``."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "This event's draw is already under way — at least one fixture has a "
+            "match or a recorded winner — so it can no longer be cut or removed."
+        )
 
 
 class LeagueNotEditableError(Exception):

--- a/api/app/tournament_errors.py
+++ b/api/app/tournament_errors.py
@@ -1,0 +1,51 @@
+"""The tournament-flow domain exception family.
+
+A neutral leaf holding the domain exceptions the transport-neutral tournament
+verbs (``tournament_edit`` today; cut/uncut and solve as they are extracted)
+raise, mirroring ``app.match_errors``.
+
+None of these is ever an ``HTTPException``: each verb is transport-neutral and
+signals a refusal with a plain domain exception, and each adapter (the HTTP
+router, the MCP tools) maps it back to the exact response it produced before.
+This module imports nothing but the standard library, so it stays a cycle-free
+leaf both the services and their adapters can import.
+"""
+
+
+class TournamentNotFoundError(Exception):
+    """Raised by the edit verb when the addressed tournament id does not resolve
+    to a row. The HTTP adapter maps this to the existing 404
+    ``"Tournament not found."``. Never an ``HTTPException`` — the caller adapts
+    it to its transport."""
+
+
+class NotTournamentOwnerError(Exception):
+    """Raised by the edit verb when the acting user is not the tournament's
+    creator. Tournament mutations are owner-gated (``created_by_user_id ==
+    actor``), not RBAC-gated. The HTTP adapter maps this to the existing 403
+    ``"You can only modify tournaments you created."``. Never an
+    ``HTTPException``."""
+
+
+class LeagueNotEditableError(Exception):
+    """Raised by the edit verb when the payload would change the tournament's
+    ``league_id`` after it has left ``draft`` (ADR-0783): once published,
+    registration is open and eligibility is live, so the ladder is settled.
+    Carries the tournament's current status so the HTTP adapter can rebuild the
+    exact 409 body (``"This tournament is {status}; its league can only be
+    changed while it is a draft."``). Never an ``HTTPException``."""
+
+    def __init__(self, status: str) -> None:
+        super().__init__(
+            f"This tournament is {status}; its league can only be changed "
+            "while it is a draft."
+        )
+        self.status = status
+
+
+class LeagueNotFoundError(Exception):
+    """Raised by the edit verb when the payload names a ``league_id`` that
+    resolves to no league — the transport-neutral equivalent of the strict
+    ``resolve_league`` 404 (``app.leagues``), which raises an ``HTTPException``
+    the FastAPI-free verb must not. The HTTP adapter maps this to the existing
+    404 ``"League not found."``. Never an ``HTTPException``."""

--- a/api/app/tournament_list.py
+++ b/api/app/tournament_list.py
@@ -1,0 +1,125 @@
+"""The batched read behind the tournament LIST surfaces.
+
+The HTTP ``GET /v1/tournaments`` list and the MCP ``list_my_tournaments`` tool
+return the *same* full aggregate — every tournament with all of its events, their
+entrants and their draws — and differ only in **which tournaments** they select:
+the HTTP list is VISIBILITY-scoped (``visible_to``), the MCP tool is OWNER-scoped
+(``created_by_user_id == caller``). So the query shape lives here, once, taking a
+WHERE predicate, and both surfaces call it — a second copy of this five-statement
+batched read would be the N+1 waiting to happen that the statement-count
+tripwires in ``tests/test_tournaments.py`` exist to catch.
+
+It sits a layer above ``tournament_queries`` (pure data access) because it also
+composes the shared ``serialize_detail`` serializer; keeping it out of
+``tournament_queries`` keeps that module import-free of the serializer.
+"""
+
+import uuid
+
+from sqlalchemy import ColumnElement, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Tournament, TournamentEvent, User
+from app.schemas.tournament import TournamentDetailRead
+from app.tournament_queries import (
+    active_entrants_by_event,
+    entrant_ratings_by_league,
+    fixtures_by_event,
+)
+from app.tournament_serialization import serialize_detail
+
+
+async def list_tournament_details(
+    db: AsyncSession,
+    *,
+    where: ColumnElement[bool],
+    current_user_id: uuid.UUID,
+) -> list[TournamentDetailRead]:
+    """Every tournament matching ``where``, newest first, as the full
+    ``TournamentDetailRead`` aggregate the list cards render.
+
+    FIVE queries, no N+1, whatever the number of tournaments or events: the
+    tournaments+usernames join (scoped by ``where``), then all their events, then
+    all those events' active entrants in one batch, then all those events'
+    fixtures in one batch (ADR-0786), then the caller's rating on every distinct
+    league those tournaments run on (which every event's ``entry_state`` is judged
+    against, ADR-0783). A per-event entry count, a per-event draw, or a
+    per-tournament rating would be the N+1 this shape exists to avoid, and a
+    statement-count tripwire in ``tests/test_tournaments.py`` fails if one comes
+    back.
+
+    ``where`` scopes the FIRST query, so the events and entrants queries are keyed
+    off the surviving ids and cannot leak a hidden tournament's contents either.
+    The HTTP list passes ``visible_to(caller)`` (a draft that is not the caller's
+    is not theirs to see); the MCP ``list_my_tournaments`` tool passes
+    ``Tournament.created_by_user_id == caller`` (owner-scoped). A predicate costs
+    no extra statement, so the tripwire still reads the same count.
+
+    ``current_user_id`` is the perspective the aggregate is projected from — the
+    ``can_edit`` flag, the per-event ``entry_state``, and the ladder ``rating``.
+    """
+    rows = (
+        await db.execute(
+            select(Tournament, User.username)
+            .join(User, User.id == Tournament.created_by_user_id)
+            .where(where)
+            .order_by(Tournament.created_at.desc())
+        )
+    ).all()
+    tournament_ids = [tournament.id for tournament, _ in rows]
+    events_by_tournament: dict[uuid.UUID, list[TournamentEvent]] = {
+        tid: [] for tid in tournament_ids
+    }
+    events: list[TournamentEvent] = []
+    if tournament_ids:
+        events = list(
+            (
+                await db.execute(
+                    select(TournamentEvent)
+                    .where(TournamentEvent.tournament_id.in_(tournament_ids))
+                    .order_by(TournamentEvent.created_at)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for event in events:
+            events_by_tournament[event.tournament_id].append(event)
+    event_ids = [e.id for e in events]
+    entrants_by_event = await active_entrants_by_event(db, event_ids)
+    # And ONE batch for every one of those events' fixtures — its draw (ADR-0786).
+    # Batched for the same reason the entrants are: the list returns every event of
+    # every tournament, so reading ``event.fixtures`` in the loop would be a SELECT
+    # per event. Uncut draws come back as ``[]``, so an event nobody has cut a draw
+    # for costs nothing and answers with an empty list rather than a null.
+    event_fixtures = await fixtures_by_event(db, event_ids)
+    # The list deliberately does NOT project standings: its cards render only event
+    # and table counts, never a results table, so it skips the game-count query and
+    # the per-event tabulation a results object would need (``game_counts=None``
+    # below). Standings are a detail-BFF concern (ADR-0788); computing them here
+    # would be work a page throws away — the same shape as #1051 for
+    # fixtures/entrants.
+    # ONE batch for the caller's ratings, keyed by league — deduplicated, because
+    # every tournament on the default league shares the one number, and because the
+    # ladders a page happens to list is not a reason to ask the same question twice.
+    ratings = await entrant_ratings_by_league(
+        db, list({tournament.league_id for tournament, _ in rows}), current_user_id
+    )
+    return [
+        serialize_detail(
+            tournament,
+            created_by_username=username,
+            current_user_id=current_user_id,
+            events=events_by_tournament[tournament.id],
+            entrants_by_event=entrants_by_event,
+            fixtures_by_event=event_fixtures,
+            game_counts=None,
+            rating=ratings[tournament.league_id],
+            # The list projects no solve strip, for the same reason it projects no
+            # standings (``game_counts=None`` above): its cards never render one, so
+            # it skips the ledger read rather than paying a query for a field every
+            # card throws away. The solve strip is a detail-BFF concern.
+            latest_schedule_solve=None,
+        )
+        for tournament, username in rows
+    ]

--- a/api/app/tournament_list.py
+++ b/api/app/tournament_list.py
@@ -1,4 +1,4 @@
-"""The batched read behind the tournament LIST surfaces.
+"""The batched reads behind the tournament LIST and DETAIL surfaces.
 
 The HTTP ``GET /v1/tournaments`` list and the MCP ``list_my_tournaments`` tool
 return the *same* full aggregate — every tournament with all of its events, their
@@ -9,8 +9,13 @@ WHERE predicate, and both surfaces call it — a second copy of this five-statem
 batched read would be the N+1 waiting to happen that the statement-count
 tripwires in ``tests/test_tournaments.py`` exist to catch.
 
-It sits a layer above ``tournament_queries`` (pure data access) because it also
-composes the shared ``serialize_detail`` serializer; keeping it out of
+The single-tournament DETAIL read (:func:`tournament_detail`) lives here for the
+same reason: the HTTP ``GET /v1/tournaments/{id}`` route and the MCP
+``get_tournament`` tool composed the identical six-statement batched read inline,
+a hairline apart, and a second copy is the drift this module exists to prevent.
+
+Both sit a layer above ``tournament_queries`` (pure data access) because they also
+compose the shared ``serialize_detail`` serializer; keeping them out of
 ``tournament_queries`` keeps that module import-free of the serializer.
 """
 
@@ -20,11 +25,15 @@ from sqlalchemy import ColumnElement, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Tournament, TournamentEvent, User
+from app.schedule_solves import latest_solve
 from app.schemas.tournament import TournamentDetailRead
 from app.tournament_queries import (
     active_entrants_by_event,
+    completed_match_ids,
+    entrant_rating,
     entrant_ratings_by_league,
     fixtures_by_event,
+    game_counts_by_match,
 )
 from app.tournament_serialization import serialize_detail
 
@@ -123,3 +132,65 @@ async def list_tournament_details(
         )
         for tournament, username in rows
     ]
+
+
+async def tournament_detail(
+    db: AsyncSession,
+    tournament: Tournament,
+    *,
+    created_by_username: str,
+    current_user_id: uuid.UUID,
+) -> TournamentDetailRead:
+    """The single-tournament DETAIL aggregate the tournament page renders, for an
+    already-loaded, already-visibility-checked ``tournament``.
+
+    The caller loads the row (scoping it by ``visible_to`` and answering the
+    not-found itself, since the HTTP route and the MCP tool 404/refuse
+    differently) and hands it in with its creator's ``created_by_username``; this
+    reader runs the shared batched composition both surfaces used to run inline —
+    SIX statements, no N+1 whatever the number of events, entrants, fixtures or
+    solves:
+
+    1. the tournament's events, in creation order;
+    2. those events' active entrants (one batch);
+    3. those events' fixtures — their draws (one batch, ADR-0786);
+    4. the games of every **completed** match on the page — the standings' raw
+       material (one batch; **no statement at all** until something is played, so an
+       unplayed tournament costs five here, a played one six);
+    5. the caller's rating on the tournament's one league (ADR-0783);
+    6. the newest row of the solve ledger (the Schedule tab's solve strip).
+
+    Then the shared ``serialize_detail`` projects it from ``current_user_id``'s
+    perspective (``can_edit``, per-event ``entry_state``, ladder ``rating``). The
+    statement-count is exactly the shape ``tests/test_tournaments.py`` pins for the
+    HTTP route, because that route composes this reader; the MCP ``get_tournament``
+    tool composes the *same* reader, so the two surfaces can never drift.
+    """
+    events = list(
+        (
+            await db.execute(
+                select(TournamentEvent)
+                .where(TournamentEvent.tournament_id == tournament.id)
+                .order_by(TournamentEvent.created_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    event_ids = [e.id for e in events]
+    entrants_by_event = await active_entrants_by_event(db, event_ids)
+    event_fixtures = await fixtures_by_event(db, event_ids)
+    game_counts = await game_counts_by_match(db, completed_match_ids(event_fixtures))
+    rating = await entrant_rating(db, tournament.league_id, current_user_id)
+    latest_schedule_solve = await latest_solve(db, tournament.id)
+    return serialize_detail(
+        tournament,
+        created_by_username=created_by_username,
+        current_user_id=current_user_id,
+        events=events,
+        entrants_by_event=entrants_by_event,
+        fixtures_by_event=event_fixtures,
+        game_counts=game_counts,
+        rating=rating,
+        latest_schedule_solve=latest_schedule_solve,
+    )

--- a/api/app/tournament_queries.py
+++ b/api/app/tournament_queries.py
@@ -15,23 +15,90 @@ import uuid
 from collections.abc import Sequence
 from datetime import datetime
 
-from sqlalchemy import and_, func, select
+from sqlalchemy import ColumnElement, and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import (
     Match,
     MatchGame,
     MatchGameScore,
+    MatchStatus,
     Tournament,
     TournamentEntry,
     TournamentEntryStatus,
     TournamentEvent,
     TournamentFixture,
+    TournamentStatus,
     User,
     UserLeagueRating,
 )
 from app.ratings.rated import is_rated_member
 from app.schemas.tournament import TournamentEntrantRead, TournamentFixtureRead
+
+# The statuses in which a tournament has been ANNOUNCED to the world. Publishing
+# is the act that makes a tournament public (ADR-0017), and nothing walks
+# backwards out of it, so everything from ``published`` onward is announced and
+# ``draft`` is not.
+#
+# An allow-list, deliberately, rather than "anything but draft": a status added
+# to the enum tomorrow is invisible to non-owners until somebody puts it in this
+# set on purpose. The inverse spelling would silently publish a future
+# pre-publish status (a ``pending_review``, a ``scheduled``) the moment it was
+# added, which is exactly the leak this predicate exists to close.
+ANNOUNCED_STATUSES: frozenset[TournamentStatus] = frozenset(
+    {
+        TournamentStatus.published,
+        TournamentStatus.live,
+        TournamentStatus.archived,
+    }
+)
+
+
+def visible_to(user_id: uuid.UUID) -> ColumnElement[bool]:
+    """Which tournaments ``user_id`` may see at all: the announced ones, plus
+    their own — whatever status their own is in.
+
+    A draft is not announced, so it is owner-only. The read routes push this into
+    the WHERE clause rather than filtering after the fact, so a hidden draft is
+    *not selected* and the detail route's existing "Tournament not found." 404
+    answers for it. 404 and not 403: a 403 would confirm that a tournament with
+    that id exists, which is precisely what an unannounced tournament must not
+    admit. A draft the caller cannot see is indistinguishable from one that was
+    never created.
+
+    ``tournament.view`` is a separate question, and it is asked first — the HTTP
+    route hangs it off a dependency and the MCP adapter checks it before this
+    predicate is ever built, so a caller without the permission is refused (403 /
+    a ``ToolError``) first. Permission says "may you read tournaments at all";
+    this says "which ones are there for you to read".
+
+    One predicate, shared by the list route, the detail route, and the MCP
+    ``get_tournament`` tool, because two copies of this rule would eventually
+    disagree — and the way they disagree is that one hides a draft another still
+    serves.
+    """
+    return or_(
+        Tournament.status.in_(ANNOUNCED_STATUSES),
+        Tournament.created_by_user_id == user_id,
+    )
+
+
+def completed_match_ids(
+    fixtures_by_event: dict[uuid.UUID, list[TournamentFixtureRead]],
+) -> list[uuid.UUID]:
+    """The ids of the matches of every **completed** fixture across the page.
+
+    The one list ``game_counts_by_match`` is batched over, gathered before any event is
+    serialized so the standings of every event are projected from a single game load
+    (ADR-0788) rather than a query per event. Only ``completed`` fixtures contribute: an
+    in-progress match's part-scored board is not a result and must not reach a standings
+    table."""
+    return [
+        f.match_id
+        for fixtures in fixtures_by_event.values()
+        for f in fixtures
+        if f.match_status is MatchStatus.completed and f.match_id is not None
+    ]
 
 
 async def active_entrants_by_event(

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -1,0 +1,398 @@
+"""Router-free serialization of loaded ``Tournament`` rows into the
+``TournamentRead`` / ``TournamentDetailRead`` (and per-event
+``TournamentEventRead``) views.
+
+This lives outside ``tournaments.py`` so that *both* the HTTP handlers and a
+future MCP tool module can produce the identical view objects without one
+adapter importing another router's internals (``api/CLAUDE.md`` — "don't import
+another router's internals"; ADR 20260719 "tournament verbs are shared functions
+behind HTTP and MCP adapters", section "Reads reuse the queries and a shared
+serializer"). It imports only domain/query/schema modules — never a router — so
+it stays cycle-free, mirroring ``app/match_serialization.py``.
+"""
+
+import uuid
+from collections import defaultdict
+from typing import Any, assert_never
+
+from app.draws import EntryId, PoolId
+from app.models import (
+    DrawType,
+    MatchStatus,
+    ScheduleSolve,
+    Tournament,
+    TournamentEvent,
+)
+from app.results import EventResults, MatchOutcome, PoolInput, results_for
+from app.schemas.tournament import (
+    EventEntryFull,
+    EventEntryOpen,
+    EventEntryRatingIneligible,
+    EventEntryState,
+    EventResultsRead,
+    PoolStandingsRead,
+    ScheduleSolveRead,
+    StandingRowRead,
+    TournamentDetailRead,
+    TournamentEntrantRead,
+    TournamentEventRead,
+    TournamentFixtureRead,
+    TournamentRead,
+)
+from app.tournament_eligibility import (
+    Eligible,
+    RatingIneligible,
+    evaluate_rating_eligibility,
+    event_is_full,
+)
+
+# Public shared surface: the serializers both the HTTP router (``tournaments.py``)
+# and the MCP adapter import. ``_serialize_event`` is public too because the
+# per-event routes (cut/uncut draw, place fixtures) serialize a single event
+# directly. Everything else (``_tournament_fields``, ``_entry_state``,
+# ``_event_results``, ``_serialize_results``) is a module-internal helper and
+# stays private.
+__all__ = [
+    "serialize",
+    "serialize_detail",
+    "serialize_event",
+]
+
+
+def _tournament_fields(
+    t: Tournament,
+    *,
+    created_by_username: str,
+    current_user_id: uuid.UUID,
+) -> dict[str, Any]:
+    # The request-scoped fields (``created_by_username``/``can_edit``) aren't on
+    # the ORM row. The JSONB columns (``address``/``table_catalogue``) are read
+    # straight off the attributes; Pydantic validates them into
+    # Address/TournamentTable when the returned dict is fed to model_validate,
+    # so the raw dicts never leave the serialize boundary.
+    return {
+        "id": t.id,
+        "name": t.name,
+        "description": t.description,
+        "status": t.status,
+        "start_date": t.start_date,
+        "end_date": t.end_date,
+        "address": t.address,
+        "table_catalogue": t.table_catalogue,
+        "league_id": t.league_id,
+        "created_by_user_id": t.created_by_user_id,
+        "created_by_username": created_by_username,
+        "can_edit": t.created_by_user_id == current_user_id,
+        "created_at": t.created_at,
+        "updated_at": t.updated_at,
+    }
+
+
+def serialize(
+    t: Tournament,
+    *,
+    created_by_username: str,
+    current_user_id: uuid.UUID,
+) -> TournamentRead:
+    return TournamentRead.model_validate(
+        _tournament_fields(
+            t, created_by_username=created_by_username, current_user_id=current_user_id
+        )
+    )
+
+
+def _entry_state(
+    e: TournamentEvent,
+    *,
+    entered: int,
+    rating: float | None,
+) -> EventEntryState:
+    """Whether THIS caller may enter THIS event — the read-path twin of the guards
+    the entry route raises 409s from, computed from facts already in hand.
+
+    No database access, and that is the point: the ``entered`` count is the length of
+    the entrants list the read has already batched (ADR-0016 — the count is derived
+    from the rows, so it cannot disagree with the list beside it), and ``rating`` is
+    the caller's rating on the **tournament's** league, resolved ONCE per tournament
+    (``entrant_ratings_by_league``) because every event of a tournament is judged on
+    the same ladder. Reaching for either from in here would be a query per event: an
+    N+1 that grows with the very field the page is describing, and the statement-count
+    tripwires in ``tests/test_tournaments.py`` fail if one appears.
+
+    **The decision is not made here.** ``evaluate_rating_eligibility`` and
+    ``event_is_full`` make it — the same two functions the ``POST …/entries`` guards
+    call — so the page that explains why Enter is not offered and the route that
+    refuses the entry cannot come to two different answers (ADR-0783). This is only
+    the translation into the wire's sum type.
+
+    That sharing is what keeps an **uncapped** event (``max_players IS NULL``,
+    ADR-0935) out of the ``event_full`` arm: ``event_is_full`` answers ``False`` for a
+    null cap however many entrants there are, so this function cannot report as full an
+    event the entry route would happily admit the reader to. Had the capacity question
+    been re-asked here — with a ``>=`` over a nullable column — it would have been a
+    ``TypeError`` on the detail page of the first uncapped event, or (worse, had it
+    been written defensively as ``max_players or 0``) a permanently, silently full one.
+
+    **The ORDER mirrors the entry route's**, and it has to: eligibility first, then
+    capacity. An ineligible player looking at a full event is told about their
+    *rating*, which is exactly what ``POST …/entries`` would tell them
+    (``test_the_rating_refusal_outranks_the_event_full_refusal``) — and it is the more
+    useful of the two facts, because it is the one that does not change when somebody
+    withdraws. Flip these two lines and the page starts promising a player a slot that
+    frees up, for an event that would refuse them anyway.
+
+    What is deliberately NOT decided here: the registration window (a fact about the
+    tournament — its status, ADR-0017), whether the caller is already entered (a fact
+    on the entrants list), whether they hold ``tournament.enter``, and whether the
+    event is doubles. All four are already on the page or in the session, and
+    restating them would be carrying a field and its own derivation. ``open`` means
+    "the event admits you", not "click here".
+
+    ``match`` with ``assert_never``, not ``isinstance``: a third eligibility outcome
+    added tomorrow is a type error here until somebody says what the page should show
+    for it, rather than falling through to ``open`` — a read must not fail in the
+    reassuring direction any more than a guard may fail in the permissive one.
+    """
+    decision = evaluate_rating_eligibility(rating=rating, predicates=e.predicates)
+    match decision:
+        case RatingIneligible():
+            return EventEntryRatingIneligible(
+                predicate_id=decision.predicate_id, rating=decision.rating
+            )
+        case Eligible():
+            if event_is_full(entered=entered, max_players=e.max_players):
+                return EventEntryFull()
+            return EventEntryOpen()
+        case _:
+            assert_never(decision)
+
+
+def _event_results(
+    e: TournamentEvent,
+    *,
+    fixtures: list[TournamentFixtureRead],
+    game_counts: dict[uuid.UUID, tuple[int, int]],
+) -> EventResultsRead | None:
+    """The event's results (ADR-0788), projected from its fixtures' completed matches,
+    or ``None`` when there are none to compute.
+
+    ``None`` in two cases, both meaning "no results here" rather than an empty table: a
+    draw type with no results strategy yet (``results_for`` raises for it — only
+    round-robin has one today), and an event whose draw has not been cut (no fixtures to
+    stand). Everything else is a real :class:`EventResultsRead`, whose standings are
+    empty of *decided* rows but full of *seated* ones while the pool is still played.
+
+    The projection is the fixed materialization convention read backwards (#788): side 1
+    is ``entry_a`` and side 2 is ``entry_b``, so the ``(side_1, side_2)`` game counts
+    are the ``(entry_a, entry_b)`` game counts, and the winner is whichever took more
+    games — derived from the live match, never from the fixture's written-back
+    ``winner_entry_id`` (which no round-robin read reads, for correction-safety)."""
+    match e.draw_type:
+        case DrawType.round_robin:
+            pass  # the projection below is round-robin-shaped
+        case (
+            DrawType.single_elim
+            | DrawType.double_elim
+            | DrawType.rr_then_ko
+            | DrawType.swiss
+        ):
+            # No results projection for these yet (``results_for`` has no strategy for
+            # them either). Spelled as a checked dispatch with an ``assert_never``
+            # catch-all rather than a bare ``is not round_robin``, so a new ``DrawType``
+            # is a type error here until its projection is written — the same guarantee
+            # ``strategy_for``/``results_for`` give (ADR-0788).
+            return None
+        case _:
+            assert_never(e.draw_type)
+    if not fixtures:
+        return None
+    by_pool: dict[str, list[TournamentFixtureRead]] = defaultdict(list)
+    for f in fixtures:
+        # A round-robin fixture is always pooled; a NULL pool would be a different draw
+        # type's fixture and has no pool table to stand in. Skip it rather than key a
+        # pool on ``None``.
+        if f.pool_id is not None:
+            by_pool[f.pool_id].append(f)
+    pool_inputs: list[PoolInput] = []
+    for pool_id, pool_fixtures in by_pool.items():
+        entrants = {
+            entry_id
+            for f in pool_fixtures
+            for entry_id in (f.entry_a_id, f.entry_b_id)
+            if entry_id is not None
+        }
+        outcomes: list[MatchOutcome] = []
+        for f in pool_fixtures:
+            if (
+                f.match_status is not MatchStatus.completed
+                or f.match_id is None
+                or f.entry_a_id is None
+                or f.entry_b_id is None
+            ):
+                continue
+            side_1_games, side_2_games = game_counts[f.match_id]
+            outcomes.append(
+                MatchOutcome(
+                    entry_a_id=EntryId(f.entry_a_id),
+                    entry_b_id=EntryId(f.entry_b_id),
+                    entry_a_games=side_1_games,
+                    entry_b_games=side_2_games,
+                )
+            )
+        pool_inputs.append(
+            PoolInput(
+                pool_id=PoolId(pool_id),
+                entrants=tuple(EntryId(entry_id) for entry_id in entrants),
+                # Count only the pairings that can still produce a result. A **voided**
+                # fixture never will — its match is terminal and ``ready_fixtures`` will
+                # not re-materialize it — so it is excluded, not counted-but-missing.
+                # Without this, a played-event account-merge collision (which voids the
+                # guest-vs-survivor self-play match) would hold the pool one outcome
+                # short of ``fixture_count`` forever: permanently un-``complete``, no
+                # champion — the opposite of ADR-0788's live-standings guarantee.
+                fixture_count=sum(
+                    1 for f in pool_fixtures if f.match_status is not MatchStatus.voided
+                ),
+                outcomes=tuple(outcomes),
+            )
+        )
+    return _serialize_results(results_for(e.draw_type).tabulate(pool_inputs))
+
+
+def _serialize_results(results: EventResults) -> EventResultsRead:
+    return EventResultsRead(
+        pools=[
+            PoolStandingsRead(
+                pool_id=pool.pool_id,
+                rows=[
+                    StandingRowRead(
+                        entry_id=row.entry_id,
+                        rank=row.rank,
+                        played=row.played,
+                        wins=row.wins,
+                        losses=row.losses,
+                        games_won=row.games_won,
+                        games_lost=row.games_lost,
+                    )
+                    for row in pool.rows
+                ],
+                complete=pool.complete,
+            )
+            for pool in results.pools
+        ],
+        complete=results.complete,
+        champion=results.champion,
+    )
+
+
+def serialize_event(
+    e: TournamentEvent,
+    *,
+    entrants: list[TournamentEntrantRead],
+    fixtures: list[TournamentFixtureRead],
+    rating: float | None,
+    game_counts: dict[uuid.UUID, tuple[int, int]] | None,
+) -> TournamentEventRead:
+    # ``entrants`` is not on the ORM row in the shape the read model wants (it
+    # needs the entrant's username, and only the *active* entries), so the fields
+    # are listed explicitly rather than validated straight off the attributes —
+    # which would also fire a lazy load. The event's ``entered`` count is not
+    # listed at all: it is a computed field over ``entrants`` (ADR-0016), so
+    # there is nothing here that could disagree with the list.
+    #
+    # ``entry_state`` is the caller's, and it is computed from the entrants already
+    # loaded plus the caller's ``rating`` on this tournament's league — passed in,
+    # never fetched here, so no serializer can turn into an N+1.
+    #
+    # ``fixtures`` — the event's draw (ADR-0786) — is passed in for exactly that
+    # reason. ``e.fixtures`` is right there on the ORM instance and would read
+    # *correctly*: a lazy load would fetch the rows and the response would be
+    # identical. It would also fire one SELECT per event, on the LIST endpoint that
+    # returns every event of every tournament — an N+1 that no assertion about the
+    # body can see. It is loaded once, in a batch, by ``fixtures_by_event``, which
+    # also owns the pool → round → position ordering, so the serializer never sorts
+    # and no two call sites can order a bracket differently.
+    return TournamentEventRead.model_validate(
+        {
+            "id": e.id,
+            "tournament_id": e.tournament_id,
+            "name": e.name,
+            "format": e.format,
+            "draw_type": e.draw_type,
+            "max_players": e.max_players,
+            "entry_fee": e.entry_fee,
+            "slot": e.slot,
+            "match_settings": e.match_settings,
+            "predicates": e.predicates,
+            "pools": e.pools,
+            "created_at": e.created_at,
+            "updated_at": e.updated_at,
+            "entrants": entrants,
+            "entry_state": _entry_state(e, entered=len(entrants), rating=rating),
+            "fixtures": fixtures,
+            # The standings, projected here from the fixtures' completed matches plus
+            # the page's one batched game load — ``None`` for an uncut or
+            # non-round-robin event (ADR-0788). Computed in the serializer, not fetched
+            # per event, for the same reason ``fixtures`` is: no read may become an N+1.
+            #
+            # ``game_counts is None`` is the tournaments *list*'s signal to skip the
+            # projection entirely: its cards render no standings (only event and table
+            # counts), so the list neither runs the game-count query nor tabulates a
+            # results object nobody reads — standings are a detail-BFF concern. A
+            # detail surface passes a real map (``{}`` when nothing is played).
+            "results": (
+                None
+                if game_counts is None
+                else _event_results(e, fixtures=fixtures, game_counts=game_counts)
+            ),
+        }
+    )
+
+
+def serialize_detail(
+    t: Tournament,
+    *,
+    created_by_username: str,
+    current_user_id: uuid.UUID,
+    events: list[TournamentEvent],
+    entrants_by_event: dict[uuid.UUID, list[TournamentEntrantRead]],
+    fixtures_by_event: dict[uuid.UUID, list[TournamentFixtureRead]],
+    game_counts: dict[uuid.UUID, tuple[int, int]] | None,
+    rating: float | None,
+    latest_schedule_solve: ScheduleSolve | None,
+) -> TournamentDetailRead:
+    # The full aggregate: tournament fields plus its events (each event's JSONB
+    # value-objects validate into Pydantic models here, at this single boundary).
+    #
+    # ONE ``rating`` for all of them — the caller's, on ``t.league_id``. A tournament
+    # names the single ladder its eligibility is judged on (ADR-0783), so every event
+    # under it is judged on the same number, and fetching it per event would be a
+    # query per event for an answer that cannot vary.
+    return TournamentDetailRead.model_validate(
+        {
+            **_tournament_fields(
+                t,
+                created_by_username=created_by_username,
+                current_user_id=current_user_id,
+            ),
+            # ``None`` is two things by design, exactly as ``results`` above is: on
+            # the DETAIL read it is the fact ("no solve ever requested"); on the LIST
+            # it is "not projected" — the list's cards render no solve strip, so it
+            # skips the ledger query the same way it skips standings.
+            "latest_schedule_solve": (
+                ScheduleSolveRead.model_validate(latest_schedule_solve)
+                if latest_schedule_solve is not None
+                else None
+            ),
+            "events": [
+                serialize_event(
+                    e,
+                    entrants=entrants_by_event[e.id],
+                    fixtures=fixtures_by_event[e.id],
+                    rating=rating,
+                    game_counts=game_counts,
+                )
+                for e in events
+            ],
+        }
+    )

--- a/api/app/tournament_solve_service.py
+++ b/api/app/tournament_solve_service.py
@@ -42,10 +42,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import ScheduleSolve, ScheduleSolveTrigger, User
 from app.schedule_solves import request_solve, tournament_has_drawn_event
-from app.tournament_edit import _load_tournament_for_update
+from app.tournament_edit import _load_owned_tournament_for_update
 from app.tournament_errors import (
     NoDrawnEventsError,
-    NotTournamentOwnerError,
     ScheduleQueueUnavailableError,
 )
 
@@ -89,9 +88,7 @@ async def request_schedule_solve(
     than serialized with expired attributes. Never raises ``HTTPException`` — the
     caller adapts each domain exception to its transport.
     """
-    tournament = await _load_tournament_for_update(db, tournament_id)
-    if tournament.created_by_user_id != actor.id:
-        raise NotTournamentOwnerError()
+    await _load_owned_tournament_for_update(db, tournament_id, actor)
     if not await tournament_has_drawn_event(db, tournament_id):
         raise NoDrawnEventsError()
     row = await request_solve(db, tournament_id, ScheduleSolveTrigger.manual)

--- a/api/app/tournament_solve_service.py
+++ b/api/app/tournament_solve_service.py
@@ -1,0 +1,105 @@
+"""The transport-neutral request-schedule-solve write verb (ADR "the schedule is
+solved; the call is pinned").
+
+The orchestration behind ``POST /v1/tournaments/{id}/schedule/solves`` — the
+Run-scheduler button — extracted out of the router so it can run without FastAPI:
+from the HTTP adapter (``app.tournaments.request_schedule_solve``) and, later, from
+an MCP tool alike, and be constructed in a plain REPL with a raw session.
+
+Per the tournament-verbs ADR (mirroring the match-flow ADR and the edit / cut-draw
+verbs in ``app.tournament_edit`` / ``app.tournament_draw_service``), it signals every
+refusal with a **domain exception** from ``app.tournament_errors`` — never an
+``HTTPException`` — and each adapter maps it back to the exact response it produced
+before:
+
+* an absent tournament → :class:`TournamentNotFoundError` (404);
+* a non-owner → :class:`NotTournamentOwnerError` (403);
+* no event with a cut draw → :class:`NoDrawnEventsError` (422);
+* the enqueue could not be placed (Redis down) → :class:`ScheduleQueueUnavailableError`
+  (503).
+
+The last one is why this verb's return type is a **non-optional**
+:class:`~app.models.ScheduleSolve`, not the ``ScheduleSolve | None`` that
+:func:`~app.schedule_solves.request_solve` returns. ``request_solve`` catches the
+``RedisError`` itself, takes its just-inserted row back out, and returns ``None``;
+this verb turns that ``None`` into :class:`ScheduleQueueUnavailableError` so the
+caller gets a real ledger row or a refusal it can adapt, never an ambiguous ``None``
+that a router would have to re-interpret (make illegal states unrepresentable).
+
+The tournament is loaded through the same ``FOR UPDATE`` loader the edit and draw
+verbs use (``app.tournament_edit._load_tournament_for_update``): the lock is not
+decoration. This verb *judges* that a draw exists and then enqueues a run against it,
+and ``request_solve``'s contract requires its callers to hold the tournament row lock
+first (lock order: tournament → schedule_solves — ``app.schedule_solves`` module
+docstring). Without the lock the "a draw exists" judgment and the enqueue would sit in
+two instants: an un-cut could commit between them and a solve would be queued for a
+tournament this verb just certified as drawable.
+"""
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import ScheduleSolve, ScheduleSolveTrigger, User
+from app.schedule_solves import request_solve, tournament_has_drawn_event
+from app.tournament_edit import _load_tournament_for_update
+from app.tournament_errors import (
+    NoDrawnEventsError,
+    NotTournamentOwnerError,
+    ScheduleQueueUnavailableError,
+)
+
+
+async def request_schedule_solve(
+    db: AsyncSession,
+    *,
+    tournament_id: uuid.UUID,
+    actor: User,
+) -> ScheduleSolve:
+    """Queue a run of the schedule solver for the tournament ``actor`` owns, and
+    return the ledger row that will carry its outcome.
+
+    Runs the same orchestration the HTTP handler used to run inline, under the
+    tournament row lock (:func:`_load_tournament_for_update`), in the ordering
+    ADR-0017 fixed for every tournament write (**404 → 403 → 422**):
+
+    * **404** — an absent tournament raises :class:`TournamentNotFoundError`.
+      Loaded first (and under lock), so ownership is judged only once the row
+      exists and a stranger probing ids learns nothing.
+    * **403** — a caller who is not the tournament's creator raises
+      :class:`NotTournamentOwnerError`. Running the scheduler is owner-gated
+      (``created_by_user_id == actor.id``), not RBAC-gated — the same family as
+      cutting a draw — and judged before the draw's *state* is looked at, so the
+      refusal never leaks whether anything is drawn.
+    * **422** — a tournament with no event that has a cut draw raises
+      :class:`NoDrawnEventsError`: the solver places a draw's fixtures, so with
+      nothing cut there is nothing to schedule. The caller's own refusal, last.
+
+    On success it requests a ``manual`` solve — the one coalesced enqueue every
+    trigger funnels into (``request_solve``): a ``queued`` run absorbs this
+    request and its row comes back; a ``running`` run gets its re-run flag set;
+    only when neither exists is a fresh row inserted and the RQ job enqueued.
+    A ``None`` return from ``request_solve`` means the enqueue itself failed
+    (Redis down) and the row was taken back out — this verb raises
+    :class:`ScheduleQueueUnavailableError` rather than returning ``None``, so the
+    adapter maps it to the existing 503 and its return type stays non-optional.
+
+    Commits and refreshes before returning: ``requested_at`` and the other server
+    defaults were never round-tripped by the INSERT, so the row is re-read rather
+    than serialized with expired attributes. Never raises ``HTTPException`` — the
+    caller adapts each domain exception to its transport.
+    """
+    tournament = await _load_tournament_for_update(db, tournament_id)
+    if tournament.created_by_user_id != actor.id:
+        raise NotTournamentOwnerError()
+    if not await tournament_has_drawn_event(db, tournament_id):
+        raise NoDrawnEventsError()
+    row = await request_solve(db, tournament_id, ScheduleSolveTrigger.manual)
+    if row is None:
+        # The enqueue failed (Redis down) and ``request_solve`` took its row back
+        # out — nothing was queued. Surface it as a refusal the adapter turns into
+        # a 503, rather than returning a ``None`` the caller must re-interpret.
+        raise ScheduleQueueUnavailableError()
+    await db.commit()
+    await db.refresh(row)
+    return row

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -31,10 +31,7 @@ from app.models import (
     User,
 )
 from app.rbac import require_permission, user_has_permission
-from app.schedule_solves import (
-    latest_solve,
-    request_solve,
-)
+from app.schedule_solves import request_solve
 from app.schemas.tournament import (
     MatchSettings,
     ScheduleSolveRead,
@@ -80,7 +77,7 @@ from app.tournament_errors import (
     ScheduleQueueUnavailableError,
     TournamentNotFoundError,
 )
-from app.tournament_list import list_tournament_details
+from app.tournament_list import list_tournament_details, tournament_detail
 from app.tournament_materialization import materialize_live_draw
 from app.tournament_queries import (
     active_entrants_by_event,
@@ -93,7 +90,6 @@ from app.tournament_queries import completed_match_ids as _completed_match_ids
 from app.tournament_queries import visible_to as _visible_to
 from app.tournament_serialization import (
     serialize,
-    serialize_detail,
     serialize_event,
 )
 from app.tournament_solve_service import (
@@ -344,6 +340,53 @@ async def _require_enter_permission(db: AsyncSession, current_user: User) -> Non
 # the rule has one home the MCP tool shares too.
 
 
+# The transport-neutral tournament write verbs (``tournament_edit`` /
+# ``tournament_draw_service`` / ``tournament_solve_service``) each raise this closed
+# family of domain exceptions for the refusals that map identically across every
+# owner-only write; ``_map_tournament_write_error`` reproduces the exact status +
+# body each adapter produced inline. ``_TOURNAMENT_WRITE_ERRORS`` is the shared
+# ``except`` tuple; the alias types the mapper. Mirrors the score-write precedent
+# (``matches._map_score_write_error`` + ``_SCORE_WRITE_ERRORS``). The genuinely
+# verb-specific arms — the strict league 404, the no-drawn-events 422, the
+# queue-down 503, and the ``DrawError`` family's 422 — stay inline in their adapters,
+# because each is one adapter's alone.
+_TournamentWriteError = (
+    TournamentNotFoundError
+    | NotTournamentOwnerError
+    | EventNotFoundError
+    | DrawUnderWayError
+    | LeagueNotEditableError
+)
+_TOURNAMENT_WRITE_ERRORS = (
+    TournamentNotFoundError,
+    NotTournamentOwnerError,
+    EventNotFoundError,
+    DrawUnderWayError,
+    LeagueNotEditableError,
+)
+
+
+def _map_tournament_write_error(exc: _TournamentWriteError) -> HTTPException:
+    """Adapt a shared tournament-write domain exception to its historical HTTP
+    response: ``TournamentNotFoundError`` → 404 ``"Tournament not found."``,
+    ``NotTournamentOwnerError`` → 403 ``"You can only modify tournaments you
+    created."``, ``EventNotFoundError`` → 404 ``"Event not found."``, and both
+    ``DrawUnderWayError`` and ``LeagueNotEditableError`` → 409 with their own
+    carried, domain-authored sentence (``str(exc)``)."""
+    if isinstance(exc, TournamentNotFoundError):
+        return HTTPException(status_code=404, detail="Tournament not found.")
+    if isinstance(exc, NotTournamentOwnerError):
+        return HTTPException(
+            status_code=403,
+            detail="You can only modify tournaments you created.",
+        )
+    if isinstance(exc, EventNotFoundError):
+        return HTTPException(status_code=404, detail="Event not found.")
+    # ``DrawUnderWayError`` and ``LeagueNotEditableError`` both carry the exact 409
+    # sentence the handler used to compose inline — rebuilt verbatim with ``str``.
+    return HTTPException(status_code=409, detail=str(exc))
+
+
 # ----- tournament routes ---------------------------------------------------
 
 
@@ -453,59 +496,17 @@ async def get_tournament(
     if row is None:
         raise HTTPException(status_code=404, detail="Tournament not found.")
     tournament, username = row
-    # A second query loads this tournament's events in creation order, and a
-    # third batches every one of those events' active entrants — the same
-    # one-statement-per-collection shape the list endpoint uses.
-    events = list(
-        (
-            await db.execute(
-                select(TournamentEvent)
-                .where(TournamentEvent.tournament_id == tournament_id)
-                .order_by(TournamentEvent.created_at)
-            )
-        )
-        .scalars()
-        .all()
-    )
-    event_ids = [e.id for e in events]
-    entrants_by_event = await active_entrants_by_event(db, event_ids)
-    # A FOURTH query batches every one of those events' fixtures — their DRAWS
-    # (ADR-0786). The draw rides on this page rather than on a ``GET …/draw`` of its
-    # own: one endpoint per page (root CLAUDE.md), so the bracket cannot become a
-    # second round-trip that the page has to wait for. Batched across the events for
-    # the same reason the entrants are — a draw read per event is an N+1 that grows
-    # with the very thing the page is describing — and it is the loader, not this
-    # route, that orders them (pool → round → position) and answers ``[]`` for an
-    # event whose draw has not been cut.
-    event_fixtures = await fixtures_by_event(db, event_ids)
-    # ONE more query batches the games of every completed tournament match on the page
-    # — what each event's standings are projected from (ADR-0788). One statement for the
-    # whole page, and **none at all** until something has been played (an unplayed
-    # detail collects no completed match ids), so an unplayed tournament still costs
-    # six and the statement-count pin holds; a played one costs the one extra.
-    game_counts = await game_counts_by_match(db, _completed_match_ids(event_fixtures))
-    # The FIFTH query: the caller's rating on the tournament's league, read ONCE for
-    # the whole page. It is what every event's ``entry_state`` is judged against
-    # (ADR-0783), and a tournament has exactly one ladder — so a rating read inside
-    # the per-event loop would issue a query per event to learn the same number, on
-    # the page whose whole job is to describe a field of events.
-    rating = await entrant_rating(db, tournament.league_id, current_user.id)
-    # The SIXTH (and last): the newest row of the tournament's solve ledger — the
-    # Schedule tab's solve strip (ADR "the schedule is solved, the call is pinned").
-    # One row by the ledger's own index, whatever the day's solve count, so the
-    # statement-count pin stays flat; ``None`` is the designed state of a tournament
-    # nobody has asked to schedule yet.
-    latest_schedule_solve = await latest_solve(db, tournament.id)
-    return serialize_detail(
+    # The six-statement batched composition — events, their entrants, their draws,
+    # the completed matches' games (standings), the caller's one ladder rating, and
+    # the newest solve — lives in the shared ``tournament_detail`` reader, which the
+    # MCP ``get_tournament`` tool composes too, so the two surfaces cannot drift. The
+    # statement-count pin (tests/test_tournaments.py) is measured against this route,
+    # which is the reader plus this one visibility-scoped load.
+    return await tournament_detail(
+        db,
         tournament,
         created_by_username=username,
         current_user_id=current_user.id,
-        events=events,
-        entrants_by_event=entrants_by_event,
-        fixtures_by_event=event_fixtures,
-        game_counts=game_counts,
-        rating=rating,
-        latest_schedule_solve=latest_schedule_solve,
     )
 
 
@@ -530,15 +531,13 @@ async def update_tournament(
         tournament = await edit_tournament(
             db, tournament_id=tournament_id, actor=current_user, updates=payload
         )
-    except TournamentNotFoundError as exc:
-        raise HTTPException(status_code=404, detail="Tournament not found.") from exc
-    except NotTournamentOwnerError as exc:
-        raise HTTPException(
-            status_code=403, detail="You can only modify tournaments you created."
-        ) from exc
-    except LeagueNotEditableError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except _TOURNAMENT_WRITE_ERRORS as exc:
+        # Shared arms: the 404 (absent), the 403 (not the owner), and the 409
+        # (league not editable) all map identically across the owner-only writes.
+        raise _map_tournament_write_error(exc) from exc
     except LeagueNotFoundError as exc:
+        # Verb-specific: only the edit verb resolves a league, so the strict 404
+        # for a ``league_id`` that names none is this adapter's alone.
         raise HTTPException(status_code=404, detail="League not found.") from exc
     # The owner is the current user, so the username and can_edit are known.
     return serialize(
@@ -1947,16 +1946,10 @@ async def cut_event_draw(
         return await _cut_event_draw(
             db, tournament_id=tournament_id, event_id=event_id, actor=current_user
         )
-    except TournamentNotFoundError as exc:
-        raise HTTPException(status_code=404, detail="Tournament not found.") from exc
-    except EventNotFoundError as exc:
-        raise HTTPException(status_code=404, detail="Event not found.") from exc
-    except NotTournamentOwnerError as exc:
-        raise HTTPException(
-            status_code=403, detail="You can only modify tournaments you created."
-        ) from exc
-    except DrawUnderWayError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except _TOURNAMENT_WRITE_ERRORS as exc:
+        # Shared arms: the two 404s (absent tournament / event), the 403 (not the
+        # owner), and the draw-under-way 409 all map identically across the writes.
+        raise _map_tournament_write_error(exc) from exc
     except DrawError as error:
         # The domain refusing to produce a draw is not a bug — it is an answer (the verb
         # already rolled back). ``from None`` so no traceback shape reaches the client;
@@ -2004,16 +1997,10 @@ async def uncut_event_draw(
         await _uncut_event_draw(
             db, tournament_id=tournament_id, event_id=event_id, actor=current_user
         )
-    except TournamentNotFoundError as exc:
-        raise HTTPException(status_code=404, detail="Tournament not found.") from exc
-    except EventNotFoundError as exc:
-        raise HTTPException(status_code=404, detail="Event not found.") from exc
-    except NotTournamentOwnerError as exc:
-        raise HTTPException(
-            status_code=403, detail="You can only modify tournaments you created."
-        ) from exc
-    except DrawUnderWayError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except _TOURNAMENT_WRITE_ERRORS as exc:
+        # Shared arms only — the un-cut never produces a ``DrawError`` (it only
+        # deletes), so every refusal it can raise maps through the shared adapter.
+        raise _map_tournament_write_error(exc) from exc
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -2315,12 +2302,11 @@ async def request_schedule_solve(
         row = await _request_schedule_solve(
             db, tournament_id=tournament_id, actor=current_user
         )
-    except TournamentNotFoundError as exc:
-        raise HTTPException(status_code=404, detail="Tournament not found.") from exc
-    except NotTournamentOwnerError as exc:
-        raise HTTPException(
-            status_code=403, detail="You can only modify tournaments you created."
-        ) from exc
+    except _TOURNAMENT_WRITE_ERRORS as exc:
+        # Shared arms: the 404 (absent) and the 403 (not the owner). The verb never
+        # raises the event/draw-under-way members of the tuple, so they cannot fire
+        # here — but catching the whole tuple keeps the one shared mapper.
+        raise _map_tournament_write_error(exc) from exc
     except NoDrawnEventsError as exc:
         # The exact 422 body this route composed inline — kept in the adapter, like
         # every other tournament refusal's HTTP copy.

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -50,7 +50,6 @@ from app.schemas.tournament import (
     TournamentFixturePlacementUpdate,
     TournamentFixtureRead,
     TournamentRead,
-    TournamentTable,
     TournamentTransitionCreate,
     TournamentUpdate,
     named_list,
@@ -65,6 +64,7 @@ from app.tournament_draws import (
     event_pools,
     uncut_draw,
 )
+from app.tournament_edit import edit_tournament
 from app.tournament_eligibility import (
     Eligible,
     RatingIneligible,
@@ -72,6 +72,12 @@ from app.tournament_eligibility import (
     event_is_full,
 )
 from app.tournament_entry_refusals import EntryRefusal, entry_refused
+from app.tournament_errors import (
+    LeagueNotEditableError,
+    LeagueNotFoundError,
+    NotTournamentOwnerError,
+    TournamentNotFoundError,
+)
 from app.tournament_list import list_tournament_details
 from app.tournament_materialization import materialize_live_draw
 from app.tournament_queries import (
@@ -326,37 +332,11 @@ async def _require_enter_permission(db: AsyncSession, current_user: User) -> Non
         raise HTTPException(status_code=403, detail="Forbidden.")
 
 
-def _enforce_league_editable(t: Tournament) -> None:
-    """Raise the 409 unless the tournament's league may still be moved.
-
-    A tournament's league is the ladder its events' rating rules are judged on
-    (ADR-0783), and it is settled the moment the tournament is published: from
-    then on registration is open and eligibility is *live*, so moving the ladder
-    underneath would silently re-judge — and could retroactively disqualify —
-    players who have already entered against the old one. ``draft`` is the only
-    status in which nobody can have entered yet, so it is the only one in which
-    the ladder is still free to move. Same guarded-edge reasoning as the lifecycle
-    itself (ADR-0017): what a tournament will accept depends on where it is.
-
-    Presence, not difference: sending the league the tournament already has, once
-    it is published, is refused too. That mirrors the transition route, where
-    re-asserting the status you already hold is a *conflict* rather than an
-    idempotent no-op — the only caller that sends a settled field is a stale one,
-    and answering 200 would tell it the field is still editable when it is not.
-
-    409, not 403 (as on the transitions route): the caller is the owner and the
-    field is theirs to edit — it is the tournament that is past the point where
-    the edit means anything. "Not you" would be a lie; the truth is "not now".
-    """
-    if t.status is TournamentStatus.draft:
-        return
-    raise HTTPException(
-        status_code=409,
-        detail=(
-            f"This tournament is {t.status.value}; its league can only be changed "
-            "while it is a draft."
-        ),
-    )
+# The league-editable-only-while-draft rule (ADR-0783) now lives on the
+# transport-neutral edit verb: ``edit_tournament`` (``app.tournament_edit``)
+# raises ``LeagueNotEditableError``, which the PATCH adapter below maps to the 409
+# this router used to raise inline. It is not a router helper any more precisely so
+# the rule has one home the MCP tool shares too.
 
 
 # ----- tournament routes ---------------------------------------------------
@@ -531,74 +511,30 @@ async def update_tournament(
     db: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
 ) -> TournamentRead:
-    # The locked loader plus an explicit ``_require_owner`` — the same pair
-    # ``create_tournament_transition`` takes, and for the same reason — rather than
-    # ``_get_owned_tournament_or_404``, which does not lock. This route now *judges
-    # the status and then writes*: the league guard below reads ``status``, and an
-    # unlocked read answers from its own statement's snapshot (READ COMMITTED). A
-    # league change could pass the ``draft`` check, the owner's publish could
-    # commit, and the UPDATE could then land behind it — moving the ladder under a
-    # tournament whose registration is already open, which is the one thing the
-    # guard exists to prevent. Same lock, on the same row, taken first, as the
-    # transition and entry routes: one lock in one order, so no pair of them can
-    # deadlock.
+    # Thin adapter over the transport-neutral ``edit_tournament`` verb: it owns the
+    # load-lock, the owner gate, the league state-rule, the STRICT league lookup,
+    # the partial apply and the table-catalogue → re-solve trigger, and signals
+    # each refusal with a domain exception. This handler maps each back to the
+    # exact status + body it produced before, so the wire contract is unchanged:
     #
-    # Load first (404 if missing), THEN check ownership (403). The ordering is
-    # intentional, and is the one the owner-scoped loader bakes in: a permitted
-    # non-creator learns the tournament exists.
-    tournament = await _get_tournament_for_update_or_404(db, tournament_id)
-    _require_owner(tournament, current_user)
-    fields = payload.model_dump(exclude_unset=True)
-    # The league is settled once the tournament leaves ``draft`` (ADR-0783), so it
-    # comes out of the generic loop: it is the one field with a *state* rule, and
-    # it is refused (409) before anything is written. The refusal is judged before
-    # the league is looked up, so a caller who cannot change it learns nothing
-    # about whether the league they named exists.
-    if "league_id" in fields:
-        _enforce_league_editable(tournament)
-        # The STRICT resolver, exactly as on create: the id is a deliberate choice
-        # by the owner, not a view preference, so an id that names no league is a
-        # 404 rather than a silent swap to the default (see app/leagues.py). It also
-        # keeps the NOT NULL FK from turning a bad id into a 500.
-        league = await resolve_league(db, fields.pop("league_id"))
-        tournament.league_id = league.id
-    # model_dump(exclude_unset=True) already recursively serializes the nested
-    # value-objects (address/table_catalogue) to plain dicts/lists, so a single
-    # setattr loop covers the JSONB columns and the scalar fields alike. Absent
-    # fields stay untouched; the schema validator already rejected an explicit
-    # null on the NOT NULL columns.
-    #
-    # Scheduling-input change detection (ADR "the schedule is solved; the call
-    # is pinned"): of everything this PATCH can touch, the solver reads exactly
-    # one thing — the table catalogue, and of the catalogue only the *ids*
-    # (labels and courts are display; ``_load_solver_inputs`` reduces the
-    # catalogue to ``TableId``s). So the before/after comparison is over the id
-    # list, parsed with the same model the write boundary validated it with: a
-    # rename/address/date-only PATCH triggers nothing, a label-only re-word of
-    # a table triggers nothing, and adding/removing/re-identifying a table
-    # triggers a re-solve.
-    catalogue_ids_before = [
-        TournamentTable.model_validate(table).id for table in tournament.table_catalogue
-    ]
-    for key, value in fields.items():
-        setattr(tournament, key, value)
-    catalogue_ids_after = [
-        TournamentTable.model_validate(table).id for table in tournament.table_catalogue
-    ]
-    if catalogue_ids_after != catalogue_ids_before and await tournament_has_drawn_event(
-        db, tournament_id
-    ):
-        # Only while it matters: with no cut draw anywhere there is nothing to
-        # place, and the ledger would fill with no-op rows — the drawn-event
-        # gate is the same one the Run-scheduler route asks. Requested inside
-        # this transaction, under the tournament row lock this handler already
-        # holds (the lock order ``request_solve`` requires). A ``None`` return
-        # (Redis down) is deliberately ignored: the edit is the thing the
-        # owner asked for, and the missing solve is recovered by the pin tick
-        # or the Run-scheduler button.
-        await request_solve(db, tournament_id, ScheduleSolveTrigger.settings_changed)
-    await db.commit()
-    await db.refresh(tournament)
+    #   TournamentNotFoundError  -> 404 "Tournament not found."
+    #   NotTournamentOwnerError  -> 403 "You can only modify tournaments you created."
+    #   LeagueNotEditableError   -> 409 "This tournament is {status}; its league …"
+    #   LeagueNotFoundError      -> 404 "League not found."
+    try:
+        tournament = await edit_tournament(
+            db, tournament_id=tournament_id, actor=current_user, updates=payload
+        )
+    except TournamentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Tournament not found.") from exc
+    except NotTournamentOwnerError as exc:
+        raise HTTPException(
+            status_code=403, detail="You can only modify tournaments you created."
+        ) from exc
+    except LeagueNotEditableError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except LeagueNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="League not found.") from exc
     # The owner is the current user, so the username and can_edit are known.
     return serialize(
         tournament,
@@ -1085,8 +1021,9 @@ async def _enforce_draw_type_frozen(
     the one the event already has changes nothing, so it is not a conflict, and a guard
     that fired on the mere presence of the key would refuse a page that PATCHes the
     whole event form back (draw type included) to move a pool's tables — the very edit
-    the freeze exists to permit. (This is where it differs from
-    ``_enforce_league_editable``, which *does* refuse the field it already holds: there,
+    the freeze exists to permit. (This is where it differs from the
+    league-editable rule — ``edit_tournament`` / ``LeagueNotEditableError`` — which
+    *does* refuse the field it already holds: there,
     the field is settled by a
     lifecycle status no request of the caller's can move, so the only client that sends
     it is a stale one. Here, the way out — remove the draw — is on the caller's own

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -55,14 +55,13 @@ from app.schemas.tournament import (
     named_list,
 )
 from app.sessions import get_current_user
+from app.tournament_draw_service import cut_event_draw as _cut_event_draw
+from app.tournament_draw_service import uncut_event_draw as _uncut_event_draw
 from app.tournament_draws import (
     DrawCurrency,
-    cut_draw,
     draw_currency_by_event,
-    draw_has_play,
     event_has_draw,
     event_pools,
-    uncut_draw,
 )
 from app.tournament_edit import edit_tournament
 from app.tournament_eligibility import (
@@ -73,6 +72,8 @@ from app.tournament_eligibility import (
 )
 from app.tournament_entry_refusals import EntryRefusal, entry_refused
 from app.tournament_errors import (
+    DrawUnderWayError,
+    EventNotFoundError,
     LeagueNotEditableError,
     LeagueNotFoundError,
     NotTournamentOwnerError,
@@ -1876,74 +1877,14 @@ def _draw_refusal(error: DrawError) -> HTTPException:
     return HTTPException(status_code=422, detail=detail)
 
 
-async def _enforce_draw_unplayed(db: AsyncSession, event: TournamentEvent) -> None:
-    """Raise the 409 once an event's draw shows **evidence of play** — the single gate
-    on both cutting and un-cutting a draw (ADR-0786).
-
-    It is what makes a re-cut safe. A cut replaces the draw wholesale, so a draw with a
-    decided fixture (a recorded winner) or a materialized one (a linked match, which may
-    already carry games on its scratchpad) cannot be re-cut without throwing away
-    results that players actually produced. The draw must never silently eat a score, so
-    the refusal is on the *evidence*, not on the tournament's status: a director may cut
-    and re-cut as often as they like right up until the first fixture becomes real.
-
-    Read under the tournament's row lock, like every other judge-then-write guard in
-    this module (``_enforce_event_has_room``): the evidence this reads is the evidence
-    the write below is authorized by, and an unlocked read would sit in a different
-    instant from it.
-
-    409, not 403: the caller is the owner and the draw is theirs — it is the draw that
-    is past the point where a re-cut means anything. "Not you" would be a lie; the truth
-    is "not now, not any more".
-
-    One sentence for both verbs, because it is one fact. A re-cut and an un-cut are
-    refused for the same reason (the fixtures that would be destroyed are the ones that
-    have been played), and two sentences saying so would be two things to keep true.
-    """
-    if not await draw_has_play(db, event.id):
-        return
-    raise HTTPException(
-        status_code=409,
-        detail=(
-            "This event's draw is already under way — at least one fixture has a match "
-            "or a recorded winner — so it can no longer be cut or removed."
-        ),
-    )
-
-
-async def _get_owned_event_for_draw_or_404(
-    db: AsyncSession,
-    tournament_id: uuid.UUID,
-    event_id: uuid.UUID,
-    current_user: User,
-) -> TournamentEvent:
-    """The event whose draw is about to be written, loaded under the tournament's row
-    lock and the owner check — the refusal ordering both draw verbs share.
-
-    **404 → 403 → 409**, the ordering ADR-0017 fixed and every route in this module
-    keeps: a tournament that does not exist (or an event that is not under it) is a 404
-    before ownership is considered, so a stranger probing ids learns nothing; a
-    non-owner is a 403 before the draw's *state* is looked at, so the refusal never
-    leaks whether an event has been played. The 409 (``_enforce_draw_unplayed``) is the
-    caller's own, and comes last.
-
-    The tournament is loaded through the **locking** loader — the same lock, on the same
-    row, taken first, that the entry, withdrawal, transition and PATCH routes take
-    (which is what keeps them free of a deadlock cycle) — and ``_require_owner`` is then
-    asked here, exactly as ``update_tournament`` and the transition route do.
-
-    The lock is not decoration. A cut reads the event's active field and writes fixtures
-    *derived from it*; Postgres runs READ COMMITTED, so an unlocked read answers from
-    its own statement's snapshot, and an entry (or a withdrawal) committing between the
-    read and the INSERT would leave a persisted draw that never matched any real field
-    of players — a pool of the wrong size, an entrant seated nowhere, or one seated in a
-    draw they had left. Every writer of the entrant field already queues on this row, so
-    taking it here is what puts the cut in the same queue: the loser blocks and re-reads
-    the field the winner *committed*.
-    """
-    tournament = await _get_tournament_for_update_or_404(db, tournament_id)
-    _require_owner(tournament, current_user)
-    return await _get_event_or_404(db, tournament_id, event_id)
+# The play-evidence gate, the owner-scoped locking load, and the ``cut_draw`` /
+# ``uncut_draw`` calls now live on the transport-neutral draw verbs
+# (``app.tournament_draw_service``): they raise ``DrawUnderWayError`` /
+# ``EventNotFoundError`` / ``NotTournamentOwnerError`` / ``TournamentNotFoundError``,
+# and let the ``DrawError`` family propagate unchanged, for the two adapters below to
+# map back to the exact codes + bodies this router used to raise inline. They are not
+# router helpers any more precisely so the cut/uncut logic has one home the MCP tool
+# will share too.
 
 
 @router.post(
@@ -1986,43 +1927,37 @@ async def cut_event_draw(
     Owner-only. Fixtures come back in pool → round → position order, exactly as the
     tournament-detail page carries them.
     """
-    # 404 → 403 first (and the tournament's row lock with them), so the draw's own
-    # state is never the reason a stranger's request is refused.
-    event = await _get_owned_event_for_draw_or_404(
-        db, tournament_id, event_id, current_user
-    )
-    # Then the one gate on the write: has this draw been played? Asked before anything
-    # is planned or deleted, so a refused re-cut leaves the standing draw exactly as it
-    # was — the guard's whole promise.
-    await _enforce_draw_unplayed(db, event)
+    # Thin adapter over the transport-neutral ``cut_event_draw`` verb: it owns the
+    # row lock, the owner gate, the event-under-tournament load, the play-evidence
+    # gate, the ``cut_draw`` core, the re-solve trigger and the read-back, and signals
+    # each refusal with a domain exception (letting the ``DrawError`` family through
+    # unchanged). This handler maps each back to the exact status + body it produced
+    # before, so the wire contract is unchanged:
+    #
+    #   TournamentNotFoundError  -> 404 "Tournament not found."
+    #   EventNotFoundError       -> 404 "Event not found."
+    #   NotTournamentOwnerError  -> 403 "You can only modify tournaments you created."
+    #   DrawUnderWayError        -> 409 "This event's draw is already under way — …"
+    #   DrawError (the family)   -> 422, the sentence ``_draw_refusal`` composes
     try:
-        # Plans, deletes and re-inserts inside THIS transaction — the lock above is
-        # still held, so the field it reads cannot move under it, and the DELETE and
-        # the INSERTs land together or not at all. A DrawError is raised before the
-        # DELETE, so a 422 destroys nothing either.
-        await cut_draw(db, event)
+        return await _cut_event_draw(
+            db, tournament_id=tournament_id, event_id=event_id, actor=current_user
+        )
+    except TournamentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Tournament not found.") from exc
+    except EventNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Event not found.") from exc
+    except NotTournamentOwnerError as exc:
+        raise HTTPException(
+            status_code=403, detail="You can only modify tournaments you created."
+        ) from exc
+    except DrawUnderWayError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except DrawError as error:
-        # The domain refusing to produce a draw is not a bug — it is an answer, and it
-        # is the caller's to act on. ``from None`` so no traceback shape reaches the
-        # client; the sentence is composed in ``_draw_refusal``.
-        await db.rollback()
+        # The domain refusing to produce a draw is not a bug — it is an answer (the verb
+        # already rolled back). ``from None`` so no traceback shape reaches the client;
+        # the sentence is composed in ``_draw_refusal``.
         raise _draw_refusal(error) from None
-    # Scheduling-input trigger (ADR "the schedule is solved; the call is
-    # pinned"): the fixtures just changed wholesale — a re-cut deleted the old
-    # rows (any pins died with them: ``pinned_at`` lives on the fixture, and
-    # the fresh rows are born unplaced and unpinned) and a first cut minted
-    # the day's inputs. No drawn-event gate here: the cut this transaction
-    # holds *is* the drawn event. Same transaction, under the tournament row
-    # lock taken above (the order ``request_solve`` requires); a ``None``
-    # return (Redis down) deliberately costs the solve, never the cut.
-    await request_solve(db, tournament_id, ScheduleSolveTrigger.settings_changed)
-    await db.commit()
-    # Read the draw back through the SAME loader the detail page reads it through, so
-    # the fixtures this mutation answers with are byte-for-byte the ones the page will
-    # show — same shape, same pool → round → position order. Composing the response
-    # from the objects just added would be a second serialization of the same rows,
-    # ordered by whatever the planner happened to emit.
-    return (await fixtures_by_event(db, [event.id]))[event.id]
 
 
 @router.delete(
@@ -2050,29 +1985,31 @@ async def uncut_event_draw(
 
     Owner-only.
     """
-    # The same 404 → 403 → 409 ordering, and the same row lock, as the cut: this verb
-    # deletes what that verb writes, and the guard that protects the fixtures cannot
-    # depend on which route is asking.
-    event = await _get_owned_event_for_draw_or_404(
-        db, tournament_id, event_id, current_user
-    )
-    await _enforce_draw_unplayed(db, event)
-    # Read before the DELETE: whether this verb is about to change anything at
-    # all. The idempotent un-cut of a never-cut draw deletes nothing and must
-    # trigger nothing.
-    had_draw = await event_has_draw(db, event.id)
-    await uncut_draw(db, [event.id])
-    if had_draw and await tournament_has_drawn_event(db, tournament_id):
-        # Scheduling-input trigger: fixtures were deleted wholesale (their
-        # pins, if any, died with the rows), which frees this event's tables
-        # and windows for whatever is still drawn. Gated on a drawn event
-        # SURVIVING the un-cut — un-cutting the only draw leaves nothing to
-        # place, and a solve row over an empty board is a no-op ledger entry.
-        # Same transaction, under the tournament row lock (the order
-        # ``request_solve`` requires); a ``None`` return (Redis down)
-        # deliberately costs the solve, never the un-cut.
-        await request_solve(db, tournament_id, ScheduleSolveTrigger.settings_changed)
-    await db.commit()
+    # Thin adapter over the transport-neutral ``uncut_event_draw`` verb: it owns the
+    # row lock, the owner gate, the event-under-tournament load, the play-evidence
+    # gate, the ``uncut_draw`` core and the ``had_draw``-gated re-solve trigger, and
+    # signals each refusal with a domain exception. This handler maps each back to the
+    # exact status + body it produced before, so the wire contract is unchanged (the
+    # un-cut never produces a ``DrawError`` — it only deletes):
+    #
+    #   TournamentNotFoundError  -> 404 "Tournament not found."
+    #   EventNotFoundError       -> 404 "Event not found."
+    #   NotTournamentOwnerError  -> 403 "You can only modify tournaments you created."
+    #   DrawUnderWayError        -> 409 "This event's draw is already under way — …"
+    try:
+        await _uncut_event_draw(
+            db, tournament_id=tournament_id, event_id=event_id, actor=current_user
+        )
+    except TournamentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Tournament not found.") from exc
+    except EventNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Event not found.") from exc
+    except NotTournamentOwnerError as exc:
+        raise HTTPException(
+            status_code=403, detail="You can only modify tournaments you created."
+        ) from exc
+    except DrawUnderWayError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -1,9 +1,8 @@
 import uuid
-from collections import defaultdict
-from typing import Any, Literal, assert_never
+from typing import Literal, assert_never
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
-from sqlalchemy import ColumnElement, exists, or_, select
+from sqlalchemy import exists, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,7 +10,6 @@ from app.db import get_session
 from app.draws import (
     DegenerateDraw,
     DrawError,
-    EntryId,
     NonSinglesDraw,
     PoolId,
     UnsupportedDrawType,
@@ -23,7 +21,6 @@ from app.models import (
     EventFormat,
     Match,
     MatchStatus,
-    ScheduleSolve,
     ScheduleSolveTrigger,
     Tournament,
     TournamentEntry,
@@ -34,23 +31,15 @@ from app.models import (
     User,
 )
 from app.rbac import require_permission, user_has_permission
-from app.results import EventResults, MatchOutcome, PoolInput, results_for
 from app.schedule_solves import (
     latest_solve,
     request_solve,
     tournament_has_drawn_event,
 )
 from app.schemas.tournament import (
-    EventEntryFull,
-    EventEntryOpen,
-    EventEntryRatingIneligible,
-    EventEntryState,
-    EventResultsRead,
     MatchSettings,
-    PoolStandingsRead,
     ScheduleSolveRead,
     Slot,
-    StandingRowRead,
     TournamentCreate,
     TournamentDetailRead,
     TournamentEntrantRead,
@@ -83,14 +72,21 @@ from app.tournament_eligibility import (
     event_is_full,
 )
 from app.tournament_entry_refusals import EntryRefusal, entry_refused
+from app.tournament_list import list_tournament_details
 from app.tournament_materialization import materialize_live_draw
 from app.tournament_queries import (
     active_entrants_by_event,
     active_entry_count,
     entrant_rating,
-    entrant_ratings_by_league,
     fixtures_by_event,
     game_counts_by_match,
+)
+from app.tournament_queries import completed_match_ids as _completed_match_ids
+from app.tournament_queries import visible_to as _visible_to
+from app.tournament_serialization import (
+    serialize,
+    serialize_detail,
+    serialize_event,
 )
 
 # Reads are gated on ``tournament.view``, creation on ``tournament.create``, and
@@ -154,363 +150,6 @@ router = APIRouter(prefix="/v1")
 
 
 # ----- helpers -------------------------------------------------------------
-
-
-def _tournament_fields(
-    t: Tournament,
-    *,
-    created_by_username: str,
-    current_user_id: uuid.UUID,
-) -> dict[str, Any]:
-    # The request-scoped fields (``created_by_username``/``can_edit``) aren't on
-    # the ORM row. The JSONB columns (``address``/``table_catalogue``) are read
-    # straight off the attributes; Pydantic validates them into
-    # Address/TournamentTable when the returned dict is fed to model_validate,
-    # so the raw dicts never leave the serialize boundary.
-    return {
-        "id": t.id,
-        "name": t.name,
-        "description": t.description,
-        "status": t.status,
-        "start_date": t.start_date,
-        "end_date": t.end_date,
-        "address": t.address,
-        "table_catalogue": t.table_catalogue,
-        "league_id": t.league_id,
-        "created_by_user_id": t.created_by_user_id,
-        "created_by_username": created_by_username,
-        "can_edit": t.created_by_user_id == current_user_id,
-        "created_at": t.created_at,
-        "updated_at": t.updated_at,
-    }
-
-
-def _serialize(
-    t: Tournament,
-    *,
-    created_by_username: str,
-    current_user_id: uuid.UUID,
-) -> TournamentRead:
-    return TournamentRead.model_validate(
-        _tournament_fields(
-            t, created_by_username=created_by_username, current_user_id=current_user_id
-        )
-    )
-
-
-def _entry_state(
-    e: TournamentEvent,
-    *,
-    entered: int,
-    rating: float | None,
-) -> EventEntryState:
-    """Whether THIS caller may enter THIS event — the read-path twin of the guards
-    the entry route raises 409s from, computed from facts already in hand.
-
-    No database access, and that is the point: the ``entered`` count is the length of
-    the entrants list the read has already batched (ADR-0016 — the count is derived
-    from the rows, so it cannot disagree with the list beside it), and ``rating`` is
-    the caller's rating on the **tournament's** league, resolved ONCE per tournament
-    (``entrant_ratings_by_league``) because every event of a tournament is judged on
-    the same ladder. Reaching for either from in here would be a query per event: an
-    N+1 that grows with the very field the page is describing, and the statement-count
-    tripwires in ``tests/test_tournaments.py`` fail if one appears.
-
-    **The decision is not made here.** ``evaluate_rating_eligibility`` and
-    ``event_is_full`` make it — the same two functions the ``POST …/entries`` guards
-    call — so the page that explains why Enter is not offered and the route that
-    refuses the entry cannot come to two different answers (ADR-0783). This is only
-    the translation into the wire's sum type.
-
-    That sharing is what keeps an **uncapped** event (``max_players IS NULL``,
-    ADR-0935) out of the ``event_full`` arm: ``event_is_full`` answers ``False`` for a
-    null cap however many entrants there are, so this function cannot report as full an
-    event the entry route would happily admit the reader to. Had the capacity question
-    been re-asked here — with a ``>=`` over a nullable column — it would have been a
-    ``TypeError`` on the detail page of the first uncapped event, or (worse, had it
-    been written defensively as ``max_players or 0``) a permanently, silently full one.
-
-    **The ORDER mirrors the entry route's**, and it has to: eligibility first, then
-    capacity. An ineligible player looking at a full event is told about their
-    *rating*, which is exactly what ``POST …/entries`` would tell them
-    (``test_the_rating_refusal_outranks_the_event_full_refusal``) — and it is the more
-    useful of the two facts, because it is the one that does not change when somebody
-    withdraws. Flip these two lines and the page starts promising a player a slot that
-    frees up, for an event that would refuse them anyway.
-
-    What is deliberately NOT decided here: the registration window (a fact about the
-    tournament — its status, ADR-0017), whether the caller is already entered (a fact
-    on the entrants list), whether they hold ``tournament.enter``, and whether the
-    event is doubles. All four are already on the page or in the session, and
-    restating them would be carrying a field and its own derivation. ``open`` means
-    "the event admits you", not "click here".
-
-    ``match`` with ``assert_never``, not ``isinstance``: a third eligibility outcome
-    added tomorrow is a type error here until somebody says what the page should show
-    for it, rather than falling through to ``open`` — a read must not fail in the
-    reassuring direction any more than a guard may fail in the permissive one.
-    """
-    decision = evaluate_rating_eligibility(rating=rating, predicates=e.predicates)
-    match decision:
-        case RatingIneligible():
-            return EventEntryRatingIneligible(
-                predicate_id=decision.predicate_id, rating=decision.rating
-            )
-        case Eligible():
-            if event_is_full(entered=entered, max_players=e.max_players):
-                return EventEntryFull()
-            return EventEntryOpen()
-        case _:
-            assert_never(decision)
-
-
-def _completed_match_ids(
-    fixtures_by_event: dict[uuid.UUID, list[TournamentFixtureRead]],
-) -> list[uuid.UUID]:
-    """The ids of the matches of every **completed** fixture across the page.
-
-    The one list ``game_counts_by_match`` is batched over, gathered before any event is
-    serialized so the standings of every event are projected from a single game load
-    (ADR-0788) rather than a query per event. Only ``completed`` fixtures contribute: an
-    in-progress match's part-scored board is not a result and must not reach a standings
-    table."""
-    return [
-        f.match_id
-        for fixtures in fixtures_by_event.values()
-        for f in fixtures
-        if f.match_status is MatchStatus.completed and f.match_id is not None
-    ]
-
-
-def _event_results(
-    e: TournamentEvent,
-    *,
-    fixtures: list[TournamentFixtureRead],
-    game_counts: dict[uuid.UUID, tuple[int, int]],
-) -> EventResultsRead | None:
-    """The event's results (ADR-0788), projected from its fixtures' completed matches,
-    or ``None`` when there are none to compute.
-
-    ``None`` in two cases, both meaning "no results here" rather than an empty table: a
-    draw type with no results strategy yet (``results_for`` raises for it — only
-    round-robin has one today), and an event whose draw has not been cut (no fixtures to
-    stand). Everything else is a real :class:`EventResultsRead`, whose standings are
-    empty of *decided* rows but full of *seated* ones while the pool is still played.
-
-    The projection is the fixed materialization convention read backwards (#788): side 1
-    is ``entry_a`` and side 2 is ``entry_b``, so the ``(side_1, side_2)`` game counts
-    are the ``(entry_a, entry_b)`` game counts, and the winner is whichever took more
-    games — derived from the live match, never from the fixture's written-back
-    ``winner_entry_id`` (which no round-robin read reads, for correction-safety)."""
-    match e.draw_type:
-        case DrawType.round_robin:
-            pass  # the projection below is round-robin-shaped
-        case (
-            DrawType.single_elim
-            | DrawType.double_elim
-            | DrawType.rr_then_ko
-            | DrawType.swiss
-        ):
-            # No results projection for these yet (``results_for`` has no strategy for
-            # them either). Spelled as a checked dispatch with an ``assert_never``
-            # catch-all rather than a bare ``is not round_robin``, so a new ``DrawType``
-            # is a type error here until its projection is written — the same guarantee
-            # ``strategy_for``/``results_for`` give (ADR-0788).
-            return None
-        case _:
-            assert_never(e.draw_type)
-    if not fixtures:
-        return None
-    by_pool: dict[str, list[TournamentFixtureRead]] = defaultdict(list)
-    for f in fixtures:
-        # A round-robin fixture is always pooled; a NULL pool would be a different draw
-        # type's fixture and has no pool table to stand in. Skip it rather than key a
-        # pool on ``None``.
-        if f.pool_id is not None:
-            by_pool[f.pool_id].append(f)
-    pool_inputs: list[PoolInput] = []
-    for pool_id, pool_fixtures in by_pool.items():
-        entrants = {
-            entry_id
-            for f in pool_fixtures
-            for entry_id in (f.entry_a_id, f.entry_b_id)
-            if entry_id is not None
-        }
-        outcomes: list[MatchOutcome] = []
-        for f in pool_fixtures:
-            if (
-                f.match_status is not MatchStatus.completed
-                or f.match_id is None
-                or f.entry_a_id is None
-                or f.entry_b_id is None
-            ):
-                continue
-            side_1_games, side_2_games = game_counts[f.match_id]
-            outcomes.append(
-                MatchOutcome(
-                    entry_a_id=EntryId(f.entry_a_id),
-                    entry_b_id=EntryId(f.entry_b_id),
-                    entry_a_games=side_1_games,
-                    entry_b_games=side_2_games,
-                )
-            )
-        pool_inputs.append(
-            PoolInput(
-                pool_id=PoolId(pool_id),
-                entrants=tuple(EntryId(entry_id) for entry_id in entrants),
-                # Count only the pairings that can still produce a result. A **voided**
-                # fixture never will — its match is terminal and ``ready_fixtures`` will
-                # not re-materialize it — so it is excluded, not counted-but-missing.
-                # Without this, a played-event account-merge collision (which voids the
-                # guest-vs-survivor self-play match) would hold the pool one outcome
-                # short of ``fixture_count`` forever: permanently un-``complete``, no
-                # champion — the opposite of ADR-0788's live-standings guarantee.
-                fixture_count=sum(
-                    1 for f in pool_fixtures if f.match_status is not MatchStatus.voided
-                ),
-                outcomes=tuple(outcomes),
-            )
-        )
-    return _serialize_results(results_for(e.draw_type).tabulate(pool_inputs))
-
-
-def _serialize_results(results: EventResults) -> EventResultsRead:
-    return EventResultsRead(
-        pools=[
-            PoolStandingsRead(
-                pool_id=pool.pool_id,
-                rows=[
-                    StandingRowRead(
-                        entry_id=row.entry_id,
-                        rank=row.rank,
-                        played=row.played,
-                        wins=row.wins,
-                        losses=row.losses,
-                        games_won=row.games_won,
-                        games_lost=row.games_lost,
-                    )
-                    for row in pool.rows
-                ],
-                complete=pool.complete,
-            )
-            for pool in results.pools
-        ],
-        complete=results.complete,
-        champion=results.champion,
-    )
-
-
-def _serialize_event(
-    e: TournamentEvent,
-    *,
-    entrants: list[TournamentEntrantRead],
-    fixtures: list[TournamentFixtureRead],
-    rating: float | None,
-    game_counts: dict[uuid.UUID, tuple[int, int]] | None,
-) -> TournamentEventRead:
-    # ``entrants`` is not on the ORM row in the shape the read model wants (it
-    # needs the entrant's username, and only the *active* entries), so the fields
-    # are listed explicitly rather than validated straight off the attributes —
-    # which would also fire a lazy load. The event's ``entered`` count is not
-    # listed at all: it is a computed field over ``entrants`` (ADR-0016), so
-    # there is nothing here that could disagree with the list.
-    #
-    # ``entry_state`` is the caller's, and it is computed from the entrants already
-    # loaded plus the caller's ``rating`` on this tournament's league — passed in,
-    # never fetched here, so no serializer can turn into an N+1.
-    #
-    # ``fixtures`` — the event's draw (ADR-0786) — is passed in for exactly that
-    # reason. ``e.fixtures`` is right there on the ORM instance and would read
-    # *correctly*: a lazy load would fetch the rows and the response would be
-    # identical. It would also fire one SELECT per event, on the LIST endpoint that
-    # returns every event of every tournament — an N+1 that no assertion about the
-    # body can see. It is loaded once, in a batch, by ``fixtures_by_event``, which
-    # also owns the pool → round → position ordering, so the serializer never sorts
-    # and no two call sites can order a bracket differently.
-    return TournamentEventRead.model_validate(
-        {
-            "id": e.id,
-            "tournament_id": e.tournament_id,
-            "name": e.name,
-            "format": e.format,
-            "draw_type": e.draw_type,
-            "max_players": e.max_players,
-            "entry_fee": e.entry_fee,
-            "slot": e.slot,
-            "match_settings": e.match_settings,
-            "predicates": e.predicates,
-            "pools": e.pools,
-            "created_at": e.created_at,
-            "updated_at": e.updated_at,
-            "entrants": entrants,
-            "entry_state": _entry_state(e, entered=len(entrants), rating=rating),
-            "fixtures": fixtures,
-            # The standings, projected here from the fixtures' completed matches plus
-            # the page's one batched game load — ``None`` for an uncut or
-            # non-round-robin event (ADR-0788). Computed in the serializer, not fetched
-            # per event, for the same reason ``fixtures`` is: no read may become an N+1.
-            #
-            # ``game_counts is None`` is the tournaments *list*'s signal to skip the
-            # projection entirely: its cards render no standings (only event and table
-            # counts), so the list neither runs the game-count query nor tabulates a
-            # results object nobody reads — standings are a detail-BFF concern. A
-            # detail surface passes a real map (``{}`` when nothing is played).
-            "results": (
-                None
-                if game_counts is None
-                else _event_results(e, fixtures=fixtures, game_counts=game_counts)
-            ),
-        }
-    )
-
-
-def _serialize_detail(
-    t: Tournament,
-    *,
-    created_by_username: str,
-    current_user_id: uuid.UUID,
-    events: list[TournamentEvent],
-    entrants_by_event: dict[uuid.UUID, list[TournamentEntrantRead]],
-    fixtures_by_event: dict[uuid.UUID, list[TournamentFixtureRead]],
-    game_counts: dict[uuid.UUID, tuple[int, int]] | None,
-    rating: float | None,
-    latest_schedule_solve: ScheduleSolve | None,
-) -> TournamentDetailRead:
-    # The full aggregate: tournament fields plus its events (each event's JSONB
-    # value-objects validate into Pydantic models here, at this single boundary).
-    #
-    # ONE ``rating`` for all of them — the caller's, on ``t.league_id``. A tournament
-    # names the single ladder its eligibility is judged on (ADR-0783), so every event
-    # under it is judged on the same number, and fetching it per event would be a
-    # query per event for an answer that cannot vary.
-    return TournamentDetailRead.model_validate(
-        {
-            **_tournament_fields(
-                t,
-                created_by_username=created_by_username,
-                current_user_id=current_user_id,
-            ),
-            # ``None`` is two things by design, exactly as ``results`` above is: on
-            # the DETAIL read it is the fact ("no solve ever requested"); on the LIST
-            # it is "not projected" — the list's cards render no solve strip, so it
-            # skips the ledger query the same way it skips standings.
-            "latest_schedule_solve": (
-                ScheduleSolveRead.model_validate(latest_schedule_solve)
-                if latest_schedule_solve is not None
-                else None
-            ),
-            "events": [
-                _serialize_event(
-                    e,
-                    entrants=entrants_by_event[e.id],
-                    fixtures=fixtures_by_event[e.id],
-                    rating=rating,
-                    game_counts=game_counts,
-                )
-                for e in events
-            ],
-        }
-    )
 
 
 async def _get_owned_tournament_or_404(
@@ -720,52 +359,6 @@ def _enforce_league_editable(t: Tournament) -> None:
     )
 
 
-# The statuses in which a tournament has been ANNOUNCED to the world. Publishing
-# is the act that makes a tournament public (ADR-0017), and nothing walks
-# backwards out of it, so everything from ``published`` onward is announced and
-# ``draft`` is not.
-#
-# An allow-list, deliberately, rather than "anything but draft": a status added
-# to the enum tomorrow is invisible to non-owners until somebody puts it in this
-# set on purpose. The inverse spelling would silently publish a future
-# pre-publish status (a ``pending_review``, a ``scheduled``) the moment it was
-# added, which is exactly the leak this predicate exists to close.
-ANNOUNCED_STATUSES: frozenset[TournamentStatus] = frozenset(
-    {
-        TournamentStatus.published,
-        TournamentStatus.live,
-        TournamentStatus.archived,
-    }
-)
-
-
-def _visible_to(user_id: uuid.UUID) -> ColumnElement[bool]:
-    """Which tournaments ``user_id`` may see at all: the announced ones, plus
-    their own — whatever status their own is in.
-
-    A draft is not announced, so it is owner-only. The read routes push this into
-    the WHERE clause rather than filtering after the fact, so a hidden draft is
-    *not selected* and the detail route's existing "Tournament not found." 404
-    answers for it. 404 and not 403: a 403 would confirm that a tournament with
-    that id exists, which is precisely what an unannounced tournament must not
-    admit. A draft the caller cannot see is indistinguishable from one that was
-    never created.
-
-    ``tournament.view`` is a separate question, and it is asked first — it is a
-    route dependency, so a caller without the permission is refused (403) before
-    this predicate is ever built. Permission says "may you read tournaments at
-    all"; this says "which ones are there for you to read".
-
-    One predicate, used by both the list and the detail route, because two copies
-    of this rule would eventually disagree — and the way they disagree is that the
-    list hides a draft the detail route still serves.
-    """
-    return or_(
-        Tournament.status.in_(ANNOUNCED_STATUSES),
-        Tournament.created_by_user_id == user_id,
-    )
-
-
 # ----- tournament routes ---------------------------------------------------
 
 
@@ -780,85 +373,20 @@ async def list_tournaments(
 ) -> list[TournamentDetailRead]:
     # The list page's cards render event-derived stats (event count, total
     # entries, table count), so the list returns the full aggregate — events, their
-    # entrants and their draws included — rather than a thinner summary. FIVE queries,
-    # no N+1, whatever the number of tournaments or events: the tournaments+usernames
-    # join, then all their events, then all those events' active entrants in one
-    # batch, then all those events' fixtures in one batch (ADR-0786), then the caller's
-    # rating on every distinct league those tournaments run on (which every event's
-    # ``entry_state`` is judged against, ADR-0783). A per-event entry count, a
-    # per-event draw, or a per-tournament rating would be the N+1 this shape exists to
-    # avoid, and a statement-count tripwire in tests/test_tournaments.py fails if one
-    # comes back.
+    # entrants and their draws included — rather than a thinner summary. The FIVE-query
+    # batched read (no N+1, whatever the number of tournaments or events) lives in the
+    # shared ``list_tournament_details`` so the MCP ``list_my_tournaments`` tool runs
+    # the exact same shape; this handler only supplies the WHERE.
     #
-    # Scoped by ``_visible_to``: somebody else's draft is not the caller's to see,
-    # so it never enters the result set — and, because the filter is a WHERE clause
-    # on the first of the four queries, the events and entrants queries are keyed
-    # off the surviving ids and cannot leak a hidden tournament's contents either.
-    # A predicate costs no extra statement, so the tripwire above still reads 4.
-    rows = (
-        await db.execute(
-            select(Tournament, User.username)
-            .join(User, User.id == Tournament.created_by_user_id)
-            .where(_visible_to(current_user.id))
-            .order_by(Tournament.created_at.desc())
-        )
-    ).all()
-    tournament_ids = [tournament.id for tournament, _ in rows]
-    events_by_tournament: dict[uuid.UUID, list[TournamentEvent]] = {
-        tid: [] for tid in tournament_ids
-    }
-    events: list[TournamentEvent] = []
-    if tournament_ids:
-        events = list(
-            (
-                await db.execute(
-                    select(TournamentEvent)
-                    .where(TournamentEvent.tournament_id.in_(tournament_ids))
-                    .order_by(TournamentEvent.created_at)
-                )
-            )
-            .scalars()
-            .all()
-        )
-        for event in events:
-            events_by_tournament[event.tournament_id].append(event)
-    event_ids = [e.id for e in events]
-    entrants_by_event = await active_entrants_by_event(db, event_ids)
-    # And ONE batch for every one of those events' fixtures — its draw (ADR-0786).
-    # Batched for the same reason the entrants are: the list returns every event of
-    # every tournament, so reading ``event.fixtures`` in the loop would be a SELECT per
-    # event. Uncut draws come back as ``[]``, so an event nobody has cut a draw for
-    # costs nothing and answers with an empty list rather than a null.
-    event_fixtures = await fixtures_by_event(db, event_ids)
-    # The list deliberately does NOT project standings: its cards render only event and
-    # table counts, never a results table, so it skips the game-count query and the
-    # per-event tabulation a results object would need (``game_counts=None`` below).
-    # Standings are a detail-BFF concern (ADR-0788); computing them here would be work a
-    # page throws away — the same shape as #1051 for fixtures/entrants.
-    # ONE batch for the caller's ratings, keyed by league — deduplicated, because
-    # every tournament on the default league shares the one number, and because the
-    # ladders a page happens to list is not a reason to ask the same question twice.
-    ratings = await entrant_ratings_by_league(
-        db, list({tournament.league_id for tournament, _ in rows}), current_user.id
+    # Scoped by ``_visible_to``: somebody else's draft is not the caller's to see, so it
+    # never enters the result set — and, because the filter is a WHERE clause on the
+    # first of the five queries, the events and entrants queries are keyed off the
+    # surviving ids and cannot leak a hidden tournament's contents either. A predicate
+    # costs no extra statement, so the statement-count tripwire in
+    # tests/test_tournaments.py still reads the same count.
+    return await list_tournament_details(
+        db, where=_visible_to(current_user.id), current_user_id=current_user.id
     )
-    return [
-        _serialize_detail(
-            tournament,
-            created_by_username=username,
-            current_user_id=current_user.id,
-            events=events_by_tournament[tournament.id],
-            entrants_by_event=entrants_by_event,
-            fixtures_by_event=event_fixtures,
-            game_counts=None,
-            rating=ratings[tournament.league_id],
-            # The list projects no solve strip, for the same reason it projects no
-            # standings (``game_counts=None`` above): its cards never render one, so
-            # it skips the ledger read rather than paying a query for a field every
-            # card throws away. The solve strip is a detail-BFF concern.
-            latest_schedule_solve=None,
-        )
-        for tournament, username in rows
-    ]
 
 
 @router.post(
@@ -907,7 +435,7 @@ async def create_tournament(
     db.add(tournament)
     await db.commit()
     await db.refresh(tournament)
-    return _serialize(
+    return serialize(
         tournament,
         created_by_username=current_user.username,
         current_user_id=current_user.id,
@@ -983,7 +511,7 @@ async def get_tournament(
     # statement-count pin stays flat; ``None`` is the designed state of a tournament
     # nobody has asked to schedule yet.
     latest_schedule_solve = await latest_solve(db, tournament.id)
-    return _serialize_detail(
+    return serialize_detail(
         tournament,
         created_by_username=username,
         current_user_id=current_user.id,
@@ -1072,7 +600,7 @@ async def update_tournament(
     await db.commit()
     await db.refresh(tournament)
     # The owner is the current user, so the username and can_edit are known.
-    return _serialize(
+    return serialize(
         tournament,
         created_by_username=current_user.username,
         current_user_id=current_user.id,
@@ -1342,7 +870,7 @@ async def create_tournament_transition(
     await db.refresh(tournament)
     # The owner is the current user (``_require_owner`` just said so), so the
     # creator's username and can_edit are both known without another query.
-    return _serialize(
+    return serialize(
         tournament,
         created_by_username=current_user.username,
         current_user_id=current_user.id,
@@ -1394,7 +922,7 @@ async def create_event(
     # No fixtures on a one-statement-old event, so no results either —
     # ``_event_results`` answers ``None`` for an uncut draw whatever the game counts, so
     # an empty map is all this needs.
-    return _serialize_event(
+    return serialize_event(
         event, entrants=[], fixtures=[], rating=rating, game_counts={}
     )
 
@@ -1707,7 +1235,7 @@ async def update_event(
     # who has just tightened a rule or lowered ``max_players`` is answered with what
     # the event says NOW, not with what it said before their edit.
     rating = await entrant_rating(db, tournament.league_id, current_user.id)
-    return _serialize_event(
+    return serialize_event(
         event,
         entrants=entrants,
         fixtures=fixtures,

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -34,7 +34,6 @@ from app.rbac import require_permission, user_has_permission
 from app.schedule_solves import (
     latest_solve,
     request_solve,
-    tournament_has_drawn_event,
 )
 from app.schemas.tournament import (
     MatchSettings,
@@ -76,7 +75,9 @@ from app.tournament_errors import (
     EventNotFoundError,
     LeagueNotEditableError,
     LeagueNotFoundError,
+    NoDrawnEventsError,
     NotTournamentOwnerError,
+    ScheduleQueueUnavailableError,
     TournamentNotFoundError,
 )
 from app.tournament_list import list_tournament_details
@@ -94,6 +95,9 @@ from app.tournament_serialization import (
     serialize,
     serialize_detail,
     serialize_event,
+)
+from app.tournament_solve_service import (
+    request_schedule_solve as _request_schedule_solve,
 )
 
 # Reads are gated on ``tournament.view``, creation on ``tournament.create``, and
@@ -2296,32 +2300,40 @@ async def request_schedule_solve(
     Owner-only, like every other tournament mutation: an absent tournament is a
     `404`, a non-owner a `403`.
     """
-    # 404 → 403 → 422, the ordering ADR-0017 fixed for this module — and the same
-    # tournament row lock every scheduling-input writer takes, taken FIRST, which is
-    # the lock ``request_solve`` requires of its callers (lock order: tournament →
-    # schedule_solves). Without it, this route's "a draw exists" judgment and its
-    # enqueue would sit in two instants: an un-cut could commit between them and a
-    # solve would be queued for a tournament this route just certified as drawable.
-    tournament = await _get_tournament_for_update_or_404(db, tournament_id)
-    _require_owner(tournament, current_user)
-    # The caller's own refusal, last: nothing drawn means nothing to schedule.
-    if not await tournament_has_drawn_event(db, tournament_id):
-        raise _no_drawn_events_refusal()
-    row = await request_solve(db, tournament_id, ScheduleSolveTrigger.manual)
-    if row is None:
-        # The enqueue itself failed (Redis down) and ``request_solve`` took its row
-        # back out — a zombie row would absorb every later trigger while no job ever
-        # runs. Nothing was queued, so the honest answer is "not available", not a
-        # ledger row that names a run that does not exist.
+    # Thin adapter over the transport-neutral ``request_schedule_solve`` verb: it
+    # owns the row lock, the owner gate, the no-drawn-events gate, the coalesced
+    # ``request_solve`` enqueue and the commit + read-back, and signals each refusal
+    # with a domain exception. This handler maps each back to the exact status +
+    # body it produced before, so the wire contract is unchanged (404 → 403 → 422,
+    # ADR-0017's ordering; the 503 is the queue-down case):
+    #
+    #   TournamentNotFoundError        -> 404 "Tournament not found."
+    #   NotTournamentOwnerError        -> 403 "You can only modify tournaments you …"
+    #   NoDrawnEventsError             -> 422 {"code": "no_drawn_events", "message": …}
+    #   ScheduleQueueUnavailableError  -> 503 "The scheduling queue is unavailable, …"
+    try:
+        row = await _request_schedule_solve(
+            db, tournament_id=tournament_id, actor=current_user
+        )
+    except TournamentNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Tournament not found.") from exc
+    except NotTournamentOwnerError as exc:
+        raise HTTPException(
+            status_code=403, detail="You can only modify tournaments you created."
+        ) from exc
+    except NoDrawnEventsError as exc:
+        # The exact 422 body this route composed inline — kept in the adapter, like
+        # every other tournament refusal's HTTP copy.
+        raise _no_drawn_events_refusal() from exc
+    except ScheduleQueueUnavailableError as exc:
+        # The enqueue failed (Redis down) and the verb took its row back out —
+        # nothing was queued, so the honest answer is "not available", not a ledger
+        # row that names a run that does not exist. Same request is safe to retry.
         raise HTTPException(
             status_code=503,
             detail=(
                 "The scheduling queue is unavailable, so the solve was not queued. "
                 "Try again in a moment."
             ),
-        )
-    await db.commit()
-    # ``requested_at`` (and the other server defaults) were never round-tripped by
-    # the INSERT, so read the row back rather than serializing expired attributes.
-    await db.refresh(row)
+        ) from exc
     return ScheduleSolveRead.model_validate(row)

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -1377,3 +1377,130 @@ async def test_get_schedule_without_view_permission_raises_tool_error(
     async with _mcp_client(raw) as client, client:
         with pytest.raises(ToolError, match="permission"):
             await client.call_tool("get_schedule", {"tournament_id": str(uuid.uuid4())})
+
+
+# ----- edit_tournament tool ------------------------------------------------
+
+
+async def test_edit_tournament_is_registered(db_session: AsyncSession) -> None:
+    """The write verb is exposed as a tool to an authenticated caller."""
+    user = await make_user(db_session, "mcp-edit-listed")
+    raw = await _mint(db_session, user)
+
+    async with _mcp_client(raw) as client, client:
+        tools = await client.list_tools()
+    assert "edit_tournament" in {tool.name for tool in tools}
+
+
+async def test_edit_tournament_owner_renames_and_it_persists(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """A bearer-authed OWNER renames a tournament via the tool: the returned view
+    carries the new name (and leaves the other fields untouched — partial
+    semantics), and the change is committed, readable back through the tool."""
+    me = await start_session(api_client, db_session)
+    await grant_permissions(db_session, me, [TOURNAMENT_VIEW, TOURNAMENT_CREATE])
+    raw = await _mint(db_session, me)
+    tournament_id = await _create_tournament(api_client)
+
+    async with _mcp_client(raw) as client, client:
+        result = await client.call_tool_mcp(
+            "edit_tournament",
+            {"tournament_id": tournament_id, "updates": {"name": "Renamed Cup"}},
+        )
+        assert result.isError is False
+        body = result.structuredContent
+        assert body is not None
+        assert body["id"] == tournament_id
+        assert body["name"] == "Renamed Cup"
+        assert body["can_edit"] is True
+        assert body["created_by_user_id"] == str(me.id)
+        # Partial semantics: an omitted field is left unchanged.
+        assert body["description"] == _tournament_payload()["description"]
+
+        # The write committed — read it back through the tool.
+        read_back = await client.call_tool_mcp(
+            "get_tournament", {"tournament_id": tournament_id}
+        )
+    assert read_back.structuredContent is not None
+    assert read_back.structuredContent["name"] == "Renamed Cup"
+
+    # And it is durable in the database.
+    db_session.expire_all()
+    persisted = (
+        await db_session.execute(
+            select(Tournament).where(Tournament.id == uuid.UUID(tournament_id))
+        )
+    ).scalar_one()
+    assert persisted.name == "Renamed Cup"
+
+
+async def test_edit_tournament_non_owner_raises_tool_error_and_writes_nothing(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """A caller who is not the tournament's creator gets a ``ToolError`` (owner-gated
+    by construction in the shared verb), and nothing is written."""
+    owner = await start_session(api_client, db_session)
+    await grant_permissions(db_session, owner, [TOURNAMENT_VIEW, TOURNAMENT_CREATE])
+    tournament_id = await _create_tournament(api_client)
+    original_name = _tournament_payload()["name"]
+
+    outsider = await make_user(db_session, "mcp-edit-outsider")
+    outsider_token = await _mint(db_session, outsider)
+
+    async with _mcp_client(outsider_token) as client, client:
+        with pytest.raises(ToolError, match="only edit tournaments you created"):
+            await client.call_tool(
+                "edit_tournament",
+                {"tournament_id": tournament_id, "updates": {"name": "Hijacked"}},
+            )
+
+    # Nothing was written: the name is still the owner's original.
+    db_session.expire_all()
+    persisted = (
+        await db_session.execute(
+            select(Tournament).where(Tournament.id == uuid.UUID(tournament_id))
+        )
+    ).scalar_one()
+    assert persisted.name == original_name
+
+
+async def test_edit_tournament_unknown_id_raises_tool_error(
+    db_session: AsyncSession,
+) -> None:
+    """An id that matches no tournament surfaces as a ``ToolError`` at the caller."""
+    me = await make_user(db_session, "mcp-edit-unknown")
+    raw = await _mint(db_session, me)
+    unknown = str(uuid.uuid4())
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match=unknown):
+            await client.call_tool(
+                "edit_tournament",
+                {"tournament_id": unknown, "updates": {"name": "Nope"}},
+            )
+
+
+async def test_edit_tournament_league_change_after_publish_raises_tool_error(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """Changing the league of a tournament that has left ``draft`` is refused
+    (ADR-0783): the owner gets a ``ToolError`` carrying the state rule, and the
+    refusal is judged before the league is even looked up (so an arbitrary id is
+    enough to trip it)."""
+    owner = await make_user(db_session, "mcp-edit-published-owner")
+    raw = await _mint(db_session, owner)
+    published = await _seed_owned_tournament(
+        db_session, owner, default_league, "Published Cup", TournamentStatus.published
+    )
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="can only be changed while it is a draft"):
+            await client.call_tool(
+                "edit_tournament",
+                {
+                    "tournament_id": str(published.id),
+                    "updates": {"league_id": str(uuid.uuid4())},
+                },
+            )

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -20,6 +20,7 @@ import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
+from decimal import Decimal
 
 import httpx
 import pytest
@@ -48,6 +49,7 @@ from app.models import (
     User,
     UserToken,
 )
+from app.models.tournament import DrawType, EventFormat
 from app.token_hashing import hash_token
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import (
@@ -1504,3 +1506,332 @@ async def test_edit_tournament_league_change_after_publish_raises_tool_error(
                     "updates": {"league_id": str(uuid.uuid4())},
                 },
             )
+
+
+# ----- build_cut / uncut draw tools ----------------------------------------
+#
+# Two pools, so the round-robin snake deals a clean draw a fixture's ``pool_id``
+# refs against — the same shape ``test_tournament_draw_service.py`` cuts across.
+_DRAW_POOL_A: dict[str, object] = {
+    "id": "p-a",
+    "name": "Pool A",
+    "slot": {"date": "2026-08-01", "start": "09:00", "end": "12:30"},
+    "table_ids": ["t1"],
+}
+_DRAW_POOL_B: dict[str, object] = {
+    "id": "p-b",
+    "name": "Pool B",
+    "slot": {"date": "2026-08-01", "start": "09:00", "end": "12:30"},
+    "table_ids": ["t2"],
+}
+
+
+async def _seed_drawable_tournament(
+    db_session: AsyncSession,
+    owner: User,
+    league: League,
+    *,
+    format: EventFormat = EventFormat.singles,
+    draw_type: DrawType = DrawType.round_robin,
+    entrants: int = 4,
+) -> tuple[Tournament, TournamentEvent]:
+    """A tournament + one event owned by ``owner`` (committed), seeded directly so a
+    draw tool can be driven against its ``event_id`` alone. A round-robin singles event
+    with two pools and ``entrants`` seeded entries is cuttable; ``format`` /
+    ``draw_type`` / ``entrants`` are knobbed to reach the un-cuttable cases (a doubles
+    event, an unsupported draw type)."""
+    tournament = Tournament(
+        name="MCP Draw Cup",
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "2727 Milvia St",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94703",
+            "country": "USA",
+        },
+        table_catalogue=[
+            {"id": "t1", "label": "Table 1", "court": "A"},
+            {"id": "t2", "label": "Table 2", "court": "A"},
+        ],
+        league_id=league.id,
+        created_by_user_id=owner.id,
+        status=TournamentStatus.draft,
+    )
+    db_session.add(tournament)
+    await db_session.commit()
+    await db_session.refresh(tournament)
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Open Singles",
+        format=format,
+        draw_type=draw_type,
+        max_players=64,
+        entry_fee=Decimal("45"),
+        slot={"date": "2026-08-01", "start": "09:00", "end": "18:00"},
+        match_settings={"rated": True, "length_games": 5},
+        predicates=[],
+        pools=[_DRAW_POOL_A, _DRAW_POOL_B],
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+    db_session.add_all(
+        [
+            TournamentEntry(
+                event_id=event.id,
+                user_id=(await make_user(db_session, "draw-e-" + uuid.uuid4().hex)).id,
+                status=TournamentEntryStatus.entered,
+                seed=n,
+            )
+            for n in range(1, entrants + 1)
+        ]
+    )
+    await db_session.commit()
+    return tournament, event
+
+
+async def test_build_cut_and_uncut_tools_are_registered(
+    db_session: AsyncSession,
+) -> None:
+    """Both draw-write verbs are exposed as tools to an authenticated caller."""
+    user = await make_user(db_session, "mcp-draw-listed")
+    raw = await _mint(db_session, user)
+
+    async with _mcp_client(raw) as client, client:
+        names = {tool.name for tool in await client.list_tools()}
+    assert {"build_cut", "uncut"} <= names
+
+
+async def test_build_cut_returns_fixtures_visible_via_schedule_then_uncut_removes_them(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """An owner cuts a singles event's draw via ``build_cut``: the fixtures come back
+    (4 entrants over 2 pools → one round-robin fixture per pool), they are visible via
+    ``get_schedule``, and ``uncut`` then tears them down (``fixtures_remaining`` = 0 and
+    the schedule shows ``[]``)."""
+    owner = await make_user(db_session, "mcp-draw-owner")
+    await grant_permissions(db_session, owner, [TOURNAMENT_VIEW])
+    raw = await _mint(db_session, owner)
+    tournament, event = await _seed_drawable_tournament(
+        db_session, owner, default_league
+    )
+    event_id, tournament_id = str(event.id), str(tournament.id)
+
+    async with _mcp_client(raw) as client, client:
+        cut = await client.call_tool_mcp("build_cut", {"event_id": event_id})
+        assert cut.isError is False
+        assert cut.structuredContent is not None
+        fixtures = cut.structuredContent["result"]
+        assert len(fixtures) == 2
+        assert all(f["pool_id"] in {"p-a", "p-b"} for f in fixtures)
+
+        # The cut draw is visible through the schedule projection.
+        schedule = await client.call_tool_mcp(
+            "get_schedule", {"tournament_id": tournament_id}
+        )
+        assert schedule.structuredContent is not None
+        group = schedule.structuredContent["events"][0]
+        assert {f["id"] for f in group["fixtures"]} == {f["id"] for f in fixtures}
+
+        # Un-cut tears the whole draw down.
+        removed = await client.call_tool_mcp("uncut", {"event_id": event_id})
+        assert removed.isError is False
+        assert removed.structuredContent is not None
+        assert removed.structuredContent["fixtures_remaining"] == 0
+        assert removed.structuredContent["event_id"] == event_id
+        assert removed.structuredContent["tournament_id"] == tournament_id
+
+        # And the schedule now carries no fixtures for the event.
+        after = await client.call_tool_mcp(
+            "get_schedule", {"tournament_id": tournament_id}
+        )
+    assert after.structuredContent is not None
+    assert after.structuredContent["events"][0]["fixtures"] == []
+
+
+async def test_uncut_of_a_never_cut_draw_is_an_idempotent_ok(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """Un-cutting an event that was never cut deletes nothing and still succeeds —
+    ``fixtures_remaining`` is 0, not a ``ToolError`` (ADR-0786's idempotent DELETE)."""
+    owner = await make_user(db_session, "mcp-uncut-noop-owner")
+    raw = await _mint(db_session, owner)
+    _, event = await _seed_drawable_tournament(db_session, owner, default_league)
+
+    async with _mcp_client(raw) as client, client:
+        removed = await client.call_tool_mcp("uncut", {"event_id": str(event.id)})
+    assert removed.isError is False
+    assert removed.structuredContent is not None
+    assert removed.structuredContent["fixtures_remaining"] == 0
+
+
+async def test_build_cut_non_owner_raises_tool_error(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A caller who is not the tournament's creator gets a ``ToolError`` — owner-gated
+    by construction in the shared verb — and no draw is cut."""
+    owner = await make_user(db_session, "mcp-draw-real-owner")
+    _, event = await _seed_drawable_tournament(db_session, owner, default_league)
+
+    outsider = await make_user(db_session, "mcp-draw-outsider")
+    outsider_token = await _mint(db_session, outsider)
+
+    async with _mcp_client(outsider_token) as client, client:
+        with pytest.raises(ToolError, match="tournaments you created"):
+            await client.call_tool("build_cut", {"event_id": str(event.id)})
+
+    # Nothing was written.
+    remaining = (
+        (
+            await db_session.execute(
+                select(TournamentFixture).where(TournamentFixture.event_id == event.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
+async def test_build_cut_unknown_event_raises_tool_error(
+    db_session: AsyncSession,
+) -> None:
+    """An event id that resolves to no event surfaces as a not-found ``ToolError``."""
+    owner = await make_user(db_session, "mcp-draw-unknown")
+    raw = await _mint(db_session, owner)
+    unknown = str(uuid.uuid4())
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match=unknown):
+            await client.call_tool("build_cut", {"event_id": unknown})
+
+
+async def test_build_cut_played_draw_raises_tool_error(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """Once the draw shows evidence of play (a fixture with a recorded winner), a
+    re-cut is refused with a ``ToolError`` naming that the draw is under way, and the
+    standing draw is left intact."""
+    owner = await make_user(db_session, "mcp-draw-played-owner")
+    raw = await _mint(db_session, owner)
+    _, event = await _seed_drawable_tournament(db_session, owner, default_league)
+    # Capture the id once, while the ORM object is fresh: the ``commit`` below expires
+    # it, and touching ``event.id`` afterwards would fire a sync lazy-load
+    # (MissingGreenlet) in async land.
+    event_id = event.id
+
+    # Cut a real draw first (own client block, closed before the DB write below — a
+    # test ``db_session`` write interleaved inside an open MCP client block trips the
+    # ASGI transport's greenlet context).
+    async with _mcp_client(raw) as client, client:
+        cut = await client.call_tool_mcp("build_cut", {"event_id": str(event_id)})
+    assert cut.isError is False
+
+    # Record a winner on one fixture — evidence of play. Read the ids off the fresh rows
+    # BEFORE the commit for the same reason.
+    fixtures = list(
+        (
+            await db_session.execute(
+                select(TournamentFixture).where(TournamentFixture.event_id == event_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    before = {f.id for f in fixtures}
+    fixtures[0].winner_entry_id = fixtures[0].entry_a_id
+    await db_session.commit()
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="under way"):
+            await client.call_tool("build_cut", {"event_id": str(event_id)})
+
+    # The standing draw is untouched — the refusal is asked before any delete.
+    db_session.expire_all()
+    still = (
+        (
+            await db_session.execute(
+                select(TournamentFixture.id).where(
+                    TournamentFixture.event_id == event_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert set(still) == before
+
+
+async def test_build_cut_non_singles_event_raises_readable_tool_error(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A doubles event can never be given a draw (ADR-0788): ``build_cut`` surfaces the
+    ``NonSinglesDraw`` refusal as a readable ``ToolError`` naming the format, and writes
+    nothing."""
+    owner = await make_user(db_session, "mcp-draw-doubles-owner")
+    raw = await _mint(db_session, owner)
+    _, event = await _seed_drawable_tournament(
+        db_session, owner, default_league, format=EventFormat.doubles
+    )
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="singles events can"):
+            await client.call_tool("build_cut", {"event_id": str(event.id)})
+
+    remaining = (
+        (
+            await db_session.execute(
+                select(TournamentFixture).where(TournamentFixture.event_id == event.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
+async def test_build_cut_unsupported_draw_type_raises_readable_tool_error(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """An ``rr-then-ko`` event has no generator yet (ADR-0786): ``build_cut`` surfaces
+    the ``UnsupportedDrawType`` refusal as a readable ``ToolError`` that names
+    round-robin as the supported type."""
+    owner = await make_user(db_session, "mcp-draw-rrko-owner")
+    raw = await _mint(db_session, owner)
+    _, event = await _seed_drawable_tournament(
+        db_session, owner, default_league, draw_type=DrawType.rr_then_ko
+    )
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="round-robin"):
+            await client.call_tool("build_cut", {"event_id": str(event.id)})
+
+
+async def test_uncut_non_owner_raises_tool_error(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """``uncut`` is owner-gated by construction too: a non-owner gets a ``ToolError``
+    and no draw is removed."""
+    owner = await make_user(db_session, "mcp-uncut-owner")
+    owner_token = await _mint(db_session, owner)
+    _, event = await _seed_drawable_tournament(db_session, owner, default_league)
+
+    # Owner cuts, so there is a real draw a non-owner might try to remove.
+    async with _mcp_client(owner_token) as client, client:
+        assert (
+            await client.call_tool_mcp("build_cut", {"event_id": str(event.id)})
+        ).isError is False
+
+    outsider = await make_user(db_session, "mcp-uncut-outsider")
+    outsider_token = await _mint(db_session, outsider)
+    async with _mcp_client(outsider_token) as client, client:
+        with pytest.raises(ToolError, match="tournaments you created"):
+            await client.call_tool("uncut", {"event_id": str(event.id)})

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -1835,3 +1835,135 @@ async def test_uncut_non_owner_raises_tool_error(
     async with _mcp_client(outsider_token) as client, client:
         with pytest.raises(ToolError, match="tournaments you created"):
             await client.call_tool("uncut", {"event_id": str(event.id)})
+
+
+# ----- request_schedule_solve tool -----------------------------------------
+
+
+async def test_request_schedule_solve_is_registered(
+    db_session: AsyncSession,
+) -> None:
+    """The solve write verb is exposed as a tool to an authenticated caller."""
+    user = await make_user(db_session, "mcp-solve-listed")
+    raw = await _mint(db_session, user)
+
+    async with _mcp_client(raw) as client, client:
+        names = {tool.name for tool in await client.list_tools()}
+    assert "request_schedule_solve" in names
+
+
+async def test_request_schedule_solve_owner_queues_a_run(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """An owner runs the scheduler for a tournament with a cut draw: the tool returns
+    a ledger row for the run (``queued``/``running``, its ``verdict`` not yet known —
+    the solve is async, its verdict read back later via ``get_schedule``), and that
+    row is durable on the tournament's solve ledger."""
+    owner = await make_user(db_session, "mcp-solve-owner")
+    await grant_permissions(db_session, owner, [TOURNAMENT_VIEW])
+    raw = await _mint(db_session, owner)
+    tournament, event = await _seed_drawable_tournament(
+        db_session, owner, default_league
+    )
+    tournament_id = str(tournament.id)
+
+    async with _mcp_client(raw) as client, client:
+        # Cut a draw first, so the tournament has fixtures the scheduler can place.
+        assert (
+            await client.call_tool_mcp("build_cut", {"event_id": str(event.id)})
+        ).isError is False
+        result = await client.call_tool_mcp(
+            "request_schedule_solve", {"tournament_id": tournament_id}
+        )
+
+    assert result.isError is False
+    body = result.structuredContent
+    assert body is not None
+    # An async run: the returned row is the queued/running ledger row, its verdict
+    # (and placement counts) not yet known — read back later via get_schedule.
+    assert body["status"] in {"queued", "running"}
+    assert body["verdict"] is None
+
+    # The run is a real, durable row on the tournament's solve ledger.
+    db_session.expire_all()
+    persisted = (
+        await db_session.execute(
+            select(ScheduleSolve).where(
+                ScheduleSolve.id == uuid.UUID(body["id"]),
+                ScheduleSolve.tournament_id == uuid.UUID(tournament_id),
+            )
+        )
+    ).scalar_one()
+    assert persisted.status in {
+        ScheduleSolveStatus.queued,
+        ScheduleSolveStatus.running,
+    }
+
+
+async def test_request_schedule_solve_without_a_drawn_event_raises_tool_error(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A tournament whose events have no cut draw has nothing to schedule: the owner
+    gets a ``ToolError`` telling them to ``build_cut`` a draw first, and no solve is
+    queued (``NoDrawnEventsError``)."""
+    owner = await make_user(db_session, "mcp-solve-undrawn-owner")
+    raw = await _mint(db_session, owner)
+    tournament, _ = await _seed_drawable_tournament(db_session, owner, default_league)
+    tournament_id = tournament.id
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="build_cut"):
+            await client.call_tool(
+                "request_schedule_solve", {"tournament_id": str(tournament_id)}
+            )
+
+    # Nothing was queued — the ledger stays empty.
+    db_session.expire_all()
+    solves = (
+        (
+            await db_session.execute(
+                select(ScheduleSolve).where(
+                    ScheduleSolve.tournament_id == tournament_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert solves == []
+
+
+async def test_request_schedule_solve_non_owner_raises_tool_error(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """Running the scheduler is owner-gated by construction in the shared verb: a
+    caller who is not the tournament's creator gets a ``ToolError`` (judged before the
+    draw state is even looked at), and no solve is queued."""
+    owner = await make_user(db_session, "mcp-solve-real-owner")
+    tournament, _ = await _seed_drawable_tournament(db_session, owner, default_league)
+    tournament_id = tournament.id
+
+    outsider = await make_user(db_session, "mcp-solve-outsider")
+    outsider_token = await _mint(db_session, outsider)
+    async with _mcp_client(outsider_token) as client, client:
+        with pytest.raises(ToolError, match="tournaments you created"):
+            await client.call_tool(
+                "request_schedule_solve", {"tournament_id": str(tournament_id)}
+            )
+
+    db_session.expire_all()
+    solves = (
+        (
+            await db_session.execute(
+                select(ScheduleSolve).where(
+                    ScheduleSolve.tournament_id == tournament_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert solves == []

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -27,14 +27,35 @@ from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
 from fastmcp.exceptions import ToolError
 from rq import Queue
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api_token_auth import API_TOKEN_CONTEXT
 from app.main import app as fastapi_app
 from app.main import mcp_app
-from app.models import User, UserToken
+from app.models import (
+    League,
+    ScheduleSolve,
+    ScheduleSolveStatus,
+    ScheduleSolveTrigger,
+    SolverVerdict,
+    Tournament,
+    TournamentEntry,
+    TournamentEntryStatus,
+    TournamentEvent,
+    TournamentFixture,
+    TournamentStatus,
+    User,
+    UserToken,
+)
 from app.token_hashing import hash_token
-from tests._helpers import enqueued_notification_jobs, make_user, start_session
+from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
+from tests._helpers import (
+    enqueued_notification_jobs,
+    grant_permissions,
+    make_user,
+    start_session,
+)
 
 MCP_URL = "http://testserver/mcp/"
 
@@ -936,3 +957,423 @@ async def test_list_my_matches_returns_only_the_callers_matches(
     listed_ids = {row["id"] for row in listed.structuredContent["items"]}
     assert mine_match_id in listed_ids
     assert foreign_match_id not in listed_ids
+
+
+# ----- get_tournament tool -------------------------------------------------
+
+
+def _tournament_payload() -> dict[str, object]:
+    """A minimal valid create-tournament body (same shape as test_tournaments)."""
+    return {
+        "name": "MCP Cup 2026",
+        "description": "An MCP-visible open.",
+        "start_date": "2026-08-01",
+        "end_date": "2026-08-02",
+        "address": {
+            "venue": "Berkeley TT Club",
+            "street": "2727 Milvia St",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94703",
+            "country": "USA",
+        },
+        "table_catalogue": [{"id": "t1", "label": "Table 1", "court": "A"}],
+    }
+
+
+def _event_payload() -> dict[str, object]:
+    """A minimal valid create-event body for a tournament (same shape as
+    test_tournaments), so the detail read exercises the events list too."""
+    return {
+        "name": "Open Singles",
+        "format": "singles",
+        "draw_type": "rr-then-ko",
+        "max_players": 64,
+        "entry_fee": 45,
+        "slot": {"date": "2026-08-01", "start": "09:00", "end": "18:00"},
+        "match_settings": {"rated": True, "length_games": 5},
+        "predicates": [{"id": "pr-1", "field": "rating", "op": "<", "value": 1500}],
+        "pools": [
+            {
+                "id": "p-os-1",
+                "name": "Pool A",
+                "slot": {"date": "2026-08-01", "start": "09:00", "end": "12:30"},
+                "table_ids": ["t1"],
+            }
+        ],
+    }
+
+
+async def _create_tournament(api_client: httpx.AsyncClient) -> str:
+    """Create a tournament (with one event) as the client's session user via HTTP
+    (committed), returning the new tournament id."""
+    response = await api_client.post("/v1/tournaments", json=_tournament_payload())
+    assert response.status_code == 201, response.text
+    tournament_id = str(response.json()["id"])
+    event = await api_client.post(
+        f"/v1/tournaments/{tournament_id}/events", json=_event_payload()
+    )
+    assert event.status_code == 201, event.text
+    return tournament_id
+
+
+async def test_get_tournament_returns_same_detail_as_http_get(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """The ``get_tournament`` tool returns the identical ``TournamentDetailRead``
+    view the HTTP ``GET /v1/tournaments/{id}`` returns for the same authenticated
+    user — same fields, events, and viewer-relative ``can_edit``."""
+    me = await start_session(api_client, db_session)
+    await grant_permissions(db_session, me, [TOURNAMENT_VIEW, TOURNAMENT_CREATE])
+    raw = await _mint(db_session, me)
+    tournament_id = await _create_tournament(api_client)
+
+    http_body = (await api_client.get(f"/v1/tournaments/{tournament_id}")).json()
+
+    async with _mcp_client(raw) as client, client:
+        result = await client.call_tool_mcp(
+            "get_tournament", {"tournament_id": tournament_id}
+        )
+
+    assert result.isError is False
+    assert result.structuredContent == http_body
+    # Spot-check the load-bearing fields the tool is meant to preserve.
+    assert result.structuredContent is not None
+    assert result.structuredContent["id"] == tournament_id
+    assert result.structuredContent["can_edit"] is True
+    assert result.structuredContent["created_by_user_id"] == str(me.id)
+    assert len(result.structuredContent["events"]) == 1
+
+
+async def test_get_tournament_unknown_id_raises_tool_error(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """An id that matches no tournament surfaces as a ``ToolError`` at the caller."""
+    me = await start_session(api_client, db_session)
+    await grant_permissions(db_session, me, [TOURNAMENT_VIEW])
+    raw = await _mint(db_session, me)
+    unknown = str(uuid.uuid4())
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match=unknown):
+            await client.call_tool("get_tournament", {"tournament_id": unknown})
+
+
+async def test_get_tournament_without_view_permission_raises_tool_error(
+    db_session: AsyncSession,
+) -> None:
+    """A caller who does not hold ``tournament.view`` is refused before any row is
+    loaded — the same gate the HTTP ``require_view`` dependency enforces."""
+    me = await make_user(db_session, "mcp-tourn-noperm")
+    raw = await _mint(db_session, me)
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="permission"):
+            await client.call_tool(
+                "get_tournament", {"tournament_id": str(uuid.uuid4())}
+            )
+
+
+async def test_get_tournament_hidden_draft_raises_tool_error_for_non_owner(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """A draft the caller does not own is not theirs to see: even holding
+    ``tournament.view``, an outsider gets the same not-found ``ToolError`` an
+    absent id would — existence is never confirmed for an unannounced draft,
+    exactly as the HTTP route hides it behind a 404 (see visible_to)."""
+    owner = await start_session(api_client, db_session)
+    await grant_permissions(db_session, owner, [TOURNAMENT_VIEW, TOURNAMENT_CREATE])
+    tournament_id = await _create_tournament(api_client)  # born ``draft``
+
+    outsider = await make_user(db_session, "mcp-tourn-outsider")
+    await grant_permissions(db_session, outsider, [TOURNAMENT_VIEW])
+    outsider_token = await _mint(db_session, outsider)
+
+    async with _mcp_client(outsider_token) as client, client:
+        with pytest.raises(ToolError, match=tournament_id):
+            await client.call_tool("get_tournament", {"tournament_id": tournament_id})
+
+
+# ----- list_my_tournaments tool --------------------------------------------
+
+
+async def _seed_owned_tournament(
+    db_session: AsyncSession,
+    owner: User,
+    league: League,
+    name: str,
+    status: TournamentStatus,
+) -> Tournament:
+    """Insert a tournament owned by ``owner`` directly (committed), so a test can
+    give a *different* user a tournament the caller doesn't own — at any status,
+    including a published one the caller can otherwise see."""
+    tournament = Tournament(
+        name=name,
+        address={
+            "venue": "Elsewhere TT",
+            "street": "1 Broadway",
+            "city": "Oakland",
+            "region": "CA",
+            "postal": "94607",
+            "country": "USA",
+        },
+        table_catalogue=[],
+        league_id=league.id,
+        created_by_user_id=owner.id,
+        status=status,
+    )
+    db_session.add(tournament)
+    await db_session.commit()
+    await db_session.refresh(tournament)
+    return tournament
+
+
+async def test_list_my_tournaments_returns_only_the_callers_own_newest_first(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """``list_my_tournaments`` is OWNER-scoped, not visibility-scoped: it returns
+    exactly the tournaments the caller created (newest first) and EXCLUDES another
+    user's — even a PUBLISHED one the caller can otherwise see via the HTTP list.
+
+    Two different api-token users each own tournaments; the caller (A) also holds
+    ``tournament.view`` and so *can* see B's published tournament through
+    ``GET /v1/tournaments`` — proving the tool's exclusion is about ownership, not
+    visibility."""
+    me = await start_session(api_client, db_session)
+    await grant_permissions(db_session, me, [TOURNAMENT_VIEW, TOURNAMENT_CREATE])
+    token_a = await _mint(db_session, me)
+    # Two tournaments owned by A, created oldest → newest so the ordering is pinned.
+    mine_first = await _create_tournament(api_client)
+    mine_second = await _create_tournament(api_client)
+
+    # A second user B owns a PUBLISHED (announced) tournament — A can *see* it via
+    # the visibility-scoped HTTP list, but does not own it.
+    other = await make_user(db_session, "mcp-list-tourn-other-owner")
+    await grant_permissions(db_session, other, [TOURNAMENT_VIEW])
+    token_b = await _mint(db_session, other)
+    theirs = await _seed_owned_tournament(
+        db_session, other, default_league, "Their Open", TournamentStatus.published
+    )
+
+    # Sanity: A genuinely *can* see B's published tournament through the
+    # visibility-scoped HTTP list — so excluding it below is about ownership.
+    visible = (await api_client.get("/v1/tournaments")).json()
+    visible_ids = {t["id"] for t in visible}
+    assert {mine_first, mine_second, str(theirs.id)} <= visible_ids
+
+    async with _mcp_client(token_a) as client, client:
+        listed = await client.call_tool_mcp("list_my_tournaments", {})
+    assert listed.isError is False
+    assert listed.structuredContent is not None
+    ids = [t["id"] for t in listed.structuredContent["result"]]
+    # Exactly A's own, newest first, and B's published tournament is excluded.
+    assert ids == [mine_second, mine_first]
+    assert str(theirs.id) not in ids
+
+    # And B's own listing is symmetric: only B's tournament, none of A's.
+    async with _mcp_client(token_b) as client_b, client_b:
+        listed_b = await client_b.call_tool_mcp("list_my_tournaments", {})
+    assert listed_b.isError is False
+    assert listed_b.structuredContent is not None
+    ids_b = [t["id"] for t in listed_b.structuredContent["result"]]
+    assert ids_b == [str(theirs.id)]
+    assert mine_first not in ids_b
+    assert mine_second not in ids_b
+
+
+async def test_list_my_tournaments_without_view_permission_raises_tool_error(
+    db_session: AsyncSession,
+) -> None:
+    """A caller who does not hold ``tournament.view`` is refused, mirroring the
+    ``tournament.view`` gate the HTTP list enforces via ``require_view``."""
+    me = await make_user(db_session, "mcp-list-tourn-noperm")
+    raw = await _mint(db_session, me)
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="permission"):
+            await client.call_tool("list_my_tournaments", {})
+
+
+# ----- get_schedule tool ---------------------------------------------------
+
+
+async def _first_event_id(db_session: AsyncSession, tournament_id: str) -> uuid.UUID:
+    """The id of the one event ``_create_tournament`` created for this tournament."""
+    return (
+        await db_session.execute(
+            select(TournamentEvent.id).where(
+                TournamentEvent.tournament_id == uuid.UUID(tournament_id)
+            )
+        )
+    ).scalar_one()
+
+
+async def _seed_placed_fixture(
+    db_session: AsyncSession,
+    event_id: uuid.UUID,
+    *,
+    table_id: str,
+    scheduled_start: datetime,
+) -> TournamentFixture:
+    """Cut a single PLACED fixture directly: two active entrants seated on it, in a
+    pool, with a table + predicted start (a naive wall-clock time, ADR-0790). The
+    enter/cut/place routes would take several acts to reach this state; the read
+    path just needs the state itself."""
+    entry_a = TournamentEntry(
+        event_id=event_id,
+        user_id=(await make_user(db_session, "sched-a-" + uuid.uuid4().hex)).id,
+        status=TournamentEntryStatus.entered,
+    )
+    entry_b = TournamentEntry(
+        event_id=event_id,
+        user_id=(await make_user(db_session, "sched-b-" + uuid.uuid4().hex)).id,
+        status=TournamentEntryStatus.entered,
+    )
+    db_session.add_all([entry_a, entry_b])
+    await db_session.commit()
+    fixture = TournamentFixture(
+        event_id=event_id,
+        pool_id="p-os-1",
+        round=1,
+        position=1,
+        entry_a_id=entry_a.id,
+        entry_b_id=entry_b.id,
+        table_id=table_id,
+        scheduled_start=scheduled_start,
+    )
+    db_session.add(fixture)
+    await db_session.commit()
+    await db_session.refresh(fixture)
+    return fixture
+
+
+async def test_get_schedule_returns_placed_fixtures_and_latest_solve_verdict(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """A tournament with a cut, PLACED draw and a solve on its ledger: ``get_schedule``
+    groups each event's fixtures with their table + predicted start, and reports the
+    latest solve's status/verdict — the same placement + solve facts the detail BFF
+    reads, in the narrow schedule projection."""
+    me = await start_session(api_client, db_session)
+    await grant_permissions(db_session, me, [TOURNAMENT_VIEW, TOURNAMENT_CREATE])
+    raw = await _mint(db_session, me)
+    tournament_id = await _create_tournament(api_client)
+    event_id = await _first_event_id(db_session, tournament_id)
+
+    scheduled_start = datetime(2026, 8, 1, 9, 0)
+    fixture = await _seed_placed_fixture(
+        db_session, event_id, table_id="t1", scheduled_start=scheduled_start
+    )
+    # A finished solve on the ledger, so the projection carries a verdict.
+    db_session.add(
+        ScheduleSolve(
+            tournament_id=uuid.UUID(tournament_id),
+            trigger=ScheduleSolveTrigger.manual,
+            status=ScheduleSolveStatus.succeeded,
+            verdict=SolverVerdict.optimal,
+            fixtures_placed=1,
+            fixtures_pinned=0,
+        )
+    )
+    await db_session.commit()
+
+    async with _mcp_client(raw) as client, client:
+        result = await client.call_tool_mcp(
+            "get_schedule", {"tournament_id": tournament_id}
+        )
+
+    assert result.isError is False
+    body = result.structuredContent
+    assert body is not None
+    assert body["tournament_id"] == tournament_id
+    assert len(body["events"]) == 1
+    group = body["events"][0]
+    assert group["event_id"] == str(event_id)
+    assert group["name"] == "Open Singles"
+    assert len(group["fixtures"]) == 1
+    placed = group["fixtures"][0]
+    assert placed["id"] == str(fixture.id)
+    assert placed["table_id"] == "t1"
+    assert placed["scheduled_start"] == scheduled_start.isoformat()
+    assert placed["pool_id"] == "p-os-1"
+    assert placed["round"] == 1
+    assert placed["position"] == 1
+    assert body["latest_schedule_solve"]["status"] == "succeeded"
+    assert body["latest_schedule_solve"]["verdict"] == "optimal"
+
+
+async def test_get_schedule_with_no_draw_and_no_solve_is_empty(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """A tournament whose event has no cut draw and which has never been solved:
+    the event group carries ``[]`` fixtures (the designed un-cut state, ADR-0786)
+    and ``latest_schedule_solve`` is ``null``."""
+    me = await start_session(api_client, db_session)
+    await grant_permissions(db_session, me, [TOURNAMENT_VIEW, TOURNAMENT_CREATE])
+    raw = await _mint(db_session, me)
+    tournament_id = await _create_tournament(api_client)
+    event_id = await _first_event_id(db_session, tournament_id)
+
+    async with _mcp_client(raw) as client, client:
+        result = await client.call_tool_mcp(
+            "get_schedule", {"tournament_id": tournament_id}
+        )
+
+    assert result.isError is False
+    body = result.structuredContent
+    assert body is not None
+    assert body["tournament_id"] == tournament_id
+    assert len(body["events"]) == 1
+    assert body["events"][0]["event_id"] == str(event_id)
+    assert body["events"][0]["fixtures"] == []
+    assert body["latest_schedule_solve"] is None
+
+
+async def test_get_schedule_unknown_id_raises_tool_error(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """An id that matches no tournament surfaces as a ``ToolError`` at the caller."""
+    me = await start_session(api_client, db_session)
+    await grant_permissions(db_session, me, [TOURNAMENT_VIEW])
+    raw = await _mint(db_session, me)
+    unknown = str(uuid.uuid4())
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match=unknown):
+            await client.call_tool("get_schedule", {"tournament_id": unknown})
+
+
+async def test_get_schedule_hidden_draft_raises_tool_error_for_non_owner(
+    api_client: httpx.AsyncClient, db_session: AsyncSession
+) -> None:
+    """A draft the caller does not own is not theirs to see: even holding
+    ``tournament.view``, an outsider gets the same not-found ``ToolError`` an absent
+    id would — the same visibility gate ``get_tournament`` and the HTTP detail read
+    keep."""
+    owner = await start_session(api_client, db_session)
+    await grant_permissions(db_session, owner, [TOURNAMENT_VIEW, TOURNAMENT_CREATE])
+    tournament_id = await _create_tournament(api_client)  # born ``draft``
+
+    outsider = await make_user(db_session, "mcp-sched-outsider")
+    await grant_permissions(db_session, outsider, [TOURNAMENT_VIEW])
+    outsider_token = await _mint(db_session, outsider)
+
+    async with _mcp_client(outsider_token) as client, client:
+        with pytest.raises(ToolError, match=tournament_id):
+            await client.call_tool("get_schedule", {"tournament_id": tournament_id})
+
+
+async def test_get_schedule_without_view_permission_raises_tool_error(
+    db_session: AsyncSession,
+) -> None:
+    """A caller who does not hold ``tournament.view`` is refused before any row is
+    loaded — the same gate the HTTP detail read's ``require_view`` dependency
+    enforces."""
+    me = await make_user(db_session, "mcp-sched-noperm")
+    raw = await _mint(db_session, me)
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="permission"):
+            await client.call_tool("get_schedule", {"tournament_id": str(uuid.uuid4())})

--- a/api/tests/test_tournament_draw_service.py
+++ b/api/tests/test_tournament_draw_service.py
@@ -1,0 +1,430 @@
+"""Service-layer tests for the transport-neutral cut / un-cut draw verbs.
+
+These drive ``app.tournament_draw_service.cut_event_draw`` /
+``uncut_event_draw`` directly with a raw ``db_session`` and no FastAPI — proving
+the write path (row-locked owner gate, event-under-tournament load, play-evidence
+gate, the ``cut_draw`` / ``uncut_draw`` core) runs, persists, and signals every
+refusal with a **domain exception** from ``app.tournament_errors`` (or lets the
+``app.draws.DrawError`` family propagate unchanged) rather than an
+``HTTPException``. The HTTP wire contract those exceptions map back to is pinned
+by the unchanged endpoint tests in ``test_tournaments.py`` (``-k draw``); this
+file is the branch matrix behind them.
+"""
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.draws import NonSinglesDraw, UnsupportedDrawType
+from app.models import (
+    League,
+    Tournament,
+    TournamentEntry,
+    TournamentEntryStatus,
+    TournamentEvent,
+    TournamentFixture,
+    TournamentStatus,
+    User,
+)
+from app.models.tournament import DrawType, EventFormat
+from app.tournament_draw_service import cut_event_draw, uncut_event_draw
+from app.tournament_errors import (
+    DrawUnderWayError,
+    EventNotFoundError,
+    NotTournamentOwnerError,
+    TournamentNotFoundError,
+)
+from tests._helpers import make_user
+
+# Two pools, so the snake has somewhere to snake to and a fixture's ``pool_id`` is a
+# ref that resolves against the right one — the same shape ``test_tournaments.py``'s
+# draw tests cut across.
+POOL_A: dict[str, object] = {
+    "id": "p-a",
+    "name": "Pool A",
+    "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+    "table_ids": ["t1"],
+}
+POOL_B: dict[str, object] = {
+    "id": "p-b",
+    "name": "Pool B",
+    "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+    "table_ids": ["t2"],
+}
+
+
+async def _make_tournament(
+    db: AsyncSession,
+    *,
+    owner: User,
+    league: League,
+) -> Tournament:
+    tournament = Tournament(
+        name="Bay Area Open 2026",
+        description="Two-day open.",
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "2727 Milvia St",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94703",
+            "country": "USA",
+        },
+        table_catalogue=[
+            {"id": "t1", "label": "Table 1", "court": "A"},
+            {"id": "t2", "label": "Table 2", "court": "A"},
+        ],
+        league_id=league.id,
+        created_by_user_id=owner.id,
+        status=TournamentStatus.draft,
+    )
+    db.add(tournament)
+    await db.commit()
+    await db.refresh(tournament)
+    return tournament
+
+
+async def _make_event(
+    db: AsyncSession,
+    tournament: Tournament,
+    *,
+    format: EventFormat = EventFormat.singles,
+    draw_type: DrawType = DrawType.round_robin,
+    pools: list[dict[str, object]] | None = None,
+) -> TournamentEvent:
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Open Singles",
+        format=format,
+        draw_type=draw_type,
+        max_players=64,
+        entry_fee=Decimal("45"),
+        slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
+        match_settings={"rated": True, "length_games": 5},
+        predicates=[],
+        pools=[POOL_A, POOL_B] if pools is None else pools,
+    )
+    db.add(event)
+    await db.commit()
+    await db.refresh(event)
+    return event
+
+
+async def _enter_field(
+    db: AsyncSession, event: TournamentEvent, count: int, *, prefix: str
+) -> list[TournamentEntry]:
+    """``count`` active, seeded (1..N) entrants — enough for the round-robin snake to
+    deal a clean draw across the two pools."""
+    entries = [
+        TournamentEntry(
+            event_id=event.id,
+            user_id=(await make_user(db, f"{prefix}{n}")).id,
+            status=TournamentEntryStatus.entered,
+            seed=n,
+        )
+        for n in range(1, count + 1)
+    ]
+    db.add_all(entries)
+    await db.commit()
+    return entries
+
+
+async def _fixture_rows(
+    db: AsyncSession, event_id: uuid.UUID
+) -> list[TournamentFixture]:
+    db.expire_all()
+    return list(
+        (
+            await db.execute(
+                select(TournamentFixture).where(TournamentFixture.event_id == event_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+# ----- the owner cuts a singles event: fixtures are created + persisted ------
+
+
+async def test_owner_cut_creates_and_persists_fixtures(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-cut")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event = await _make_event(db_session, tournament)
+    # Capture PKs before the verb commits — the commit expires the ORM objects, so
+    # reading their ids afterwards would trigger a sync lazy-load in async land.
+    tournament_id, event_id = tournament.id, event.id
+    await _enter_field(db_session, event, 4, prefix="cut")
+    await db_session.refresh(owner)
+
+    result = await cut_event_draw(
+        db_session, tournament_id=tournament_id, event_id=event_id, actor=owner
+    )
+
+    # Four singles over two pools: 2 apiece, one round-robin fixture in each pool.
+    assert len(result) == 2
+    rows = await _fixture_rows(db_session, event_id)
+    # The verb answers with the persisted draw — same rows, same ids.
+    assert {f.id for f in result} == {r.id for r in rows}
+    # Every fixture seats two known entrants, none played.
+    assert all(
+        r.entry_a_id is not None
+        and r.entry_b_id is not None
+        and r.winner_entry_id is None
+        and r.match_id is None
+        for r in rows
+    )
+
+
+# ----- a re-cut on a drawn-but-unplayed event replaces wholesale -------------
+
+
+async def test_recut_of_an_unplayed_draw_replaces_wholesale(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-recut")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event = await _make_event(db_session, tournament)
+    tournament_id, event_id = tournament.id, event.id
+    await _enter_field(db_session, event, 4, prefix="recut")
+
+    await db_session.refresh(owner)
+    first = await cut_event_draw(
+        db_session, tournament_id=tournament_id, event_id=event_id, actor=owner
+    )
+    first_ids = {f.id for f in first}
+
+    await db_session.refresh(owner)
+    second = await cut_event_draw(
+        db_session, tournament_id=tournament_id, event_id=event_id, actor=owner
+    )
+    second_ids = {f.id for f in second}
+
+    # Wholesale, not a reconcile: the old rows were deleted and a fresh set minted,
+    # so no id survives, and the event holds exactly the second draw.
+    assert first_ids.isdisjoint(second_ids)
+    rows = await _fixture_rows(db_session, event_id)
+    assert {r.id for r in rows} == second_ids
+
+
+# ----- evidence of play refuses both a re-cut and an un-cut ------------------
+
+
+@pytest.mark.parametrize("verb", [cut_event_draw, uncut_event_draw])
+async def test_a_played_draw_refuses_recut_and_uncut(
+    db_session: AsyncSession,
+    default_league: League,
+    verb: object,
+) -> None:
+    owner = await make_user(db_session, "owner-played")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event = await _make_event(db_session, tournament)
+    tournament_id, event_id = tournament.id, event.id
+    await _enter_field(db_session, event, 4, prefix="played")
+
+    await db_session.refresh(owner)
+    await cut_event_draw(
+        db_session, tournament_id=tournament_id, event_id=event_id, actor=owner
+    )
+
+    # Record a winner on one fixture — evidence of play (``draw_has_play``): a re-cut
+    # or an un-cut would throw away a result a player produced.
+    rows = await _fixture_rows(db_session, event_id)
+    rows[0].winner_entry_id = rows[0].entry_a_id
+    await db_session.commit()
+    before = {r.id for r in await _fixture_rows(db_session, event_id)}
+
+    await db_session.refresh(owner)
+    with pytest.raises(DrawUnderWayError):
+        await verb(  # type: ignore[operator]  # parametrized over the two verbs
+            db_session, tournament_id=tournament_id, event_id=event_id, actor=owner
+        )
+
+    # The refusal is asked before anything is deleted, so the standing draw is intact.
+    assert {r.id for r in await _fixture_rows(db_session, event_id)} == before
+
+
+# ----- an event that cannot produce a draw raises the DrawError family -------
+
+
+async def test_a_non_singles_event_raises_non_singles_draw(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-doubles")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event = await _make_event(db_session, tournament, format=EventFormat.doubles)
+    tournament_id, event_id = tournament.id, event.id
+    await _enter_field(db_session, event, 4, prefix="doubles")
+
+    await db_session.refresh(owner)
+    with pytest.raises(NonSinglesDraw):
+        await cut_event_draw(
+            db_session, tournament_id=tournament_id, event_id=event_id, actor=owner
+        )
+
+    # Refused before the DELETE, so nothing was written.
+    assert await _fixture_rows(db_session, event_id) == []
+
+
+async def test_an_unimplemented_draw_type_raises_unsupported_draw_type(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-rrko")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    # ``rr-then-ko`` has no generator today (ADR-0786): the strategy is chosen before
+    # the field is read, so this is refused whatever the entrants.
+    event = await _make_event(db_session, tournament, draw_type=DrawType.rr_then_ko)
+    tournament_id, event_id = tournament.id, event.id
+    await _enter_field(db_session, event, 4, prefix="rrko")
+
+    await db_session.refresh(owner)
+    with pytest.raises(UnsupportedDrawType):
+        await cut_event_draw(
+            db_session, tournament_id=tournament_id, event_id=event_id, actor=owner
+        )
+
+    assert await _fixture_rows(db_session, event_id) == []
+
+
+# ----- un-cut removes the fixtures -------------------------------------------
+
+
+async def test_uncut_removes_the_fixtures(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-uncut")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event = await _make_event(db_session, tournament)
+    tournament_id, event_id = tournament.id, event.id
+    await _enter_field(db_session, event, 4, prefix="uncut")
+
+    await db_session.refresh(owner)
+    await cut_event_draw(
+        db_session, tournament_id=tournament_id, event_id=event_id, actor=owner
+    )
+    assert await _fixture_rows(db_session, event_id) != []
+
+    await db_session.refresh(owner)
+    result = await uncut_event_draw(
+        db_session, tournament_id=tournament_id, event_id=event_id, actor=owner
+    )
+
+    assert result is None
+    assert await _fixture_rows(db_session, event_id) == []
+
+
+async def test_uncut_of_a_never_cut_draw_is_a_no_op(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """An event with no draw is already in the state the un-cut asks for — deleting
+    nothing is a success, not a 404 (the router answers 204 either way)."""
+    owner = await make_user(db_session, "owner-idem")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event = await _make_event(db_session, tournament)
+    tournament_id, event_id = tournament.id, event.id
+
+    result = await uncut_event_draw(
+        db_session, tournament_id=tournament_id, event_id=event_id, actor=owner
+    )
+
+    assert result is None
+    assert await _fixture_rows(db_session, event_id) == []
+
+
+# ----- a non-owner is refused with a domain exception -----------------------
+
+
+@pytest.mark.parametrize("verb", [cut_event_draw, uncut_event_draw])
+async def test_a_non_owner_is_refused(
+    db_session: AsyncSession,
+    default_league: League,
+    verb: object,
+) -> None:
+    owner = await make_user(db_session, "owner-guard")
+    stranger = await make_user(db_session, "stranger-guard")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event = await _make_event(db_session, tournament)
+    tournament_id, event_id = tournament.id, event.id
+    await _enter_field(db_session, event, 4, prefix="guard")
+
+    with pytest.raises(NotTournamentOwnerError):
+        await verb(  # type: ignore[operator]  # parametrized over the two verbs
+            db_session,
+            tournament_id=tournament_id,
+            event_id=event_id,
+            actor=stranger,
+        )
+
+    # The ownership gate is asked before the draw's own state, so nothing changed.
+    assert await _fixture_rows(db_session, event_id) == []
+
+
+# ----- a missing tournament / event raises the 404-domain exception ---------
+
+
+async def test_a_missing_tournament_raises_not_found(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-missing-t")
+
+    with pytest.raises(TournamentNotFoundError):
+        await cut_event_draw(
+            db_session,
+            tournament_id=uuid.uuid4(),
+            event_id=uuid.uuid4(),
+            actor=owner,
+        )
+
+
+async def test_a_missing_event_raises_event_not_found(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-missing-e")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+    await db_session.refresh(owner)
+
+    with pytest.raises(EventNotFoundError):
+        await cut_event_draw(
+            db_session,
+            tournament_id=tournament_id,
+            event_id=uuid.uuid4(),
+            actor=owner,
+        )
+
+
+async def test_an_event_under_the_wrong_tournament_raises_event_not_found(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A right event id under the wrong tournament id is a miss, not a
+    cross-tournament draw — the event is scoped by both ids."""
+    owner = await make_user(db_session, "owner-cross")
+    other_owner = await make_user(db_session, "owner-cross-other")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+    other = await _make_tournament(db_session, owner=other_owner, league=default_league)
+    event = await _make_event(db_session, other)
+    event_id = event.id
+    await db_session.refresh(owner)
+
+    with pytest.raises(EventNotFoundError):
+        await cut_event_draw(
+            db_session,
+            tournament_id=tournament_id,
+            event_id=event_id,
+            actor=owner,
+        )

--- a/api/tests/test_tournament_edit.py
+++ b/api/tests/test_tournament_edit.py
@@ -1,0 +1,368 @@
+"""Service-layer tests for the transport-neutral ``edit_tournament`` verb.
+
+These drive ``app.tournament_edit.edit_tournament`` directly with a raw
+``db_session`` and no FastAPI — proving the write path (owner gate, league
+state-rule, STRICT league lookup, table-catalogue → re-solve) runs, persists,
+and signals every refusal with a **domain exception** from
+``app.tournament_errors`` rather than an ``HTTPException``. The HTTP wire contract
+those exceptions map back to is pinned by the unchanged endpoint tests in
+``test_tournaments.py``; this file is the branch matrix behind them.
+"""
+
+import uuid
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    League,
+    LeagueVisibility,
+    RatingStrategy,
+    ScheduleSolve,
+    ScheduleSolveStatus,
+    ScheduleSolveTrigger,
+    Tournament,
+    TournamentEvent,
+    TournamentFixture,
+    TournamentStatus,
+    User,
+)
+from app.models.tournament import DrawType, EventFormat
+from app.schemas.tournament import Address, TournamentTable, TournamentUpdate
+from app.tournament_edit import edit_tournament
+from app.tournament_errors import (
+    LeagueNotEditableError,
+    LeagueNotFoundError,
+    NotTournamentOwnerError,
+    TournamentNotFoundError,
+)
+from tests._helpers import make_user
+
+
+@pytest_asyncio.fixture
+async def other_league(
+    db_session: AsyncSession, rating_strategies: dict[str, RatingStrategy]
+) -> League:
+    """A second, non-default league — so "moved to the league the caller named"
+    is distinguishable from "carries the default, always" (the two ids differ).
+    Mirrors the fixture of the same name in ``test_tournaments.py``."""
+    league = League(
+        name="Bay Area Ladder",
+        description="A second ladder. Not the default.",
+        visibility=LeagueVisibility.public,
+        is_default=False,
+        rating_strategy_id=rating_strategies["glicko2"].id,
+    )
+    db_session.add(league)
+    await db_session.commit()
+    return league
+
+
+def _address() -> dict[str, str]:
+    return {
+        "venue": "Berkeley TT Club",
+        "street": "2727 Milvia St",
+        "city": "Berkeley",
+        "region": "CA",
+        "postal": "94703",
+        "country": "USA",
+    }
+
+
+async def _make_tournament(
+    db: AsyncSession,
+    *,
+    owner: User,
+    league: League,
+    status: TournamentStatus = TournamentStatus.draft,
+    table_catalogue: list[dict[str, str]] | None = None,
+) -> Tournament:
+    tournament = Tournament(
+        name="Bay Area Open 2026",
+        description="Two-day open.",
+        address=_address(),
+        table_catalogue=table_catalogue
+        or [
+            {"id": "t1", "label": "Table 1", "court": "A"},
+            {"id": "t2", "label": "Table 2", "court": "A"},
+        ],
+        league_id=league.id,
+        created_by_user_id=owner.id,
+        status=status,
+    )
+    db.add(tournament)
+    await db.commit()
+    await db.refresh(tournament)
+    return tournament
+
+
+async def _draw_an_event(db: AsyncSession, tournament: Tournament) -> None:
+    """Give the tournament one event with one cut fixture, so
+    ``tournament_has_drawn_event`` answers True."""
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Open Singles",
+        format=EventFormat.singles,
+        draw_type=DrawType.rr_then_ko,
+        max_players=64,
+        entry_fee=Decimal("45"),
+        slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
+        match_settings={"rated": True, "length_games": 5},
+        predicates=[],
+        pools=[],
+    )
+    db.add(event)
+    await db.flush()
+    db.add(TournamentFixture(event_id=event.id, pool_id=None, round=1, position=1))
+    await db.commit()
+
+
+async def _persisted_league_id(db: AsyncSession, tournament_id: uuid.UUID) -> uuid.UUID:
+    return (
+        (await db.execute(select(Tournament).where(Tournament.id == tournament_id)))
+        .scalar_one()
+        .league_id
+    )
+
+
+async def _queued_solves(
+    db: AsyncSession, tournament_id: uuid.UUID
+) -> list[ScheduleSolve]:
+    db.expire_all()
+    return list(
+        (
+            await db.execute(
+                select(ScheduleSolve).where(
+                    ScheduleSolve.tournament_id == tournament_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+# ----- owner edit succeeds + persists ---------------------------------------
+
+
+async def test_owner_edit_updates_and_persists(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-edit")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    # Capture the PK before the verb commits — the commit expires ``tournament``,
+    # so reading ``tournament.id`` afterwards would trigger a sync lazy-load.
+    tournament_id = tournament.id
+
+    new_address = {**_address(), "venue": "Palo Alto Community Center"}
+    result = await edit_tournament(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        updates=TournamentUpdate(
+            name="Bay Area Major",
+            address=Address(**new_address),
+        ),
+    )
+
+    assert result.name == "Bay Area Major"
+    assert result.address == new_address
+    # The edit does not touch the lifecycle.
+    assert result.status is TournamentStatus.draft
+
+    # Persisted on the row, not merely returned.
+    db_session.expire_all()
+    row = (
+        await db_session.execute(
+            select(Tournament).where(Tournament.id == tournament_id)
+        )
+    ).scalar_one()
+    assert row.name == "Bay Area Major"
+    assert row.address == new_address
+
+
+# ----- non-owner is refused with a domain exception -------------------------
+
+
+async def test_non_owner_raises_not_owner(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-guard")
+    stranger = await make_user(db_session, "stranger")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+
+    with pytest.raises(NotTournamentOwnerError):
+        await edit_tournament(
+            db_session,
+            tournament_id=tournament_id,
+            actor=stranger,
+            updates=TournamentUpdate(name="Hijack"),
+        )
+
+    # Nothing was written.
+    db_session.expire_all()
+    row = (
+        await db_session.execute(
+            select(Tournament).where(Tournament.id == tournament_id)
+        )
+    ).scalar_one()
+    assert row.name == "Bay Area Open 2026"
+
+
+async def test_missing_tournament_raises_not_found(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-missing")
+
+    with pytest.raises(TournamentNotFoundError):
+        await edit_tournament(
+            db_session,
+            tournament_id=uuid.uuid4(),
+            actor=owner,
+            updates=TournamentUpdate(name="Nowhere"),
+        )
+
+
+# ----- league state-rule and STRICT lookup ----------------------------------
+
+
+async def test_league_change_while_draft_moves_the_ladder(
+    db_session: AsyncSession,
+    default_league: League,
+    other_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-league-draft")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+
+    result = await edit_tournament(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        updates=TournamentUpdate(league_id=other_league.id),
+    )
+
+    assert result.league_id == other_league.id
+    assert await _persisted_league_id(db_session, tournament_id) == other_league.id
+
+
+@pytest.mark.parametrize(
+    "status",
+    [TournamentStatus.published, TournamentStatus.live, TournamentStatus.archived],
+    ids=lambda s: s.value,
+)
+async def test_league_change_after_publish_raises_not_editable(
+    db_session: AsyncSession,
+    default_league: League,
+    other_league: League,
+    status: TournamentStatus,
+) -> None:
+    owner = await make_user(db_session, f"owner-league-{status.value}")
+    tournament = await _make_tournament(
+        db_session, owner=owner, league=default_league, status=status
+    )
+    tournament_id = tournament.id
+
+    with pytest.raises(LeagueNotEditableError) as excinfo:
+        await edit_tournament(
+            db_session,
+            tournament_id=tournament_id,
+            actor=owner,
+            updates=TournamentUpdate(league_id=other_league.id),
+        )
+
+    # Carries the current status, so the HTTP adapter can rebuild the exact 409
+    # body (and the message the adapter sends is `status.value` verbatim).
+    assert excinfo.value.status == status.value
+    assert status.value in str(excinfo.value)
+    # The ladder did not move.
+    assert await _persisted_league_id(db_session, tournament_id) == default_league.id
+
+
+async def test_league_that_names_no_league_raises_not_found(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    owner = await make_user(db_session, "owner-bad-league")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+
+    with pytest.raises(LeagueNotFoundError):
+        await edit_tournament(
+            db_session,
+            tournament_id=tournament_id,
+            actor=owner,
+            updates=TournamentUpdate(league_id=uuid.uuid4()),
+        )
+
+    # The STRICT lookup did not silently swap the ladder to the default.
+    assert await _persisted_league_id(db_session, tournament_id) == default_league.id
+
+
+# ----- table-catalogue change on a drawn tournament requests a solve --------
+
+
+async def test_table_catalogue_change_on_a_drawn_tournament_requests_a_solve(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """Re-identifying a table changes the solver's inputs, and the tournament has a
+    cut draw, so the edit queues a ``settings_changed`` solve in the same
+    transaction."""
+    owner = await make_user(db_session, "owner-solve")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+    await _draw_an_event(db_session, tournament)
+
+    assert await _queued_solves(db_session, tournament_id) == []
+
+    # The intervening commits (draw + the solve-ledger read) expired ``owner``;
+    # a real request holds a freshly-loaded ``current_user``, so refresh it back
+    # to a loaded state before handing it to the verb.
+    await db_session.refresh(owner)
+    await edit_tournament(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        updates=TournamentUpdate(
+            table_catalogue=[
+                TournamentTable(id="t1", label="Table 1", court="A"),
+                TournamentTable(id="t3", label="Table 3", court="B"),
+            ]
+        ),
+    )
+
+    (solve,) = await _queued_solves(db_session, tournament_id)
+    assert solve.trigger is ScheduleSolveTrigger.settings_changed
+    assert solve.status is ScheduleSolveStatus.queued
+
+
+async def test_table_catalogue_change_without_a_draw_requests_no_solve(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """With no cut draw there is nothing to place, so the same catalogue change
+    queues no solve — the drawn-event gate, verified from the negative side."""
+    owner = await make_user(db_session, "owner-nosolve")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+
+    await edit_tournament(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        updates=TournamentUpdate(
+            table_catalogue=[
+                TournamentTable(id="t9", label="Table 9", court="C"),
+            ]
+        ),
+    )
+
+    assert await _queued_solves(db_session, tournament_id) == []

--- a/api/tests/test_tournament_solve_service.py
+++ b/api/tests/test_tournament_solve_service.py
@@ -1,0 +1,262 @@
+"""The transport-neutral request-schedule-solve verb
+(``app.tournament_solve_service.request_schedule_solve``) — the FastAPI-free core
+the Run-scheduler route (and, later, an MCP tool) drives, exercised here directly
+against ``db_session`` with no HTTP layer.
+
+These prove the refusals and the coalescing at the *service* seam: the route tests
+(``tests/test_schedule_solve_route.py``) then prove the HTTP adapter maps each
+domain exception back to the exact status + body the wire contract promises.
+
+Under conftest's autouse **synchronous** fake queue, the enqueued job runs inline
+at enqueue time — before this verb commits — opens its own engine (pointed at the
+test database by the ``_job_database`` fixture below), finds no committed ``queued``
+row, and exits as stale. So a request lands its row committed as ``queued``, exactly
+what a real client sees the instant the 202 lands.
+"""
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from redis.exceptions import RedisError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import queue as queue_module
+from app.leagues import get_default_league
+from app.models import (
+    DrawType,
+    EventFormat,
+    ScheduleSolve,
+    ScheduleSolveStatus,
+    ScheduleSolveTrigger,
+    Tournament,
+    TournamentEntry,
+    TournamentEvent,
+    TournamentStatus,
+    User,
+)
+from app.tournament_draws import cut_draw
+from app.tournament_errors import (
+    NoDrawnEventsError,
+    NotTournamentOwnerError,
+    ScheduleQueueUnavailableError,
+    TournamentNotFoundError,
+)
+from app.tournament_solve_service import request_schedule_solve
+from tests._helpers import make_user
+
+DATE = "2030-01-01"
+
+
+@pytest.fixture(autouse=True)
+def _job_database(monkeypatch: pytest.MonkeyPatch, postgres_url: str) -> None:
+    """The inline solve job (conftest's sync fake queue) opens its own engine
+    from ``DATABASE_URL``; point it at the test database so it reads the same
+    Postgres as the test rather than failing to connect."""
+    monkeypatch.setenv("DATABASE_URL", postgres_url)
+
+
+async def _make_tournament(
+    db: AsyncSession,
+    *,
+    with_event: bool = True,
+    cut: bool = True,
+    entrants: int = 4,
+    tables: tuple[str, ...] = ("t1", "t2"),
+) -> tuple[uuid.UUID, User]:
+    """A published tournament and its owner: a two-table catalogue and (unless
+    ``with_event=False``) one pooled round-robin event whose single pool spans
+    both tables, ``entrants`` entered players, and (unless ``cut=False``) a cut
+    draw. Written straight to the database — creation routes are not under test
+    here. Returns ``(tournament_id, owner)``."""
+    owner = await make_user(db, f"director-{uuid.uuid4().hex[:8]}")
+    league = await get_default_league(db)
+    assert league is not None, "the autouse default_league fixture seeds this"
+
+    tournament = Tournament(
+        name="Scheduled Open",
+        status=TournamentStatus.published,
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "1 Shattuck Ave",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94704",
+            "country": "USA",
+        },
+        table_catalogue=[
+            {"id": table, "label": table.upper(), "court": "Main"} for table in tables
+        ],
+        league_id=league.id,
+        created_by_user_id=owner.id,
+    )
+    db.add(tournament)
+    await db.flush()
+
+    if not with_event:
+        await db.commit()
+        return tournament.id, owner
+
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Open Singles",
+        format=EventFormat.singles,
+        draw_type=DrawType.round_robin,
+        max_players=None,
+        entry_fee=Decimal("0.00"),
+        slot={"date": DATE, "start": "09:00", "end": "17:00"},
+        match_settings={"rated": False, "length_games": 3},
+        pools=[
+            {
+                "id": "pool-a",
+                "name": "Pool A",
+                "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
+                "table_ids": list(tables),
+            }
+        ],
+    )
+    db.add(event)
+    await db.flush()
+
+    for _ in range(entrants):
+        player = await make_user(db, f"player-{uuid.uuid4().hex[:8]}")
+        db.add(TournamentEntry(event_id=event.id, user_id=player.id))
+    await db.flush()
+
+    if cut:
+        await cut_draw(db, event)
+    await db.commit()
+    return tournament.id, owner
+
+
+async def _solve_rows(
+    db: AsyncSession, tournament_id: uuid.UUID
+) -> list[ScheduleSolve]:
+    return list(
+        (
+            await db.execute(
+                select(ScheduleSolve)
+                .where(ScheduleSolve.tournament_id == tournament_id)
+                .order_by(ScheduleSolve.requested_at, ScheduleSolve.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def test_owner_requests_a_solve_on_a_drawn_tournament(
+    db_session: AsyncSession,
+) -> None:
+    """The happy path: the owner of a tournament with a cut draw gets a freshly
+    queued ``manual`` ledger row, and it is the one and only row on the ledger."""
+    tournament_id, owner = await _make_tournament(db_session)
+
+    row = await request_schedule_solve(
+        db_session, tournament_id=tournament_id, actor=owner
+    )
+
+    assert row.status is ScheduleSolveStatus.queued
+    assert row.trigger is ScheduleSolveTrigger.manual
+    assert row.requested_at is not None
+    (persisted,) = await _solve_rows(db_session, tournament_id)
+    assert persisted.id == row.id
+
+
+async def test_a_second_request_in_flight_coalesces_onto_the_same_row(
+    db_session: AsyncSession,
+) -> None:
+    """One solve in flight per tournament: a second request while a run is queued
+    is absorbed by it — the same row comes back and exactly one ``queued`` row
+    exists, nothing double-queued."""
+    tournament_id, owner = await _make_tournament(db_session)
+
+    first = await request_schedule_solve(
+        db_session, tournament_id=tournament_id, actor=owner
+    )
+    second = await request_schedule_solve(
+        db_session, tournament_id=tournament_id, actor=owner
+    )
+
+    assert second.id == first.id
+    assert second.status is ScheduleSolveStatus.queued
+    (row,) = await _solve_rows(db_session, tournament_id)
+    assert row.id == first.id
+
+
+async def test_no_drawn_event_is_refused(db_session: AsyncSession) -> None:
+    """A tournament whose only event has no cut draw has nothing the solver can
+    place: :class:`NoDrawnEventsError`, and nothing lands on the ledger."""
+    tournament_id, owner = await _make_tournament(db_session, cut=False)
+
+    with pytest.raises(NoDrawnEventsError):
+        await request_schedule_solve(
+            db_session, tournament_id=tournament_id, actor=owner
+        )
+
+    assert await _solve_rows(db_session, tournament_id) == []
+
+
+async def test_a_tournament_with_no_events_is_refused(
+    db_session: AsyncSession,
+) -> None:
+    """The same refusal for a tournament with no events at all — nothing drawn is
+    nothing drawn, whatever the arity."""
+    tournament_id, owner = await _make_tournament(db_session, with_event=False)
+
+    with pytest.raises(NoDrawnEventsError):
+        await request_schedule_solve(
+            db_session, tournament_id=tournament_id, actor=owner
+        )
+
+    assert await _solve_rows(db_session, tournament_id) == []
+
+
+async def test_a_non_owner_is_refused(db_session: AsyncSession) -> None:
+    """Running the scheduler is owner-gated: a stranger — even a fully-permitted
+    platform user — is refused with :class:`NotTournamentOwnerError` before the
+    draw's state is even looked at, and nothing lands on the ledger."""
+    tournament_id, _owner = await _make_tournament(db_session)
+    stranger = await make_user(db_session, f"stranger-{uuid.uuid4().hex[:8]}")
+
+    with pytest.raises(NotTournamentOwnerError):
+        await request_schedule_solve(
+            db_session, tournament_id=tournament_id, actor=stranger
+        )
+
+    assert await _solve_rows(db_session, tournament_id) == []
+
+
+async def test_a_missing_tournament_is_refused(db_session: AsyncSession) -> None:
+    """An id that resolves to no row raises :class:`TournamentNotFoundError` — the
+    404 the adapter maps it to, before ownership is even a question."""
+    stranger = await make_user(db_session, f"stranger-{uuid.uuid4().hex[:8]}")
+
+    with pytest.raises(TournamentNotFoundError):
+        await request_schedule_solve(
+            db_session, tournament_id=uuid.uuid4(), actor=stranger
+        )
+
+
+async def test_queue_down_is_refused_and_no_row_survives(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the enqueue cannot be placed (Redis down), ``request_solve`` takes its
+    row back out and this verb raises :class:`ScheduleQueueUnavailableError` rather
+    than returning ``None`` — and nothing is left on the ledger (no zombie row that
+    would absorb every later trigger while no job ever runs)."""
+    tournament_id, owner = await _make_tournament(db_session)
+
+    class _DeadQueue:
+        def enqueue(self, *args: object, **kwargs: object) -> None:
+            raise RedisError("redis is down")
+
+    monkeypatch.setattr(queue_module, "get_queue", lambda: _DeadQueue())
+
+    with pytest.raises(ScheduleQueueUnavailableError):
+        await request_schedule_solve(
+            db_session, tournament_id=tournament_id, actor=owner
+        )
+
+    assert await _solve_rows(db_session, tournament_id) == []

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -4644,7 +4644,14 @@ async def test_a_draw_error_nobody_wrote_copy_for_refuses_without_leaking_its_me
             "tournament_fixtures.pool_id='p-a' has a NULL seat at (round=2, position=1)"
         )
 
-    monkeypatch.setattr("app.tournaments.cut_draw", _raise_an_unknown_draw_error)
+    # The ``cut_draw`` core call moved onto the transport-neutral draw verb
+    # (``app.tournament_draw_service``); the HTTP handler is now a thin adapter over
+    # it. Patch the seam where the call now lives — the assertion (an unknown
+    # ``DrawError`` subclass gets the generic 422, leaking none of its message) is
+    # unchanged; only the location of the function being forced to raise moved.
+    monkeypatch.setattr(
+        "app.tournament_draw_service.cut_draw", _raise_an_unknown_draw_error
+    )
 
     response = await client.post(_draw_url(tournament_id, event["id"]))
 

--- a/docs/adr/20260719-tournament-verbs-are-shared-functions-behind-http-and-mcp-adapters.md
+++ b/docs/adr/20260719-tournament-verbs-are-shared-functions-behind-http-and-mcp-adapters.md
@@ -1,0 +1,157 @@
+# Tournament read/write verbs are shared functions behind HTTP and MCP adapters
+
+Date: 2026-07-19 (date-numbered — sequential numbers collide across concurrent
+worktrees; see ADR-0788's note and the duplicate 0915s in this directory)
+
+## Status
+
+Accepted — decided before implementation, from a described goal ("add MCP tools
+for some tournament functionality: get a tournament, edit a tournament, build a
+cut, run a simulation, get a schedule"). No issue number yet. Builds directly on
+**the match-flow MCP ADR** (`20260718-the-match-flow-is-shared-services-behind-http-and-mcp-adapters.md`)
+— this is that same pattern applied to the tournament domain — and reuses the
+opaque `context="api"` bearer auth from **PR #1130/#1131**.
+
+## Context
+
+We want an agent to drive part of the tournament flow over the existing MCP
+server (`api/app/mcp_server.py`, mounted at `/mcp`), the same way it already
+drives the match flow. The five requested verbs, once mapped onto what the
+codebase actually has, are:
+
+1. **Get a tournament** — the BFF detail read `GET /v1/tournaments/{id}`
+   (`get_tournament`, `tournaments.py:917`), returning `TournamentDetailRead`.
+2. **Edit a tournament** — `PATCH /v1/tournaments/{id}` (`update_tournament`,
+   `tournaments.py:999`), request `TournamentUpdate`, owner-gated.
+3. **Build a cut** — `POST /v1/tournaments/{id}/events/{event_id}/draw`
+   (`cut_event_draw`, `tournaments.py:2484`), which **cuts a draw**: generates an
+   event's **fixtures** from its entrants (`cut_draw`, `tournament_draws.py:356`).
+   Its inverse — **uncut** — is `DELETE .../draw` (`uncut_draw`).
+4. **Run a simulation** — there is **no "simulation"** in this domain. The
+   nearest — and the intended — capability is running the **scheduler**: request
+   a **solve** via `POST /v1/tournaments/{id}/schedule/solves`
+   (`request_schedule_solve`, `tournaments.py:2862` → `request_solve`,
+   `schedule_solves.py:273`), the CP-SAT job that computes *when and where*
+   matches play. See the **Solve** glossary entry (`CONTEXT.md`): a solve is not
+   a what-if projection of outcomes.
+5. **Get a schedule** — there is **deliberately no** `GET .../schedule` endpoint;
+   the schedule (each event's fixtures with their **placement**, plus the latest
+   **solve**) rides the detail BFF (`tournaments.py:2614-2631`).
+
+Two structural facts make this unlike the match flow:
+
+- **The domain cores are already extracted.** `cut_draw` / `uncut_draw`
+  (`tournament_draws.py`) and `request_solve` (`schedule_solves.py`) are already
+  standalone, FastAPI-free functions. What is *not* extracted is the per-handler
+  **glue** around them: owner-gating (`_require_owner`), the `FOR UPDATE`
+  load-lock (`_get_tournament_for_update_or_404`), and the machine-readable
+  **refusal codes** (`_draw_refusal`, `_no_drawn_events_refusal`). There is no
+  `TournamentService` class; `tournaments.py` is a ~2,900-line router.
+- **Writes are owner-gated, not RBAC-gated.** Every tournament mutation checks
+  `created_by_user_id == current_user.id`; reads require the `tournament.view`
+  permission plus a `_visible_to` visibility filter.
+
+## Decision
+
+### The three write verbs get transport-neutral shared functions; HTTP handlers become adapters
+
+For just these three paths (edit, cut/uncut, request-solve) — **not** the whole
+router — the owner-check + load-lock + refusal-raising orchestration is extracted
+into transport-neutral functions that raise **domain exceptions** (never
+`HTTPException`), constructible with a raw session. The existing HTTP handlers
+are refactored into thin adapters that call these functions and map each domain
+exception to the **exact status code and body they produce today** — the wire
+contract does not move a byte, and the existing endpoint tests are the proof. The
+MCP tools call the same functions and map the same exceptions to actionable
+`ToolError`s.
+
+Rejected: **replicating the glue inside `mcp_server.py`** (calling the
+already-shared `cut_draw` / `request_solve` cores directly and re-implementing
+owner-check + refusal mapping there). It is faster and leaves the handlers
+untouched, but it puts the owner/refusal logic in two places — the precise drift
+the match-flow ADR exists to prevent. We are following that ADR, not diverging
+from it for convenience.
+
+Rejected: **extracting a full `TournamentService` class** over the whole router
+now. The three verbs do not need it, and a 2,900-line refactor is out of scope.
+
+### Reads reuse the queries and a shared serializer, gated exactly as HTTP
+
+`get_tournament` (MCP) reuses the same `tournament_queries.*` reads +
+`latest_solve` and the `_serialize_detail` serializer the HTTP handler uses; the
+serializer moves to a module both surfaces import (as the match ADR moved
+`_serialize_details`), so neither router depends on the other's internals. MCP
+reads enforce the **same** `tournament.view` permission and `_visible_to`
+visibility as the HTTP read — the MCP surface is not a way around them.
+
+### `get_schedule` is a dedicated tool with a new projection schema
+
+Rather than fold the schedule into `get_tournament`, MCP gets a dedicated
+`get_schedule` verb returning a narrower, agent-shaped **schedule projection** —
+each event's fixtures (pairing, table, predicted start, pool/round/position)
+grouped for reading, plus the latest solve's status/verdict. It reuses the same
+`fixtures_by_event` + `latest_solve` queries and the existing
+`TournamentFixtureRead` / `ScheduleSolveRead` shapes; the only new artifact is a
+small wrapper response schema. This schema is **MCP-only** — a mounted sub-app
+does not contribute to the parent `openapi.json`, so it never reaches
+`schema.d.ts` / `Types.swift`, and the regen step stays a drift no-op.
+
+### The tool surface is seven curated verbs
+
+Reads: `get_tournament`, `get_schedule`, `list_my_tournaments`. Writes
+(owner-gated): `edit_tournament`
+(mirrors the **full** `TournamentUpdate` partial, table catalogue included, so
+the two surfaces never disagree on what is editable), `build_cut` and `uncut`
+(the cut/uncut pair, per event), `request_schedule_solve` (the "run a
+simulation" verb; async — returns the queued `ScheduleSolveRead`, and the caller
+reads the verdict later via `get_schedule` / `get_tournament`).
+
+`list_my_tournaments` is the discovery read that makes the surface drivable: an
+agent needs a `tournament_id` before it can call anything else. It is
+**owner-scoped** (`created_by_user_id == caller`), not visibility-scoped like the
+HTTP `GET /v1/tournaments` list — because the write verbs are owner-gated, the
+tournaments an agent can act on are the ones it created. It reuses that list's
+exact batched-query machinery with the added owner filter and returns
+`list[TournamentDetailRead]` (no new schema).
+
+### Access is inherited; writes are owner-gated
+
+As in the match ADR, an MCP call is authorized exactly like its HTTP twin: a
+valid `context="api"` token identifies the caller, minting stays gated on
+`api_token.manage` (operator-only for now — a known, inherited limitation), and
+**write verbs additionally require the caller to be the tournament's owner** — an
+MCP caller can only edit/cut/solve tournaments they created.
+
+### Errors surface as actionable `ToolError`s
+
+Refusals map to `ToolError`s that name the recovery: a cut refused for
+evidence-of-play, a solve refused because no event is drawn
+(`no_drawn_events`), a league change refused after publish, an absent
+tournament/event. Reconcilable/again-later cases (a solve already in flight, a
+lock held) say "retry". Machine-readable **refusal codes** (ADR-0968) are carried
+in the message text for the agent.
+
+### Testing is three-tiered
+
+The extracted **write functions** carry the branch matrix (owner-gate,
+refusals, the edit state-rules, cut/uncut, solve coalescing) via direct
+construction with a real `db_session`. The existing **HTTP endpoint tests stay
+green and unchanged**, proving the wire contract held. **MCP tests are thin**: a
+valid bearer token drives a read + one representative write per verb, an
+invalid/missing/tombstoned token is rejected at the transport, and one
+representative refusal surfaces as a `ToolError`.
+
+## Consequences
+
+- **One source of truth per tournament verb.** The owner/lock/refusal
+  orchestration for edit, cut, and solve lives once; HTTP and MCP are thin
+  adapters. A future third caller reuses the same functions.
+- **The HTTP wire contract is unchanged** for the three refactored routes; the
+  endpoint tests are the proof, and a required change to one is a red flag.
+- **`api/`-only, no schema change / migration.** Reuses existing models; the one
+  new Pydantic schema is the MCP-only schedule projection. No web/iOS change;
+  regen is a drift check expected to no-op.
+- **The MCP tournament surface is operator-only and owner-gated** — inherited
+  limitations, documented, not bugs.
+- **"Simulation" is retired as vocabulary** in favour of **solve** (`CONTEXT.md`),
+  so the tool is named `request_schedule_solve`, not `run_simulation`.


### PR DESCRIPTION
Adds seven curated tournament verbs to the MCP server (`/mcp`), following the match-flow MCP pattern and its shared-services ADR. `api/`-only, no migration, no web/iOS change; the OpenAPI wire contract is **byte-identical** to base (regen is a no-op — verified).

Decisions captured in `docs/adr/20260719-tournament-verbs-are-shared-functions-behind-http-and-mcp-adapters.md` (+ a `CONTEXT.md` "Solve" glossary entry: "simulation" is not fortymm vocabulary — the CP-SAT run is a **solve**).

## Tools
Reads: `get_tournament`, `list_my_tournaments` (owner-scoped), `get_schedule` (a dedicated MCP-only projection of each event's placed fixtures + latest solve verdict).
Writes (owner-gated): `edit_tournament` (mirrors the full `TournamentUpdate`), `build_cut` + `uncut` (draw generation/teardown), `request_schedule_solve` (the "run a simulation" verb — a scheduler **solve**; async, returns the queued `ScheduleSolveRead`).

## Architecture (ADR-faithful)
For the three write paths (edit, cut/uncut, request-solve), the owner-check + `FOR UPDATE` load-lock + refusal orchestration was extracted into **transport-neutral, FastAPI-free cores** that raise **domain exceptions** (`app/tournament_errors.py`). The HTTP handlers became **thin adapters** mapping those to their exact existing status codes + bodies — the wire contract does not move a byte, and the existing endpoint tests (unchanged) prove it. The MCP tools call the same cores and map to actionable `ToolError`s. Reads reuse a shared serializer + a shared detail/list reader so HTTP and MCP can't drift.

## Testing
- Full API suite green (**1513 passed**): service-layer branch matrices (owner-gate, refusals, edit state-rules, cut/uncut, solve coalescing + queue-down), the existing HTTP endpoint tests as an unchanged wire-contract net, and thin MCP round-trips (read + write per verb, transport auth-reject, refusals → `ToolError`).
- `ruff` + `mypy --strict` clean.
- OpenAPI: branch `openapi.json` byte-identical to base; `schema.d.ts`/`Types.swift` untouched.

## Not observable in the UI
This is an MCP/agent surface with no web/iOS screen — verified via MCP-client round-trips in the test suite, not a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)