### PR TITLE
Coalesce rest shadows to one-per-human so two close completions don't blank the schedule (#1145)

### DIFF
--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -873,6 +873,20 @@ async def _load_solver_inputs(
                     )
                 )
 
+    # One shadow per human, not per match (app.scheduling's ``RestShadow``
+    # contract): a human who completed two matches within REST_MIN of each
+    # other accumulated a shadow *per completion* above — two fixed rest
+    # intervals that land under the solver's per-player ``AddNoOverlap`` and are
+    # mutually unsatisfiable, turning ONE player's close completions into a
+    # whole-tournament ``infeasible`` (#1145). Coalesce to the latest
+    # completion: rest is "time since your last match", so the max
+    # ``completed_at_min`` per human subsumes every earlier one.
+    latest_shadow: dict[PlayerId, RestShadow] = {}
+    for shadow in rest_shadows:
+        existing = latest_shadow.get(shadow.player_id)
+        if existing is None or shadow.completed_at_min > existing.completed_at_min:
+            latest_shadow[shadow.player_id] = shadow
+
     snapshot = ScheduleSnapshot(
         table_ids=catalogue,
         pools=schedule_pools,
@@ -881,7 +895,7 @@ async def _load_solver_inputs(
         now_min=now_min,
         in_progress=tuple(in_progress),
         previous_plan=tuple(previous_plan),
-        rest_shadows=tuple(rest_shadows),
+        rest_shadows=tuple(latest_shadow.values()),
     )
 
     # The fingerprint payload is the *wall-clock* form of exactly these inputs

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -171,6 +171,7 @@ from app.scheduling import (
     TableId,
     Window,
     WindowTooShortForMatch,
+    coalesce_rest_shadows,
 )
 from app.schemas.notification import NotificationJob
 from app.schemas.schedule_solve import (
@@ -874,19 +875,9 @@ async def _load_solver_inputs(
                 )
 
     # One shadow per human, not per match (app.scheduling's ``RestShadow``
-    # contract): a human who completed two matches within REST_MIN of each
-    # other accumulated a shadow *per completion* above — two fixed rest
-    # intervals that land under the solver's per-player ``AddNoOverlap`` and are
-    # mutually unsatisfiable, turning ONE player's close completions into a
-    # whole-tournament ``infeasible`` (#1145). Coalesce to the latest
-    # completion: rest is "time since your last match", so the max
-    # ``completed_at_min`` per human subsumes every earlier one.
-    latest_shadow: dict[PlayerId, RestShadow] = {}
-    for shadow in rest_shadows:
-        existing = latest_shadow.get(shadow.player_id)
-        if existing is None or shadow.completed_at_min > existing.completed_at_min:
-            latest_shadow[shadow.player_id] = shadow
-
+    # contract): a human who completed two matches within REST_MIN of each other
+    # accumulated a shadow *per completion* above, which would make the whole
+    # solve ``infeasible`` (#1145). Coalesce to the latest completion.
     snapshot = ScheduleSnapshot(
         table_ids=catalogue,
         pools=schedule_pools,
@@ -895,7 +886,7 @@ async def _load_solver_inputs(
         now_min=now_min,
         in_progress=tuple(in_progress),
         previous_plan=tuple(previous_plan),
-        rest_shadows=tuple(latest_shadow.values()),
+        rest_shadows=coalesce_rest_shadows(rest_shadows),
     )
 
     # The fingerprint payload is the *wall-clock* form of exactly these inputs

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -751,7 +751,20 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
     # window is a constant, so it needs no makespan/horizon bound, and a player
     # who appears in nothing but a shadow is a harmless lone interval (per-
     # player NoOverlap only fires with more than one).
+    #
+    # Coalesce to one shadow per human first — belt-and-suspenders for the
+    # snapshot builder's own "one entry per human, not per match" contract
+    # (:class:`RestShadow`). Two fixed rest intervals for a single player under
+    # the per-player ``AddNoOverlap`` below are mutually unsatisfiable, and a
+    # lone player's contradiction makes the WHOLE solve INFEASIBLE (#1145). Keep
+    # the latest completion: rest is "time since your last match", so the max
+    # ``completed_at_min`` per human already subsumes every earlier one's floor.
+    latest_shadow: dict[PlayerId, RestShadow] = {}
     for shadow in snapshot.rest_shadows:
+        existing = latest_shadow.get(shadow.player_id)
+        if existing is None or shadow.completed_at_min > existing.completed_at_min:
+            latest_shadow[shadow.player_id] = shadow
+    for shadow in latest_shadow.values():
         player_intervals[shadow.player_id].append(
             model.NewFixedSizeIntervalVar(
                 shadow.completed_at_min,

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -105,6 +105,7 @@ from __future__ import annotations
 
 import enum
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any, Literal, NewType
 
@@ -286,6 +287,24 @@ class RestShadow:
 
     player_id: PlayerId
     completed_at_min: int
+
+
+def coalesce_rest_shadows(shadows: Iterable[RestShadow]) -> tuple[RestShadow, ...]:
+    """One shadow per human, keeping the latest completion.
+
+    :class:`RestShadow`'s contract is one entry per human, not per match — but a
+    player who completed two matches within :data:`REST_MIN` of each other yields
+    a shadow *per completion*, i.e. two fixed rest intervals that land under the
+    solver's per-player ``AddNoOverlap`` and are mutually unsatisfiable, turning
+    ONE player's close completions into a whole-tournament ``infeasible`` (#1145).
+    Rest is "time since your last match", so the max ``completed_at_min`` per
+    human subsumes every earlier one's floor — keep only that one."""
+    latest: dict[PlayerId, RestShadow] = {}
+    for shadow in shadows:
+        existing = latest.get(shadow.player_id)
+        if existing is None or shadow.completed_at_min > existing.completed_at_min:
+            latest[shadow.player_id] = shadow
+    return tuple(latest.values())
 
 
 @dataclass(frozen=True, slots=True)
@@ -752,19 +771,12 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
     # who appears in nothing but a shadow is a harmless lone interval (per-
     # player NoOverlap only fires with more than one).
     #
-    # Coalesce to one shadow per human first — belt-and-suspenders for the
-    # snapshot builder's own "one entry per human, not per match" contract
-    # (:class:`RestShadow`). Two fixed rest intervals for a single player under
-    # the per-player ``AddNoOverlap`` below are mutually unsatisfiable, and a
-    # lone player's contradiction makes the WHOLE solve INFEASIBLE (#1145). Keep
-    # the latest completion: rest is "time since your last match", so the max
-    # ``completed_at_min`` per human already subsumes every earlier one's floor.
-    latest_shadow: dict[PlayerId, RestShadow] = {}
-    for shadow in snapshot.rest_shadows:
-        existing = latest_shadow.get(shadow.player_id)
-        if existing is None or shadow.completed_at_min > existing.completed_at_min:
-            latest_shadow[shadow.player_id] = shadow
-    for shadow in latest_shadow.values():
+    # Coalesce to one shadow per human first (:func:`coalesce_rest_shadows`) —
+    # belt-and-suspenders for the snapshot builder's own "one entry per human"
+    # contract. Two fixed rest intervals for a single player under the per-player
+    # ``AddNoOverlap`` below are mutually unsatisfiable, and a lone player's
+    # contradiction makes the WHOLE solve INFEASIBLE (#1145).
+    for shadow in coalesce_rest_shadows(snapshot.rest_shadows):
         player_intervals[shadow.player_id].append(
             model.NewFixedSizeIntervalVar(
                 shadow.completed_at_min,

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -519,6 +519,48 @@ class TestRestShadows:
         assert inputs is not None
         assert inputs.snapshot.rest_shadows == ()
 
+    async def test_two_completions_within_rest_coalesce_to_one_shadow(
+        self, db_session: AsyncSession
+    ) -> None:
+        """One entry per human, not per match (#1145): a human who completes
+        two matches within REST_MIN accumulates a shadow per completion in the
+        raw scan — coalesced to exactly ONE, anchored at the LATER completion
+        (rest = time since your last match), so the solver never receives two
+        mutually unsatisfiable fixed rest intervals for one player."""
+        tournament_id, event_id = await _make_tournament(db_session)
+        fixtures = await _fixtures_of(db_session, event_id)
+        # Two fixtures sharing a human: in a 4-player round robin every player
+        # appears in 3 fixtures, so a shared entry always exists.
+        first = fixtures[0]
+        shared_entry = first.entry_a_id
+        second = next(
+            f for f in fixtures[1:] if shared_entry in (f.entry_a_id, f.entry_b_id)
+        )
+        # Complete both 2 minutes apart, both within REST_MIN of ``now`` so
+        # neither window has closed and both would otherwise cast a shadow.
+        early_wall = BASE + timedelta(minutes=30)
+        late_wall = BASE + timedelta(minutes=32)
+        users_first = await _mark_completed(
+            db_session, first, completed_at=early_wall.astimezone()
+        )
+        shared_user = users_first[0]  # entry_a's user == the shared human
+        await _mark_completed(db_session, second, completed_at=late_wall.astimezone())
+        now = BASE + timedelta(minutes=35)
+
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=now, lock=False
+        )
+
+        assert inputs is not None
+        shared_shadows = [
+            shadow
+            for shadow in inputs.snapshot.rest_shadows
+            if shadow.player_id == shared_user
+        ]
+        assert len(shared_shadows) == 1
+        # Anchored at the later completion (offset 32), not the earlier (30).
+        assert shared_shadows[0].completed_at_min == 32
+
 
 class TestRequestSolveCoalescing:
     async def test_two_requests_coalesce_into_one_queued_row(

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -836,6 +836,39 @@ class TestRestShadows:
         placed = {p.fixture_id: p for p in result.placements}
         assert placed[FixtureId("F1")].start_min == 0  # ghost's rest binds no one
 
+    def test_two_shadows_for_one_human_solve_feasibly(self) -> None:
+        """UAT wave-2 reproduction (#1145): a single human handed *two* rest
+        shadows (two completions within REST_MIN of each other) must not sink
+        the whole solve. Two fixed rest intervals for one player under the
+        per-player no-overlap are mutually unsatisfiable — before the coalesce
+        this returned global ``infeasible`` and blanked every placement.
+
+        The defensive dedup in the pure module keeps the latest completion, so
+        the solve is feasible, the unrelated fixture still lands, and P1's own
+        fixture is held to the *later* shadow's floor (``2 + REST_MIN``), not
+        the earlier one's. (``_assert_hard_constraints`` is deliberately NOT
+        used: its checker models each shadow as an independent floor — exactly
+        the pre-fix contract this coalesce retires — so it would reject two
+        shadows for one player rather than reflect the dedup.)"""
+        p1, p2, p3, p4 = _players(4)
+        snapshot = _one_pool_snapshot(
+            (_fixture(1, p1, p2), _fixture(2, p3, p4)),
+            # Two completions for P1, 2 minutes apart — both within REST_MIN.
+            rest_shadows=(RestShadow(p1, 0), RestShadow(p1, 2)),
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        # Would be Verdict.infeasible + no placements without the dedup.
+        assert result.verdict in SOLVED
+        placed = {p.fixture_id: p for p in result.placements}
+        assert set(placed) == {FixtureId("F1"), FixtureId("F2")}
+        # The surviving shadow is the *later* completion: P1's floor is
+        # ``2 + REST_MIN == 12``, snapped up to the next 5-minute grid start,
+        # 15 — strictly later than the earlier shadow's floor (``0 + REST_MIN``
+        # → grid start 10), so this pins the coalesce to the MAX completion.
+        assert placed[FixtureId("F1")].start_min == 15
+        # P1-free fixture is unaffected — it takes the very first slot.
+        assert placed[FixtureId("F2")].start_min == 0
+
     def test_issue_1075_freed_table_idles_rather_than_recalling(self) -> None:
         """#1075 shape: 5 players, 2 tables, best-of-5 (35-minute matches), a
         round-robin of fixtures, and P1 who *just* finished at ``now``. The two


### PR DESCRIPTION
## Summary

Fixes #1145. When a single player has **two matches complete within `REST_MIN` (10 min) of each other**, the schedule solver appended **two overlapping fixed rest-shadow intervals for that player under one `AddNoOverlap`** — mutually unsatisfiable — so the **entire** solve returned `infeasible` and every remaining placement was blanked. One player's two close completions took down the whole tournament's schedule (observed on UAT Soak-5, wave 2).

## Root cause

`_load_solver_inputs` (`schedule_solves.py`) did `rest_shadows.extend(...)` **once per completed fixture**, so a human with two recent completions accumulated **two** `RestShadow` entries — violating the snapshot's own documented contract ("one entry per human, not per match", `RestShadow` / `app.scheduling` docstring). Those two fixed intervals then landed under the per-player `AddNoOverlap` and could not be made non-overlapping.

## Fix

Rest is "time since your **last** match," so a player needs **one** rest obligation, not one per completion. Coalesce to the shadow with the latest `completed_at_min` per human (issue's option 1):

- **Primary** — the snapshot builder coalesces after accumulation, restoring the "one entry per human" invariant at the boundary that declares it.
- **Defensive** — the pure solver module coalesces again just before the `AddNoOverlap` assembly, so any caller passing two shadows for one human is safe from the catastrophic global-infeasible failure.
- The coalescing rule lives once, in `coalesce_rest_shadows()` (home of `RestShadow`), used by both layers.

Internal solver logic only — **no route/schema/docstring change, `openapi.json` unchanged**, so no client-type regen.

## Testing

- New red→green tests (fail before, pass after): a builder input with two completions <10 min apart yields **exactly one** shadow anchored at the **later** completion; a snapshot with two shadows for one human solves **feasibly** and places the remaining fixtures instead of global `infeasible` (the UAT wave-2 reproduction).
- Full API gate green: `ruff check`, `ruff format --check`, `mypy --strict`, **1534 pytest passed**.
- Not UI-observable (pure scheduler logic) → no browser/Simulator QA pass applies.

Closes #1145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)