### PR TITLE
Solver tolerates overlapping in-progress facts instead of blanking the board (#1144)

### DIFF
--- a/api/app/admin_schedule_solves.py
+++ b/api/app/admin_schedule_solves.py
@@ -21,7 +21,10 @@ from app.db import get_session
 from app.models import ScheduleSolve, Tournament
 from app.rbac import require_permission
 from app.schemas.admin import AdminScheduleSolveListResponse, AdminScheduleSolveRead
-from app.schemas.schedule_solve import parse_infeasibility_reasons
+from app.schemas.schedule_solve import (
+    parse_infeasibility_reasons,
+    parse_placement_conflicts,
+)
 
 # Gates the Administration area's solve-ledger page. Seeded (scripts/seed_rbac.py)
 # and granted to the Administrator role, like the other admin-tool permissions.
@@ -51,6 +54,7 @@ def _serialize(solve: ScheduleSolve, tournament_name: str) -> AdminScheduleSolve
         fixtures_pinned=solve.fixtures_pinned,
         error=solve.error,
         infeasibility_reasons=parse_infeasibility_reasons(solve.infeasibility_reasons),
+        placement_conflicts=parse_placement_conflicts(solve.placement_conflicts),
         input_fingerprint=solve.input_fingerprint,
         rerun_requested=solve.rerun_requested,
         tournament_id=solve.tournament_id,

--- a/api/app/models/schedule_solve.py
+++ b/api/app/models/schedule_solve.py
@@ -146,6 +146,17 @@ class ScheduleSolve(Base):
     infeasibility_reasons: Mapped[list[dict[str, Any]] | None] = mapped_column(
         JSONB, nullable=True
     )
+    #: Resolved in-progress-vs-in-progress placement conflicts a solve reported
+    #: (ADR "overlapping in-progress matches are tolerated and reported") — ids
+    #: humanized to player names and table labels, kept raw here; a later
+    #: boundary parses this into Pydantic models. Distinct from
+    #: ``infeasibility_reasons``: a conflict is orthogonal to the verdict, so
+    #: this is written on **any** verdict where the solver ran (a placed
+    #: ``optimal``/``feasible`` board can still carry conflicts) — ``[]`` when
+    #: there were none. ``NULL`` only before a solve reaches its apply.
+    placement_conflicts: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        JSONB, nullable=True
+    )
     #: The coalesced enqueue's second arm: a trigger that lands while this row is
     #: ``running`` cannot be absorbed by a queued row (there isn't one) and must
     #: not enqueue a second job (one solve in flight per tournament) — so it sets

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -147,6 +147,7 @@ from app.models import (
     TournamentEvent,
     TournamentFixture,
     TournamentStatus,
+    User,
 )
 from app.rq_async import run_async_db_job
 from app.scheduling import (
@@ -158,6 +159,8 @@ from app.scheduling import (
     InProgressMatch,
     NoSingleCause,
     Pin,
+    PlacementConflict,
+    PlayerConflict,
     PlayerId,
     PoolHasNoTables,
     PoolId,
@@ -168,6 +171,7 @@ from app.scheduling import (
     SchedulePool,
     ScheduleSnapshot,
     SolveResult,
+    TableConflict,
     TableId,
     Window,
     WindowTooShortForMatch,
@@ -175,10 +179,14 @@ from app.scheduling import (
 )
 from app.schemas.notification import NotificationJob
 from app.schemas.schedule_solve import (
+    ConflictFixtureRead,
     NoSingleCauseRead,
+    PlayerConflictRead,
     PoolHasNoTablesRead,
     PoolOverCapacityRead,
+    ResolvedConflict,
     ResolvedReason,
+    TableConflictRead,
     WindowTooShortForMatchRead,
 )
 from app.schemas.tournament import MatchSettings as EventMatchSettings
@@ -507,7 +515,15 @@ class SolveInputs:
     *infeasible* solve's structured reasons through — pool id → name+clock,
     fixture id → its event's ``length_games``. They derive from the same
     fingerprinted inputs, so the fresh read's maps match the ones the reasons
-    were computed against."""
+    were computed against.
+
+    ``table_labels`` (solver ``TableId`` → the catalogue label),
+    ``player_names`` (solver ``PlayerId`` — a user-id string — → display
+    username), and ``fixture_matchups`` (``str(fixture.id)`` → the two players'
+    usernames) are the sibling lookups the apply humanizes a solve's
+    *placement conflicts* through (ADR "overlapping in-progress matches are
+    tolerated and reported"). Same fingerprinted provenance, so the fresh read's
+    maps resolve exactly the ids a conflict carries."""
 
     snapshot: ScheduleSnapshot
     fingerprint: str
@@ -518,6 +534,9 @@ class SolveInputs:
     withdrawn_entry_ids: frozenset[uuid.UUID] = frozenset()
     pool_resolutions: dict[str, _PoolResolution] = field(default_factory=dict)
     fixture_best_of: dict[str, Literal[1, 3, 5, 7]] = field(default_factory=dict)
+    table_labels: dict[str, str] = field(default_factory=dict)
+    player_names: dict[str, str] = field(default_factory=dict)
+    fixture_matchups: dict[str, tuple[str, str]] = field(default_factory=dict)
 
 
 def _fingerprint(payload: dict[str, Any]) -> str:
@@ -658,6 +677,25 @@ async def _load_solver_inputs(
             else:
                 withdrawn_entry_ids.add(entry_id)
 
+    # user_id → display username: the DB-aware resolution a placement conflict's
+    # shared human (and each colliding fixture's matchup) is humanized through.
+    # Loaded off the same entrant set the snapshot is built from — one IN-query,
+    # like ``load_copy_ingredients`` — so it resolves exactly the user ids the
+    # solver's PlayerIds are stringified from.
+    user_names: dict[uuid.UUID, str] = {}
+    if entry_user:
+        user_names = {
+            user_id: username
+            for user_id, username in (
+                await db.execute(
+                    select(User.id, User.username).where(
+                        User.id.in_(set(entry_user.values()))
+                    )
+                )
+            ).all()
+        }
+    player_names = {str(user_id): name for user_id, name in user_names.items()}
+
     match_status: dict[uuid.UUID, MatchStatus] = {}
     # A completed match's stable completion stamp (``None`` for one deemed
     # completed via ``winner_entry_id`` alone), the anchor a rest shadow needs
@@ -679,10 +717,13 @@ async def _load_solver_inputs(
 
     # Parse the JSONB value-objects once, at this boundary, with the same
     # models the write boundary validated them with (parse, don't validate).
-    catalogue = tuple(
-        TableId(TournamentTable.model_validate(table).id)
-        for table in tournament.table_catalogue
-    )
+    parsed_tables = [
+        TournamentTable.model_validate(table) for table in tournament.table_catalogue
+    ]
+    catalogue = tuple(TableId(table.id) for table in parsed_tables)
+    # table_id → catalogue label: the DB-aware resolution a placement conflict's
+    # shared table is humanized through (mirrors ``load_copy_ingredients``).
+    table_labels = {table.id: table.label for table in parsed_tables}
     parsed_events: list[tuple[TournamentEvent, EventMatchSettings, list[Pool]]] = [
         (
             event,
@@ -712,6 +753,10 @@ async def _load_solver_inputs(
     # reasons carry.
     pool_resolutions: dict[str, _PoolResolution] = {}
     fixture_best_of: dict[str, Literal[1, 3, 5, 7]] = {}
+    # fixture id → its matchup (the two players' usernames): the DB-aware
+    # resolution a placement conflict names each colliding fixture through.
+    # Built in the fixture loop below, alongside ``fixture_best_of``.
+    fixture_matchups: dict[str, tuple[str, str]] = {}
     for event, _settings, pools in parsed_events:
         for pool in pools:
             key = f"{event.id}:{pool.id}"
@@ -812,9 +857,15 @@ async def _load_solver_inputs(
                     )
             fixture_id = FixtureId(str(fixture.id))
             # Only placeable (pooled, both-sides-known) fixtures reach here, and
-            # only such a fixture can surface in a WindowTooShortForMatch reason —
-            # so this is exactly the set the apply resolves best_of for.
+            # only such a fixture can surface in a WindowTooShortForMatch reason
+            # or a placement conflict — so this is exactly the set the apply
+            # resolves best_of and matchup names for. Both entries are non-None
+            # (guarded above) and their users were loaded into ``user_names``.
             fixture_best_of[fixture_id] = settings.length_games
+            fixture_matchups[fixture_id] = (
+                user_names[entry_user[fixture.entry_a_id]],
+                user_names[entry_user[fixture.entry_b_id]],
+            )
             schedule_fixtures.append(
                 ScheduleFixture(
                     id=fixture_id,
@@ -952,6 +1003,9 @@ async def _load_solver_inputs(
         withdrawn_entry_ids=frozenset(withdrawn_entry_ids),
         pool_resolutions=pool_resolutions,
         fixture_best_of=fixture_best_of,
+        table_labels=table_labels,
+        player_names=player_names,
+        fixture_matchups=fixture_matchups,
     )
 
 
@@ -1005,6 +1059,54 @@ def _resolve_reason(reason: InfeasibilityReason, inputs: SolveInputs) -> Resolve
             )
         case _:
             assert_never(reason)
+
+
+def _conflict_fixture(
+    fixture_id: FixtureId, inputs: SolveInputs
+) -> ConflictFixtureRead:
+    """Name one colliding in-progress fixture by its matchup — the two players
+    facing off (``inputs.fixture_matchups``). Direct lookup is safe: the apply
+    resolves only after the drift guard proved this read's inputs identical to
+    the ones the conflicts were computed against, and every in-progress fixture
+    a conflict names is a placeable fixture whose matchup was recorded here."""
+    player_a, player_b = inputs.fixture_matchups[fixture_id]
+    return ConflictFixtureRead(
+        fixture_id=fixture_id, player_a=player_a, player_b=player_b
+    )
+
+
+def _resolve_conflict(
+    conflict: PlacementConflict, inputs: SolveInputs
+) -> ResolvedConflict:
+    """Humanize one pure, id-only placement conflict into its resolved read form
+    (ADR "overlapping in-progress matches are tolerated and reported"): the
+    shared table's catalogue label comes from ``inputs.table_labels``, the
+    shared human's display name from ``inputs.player_names``, and each colliding
+    fixture is named by its matchup. Same direct-lookup safety as
+    :func:`_resolve_reason` (post-drift-guard).
+
+    An exhaustive ``match`` with an ``assert_never`` floor, no catch-all: adding
+    an arm to :data:`app.scheduling.PlacementConflict` is a type error here until
+    it is handled."""
+    match conflict:
+        case TableConflict():
+            return TableConflictRead(
+                table_label=inputs.table_labels[conflict.table_id],
+                fixtures=[
+                    _conflict_fixture(fixture_id, inputs)
+                    for fixture_id in conflict.fixture_ids
+                ],
+            )
+        case PlayerConflict():
+            return PlayerConflictRead(
+                player_name=inputs.player_names[conflict.player_id],
+                fixtures=[
+                    _conflict_fixture(fixture_id, inputs)
+                    for fixture_id in conflict.fixture_ids
+                ],
+            )
+        case _:
+            assert_never(conflict)
 
 
 def run_schedule_solve(schedule_solve_id: str) -> None:
@@ -1257,6 +1359,21 @@ async def _apply_result(
                 # has no ``unknown``, and a run that proved nothing has none.
                 row.status = ScheduleSolveStatus.failed
                 row.error = TIME_CAP_ERROR
+
+        # Placement conflicts are orthogonal to the verdict (ADR "overlapping
+        # in-progress matches are tolerated and reported"): the solver reports
+        # in-progress-vs-in-progress overlaps on ANY verdict — a fully-placed
+        # ``optimal``/``feasible`` board can carry them, and so can an
+        # ``infeasible``/``unknown`` one — so this write is NOT gated on a
+        # branch above. Resolved (ids → player names, table labels) against the
+        # same fingerprint-matched ``fresh`` maps the reasons use, and always a
+        # list (``[]`` when there were none) so the read boundary never sees
+        # NULL for an applied run. Parsed back at read via
+        # ``schemas.schedule_solve.parse_placement_conflicts``.
+        row.placement_conflicts = [
+            _resolve_conflict(conflict, fresh).model_dump()
+            for conflict in result.conflicts
+        ]
 
         if rerun_was_requested:
             await request_solve(db, tournament_id, ScheduleSolveTrigger.rerun)

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -1088,22 +1088,19 @@ def _resolve_conflict(
     An exhaustive ``match`` with an ``assert_never`` floor, no catch-all: adding
     an arm to :data:`app.scheduling.PlacementConflict` is a type error here until
     it is handled."""
+    fixtures = [
+        _conflict_fixture(fixture_id, inputs) for fixture_id in conflict.fixture_ids
+    ]
     match conflict:
         case TableConflict():
             return TableConflictRead(
                 table_label=inputs.table_labels[conflict.table_id],
-                fixtures=[
-                    _conflict_fixture(fixture_id, inputs)
-                    for fixture_id in conflict.fixture_ids
-                ],
+                fixtures=fixtures,
             )
         case PlayerConflict():
             return PlayerConflictRead(
                 player_name=inputs.player_names[conflict.player_id],
-                fixtures=[
-                    _conflict_fixture(fixture_id, inputs)
-                    for fixture_id in conflict.fixture_ids
-                ],
+                fixtures=fixtures,
             )
         case _:
             assert_never(conflict)

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -312,11 +312,15 @@ def coalesce_rest_shadows(shadows: Iterable[RestShadow]) -> tuple[RestShadow, ..
 
     :class:`RestShadow`'s contract is one entry per human, not per match — but a
     player who completed two matches within :data:`REST_MIN` of each other yields
-    a shadow *per completion*, i.e. two fixed rest intervals that land under the
-    solver's per-player ``AddNoOverlap`` and are mutually unsatisfiable, turning
-    ONE player's close completions into a whole-tournament ``infeasible`` (#1145).
-    Rest is "time since your last match", so the max ``completed_at_min`` per
-    human subsumes every earlier one's floor — keep only that one."""
+    a shadow *per completion*, i.e. two fixed rest intervals for one player that
+    would once have landed mutually-unsatisfiable under the solver's per-player
+    ``AddNoOverlap``, turning ONE player's close completions into a whole-tournament
+    ``infeasible`` (#1145). The per-resource fixed-obstacle merge in
+    :func:`_build_model` now absorbs any such fixed-vs-fixed overlap, so this is no
+    longer the sole guard against that infeasibility — but keeping one shadow per
+    human is still correct deduplication: rest is "time since your last match", so
+    the max ``completed_at_min`` per human subsumes every earlier one's floor —
+    keep only that one."""
     latest: dict[PlayerId, RestShadow] = {}
     for shadow in shadows:
         existing = latest.get(shadow.player_id)

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -40,6 +40,24 @@ A **genuinely in-progress** (being-played) match is different: it stays fully
 fixed in both dimensions — reality is not a variable, and a match underway must
 never move.
 
+**Overlapping in-progress facts are tolerated, not fatal.** Two in-progress
+blocks recorded on the same table, or one human in two of them at once, are
+never physical truth — a table holds one match, a human plays one — so they can
+only be contradictory data from a director's *soft* manual placement PATCH. A
+naïve model would hand two rigid, overlapping fixed intervals to ``AddNoOverlap``
+and prove the WHOLE day infeasible, blanking every placement over one bad pin
+(#1144). Instead, before ``AddNoOverlap`` the *fixed* obstacle intervals on each
+resource (in-progress occupancy plus rest shadows) are **merged into their
+union**: fixed-vs-fixed can then never force infeasibility, while every variable
+interval still routes conservatively around the merged occupancy (nobody else is
+scheduled onto a genuinely-held table or human). The solver does **not** pick
+which of the colliding matches is "real" and never moves, re-times, or drops a
+live match; it reports the in-progress-vs-in-progress overlaps as
+:data:`PlacementConflict`s on :attr:`SolveResult.conflicts` — orthogonal to the
+verdict, so a fully-placed ``optimal`` board can still carry them — for the
+director to resolve. Rest-shadow overlaps are merged the same way but not
+reported (they are not a director-actionable double-booking).
+
 **Rest across the completion boundary.** A player's 10-minute rest floor
 (:data:`REST_MIN`) is a hard constraint, and it must survive a match *ending*,
 not just a match running. A completed fixture occupies nothing and appears in
@@ -430,6 +448,44 @@ InfeasibilityReason = (
 
 
 @dataclass(frozen=True, slots=True)
+class TableConflict:
+    """Two or more in-progress matches recorded on the *same table* at
+    overlapping times — physically impossible (a table holds one match), so it
+    can only be contradictory data from a soft manual placement PATCH. Carries
+    the shared ``table_id`` and the overlapping ``fixture_ids`` (sorted). The
+    solver tolerates it — it merges the overlapping occupancy into one union so
+    it never blanks the board — and reports it here for the director to resolve;
+    it never adjudicates which match is 'real' and never moves a live match."""
+
+    table_id: TableId
+    fixture_ids: tuple[FixtureId, ...]
+    kind: Literal["table_conflict"] = "table_conflict"
+
+
+@dataclass(frozen=True, slots=True)
+class PlayerConflict:
+    """Two or more in-progress matches sharing a *human* whose rest-padded
+    occupancy intervals overlap — physically impossible (a human plays one
+    match at a time), so it is contradictory data from a soft manual PATCH.
+    Carries the shared ``player_id`` and the overlapping ``fixture_ids``
+    (sorted). Tolerated-and-reported exactly like :class:`TableConflict`."""
+
+    player_id: PlayerId
+    fixture_ids: tuple[FixtureId, ...]
+    kind: Literal["player_conflict"] = "player_conflict"
+
+
+#: The closed set of placement conflicts a solve can *report* (distinct from the
+#: :data:`InfeasibilityReason`s that explain a failed solve — a conflict is
+#: orthogonal to the verdict and can ride on a fully-placed ``optimal`` board).
+#: A discriminated union over ``kind``, DB-blind exactly like the reasons union:
+#: ids + minute-ints only, so a downstream DB-aware layer resolves them into
+#: names and wall-clock. Each arm names one shared resource and the in-progress
+#: fixtures colliding on it — the director-actionable "you double-booked" signal.
+PlacementConflict = TableConflict | PlayerConflict
+
+
+@dataclass(frozen=True, slots=True)
 class SolveResult:
     """A solve's whole answer. Placements cover every active fixture that is
     not in progress — called fixtures on their fixed table at the promised or a
@@ -441,24 +497,37 @@ class SolveResult:
     :attr:`Verdict.infeasible` and empty (``()``) for every other verdict
     (optimal / feasible / unknown, including the trivial no-active-fixtures
     optimal). It carries the structured, id-and-minute-only explanation of
-    *why* the day does not fit — see :data:`InfeasibilityReason`."""
+    *why* the day does not fit — see :data:`InfeasibilityReason`.
+
+    ``conflicts`` is **orthogonal to the verdict**: it reports the in-progress-
+    vs-in-progress overlaps found in the snapshot (two matches recorded on one
+    table, or one human in two matches — contradictory data from a soft manual
+    PATCH). Such overlaps are *tolerated*, not fatal — the solver merges the
+    overlapping fixed occupancy into its union so it can never blank the board
+    (#1144) — so a fully-placed ``optimal`` / ``feasible`` result can still carry
+    conflicts. It never adjudicates which match is real and never moves a live
+    match; the report is the director-actionable "you double-booked" signal.
+    See :data:`PlacementConflict`."""
 
     verdict: Verdict
     placements: tuple[PlacedFixture, ...]
     stats: SolveStats
     reasons: tuple[InfeasibilityReason, ...] = ()
+    conflicts: tuple[PlacementConflict, ...] = ()
 
 
 def _no_plan(
     verdict: Verdict,
     wall_time_ms: int = 0,
     reasons: tuple[InfeasibilityReason, ...] = (),
+    conflicts: tuple[PlacementConflict, ...] = (),
 ) -> SolveResult:
     return SolveResult(
         verdict=verdict,
         placements=(),
         stats=SolveStats(wall_time_ms=wall_time_ms, objective=None),
         reasons=reasons,
+        conflicts=conflicts,
     )
 
 
@@ -575,6 +644,50 @@ class _SolverModel:
     pin_starts: dict[FixtureId, Any]
     pin_tables: dict[FixtureId, TableId]
     pin_durations: dict[FixtureId, int]
+    #: In-progress-vs-in-progress overlaps detected from the snapshot (orthogonal
+    #: to the solve outcome), carried so :func:`solve` attaches them to whatever
+    #: verdict CP-SAT reaches — a placed board can still report conflicts.
+    conflicts: tuple[PlacementConflict, ...]
+
+
+def _merge_spans(spans: Iterable[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Union mutually-overlapping half-open ``[start, end)`` intervals.
+
+    A sort-and-sweep over connected overlap components: adjacency
+    (``start == end`` of the predecessor) does *not* merge — only a genuine
+    overlap does. Used to collapse the *fixed* obstacle intervals on one
+    resource (in-progress occupancy + rest shadows) into disjoint blocks before
+    ``AddNoOverlap``, so two contradictory fixed facts can never force
+    infeasibility while their union stays blocked for every variable interval."""
+    ordered = sorted(spans)
+    merged: list[tuple[int, int]] = []
+    for start, end in ordered:
+        if merged and start < merged[-1][1]:
+            last_start, last_end = merged[-1]
+            merged[-1] = (last_start, max(last_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _overlapping_fixture_ids(
+    spans: list[tuple[int, int, FixtureId]],
+) -> tuple[FixtureId, ...]:
+    """The fixtures that pairwise-overlap at least one other on one resource.
+
+    Half-open overlap (``s1 < e2 and s2 < e1``), pairwise over the resource's
+    in-progress spans (counts are tiny). Returns the sorted union of every
+    fixture caught in *any* overlap, so a resource is reported once with the
+    full set colliding on it — empty when nothing overlaps."""
+    colliding: set[FixtureId] = set()
+    for i in range(len(spans)):
+        start_i, end_i, fixture_i = spans[i]
+        for j in range(i + 1, len(spans)):
+            start_j, end_j, fixture_j = spans[j]
+            if start_i < end_j and start_j < end_i:
+                colliding.add(fixture_i)
+                colliding.add(fixture_j)
+    return tuple(sorted(colliding))
 
 
 def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
@@ -612,6 +725,46 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
         f.id: max(running[f.id].start_min + duration_of(f), now + BUCKET_MIN)
         for f in in_progress
     }
+
+    # The *fixed* occupancy spans each in-progress match projects onto its table
+    # and its two humans (the human span is rest-padded, so a shared-human
+    # overlap is judged on the same padded interval per-player NoOverlap uses).
+    # Kept as numeric half-open spans so they can be both (a) merged before
+    # AddNoOverlap — two overlapping fixed facts are contradictory data that
+    # must never blank the board (#1144) — and (b) scanned for the director-
+    # actionable in-progress-vs-in-progress conflicts reported on the result.
+    table_inprog: defaultdict[TableId, list[tuple[int, int, FixtureId]]] = defaultdict(
+        list
+    )
+    player_inprog: defaultdict[PlayerId, list[tuple[int, int, FixtureId]]] = (
+        defaultdict(list)
+    )
+    for fixture in in_progress:
+        match_row = running[fixture.id]
+        occ_end = occupancy_ends[fixture.id]
+        table_inprog[match_row.table_id].append(
+            (match_row.start_min, occ_end, fixture.id)
+        )
+        for player in (fixture.player_a_id, fixture.player_b_id):
+            player_inprog[player].append(
+                (match_row.start_min, occ_end + REST_MIN, fixture.id)
+            )
+
+    # Report narrowly: only in-progress-vs-in-progress overlaps (rest-shadow
+    # overlaps are merged below but never reported). Deterministically ordered
+    # by shared resource id, each resource reported once with its colliding set.
+    conflicts: tuple[PlacementConflict, ...] = (
+        *(
+            TableConflict(table_id=table_id, fixture_ids=overlapping)
+            for table_id, spans in sorted(table_inprog.items())
+            if (overlapping := _overlapping_fixture_ids(spans))
+        ),
+        *(
+            PlayerConflict(player_id=player_id, fixture_ids=overlapping)
+            for player_id, spans in sorted(player_inprog.items())
+            if (overlapping := _overlapping_fixture_ids(spans))
+        ),
+    )
 
     # The latest minute anything can end — the domain ceiling for every start
     # variable (a called match's included, since it can now slide) and for the
@@ -727,8 +880,9 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
 
     if reasons:
         # A certain structural infeasibility: refuse without building or running
-        # CP-SAT, but carry every cause we found rather than a bare verdict.
-        return _no_plan(Verdict.infeasible, reasons=tuple(reasons))
+        # CP-SAT, but carry every cause we found rather than a bare verdict — and
+        # any in-progress conflict too (orthogonal to why the day doesn't fit).
+        return _no_plan(Verdict.infeasible, reasons=tuple(reasons), conflicts=conflicts)
 
     model = cp_model.CpModel()
     table_intervals: defaultdict[TableId, list[Any]] = defaultdict(list)
@@ -739,51 +893,47 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
     # called fixtures contribute (a called match's slide is anchored here).
     wait_terms: list[Any] = []
 
-    # In-progress matches: fixed occupancy from their *actual* start. Their
-    # players rest for REST_MIN after the occupancy end, like everyone else.
-    for fixture in in_progress:
-        match_row = running[fixture.id]
-        occ_end = occupancy_ends[fixture.id]
-        table_intervals[match_row.table_id].append(
-            model.NewIntervalVar(
-                match_row.start_min,
-                occ_end - match_row.start_min,
-                occ_end,
-                f"run_{fixture.id}",
-            )
-        )
-        for player in (fixture.player_a_id, fixture.player_b_id):
-            player_intervals[player].append(
-                model.NewIntervalVar(
-                    match_row.start_min,
-                    occ_end - match_row.start_min + REST_MIN,
-                    occ_end + REST_MIN,
-                    f"run_{fixture.id}_{player}",
-                )
-            )
-        fixed_ends.append(occ_end)
+    # In-progress matches project fixed occupancy from their *actual* start (the
+    # players' spans rest-padded), and each still bounds the makespan.
+    fixed_ends.extend(occupancy_ends.values())
 
     # Rest shadows: a human who just completed a match rests until
-    # completed_at + REST_MIN. A fixed interval on that player's list projects
-    # the floor across the completion boundary — the completed fixture itself
-    # is dropped and unplaced, but its rest lingers. Fixed (no variable): the
-    # window is a constant, so it needs no makespan/horizon bound, and a player
-    # who appears in nothing but a shadow is a harmless lone interval (per-
-    # player NoOverlap only fires with more than one).
-    #
-    # Coalesce to one shadow per human first (:func:`coalesce_rest_shadows`) —
-    # belt-and-suspenders for the snapshot builder's own "one entry per human"
-    # contract. Two fixed rest intervals for a single player under the per-player
-    # ``AddNoOverlap`` below are mutually unsatisfiable, and a lone player's
-    # contradiction makes the WHOLE solve INFEASIBLE (#1145).
+    # completed_at + REST_MIN — a fixed span on that player's list that projects
+    # the floor across the completion boundary (the completed fixture itself is
+    # dropped and unplaced, but its rest lingers). Fixed, no variable, so it
+    # needs no makespan/horizon bound. Coalesced to one per human first
+    # (:func:`coalesce_rest_shadows`) — belt-and-suspenders for the snapshot
+    # builder's "one entry per human" contract — and folded into the same
+    # per-player fixed-span pool as the in-progress occupancy so the merge below
+    # absorbs any shadow-vs-occupancy overlap too.
+    player_fixed_spans: defaultdict[PlayerId, list[tuple[int, int]]] = defaultdict(list)
+    for player_id, spans in player_inprog.items():
+        player_fixed_spans[player_id].extend((s, e) for s, e, _ in spans)
     for shadow in coalesce_rest_shadows(snapshot.rest_shadows):
-        player_intervals[shadow.player_id].append(
-            model.NewFixedSizeIntervalVar(
-                shadow.completed_at_min,
-                REST_MIN,
-                f"rest_{shadow.player_id}_{shadow.completed_at_min}",
-            )
+        player_fixed_spans[shadow.player_id].append(
+            (shadow.completed_at_min, shadow.completed_at_min + REST_MIN)
         )
+
+    # Merge broadly: collapse each resource's *fixed* spans into their disjoint
+    # union before AddNoOverlap. Two overlapping fixed facts (two in-progress
+    # matches on one table or one human, or a shadow-vs-occupancy overlap) are
+    # physically impossible data that would otherwise make AddNoOverlap
+    # unsatisfiable and blank the WHOLE board (#1144). The union stays fully
+    # blocked for every *variable* interval (unpinned placements, sliding pins),
+    # so no one else is scheduled onto genuinely-held occupancy — conservative
+    # for everyone else — while fixed-vs-fixed can never force infeasibility. We
+    # never move, re-time, or drop the live matches themselves; only what the
+    # *other* fixtures see as occupied changes.
+    for table_id, spans in table_inprog.items():
+        for lo, hi in _merge_spans((s, e) for s, e, _ in spans):
+            table_intervals[table_id].append(
+                model.NewFixedSizeIntervalVar(lo, hi - lo, f"fixed_t_{table_id}_{lo}")
+            )
+    for player_id, merge_spans in player_fixed_spans.items():
+        for lo, hi in _merge_spans(merge_spans):
+            player_intervals[player_id].append(
+                model.NewFixedSizeIntervalVar(lo, hi - lo, f"fixed_p_{player_id}_{lo}")
+            )
 
     # Called matches: table hard-fixed, start a free variable pushable only
     # later. The start lives on `table_intervals[pin.table_id]` alone — no
@@ -947,6 +1097,7 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
         pin_starts=pin_starts,
         pin_tables=pin_tables,
         pin_durations=pin_durations,
+        conflicts=conflicts,
     )
 
 
@@ -1000,9 +1151,10 @@ def solve(
             reasons=(
                 NoSingleCause(required_min=required_min, available_min=available_min),
             ),
+            conflicts=built.conflicts,
         )
     if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
-        return _no_plan(Verdict.unknown, wall_time_ms)
+        return _no_plan(Verdict.unknown, wall_time_ms, conflicts=built.conflicts)
 
     placements: list[PlacedFixture] = []
     # Called matches: table is the pin's fixed table; start is read back from
@@ -1038,6 +1190,7 @@ def solve(
             wall_time_ms=wall_time_ms,
             objective=int(solver.ObjectiveValue()),
         ),
+        conflicts=built.conflicts,
     )
 
 

--- a/api/app/schemas/schedule_solve.py
+++ b/api/app/schemas/schedule_solve.py
@@ -99,3 +99,74 @@ def parse_infeasibility_reasons(
     if raw is None:
         return []
     return _REASONS_ADAPTER.validate_python(raw)
+
+
+class ConflictFixtureRead(BaseModel):
+    """One of the in-progress matches caught in a conflict, named the way the
+    director reads a fixture — by its **matchup**, the two players facing off
+    (:attr:`player_a` / :attr:`player_b`, their display usernames). The raw
+    ``fixture_id`` rides along so a surface can key/deep-link without re-deriving
+    it from the names. Resolved once at apply from the pure conflict's fixture
+    ids; the client formats the ``a vs b`` label itself."""
+
+    fixture_id: str
+    player_a: str
+    player_b: str
+
+
+class TableConflictRead(BaseModel):
+    """Two or more in-progress matches recorded on the *same table* at
+    overlapping times — physically impossible (a table holds one match), so
+    contradictory data from a soft manual placement PATCH. Resolved: the table's
+    catalogue ``table_label`` (never the raw value-object id) and the colliding
+    ``fixtures``, each named by its matchup. The DB-aware mirror of
+    :class:`app.scheduling.TableConflict`."""
+
+    kind: Literal["table_conflict"] = "table_conflict"
+    table_label: str
+    fixtures: list[ConflictFixtureRead]
+
+
+class PlayerConflictRead(BaseModel):
+    """Two or more in-progress matches sharing a *human* whose occupancy
+    overlaps — physically impossible (a human plays one match at a time), so
+    contradictory data from a soft manual PATCH. Resolved: the human's display
+    ``player_name`` and the colliding ``fixtures``, each named by its matchup.
+    The DB-aware mirror of :class:`app.scheduling.PlayerConflict`."""
+
+    kind: Literal["player_conflict"] = "player_conflict"
+    player_name: str
+    fixtures: list[ConflictFixtureRead]
+
+
+#: The closed set of *resolved* placement conflicts a solve can report — the
+#: DB-aware mirror of :data:`app.scheduling.PlacementConflict`, humanized once at
+#: apply (ids → player names, table labels) and parsed back here at every read.
+#: Discriminated on ``kind`` so a renderer is a total function of it (add an arm
+#: → a type error until handled). Distinct from :data:`ResolvedReason`: a
+#: conflict is orthogonal to the verdict — a fully-placed board can carry one.
+ResolvedConflict = Annotated[
+    TableConflictRead | PlayerConflictRead,
+    Field(discriminator="kind"),
+]
+
+#: Parses the ledger's raw ``placement_conflicts`` JSONB (``list[dict]``) back
+#: into the typed union in one place (parse, don't validate). Built once at
+#: import — a ``TypeAdapter`` is reusable and cached.
+_CONFLICTS_ADAPTER: TypeAdapter[list[ResolvedConflict]] = TypeAdapter(
+    list[ResolvedConflict]
+)
+
+
+def parse_placement_conflicts(
+    raw: list[dict[str, Any]] | None,
+) -> list[ResolvedConflict]:
+    """Turn the ledger's ``placement_conflicts`` JSONB into typed conflicts.
+
+    ``None`` (a solve that never reached its apply left the column NULL) parses
+    to the empty list — no conflicts to report, not an error. A solve that did
+    apply writes ``[]`` for the (overwhelmingly common) no-conflict case, which
+    parses to the same empty list."""
+    if raw is None:
+        return []
+    return _CONFLICTS_ADAPTER.validate_python(raw)

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -21,7 +21,12 @@ from app.models.schedule_solve import (
     SolverVerdict,
 )
 from app.models.tournament import DrawType, EventFormat, TournamentStatus
-from app.schemas.schedule_solve import ResolvedReason, parse_infeasibility_reasons
+from app.schemas.schedule_solve import (
+    ResolvedConflict,
+    ResolvedReason,
+    parse_infeasibility_reasons,
+    parse_placement_conflicts,
+)
 
 # ----- bounded numerics (the column is a constraint too) ---------------------
 
@@ -605,6 +610,15 @@ class ScheduleSolveRead(BaseModel):
     could not be scheduled (pool names, ``HH:MM`` window bounds, the integer
     minutes to format); every other row carries ``[]``. Parsed from the ledger's
     raw JSONB at this boundary so no downstream reader touches a bare dict.
+
+    ``placement_conflicts`` is **never null** either — always a list, ``[]`` on
+    every row without conflicts (so a client never null-checks it). It is
+    orthogonal to the verdict: even a fully-*placed* board can flag overlapping
+    in-progress matches (two matches on one table, or one human in two at once,
+    from a soft manual placement PATCH). It carries the resolved, DB-humanized
+    conflicts — table labels and player names, each colliding fixture named by
+    its matchup — parsed from the ledger's raw JSONB at this boundary so no
+    downstream reader touches a bare dict.
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -621,6 +635,7 @@ class ScheduleSolveRead(BaseModel):
     fixtures_pinned: int | None
     error: str | None
     infeasibility_reasons: list[ResolvedReason]
+    placement_conflicts: list[ResolvedConflict]
 
     @field_validator("infeasibility_reasons", mode="before")
     @classmethod
@@ -632,6 +647,17 @@ class ScheduleSolveRead(BaseModel):
         inward. A value already parsed to typed reasons passes back through
         unchanged."""
         return parse_infeasibility_reasons(value)
+
+    @field_validator("placement_conflicts", mode="before")
+    @classmethod
+    def _parse_placement_conflicts(cls, value: Any) -> list[ResolvedConflict]:
+        """Parse the ledger's raw ``placement_conflicts`` JSONB
+        (``list[dict] | None``) into the typed union at the boundary, mapping the
+        NULL of a row that never reached its apply to ``[]`` — so
+        ``model_validate`` on a ``ScheduleSolve`` row never fails on a null
+        column and no raw dict leaks inward. A value already parsed to typed
+        conflicts passes back through unchanged."""
+        return parse_placement_conflicts(value)
 
 
 class StandingRowRead(BaseModel):

--- a/api/migrations/versions/20260720_0000_0016_add_placement_conflicts_to_schedule_solves.py
+++ b/api/migrations/versions/20260720_0000_0016_add_placement_conflicts_to_schedule_solves.py
@@ -1,0 +1,37 @@
+"""add placement_conflicts to schedule_solves
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-07-20 00:00:00.000000
+
+A new JSONB column carrying a solve's *resolved* in-progress-vs-in-progress
+placement conflicts (ADR "overlapping in-progress matches are tolerated and
+reported"). Parallel to ``infeasibility_reasons`` but orthogonal to the
+verdict: two matches recorded on one table (or one human in two) are
+contradictory data the solver tolerates rather than letting them blank the
+board (#1144), and a fully-placed ``optimal``/``feasible`` solve can still
+carry them. Written on any verdict where the solver ran (``[]`` when there were
+none), NULL only before a solve reaches its apply.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0016"
+down_revision: Union[str, None] = "0015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "schedule_solves",
+        sa.Column("placement_conflicts", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("schedule_solves", "placement_conflicts")

--- a/api/tests/test_schedule_solve_models.py
+++ b/api/tests/test_schedule_solve_models.py
@@ -214,6 +214,7 @@ async def test_schedule_solve_read_refuses_an_unknown_enum_value(
         "fixtures_pinned": None,
         "error": None,
         "infeasibility_reasons": [],
+        "placement_conflicts": [],
     }
     assert ScheduleSolveRead.model_validate(payload).trigger is (
         ScheduleSolveTrigger.manual

--- a/api/tests/test_schedule_solve_route.py
+++ b/api/tests/test_schedule_solve_route.py
@@ -385,6 +385,9 @@ async def test_solve_strip_carries_the_newest_row_by_requested_at(
     # Never-infeasible rows carry an empty list, never a null — the client never
     # null-checks ``infeasibility_reasons``.
     assert strip["infeasibility_reasons"] == []
+    # A row that never reached its apply carries ``[]`` conflicts, never a null —
+    # the client never null-checks ``placement_conflicts`` either.
+    assert strip["placement_conflicts"] == []
 
 
 async def test_solve_strip_carries_resolved_infeasibility_reasons(
@@ -439,6 +442,71 @@ async def test_solve_strip_carries_resolved_infeasibility_reasons(
     assert over_capacity["required_min"] == 600
     assert over_capacity["capacity_min"] == 480
     assert over_capacity["table_count"] == 1
+
+
+async def test_solve_strip_carries_resolved_placement_conflicts(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A solve whose applied board still overlaps in-progress matches carries the
+    resolved conflicts on the strip — orthogonal to the verdict, so a ``succeeded``
+    run can flag them. Parsed from the ledger's raw ``placement_conflicts`` JSONB
+    into the typed union at the read boundary: a table conflict resolved to its
+    ``table_label`` and a player conflict to its ``player_name``, each colliding
+    fixture named by its matchup — so a client renders them without any further
+    lookup."""
+    client, owner = authed_client
+    tournament_id, _ = await _make_tournament(db_session, owner)
+    solve = ScheduleSolve(
+        tournament_id=tournament_id,
+        trigger=ScheduleSolveTrigger.manual,
+        status=ScheduleSolveStatus.succeeded,
+        verdict=SolverVerdict.optimal,
+        requested_at=datetime(2030, 1, 1, 9, 0, tzinfo=UTC),
+        placement_conflicts=[
+            {
+                "kind": "table_conflict",
+                "table_label": "Table 1",
+                "fixtures": [
+                    {"fixture_id": "f-1", "player_a": "Ada", "player_b": "Babbage"},
+                    {"fixture_id": "f-2", "player_a": "Carol", "player_b": "Dave"},
+                ],
+            },
+            {
+                "kind": "player_conflict",
+                "player_name": "Ada",
+                "fixtures": [
+                    {"fixture_id": "f-1", "player_a": "Ada", "player_b": "Babbage"},
+                    {"fixture_id": "f-3", "player_a": "Ada", "player_b": "Erin"},
+                ],
+            },
+        ],
+    )
+    db_session.add(solve)
+    await db_session.commit()
+
+    strip = (await client.get(_detail_url(tournament_id))).json()[
+        "latest_schedule_solve"
+    ]
+
+    assert strip["id"] == str(solve.id)
+    assert strip["status"] == "succeeded"
+    # A non-infeasible verdict, yet conflicts still ride along — the two are
+    # orthogonal.
+    assert strip["infeasibility_reasons"] == []
+    conflicts = strip["placement_conflicts"]
+    assert [c["kind"] for c in conflicts] == ["table_conflict", "player_conflict"]
+    table = conflicts[0]
+    assert table["table_label"] == "Table 1"
+    assert [f["fixture_id"] for f in table["fixtures"]] == ["f-1", "f-2"]
+    assert table["fixtures"][0] == {
+        "fixture_id": "f-1",
+        "player_a": "Ada",
+        "player_b": "Babbage",
+    }
+    player = conflicts[1]
+    assert player["player_name"] == "Ada"
+    assert [f["fixture_id"] for f in player["fixtures"]] == ["f-1", "f-3"]
 
 
 async def test_after_the_drained_job_the_solve_strip_and_pin_facts_reach_the_page(

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -64,6 +64,7 @@ from app.models import (
     TournamentEvent,
     TournamentFixture,
     TournamentStatus,
+    User,
 )
 from app.schedule_solves import (
     JOB_TIMEOUT_MARGIN_S,
@@ -86,9 +87,12 @@ from app.scheduling import (
 )
 from app.schemas.notification import NotificationJob
 from app.schemas.schedule_solve import (
+    PlayerConflictRead,
     PoolHasNoTablesRead,
     PoolOverCapacityRead,
+    TableConflictRead,
     parse_infeasibility_reasons,
+    parse_placement_conflicts,
 )
 from app.tournament_draws import cut_draw
 from tests._helpers import hijack_solve, make_user
@@ -288,6 +292,19 @@ async def _fixture_user_ids(
     ).all()
     by_entry = {entry_id: str(user_id) for entry_id, user_id in rows}
     return by_entry[entry_a_id], by_entry[entry_b_id]
+
+
+async def _entry_username(db: AsyncSession, entry_id: uuid.UUID) -> str:
+    """The display username behind a tournament entry — what a placement
+    conflict resolves a player/matchup id to."""
+    user_id = (
+        await db.execute(
+            select(TournamentEntry.user_id).where(TournamentEntry.id == entry_id)
+        )
+    ).scalar_one()
+    return (
+        await db.execute(select(User.username).where(User.id == user_id))
+    ).scalar_one()
 
 
 async def _link_match(
@@ -1269,6 +1286,137 @@ class TestSolveJob:
         (ledger,) = await _solve_rows(db_session, tournament_id)
         assert ledger.status is ScheduleSolveStatus.failed
         assert ledger.infeasibility_reasons is None
+
+    async def test_placement_conflicts_are_resolved_and_persisted_on_placed_board(
+        self,
+        db_session: AsyncSession,
+        solver_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Two in-progress matches recorded on one table AND sharing a player
+        are contradictory data the solver tolerates (it merges the occupancy so
+        the board still places) yet REPORTS. At apply the id-and-minute
+        conflicts are humanized — table label, player name, each colliding
+        fixture named by its matchup — and persisted to ``placement_conflicts``
+        on the (optimal/feasible) verdict, NOT gated on infeasible."""
+        tournament_id, event_id = await _make_tournament(db_session)
+        fixtures = await _fixtures_of(db_session, event_id)
+        first_fixture = fixtures[0]
+        partner: TournamentFixture | None = None
+        shared_entry_id: uuid.UUID | None = None
+        for candidate in fixtures[1:]:
+            common = {first_fixture.entry_a_id, first_fixture.entry_b_id} & {
+                candidate.entry_a_id,
+                candidate.entry_b_id,
+            }
+            if common:
+                shared_entry_id = next(iter(common))
+                partner = candidate
+                break
+        assert partner is not None and shared_entry_id is not None
+
+        # Stage both as physically underway on the SAME table at the SAME start
+        # (a soft double-book): pinned, live, promised start already arrived.
+        colliding = (first_fixture, partner)
+        for fixture in colliding:
+            await _link_match(db_session, fixture, status=MatchStatus.in_progress)
+            fixture.table_id = "t1"
+            fixture.scheduled_start = BASE
+            fixture.pinned_at = BASE - timedelta(minutes=5)
+        await db_session.commit()
+
+        # Capture ids/entries before the session is expired below (an expired
+        # ORM instance would sync-lazy-load — MissingGreenlet).
+        fixture_entries: dict[uuid.UUID, tuple[uuid.UUID, uuid.UUID]] = {}
+        for fixture in colliding:
+            assert fixture.entry_a_id is not None and fixture.entry_b_id is not None
+            fixture_entries[fixture.id] = (fixture.entry_a_id, fixture.entry_b_id)
+        colliding_ids = set(fixture_entries)
+
+        # The frame is 2030 and the job's wall-clock ``now`` is years off, so
+        # compute the genuine solve at a moment INSIDE the in-progress window
+        # (where the pins read as underway) and replay it through the ``_solve``
+        # seam — the same deterministic-staging trick ``_slide_pin_later`` uses.
+        # The conflicts on this result are the pure module's own, from the real
+        # overlapping in-progress data.
+        controlled_now = BASE + timedelta(minutes=30)
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=controlled_now, lock=False
+        )
+        assert inputs is not None
+        genuine = scheduling.solve(inputs.snapshot)
+        assert genuine.verdict in (Verdict.optimal, Verdict.feasible)
+        assert {conflict.kind for conflict in genuine.conflicts} == {
+            "table_conflict",
+            "player_conflict",
+        }
+
+        monkeypatch.setattr(
+            schedule_solves,
+            "_solve",
+            lambda snapshot, time_cap_s, num_search_workers: genuine,
+        )
+
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+        assert row is not None
+        row_id = row.id
+        await db_session.commit()
+        _run_recorded_job(solver_queue, row_id)
+
+        db_session.expire_all()
+        (ledger,) = await _solve_rows(db_session, tournament_id)
+        assert ledger.status is ScheduleSolveStatus.succeeded
+
+        conflicts = parse_placement_conflicts(ledger.placement_conflicts)
+        (table_conflict,) = [c for c in conflicts if isinstance(c, TableConflictRead)]
+        (player_conflict,) = [c for c in conflicts if isinstance(c, PlayerConflictRead)]
+
+        # The catalogue LABEL, never the raw ``t1`` value-object id.
+        assert table_conflict.table_label == "T1"
+        # Both colliding matches, each named by its matchup (the two players).
+        assert {f.fixture_id for f in table_conflict.fixtures} == {
+            str(fixture_id) for fixture_id in colliding_ids
+        }
+
+        # The shared human, resolved to their display name; same two fixtures.
+        shared_username = await _entry_username(db_session, shared_entry_id)
+        assert player_conflict.player_name == shared_username
+        assert {f.fixture_id for f in player_conflict.fixtures} == {
+            str(fixture_id) for fixture_id in colliding_ids
+        }
+
+        # Each colliding fixture is named by BOTH its players' usernames, in
+        # (entry_a, entry_b) order — the id→name resolution is correct.
+        for fixture_id, (entry_a, entry_b) in fixture_entries.items():
+            named = next(
+                f for f in table_conflict.fixtures if f.fixture_id == str(fixture_id)
+            )
+            assert named.player_a == await _entry_username(db_session, entry_a)
+            assert named.player_b == await _entry_username(db_session, entry_b)
+
+    async def test_clean_solve_persists_empty_placement_conflicts(
+        self, db_session: AsyncSession, solver_queue: Queue
+    ) -> None:
+        """A solve with no overlapping in-progress data still writes
+        ``placement_conflicts`` — an empty list, never NULL — on the applied
+        verdict, so the read boundary parses a placed board that simply has
+        nothing to report the same way it parses one that does."""
+        tournament_id, _event_id = await _make_tournament(db_session)
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+        assert row is not None
+        row_id = row.id
+        await db_session.commit()
+        _run_recorded_job(solver_queue, row_id)
+
+        db_session.expire_all()
+        (ledger,) = await _solve_rows(db_session, tournament_id)
+        assert ledger.status is ScheduleSolveStatus.succeeded
+        assert ledger.placement_conflicts == []
+        assert parse_placement_conflicts(ledger.placement_conflicts) == []
 
 
 class TestDriftGuard:

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -27,6 +27,7 @@ from app.scheduling import (
     NoSingleCause,
     Pin,
     PlacedFixture,
+    PlayerConflict,
     PlayerId,
     PoolHasNoTables,
     PoolId,
@@ -37,6 +38,7 @@ from app.scheduling import (
     SchedulePool,
     ScheduleSnapshot,
     SolveResult,
+    TableConflict,
     TableId,
     Verdict,
     Window,
@@ -915,6 +917,103 @@ class TestRestShadows:
         assert len(started_at_zero) == 2
         for fixture in started_at_zero:
             assert p1 not in (fixture.player_a_id, fixture.player_b_id)
+
+
+class TestInProgressConflicts:
+    """Two *fully-fixed in-progress* blocks that overlap on one resource are
+    physically impossible data (a table holds one match, a human plays one) that
+    can only arrive via a director's soft manual placement PATCH. They are
+    tolerated-and-reported, never fatal (#1144): the solver merges the
+    overlapping fixed occupancy so the board still places, and reports the
+    collision on ``result.conflicts`` for the director to resolve — it never
+    picks a survivor and never moves a live match."""
+
+    def test_overlap_on_a_table_is_tolerated_and_reported(self) -> None:
+        """Two in-progress matches recorded on the SAME table at overlapping
+        times. Before #1144 this handed two rigid, overlapping fixed intervals
+        to ``AddNoOverlap`` and proved the WHOLE day ``infeasible`` with zero
+        placements. Now the occupancy is merged, so the board still solves: the
+        other active fixture is placed, the two running matches stay excluded
+        from output, and the table collision is reported once with both
+        fixtures."""
+        p1, p2, p3, p4, p5, p6 = _players(6)
+        tables = _tables(2)
+        snapshot = ScheduleSnapshot(
+            table_ids=tables,
+            pools=(SchedulePool(PoolId("A"), tables, Window(0, 480)),),
+            events=(EventSettings(EventId("E1"), 3),),
+            fixtures=(
+                _fixture(1, p1, p2),  # in-progress on T1 → occupancy [0, 25)
+                _fixture(2, p3, p4),  # in-progress on T1 → occupancy [10, 35)
+                _fixture(3, p5, p6),  # active, unpinned — must still be placed
+            ),
+            now_min=0,
+            in_progress=(
+                InProgressMatch(FixtureId("F1"), TableId("T1"), 0),
+                InProgressMatch(FixtureId("F2"), TableId("T1"), 10),
+            ),
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        # Tolerated, not fatal: a placed board that also carries the conflict.
+        assert result.verdict in SOLVED
+        assert result.placements != ()
+        assert {p.fixture_id for p in result.placements} == {FixtureId("F3")}
+        assert result.conflicts == (
+            TableConflict(TableId("T1"), (FixtureId("F1"), FixtureId("F2"))),
+        )
+
+    def test_overlap_on_a_player_is_tolerated_and_reported(self) -> None:
+        """Variant sharing a HUMAN on different tables: P1 is recorded in two
+        in-progress matches at once. Same tolerate-and-report outcome, but the
+        collision is a ``PlayerConflict`` on the shared human (no table conflict,
+        since the two matches are on different tables)."""
+        p1, p2, p3, p4, p5 = _players(5)
+        tables = _tables(3)
+        snapshot = ScheduleSnapshot(
+            table_ids=tables,
+            pools=(SchedulePool(PoolId("A"), tables, Window(0, 480)),),
+            events=(EventSettings(EventId("E1"), 3),),
+            fixtures=(
+                _fixture(1, p1, p2),  # in-progress on T1, human P1
+                _fixture(2, p1, p3),  # in-progress on T2, human P1 again — clash
+                _fixture(3, p4, p5),  # active, unpinned — must still be placed
+            ),
+            now_min=0,
+            in_progress=(
+                InProgressMatch(FixtureId("F1"), TableId("T1"), 0),
+                InProgressMatch(FixtureId("F2"), TableId("T2"), 10),
+            ),
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict in SOLVED
+        assert result.placements != ()
+        assert {p.fixture_id for p in result.placements} == {FixtureId("F3")}
+        assert result.conflicts == (
+            PlayerConflict(PlayerId("P1"), (FixtureId("F1"), FixtureId("F2"))),
+        )
+
+    def test_non_overlapping_in_progress_yields_no_conflicts(self) -> None:
+        """A clean snapshot — one running match, no double-booking — reports an
+        empty conflict tuple, the contract's other half."""
+        p1, p2, p3, p4 = _players(4)
+        snapshot = _one_pool_snapshot(
+            (_fixture(1, p1, p2), _fixture(2, p3, p4)),
+            in_progress=(InProgressMatch(FixtureId("F1"), TableId("T1"), 0),),
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict in SOLVED
+        assert result.conflicts == ()
+
+    def test_conflict_free_day_reports_no_conflicts(self) -> None:
+        """No in-progress matches at all: a plain solvable day carries no
+        conflicts."""
+        p1, p2, p3, p4 = _players(4)
+        result = solve(
+            _one_pool_snapshot((_fixture(1, p1, p2), _fixture(2, p3, p4))),
+            time_cap_s=CAP,
+        )
+        assert result.verdict in SOLVED
+        assert result.conflicts == ()
 
 
 class TestDegenerateAndStability:

--- a/docs/adr/20260720-overlapping-in-progress-matches-are-tolerated-and-reported.md
+++ b/docs/adr/20260720-overlapping-in-progress-matches-are-tolerated-and-reported.md
@@ -1,0 +1,106 @@
+# Overlapping in-progress matches are tolerated and reported, never fatal
+
+Date: 2026-07-20
+Status: accepted
+(Number this ADR by its PR at land time; date-prefixed until then.)
+
+Amends ["A called match holds its table and slides later"](20260719-a-called-match-holds-its-table-and-slides-later.md)
+and ["An infeasible solve explains itself with a resolved reason"](20260718-an-infeasible-solve-explains-itself-with-a-resolved-reason.md).
+Closes #1144. Defers the call-time prevention half to #1147.
+
+## Context
+
+[#1141](20260719-a-called-match-holds-its-table-and-slides-later.md) made a *called,
+not-yet-started* pin's start a soft floor that slides behind an overrunning predecessor, so
+pins essentially stopped being a source of infeasibility. It did **not** cover the residual
+path: a placement that collides with a **fully-fixed, in-progress** block on the same table or
+the same human. Genuinely in-progress matches stay rigid in both dimensions — reality outranks
+any plan — so two in-progress intervals that overlap are `AddNoOverlap`-unsatisfiable and make
+the **entire** solve `infeasible`, dropping **all** placements. One bad pin blanks the whole
+board (#1144).
+
+**Two overlapping in-progress blocks are never physical truth.** A table holds one match; a
+human plays one match. The state only exists as **contradictory data**: the solver reads a
+match's *actual* occupancy from its **mutable pin** (`table_id` + `scheduled_start`), because
+there is no separate ground-truth "actually started at / on table X" — a real "match started"
+fact is a later drop-in. So a director's manual placement PATCH — deliberately **soft** per
+[ADR-0790](20260716-the-schedule-is-solved-the-call-is-pinned.md) (out-of-window / occupied-table
+saves succeed and surface downstream, never block) — can move an already-live match onto an
+occupied table or a busy human, and the next solve faithfully models the impossible data as two
+rigid intervals and blanks.
+
+This is the **only** way in. The **automatic** call path already refuses it: the resource-freedom
+gate ([#1106](20260718-a-tournament-match-is-called-only-when-its-table-and-players-are-free.md),
+`match_calls._held_resources`) defers any due fixture whose table or human is held by an unfinished
+in-progress match. The solver's own placements can't self-collide (it enforces no-overlap), and
+#1141 slides not-yet-called matches. Only the manual, soft PATCH bypasses the gate.
+
+**We cannot tell which of two colliding in-progress matches is "real."** A fixture carries only
+`scheduled_start` (mutable, ADR-0790-editable — the repro re-pins to a *past* start) and
+`pinned_at` (refreshed by the system's own moved-repairs). Any winner-guess (earliest-start,
+latest-pinned) is defeated by the very edits that create the collision. So the fix must **not**
+pick a survivor, and must **never move, eject, or re-time a live match** — a match underway is
+sacrosanct (#1141).
+
+## Decision
+
+**The solve refuses to let two contradictory in-progress facts blank the board. It tolerates the
+overlap, keeps every fixed block binding on everything it controls, and reports the conflict —
+it never resolves which match is real, and never touches a live match.** This is the
+ADR-0790-consistent downstream surfacing of a soft write: the write succeeds, the problem shows
+up in the next solve as an advisory rather than a wedged board.
+
+### In the solver (`api/app/scheduling.py`)
+
+- **Merge broadly.** On each resource's interval list (every table, every player), before
+  `AddNoOverlap`, mutually-overlapping **fixed** obstacle intervals are merged into their union.
+  Fixed-vs-fixed can then never force infeasibility, while every **variable** interval (unpinned
+  placement, sliding pin) still routes conservatively around the merged occupancy — the union
+  stays blocked, so no one else is scheduled onto a genuinely-held table or human. This is the
+  general "no fixed-fixed contradiction ever" guarantee; it also absorbs any rest-shadow overlap
+  in the same stroke.
+- **Report narrowly.** The module detects the **in-progress-vs-in-progress** overlapping pairs
+  (the director-actionable ones) and returns them on `SolveResult` as DB-blind, discriminated
+  report values: `table_conflict` (a shared `table_id` + the overlapping `fixture_id`s) and
+  `player_conflict` (a shared `player_id` + the overlapping `fixture_id`s). Rest-shadow overlaps
+  are merged but not reported.
+- **In-progress matches are still excluded from output placements** and are never moved, re-timed,
+  or dropped. The merge changes only what the *other* fixtures see as occupied, not the running
+  matches themselves.
+- **The verdict is unchanged by a conflict.** A solve that placed the board is `optimal` /
+  `feasible` and *also* carries conflicts; the two are orthogonal. A genuine unpinned-demand
+  overflow (out of scope here) still surfaces as the existing structural `infeasible` reasons.
+
+### At apply (`api/app/schedule_solves.py`) and the read boundary
+
+- The conflicts are **resolved** (ids → player names, table labels) using the same resolution
+  lookups the infeasibility reasons already use, and persisted to a **new** JSONB column,
+  `schedule_solves.placement_conflicts` — parallel to `infeasibility_reasons`, but written on
+  **any** verdict (a placed board can still carry conflicts). A discriminated `ResolvedConflict`
+  read union parses it back, exactly like `parse_infeasibility_reasons`.
+- **No player notification, no correction fires.** Nothing moved, so there is no "moved"/"cancelled"
+  pin repair to send. The audience is the **director** ("you double-booked"), not the entrants.
+
+### On the director's surfaces (`web-client`)
+
+- The resolved conflicts render as a warning on the **solve-strip** and **solve-ledger** — the two
+  places the director already reads solve outcomes — naming the two fixtures and the shared table
+  or human (e.g. *"F1 and crafty-vs-spiked overlap on Table 1"*).
+
+## Consequences
+
+- **A single bad pin can no longer blank the board.** The catastrophic blast radius (#1144) is
+  gone regardless of how the contradictory data arose — a soft write's problem is now an advisory,
+  not a wedged day.
+- **The solver never adjudicates reality.** It does not pick a survivor or pretend a live match
+  isn't running; it tolerates the recorded contradiction, stays conservative for everyone else,
+  and hands the director exactly what to fix. This keeps "a match underway must never move"
+  (#1141) intact.
+- **Prevention is deferred, not skipped.** #1147 extends the #1106 `_held_resources` gate to the
+  manual placement PATCH as a **confirm-warning** (not a hard block — ADR-0790 keeps manual
+  placement soft), so a director is warned *before* creating the collision. This backstop makes
+  the conflict report rare rather than routine; it does not replace it, since a warning can be
+  confirmed through and direct/racing edits bypass a UX guard.
+- **The report channel is new but mirrors the reasons channel.** `placement_conflicts` follows
+  the established emit-in-the-pure-module → resolve-at-apply → parse-at-read → render-on-the-strip
+  pattern, so it adds surface without a new shape of surface.

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -2477,6 +2477,47 @@ internal enum Components {
             internal typealias InfeasibilityReasonsPayload = [Components.Schemas.AdminScheduleSolveRead.InfeasibilityReasonsPayloadPayload]
             /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/infeasibility_reasons`.
             internal var infeasibilityReasons: Components.Schemas.AdminScheduleSolveRead.InfeasibilityReasonsPayload
+            /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/PlacementConflictsPayload`.
+            internal enum PlacementConflictsPayloadPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/PlacementConflictsPayload/PlayerConflictRead`.
+                case playerConflict(Components.Schemas.PlayerConflictRead)
+                /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/PlacementConflictsPayload/TableConflictRead`.
+                case tableConflict(Components.Schemas.TableConflictRead)
+                internal enum CodingKeys: String, CodingKey {
+                    case kind
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    let discriminator = try container.decode(
+                        Swift.String.self,
+                        forKey: .kind
+                    )
+                    switch discriminator {
+                    case "player_conflict":
+                        self = .playerConflict(try .init(from: decoder))
+                    case "table_conflict":
+                        self = .tableConflict(try .init(from: decoder))
+                    default:
+                        throw Swift.DecodingError.unknownOneOfDiscriminator(
+                            discriminatorKey: CodingKeys.kind,
+                            discriminatorValue: discriminator,
+                            codingPath: decoder.codingPath
+                        )
+                    }
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    switch self {
+                    case let .playerConflict(value):
+                        try value.encode(to: encoder)
+                    case let .tableConflict(value):
+                        try value.encode(to: encoder)
+                    }
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/placement_conflicts`.
+            internal typealias PlacementConflictsPayload = [Components.Schemas.AdminScheduleSolveRead.PlacementConflictsPayloadPayload]
+            /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/placement_conflicts`.
+            internal var placementConflicts: Components.Schemas.AdminScheduleSolveRead.PlacementConflictsPayload
             /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/input_fingerprint`.
             internal var inputFingerprint: Swift.String?
             /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/rerun_requested`.
@@ -2500,6 +2541,7 @@ internal enum Components {
             ///   - fixturesPinned:
             ///   - error:
             ///   - infeasibilityReasons:
+            ///   - placementConflicts:
             ///   - inputFingerprint:
             ///   - rerunRequested:
             ///   - tournamentId:
@@ -2517,6 +2559,7 @@ internal enum Components {
                 fixturesPinned: Swift.Int? = nil,
                 error: Swift.String? = nil,
                 infeasibilityReasons: Components.Schemas.AdminScheduleSolveRead.InfeasibilityReasonsPayload,
+                placementConflicts: Components.Schemas.AdminScheduleSolveRead.PlacementConflictsPayload,
                 inputFingerprint: Swift.String? = nil,
                 rerunRequested: Swift.Bool,
                 tournamentId: Swift.String,
@@ -2534,6 +2577,7 @@ internal enum Components {
                 self.fixturesPinned = fixturesPinned
                 self.error = error
                 self.infeasibilityReasons = infeasibilityReasons
+                self.placementConflicts = placementConflicts
                 self.inputFingerprint = inputFingerprint
                 self.rerunRequested = rerunRequested
                 self.tournamentId = tournamentId
@@ -2552,6 +2596,7 @@ internal enum Components {
                 case fixturesPinned = "fixtures_pinned"
                 case error
                 case infeasibilityReasons = "infeasibility_reasons"
+                case placementConflicts = "placement_conflicts"
                 case inputFingerprint = "input_fingerprint"
                 case rerunRequested = "rerun_requested"
                 case tournamentId = "tournament_id"
@@ -2882,6 +2927,42 @@ internal enum Components {
             internal enum CodingKeys: String, CodingKey {
                 case token
                 case skipMerge = "skip_merge"
+            }
+        }
+        /// One of the in-progress matches caught in a conflict, named the way the
+        /// director reads a fixture — by its **matchup**, the two players facing off
+        /// (:attr:`player_a` / :attr:`player_b`, their display usernames). The raw
+        /// ``fixture_id`` rides along so a surface can key/deep-link without re-deriving
+        /// it from the names. Resolved once at apply from the pure conflict's fixture
+        /// ids; the client formats the ``a vs b`` label itself.
+        ///
+        /// - Remark: Generated from `#/components/schemas/ConflictFixtureRead`.
+        internal struct ConflictFixtureRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/ConflictFixtureRead/fixture_id`.
+            internal var fixtureId: Swift.String
+            /// - Remark: Generated from `#/components/schemas/ConflictFixtureRead/player_a`.
+            internal var playerA: Swift.String
+            /// - Remark: Generated from `#/components/schemas/ConflictFixtureRead/player_b`.
+            internal var playerB: Swift.String
+            /// Creates a new `ConflictFixtureRead`.
+            ///
+            /// - Parameters:
+            ///   - fixtureId:
+            ///   - playerA:
+            ///   - playerB:
+            internal init(
+                fixtureId: Swift.String,
+                playerA: Swift.String,
+                playerB: Swift.String
+            ) {
+                self.fixtureId = fixtureId
+                self.playerA = playerA
+                self.playerB = playerB
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case fixtureId = "fixture_id"
+                case playerA = "player_a"
+                case playerB = "player_b"
             }
         }
         /// - Remark: Generated from `#/components/schemas/ConsumeLoginRequest`.
@@ -5619,6 +5700,45 @@ internal enum Components {
                 case leagueCount = "league_count"
             }
         }
+        /// Two or more in-progress matches sharing a *human* whose occupancy
+        /// overlaps — physically impossible (a human plays one match at a time), so
+        /// contradictory data from a soft manual PATCH. Resolved: the human's display
+        /// ``player_name`` and the colliding ``fixtures``, each named by its matchup.
+        /// The DB-aware mirror of :class:`app.scheduling.PlayerConflict`.
+        ///
+        /// - Remark: Generated from `#/components/schemas/PlayerConflictRead`.
+        internal struct PlayerConflictRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/PlayerConflictRead/kind`.
+            internal enum KindPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case playerConflict = "player_conflict"
+            }
+            /// - Remark: Generated from `#/components/schemas/PlayerConflictRead/kind`.
+            internal var kind: Components.Schemas.PlayerConflictRead.KindPayload?
+            /// - Remark: Generated from `#/components/schemas/PlayerConflictRead/player_name`.
+            internal var playerName: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PlayerConflictRead/fixtures`.
+            internal var fixtures: [Components.Schemas.ConflictFixtureRead]
+            /// Creates a new `PlayerConflictRead`.
+            ///
+            /// - Parameters:
+            ///   - kind:
+            ///   - playerName:
+            ///   - fixtures:
+            internal init(
+                kind: Components.Schemas.PlayerConflictRead.KindPayload? = nil,
+                playerName: Swift.String,
+                fixtures: [Components.Schemas.ConflictFixtureRead]
+            ) {
+                self.kind = kind
+                self.playerName = playerName
+                self.fixtures = fixtures
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case kind
+                case playerName = "player_name"
+                case fixtures
+            }
+        }
         /// Profile-page bundle: the hero (`PlayerSummary` fields + the standing
         /// block below) plus the player's six most recent matches inline. Saves a round
         /// trip on initial load — `GET /v1/players/{id}` returns this so the profile
@@ -7182,6 +7302,15 @@ internal enum Components {
         /// minutes to format); every other row carries ``[]``. Parsed from the ledger's
         /// raw JSONB at this boundary so no downstream reader touches a bare dict.
         ///
+        /// ``placement_conflicts`` is **never null** either — always a list, ``[]`` on
+        /// every row without conflicts (so a client never null-checks it). It is
+        /// orthogonal to the verdict: even a fully-*placed* board can flag overlapping
+        /// in-progress matches (two matches on one table, or one human in two at once,
+        /// from a soft manual placement PATCH). It carries the resolved, DB-humanized
+        /// conflicts — table labels and player names, each colliding fixture named by
+        /// its matchup — parsed from the ledger's raw JSONB at this boundary so no
+        /// downstream reader touches a bare dict.
+        ///
         /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead`.
         internal struct ScheduleSolveRead: Codable, Hashable, Sendable {
             /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/id`.
@@ -7277,6 +7406,47 @@ internal enum Components {
             internal typealias InfeasibilityReasonsPayload = [Components.Schemas.ScheduleSolveRead.InfeasibilityReasonsPayloadPayload]
             /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/infeasibility_reasons`.
             internal var infeasibilityReasons: Components.Schemas.ScheduleSolveRead.InfeasibilityReasonsPayload
+            /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/PlacementConflictsPayload`.
+            internal enum PlacementConflictsPayloadPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/PlacementConflictsPayload/PlayerConflictRead`.
+                case playerConflict(Components.Schemas.PlayerConflictRead)
+                /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/PlacementConflictsPayload/TableConflictRead`.
+                case tableConflict(Components.Schemas.TableConflictRead)
+                internal enum CodingKeys: String, CodingKey {
+                    case kind
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    let container = try decoder.container(keyedBy: CodingKeys.self)
+                    let discriminator = try container.decode(
+                        Swift.String.self,
+                        forKey: .kind
+                    )
+                    switch discriminator {
+                    case "player_conflict":
+                        self = .playerConflict(try .init(from: decoder))
+                    case "table_conflict":
+                        self = .tableConflict(try .init(from: decoder))
+                    default:
+                        throw Swift.DecodingError.unknownOneOfDiscriminator(
+                            discriminatorKey: CodingKeys.kind,
+                            discriminatorValue: discriminator,
+                            codingPath: decoder.codingPath
+                        )
+                    }
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    switch self {
+                    case let .playerConflict(value):
+                        try value.encode(to: encoder)
+                    case let .tableConflict(value):
+                        try value.encode(to: encoder)
+                    }
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/placement_conflicts`.
+            internal typealias PlacementConflictsPayload = [Components.Schemas.ScheduleSolveRead.PlacementConflictsPayloadPayload]
+            /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/placement_conflicts`.
+            internal var placementConflicts: Components.Schemas.ScheduleSolveRead.PlacementConflictsPayload
             /// Creates a new `ScheduleSolveRead`.
             ///
             /// - Parameters:
@@ -7292,6 +7462,7 @@ internal enum Components {
             ///   - fixturesPinned:
             ///   - error:
             ///   - infeasibilityReasons:
+            ///   - placementConflicts:
             internal init(
                 id: Swift.String,
                 trigger: Components.Schemas.ScheduleSolveTrigger,
@@ -7304,7 +7475,8 @@ internal enum Components {
                 fixturesPlaced: Swift.Int? = nil,
                 fixturesPinned: Swift.Int? = nil,
                 error: Swift.String? = nil,
-                infeasibilityReasons: Components.Schemas.ScheduleSolveRead.InfeasibilityReasonsPayload
+                infeasibilityReasons: Components.Schemas.ScheduleSolveRead.InfeasibilityReasonsPayload,
+                placementConflicts: Components.Schemas.ScheduleSolveRead.PlacementConflictsPayload
             ) {
                 self.id = id
                 self.trigger = trigger
@@ -7318,6 +7490,7 @@ internal enum Components {
                 self.fixturesPinned = fixturesPinned
                 self.error = error
                 self.infeasibilityReasons = infeasibilityReasons
+                self.placementConflicts = placementConflicts
             }
             internal enum CodingKeys: String, CodingKey {
                 case id
@@ -7332,6 +7505,7 @@ internal enum Components {
                 case fixturesPinned = "fixtures_pinned"
                 case error
                 case infeasibilityReasons = "infeasibility_reasons"
+                case placementConflicts = "placement_conflicts"
             }
         }
         /// The run's lifecycle. ``infeasible`` is a *terminal outcome*, not a failure:
@@ -7650,6 +7824,46 @@ internal enum Components {
             case scheduled = "scheduled"
             case live = "live"
             case final = "final"
+        }
+        /// Two or more in-progress matches recorded on the *same table* at
+        /// overlapping times — physically impossible (a table holds one match), so
+        /// contradictory data from a soft manual placement PATCH. Resolved: the table's
+        /// catalogue ``table_label`` (never the raw value-object id) and the colliding
+        /// ``fixtures``, each named by its matchup. The DB-aware mirror of
+        /// :class:`app.scheduling.TableConflict`.
+        ///
+        /// - Remark: Generated from `#/components/schemas/TableConflictRead`.
+        internal struct TableConflictRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/TableConflictRead/kind`.
+            internal enum KindPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case tableConflict = "table_conflict"
+            }
+            /// - Remark: Generated from `#/components/schemas/TableConflictRead/kind`.
+            internal var kind: Components.Schemas.TableConflictRead.KindPayload?
+            /// - Remark: Generated from `#/components/schemas/TableConflictRead/table_label`.
+            internal var tableLabel: Swift.String
+            /// - Remark: Generated from `#/components/schemas/TableConflictRead/fixtures`.
+            internal var fixtures: [Components.Schemas.ConflictFixtureRead]
+            /// Creates a new `TableConflictRead`.
+            ///
+            /// - Parameters:
+            ///   - kind:
+            ///   - tableLabel:
+            ///   - fixtures:
+            internal init(
+                kind: Components.Schemas.TableConflictRead.KindPayload? = nil,
+                tableLabel: Swift.String,
+                fixtures: [Components.Schemas.ConflictFixtureRead]
+            ) {
+                self.kind = kind
+                self.tableLabel = tableLabel
+                self.fixtures = fixtures
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case kind
+                case tableLabel = "table_label"
+                case fixtures
+            }
         }
         /// Outcome of firing a test push to the current user's devices.
         ///

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1548,6 +1548,8 @@ export interface components {
             error: string | null;
             /** Infeasibility Reasons */
             infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["NoSingleCauseRead"])[];
+            /** Placement Conflicts */
+            placement_conflicts: (components["schemas"]["TableConflictRead"] | components["schemas"]["PlayerConflictRead"])[];
             /** Input Fingerprint */
             input_fingerprint: string | null;
             /** Rerun Requested */
@@ -1668,6 +1670,23 @@ export interface components {
              * @default false
              */
             skip_merge: boolean;
+        };
+        /**
+         * ConflictFixtureRead
+         * @description One of the in-progress matches caught in a conflict, named the way the
+         *     director reads a fixture — by its **matchup**, the two players facing off
+         *     (:attr:`player_a` / :attr:`player_b`, their display usernames). The raw
+         *     ``fixture_id`` rides along so a surface can key/deep-link without re-deriving
+         *     it from the names. Resolved once at apply from the pure conflict's fixture
+         *     ids; the client formats the ``a vs b`` label itself.
+         */
+        ConflictFixtureRead: {
+            /** Fixture Id */
+            fixture_id: string;
+            /** Player A */
+            player_a: string;
+            /** Player B */
+            player_b: string;
         };
         /** ConsumeLoginRequest */
         ConsumeLoginRequest: {
@@ -2743,6 +2762,25 @@ export interface components {
             league_count: number;
         };
         /**
+         * PlayerConflictRead
+         * @description Two or more in-progress matches sharing a *human* whose occupancy
+         *     overlaps — physically impossible (a human plays one match at a time), so
+         *     contradictory data from a soft manual PATCH. Resolved: the human's display
+         *     ``player_name`` and the colliding ``fixtures``, each named by its matchup.
+         *     The DB-aware mirror of :class:`app.scheduling.PlayerConflict`.
+         */
+        PlayerConflictRead: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "player_conflict";
+            /** Player Name */
+            player_name: string;
+            /** Fixtures */
+            fixtures: components["schemas"]["ConflictFixtureRead"][];
+        };
+        /**
          * PlayerDetail
          * @description Profile-page bundle: the hero (`PlayerSummary` fields + the standing
          *     block below) plus the player's six most recent matches inline. Saves a round
@@ -3415,6 +3453,15 @@ export interface components {
          *     could not be scheduled (pool names, ``HH:MM`` window bounds, the integer
          *     minutes to format); every other row carries ``[]``. Parsed from the ledger's
          *     raw JSONB at this boundary so no downstream reader touches a bare dict.
+         *
+         *     ``placement_conflicts`` is **never null** either — always a list, ``[]`` on
+         *     every row without conflicts (so a client never null-checks it). It is
+         *     orthogonal to the verdict: even a fully-*placed* board can flag overlapping
+         *     in-progress matches (two matches on one table, or one human in two at once,
+         *     from a soft manual placement PATCH). It carries the resolved, DB-humanized
+         *     conflicts — table labels and player names, each colliding fixture named by
+         *     its matchup — parsed from the ledger's raw JSONB at this boundary so no
+         *     downstream reader touches a bare dict.
          */
         ScheduleSolveRead: {
             /**
@@ -3444,6 +3491,8 @@ export interface components {
             error: string | null;
             /** Infeasibility Reasons */
             infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["NoSingleCauseRead"])[];
+            /** Placement Conflicts */
+            placement_conflicts: (components["schemas"]["TableConflictRead"] | components["schemas"]["PlayerConflictRead"])[];
         };
         /**
          * ScheduleSolveStatus
@@ -3575,6 +3624,26 @@ export interface components {
          * @enum {string}
          */
         Status: "scheduled" | "live" | "final";
+        /**
+         * TableConflictRead
+         * @description Two or more in-progress matches recorded on the *same table* at
+         *     overlapping times — physically impossible (a table holds one match), so
+         *     contradictory data from a soft manual placement PATCH. Resolved: the table's
+         *     catalogue ``table_label`` (never the raw value-object id) and the colliding
+         *     ``fixtures``, each named by its matchup. The DB-aware mirror of
+         *     :class:`app.scheduling.TableConflict`.
+         */
+        TableConflictRead: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "table_conflict";
+            /** Table Label */
+            table_label: string;
+            /** Fixtures */
+            fixtures: components["schemas"]["ConflictFixtureRead"][];
+        };
         /**
          * TestNotificationResponse
          * @description Outcome of firing a test push to the current user's devices.

--- a/web-client/src/components/scheduling/solve-ledger-page.factory.ts
+++ b/web-client/src/components/scheduling/solve-ledger-page.factory.ts
@@ -1,9 +1,13 @@
 import type { components } from '@/api/schema'
-import { buildAdminScheduleSolveRead } from '@/mocks/factories/tournaments/tournament.factory'
+import {
+  buildAdminScheduleSolveRead,
+  buildPlayerConflictRead,
+  buildTableConflictRead,
+} from '@/mocks/factories/tournaments/tournament.factory'
 
 type AdminScheduleSolveRead = components['schemas']['AdminScheduleSolveRead']
 
-export { buildAdminScheduleSolveRead }
+export { buildAdminScheduleSolveRead, buildTableConflictRead, buildPlayerConflictRead }
 
 /**
  * The variety page: one row per designed outcome, newest first — the seed the

--- a/web-client/src/components/scheduling/solve-ledger-page.test.tsx
+++ b/web-client/src/components/scheduling/solve-ledger-page.test.tsx
@@ -7,6 +7,8 @@ import {
   buildAdminScheduleSolveRead,
   buildLedgerRows,
   buildLedgerVariety,
+  buildPlayerConflictRead,
+  buildTableConflictRead,
 } from './solve-ledger-page.factory'
 import { solveLedgerPage } from './solve-ledger-page.page'
 
@@ -161,6 +163,52 @@ describe('SolveLedgerPage', () => {
     expect(detail).toHaveTextContent('Input fingerprint')
     // No reason list is rendered when the (normally ≥1) list is somehow empty.
     expect(detail?.querySelector('.solve-ledger-detail-reasons')).toBeNull()
+  })
+
+  it('expands a SUCCEEDED row that carries a placement conflict — a caution, not a failure headline — naming both matches and the shared table AND human', async () => {
+    solveLedgerPage.render([
+      buildAdminScheduleSolveRead({
+        id: 'sv-conflicts',
+        status: 'succeeded',
+        verdict: 'feasible',
+        fixtures_placed: 9,
+        fixtures_pinned: 2,
+        placement_conflicts: [buildTableConflictRead(), buildPlayerConflictRead()],
+      }),
+    ])
+    const user = solveLedgerPage.user()
+
+    const row = await solveLedgerPage.findRow('sv-conflicts')
+    // A placed board still reads "Solved" — the conflict is a caution, orthogonal.
+    expect(within(row).getByText('Solved')).toBeInTheDocument()
+
+    await user.click(within(row).getByRole('button', { name: 'Show run details' }))
+    const detail = solveLedgerPage.queryDetail('sv-conflicts')
+    expect(detail).toHaveTextContent('Overlapping matches on the board')
+    // The table conflict, named by matchup + shared table…
+    expect(detail).toHaveTextContent(
+      'crafty-vs-spiked and dazed-vs-confused overlap on Table 1',
+    )
+    // …and the player conflict, named by the shared human.
+    expect(detail).toHaveTextContent(
+      'crafty-vs-spiked-frigatebird and spiked-frigatebird-vs-nimble overlap on spiked-frigatebird',
+    )
+    // A solved board carries no failure headline — the caution never reads as a
+    // broken or infeasible run.
+    expect(detail).not.toHaveTextContent("The day doesn't fit")
+    expect(detail).not.toHaveTextContent('The scheduler hit a problem')
+    // Still the fingerprint footer, as every expansion has.
+    expect(detail).toHaveTextContent('Input fingerprint')
+  })
+
+  it('offers no expansion on a clean solved board (placement_conflicts: [])', async () => {
+    solveLedgerPage.render([
+      buildAdminScheduleSolveRead({ id: 'sv-clean', status: 'succeeded', placement_conflicts: [] }),
+    ])
+    const clean = await solveLedgerPage.findRow('sv-clean')
+    expect(
+      within(clean).queryByRole('button', { name: /run details/i }),
+    ).not.toBeInTheDocument()
   })
 
   it('renders the designed empty state when no solver has ever run', async () => {

--- a/web-client/src/components/scheduling/solve-ledger-page.tsx
+++ b/web-client/src/components/scheduling/solve-ledger-page.tsx
@@ -11,6 +11,8 @@ import {
   fmtWallTime,
   infeasibilityReasonCopy,
   infeasibilityReasonKey,
+  placementConflictKey,
+  placementConflictSentence,
 } from '@/components/tournaments/data/solve'
 import { fmtDateTimeShort } from '@/lib/dates'
 
@@ -269,7 +271,12 @@ function LedgerRow({
   // A local, so `hasFailureDetail`'s type predicate narrows it for the
   // `FAILURE_HEADLINE` lookup below (a property access won't stay narrowed).
   const status = solve.status
-  const expandable = hasFailureDetail(status)
+  const hasFailure = hasFailureDetail(status)
+  // A placed board can still carry a caution (ADR "overlapping-in-progress-
+  // matches-are-tolerated-and-reported") — orthogonal to the verdict, so a
+  // succeeded row with overlapping in-progress matches is expandable too.
+  const hasConflicts = solve.placementConflicts.length > 0
+  const expandable = hasFailure || hasConflicts
   const detailId = `solve-detail-${solve.id}`
 
   return (
@@ -342,11 +349,14 @@ function LedgerRow({
         <tr className="solve-ledger-detail-row">
           <td colSpan={COLUMN_COUNT}>
             <div id={detailId} data-testid={detailId} className="solve-ledger-detail">
-              <div className="solve-ledger-detail-title">
-                {/* `expandable` is `hasFailureDetail`'s type predicate, so
-                    `status` is already narrowed to the two headline keys here. */}
-                {FAILURE_HEADLINE[status]}
-              </div>
+              {/* `hasFailure` is `hasFailureDetail`'s type predicate, so `status`
+                  is narrowed to the two headline keys here. A placed board with
+                  only a conflict caution has no failure headline. */}
+              {hasFailure && (
+                <div className="solve-ledger-detail-title">
+                  {FAILURE_HEADLINE[status]}
+                </div>
+              )}
               {/* The server's own account of why the job broke — the one wire
                   sentence this page carries, because it is the actionable
                   content (the solve strip's precedent). */}
@@ -374,6 +384,27 @@ function LedgerRow({
                     )
                   })}
                 </ul>
+              )}
+              {/* Overlapping in-progress matches the solve TOLERATED and reported
+                  — the SAME caution the Schedule tab's strip shows, rendered
+                  through the one shared `placementConflictSentence` so the two
+                  surfaces cannot drift. Present on ANY verdict (a placed board
+                  can still carry it), so it is not gated on `status`. */}
+              {hasConflicts && (
+                <div className="solve-ledger-detail-conflicts">
+                  <div className="solve-ledger-detail-title solve-ledger-detail-conflicts-title">
+                    Overlapping matches on the board
+                  </div>
+                  <ul className="solve-ledger-detail-reasons">
+                    {solve.placementConflicts.map((conflict, i) => (
+                      <li key={placementConflictKey(conflict, i)}>
+                        <span className="solve-ledger-detail-reason-sentence">
+                          {placementConflictSentence(conflict)}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               )}
               <div className="solve-ledger-detail-fingerprint">
                 <span className="solve-ledger-detail-label">

--- a/web-client/src/components/scheduling/solve-ledger.css
+++ b/web-client/src/components/scheduling/solve-ledger.css
@@ -133,6 +133,17 @@
 .match-list-page .solve-ledger-detail-reason-sentence {
   color: var(--fg-2);
 }
+/* The placed-board caution — overlapping in-progress matches the solve tolerated
+ * and reported. Warn-toned title, distinct from the --loss failure headline, so
+ * a solved board's caution never reads as a broken run. */
+.match-list-page .solve-ledger-detail-conflicts {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.match-list-page .solve-ledger-detail-conflicts-title {
+  color: var(--warn);
+}
 .match-list-page .solve-ledger-detail-reason-remedy {
   color: var(--fg-3);
 }

--- a/web-client/src/components/tournaments/data/helpers.test.ts
+++ b/web-client/src/components/tournaments/data/helpers.test.ts
@@ -1,4 +1,5 @@
 import {
+  conjoinWithAnd,
   daysBetween,
   effectiveDateRange,
   fmtDateRange,
@@ -272,5 +273,23 @@ describe('findPoolConflicts', () => {
       buildPool({ slot: { date: '2026-06-14', start: '09:00', end: '12:00' }, tableIds: ['t1'] }),
     ])
     expect(conflicts).toEqual([])
+  })
+})
+
+describe('conjoinWithAnd', () => {
+  it('joins with commas and a trailing "and": A, B and C', () => {
+    expect(conjoinWithAnd(['A', 'B', 'C'])).toBe('A, B and C')
+  })
+
+  it('two labels join with a bare "and", no comma', () => {
+    expect(conjoinWithAnd(['A', 'B'])).toBe('A and B')
+  })
+
+  it('a single label stands alone', () => {
+    expect(conjoinWithAnd(['A'])).toBe('A')
+  })
+
+  it('an empty list is the empty string, never "undefined"', () => {
+    expect(conjoinWithAnd([])).toBe('')
   })
 })

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -154,6 +154,15 @@ export function daysBetween(
   return Math.max(1, Math.round((db.getTime() - da.getTime()) / 86_400_000) + 1)
 }
 
+/** Join labels the way a sentence does: `A`, `A and B`, `A, B and C`. The single
+ * definition behind every "list of things" sentence in the tournament UI (a save
+ * failure's fields, a refusal's pools, a solve's conflicting matches), so the
+ * comma-and-conjunction rule can't drift between them. Empty in → `''`. */
+export function conjoinWithAnd(labels: string[]): string {
+  if (labels.length <= 1) return labels[0] ?? ''
+  return `${labels.slice(0, -1).join(', ')} and ${labels[labels.length - 1]}`
+}
+
 /** A tournament's real date span is the min/max of its events' slots; falls
  * back to the seeded `startDate`/`endDate` when there are no events. */
 export function effectiveDateRange(t: Tournament): {

--- a/web-client/src/components/tournaments/data/save-failure.ts
+++ b/web-client/src/components/tournaments/data/save-failure.ts
@@ -35,6 +35,8 @@
 
 import { validationFields, ApiError, extractDetail } from '@/api/client'
 
+import { conjoinWithAnd } from './helpers'
+
 /**
  * What happened when the save was refused.
  *
@@ -212,12 +214,6 @@ function refusedLabels(failure: SaveFailure, target: SaveTarget): string[] {
     .filter((label): label is string => label !== undefined)
 }
 
-/** Join field labels the way a sentence does: "the Event name and the Player limit". */
-function list(labels: string[]): string {
-  if (labels.length === 1) return labels[0]
-  return `${labels.slice(0, -1).join(', ')} and ${labels[labels.length - 1]}`
-}
-
 /**
  * What the organizer is told. Every sentence here is the client's — the only one
  * that is not is the `refused` arm's, which is a sentence the API *wrote for a
@@ -238,7 +234,7 @@ export function saveFailureMessage(
         // thing we know is that something in this draft is not acceptable.
         return `Some of this ${target.subject}'s details were rejected. Check the fields and try again.`
       }
-      return `The ${list(labels)} ${
+      return `The ${conjoinWithAnd(labels)} ${
         labels.length === 1 ? 'was' : 'were'
       } rejected. Check ${labels.length === 1 ? 'that field' : 'those fields'} and try again.`
     }

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -3,7 +3,7 @@
 // consistent default (a published two-day open, an Open Singles event, etc.)
 // that callers tweak via overrides.
 
-import type { ScheduleSolve } from './solve'
+import type { ConflictFixture, PlacementConflict, ScheduleSolve } from './solve'
 import type {
   Address,
   Entrant,
@@ -283,6 +283,66 @@ export function buildScheduleSolve(
     // A succeeded run has no infeasibility reasons; the list is always present
     // (`[]` off the infeasible path). An infeasible fixture overrides this.
     infeasibilityReasons: [],
+    // A clean board has no overlapping in-progress matches; the list is always
+    // present (`[]` on a clean board) and orthogonal to the verdict — a fixture
+    // proving the caution passes a `placementConflicts` override on ANY status.
+    placementConflicts: [],
+    ...overrides,
+  }
+}
+
+/** One in-progress match caught in a placement conflict, named by its matchup —
+ * `crafty` vs `spiked` by default. A conflict fixture a test wants a specific
+ * matchup for overrides the two player names. */
+export function buildConflictFixture(
+  overrides: Partial<ConflictFixture> = {},
+): ConflictFixture {
+  return {
+    fixtureId: 'fx-conflict-1',
+    playerA: 'crafty',
+    playerB: 'spiked',
+    ...overrides,
+  }
+}
+
+/** A **table** placement conflict (ADR "overlapping-in-progress-matches-are-
+ * tolerated-and-reported"): two in-progress matches — `crafty-vs-spiked` and
+ * `dazed-vs-confused` — recorded on the same table (`Table 1`). */
+export function buildTableConflict(
+  overrides: Partial<Extract<PlacementConflict, { kind: 'table_conflict' }>> = {},
+): PlacementConflict {
+  return {
+    kind: 'table_conflict',
+    tableLabel: 'Table 1',
+    fixtures: [
+      buildConflictFixture({ fixtureId: 'fx-conflict-a', playerA: 'crafty', playerB: 'spiked' }),
+      buildConflictFixture({ fixtureId: 'fx-conflict-b', playerA: 'dazed', playerB: 'confused' }),
+    ],
+    ...overrides,
+  }
+}
+
+/** A **player** placement conflict: two in-progress matches sharing a human
+ * (`spiked-frigatebird`) — `crafty-vs-spiked-frigatebird` and
+ * `spiked-frigatebird-vs-nimble`. */
+export function buildPlayerConflict(
+  overrides: Partial<Extract<PlacementConflict, { kind: 'player_conflict' }>> = {},
+): PlacementConflict {
+  return {
+    kind: 'player_conflict',
+    playerName: 'spiked-frigatebird',
+    fixtures: [
+      buildConflictFixture({
+        fixtureId: 'fx-conflict-c',
+        playerA: 'crafty',
+        playerB: 'spiked-frigatebird',
+      }),
+      buildConflictFixture({
+        fixtureId: 'fx-conflict-d',
+        playerA: 'spiked-frigatebird',
+        playerB: 'nimble',
+      }),
+    ],
     ...overrides,
   }
 }

--- a/web-client/src/components/tournaments/data/solve.test.ts
+++ b/web-client/src/components/tournaments/data/solve.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { ApiError } from '@/api/client'
 import { buildScheduleSolveRead } from '@/mocks/factories/tournaments/tournament.factory'
 
-import { buildScheduleSolve } from './seed.factory'
+import {
+  buildPlayerConflict,
+  buildScheduleSolve,
+  buildTableConflict,
+} from './seed.factory'
 import {
   LIVE_POLL_MS,
   SOLVE_IN_FLIGHT_POLL_MS,
@@ -14,6 +18,8 @@ import {
   infeasibilityReasonSchema,
   parseLatestScheduleSolve,
   parseScheduleSolve,
+  placementConflictSchema,
+  placementConflictSentence,
   runSchedulerNotice,
   scheduleRefetchInterval,
   solveInFlight,
@@ -171,6 +177,125 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
 
   it('defaults to an empty list off the infeasible path', () => {
     expect(parseLatestScheduleSolve(buildScheduleSolveRead())?.infeasibilityReasons).toEqual([])
+  })
+})
+
+// ----- the placement conflicts: parse boundary --------------------------------
+
+describe('placementConflictSchema (the parse boundary)', () => {
+  it('parses a table_conflict into its client arm, snake→camel, fixtures named by matchup', () => {
+    expect(
+      placementConflictSchema.parse({
+        kind: 'table_conflict',
+        table_label: 'Table 1',
+        fixtures: [
+          { fixture_id: 'fx-a', player_a: 'crafty', player_b: 'spiked' },
+          { fixture_id: 'fx-b', player_a: 'dazed', player_b: 'confused' },
+        ],
+      }),
+    ).toEqual({
+      kind: 'table_conflict',
+      tableLabel: 'Table 1',
+      fixtures: [
+        { fixtureId: 'fx-a', playerA: 'crafty', playerB: 'spiked' },
+        { fixtureId: 'fx-b', playerA: 'dazed', playerB: 'confused' },
+      ],
+    })
+  })
+
+  it('parses a player_conflict into its client arm', () => {
+    expect(
+      placementConflictSchema.parse({
+        kind: 'player_conflict',
+        player_name: 'spiked-frigatebird',
+        fixtures: [{ fixture_id: 'fx-c', player_a: 'crafty', player_b: 'spiked-frigatebird' }],
+      }),
+    ).toEqual({
+      kind: 'player_conflict',
+      playerName: 'spiked-frigatebird',
+      fixtures: [{ fixtureId: 'fx-c', playerA: 'crafty', playerB: 'spiked-frigatebird' }],
+    })
+  })
+
+  it('refuses a conflict kind this client has no words for — it must fail the parse, not blank the warning', () => {
+    expect(() =>
+      placementConflictSchema.parse({ kind: 'venue_conflict', fixtures: [] }),
+    ).toThrow()
+  })
+
+  it('carries conflicts onto the domain row — on a SUCCEEDED board (orthogonal to the verdict)', () => {
+    const parsed = parseLatestScheduleSolve(
+      buildScheduleSolveRead({
+        status: 'succeeded',
+        verdict: 'feasible',
+        placement_conflicts: [
+          {
+            kind: 'table_conflict',
+            table_label: 'Table 1',
+            fixtures: [{ fixture_id: 'fx-a', player_a: 'crafty', player_b: 'spiked' }],
+          },
+        ],
+      }),
+    )
+    expect(parsed?.placementConflicts).toEqual([
+      {
+        kind: 'table_conflict',
+        tableLabel: 'Table 1',
+        fixtures: [{ fixtureId: 'fx-a', playerA: 'crafty', playerB: 'spiked' }],
+      },
+    ])
+  })
+
+  it('fails the whole solve row when one conflict arm is unknown — the boundary rejects', () => {
+    expect(() =>
+      parseLatestScheduleSolve(
+        buildScheduleSolveRead({
+          placement_conflicts: [{ kind: 'poltergeist', fixtures: [] }] as never,
+        }),
+      ),
+    ).toThrow()
+  })
+
+  it('defaults to an empty list on a clean board', () => {
+    expect(parseLatestScheduleSolve(buildScheduleSolveRead())?.placementConflicts).toEqual([])
+  })
+
+  it('refuses an ABSENT placement_conflicts — an array the API guarantees present cannot be dropped', () => {
+    const { placement_conflicts, ...missing } = buildScheduleSolveRead()
+    void placement_conflicts
+    expect(() => parseLatestScheduleSolve(missing)).toThrow()
+  })
+})
+
+// ----- the placement conflicts: shared copy -----------------------------------
+
+describe('placementConflictSentence', () => {
+  it('names a table conflict as the two matches overlapping on the table', () => {
+    expect(placementConflictSentence(buildTableConflict())).toBe(
+      'crafty-vs-spiked and dazed-vs-confused overlap on Table 1',
+    )
+  })
+
+  it('names a player conflict as the two matches overlapping on the human', () => {
+    expect(placementConflictSentence(buildPlayerConflict())).toBe(
+      'crafty-vs-spiked-frigatebird and spiked-frigatebird-vs-nimble overlap on spiked-frigatebird',
+    )
+  })
+
+  it('lists three overlapping matches with an Oxford-style join', () => {
+    expect(
+      placementConflictSentence(
+        buildTableConflict({
+          fixtures: [
+            { fixtureId: 'a', playerA: 'crafty', playerB: 'spiked' },
+            { fixtureId: 'b', playerA: 'dazed', playerB: 'confused' },
+            { fixtureId: 'c', playerA: 'nimble', playerB: 'quick' },
+          ],
+        }),
+      ),
+    ).toBe(
+      'crafty-vs-spiked, dazed-vs-confused and nimble-vs-quick overlap on Table 1',
+    )
   })
 })
 

--- a/web-client/src/components/tournaments/data/solve.ts
+++ b/web-client/src/components/tournaments/data/solve.ts
@@ -22,6 +22,7 @@ import { z } from 'zod'
 import { ApiError } from '@/api/client'
 import type { components } from '@/api/schema'
 
+import { conjoinWithAnd } from './helpers'
 import type { TournamentStatus } from './types'
 
 type ScheduleSolveWire = components['schemas']['ScheduleSolveRead']
@@ -654,19 +655,13 @@ export function conflictFixtureLabel(fixture: ConflictFixture): string {
   return `${fixture.playerA}-vs-${fixture.playerB}`
 }
 
-/** Join fixture labels into a natural list: `A and B`, `A, B and C`. */
-function joinFixtureLabels(labels: string[]): string {
-  if (labels.length <= 1) return labels[0] ?? ''
-  return `${labels.slice(0, -1).join(', ')} and ${labels[labels.length - 1]}`
-}
-
 /** One conflict as the director's caution sentence, naming the colliding matches
  * and the shared resource: `crafty-vs-spiked and dazed-vs-confused overlap on
  * Table 1` (table) / `… overlap on spiked-frigatebird` (human). Exhaustive over
  * `kind` — a `never` default makes a third arm a compile error until it has
  * words, so a conflict can never reach the UI as a blank line. */
 export function placementConflictSentence(conflict: PlacementConflict): string {
-  const matches = joinFixtureLabels(conflict.fixtures.map(conflictFixtureLabel))
+  const matches = conjoinWithAnd(conflict.fixtures.map(conflictFixtureLabel))
   switch (conflict.kind) {
     case 'table_conflict':
       return `${matches} overlap on ${conflict.tableLabel}`

--- a/web-client/src/components/tournaments/data/solve.ts
+++ b/web-client/src/components/tournaments/data/solve.ts
@@ -223,6 +223,114 @@ export function infeasibilityReasonFromWire(
 export const infeasibilityReasonSchema =
   infeasibilityReasonWireSchema.transform(infeasibilityReasonFromWire)
 
+// ----- overlapping in-progress matches: the resolved placement conflicts ------
+//
+// A solve tolerates two *in-progress* matches that a soft manual PATCH parked on
+// the same table or the same human (the ADR "overlapping-in-progress-matches-
+// are-tolerated-and-reported") — it never blanks the board over contradictory
+// data, it keeps the fixed blocks binding and *reports* the overlap. The report
+// is DB-resolved at apply (ids → a table label / a human's name, each fixture
+// named by its matchup) and shipped on `ScheduleSolveRead.placement_conflicts`:
+// ALWAYS a list, `[]` on a clean board — and, unlike the infeasibility reasons,
+// present on ANY verdict (a *placed* board can still carry a caution; the two
+// are orthogonal). The `kind` discriminant is data the surfaces switch on, so —
+// like the infeasibility arms — a conflict kind this client has no words for
+// must FAIL the parse here, not blank a warning row two components later. Names
+// are data (a `player_name` is like a username); the *sentence* is the client's,
+// minted in `placementConflictSentence` below.
+
+type ConflictFixtureWire = components['schemas']['ConflictFixtureRead']
+type TableConflictWire = components['schemas']['TableConflictRead']
+type PlayerConflictWire = components['schemas']['PlayerConflictRead']
+
+/** One in-progress match caught in a conflict, named the way the director reads
+ * a fixture — by its **matchup**, the two players facing off. The raw `fixtureId`
+ * rides along so a surface can key/deep-link without re-deriving it. */
+export interface ConflictFixture {
+  fixtureId: string
+  playerA: string
+  playerB: string
+}
+
+/**
+ * One resolved placement conflict a solve carries, in the domain's camelCase — a
+ * discriminated union over `kind`, one arm per shared resource two overlapping
+ * in-progress matches can contradict. The `kind` string stays snake_case (it is
+ * the wire's discriminant); every other field is mapped snake→camel.
+ *
+ * - **`table_conflict`** — two in-progress matches recorded on the same table at
+ *   overlapping times (a table holds one match).
+ * - **`player_conflict`** — two in-progress matches sharing a human whose
+ *   occupancy overlaps (a human plays one match at a time).
+ */
+export type PlacementConflict =
+  | { kind: 'table_conflict'; tableLabel: string; fixtures: ConflictFixture[] }
+  | { kind: 'player_conflict'; playerName: string; fixtures: ConflictFixture[] }
+
+/** The wire fixture, as it really arrives: snake_case. `satisfies` it against the
+ * generated schema so a field renamed in the API is a compile error here. */
+const conflictFixtureWireSchema = z.object({
+  fixture_id: z.string(),
+  player_a: z.string(),
+  player_b: z.string(),
+}) satisfies z.ZodType<ConflictFixtureWire>
+
+const tableConflictWireSchema = z.object({
+  kind: z.literal('table_conflict'),
+  table_label: z.string(),
+  fixtures: z.array(conflictFixtureWireSchema),
+}) satisfies z.ZodType<TableConflictWire>
+
+const playerConflictWireSchema = z.object({
+  kind: z.literal('player_conflict'),
+  player_name: z.string(),
+  fixtures: z.array(conflictFixtureWireSchema),
+}) satisfies z.ZodType<PlayerConflictWire>
+
+/** The two arms as one `z.discriminatedUnion('kind', …)` — an unknown `kind` has
+ * no arm and throws, which is exactly the boundary rule: a conflict this client
+ * cannot render must fail the parse, not blank the warning. */
+export const placementConflictWireSchema = z.discriminatedUnion('kind', [
+  tableConflictWireSchema,
+  playerConflictWireSchema,
+])
+
+function conflictFixtureFromWire(f: ConflictFixtureWire): ConflictFixture {
+  return { fixtureId: f.fixture_id, playerA: f.player_a, playerB: f.player_b }
+}
+
+/** One wire arm → one domain `PlacementConflict`. Annotated so the union above
+ * and the wire arms are one thing. Exhaustive over `kind` (a `never` default), so
+ * a third arm added to the API cannot slip through unmapped. */
+export function placementConflictFromWire(
+  c: z.infer<typeof placementConflictWireSchema>,
+): PlacementConflict {
+  switch (c.kind) {
+    case 'table_conflict':
+      return {
+        kind: c.kind,
+        tableLabel: c.table_label,
+        fixtures: c.fixtures.map(conflictFixtureFromWire),
+      }
+    case 'player_conflict':
+      return {
+        kind: c.kind,
+        playerName: c.player_name,
+        fixtures: c.fixtures.map(conflictFixtureFromWire),
+      }
+    default: {
+      const exhaustive: never = c
+      return exhaustive
+    }
+  }
+}
+
+/** The per-conflict parser: the wire arm plus the snake→camel mapping, one Zod
+ * pipeline. Embedded in `scheduleSolveWireSchema` below, which the admin ledger's
+ * wire schema `.extend()`s — so both surfaces parse conflicts through this arm. */
+export const placementConflictSchema =
+  placementConflictWireSchema.transform(placementConflictFromWire)
+
 /**
  * One row of the tournament's **solve ledger**, in the domain's spelling — the
  * latest run of the placement solver, as the detail payload carries it.
@@ -250,6 +358,11 @@ export interface ScheduleSolve {
    * nullable stage marker like the fields above: the API guarantees the array is
    * present, and an absent key is a payload we reject rather than read as `[]`. */
   infeasibilityReasons: InfeasibilityReason[]
+  /** Overlapping in-progress matches the solve *tolerated and reported* — **always
+   * a list**, never null (`[]` on a clean board). Orthogonal to the verdict: a
+   * placed/succeeded board can still carry a caution here. Like the reasons, an
+   * absent key is a payload we reject rather than read as `[]`. */
+  placementConflicts: PlacementConflict[]
 }
 
 /** The wire shape (`ScheduleSolveRead`), as it really arrives: snake_case, every
@@ -272,6 +385,10 @@ export const scheduleSolveWireSchema = z.object({
   // Always present (a non-nullable list); each element is parsed through the
   // discriminated union, so an unknown arm `kind` fails the whole row.
   infeasibility_reasons: z.array(infeasibilityReasonSchema),
+  // Always present too, and on ANY verdict (a placed board can still carry a
+  // caution); each element parsed through the conflict union, so an unknown arm
+  // `kind` fails the whole row.
+  placement_conflicts: z.array(placementConflictSchema),
 })
 
 /** The snake→camel mapping, one wire row → one domain `ScheduleSolve`. Annotated
@@ -296,6 +413,8 @@ export function scheduleSolveFromWire(
     error: s.error,
     // Already snake→camel-mapped by `infeasibilityReasonSchema`'s transform.
     infeasibilityReasons: s.infeasibility_reasons,
+    // Already snake→camel-mapped by `placementConflictSchema`'s transform.
+    placementConflicts: s.placement_conflicts,
   }
 }
 
@@ -519,6 +638,54 @@ export function infeasibilityReasonKey(reason: InfeasibilityReason, i: number): 
   return 'poolName' in reason
     ? `${reason.kind}:${reason.poolName}:${i}`
     : `${reason.kind}:${i}`
+}
+
+// ----- copy: the placement conflicts → the director's words -------------------
+//
+// ONE shared module, in the spirit of `infeasibilityReasonCopy`: both the
+// Schedule-tab solve strip and the admin solve ledger import
+// `placementConflictSentence` and render the SAME warning, so the two surfaces
+// cannot drift on how a conflict reads. Pure functions, unit-tested here.
+
+/** A fixture's matchup label — the two players facing off, `crafty-vs-spiked`.
+ * How the director already reads a fixture, so the warning names matches, not
+ * ids. */
+export function conflictFixtureLabel(fixture: ConflictFixture): string {
+  return `${fixture.playerA}-vs-${fixture.playerB}`
+}
+
+/** Join fixture labels into a natural list: `A and B`, `A, B and C`. */
+function joinFixtureLabels(labels: string[]): string {
+  if (labels.length <= 1) return labels[0] ?? ''
+  return `${labels.slice(0, -1).join(', ')} and ${labels[labels.length - 1]}`
+}
+
+/** One conflict as the director's caution sentence, naming the colliding matches
+ * and the shared resource: `crafty-vs-spiked and dazed-vs-confused overlap on
+ * Table 1` (table) / `… overlap on spiked-frigatebird` (human). Exhaustive over
+ * `kind` — a `never` default makes a third arm a compile error until it has
+ * words, so a conflict can never reach the UI as a blank line. */
+export function placementConflictSentence(conflict: PlacementConflict): string {
+  const matches = joinFixtureLabels(conflict.fixtures.map(conflictFixtureLabel))
+  switch (conflict.kind) {
+    case 'table_conflict':
+      return `${matches} overlap on ${conflict.tableLabel}`
+    case 'player_conflict':
+      return `${matches} overlap on ${conflict.playerName}`
+    default: {
+      const exhaustive: never = conflict
+      return exhaustive
+    }
+  }
+}
+
+/** A stable-enough React key for one placement conflict: its `kind`, the resource
+ * it names, and the list index. Shared so every surface that lists the conflicts
+ * keys them the same way by import, not by convention. */
+export function placementConflictKey(conflict: PlacementConflict, i: number): string {
+  const resource =
+    conflict.kind === 'table_conflict' ? conflict.tableLabel : conflict.playerName
+  return `${conflict.kind}:${resource}:${i}`
 }
 
 // ----- polling ----------------------------------------------------------------

--- a/web-client/src/components/tournaments/tournament-detail-page/solve-strip.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/solve-strip.page.tsx
@@ -43,6 +43,15 @@ const scoped = (container: Container) => ({
     fireEvent.click(container.getByTestId('run-scheduler'))
   },
 
+  /** The placed-board caution: overlapping in-progress matches the solve
+   * tolerated and reported — present only when the solve carries conflicts. */
+  queryConflicts() {
+    return container.queryByTestId('solve-strip-conflicts')
+  },
+  getConflictsText() {
+    return text(container.getByTestId('solve-strip-conflicts'))
+  },
+
   /** The inline refusal (the strip's only error surface — there is no toast). */
   queryNotice() {
     return container.queryByTestId('run-scheduler-notice')

--- a/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { ApiError } from '@/api/client'
 import { waitFor } from '@/test/utilities'
 
-import { buildScheduleSolve } from '../data/seed.factory'
+import {
+  buildPlayerConflict,
+  buildScheduleSolve,
+  buildTableConflict,
+} from '../data/seed.factory'
 import { solveStripPage } from './solve-strip.page'
 
 /** The refusal the route really sends for "nothing is drawn" — the ADR-0968
@@ -159,6 +163,39 @@ describe('SolveStrip', () => {
     // A broken job is NOT the infeasible outcome — no resolved reason leaks in.
     expect(text).not.toContain('has no tables assigned')
     expect(text).not.toContain("The day doesn't fit")
+  })
+
+  // ----- the placed-board caution: overlapping in-progress matches -----------
+
+  it('warns about overlapping in-progress matches on a SUCCEEDED board — a caution, not the infeasible banner — naming both matches and the shared table AND human', () => {
+    solveStripPage.render({
+      solve: buildScheduleSolve({
+        status: 'succeeded',
+        verdict: 'feasible',
+        placementConflicts: [buildTableConflict(), buildPlayerConflict()],
+      }),
+    })
+    // The board is still solved — the caution rides UNDER the success line.
+    expect(solveStripPage.getStateText('succeeded')).toContain('Schedule solved')
+    const text = solveStripPage.getConflictsText()
+    expect(text).toContain('Overlapping matches on the board')
+    // The table conflict: both matches, named by matchup, and the shared table.
+    expect(text).toContain('crafty-vs-spiked and dazed-vs-confused overlap on Table 1')
+    // The player conflict: the shared human.
+    expect(text).toContain(
+      'crafty-vs-spiked-frigatebird and spiked-frigatebird-vs-nimble overlap on spiked-frigatebird',
+    )
+    // It is a caution, not the "nothing placed" infeasible banner.
+    expect(text).not.toContain("The day doesn't fit")
+    // And not a refusal — no notice rings.
+    expect(solveStripPage.queryNotice()).toBeNull()
+  })
+
+  it('renders NO conflict warning on a clean board (placement_conflicts: [])', () => {
+    solveStripPage.render({
+      solve: buildScheduleSolve({ status: 'succeeded', placementConflicts: [] }),
+    })
+    expect(solveStripPage.queryConflicts()).toBeNull()
   })
 
   // ----- the Run-scheduler button --------------------------------------------

--- a/web-client/src/components/tournaments/tournament-detail-page/solve-strip.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/solve-strip.tsx
@@ -19,6 +19,8 @@ import {
   fmtWallTime,
   infeasibilityReasonCopy,
   infeasibilityReasonKey,
+  placementConflictKey,
+  placementConflictSentence,
   runSchedulerNotice,
   solveInFlight,
   solveStripState,
@@ -182,6 +184,40 @@ const SolveState = ({ solve, canEdit }: { solve: ScheduleSolve | null; canEdit: 
 }
 
 /**
+ * Overlapping in-progress matches the solve **tolerated and reported** (ADR
+ * "overlapping-in-progress-matches-are-tolerated-and-reported") — a *placed board
+ * with a caution*, deliberately distinct from the `infeasible` "nothing placed"
+ * banner: the board is fine, but two live matches contradict each other on a
+ * table or a human, and only the director can fix it. A warn-toned `Alert` (the
+ * pools double-booked precedent), rendered only when the (always-present) list is
+ * non-empty. Orthogonal to the solve's state, so it renders under whatever the
+ * `SolveState` line above says.
+ */
+const ConflictWarning = ({ solve }: { solve: ScheduleSolve | null }) => {
+  if (solve === null || solve.placementConflicts.length === 0) return null
+  return (
+    <Alert
+      data-testid="solve-strip-conflicts"
+      className="mt-2.5 border-[color:var(--warn)]/40 bg-[color:var(--warn)]/10"
+    >
+      <TriangleAlert className="text-[color:var(--warn)]" />
+      <AlertTitle className="text-[color:var(--warn)]">
+        Overlapping matches on the board
+      </AlertTitle>
+      <AlertDescription className="text-[color:var(--fg-3)]">
+        <ul className="space-y-1">
+          {solve.placementConflicts.map((conflict, i) => (
+            <li key={placementConflictKey(conflict, i)}>
+              {placementConflictSentence(conflict)}
+            </li>
+          ))}
+        </ul>
+      </AlertDescription>
+    </Alert>
+  )
+}
+
+/**
  * The Schedule tab's **solve strip** (ADR "the schedule is solved; the call is
  * pinned"): what the latest run of the placement solver has to say, plus the
  * owner's **Run scheduler** button.
@@ -253,6 +289,11 @@ export const SolveStrip = ({ solve, canEdit, onRun }: SolveStripProps) => {
           )}
         </div>
       </Card>
+
+      {/* A placed board's caution: overlapping in-progress matches the solve
+          tolerated rather than blanked the board over. Orthogonal to the state
+          above, so it rides under whatever the strip says. */}
+      <ConflictWarning solve={solve} />
 
       {/* The refusal, where the click was — an `Alert` (the app talking back),
           never a toast that leaves in four seconds. */}

--- a/web-client/src/mocks/factories/tournaments/solver-sim.ts
+++ b/web-client/src/mocks/factories/tournaments/solver-sim.ts
@@ -59,6 +59,8 @@ export function queuedSolveRow(id: string): ScheduleSolveRead {
     error: null,
     // Always a list; a queued run has reached no infeasibility.
     infeasibility_reasons: [],
+    // Always a list; a queued run has placed nothing, so no overlap to report.
+    placement_conflicts: [],
   }
 }
 

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -10,6 +10,9 @@ type EventResultsRead = components['schemas']['EventResultsRead']
 type PoolStandingsRead = components['schemas']['PoolStandingsRead']
 type StandingRowRead = components['schemas']['StandingRowRead']
 type ScheduleSolveRead = components['schemas']['ScheduleSolveRead']
+type ConflictFixtureRead = components['schemas']['ConflictFixtureRead']
+type TableConflictRead = components['schemas']['TableConflictRead']
+type PlayerConflictRead = components['schemas']['PlayerConflictRead']
 type AdminScheduleSolveRead = components['schemas']['AdminScheduleSolveRead']
 type AdminScheduleSolveListResponse =
   components['schemas']['AdminScheduleSolveListResponse']
@@ -126,6 +129,65 @@ export function buildScheduleSolveRead(
     // A succeeded run has no infeasibility reasons; the field is always a list
     // (`[]` off the infeasible path). Infeasible fixtures override this.
     infeasibility_reasons: [],
+    // A clean board has no overlapping in-progress matches; the field is always a
+    // list (`[]` on a clean board) and orthogonal to the verdict — a fixture
+    // proving the caution passes `placement_conflicts` on ANY status.
+    placement_conflicts: [],
+    ...overrides,
+  }
+}
+
+/** One in-progress match caught in a placement conflict, on the wire — named by
+ * its matchup (`crafty` vs `spiked`, resolved usernames), the raw `fixture_id`
+ * riding along. */
+export function buildConflictFixtureRead(
+  overrides: Partial<ConflictFixtureRead> = {},
+): ConflictFixtureRead {
+  return {
+    fixture_id: 'fx-conflict-a',
+    player_a: 'crafty',
+    player_b: 'spiked',
+    ...overrides,
+  }
+}
+
+/** A **table** placement conflict on the wire (ADR "overlapping-in-progress-
+ * matches-are-tolerated-and-reported"): two in-progress matches recorded on the
+ * same table (`Table 1`). */
+export function buildTableConflictRead(
+  overrides: Partial<TableConflictRead> = {},
+): TableConflictRead {
+  return {
+    kind: 'table_conflict',
+    table_label: 'Table 1',
+    fixtures: [
+      buildConflictFixtureRead({ fixture_id: 'fx-conflict-a', player_a: 'crafty', player_b: 'spiked' }),
+      buildConflictFixtureRead({ fixture_id: 'fx-conflict-b', player_a: 'dazed', player_b: 'confused' }),
+    ],
+    ...overrides,
+  }
+}
+
+/** A **player** placement conflict on the wire: two in-progress matches sharing a
+ * human (`spiked-frigatebird`). */
+export function buildPlayerConflictRead(
+  overrides: Partial<PlayerConflictRead> = {},
+): PlayerConflictRead {
+  return {
+    kind: 'player_conflict',
+    player_name: 'spiked-frigatebird',
+    fixtures: [
+      buildConflictFixtureRead({
+        fixture_id: 'fx-conflict-c',
+        player_a: 'crafty',
+        player_b: 'spiked-frigatebird',
+      }),
+      buildConflictFixtureRead({
+        fixture_id: 'fx-conflict-d',
+        player_a: 'spiked-frigatebird',
+        player_b: 'nimble',
+      }),
+    ],
     ...overrides,
   }
 }

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -33,6 +33,7 @@ import {
   stepScheduleSolve,
 } from '@/mocks/factories/tournaments/solver-sim'
 import { mockUuid } from '@/mocks/mock-uuid'
+import { conjoinWithAnd } from '@/components/tournaments/data/helpers'
 
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
 type TournamentRead = components['schemas']['TournamentRead']
@@ -890,9 +891,7 @@ const NOTHING_TO_START =
 /** The things a refusal is about, as a human would say them: `“Pool B”`, or
  * `“Pool B” and “Pool C”` (`named_list`, `api/app/schemas/tournament.py`). */
 function namedList(names: string[]): string {
-  const quoted = names.map((name) => `“${name}”`)
-  if (quoted.length === 1) return quoted[0]
-  return `${quoted.slice(0, -1).join(', ')} and ${quoted[quoted.length - 1]}`
+  return conjoinWithAnd(names.map((name) => `“${name}”`))
 }
 
 /** Where one event's draw stands (`DrawCurrency`, `api/app/tournament_draws.py`).


### PR DESCRIPTION
## What & why

Closes #1144. A single manual placement/call that conflicts with an already-**fixed** in-progress block (same table, or same human) used to make the **entire** schedule solve `infeasible` and drop **all** placements — one bad pin blanked the whole board.

Two overlapping in-progress matches are **never physical truth** (a table holds one match; a human plays one match). They only exist as **contradictory data** from a director's *soft* manual placement PATCH (ADR-0790) — the automatic call path is already gated against it (#1106). And there's no ground-truth "actually started at/on table X" (only the mutable pin), so we **cannot** tell which colliding match is real, and must **never move a live match**.

## Approach — tolerate · merge · report (no winner-guess)

The solver now refuses to let two recorded realities blank the board:

- **`scheduling.py`** — per resource (each table, each player), mutually-overlapping **fixed** obstacle intervals are merged into their union before `AddNoOverlap` (merge **broadly** — absorbs rest shadows too), so fixed-vs-fixed can never force infeasibility while every variable placement still routes around the union. The in-progress-vs-in-progress overlapping pairs are detected and returned on `SolveResult.conflicts` (report **narrowly**) as DB-blind `TableConflict` / `PlayerConflict`. In-progress matches are still excluded from output placements and are never moved.
- **`schedule_solves.py` + model + migration `0016`** — a new `placement_conflicts` JSONB column, written on **any** verdict (a placed board can carry conflicts), holding the resolved, DB-humanized conflicts (fixtures named by matchup, table label, player name).
- **schemas** — `ResolvedConflict` read union + parser; exposed on `ScheduleSolveRead` (never null — `[]` when none).
- **web-client** — parsed at the Zod boundary and rendered as a **caution** (distinct from the "nothing placed" infeasibility banner) on the **solve-strip** and **solve-ledger**, naming the two matches + shared resource ("crafty-vs-spiked and dazed-vs-confused overlap on Table 1").

Verdict stays `optimal`/`feasible`; a genuine unpinned-demand overflow still surfaces the existing structural infeasibility reasons. Decision captured in `docs/adr/20260720-overlapping-in-progress-matches-are-tolerated-and-reported.md`.

The **prevention** half — a call-time confirm-warning extending the #1106 gate to the manual PATCH path — is deferred to **#1147**.

## Testing

- **api**: ruff + `mypy --strict` + **pytest 1541 passed**. New coverage: overlapping in-progress → `optimal` + placed board + named conflicts (fail-before/pass-after); resolve+persist on a placed board; ledger read exposes them (`[]` when none); migration `0016` up/down on a fresh Postgres.
- **web-client**: **vitest 2844**, eslint clean, build. Conflict render + Zod boundary (rejects unknown `kind`) asserted on both surfaces with the exact sentences; `[]` → no warning.
- **OpenAPI** regenerated (`schema.d.ts` + iOS `Types.swift`), drift-free. **iOS BUILD SUCCEEDED**.
- **web-client e2e**: 287 passed (2 unrelated flakes green on re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)