### PR TITLE
Mirror the chore work order into the native task list

### DIFF
--- a/.claude/skills/do-chores/SKILL.md
+++ b/.claude/skills/do-chores/SKILL.md
@@ -33,12 +33,27 @@ the board, or `gh` lacks the `project` scope, **note it and keep driving**; neve
 a board hiccup stop the work. Do this once at the start of a run (it's idempotent, so
 a resume re-running it is harmless).
 
+**Build the native task list.** Mirror the work order into Claude Code's native task
+list (the `TodoWrite` tool) so the run's progress shows up in the UI, not just as
+checkboxes in the file — a parent task per slice, a child task per chore, per
+[native-tasks.md](../to-chores/native-tasks.md). **Derive each task's status from the
+checkboxes** (ticked → completed, `⚠ BLOCKED` → pending with the marker kept in the
+task text, else pending) so a resume rebuilds the same picture rather than restarting
+from scratch. The checkboxes stay the source of truth; the task list is a live view of
+them.
+
 ## Drive loop
+
+Keep the native task list in lockstep with the checkboxes as you go (see
+[native-tasks.md](../to-chores/native-tasks.md)): a chore's task goes `in_progress`
+the moment you dispatch it, `completed` only when its box is ticked, and a slice's
+parent task `completed` when the slice closes. This is what makes the run legible in
+the UI — do it as a side effect of each step below, not as a separate bookkeeping pass.
 
 Repeat until every chore is ticked or every remaining chore is blocked:
 
 1. **Find ready chores** — unticked, not blocked, with **all `depends-on` ticked**.
-2. **Dispatch:**
+2. **Dispatch:** mark each chore's native task `in_progress` as you send it out.
    - `[main]` chores — do them **inline** yourself (regen, integration, glue). You
      are the main session; the cross-layer work is yours.
    - Any other tag — hand off via the Agent tool with `subagent_type` = the tag
@@ -67,17 +82,20 @@ Repeat until every chore is ticked or every remaining chore is blocked:
    the code? is there a discriminating assertion?), **runs the `Demo`**, and checks
    the chore stayed inside its `Scope`. It returns `PASS`, `FAIL`, or `INCONCLUSIVE`.
 
-   - **PASS** → tick the box.
-   - **FAIL** → treat exactly like a chore failure (see below). Mark `⚠ BLOCKED`.
+   - **PASS** → tick the box **and** mark the chore's task `completed`.
+   - **FAIL** → treat exactly like a chore failure (see below). Mark `⚠ BLOCKED` on
+     the line and keep the task `pending` with `⚠ BLOCKED` in its text.
    - **INCONCLUSIVE** → *not* a pass. Resolve what it couldn't establish, or block.
+     Leave the task `in_progress` until it resolves.
 
    Never tick a box on a report you did not have independently reproduced. Never
    verify a chore with the agent that implemented it, and never let a `[main]` chore
    grade itself either — dispatch the verifier for those too.
 4. **Close the slice** — when every chore in a slice is ticked, run the slice's
    **demoable outcome** end-to-end as a final check, then **commit the slice** (a
-   working, demoable increment; message names the slice). Do not squash slices into
-   one commit — per-slice commits are the audit trail.
+   working, demoable increment; message names the slice) and mark the slice's parent
+   task `completed`. Do not squash slices into one commit — per-slice commits are the
+   audit trail.
 
 Every chore ends in a demo, and every slice ends in a demoable increment. If a chore
 has no `Demo` — nothing observable, even at a REPL or a job invocation — that is a
@@ -91,7 +109,8 @@ The `## Testing notes` section is **not** this skill's job — it belongs to
 
 If a chore fails or its Verify won't go green:
 
-- Mark it `⚠ BLOCKED: <reason>` in the file and leave the box unticked.
+- Mark it `⚠ BLOCKED: <reason>` in the file and leave the box unticked; keep its
+  native task `pending` with `⚠ BLOCKED` in the text so the block is visible in the UI.
 - **Stop that slice** — do not start its remaining chores, do not retry-thrash, do
   not commit a half-slice.
 - **Other slices whose deps are met may continue.**

--- a/.claude/skills/to-chores/SKILL.md
+++ b/.claude/skills/to-chores/SKILL.md
@@ -129,12 +129,16 @@ testing notes. Ask:
 
 Iterate until the user approves. Then write the work order to
 **`.claude/work-order.md`** (gitignored; override with a path argument if given),
-using the template in [work-order-format.md](./work-order-format.md). Finish by
-telling the user the work order is ready and to run `/do-chores`.
+using the template in [work-order-format.md](./work-order-format.md). Then
+**mirror it into the native task list** — a parent task per slice, a child task per
+chore, all `pending` — per [native-tasks.md](./native-tasks.md), so the breakdown
+shows up in the UI as a task tree rather than only as checkboxes in a file. Finish
+by telling the user the work order is ready and to run `/do-chores`.
 
 ## Completion criterion
 
 The work order is written, every chore passes the four-part gate (including a
 falsifiable `Proves` line), every cross-layer seam has a `[main]` chore, every
 `depends-on` references a real chore ID, the `## Testing notes` section is present,
-and the user has approved the breakdown.
+the native task list mirrors the work order (a parent task per slice, a child task
+per chore), and the user has approved the breakdown.

--- a/.claude/skills/to-chores/native-tasks.md
+++ b/.claude/skills/to-chores/native-tasks.md
@@ -1,0 +1,48 @@
+# Mirroring the work order into the native task list
+
+Both `/to-chores` and `/do-chores` mirror the work order into Claude Code's
+**native task list** (the `TodoWrite` tool) so the slice/chore breakdown — and,
+while `/do-chores` runs, its live progress — shows up in the UI instead of living
+only as checkboxes in `.claude/work-order.md`. This file is the single source of
+truth for that mapping; both skills reference it so they can't drift.
+
+## The shape: tasks made of tasks
+
+The work order is already two levels deep, and the task list mirrors both levels:
+
+- **Each tracer-bullet slice → one parent task.** Its text is the slice's demoable
+  outcome (`Slice 1: <outcome>`). This is the "task made of tasks."
+- **Each chore → one child task** under its slice's parent. Its text is the chore
+  ID + agent tag + the one-line "what to build"
+  (`1a [api] Add rating to the profile BFF response + schema`).
+
+Always keep the **chore ID** in the task text — it's the stable handle that ties a
+task back to its line in the work order, and it's what lets a resume reconcile the
+two instead of guessing.
+
+If the running Claude Code build's task tool doesn't support nested subtasks, fall
+back to a flat list of one task per chore, each prefixed with its slice number
+(`S1 · 1a [api] …`), so the grouping is still legible. Never drop the per-chore
+granularity — **one task per chore is the floor**.
+
+## Status is derived from the work order, never invented
+
+The work-order checkboxes remain the source of truth for run state; the task list
+is a *view* of them. Map status straight across so a resume rebuilds the same
+picture rather than starting fresh:
+
+| Work-order state | Native task status |
+| --- | --- |
+| Unticked `- [ ]`, no marker | pending |
+| Chore currently dispatched / being verified | in_progress |
+| Ticked `- [x]` (verified) | completed |
+| `⚠ BLOCKED: …` | pending, with `⚠ BLOCKED` kept in the task text |
+
+A slice's parent task is `completed` only when **every** chore under it is ticked —
+the same bar `/do-chores` uses to close and commit a slice. A slice with any
+pending or blocked chore stays `in_progress` (or pending, if untouched).
+
+When `/do-chores` fans a batch of ready chores across different trees, each
+dispatched chore's task goes `in_progress` together and flips to `completed` only
+after its `verifier` passes — never tick a task on the implementer's claim alone,
+exactly as the checkbox is never ticked on it.


### PR DESCRIPTION
## What

Makes the `/to-chores` → `/do-chores` skill pair emit **native Claude Code tasks** (the `TodoWrite` task list) that mirror the work order, so chore progress shows up in the UI instead of living only as checkboxes in the gitignored `.claude/work-order.md`.

Requested: "tasks made of tasks that essentially track the chores so it's easier to see what's going on."

## Mapping (tasks made of tasks)

- **Tracer-bullet slice → parent task** (the "task made of tasks")
- **Chore → child task** under its slice
- Status is a *view* of the checkboxes, never invented: ticked → completed, dispatched → in_progress, `⚠ BLOCKED` → pending with the marker kept.

## Changes

- **New `native-tasks.md`** (colocated with `work-order-format.md`) — single source of truth for the work-order → task-list mapping, referenced by both skills so they can't drift. Includes a flat-list fallback if the running build lacks nested subtasks.
- **`to-chores`** — after writing the work order, seeds the task tree (all `pending`); completion criterion updated.
- **`do-chores`** — builds the task list from the checkboxes at setup (resumable), and keeps it in lockstep through the drive loop (in_progress on dispatch, completed on verified tick, BLOCKED reflected, slice parent completed on slice close).

Skills-only markdown change; no runtime code touched. Cross-reference links verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8vFhoAoub2Hyjqup1syPb