### PR TITLE
Auth0 OAuth for the MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,4 +35,4 @@ MCP_PUBLIC_BASE_URL=https://uat.fortymm.com/api
 # Public MCP resource URL used in the RFC 9728 protected-resource metadata.
 MCP_PUBLIC_RESOURCE_URL=https://uat.fortymm.com/api/mcp
 # Redirect URI registered with the Auth0 web app for GET /v1/auth0/link/callback.
-AUTH0_LINK_REDIRECT_URI=https://uat.fortymm.com/api/auth0/link/callback
+AUTH0_LINK_REDIRECT_URI=https://uat.fortymm.com/api/v1/auth0/link/callback

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,26 @@ EMAIL_FROM=FortyMM <noreply@fortymm.com>
 
 # Public URL the API renders into confirmation/sign-in email links.
 APP_BASE_URL=https://uat.fortymm.com
+
+# --- Auth0 / MCP OAuth Resource Server ---
+# The MCP server trusts Auth0 as its OAuth Authorization Server; see
+# docs/adr/20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0.md.
+# The six non-secret vars below are also set in deploy/uat/values.yaml (rendered
+# into the api-config ConfigMap); they live here too so the operator sees the
+# full set. Only AUTH0_LINK_CLIENT_SECRET is a real secret and flows solely
+# through .env → the fortymm-uat-env Secret.
+
+# Auth0 tenant domain (the JWT issuer), e.g. fortymm.us.auth0.com.
+AUTH0_DOMAIN=
+# Auth0 API identifier for the MCP Resource Server — the token `aud` claim.
+AUTH0_AUDIENCE=
+# Client id of the Auth0 Regular Web App (confidential client) for account-link.
+AUTH0_LINK_CLIENT_ID=
+# Client secret of that Auth0 web app — the ONLY Auth0 secret (keep out of git).
+AUTH0_LINK_CLIENT_SECRET=
+# Public base URL the MCP server advertises (nginx strips /api at the edge).
+MCP_PUBLIC_BASE_URL=https://uat.fortymm.com/api
+# Public MCP resource URL used in the RFC 9728 protected-resource metadata.
+MCP_PUBLIC_RESOURCE_URL=https://uat.fortymm.com/api/mcp
+# Redirect URI registered with the Auth0 web app for GET /v1/auth0/link/callback.
+AUTH0_LINK_REDIRECT_URI=https://uat.fortymm.com/api/auth0/link/callback

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -432,6 +432,48 @@ async def merge_user(
         )
     )
 
+    # The unique Auth0 binding (``users.auth0_sub``, ADR "the MCP server is an
+    # OAuth Resource Server trusting Auth0"). Unlike every re-point above this is
+    # a plain UNIQUE column, NOT a foreign key to ``users.id`` — so there is no FK
+    # to re-point, it is *move-or-null*. But the same principle the CLAUDE.md rule
+    # states for FKs applies: don't strand data on the tombstone, don't break the
+    # survivor. The value is a live-looking, one-to-one identity binding; a
+    # tombstoned ghost left holding it would occupy the ``sub`` on the unique index
+    # so the real human could never re-link it, and would surface the ghost as that
+    # identity's owner. So the tombstone must end with ``auth0_sub = NULL``.
+    #
+    # A guest never links (linking requires being signed in), so the ephemeral's
+    # ``auth0_sub`` is virtually always NULL and this whole block is a no-op — the
+    # common case, handled cleanly by the ``is not None`` guard. In the rare case
+    # it is set: if the survivor has none, the binding is the same human's and
+    # follows the merge onto the survivor exactly as ownership does; if the
+    # survivor already holds one, the survivor's link stands and the ephemeral's is
+    # simply dropped. The ephemeral is nulled FIRST (freeing the value from the
+    # unique index) so the survivor UPDATE can adopt it without the two rows
+    # momentarily colliding — the constraint is checked per statement, not deferred.
+    auth0_subs: dict[uuid.UUID, str | None] = dict(
+        (
+            await db.execute(
+                select(User.id, User.auth0_sub).where(
+                    User.id.in_([from_user_id, to_user_id])
+                )
+            )
+        )
+        .tuples()
+        .all()
+    )
+    ephemeral_auth0_sub = auth0_subs.get(from_user_id)
+    if ephemeral_auth0_sub is not None:
+        await db.execute(
+            update(User).where(User.id == from_user_id).values(auth0_sub=None)
+        )
+        if auth0_subs.get(to_user_id) is None:
+            await db.execute(
+                update(User)
+                .where(User.id == to_user_id)
+                .values(auth0_sub=ephemeral_auth0_sub)
+            )
+
     # Tombstone: keep the row (and its session tokens) so the guest's cookie
     # still resolves and the auth layer can report the merge.
     await db.execute(

--- a/api/app/account_merge.py
+++ b/api/app/account_merge.py
@@ -451,28 +451,24 @@ async def merge_user(
     # simply dropped. The ephemeral is nulled FIRST (freeing the value from the
     # unique index) so the survivor UPDATE can adopt it without the two rows
     # momentarily colliding — the constraint is checked per statement, not deferred.
-    auth0_subs: dict[uuid.UUID, str | None] = dict(
-        (
-            await db.execute(
-                select(User.id, User.auth0_sub).where(
-                    User.id.in_([from_user_id, to_user_id])
-                )
-            )
-        )
-        .tuples()
-        .all()
-    )
-    ephemeral_auth0_sub = auth0_subs.get(from_user_id)
-    if ephemeral_auth0_sub is not None:
+    freed = (
+        await db.execute(select(User.auth0_sub).where(User.id == from_user_id))
+    ).scalar_one_or_none()
+    if freed is not None:
+        # Null the ephemeral FIRST (freeing the value from the unique index) so the
+        # survivor UPDATE can adopt it without the two rows momentarily colliding —
+        # the constraint is checked per statement, not deferred. The survivor's
+        # ``auth0_sub IS NULL`` guard carries the "adopt only where the survivor has
+        # none" rule declaratively: if the survivor already holds a binding, its
+        # own link stands and the ephemeral's is simply dropped.
         await db.execute(
             update(User).where(User.id == from_user_id).values(auth0_sub=None)
         )
-        if auth0_subs.get(to_user_id) is None:
-            await db.execute(
-                update(User)
-                .where(User.id == to_user_id)
-                .values(auth0_sub=ephemeral_auth0_sub)
-            )
+        await db.execute(
+            update(User)
+            .where(User.id == to_user_id, User.auth0_sub.is_(None))
+            .values(auth0_sub=freed)
+        )
 
     # Tombstone: keep the row (and its session tokens) so the guest's cookie
     # still resolves and the auth layer can report the merge.

--- a/api/app/api_token_auth.py
+++ b/api/app/api_token_auth.py
@@ -3,10 +3,15 @@
 The single place that turns a raw ``api``-context bearer token into the live
 ``User`` behind it: ``hash_token(raw)`` → ``User`` joined to its ``UserToken``
 where ``context == API_TOKEN_CONTEXT`` and the user is not tombstoned. Router-free
-(no FastAPI imports) so both the HTTP bearer path (``app.sessions`` — the
-``Authorization: Bearer`` header) and the FastMCP ``TokenVerifier`` (the ``/mcp``
-transport, see the shared-services ADR) resolve tokens through exactly this
-function and can never drift.
+(no FastAPI imports) so the HTTP bearer path (``app.sessions`` — the
+``Authorization: Bearer`` header the iOS app sends) resolves tokens through
+exactly this function.
+
+The MCP surface no longer authenticates through this resolver: as of the 20260722
+Auth0 Resource-Server ADR the FastMCP ``TokenVerifier`` on the ``/mcp`` transport
+verifies an Auth0-issued JWT and maps its ``sub`` to a **linked** user via
+``app.auth0_identity.resolve_linked_user`` — it never sees an opaque ``api``-context
+token. So this shared resolver now backs the HTTP bearer path only.
 
 Lives alongside ``app/token_hashing.py`` (the router-free home for the hasher it
 calls) rather than in either router.

--- a/api/app/auth0_identity.py
+++ b/api/app/auth0_identity.py
@@ -1,0 +1,41 @@
+"""Shared Auth0 ``sub`` → linked ``User`` resolver.
+
+The single place that turns an Auth0 subject identifier (the ``sub`` claim of a
+verified token) into the live ``User`` that explicitly linked it: ``User`` where
+``auth0_sub == sub`` and the user is not tombstoned. Router-free (no FastAPI
+imports) so the MCP OAuth Resource-Server verifier (the ``/mcp`` transport, see
+``docs/adr/20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0.md``)
+resolves every subject through exactly this function and can never drift.
+
+Mirrors ``app/api_token_auth.py::find_api_token_user`` — the same router-free,
+importable shape and the same tombstone exclusion — since both are shared
+identity resolvers behind the MCP surface.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import User
+
+
+async def resolve_linked_user(db: AsyncSession, sub: str) -> User | None:
+    """Resolve the live ``User`` whose ``auth0_sub`` matches ``sub``, or ``None``
+    when no live user linked that subject.
+
+    ``sub`` is the subject identifier already parsed out of a verified Auth0
+    token — this function owns only the ``auth0_sub`` → user lookup. Tombstoned
+    (merged-away) users are excluded in the query — ``merged_into_user_id IS
+    NULL`` — so a subject linked to a folded-in guest simply doesn't resolve,
+    the same way the auth-layer session queries keep ghosts from surfacing.
+
+    The one-to-one link invariant (``users.auth0_sub`` is unique) means at most
+    one row can match, so this returns exactly the one live user that linked
+    ``sub`` and nobody otherwise.
+    """
+    result = await db.execute(
+        select(User).where(
+            User.auth0_sub == sub,
+            User.merged_into_user_id.is_(None),
+        )
+    )
+    return result.scalar_one_or_none()

--- a/api/app/auth0_link.py
+++ b/api/app/auth0_link.py
@@ -226,9 +226,13 @@ async def _exchange_code(config: LinkConfig, *, code: str, code_verifier: str) -
 
 
 async def _fetch_jwks(config: LinkConfig) -> dict[str, Any]:
-    """Fetch the tenant's public JWKS. Raises ``httpx.HTTPError`` on failure."""
+    """Fetch the tenant's public JWKS. Raises ``httpx.HTTPError`` on failure.
+
+    The JWKS URL comes from ``settings.auth0_jwks_uri`` (built from the same
+    ``auth0_domain`` this ``config`` was derived from) so the tenant URL topology
+    lives in exactly one place (``app.config``)."""
     async with _http_client() as client:
-        response = await client.get(f"https://{config.domain}/.well-known/jwks.json")
+        response = await client.get(get_settings().auth0_jwks_uri)
         response.raise_for_status()
         data: dict[str, Any] = response.json()
         return data
@@ -252,7 +256,10 @@ def _verify_id_token(config: LinkConfig, id_token: str, jwks: dict[str, Any]) ->
         signing_key,
         algorithms=["RS256"],
         audience=config.client_id,
-        issuer=f"https://{config.domain}/",
+        # ``iss`` from ``settings.auth0_issuer`` — the same single-source tenant URL
+        # construction the MCP verifier uses (``app.config``), built from the
+        # ``auth0_domain`` this ``config`` was derived from.
+        issuer=get_settings().auth0_issuer,
     )
     return Auth0IdClaims.model_validate(claims).sub
 

--- a/api/app/auth0_link.py
+++ b/api/app/auth0_link.py
@@ -30,14 +30,15 @@ import os
 import secrets
 import time
 from dataclasses import dataclass
-from typing import Annotated, Any
+from typing import Annotated
 from urllib.parse import urlencode
 
 import httpx
 import jwt
-from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, Request, status
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, ConfigDict, ValidationError
+from pyrate_limiter import Duration, Rate
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -45,9 +46,31 @@ from app.auth0_identity import resolve_linked_user
 from app.config import Settings, get_settings
 from app.db import get_session
 from app.models import User
-from app.sessions import get_current_user
+from app.rate_limiting import RedisRateLimiter
+from app.rbac import require_permission
+from app.sessions import (
+    SESSION_COOKIE_NAME,
+    _client_ip,
+    _hash_cookie_for_key,
+    get_current_user,
+)
 
-router = APIRouter(prefix="/v1")
+# The fortymm permission a signed-in user must hold to bind / read / clear an
+# Auth0 identity — deliberately the *same* grant the MCP transport enforces
+# (``app.mcp_server.MCP_ACCESS_PERMISSION``), so the UI gating and the API gating
+# stay consistent: only a user allowed to reach the MCP surface may bind the
+# Auth0 identity that surface authenticates against (see the 20260722 Auth0
+# Resource-Server ADR). Held as a literal here to avoid importing the heavy
+# FastMCP module just for the constant.
+MCP_ACCESS_PERMISSION = "mcp.access"
+
+# Every link route is session-gated *and* permission-gated: ``require_permission``
+# depends on ``get_current_user`` (so a cookieless caller still 401s) and then
+# refuses a signed-in user who lacks ``mcp.access`` with a 403.
+router = APIRouter(
+    prefix="/v1",
+    dependencies=[Depends(require_permission(MCP_ACCESS_PERMISSION))],
+)
 
 # Cookie the PKCE ``code_verifier`` + CSRF ``state`` ride in across the Auth0
 # round-trip. Signed (HS256) with the Auth0 web app's ``client_secret`` and set
@@ -61,6 +84,39 @@ PKCE_TTL_SECONDS = 10 * 60
 # resolves against the public origin the callback was reached on (behind nginx's
 # ``/api`` strip on UAT), landing back on the web client's settings page.
 LINK_SUCCESS_REDIRECT = "/settings?linked=1"
+
+
+async def _link_rate_limit_key(request: Request) -> str:
+    """Key the per-session limiter by hashed session cookie so users behind a
+    shared NAT aren't penalised collectively. Fall back to client IP for a
+    cookie-less request (it 401s downstream anyway, but still counts)."""
+    cookie = request.cookies.get(SESSION_COOKIE_NAME)
+    if cookie:
+        return f"session:{_hash_cookie_for_key(cookie)}"
+    return f"ip:{_client_ip(request)}"
+
+
+async def _link_ip_rate_limit_key(request: Request) -> str:
+    """Per-IP key for the looser ceiling that catches an attacker cycling fresh
+    ``GET /v1/session`` cookies to reset the per-session bucket for free."""
+    return f"auth0-link-ip:{_client_ip(request)}"
+
+
+# Two-tier limit on the two session-reachable, Auth0-touching link routes
+# (``start`` mints a handshake; ``callback`` exchanges a code + fetches JWKS).
+# ``start`` + ``callback`` share these buckets, so a full link attempt costs two
+# hits: the per-session cap allows a handful of attempts per hour, and the looser
+# per-IP ceiling stops session-cycling from multiplying that budget.
+auth0_link_rate_limit = RedisRateLimiter(
+    rates=[Rate(10, Duration.HOUR)],
+    bucket_key="auth0-link",
+    identifier=_link_rate_limit_key,
+)
+auth0_link_ip_rate_limit = RedisRateLimiter(
+    rates=[Rate(40, Duration.HOUR)],
+    bucket_key="auth0-link-ip",
+    identifier=_link_ip_rate_limit_key,
+)
 
 
 class LinkStatus(BaseModel):
@@ -225,8 +281,12 @@ async def _exchange_code(config: LinkConfig, *, code: str, code_verifier: str) -
         return Auth0TokenResponse.model_validate(response.json()).id_token
 
 
-async def _fetch_jwks(config: LinkConfig) -> dict[str, Any]:
-    """Fetch the tenant's public JWKS. Raises ``httpx.HTTPError`` on failure.
+async def _fetch_jwks(config: LinkConfig) -> jwt.PyJWKSet:
+    """Fetch the tenant's public JWKS, parsed at the boundary into a typed
+    ``jwt.PyJWKSet`` so no ``dict[str, Any]`` crosses into the interior. Raises
+    ``httpx.HTTPError`` on a transport / non-2xx failure and ``jwt.PyJWTError``
+    (``PyJWKSetError``) when the body isn't a well-formed key set — both caught by
+    the handler and turned into a clean 400.
 
     The JWKS URL comes from ``settings.auth0_jwks_uri`` (built from the same
     ``auth0_domain`` this ``config`` was derived from) so the tenant URL topology
@@ -234,11 +294,10 @@ async def _fetch_jwks(config: LinkConfig) -> dict[str, Any]:
     async with _http_client() as client:
         response = await client.get(get_settings().auth0_jwks_uri)
         response.raise_for_status()
-        data: dict[str, Any] = response.json()
-        return data
+        return jwt.PyJWKSet.from_dict(response.json())
 
 
-def _verify_id_token(config: LinkConfig, id_token: str, jwks: dict[str, Any]) -> str:
+def _verify_id_token(config: LinkConfig, id_token: str, jwks: jwt.PyJWKSet) -> str:
     """Verify the id_token (RS256 against the tenant JWKS, ``aud`` = the link
     client id, ``iss`` = ``https://{domain}/``) and return its ``sub``.
 
@@ -247,8 +306,7 @@ def _verify_id_token(config: LinkConfig, id_token: str, jwks: dict[str, Any]) ->
     ``ValidationError`` when the verified claims carry no ``sub`` — the handler
     catches both."""
     kid = jwt.get_unverified_header(id_token).get("kid")
-    key_set = jwt.PyJWKSet.from_dict(jwks)
-    signing_key = next((k.key for k in key_set.keys if k.key_id == kid), None)
+    signing_key = next((k.key for k in jwks.keys if k.key_id == kid), None)
     if signing_key is None:
         raise jwt.InvalidKeyError("no JWKS key matches the id_token kid")
     claims = jwt.decode(
@@ -275,7 +333,14 @@ async def _resolve_auth0_sub(
     return _verify_id_token(config, id_token, jwks)
 
 
-@router.get("/auth0/link/start", response_class=RedirectResponse)
+@router.get(
+    "/auth0/link/start",
+    response_class=RedirectResponse,
+    dependencies=[
+        Depends(auth0_link_ip_rate_limit),
+        Depends(auth0_link_rate_limit),
+    ],
+)
 async def start_link(
     settings: Settings = Depends(get_settings),
     _current_user: User = Depends(get_current_user),
@@ -355,7 +420,14 @@ async def _bind_auth0_sub(db: AsyncSession, current_user: User, sub: str) -> Non
         ) from exc
 
 
-@router.get("/auth0/link/callback", response_class=RedirectResponse)
+@router.get(
+    "/auth0/link/callback",
+    response_class=RedirectResponse,
+    dependencies=[
+        Depends(auth0_link_ip_rate_limit),
+        Depends(auth0_link_rate_limit),
+    ],
+)
 async def link_callback(
     code: Annotated[str, Query()],
     state: Annotated[str, Query()],

--- a/api/app/auth0_link.py
+++ b/api/app/auth0_link.py
@@ -1,0 +1,433 @@
+"""Account-link lifecycle routes: bind / read / clear a fortymm user's Auth0 identity.
+
+A logged-in fortymm user links their account to an Auth0 identity **once** via a
+server-side authorization-code + PKCE flow, so the MCP OAuth Resource Server can
+later map a verified Auth0 token's ``sub`` back to this user (see
+``docs/adr/20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0.md``).
+This module owns only the *link* side — the four HTTP routes and the token
+exchange / id_token verification that binds an Auth0 ``sub`` to
+``users.auth0_sub``. The MCP-time ``sub`` → ``User`` resolution lives in
+``app/auth0_identity.py`` (the shared resolver both surfaces call).
+
+**PKCE / CSRF state survives the redirect in a short-lived signed cookie**, not
+Redis or a server-side store. The ``code_verifier`` and CSRF ``state`` are packed
+into an HS256 JWT signed with the Auth0 web app's ``client_secret`` (a secret we
+already hold whenever linking is configured), set as an httponly cookie for the
+few minutes the round-trip lasts, and verified on the callback. This keeps the
+flow **stateless** — it needs no shared store and survives round-robin across the
+two UAT api replicas with no session affinity — matching the stateless-http
+stance the ADR takes for the MCP surface itself.
+
+The interior never traffics in ``dict[str, Any]``: the Auth0 token response and
+the verified id_token claims are parsed into Pydantic models at the boundary, and
+only specific exceptions (``httpx.HTTPError``, ``jwt.PyJWTError``,
+``ValidationError``) are caught — a programmer error still crashes loudly.
+"""
+
+import base64
+import hashlib
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Annotated, Any
+from urllib.parse import urlencode
+
+import httpx
+import jwt
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, status
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, ConfigDict, ValidationError
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth0_identity import resolve_linked_user
+from app.config import Settings, get_settings
+from app.db import get_session
+from app.models import User
+from app.sessions import get_current_user
+
+router = APIRouter(prefix="/v1")
+
+# Cookie the PKCE ``code_verifier`` + CSRF ``state`` ride in across the Auth0
+# round-trip. Signed (HS256) with the Auth0 web app's ``client_secret`` and set
+# httponly for the few minutes the flow lasts; SameSite=Lax so it survives the
+# top-level GET navigation back from Auth0 to our callback.
+PKCE_COOKIE_NAME = "auth0_link_pkce"
+# The link handshake is a browser round-trip through Auth0's login — a few
+# minutes at most. Short-lived so a leaked cookie can't be replayed later.
+PKCE_TTL_SECONDS = 10 * 60
+# Where the callback sends the browser once the link is bound. Relative so it
+# resolves against the public origin the callback was reached on (behind nginx's
+# ``/api`` strip on UAT), landing back on the web client's settings page.
+LINK_SUCCESS_REDIRECT = "/settings?linked=1"
+
+
+class LinkStatus(BaseModel):
+    """Whether the current user has an Auth0 identity bound. The GET status body
+    and the DELETE (now-cleared) body both use it, so a client updates the same
+    shape either way."""
+
+    linked: bool
+
+
+class Auth0TokenResponse(BaseModel):
+    """The subset of Auth0's ``/oauth/token`` response we consume. Auth0 also
+    returns ``access_token`` / ``token_type`` / ``expires_in`` etc.; we only need
+    the id_token (identity is authentication-only here), so extra keys are
+    ignored rather than rejected."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id_token: str
+
+
+class Auth0IdClaims(BaseModel):
+    """The one claim we bind from a verified id_token. ``jwt.decode`` already
+    checked the signature / ``aud`` / ``iss`` / ``exp`` before we parse; this
+    turns the surviving claim blob into a typed value so the interior never holds
+    a stringly-keyed ``dict``."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    sub: str
+
+
+@dataclass(frozen=True)
+class LinkConfig:
+    """The four Auth0 settings the confidential code flow needs, proven non-empty.
+    Built by :func:`_link_config`, which returns ``None`` when linking is
+    unconfigured so callers fail closed rather than 500 on a blank domain."""
+
+    domain: str
+    client_id: str
+    client_secret: str
+    redirect_uri: str
+
+
+def _link_config(settings: Settings) -> LinkConfig | None:
+    """The Auth0 link configuration, or ``None`` when any required piece is unset.
+
+    Linking needs all four to run the confidential code exchange; with any empty
+    the feature is simply not configured (local / qa / e2e), and the routes fail
+    closed with a clean 404 instead of attempting a request against a blank host.
+    """
+    if not (
+        settings.auth0_domain
+        and settings.auth0_link_client_id
+        and settings.auth0_link_client_secret
+        and settings.auth0_link_redirect_uri
+    ):
+        return None
+    return LinkConfig(
+        domain=settings.auth0_domain,
+        client_id=settings.auth0_link_client_id,
+        client_secret=settings.auth0_link_client_secret,
+        redirect_uri=settings.auth0_link_redirect_uri,
+    )
+
+
+def _require_link_config(settings: Settings) -> LinkConfig:
+    """``_link_config`` or a clean 404 — never a 500 on an unconfigured tenant."""
+    config = _link_config(settings)
+    if config is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Auth0 account linking is not configured.",
+        )
+    return config
+
+
+def _cookie_secure() -> bool:
+    """Mirror the session cookie's Secure attribute (``SESSION_COOKIE_SECURE``),
+    so local non-HTTPS dev can drop it exactly as the session flow does."""
+    return os.environ.get("SESSION_COOKIE_SECURE", "true").lower() != "false"
+
+
+def _pkce_challenge(code_verifier: str) -> str:
+    """The S256 code challenge for ``code_verifier`` — base64url(sha256(verifier))
+    with padding stripped, per RFC 7636."""
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _sign_pkce_cookie(secret: str, *, state: str, code_verifier: str) -> str:
+    """Pack the CSRF ``state`` and PKCE ``code_verifier`` into a short-lived HS256
+    JWT signed with the Auth0 ``client_secret``. The signature makes the cookie
+    tamper-evident, and the ``exp`` bounds the replay window — no server-side
+    store needed."""
+    now = int(time.time())
+    payload = {
+        "state": state,
+        "cv": code_verifier,
+        "iat": now,
+        "exp": now + PKCE_TTL_SECONDS,
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _read_pkce_cookie(secret: str, cookie: str) -> tuple[str, str] | None:
+    """Verify + decode the PKCE cookie, returning ``(state, code_verifier)`` or
+    ``None`` when it's missing a claim, tampered, or expired (``jwt.decode``
+    enforces ``exp``). ``None`` — not a raise — so the caller shapes the rejection."""
+    try:
+        payload = jwt.decode(cookie, secret, algorithms=["HS256"])
+    except jwt.PyJWTError:
+        return None
+    state = payload.get("state")
+    code_verifier = payload.get("cv")
+    if not isinstance(state, str) or not isinstance(code_verifier, str):
+        return None
+    return state, code_verifier
+
+
+def _authorize_url(config: LinkConfig, *, state: str, code_challenge: str) -> str:
+    """The Auth0 ``/authorize`` URL for an authorization-code + PKCE login,
+    requesting only ``openid`` (we bind ``sub``, no profile/PII)."""
+    query = urlencode(
+        {
+            "response_type": "code",
+            "client_id": config.client_id,
+            "redirect_uri": config.redirect_uri,
+            "scope": "openid",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+        }
+    )
+    return f"https://{config.domain}/authorize?{query}"
+
+
+def _http_client() -> httpx.AsyncClient:
+    """The outbound client for the Auth0 token + JWKS calls. A named seam so tests
+    substitute an ``httpx.MockTransport`` and no real network call happens."""
+    return httpx.AsyncClient(timeout=10.0)
+
+
+async def _exchange_code(config: LinkConfig, *, code: str, code_verifier: str) -> str:
+    """Exchange the authorization ``code`` (+ PKCE verifier) for the raw id_token
+    JWT at Auth0's ``/oauth/token``. Raises ``httpx.HTTPError`` on a transport /
+    non-2xx failure and ``ValidationError`` when the body lacks an ``id_token`` —
+    both caught by the handler and turned into a clean 400."""
+    async with _http_client() as client:
+        response = await client.post(
+            f"https://{config.domain}/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": config.client_id,
+                "client_secret": config.client_secret,
+                "code": code,
+                "redirect_uri": config.redirect_uri,
+                "code_verifier": code_verifier,
+            },
+        )
+        response.raise_for_status()
+        return Auth0TokenResponse.model_validate(response.json()).id_token
+
+
+async def _fetch_jwks(config: LinkConfig) -> dict[str, Any]:
+    """Fetch the tenant's public JWKS. Raises ``httpx.HTTPError`` on failure."""
+    async with _http_client() as client:
+        response = await client.get(f"https://{config.domain}/.well-known/jwks.json")
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+        return data
+
+
+def _verify_id_token(config: LinkConfig, id_token: str, jwks: dict[str, Any]) -> str:
+    """Verify the id_token (RS256 against the tenant JWKS, ``aud`` = the link
+    client id, ``iss`` = ``https://{domain}/``) and return its ``sub``.
+
+    Raises ``jwt.PyJWTError`` on any verification failure (bad signature, wrong
+    audience/issuer, expiry, or no JWKS key matching the token's ``kid``) and
+    ``ValidationError`` when the verified claims carry no ``sub`` — the handler
+    catches both."""
+    kid = jwt.get_unverified_header(id_token).get("kid")
+    key_set = jwt.PyJWKSet.from_dict(jwks)
+    signing_key = next((k.key for k in key_set.keys if k.key_id == kid), None)
+    if signing_key is None:
+        raise jwt.InvalidKeyError("no JWKS key matches the id_token kid")
+    claims = jwt.decode(
+        id_token,
+        signing_key,
+        algorithms=["RS256"],
+        audience=config.client_id,
+        issuer=f"https://{config.domain}/",
+    )
+    return Auth0IdClaims.model_validate(claims).sub
+
+
+async def _resolve_auth0_sub(
+    config: LinkConfig, *, code: str, code_verifier: str
+) -> str:
+    """The full callback exchange: code → id_token → verified ``sub``. Its raised
+    exceptions (``httpx.HTTPError`` / ``jwt.PyJWTError`` / ``ValidationError``)
+    are the boundary failures the handler maps to a 400."""
+    id_token = await _exchange_code(config, code=code, code_verifier=code_verifier)
+    jwks = await _fetch_jwks(config)
+    return _verify_id_token(config, id_token, jwks)
+
+
+@router.get("/auth0/link/start", response_class=RedirectResponse)
+async def start_link(
+    settings: Settings = Depends(get_settings),
+    _current_user: User = Depends(get_current_user),
+) -> RedirectResponse:
+    """Begin linking the signed-in user's account to an Auth0 identity.
+
+    Generates a PKCE ``code_verifier`` + CSRF ``state``, stashes them in a
+    short-lived signed httponly cookie (no server-side store, so the flow is
+    stateless across replicas), and 302-redirects the browser to Auth0's
+    ``/authorize`` for an authorization-code + PKCE login requesting only the
+    ``openid`` scope. The matching callback completes the bind.
+
+    Requires an established fortymm session (the link is bound to *you*). Returns
+    a clean ``404`` when Auth0 linking is not configured for this deployment,
+    never a ``500``.
+    """
+    config = _require_link_config(settings)
+    state = secrets.token_urlsafe(32)
+    code_verifier = secrets.token_urlsafe(64)
+    cookie = _sign_pkce_cookie(
+        config.client_secret, state=state, code_verifier=code_verifier
+    )
+    redirect = RedirectResponse(
+        url=_authorize_url(
+            config, state=state, code_challenge=_pkce_challenge(code_verifier)
+        ),
+        status_code=status.HTTP_302_FOUND,
+    )
+    redirect.set_cookie(
+        key=PKCE_COOKIE_NAME,
+        value=cookie,
+        max_age=PKCE_TTL_SECONDS,
+        path="/",
+        httponly=True,
+        secure=_cookie_secure(),
+        samesite="lax",
+    )
+    return redirect
+
+
+def _clear_pkce_cookie(response: RedirectResponse) -> None:
+    """Drop the PKCE cookie once the callback consumes it (single-use), mirroring
+    the attributes it was set with so the browser actually matches and clears it."""
+    response.delete_cookie(
+        key=PKCE_COOKIE_NAME,
+        path="/",
+        httponly=True,
+        secure=_cookie_secure(),
+        samesite="lax",
+    )
+
+
+async def _bind_auth0_sub(db: AsyncSession, current_user: User, sub: str) -> None:
+    """Bind ``sub`` to ``current_user``, enforcing the one-to-one link invariant.
+
+    If a *different* live (non-tombstoned) user already holds this ``sub`` →
+    ``409`` and nothing moves (no silent takeover). If the current user already
+    holds a different ``sub`` this overwrites it (their own re-link); a repeat of
+    the same ``sub`` is an idempotent no-op. The unique constraint on
+    ``users.auth0_sub`` is the backstop: a race that slips past the pre-check
+    surfaces as ``IntegrityError`` → the same ``409``.
+    """
+    existing = await resolve_linked_user(db, sub)
+    if existing is not None and existing.id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="That Auth0 identity is already linked to another account.",
+        )
+    current_user.auth0_sub = sub
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="That Auth0 identity is already linked to another account.",
+        ) from exc
+
+
+@router.get("/auth0/link/callback", response_class=RedirectResponse)
+async def link_callback(
+    code: Annotated[str, Query()],
+    state: Annotated[str, Query()],
+    pkce_cookie: Annotated[str | None, Cookie(alias=PKCE_COOKIE_NAME)] = None,
+    settings: Settings = Depends(get_settings),
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> RedirectResponse:
+    """Complete the Auth0 account link and redirect back to settings.
+
+    Validates the returned ``state`` against the signed PKCE cookie, exchanges the
+    ``code`` for an id_token at Auth0, verifies it (RS256 via the tenant JWKS,
+    ``aud`` = the link client id, ``iss`` = the tenant), and binds its ``sub`` to
+    the **current session user** (one-to-one; a ``sub`` already held by a
+    different live user is rejected ``409`` and left in place — see
+    ``_bind_auth0_sub``). On success it 302-redirects to ``/settings?linked=1``.
+
+    Requires an established fortymm session. Rejects a missing / mismatched /
+    expired ``state`` with ``400``, an exchange or id_token-verification failure
+    with ``400``, and returns ``404`` when linking is unconfigured.
+    """
+    config = _require_link_config(settings)
+
+    stored = (
+        _read_pkce_cookie(config.client_secret, pkce_cookie)
+        if pkce_cookie is not None
+        else None
+    )
+    if stored is None or not secrets.compare_digest(stored[0], state):
+        # Missing/tampered/expired cookie, or a state that doesn't match what we
+        # issued — a forged or stale callback. Refuse before touching Auth0.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The account-link request is invalid or has expired. Try again.",
+        )
+    _, code_verifier = stored
+
+    try:
+        sub = await _resolve_auth0_sub(config, code=code, code_verifier=code_verifier)
+    except (httpx.HTTPError, jwt.PyJWTError, ValidationError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Could not verify the Auth0 sign-in. Try linking again.",
+        ) from exc
+
+    await _bind_auth0_sub(db, current_user, sub)
+
+    redirect = RedirectResponse(
+        url=LINK_SUCCESS_REDIRECT, status_code=status.HTTP_302_FOUND
+    )
+    _clear_pkce_cookie(redirect)
+    return redirect
+
+
+@router.get("/auth0/link", response_model=LinkStatus)
+async def link_status(
+    current_user: User = Depends(get_current_user),
+) -> LinkStatus:
+    """Whether the signed-in user has an Auth0 identity bound.
+
+    ``linked`` is true once the user has completed the link flow (their
+    ``users.auth0_sub`` is set). Requires an established fortymm session; needs no
+    Auth0 configuration (it only reads local state)."""
+    return LinkStatus(linked=current_user.auth0_sub is not None)
+
+
+@router.delete("/auth0/link", response_model=LinkStatus)
+async def unlink(
+    db: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> LinkStatus:
+    """Clear the signed-in user's Auth0 binding.
+
+    Drops ``users.auth0_sub`` so the identity can be re-linked (here or to a
+    different account) and any agent authenticating as that ``sub`` stops
+    resolving to this user. Idempotent — clearing an already-unlinked account is a
+    no-op ``linked=false``. Requires an established fortymm session; needs no Auth0
+    configuration."""
+    if current_user.auth0_sub is not None:
+        current_user.auth0_sub = None
+        await db.commit()
+    return LinkStatus(linked=False)

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -32,6 +32,38 @@ class Settings(BaseSettings):
     #: ahead of pending real solves, so a low cap keeps a preview snappy.
     preview_solver_time_cap_s: float = 5.0
 
+    #: Auth0 tenant domain (e.g. ``fortymm.us.auth0.com``) — the issuer the MCP
+    #: JWT verifier trusts and the origin its JWKS is fetched from. Empty means
+    #: Auth0 is unconfigured: the api still boots and MCP still mounts, but every
+    #: MCP request 401s (fail-closed — see the "fails closed when unconfigured"
+    #: consequence in the Auth0 Resource-Server ADR).
+    auth0_domain: str = ""
+
+    #: Auth0 API identifier registered for the MCP Resource Server — the ``aud``
+    #: an agent's access token must carry to be accepted. Empty = fail-closed.
+    auth0_audience: str = ""
+
+    #: Client id of the Auth0 Regular Web Application (confidential client) used
+    #: for the one-time account-link code flow. Empty = link flow unconfigured.
+    auth0_link_client_id: str = ""
+
+    #: Client secret of that Auth0 web application — the only Auth0 secret we
+    #: store (verification needs no secret; JWKS is public). Empty = fail-closed.
+    auth0_link_client_secret: str = ""
+
+    #: Public base URL of the MCP server (e.g. ``https://uat.fortymm.com/api``).
+    #: Passed explicitly rather than derived from the internal ``/mcp/`` mount so
+    #: the protected-resource metadata reflects the public origin behind nginx.
+    mcp_public_base_url: str = ""
+
+    #: Public resource identifier advertised in the RFC 9728 protected-resource
+    #: metadata (the MCP server's public origin). Empty = fail-closed.
+    mcp_public_resource_url: str = ""
+
+    #: Redirect URI registered with the Auth0 web application for the account-link
+    #: callback (``GET /v1/auth0/link/callback``). Empty = link flow unconfigured.
+    auth0_link_redirect_uri: str = ""
+
 
 def get_settings() -> Settings:
     """Read settings from the environment.

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -64,6 +64,23 @@ class Settings(BaseSettings):
     #: callback (``GET /v1/auth0/link/callback``). Empty = link flow unconfigured.
     auth0_link_redirect_uri: str = ""
 
+    @property
+    def auth0_issuer(self) -> str:
+        """The Auth0 tenant's OIDC issuer — ``https://{domain}/`` (Auth0 mints
+        tokens with the trailing slash). The single source of the ``iss`` both the
+        MCP JWT verifier (``app.mcp_server``) and the account-link id_token
+        verification (``app.auth0_link``) trust, so the tenant URL topology is
+        built in exactly one place. Meaningful only when ``auth0_domain`` is set."""
+        return f"https://{self.auth0_domain}/"
+
+    @property
+    def auth0_jwks_uri(self) -> str:
+        """The Auth0 tenant's JWKS endpoint — ``https://{domain}/.well-known/jwks.json``,
+        where both the MCP verifier and the account-link flow fetch the tenant's
+        public signing keys. The single source of that URL (see ``auth0_issuer``).
+        Meaningful only when ``auth0_domain`` is set."""
+        return f"https://{self.auth0_domain}/.well-known/jwks.json"
+
 
 def get_settings() -> Settings:
     """Read settings from the environment.

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -20,6 +20,7 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from app import db, queue
 from app.admin_schedule_solves import router as admin_schedule_solves_router
 from app.api_tokens import router as api_tokens_router
+from app.auth0_link import router as auth0_link_router
 from app.dashboard import router as dashboard_router
 from app.match_calls import pin_tick_loop
 from app.matches import router as matches_router
@@ -208,6 +209,7 @@ async def csrf_protect(
 app.include_router(sessions_router)
 app.include_router(rbac_router)
 app.include_router(api_tokens_router)
+app.include_router(auth0_link_router)
 app.include_router(matches_router)
 app.include_router(players_router)
 app.include_router(dashboard_router)

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -258,23 +258,32 @@ class FortymmAuth0TokenVerifier(JWTVerifier):
 def _build_mcp_auth() -> RemoteAuthProvider:
     """Wire the MCP transport auth from :class:`~app.config.Settings`.
 
-    When Auth0 is configured (``auth0_domain`` + ``auth0_audience`` both set) the
-    provider wraps a :class:`FortymmAuth0TokenVerifier` pointed at the tenant's
-    JWKS, and advertises the tenant as its authorization server. When it is not
-    (the local / qa / e2e / dev-compose default), the provider wraps the
-    reject-all verifier and uses a placeholder origin — so the api boots and MCP
-    mounts, but every request 401s (fail-closed). The public ``base_url`` /
+    Auth0 is treated as configured **all-or-nothing**: only when ALL of
+    ``auth0_domain``, ``auth0_audience``, ``mcp_public_base_url`` and
+    ``mcp_public_resource_url`` are set does the provider wrap a real
+    :class:`FortymmAuth0TokenVerifier` (pointed at the tenant's JWKS/issuer) and
+    advertise the tenant as its authorization server. A PARTIAL config — e.g. a
+    deployment that sets the tenant but forgets the public URLs — falls back to
+    the reject-all verifier just like the empty (local / qa / e2e / dev-compose)
+    default, so the api boots and MCP mounts but every request 401s (fail-closed).
+    This never ships a live verifier advertising the ``.invalid`` placeholder
+    origin (broken RFC 9728 discovery). The public ``base_url`` /
     ``resource_base_url`` come straight from config (never derived from the
-    internal mount) so the RFC 9728 metadata reflects the origin behind nginx."""
+    internal mount) so the metadata reflects the origin behind nginx."""
     settings = get_settings()
-    if settings.auth0_domain and settings.auth0_audience:
+    if (
+        settings.auth0_domain
+        and settings.auth0_audience
+        and settings.mcp_public_base_url
+        and settings.mcp_public_resource_url
+    ):
         token_verifier: TokenVerifier = FortymmAuth0TokenVerifier(
-            jwks_uri=f"https://{settings.auth0_domain}/.well-known/jwks.json",
-            issuer=f"https://{settings.auth0_domain}/",
+            jwks_uri=settings.auth0_jwks_uri,
+            issuer=settings.auth0_issuer,
             audience=settings.auth0_audience,
             algorithm="RS256",
         )
-        authorization_server = f"https://{settings.auth0_domain}/"
+        authorization_server = settings.auth0_issuer
     else:
         token_verifier = _RejectAllTokenVerifier()
         authorization_server = _UNCONFIGURED_ORIGIN

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -1,16 +1,27 @@
 """The FortyMM MCP server: a FastMCP app mounted at ``/mcp`` on the FastAPI app.
 
 Router-free (no FastAPI imports); it owns a configured :data:`mcp` ``FastMCP``
-instance whose transport authentication is a :class:`FortymmTokenVerifier`. The
-curated match-flow verbs are registered here as tools (starting with the
+instance whose transport authentication is an Auth0 OAuth Resource-Server
+verifier (:class:`FortymmAuth0TokenVerifier` behind a ``RemoteAuthProvider``).
+The curated match-flow verbs are registered here as tools (starting with the
 :func:`get_match` read); each reuses the shared match service + serializer so the
 MCP and HTTP surfaces can never drift.
 
-Auth reuses the exact same resolver as the HTTP bearer path
-(:func:`app.api_token_auth.find_api_token_user`), wrapped in a FastMCP
-``TokenVerifier`` so an unauthenticated MCP call fails **at the transport**, not
-inside a tool, and the two surfaces can never drift (see the shared-services
-ADR). Every tool authenticates before it runs.
+Auth is the MCP 2025 OAuth flow with Auth0 as the Authorization Server and this
+server as a stateless Resource Server (see
+``docs/adr/20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0.md``).
+The verifier does RS256/JWKS/iss/aud/exp checks on the Auth0-issued access token,
+then resolves its ``sub`` to the explicitly **linked**, non-tombstoned ``User``
+(:func:`app.auth0_identity.resolve_linked_user`) and admits it only if that user
+holds the ``mcp.access`` permission — so an unauthenticated or unauthorized MCP
+call fails **at the transport** (401), not inside a tool. The old opaque
+``context="api"`` bearer token is no longer accepted on the MCP surface (it stays
+alive for HTTP/iOS). Every tool authenticates before it runs.
+
+**Fails closed when unconfigured.** With ``AUTH0_*`` empty (local / qa / e2e /
+dev-compose all boot the api without Auth0), the api still imports and MCP still
+mounts, but the verifier rejects every request — construction never touches Auth0
+and a reject-all verifier 401s every call.
 
 Tools run outside a FastAPI request, so they cannot use the request-scoped
 ``get_session`` dependency — they own the session lifecycle themselves via
@@ -28,13 +39,19 @@ from typing import Annotated, Literal
 from anyio import to_thread
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
-from fastmcp.server.auth import AccessToken, TokenVerifier
+from fastmcp.server.auth import (
+    AccessToken,
+    JWTVerifier,
+    RemoteAuthProvider,
+    TokenVerifier,
+)
 from fastmcp.server.dependencies import get_access_token
-from pydantic import BaseModel, Field
+from pydantic import AnyHttpUrl, BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api_token_auth import find_api_token_user
+from app.auth0_identity import resolve_linked_user
+from app.config import get_settings
 from app.db import get_sessionmaker
 from app.draws import (
     DegenerateDraw,
@@ -167,46 +184,122 @@ async def mcp_session() -> AsyncIterator[AsyncSession]:
         yield session
 
 
-class FortymmTokenVerifier(TokenVerifier):
-    """Authenticates every MCP request against a ``context="api"`` bearer token.
+# The fortymm permission an Auth0-linked user must hold for the MCP transport to
+# admit them — the new seeded RBAC grant on the Beta tester role
+# (``scripts/seed_rbac.py``). Auth0 proves *who* the caller is (the token's
+# ``sub``); this grant decides *whether* they may reach the MCP surface at all, so
+# revoking it cuts an agent off immediately even while its Auth0 token is still
+# valid (see the Auth0 Resource-Server ADR).
+MCP_ACCESS_PERMISSION = "mcp.access"
 
-    FastMCP hands us the raw token parsed out of the ``Authorization: Bearer``
-    header; we resolve it through the one shared
-    :func:`~app.api_token_auth.find_api_token_user` lookup (sha256 hash → live,
-    non-tombstoned ``User``). On success we return an ``AccessToken`` carrying
-    the resolved user id as ``subject``/``client_id`` (and under a ``user_id``
-    claim) so tools can identify the caller without re-resolving. On any failure
-    — missing, unknown, or tombstoned-user token — we return ``None``, which
-    FastMCP turns into a 401 at the transport before any tool body runs.
-    """
+# A fail-closed placeholder origin used only when Auth0 is unconfigured (``AUTH0_*``
+# empty). ``RemoteAuthProvider`` validates its URLs as ``AnyHttpUrl``, so an empty
+# ``base_url`` / ``authorization_servers`` entry would raise at import; this
+# stand-in lets construction succeed while the reject-all verifier 401s every
+# request. The ``.invalid`` TLD (RFC 6761) can never resolve, so it can never be
+# mistaken for a live metadata origin.
+_UNCONFIGURED_ORIGIN = "https://mcp-unconfigured.fortymm.invalid"
+
+
+class _RejectAllTokenVerifier(TokenVerifier):
+    """The fail-closed verifier the MCP transport uses when Auth0 is unconfigured.
+
+    With ``AUTH0_*`` empty there is no issuer/audience/JWKS to trust, so every
+    token is rejected outright — the api still boots and MCP still mounts, but
+    every MCP request 401s (ADR "fails closed when unconfigured"). Constructing
+    this touches no Auth0 config, so ``from app.main import app`` succeeds with an
+    empty environment."""
 
     async def verify_token(self, token: str) -> AccessToken | None:
-        async with mcp_session() as db:
-            user = await find_api_token_user(db, token)
-        if user is None:
+        return None
+
+
+class FortymmAuth0TokenVerifier(JWTVerifier):
+    """Authenticates every MCP request against an Auth0-issued RS256 JWT, then
+    authorizes it against fortymm RBAC.
+
+    The :class:`JWTVerifier` base does the authentication (JWKS fetch with a
+    built-in cache, and RS256 / issuer / audience / expiry checks); we override
+    :meth:`verify_token` to add fortymm's authorization on top. On a token that
+    fails verification we return ``None`` (→ 401). On a verified token we read its
+    ``sub`` and resolve it to the explicitly **linked**, non-tombstoned ``User``
+    (:func:`app.auth0_identity.resolve_linked_user`); a ``sub`` linked to no live
+    user, or a linked user lacking ``mcp.access``, is also ``None`` (→ 401).
+
+    On success we return an ``AccessToken`` that preserves the existing tool
+    contract: the resolved user id rides as ``subject`` / ``client_id`` and under
+    a ``user_id`` claim, so :func:`_authenticated_user_id` and every ``@mcp.tool``
+    are untouched by the switch from the opaque token to Auth0."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        access = await super().verify_token(token)
+        if access is None:
             return None
-        user_id = str(user.id)
+        sub = access.claims.get("sub")
+        if not isinstance(sub, str) or not sub:
+            return None
+        async with mcp_session() as db:
+            user = await resolve_linked_user(db, sub)
+            if user is None:
+                return None
+            if not await user_has_permission(db, user.id, MCP_ACCESS_PERMISSION):
+                return None
+            user_id = str(user.id)
         return AccessToken(
             token=token,
             client_id=user_id,
             subject=user_id,
-            scopes=[],
-            claims={"user_id": user_id},
+            scopes=access.scopes,
+            expires_at=access.expires_at,
+            claims={**access.claims, "user_id": user_id},
         )
 
 
-# The mounted MCP server. ``auth`` wires the verifier so authentication happens
-# at the transport for every request; each tool below reads the resolved caller
-# from the FastMCP auth context rather than re-parsing the bearer token.
-mcp: FastMCP[None] = FastMCP("FortyMM", auth=FortymmTokenVerifier())
+def _build_mcp_auth() -> RemoteAuthProvider:
+    """Wire the MCP transport auth from :class:`~app.config.Settings`.
+
+    When Auth0 is configured (``auth0_domain`` + ``auth0_audience`` both set) the
+    provider wraps a :class:`FortymmAuth0TokenVerifier` pointed at the tenant's
+    JWKS, and advertises the tenant as its authorization server. When it is not
+    (the local / qa / e2e / dev-compose default), the provider wraps the
+    reject-all verifier and uses a placeholder origin — so the api boots and MCP
+    mounts, but every request 401s (fail-closed). The public ``base_url`` /
+    ``resource_base_url`` come straight from config (never derived from the
+    internal mount) so the RFC 9728 metadata reflects the origin behind nginx."""
+    settings = get_settings()
+    if settings.auth0_domain and settings.auth0_audience:
+        token_verifier: TokenVerifier = FortymmAuth0TokenVerifier(
+            jwks_uri=f"https://{settings.auth0_domain}/.well-known/jwks.json",
+            issuer=f"https://{settings.auth0_domain}/",
+            audience=settings.auth0_audience,
+            algorithm="RS256",
+        )
+        authorization_server = f"https://{settings.auth0_domain}/"
+    else:
+        token_verifier = _RejectAllTokenVerifier()
+        authorization_server = _UNCONFIGURED_ORIGIN
+    return RemoteAuthProvider(
+        token_verifier=token_verifier,
+        authorization_servers=[AnyHttpUrl(authorization_server)],
+        base_url=settings.mcp_public_base_url or _UNCONFIGURED_ORIGIN,
+        resource_base_url=settings.mcp_public_resource_url or None,
+        resource_name="FortyMM",
+    )
+
+
+# The mounted MCP server. ``auth`` wires the Auth0 Resource-Server provider so
+# authentication happens at the transport for every request; each tool below reads
+# the resolved caller from the FastMCP auth context rather than re-parsing the token.
+mcp: FastMCP[None] = FastMCP("FortyMM", auth=_build_mcp_auth())
 
 
 def _authenticated_user_id() -> uuid.UUID:
     """The resolved caller's ``users.id`` from the FastMCP auth context.
 
-    The transport already authenticated the request (``FortymmTokenVerifier``);
-    that minted an :class:`AccessToken` carrying the resolved user id under a
-    ``user_id`` claim (and as ``subject``). We read it back here rather than
+    The transport already authenticated the request
+    (``FortymmAuth0TokenVerifier``); that minted an :class:`AccessToken` carrying
+    the resolved user id under a ``user_id`` claim (and as ``subject``). We read
+    it back here rather than
     re-resolving the token, so a tool body can identify its caller. A tool only
     runs after the verifier returned a token, so an absent token / claim is an
     internal invariant break, not a client error — surface it loudly as a

--- a/api/app/models/user.py
+++ b/api/app/models/user.py
@@ -22,6 +22,13 @@ class User(Base):
     email: Mapped[str | None] = mapped_column(
         String(320), unique=True, nullable=True, index=True
     )
+    # Auth0 subject (`sub`) bound to this user by the in-session link flow. One
+    # Auth0 identity maps to at most one fortymm user (unique); NULL until the
+    # user explicitly links. See ADR
+    # ``20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0``.
+    auth0_sub: Mapped[str | None] = mapped_column(
+        String(255), unique=True, nullable=True, index=True
+    )
     confirmed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -381,10 +381,12 @@ async def _find_api_token_user(db: AsyncSession, authorization: str) -> User | N
     ``POST /v1/api-tokens`` (issue #1130): the scheme is matched
     case-insensitively (``Bearer``/``bearer``) and split off the raw token, which
     is then resolved by the shared ``api_token_auth.find_api_token_user`` — the
-    single place the ``hash_token`` → live-user lookup lives, so this HTTP bearer
-    path and the MCP ``TokenVerifier`` can't drift. An unresolved token (unknown
-    or tombstoned) returns ``None`` and the caller falls through to the ordinary
-    ``session_ended`` 401.
+    single place the ``hash_token`` → live-user lookup lives. That shared resolver
+    now backs this HTTP ``Authorization: Bearer`` path (the iOS app) only; the MCP
+    surface no longer resolves opaque tokens through it — it authenticates via an
+    Auth0-issued JWT and ``resolve_linked_user`` instead (see the 20260722 Auth0
+    Resource-Server ADR). An unresolved token (unknown or tombstoned) returns
+    ``None`` and the caller falls through to the ordinary ``session_ended`` 401.
     """
     scheme, _, raw_token = authorization.partition(" ")
     if scheme.lower() != "bearer" or not raw_token:

--- a/api/migrations/versions/20260722_0000_0017_add_auth0_sub_to_users.py
+++ b/api/migrations/versions/20260722_0000_0017_add_auth0_sub_to_users.py
@@ -1,0 +1,37 @@
+"""add auth0_sub to users
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-07-22 00:00:00.000000
+
+A nullable, unique ``auth0_sub`` column binds a fortymm user to an Auth0
+subject (``sub``) via the in-session link flow. The binding is one-to-one: at
+most one user may carry a given ``sub`` (unique constraint), and a user carries
+at most one ``sub``. NULL until the user explicitly links. See ADR
+``20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0``.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0017"
+down_revision: Union[str, None] = "0016"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("auth0_sub", sa.String(length=255), nullable=True),
+    )
+    op.create_unique_constraint("uq_users_auth0_sub", "users", ["auth0_sub"])
+    op.create_index("ix_users_auth0_sub", "users", ["auth0_sub"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_auth0_sub", table_name="users")
+    op.drop_constraint("uq_users_auth0_sub", "users", type_="unique")
+    op.drop_column("users", "auth0_sub")

--- a/api/scripts/seed_rbac.py
+++ b/api/scripts/seed_rbac.py
@@ -27,6 +27,7 @@ PERMISSIONS = [
         "api_token.manage",
         "Generate and rotate a personal API token for programmatic bearer auth.",
     ),
+    ("mcp.access", "Connect an agent to the MCP server over Auth0 OAuth."),
 ]
 
 # The default `User` role is *not* listed here: it carries no permissions and
@@ -48,7 +49,7 @@ ROLES = [
         "Beta tester",
         "Early-access testers who can view, create, and enter tournaments. Editing,"
         " publishing, and deleting a tournament is reserved for its creator.",
-        ["tournament.view", "tournament.create", "tournament.enter"],
+        ["tournament.view", "tournament.create", "tournament.enter", "mcp.access"],
     ),
 ]
 

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -2217,3 +2217,102 @@ async def test_merge_solo_match_survives_with_sentinel_side(
     # sentinel (untouched by any prune or void).
     assert [len(s.players) for s in sides] == [1, 0]
     assert sides[0].players[0].user_id == verified.id
+
+
+# ----- the unique Auth0 binding (users.auth0_sub) -------------------------
+#
+# ``auth0_sub`` is a plain UNIQUE column, not an FK to ``users.id`` — so the merge
+# moves-or-nulls it rather than re-pointing an FK. The invariant the tests below
+# pin: the merge never leaves the tombstoned ghost holding the unique binding (it
+# would occupy the value so the real human could never re-link) and never clobbers
+# a binding the survivor already holds.
+
+
+async def _auth0_subs(
+    db: AsyncSession, *user_ids: uuid.UUID
+) -> dict[uuid.UUID, str | None]:
+    """Read ``auth0_sub`` straight from the rows (``populate_existing`` because the
+    merge writes with bulk statements the identity map never sees, and the test
+    sessionmaker does not expire on commit)."""
+    return dict(
+        (
+            await db.execute(
+                select(User.id, User.auth0_sub)
+                .where(User.id.in_(user_ids))
+                .execution_options(populate_existing=True)
+            )
+        )
+        .tuples()
+        .all()
+    )
+
+
+async def test_merge_moves_auth0_sub_to_a_survivor_that_lacks_one(
+    db_session: AsyncSession,
+):
+    """The rare linked-ephemeral case. The ephemeral holds a unique ``auth0_sub``
+    and the survivor has none — the binding is the same human's, so it FOLLOWS the
+    merge onto the survivor, and the tombstone is left with ``auth0_sub = NULL``.
+    Nothing may strand the unique value on the tombstoned ghost (which would occupy
+    the ``sub`` so the real human could never re-link it)."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    ephemeral.auth0_sub = "auth0|guest-linked-sub"
+    await db_session.commit()
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    subs = await _auth0_subs(db_session, ephemeral.id, verified.id)
+    assert subs[verified.id] == "auth0|guest-linked-sub", (
+        "the binding is the same human's — it must follow the merge onto the survivor"
+    )
+    assert subs[ephemeral.id] is None, (
+        "the tombstoned ghost must not be left holding the unique auth0_sub"
+    )
+
+
+async def test_merge_keeps_the_survivors_auth0_sub_and_nulls_the_ephemerals(
+    db_session: AsyncSession,
+):
+    """Both parties are linked (contrived — a guest virtually never links, and a
+    ``sub`` is one-to-one so the two values differ). The survivor's link stands
+    untouched and the ephemeral's is dropped, so the tombstone ends with
+    ``auth0_sub = NULL`` and the survivor keeps the binding it already held."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    ephemeral.auth0_sub = "auth0|guest-sub"
+    verified.auth0_sub = "auth0|survivor-sub"
+    await db_session.commit()
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    subs = await _auth0_subs(db_session, ephemeral.id, verified.id)
+    assert subs[verified.id] == "auth0|survivor-sub", (
+        "the survivor's own binding is not the merge's to overwrite"
+    )
+    assert subs[ephemeral.id] is None, (
+        "the ephemeral's binding is dropped so the tombstone strands nothing"
+    )
+
+
+async def test_merge_is_a_no_op_when_the_ephemeral_has_no_auth0_sub(
+    db_session: AsyncSession,
+):
+    """The common case: a guest never links, so the ephemeral's ``auth0_sub`` is
+    NULL. The block is a clean no-op — the survivor's binding (whether it has one
+    or not) is untouched, and the tombstone has NULL either way."""
+    ephemeral = await _make_ephemeral(db_session, "drifting-grouse")
+    verified = await _make_verified(db_session, "rita@example.com")
+    verified.auth0_sub = "auth0|survivor-sub"
+    await db_session.commit()
+
+    await merge_user(db_session, from_user_id=ephemeral.id, to_user_id=verified.id)
+    await db_session.commit()
+
+    subs = await _auth0_subs(db_session, ephemeral.id, verified.id)
+    assert subs[verified.id] == "auth0|survivor-sub", (
+        "the survivor's link is untouched when the ephemeral never linked"
+    )
+    assert subs[ephemeral.id] is None

--- a/api/tests/test_auth0_identity.py
+++ b/api/tests/test_auth0_identity.py
@@ -1,0 +1,72 @@
+"""Unit tests for the shared ``resolve_linked_user`` Auth0-subject resolver.
+
+The bare ``auth0_sub`` → live ``User`` lookup the MCP OAuth verifier calls to map
+a verified token's ``sub`` to the one fortymm user that linked it. Exercised
+directly against a real ``db_session`` — no HTTP/token framing — since that
+framing lives in the caller (the verifier).
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth0_identity import resolve_linked_user
+from app.models import User
+from tests._helpers import make_user
+
+
+async def _link(db_session: AsyncSession, user: User, sub: str) -> None:
+    """Bind ``sub`` to ``user`` the way the link callback does."""
+    user.auth0_sub = sub
+    await db_session.commit()
+
+
+async def test_linked_user_resolves_by_sub(db_session: AsyncSession) -> None:
+    user = await make_user(db_session, "auth0-linked")
+    sub = "auth0|" + uuid.uuid4().hex
+    await _link(db_session, user, sub)
+
+    resolved = await resolve_linked_user(db_session, sub)
+
+    assert resolved is not None
+    assert resolved.id == user.id
+
+
+async def test_unknown_sub_resolves_to_none(db_session: AsyncSession) -> None:
+    # A well-formed but never-linked subject matches no user.
+    resolved = await resolve_linked_user(db_session, "auth0|" + uuid.uuid4().hex)
+
+    assert resolved is None
+
+
+async def test_tombstoned_linked_user_resolves_to_none(
+    db_session: AsyncSession,
+) -> None:
+    """A linked user who was merged away (``merged_into_user_id`` set) does not
+    resolve — the folded-in ghost never authenticates."""
+    owner = await make_user(db_session, "auth0-merge-owner")
+    guest = await make_user(db_session, "auth0-merged-guest")
+    sub = "auth0|" + uuid.uuid4().hex
+    await _link(db_session, guest, sub)
+
+    guest.merged_into_user_id = owner.id
+    guest.merged_at = datetime.now(UTC)
+    await db_session.commit()
+
+    resolved = await resolve_linked_user(db_session, sub)
+
+    assert resolved is None
+
+
+async def test_blank_sub_does_not_match_null_auth0_sub_user(
+    db_session: AsyncSession,
+) -> None:
+    """An empty/blank subject must not resolve a user who never linked (whose
+    ``auth0_sub`` is NULL) — an unlinked user's NULL column is not an empty
+    string to match against."""
+    await make_user(db_session, "auth0-never-linked")
+
+    resolved = await resolve_linked_user(db_session, "")
+
+    assert resolved is None

--- a/api/tests/test_auth0_link.py
+++ b/api/tests/test_auth0_link.py
@@ -1,0 +1,272 @@
+"""The Auth0 account-link lifecycle routes (``app/auth0_link.py``).
+
+A signed-in fortymm user binds exactly one Auth0 identity, reads its status, and
+clears it — and cannot hijack another user's binding. The Auth0 ``/oauth/token``
+and JWKS endpoints are mocked end-to-end with ``httpx.MockTransport`` (no real
+network), and the id_token is signed with a locally-generated RS256 keypair whose
+public JWK the mock JWKS serves — so the real exchange + verification code path
+runs, not a stubbed seam.
+
+Covered: status reports ``linked=false`` then ``linked=true`` after a successful
+mocked callback; a callback whose ``sub`` already belongs to another user is
+``409`` and leaves that user's binding untouched; ``DELETE`` clears it; ``start``
+with Auth0 unconfigured fails cleanly (``404``, not ``500``); and an
+invalid/mismatched ``state`` on the callback is rejected.
+"""
+
+import json
+import time
+import uuid
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.auth0_link as auth0_link
+from app.main import app as fastapi_app
+from tests._helpers import make_user, start_session
+
+DOMAIN = "fortymm-test.us.auth0.com"
+CLIENT_ID = "link-client-abc"
+# Realistic length: a real Auth0 client secret is 40+ chars, above the HS256 key
+# floor, so the signed PKCE cookie doesn't trip an insecure-key-length warning.
+CLIENT_SECRET = "link-client-secret-" + "x" * 40
+REDIRECT_URI = "https://uat.fortymm.com/api/v1/auth0/link/callback"
+ISSUER = f"https://{DOMAIN}/"
+KID = "test-signing-key-1"
+
+
+@pytest.fixture
+def configured_auth0(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point ``Settings`` at a fully-configured Auth0 tenant. ``get_settings``
+    reads the environment fresh per call, so ``setenv`` takes effect per test."""
+    monkeypatch.setenv("AUTH0_DOMAIN", DOMAIN)
+    monkeypatch.setenv("AUTH0_LINK_CLIENT_ID", CLIENT_ID)
+    monkeypatch.setenv("AUTH0_LINK_CLIENT_SECRET", CLIENT_SECRET)
+    monkeypatch.setenv("AUTH0_LINK_REDIRECT_URI", REDIRECT_URI)
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair() -> tuple[str, dict[str, object]]:
+    """A private-key PEM to sign id_tokens with, and the matching public JWK the
+    mocked JWKS serves. Module-scoped: keygen is slow and the key is stateless."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    jwk: dict[str, object] = json.loads(RSAAlgorithm.to_jwk(key.public_key()))
+    jwk["kid"] = KID
+    jwk["use"] = "sig"
+    jwk["alg"] = "RS256"
+    return private_pem, jwk
+
+
+def _id_token(private_pem: str, *, sub: str, aud: str = CLIENT_ID) -> str:
+    now = int(time.time())
+    return jwt.encode(
+        {"sub": sub, "aud": aud, "iss": ISSUER, "iat": now, "exp": now + 300},
+        private_pem,
+        algorithm="RS256",
+        headers={"kid": KID},
+    )
+
+
+def _install_auth0_mock(
+    monkeypatch: pytest.MonkeyPatch, *, id_token: str, jwk: dict[str, object]
+) -> None:
+    """Route Auth0's ``/oauth/token`` and JWKS through an in-memory transport, so
+    the real exchange + verification runs with no network."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/oauth/token":
+            return httpx.Response(
+                200, json={"id_token": id_token, "token_type": "Bearer"}
+            )
+        if request.url.path == "/.well-known/jwks.json":
+            return httpx.Response(200, json={"keys": [jwk]})
+        return httpx.Response(404)
+
+    monkeypatch.setattr(
+        auth0_link,
+        "_http_client",
+        lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+
+async def _start_and_get_state(api_client: httpx.AsyncClient) -> str:
+    """Hit ``start``, assert the 302 to Auth0, and return the CSRF ``state`` from
+    the authorize URL. The signed PKCE cookie lands in the client's jar as a
+    side effect (used by the follow-up callback)."""
+    response = await api_client.get("/v1/auth0/link/start")
+    assert response.status_code == 302, response.text
+    location = response.headers["location"]
+    assert location.startswith(f"https://{DOMAIN}/authorize?")
+    query = parse_qs(urlparse(location).query)
+    assert query["code_challenge_method"] == ["S256"]
+    assert query["client_id"] == [CLIENT_ID]
+    return query["state"][0]
+
+
+async def test_status_false_then_true_after_link(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    configured_auth0: None,
+    rsa_keypair: tuple[str, dict[str, object]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_pem, jwk = rsa_keypair
+    user = await start_session(api_client, db_session)
+
+    before = await api_client.get("/v1/auth0/link")
+    assert before.status_code == 200, before.text
+    assert before.json() == {"linked": False}
+
+    sub = "auth0|" + uuid.uuid4().hex
+    _install_auth0_mock(monkeypatch, id_token=_id_token(private_pem, sub=sub), jwk=jwk)
+
+    state = await _start_and_get_state(api_client)
+    callback = await api_client.get(
+        f"/v1/auth0/link/callback?code=auth-code&state={state}"
+    )
+    assert callback.status_code == 302, callback.text
+    assert callback.headers["location"] == "/settings?linked=1"
+
+    after = await api_client.get("/v1/auth0/link")
+    assert after.json() == {"linked": True}
+
+    await db_session.refresh(user)
+    assert user.auth0_sub == sub
+
+
+async def test_callback_rejects_sub_already_linked_to_another_user(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    configured_auth0: None,
+    rsa_keypair: tuple[str, dict[str, object]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_pem, jwk = rsa_keypair
+    me = await start_session(api_client, db_session)
+
+    # Another live user already holds the sub the callback will present.
+    sub = "auth0|" + uuid.uuid4().hex
+    other = await make_user(db_session, "auth0-owner")
+    other.auth0_sub = sub
+    await db_session.commit()
+
+    _install_auth0_mock(monkeypatch, id_token=_id_token(private_pem, sub=sub), jwk=jwk)
+
+    state = await _start_and_get_state(api_client)
+    callback = await api_client.get(
+        f"/v1/auth0/link/callback?code=auth-code&state={state}"
+    )
+    assert callback.status_code == 409, callback.text
+
+    # The other user's binding is untouched, and I did not steal it.
+    await db_session.refresh(other)
+    await db_session.refresh(me)
+    assert other.auth0_sub == sub
+    assert me.auth0_sub is None
+
+
+async def test_delete_clears_binding(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    user = await start_session(api_client, db_session)
+    user.auth0_sub = "auth0|" + uuid.uuid4().hex
+    await db_session.commit()
+
+    response = await api_client.delete("/v1/auth0/link")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"linked": False}
+
+    await db_session.refresh(user)
+    assert user.auth0_sub is None
+
+    # Idempotent: clearing an already-unlinked account is a clean no-op.
+    again = await api_client.delete("/v1/auth0/link")
+    assert again.status_code == 200, again.text
+    assert again.json() == {"linked": False}
+
+
+async def test_start_unconfigured_fails_cleanly(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No AUTH0_* env set — linking is unconfigured. Must be a clean 404, not 500.
+    for name in (
+        "AUTH0_DOMAIN",
+        "AUTH0_LINK_CLIENT_ID",
+        "AUTH0_LINK_CLIENT_SECRET",
+        "AUTH0_LINK_REDIRECT_URI",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    await start_session(api_client, db_session)
+
+    response = await api_client.get("/v1/auth0/link/start")
+    assert response.status_code == 404, response.text
+
+
+async def test_callback_rejects_mismatched_state(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    configured_auth0: None,
+    rsa_keypair: tuple[str, dict[str, object]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_pem, jwk = rsa_keypair
+    user = await start_session(api_client, db_session)
+    _install_auth0_mock(
+        monkeypatch,
+        id_token=_id_token(private_pem, sub="auth0|" + uuid.uuid4().hex),
+        jwk=jwk,
+    )
+
+    # Real start (issues the signed PKCE cookie) but a forged state on the callback.
+    await _start_and_get_state(api_client)
+    callback = await api_client.get(
+        "/v1/auth0/link/callback?code=auth-code&state=not-the-issued-state"
+    )
+    assert callback.status_code == 400, callback.text
+
+    await db_session.refresh(user)
+    assert user.auth0_sub is None
+
+
+async def test_callback_without_pkce_cookie_rejected(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    configured_auth0: None,
+) -> None:
+    # A callback that never went through ``start`` carries no PKCE cookie — reject
+    # before touching Auth0, so no exchange is attempted.
+    await start_session(api_client, db_session)
+    response = await api_client.get(
+        "/v1/auth0/link/callback?code=auth-code&state=whatever"
+    )
+    assert response.status_code == 400, response.text
+
+
+async def test_link_routes_require_a_session(
+    api_client: httpx.AsyncClient,
+    configured_auth0: None,
+) -> None:
+    # Cookieless client: every route is session-gated, so all three 401.
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=fastapi_app),
+        base_url="https://testserver",
+    ) as anon:
+        assert (await anon.get("/v1/auth0/link")).status_code == 401
+        assert (await anon.get("/v1/auth0/link/start")).status_code == 401
+        assert (
+            await anon.get("/v1/auth0/link/callback?code=c&state=s")
+        ).status_code == 401

--- a/api/tests/test_auth0_link.py
+++ b/api/tests/test_auth0_link.py
@@ -11,7 +11,10 @@ Covered: status reports ``linked=false`` then ``linked=true`` after a successful
 mocked callback; a callback whose ``sub`` already belongs to another user is
 ``409`` and leaves that user's binding untouched; ``DELETE`` clears it; ``start``
 with Auth0 unconfigured fails cleanly (``404``, not ``500``); and an
-invalid/mismatched ``state`` on the callback is rejected.
+invalid/mismatched ``state`` on the callback is rejected. Also: every route is
+gated on the ``mcp.access`` permission (a signed-in user lacking it is ``403``, a
+holder is admitted), and the Auth0-touching routes are two-tier rate limited
+(the per-session cap trips ``429``).
 """
 
 import json
@@ -29,7 +32,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.auth0_link as auth0_link
 from app.main import app as fastapi_app
-from tests._helpers import make_user, start_session
+from tests._helpers import grant_permissions, make_user, start_session
+
+MCP_ACCESS = "mcp.access"
 
 DOMAIN = "fortymm-test.us.auth0.com"
 CLIENT_ID = "link-client-abc"
@@ -123,6 +128,7 @@ async def test_status_false_then_true_after_link(
 ) -> None:
     private_pem, jwk = rsa_keypair
     user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, [MCP_ACCESS])
 
     before = await api_client.get("/v1/auth0/link")
     assert before.status_code == 200, before.text
@@ -154,6 +160,7 @@ async def test_callback_rejects_sub_already_linked_to_another_user(
 ) -> None:
     private_pem, jwk = rsa_keypair
     me = await start_session(api_client, db_session)
+    await grant_permissions(db_session, me, [MCP_ACCESS])
 
     # Another live user already holds the sub the callback will present.
     sub = "auth0|" + uuid.uuid4().hex
@@ -181,6 +188,7 @@ async def test_delete_clears_binding(
     db_session: AsyncSession,
 ) -> None:
     user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, [MCP_ACCESS])
     user.auth0_sub = "auth0|" + uuid.uuid4().hex
     await db_session.commit()
 
@@ -210,7 +218,8 @@ async def test_start_unconfigured_fails_cleanly(
         "AUTH0_LINK_REDIRECT_URI",
     ):
         monkeypatch.delenv(name, raising=False)
-    await start_session(api_client, db_session)
+    user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, [MCP_ACCESS])
 
     response = await api_client.get("/v1/auth0/link/start")
     assert response.status_code == 404, response.text
@@ -225,6 +234,7 @@ async def test_callback_rejects_mismatched_state(
 ) -> None:
     private_pem, jwk = rsa_keypair
     user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, [MCP_ACCESS])
     _install_auth0_mock(
         monkeypatch,
         id_token=_id_token(private_pem, sub="auth0|" + uuid.uuid4().hex),
@@ -249,7 +259,8 @@ async def test_callback_without_pkce_cookie_rejected(
 ) -> None:
     # A callback that never went through ``start`` carries no PKCE cookie — reject
     # before touching Auth0, so no exchange is attempted.
-    await start_session(api_client, db_session)
+    user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, [MCP_ACCESS])
     response = await api_client.get(
         "/v1/auth0/link/callback?code=auth-code&state=whatever"
     )
@@ -270,3 +281,54 @@ async def test_link_routes_require_a_session(
         assert (
             await anon.get("/v1/auth0/link/callback?code=c&state=s")
         ).status_code == 401
+
+
+async def test_link_routes_require_mcp_access(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    configured_auth0: None,
+) -> None:
+    # A signed-in user who does NOT hold ``mcp.access`` is refused at every link
+    # route with a 403 — binding an Auth0 identity is gated on the same permission
+    # the MCP surface enforces, not merely on "is signed in".
+    await start_session(api_client, db_session)
+
+    assert (await api_client.get("/v1/auth0/link")).status_code == 403
+    assert (await api_client.get("/v1/auth0/link/start")).status_code == 403
+    assert (
+        await api_client.get("/v1/auth0/link/callback?code=c&state=s")
+    ).status_code == 403
+
+
+async def test_link_status_admits_user_with_mcp_access(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    configured_auth0: None,
+) -> None:
+    # Granting ``mcp.access`` flips the 403 above to a normal 200 — the gate is the
+    # permission, and a holder passes it.
+    user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, [MCP_ACCESS])
+
+    response = await api_client.get("/v1/auth0/link")
+    assert response.status_code == 200, response.text
+    assert response.json() == {"linked": False}
+
+
+async def test_start_link_rate_limited(
+    api_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    configured_auth0: None,
+) -> None:
+    # ``start`` shares a per-session bucket of 10/hr with ``callback``; the 11th hit
+    # in the window 429s (the per-IP ceiling is looser, so the session cap trips
+    # first for a single client).
+    user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, [MCP_ACCESS])
+
+    for i in range(10):
+        response = await api_client.get("/v1/auth0/link/start")
+        assert response.status_code == 302, (i, response.text)
+
+    over = await api_client.get("/v1/auth0/link/start")
+    assert over.status_code == 429, over.text

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -44,3 +44,34 @@ def test_get_settings_rereads_env_on_every_call(
 
     monkeypatch.setenv("SOLVER_TIME_CAP_S", "99")
     assert get_settings().solver_time_cap_s == 99.0
+
+
+#: The seven Auth0 / MCP OAuth settings, paired with the env var pydantic-settings
+#: maps each from. Empty (unset) means unconfigured = fail-closed per the Auth0
+#: Resource-Server ADR.
+AUTH0_SETTINGS: list[tuple[str, str]] = [
+    ("auth0_domain", "AUTH0_DOMAIN"),
+    ("auth0_audience", "AUTH0_AUDIENCE"),
+    ("auth0_link_client_id", "AUTH0_LINK_CLIENT_ID"),
+    ("auth0_link_client_secret", "AUTH0_LINK_CLIENT_SECRET"),
+    ("mcp_public_base_url", "MCP_PUBLIC_BASE_URL"),
+    ("mcp_public_resource_url", "MCP_PUBLIC_RESOURCE_URL"),
+    ("auth0_link_redirect_uri", "AUTH0_LINK_REDIRECT_URI"),
+]
+
+
+@pytest.mark.parametrize("attr, env_var", AUTH0_SETTINGS)
+def test_auth0_setting_reads_from_env(
+    monkeypatch: pytest.MonkeyPatch, attr: str, env_var: str
+) -> None:
+    monkeypatch.setenv(env_var, f"value-for-{env_var}")
+    assert getattr(get_settings(), attr) == f"value-for-{env_var}"
+
+
+@pytest.mark.parametrize("attr, env_var", AUTH0_SETTINGS)
+def test_auth0_setting_defaults_to_empty_when_unset(
+    monkeypatch: pytest.MonkeyPatch, attr: str, env_var: str
+) -> None:
+    """Empty (unconfigured) is the fail-closed default — MCP 401s until set."""
+    monkeypatch.delenv(env_var, raising=False)
+    assert getattr(get_settings(), attr) == ""

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -1,21 +1,31 @@
-"""Transport-auth tests for the mounted FastMCP server (chore 1c).
+"""Transport-auth + tool-behavior tests for the mounted FastMCP server.
 
 These drive the **mounted** app over HTTP (httpx ``ASGITransport`` against the
 FastAPI app, wrapped in a FastMCP ``Client`` speaking Streamable HTTP) so the
-``FortymmTokenVerifier`` actually runs at the transport — an in-memory
-``Client(mcp)`` would bypass it. The server exposes **zero tools** for now, so a
-valid token proves only that ``list_tools`` succeeds (empty is fine); the point
-is that missing / invalid / tombstoned-user tokens are rejected **before** any
-tool body, at the transport.
+Auth0 OAuth Resource-Server verifier (``FortymmAuth0TokenVerifier`` behind a
+``RemoteAuthProvider``) actually runs at the transport — an in-memory
+``Client(mcp)`` would bypass it. The point is that only a valid Auth0 JWT for an
+explicitly linked user holding ``mcp.access`` is admitted; every other case
+(missing / bad-signature / wrong-``aud`` / wrong-``iss`` / unlinked-``sub`` /
+un-permitted / tombstoned) is rejected **before** any tool body, at the transport.
+
+**Auth harness.** The module-level ``mcp`` is built with ``AUTH0_*`` empty (its
+fail-closed reject-all verifier), so the autouse ``_mcp_auth0_verifier`` fixture
+swaps in a real ``FortymmAuth0TokenVerifier`` keyed to a locally-generated RS256
+**static public key** with the test issuer/audience — no Auth0 network or JWKS
+mock needed, the signature verifies against the seeded key directly. Test tokens
+are signed with the matching private key (:func:`_sign_token`); a user is made
+admissible by linking a ``sub`` and granting ``mcp.access`` (:func:`_mint`).
 
 The MCP app carries its own lifespan (the Streamable-HTTP session manager);
 ``ASGITransport`` does not fire it, so each test enters ``mcp_app.lifespan``
-explicitly. The verifier resolves tokens against the process-wide engine
-(``DATABASE_URL`` is pointed at the test Postgres by the autouse
-``_solver_job_database`` fixture), so tokens are committed via ``db_session``
+explicitly. The verifier resolves the token's ``sub`` against the process-wide
+engine (``DATABASE_URL`` is pointed at the test Postgres by the autouse
+``_solver_job_database`` fixture), so links/grants are committed via ``db_session``
 first — the verifier's own connection only sees committed rows.
 """
 
+import time
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -25,7 +35,10 @@ from zoneinfo import ZoneInfo
 
 import fakeredis
 import httpx
+import jwt
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
 from fastmcp.exceptions import ToolError
@@ -34,11 +47,14 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import queue as queue_module
-from app.api_token_auth import API_TOKEN_CONTEXT
 from app.main import app as fastapi_app
-from app.main import mcp_app
+from app.main import mcp, mcp_app
+from app.mcp_server import MCP_ACCESS_PERMISSION, FortymmAuth0TokenVerifier
 from app.models import (
     League,
+    Permission,
+    Role,
+    RolePermission,
     ScheduleSolve,
     ScheduleSolveStatus,
     ScheduleSolveTrigger,
@@ -50,10 +66,9 @@ from app.models import (
     TournamentFixture,
     TournamentStatus,
     User,
-    UserToken,
+    UserRole,
 )
 from app.models.tournament import DrawType, EventFormat
-from app.token_hashing import hash_token
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import (
     enqueued_notification_jobs,
@@ -64,16 +79,120 @@ from tests._helpers import (
 
 MCP_URL = "http://testserver/mcp/"
 
+# The test Auth0 tenant the verifier is pointed at. The issuer carries Auth0's
+# trailing slash (``https://{domain}/``), and the audience is the API identifier
+# the agent's access token must carry — both matched by the autouse verifier.
+DOMAIN = "fortymm-test.us.auth0.com"
+ISSUER = f"https://{DOMAIN}/"
+AUDIENCE = "https://api.fortymm.test/mcp"
+KID = "test-signing-key-1"
+
+
+def _generate_keypair() -> tuple[str, str]:
+    """A private-key PEM to sign access tokens with, and the matching public-key
+    PEM the verifier trusts as a static key (no JWKS endpoint needed)."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    public_pem = (
+        key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+    )
+    return private_pem, public_pem
+
+
+# The tenant's signing keypair (module-level so keygen runs once) and a second,
+# unrelated keypair whose private key signs the "bad signature" forgery.
+_PRIVATE_PEM, _PUBLIC_PEM = _generate_keypair()
+_WRONG_PRIVATE_PEM, _ = _generate_keypair()
+
+
+@pytest.fixture(autouse=True)
+def _mcp_auth0_verifier(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the mounted MCP transport's verifier at the test signing key.
+
+    The module-level ``mcp`` is built with ``AUTH0_*`` empty (its fail-closed
+    reject-all verifier), so every test swaps in a real
+    ``FortymmAuth0TokenVerifier`` keyed to the locally-generated RS256 static
+    public key, with the test issuer/audience. Mutating the provider's
+    ``token_verifier`` — the object the auth middleware baked into ``mcp_app``
+    already holds — is what reaches the running mounted app."""
+    verifier = FortymmAuth0TokenVerifier(
+        public_key=_PUBLIC_PEM,
+        issuer=ISSUER,
+        audience=AUDIENCE,
+        algorithm="RS256",
+    )
+    monkeypatch.setattr(mcp.auth, "token_verifier", verifier)
+
+
+def _sign_token(
+    *,
+    sub: str,
+    aud: str = AUDIENCE,
+    iss: str = ISSUER,
+    private_pem: str | None = None,
+    expires_in: int = 300,
+) -> str:
+    """Sign an RS256 access token for ``sub`` — the credential an agent presents
+    to the MCP transport. Defaults to the tenant key + right issuer/audience; the
+    knobs reach the wrong-``aud`` / wrong-``iss`` / bad-signature rejection cases."""
+    now = int(time.time())
+    return jwt.encode(
+        {"sub": sub, "aud": aud, "iss": iss, "iat": now, "exp": now + expires_in},
+        private_pem or _PRIVATE_PEM,
+        algorithm="RS256",
+        headers={"kid": KID},
+    )
+
+
+async def _link(db_session: AsyncSession, user: User, sub: str | None = None) -> str:
+    """Bind an Auth0 ``sub`` to ``user`` (committed), the same one-to-one link the
+    account-link flow writes. Returns the ``sub`` for signing a token for it."""
+    sub = sub or "auth0|" + uuid.uuid4().hex
+    user.auth0_sub = sub
+    await db_session.commit()
+    return sub
+
+
+async def _grant_mcp_access(db_session: AsyncSession, user: User) -> None:
+    """Grant ``user`` the ``mcp.access`` permission through real RBAC rows (its own
+    role, so it never collides with a ``grant_permissions`` role for the same user).
+    The seed grants this via the Beta tester role; tests grant it directly."""
+    permission = (
+        await db_session.execute(
+            select(Permission).where(Permission.name == MCP_ACCESS_PERMISSION)
+        )
+    ).scalar_one_or_none()
+    if permission is None:
+        permission = Permission(
+            name=MCP_ACCESS_PERMISSION, description=MCP_ACCESS_PERMISSION
+        )
+        db_session.add(permission)
+        await db_session.flush()
+    role = Role(name=f"mcp-access-{user.id}", description="Per-user test mcp.access.")
+    db_session.add(role)
+    await db_session.flush()
+    db_session.add(RolePermission(role_id=role.id, permission_id=permission.id))
+    db_session.add(UserRole(user_id=user.id, role_id=role.id))
+    await db_session.commit()
+
 
 async def _mint(db_session: AsyncSession, user: User) -> str:
-    """Store an ``api``-context token for ``user`` (only the sha256 hash lands in
-    the DB, as production does) and return the raw token."""
-    raw = "api-raw-" + uuid.uuid4().hex
-    db_session.add(
-        UserToken(user_id=user.id, context=API_TOKEN_CONTEXT, token=hash_token(raw))
-    )
-    await db_session.commit()
-    return raw
+    """Make ``user`` admissible to the MCP transport and return a bearer token for
+    it: link an Auth0 ``sub``, grant ``mcp.access``, and sign an RS256 access token
+    for that subject. Replaces the old opaque ``context="api"`` bearer token — every
+    tool-behavior test authenticates as a linked + permitted user through this."""
+    sub = await _link(db_session, user)
+    await _grant_mcp_access(db_session, user)
+    return _sign_token(sub=sub)
 
 
 @asynccontextmanager
@@ -127,14 +246,14 @@ async def _assert_rejected(client: Client) -> None:
     assert exc_info.value.response.status_code == 401
 
 
-async def test_valid_api_token_can_list_tools(db_session: AsyncSession) -> None:
-    """A live ``context="api"`` bearer token authenticates at the transport and
-    can complete the initialize + ``list_tools`` handshake. The curated
-    match-flow verbs are exposed — ``get_match`` is registered."""
-    user = await make_user(db_session, "mcp-token-owner")
-    raw = await _mint(db_session, user)
+async def test_valid_auth0_jwt_can_list_tools(db_session: AsyncSession) -> None:
+    """A valid Auth0 JWT for a linked user holding ``mcp.access`` authenticates at
+    the transport and can complete the initialize + ``list_tools`` handshake. The
+    curated match-flow verbs are exposed — ``get_match`` is registered."""
+    user = await make_user(db_session, "mcp-jwt-owner")
+    token = await _mint(db_session, user)
 
-    async with _mcp_client(raw) as client, client:
+    async with _mcp_client(token) as client, client:
         tools = await client.list_tools()
 
     assert "get_match" in {tool.name for tool in tools}
@@ -147,24 +266,80 @@ async def test_missing_token_is_rejected(db_session: AsyncSession) -> None:
         await _assert_rejected(client)
 
 
-async def test_invalid_token_is_rejected(db_session: AsyncSession) -> None:
-    """A well-formed but never-minted token resolves to no user → 401."""
-    async with _mcp_client("api-raw-" + uuid.uuid4().hex) as client:
+async def test_bad_signature_is_rejected(db_session: AsyncSession) -> None:
+    """A JWT signed by a key other than the tenant's — right ``iss`` / ``aud`` /
+    ``sub``, valid linked+permitted user — fails RS256 signature verification →
+    401, before any tool body."""
+    user = await make_user(db_session, "mcp-badsig-owner")
+    sub = await _link(db_session, user)
+    await _grant_mcp_access(db_session, user)
+    forged = _sign_token(sub=sub, private_pem=_WRONG_PRIVATE_PEM)
+
+    async with _mcp_client(forged) as client:
         await _assert_rejected(client)
 
 
-async def test_tombstoned_users_token_is_rejected(db_session: AsyncSession) -> None:
-    """A valid token whose user was merged away (``merged_into_user_id`` set) is
-    rejected — the folded-in ghost never authenticates through MCP either."""
+async def test_wrong_audience_is_rejected(db_session: AsyncSession) -> None:
+    """A validly-signed token whose ``aud`` is not our API identifier is refused —
+    the token was minted for a different resource server."""
+    user = await make_user(db_session, "mcp-aud-owner")
+    sub = await _link(db_session, user)
+    await _grant_mcp_access(db_session, user)
+    token = _sign_token(sub=sub, aud="https://not-our-api.example.com/")
+
+    async with _mcp_client(token) as client:
+        await _assert_rejected(client)
+
+
+async def test_wrong_issuer_is_rejected(db_session: AsyncSession) -> None:
+    """A validly-signed token from a different issuer is refused — only our Auth0
+    tenant is trusted."""
+    user = await make_user(db_session, "mcp-iss-owner")
+    sub = await _link(db_session, user)
+    await _grant_mcp_access(db_session, user)
+    token = _sign_token(sub=sub, iss="https://evil.example.com/")
+
+    async with _mcp_client(token) as client:
+        await _assert_rejected(client)
+
+
+async def test_unlinked_sub_is_rejected(db_session: AsyncSession) -> None:
+    """A validly-signed token whose ``sub`` is linked to no user is rejected: Auth0
+    authenticated it, but fortymm has no linked account for that subject."""
+    token = _sign_token(sub="auth0|" + uuid.uuid4().hex)
+
+    async with _mcp_client(token) as client:
+        await _assert_rejected(client)
+
+
+async def test_linked_user_without_mcp_access_is_rejected(
+    db_session: AsyncSession,
+) -> None:
+    """A linked user who does NOT hold ``mcp.access`` is rejected at the transport —
+    authentication is Auth0, but authorization is fortymm RBAC, and revoking the
+    grant cuts the agent off even while its token is still valid."""
+    user = await make_user(db_session, "mcp-noaccess-owner")
+    sub = await _link(db_session, user)  # linked, but never granted mcp.access
+    token = _sign_token(sub=sub)
+
+    async with _mcp_client(token) as client:
+        await _assert_rejected(client)
+
+
+async def test_tombstoned_linked_users_token_is_rejected(
+    db_session: AsyncSession,
+) -> None:
+    """A linked + permitted user who was merged away (``merged_into_user_id`` set)
+    no longer resolves — the folded-in ghost never authenticates through MCP."""
     owner = await make_user(db_session, "mcp-merge-owner")
     guest = await make_user(db_session, "mcp-merged-guest")
-    raw = await _mint(db_session, guest)
+    token = await _mint(db_session, guest)
 
     guest.merged_into_user_id = owner.id
     guest.merged_at = datetime.now(UTC)
     await db_session.commit()
 
-    async with _mcp_client(raw) as client:
+    async with _mcp_client(token) as client:
         await _assert_rejected(client)
 
 

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -49,7 +49,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import queue as queue_module
 from app.main import app as fastapi_app
 from app.main import mcp, mcp_app
-from app.mcp_server import MCP_ACCESS_PERMISSION, FortymmAuth0TokenVerifier
+from app.mcp_server import (
+    MCP_ACCESS_PERMISSION,
+    FortymmAuth0TokenVerifier,
+    _build_mcp_auth,
+    _RejectAllTokenVerifier,
+)
 from app.models import (
     League,
     Permission,
@@ -341,6 +346,45 @@ async def test_tombstoned_linked_users_token_is_rejected(
 
     async with _mcp_client(token) as client:
         await _assert_rejected(client)
+
+
+def test_partial_auth0_config_yields_reject_all_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A PARTIAL Auth0 config — tenant ``domain`` + ``audience`` set, but the public
+    ``mcp_public_base_url`` left empty — is treated as unconfigured all-or-nothing:
+    ``_build_mcp_auth`` wraps the fail-closed reject-all verifier, NOT a real
+    ``FortymmAuth0TokenVerifier``. Without this the api would ship a live verifier
+    advertising the ``.invalid`` placeholder resource origin (broken RFC 9728
+    discovery) far from the missing-config line. Construction still succeeds (the
+    api boots), but every MCP request 401s at the reject-all verifier."""
+    monkeypatch.setenv("AUTH0_DOMAIN", DOMAIN)
+    monkeypatch.setenv("AUTH0_AUDIENCE", AUDIENCE)
+    # A resource URL is present; only the base URL is missing — proving that ANY
+    # missing piece flips the whole config to fail-closed.
+    monkeypatch.setenv("MCP_PUBLIC_RESOURCE_URL", "https://uat.fortymm.com/api")
+    monkeypatch.delenv("MCP_PUBLIC_BASE_URL", raising=False)
+
+    provider = _build_mcp_auth()
+
+    assert isinstance(provider.token_verifier, _RejectAllTokenVerifier)
+    assert not isinstance(provider.token_verifier, FortymmAuth0TokenVerifier)
+
+
+def test_full_auth0_config_yields_real_verifier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The counterpart proving the partial-config fallback above is not vacuous:
+    with ALL four Auth0/MCP settings present, ``_build_mcp_auth`` wraps the real
+    ``FortymmAuth0TokenVerifier``."""
+    monkeypatch.setenv("AUTH0_DOMAIN", DOMAIN)
+    monkeypatch.setenv("AUTH0_AUDIENCE", AUDIENCE)
+    monkeypatch.setenv("MCP_PUBLIC_BASE_URL", "https://uat.fortymm.com/api")
+    monkeypatch.setenv("MCP_PUBLIC_RESOURCE_URL", "https://uat.fortymm.com/api")
+
+    provider = _build_mcp_auth()
+
+    assert isinstance(provider.token_verifier, FortymmAuth0TokenVerifier)
 
 
 # ----- get_match tool ------------------------------------------------------

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -28,6 +28,7 @@ from tests._helpers import CSRF_EVENT_HOOKS
 BETA_TESTER = "Beta tester"
 ADMINISTRATOR = "Administrator"
 API_TOKEN_MANAGE = "api_token.manage"
+MCP_ACCESS = "mcp.access"
 
 
 @pytest_asyncio.fixture
@@ -812,14 +813,18 @@ async def test_seed_grants_beta_tester_the_tournament_permissions(
 ):
     """A freshly seeded database lets a Beta tester enter a tournament as well
     as view and create one — self-registration is gated on its own permission
-    (#781), since a player entering themselves is not the tournament's owner."""
+    (#781), since a player entering themselves is not the tournament's owner.
+    The bundle also carries `mcp.access` so early-access testers can connect an
+    agent to the MCP server."""
     counts = await seed_rbac.upsert_rbac(db_session)
     await db_session.commit()
     assert counts.permissions == len(seed_rbac.PERMISSIONS)
     assert counts.roles == len(seed_rbac.ROLES)
 
     granted = await _role_permission_names(db_session, BETA_TESTER)
-    assert granted == sorted([TOURNAMENT_VIEW, TOURNAMENT_CREATE, TOURNAMENT_ENTER])
+    assert granted == sorted(
+        [TOURNAMENT_VIEW, TOURNAMENT_CREATE, TOURNAMENT_ENTER, MCP_ACCESS]
+    )
 
 
 async def test_seed_is_idempotent(db_session: AsyncSession):
@@ -855,7 +860,7 @@ async def test_seed_is_idempotent(db_session: AsyncSession):
     )
     assert len(links) == 1
     assert await _role_permission_names(db_session, BETA_TESTER) == sorted(
-        [TOURNAMENT_VIEW, TOURNAMENT_CREATE, TOURNAMENT_ENTER]
+        [TOURNAMENT_VIEW, TOURNAMENT_CREATE, TOURNAMENT_ENTER, MCP_ACCESS]
     )
 
 

--- a/api/tests/test_seed_mcp_access.py
+++ b/api/tests/test_seed_mcp_access.py
@@ -1,0 +1,95 @@
+"""The RBAC seed grants `mcp.access` to Beta testers and nobody else by default.
+
+Proves the ADR-decided default (20260722 — "The MCP server is an OAuth Resource
+Server trusting Auth0"): a fresh or re-seeded deploy hands MCP access to the
+opt-in "Beta tester" bundle only, and the seed stays idempotent.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Permission, Role, RolePermission
+from scripts import seed_rbac
+
+MCP_ACCESS = "mcp.access"
+BETA_TESTER = "Beta tester"
+
+
+async def _role_permission_names(db: AsyncSession, role_name: str) -> set[str]:
+    names = (
+        (
+            await db.execute(
+                select(Permission.name)
+                .join(RolePermission, RolePermission.permission_id == Permission.id)
+                .join(Role, Role.id == RolePermission.role_id)
+                .where(Role.name == role_name)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return set(names)
+
+
+async def test_seed_creates_the_mcp_access_permission(db_session: AsyncSession):
+    """The `mcp.access` permission row exists after a seed run."""
+    await seed_rbac.upsert_rbac(db_session)
+    await db_session.commit()
+
+    perm = (
+        await db_session.execute(
+            select(Permission).where(Permission.name == MCP_ACCESS)
+        )
+    ).scalar_one_or_none()
+    assert perm is not None
+    assert perm.description == "Connect an agent to the MCP server over Auth0 OAuth."
+
+
+async def test_seed_grants_mcp_access_to_beta_tester_only(db_session: AsyncSession):
+    """The Beta tester bundle holds `mcp.access` (via a `RolePermission` link);
+    no other seeded role does — MCP stays deliberately gated, not open to all."""
+    await seed_rbac.upsert_rbac(db_session)
+    await db_session.commit()
+
+    assert MCP_ACCESS in await _role_permission_names(db_session, BETA_TESTER)
+
+    for role_name, _, _ in seed_rbac.ROLES:
+        if role_name == BETA_TESTER:
+            continue
+        assert MCP_ACCESS not in await _role_permission_names(db_session, role_name)
+
+
+async def test_seed_mcp_access_is_idempotent(db_session: AsyncSession):
+    """A second seed run inserts nothing: the permission, the role, and the grant
+    are all left untouched (every boot re-runs the seed)."""
+    await seed_rbac.upsert_rbac(db_session)
+    await db_session.commit()
+
+    second = await seed_rbac.upsert_rbac(db_session)
+    await db_session.commit()
+    assert second == seed_rbac.SeedCounts(permissions=0, roles=0, links=0)
+
+    perms = (
+        (
+            await db_session.execute(
+                select(Permission).where(Permission.name == MCP_ACCESS)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(perms) == 1
+
+    links = (
+        (
+            await db_session.execute(
+                select(RolePermission).where(
+                    RolePermission.permission_id == perms[0].id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(links) == 1
+    assert MCP_ACCESS in await _role_permission_names(db_session, BETA_TESTER)

--- a/api/tests/test_user_model.py
+++ b/api/tests/test_user_model.py
@@ -44,3 +44,24 @@ async def test_email_defaults_to_null_and_is_unique(db_session: AsyncSession):
     db_session.add(User(username="erin", email="dup@example.com"))
     with pytest.raises(IntegrityError):
         await db_session.commit()
+
+
+async def test_auth0_sub_defaults_to_null_and_round_trips(db_session: AsyncSession):
+    u = User(username="frank")
+    db_session.add(u)
+    await db_session.commit()
+    await db_session.refresh(u)
+    assert u.auth0_sub is None
+
+    u.auth0_sub = "auth0|abc123"
+    await db_session.commit()
+    await db_session.refresh(u)
+    assert u.auth0_sub == "auth0|abc123"
+
+
+async def test_auth0_sub_is_unique(db_session: AsyncSession):
+    db_session.add(User(username="grace", auth0_sub="auth0|dup"))
+    await db_session.commit()
+    db_session.add(User(username="heidi", auth0_sub="auth0|dup"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()

--- a/deploy/uat/templates/_helpers.tpl
+++ b/deploy/uat/templates/_helpers.tpl
@@ -117,6 +117,25 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # RFC 9728 protected-resource metadata for the MCP OAuth Resource Server.
+    # The server advertises this URL at the PUBLIC ORIGIN ROOT via the 401
+    # `WWW-Authenticate: Bearer resource_metadata="…"` challenge on /mcp/, e.g.
+    # https://uat.fortymm.com/.well-known/oauth-protected-resource/api/mcp/ — the
+    # RFC 9728 path-insertion form. The `/api` there is MID-path (part of the
+    # resource identifier), NOT a strippable prefix, so the /api/ rewrite above
+    # can't reach it. Internally FastMCP serves the metadata UNDER its mount
+    # (/mcp/.well-known/oauth-protected-resource/…), so prepend /mcp to the
+    # origin-root path. Unauthenticated by design — discovery precedes any token.
+    location /.well-known/oauth-protected-resource {
+        rewrite ^(.*)$ /mcp$1 break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Browser telemetry (Grafana Faro) -> Alloy faro.receiver in the
     # `monitoring` namespace (deploy/observability). resolver + variable
     # upstream so this nginx starts even before the observability release

--- a/deploy/uat/values.yaml
+++ b/deploy/uat/values.yaml
@@ -46,6 +46,22 @@ config:
   # process for nearly every trigger) reads it to size the RQ job_timeout, so
   # both consume it via this shared ConfigMap.
   SOLVER_TIME_CAP_S: "10"
+  # --- Auth0 / MCP OAuth Resource Server (non-secret identifiers only) ---
+  # See docs/adr/20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0.md.
+  # The AUTH0_LINK_CLIENT_SECRET is a secret and lives in the .env-backed
+  # `fortymm-uat-env` Secret — NEVER put it here in the ConfigMap.
+  #
+  # Operator fills these three from the Auth0 tenant (empty = MCP auth
+  # unconfigured; the api still boots but every MCP request 401s):
+  AUTH0_DOMAIN: ""        # e.g. fortymm.us.auth0.com — the JWT issuer
+  AUTH0_AUDIENCE: ""      # Auth0 API identifier for the MCP Resource Server (token `aud`)
+  AUTH0_LINK_CLIENT_ID: ""  # client id of the Auth0 Regular Web App used for the account-link flow
+  # Deployment-derived public URLs (the MCP server is public at
+  # uat.fortymm.com/api/mcp behind nginx that strips /api — metadata must
+  # reflect the public origin, not the internal mount):
+  MCP_PUBLIC_BASE_URL: https://uat.fortymm.com/api
+  MCP_PUBLIC_RESOURCE_URL: https://uat.fortymm.com/api/mcp
+  AUTH0_LINK_REDIRECT_URI: https://uat.fortymm.com/api/auth0/link/callback
 
 postgres:
   user: postgres

--- a/deploy/uat/values.yaml
+++ b/deploy/uat/values.yaml
@@ -61,7 +61,7 @@ config:
   # reflect the public origin, not the internal mount):
   MCP_PUBLIC_BASE_URL: https://uat.fortymm.com/api
   MCP_PUBLIC_RESOURCE_URL: https://uat.fortymm.com/api/mcp
-  AUTH0_LINK_REDIRECT_URI: https://uat.fortymm.com/api/auth0/link/callback
+  AUTH0_LINK_REDIRECT_URI: https://uat.fortymm.com/api/v1/auth0/link/callback
 
 postgres:
   user: postgres

--- a/docs/adr/20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0.md
+++ b/docs/adr/20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0.md
@@ -1,0 +1,123 @@
+# The MCP server is an OAuth Resource Server trusting Auth0
+
+Date: 2026-07-22 (date-numbered — sequential numbers collide across concurrent
+worktrees; see the note in `20260718-the-match-flow-is-shared-services-behind-http-and-mcp-adapters.md`)
+
+## Status
+
+Accepted — decided before implementation, from a described goal ("use Auth0 for
+some kind of tokens so we can easily connect agents to our MCP server"). No
+issue number yet.
+
+**Supersedes** the auth stance of
+`20260718-the-match-flow-is-shared-services-behind-http-and-mcp-adapters.md`
+and `20260719-tournament-verbs-are-shared-functions-behind-http-and-mcp-adapters.md`
+— specifically their "MCP auth reuses the opaque `context="api"` bearer token,
+access is inherited from who-can-mint (operator-only), no MCP-specific RBAC"
+decision. Those ADRs' *shared-service-layer* decision (one service behind HTTP
+and MCP adapters) is unchanged; only how the **MCP transport authenticates** and
+**who is authorized** changes here.
+
+## Context
+
+Today the MCP server (`app/mcp_server.py`, FastMCP 3.4.x, streamable-HTTP at
+`/mcp/`, public at `uat.fortymm.com/api/mcp/`) authenticates with an **opaque
+personal bearer token** — a `UserToken` with `context="api"`, minted only via
+`POST /v1/api-tokens` behind the operator-only `api_token.manage` permission.
+The prior MCP ADRs flagged this as **operator-only until token minting is
+broadened (#1130)**: a human operator mints a long-lived secret and pastes it
+into an agent host. That is friction, it hands a bearer secret around, and it
+scopes MCP to operators only.
+
+We want agents (Claude, Cursor, …) to connect through the **standard MCP 2025
+OAuth flow**: the agent host pops a browser, the human logs in, the host
+receives a token automatically and refreshes it on its own. That requires an
+OAuth Authorization Server. Rather than build one, we trust **Auth0** as the
+Authorization Server and make the MCP server an **OAuth Resource Server**.
+
+A tension shapes the mechanism: the MCP server runs `stateless_http=True` across
+two UAT replicas with no session affinity (the reason called out in `main.py`).
+Any auth that needs per-process state (a client store, self-minted refresh
+tokens) is incompatible with that deployment.
+
+## Decision
+
+**The MCP server is a stateless OAuth 2.1 Resource Server that trusts Auth0 for
+authentication only; all authorization stays in fortymm RBAC.**
+
+Concretely:
+
+1. **Mechanism: `RemoteAuthProvider` wrapping a `JWTVerifier`, not
+   `Auth0Provider`.** FastMCP's `Auth0Provider` is a stateful OAuth *proxy* (it
+   mints its own FastMCP JWTs, needs a `client_secret` and an `AsyncKeyValue`
+   client store) — incompatible with our stateless, multi-replica deployment.
+   `RemoteAuthProvider` is the pure, stateless Resource-Server primitive: it
+   wraps a `TokenVerifier` and serves the RFC 9728 protected-resource metadata +
+   `401 WWW-Authenticate` challenge that MCP clients need for discovery and
+   Dynamic Client Registration against Auth0 directly. `JWTVerifier` does the
+   verification: JWKS fetch (built-in 1-hour cache), and `RS256` / `iss` / `aud`
+   / `exp` checks. Because verification is pure signature checking, it survives
+   round-robin across replicas with no shared state.
+
+2. **The public-origin identity.** The server is mounted internally at `/mcp/`
+   but is public at `uat.fortymm.com/api/mcp/` behind nginx that strips `/api`.
+   The resource identifier and every URL in the protected-resource metadata must
+   reflect the **public** origin, or client discovery breaks. So `base_url` /
+   `resource_base_url` are passed as explicit public values from config, never
+   derived from the internal mount.
+
+3. **Auth0 is authentication-only; authorization is fortymm RBAC.** The token
+   proves *who* the caller is (its `sub`); it does not decide *what* they may do.
+   We do **not** require Auth0 scopes/permissions. Access requires, in fortymm:
+   an explicitly **linked** account (§4) that holds the new **`mcp.access`**
+   permission. One source of truth for grant/revoke (the existing RBAC admin
+   UI), and revoking `mcp.access` cuts an agent off immediately even while its
+   Auth0 token is still valid.
+
+4. **Identity is bound by an explicit, in-session link — not email-matching or
+   auto-provisioning.** A new nullable, unique `users.auth0_sub` column holds the
+   binding. A logged-in fortymm user links once via a server-side confidential
+   OAuth code flow (`GET /v1/auth0/link/start` → Auth0 login → `GET
+   /v1/auth0/link/callback` exchanges the code, verifies the id_token, binds its
+   `sub` to `current_user`). The binding is **one-to-one**: a `sub` already
+   linked to a different live user is rejected (no silent takeover); a user may
+   overwrite their own binding; a repeat of the same `sub` is a no-op. We store
+   `sub` only — no email/PII we don't use for authz. At MCP time the verifier
+   resolves the token's `sub` → the linked, non-tombstoned `User`.
+
+5. **The `mcp.access` permission is granted via the Beta tester role.** It is a
+   new seeded permission (`scripts/seed_rbac.py`), added to the existing "Beta
+   tester" bundle, so early-access testers can self-serve-connect an agent while
+   the capability stays deliberately gated (not open to every user).
+
+6. **The homegrown token is replaced on the MCP surface only.** The MCP verifier
+   stops resolving `context="api"` tokens. The opaque token and its HTTP bearer
+   path (`sessions._resolve_current_user`, `POST /v1/api-tokens`, the admin UI)
+   are **kept** — the iOS app depends on HTTP bearer. Migrating HTTP bearer to
+   Auth0 (and then deleting `api_tokens.py`) is deliberately out of scope.
+
+The tool contract is unchanged: the verifier injects `claims["user_id"]` after
+mapping, so every `@mcp.tool` and `_authenticated_user_id()` are untouched.
+
+## Consequences
+
+- **Better agent onboarding, no shared secret.** Hosts complete an OAuth login
+  and manage token lifecycle themselves; no operator pastes a long-lived bearer.
+- **A one-time human link step per user.** A fortymm user must log into Auth0
+  once (Google/DB connection) while signed into fortymm to bind the two
+  identities. Auth0 is a new, separate identity system from fortymm's magic-link
+  login; the link is what ties them.
+- **Two Auth0 registrations:** an API/Resource-Server (audience for the agent's
+  token) and a Regular Web Application (confidential client for the link flow).
+  The only secret we store is that web app's `client_secret`; verification needs
+  no secret (JWKS is public).
+- **Fails closed when unconfigured.** With `AUTH0_*` unset (local/qa/e2e
+  compose), the api still boots and MCP still mounts, but every MCP request 401s
+  — no valid issuer/audience can be satisfied. Unit tests exercise the verifier
+  with a locally-generated RS256 keypair; the full browser flow is a UAT concern.
+- **The opaque-token MCP connection stops working on UAT** once this ships; a
+  user re-adds the server as an OAuth connector and links their account.
+- **A verification risk to close during rollout:** every advertised `.well-known`
+  metadata URL must be reachable through nginx with the `/api` strip, and Auth0
+  must honor the resource indicator so the issued token's `aud` matches our API
+  identifier. Both are checked end-to-end against UAT, not assumed.

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -216,6 +216,65 @@ internal protocol APIProtocol: Sendable {
     /// - Remark: HTTP `POST /v1/api-tokens`.
     /// - Remark: Generated from `#/paths//v1/api-tokens/post(create_api_token_v1_api_tokens_post)`.
     func createApiTokenV1ApiTokensPost(_ input: Operations.CreateApiTokenV1ApiTokensPost.Input) async throws -> Operations.CreateApiTokenV1ApiTokensPost.Output
+    /// Start Link
+    ///
+    /// Begin linking the signed-in user's account to an Auth0 identity.
+    ///
+    /// Generates a PKCE ``code_verifier`` + CSRF ``state``, stashes them in a
+    /// short-lived signed httponly cookie (no server-side store, so the flow is
+    /// stateless across replicas), and 302-redirects the browser to Auth0's
+    /// ``/authorize`` for an authorization-code + PKCE login requesting only the
+    /// ``openid`` scope. The matching callback completes the bind.
+    ///
+    /// Requires an established fortymm session (the link is bound to *you*). Returns
+    /// a clean ``404`` when Auth0 linking is not configured for this deployment,
+    /// never a ``500``.
+    ///
+    /// - Remark: HTTP `GET /v1/auth0/link/start`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/start/get(start_link_v1_auth0_link_start_get)`.
+    func startLinkV1Auth0LinkStartGet(_ input: Operations.StartLinkV1Auth0LinkStartGet.Input) async throws -> Operations.StartLinkV1Auth0LinkStartGet.Output
+    /// Link Callback
+    ///
+    /// Complete the Auth0 account link and redirect back to settings.
+    ///
+    /// Validates the returned ``state`` against the signed PKCE cookie, exchanges the
+    /// ``code`` for an id_token at Auth0, verifies it (RS256 via the tenant JWKS,
+    /// ``aud`` = the link client id, ``iss`` = the tenant), and binds its ``sub`` to
+    /// the **current session user** (one-to-one; a ``sub`` already held by a
+    /// different live user is rejected ``409`` and left in place — see
+    /// ``_bind_auth0_sub``). On success it 302-redirects to ``/settings?linked=1``.
+    ///
+    /// Requires an established fortymm session. Rejects a missing / mismatched /
+    /// expired ``state`` with ``400``, an exchange or id_token-verification failure
+    /// with ``400``, and returns ``404`` when linking is unconfigured.
+    ///
+    /// - Remark: HTTP `GET /v1/auth0/link/callback`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/callback/get(link_callback_v1_auth0_link_callback_get)`.
+    func linkCallbackV1Auth0LinkCallbackGet(_ input: Operations.LinkCallbackV1Auth0LinkCallbackGet.Input) async throws -> Operations.LinkCallbackV1Auth0LinkCallbackGet.Output
+    /// Link Status
+    ///
+    /// Whether the signed-in user has an Auth0 identity bound.
+    ///
+    /// ``linked`` is true once the user has completed the link flow (their
+    /// ``users.auth0_sub`` is set). Requires an established fortymm session; needs no
+    /// Auth0 configuration (it only reads local state).
+    ///
+    /// - Remark: HTTP `GET /v1/auth0/link`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/get(link_status_v1_auth0_link_get)`.
+    func linkStatusV1Auth0LinkGet(_ input: Operations.LinkStatusV1Auth0LinkGet.Input) async throws -> Operations.LinkStatusV1Auth0LinkGet.Output
+    /// Unlink
+    ///
+    /// Clear the signed-in user's Auth0 binding.
+    ///
+    /// Drops ``users.auth0_sub`` so the identity can be re-linked (here or to a
+    /// different account) and any agent authenticating as that ``sub`` stops
+    /// resolving to this user. Idempotent — clearing an already-unlinked account is a
+    /// no-op ``linked=false``. Requires an established fortymm session; needs no Auth0
+    /// configuration.
+    ///
+    /// - Remark: HTTP `DELETE /v1/auth0/link`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/delete(unlink_v1_auth0_link_delete)`.
+    func unlinkV1Auth0LinkDelete(_ input: Operations.UnlinkV1Auth0LinkDelete.Input) async throws -> Operations.UnlinkV1Auth0LinkDelete.Output
     /// List Matches
     ///
     /// - Remark: HTTP `GET /v1/matches`.
@@ -1312,6 +1371,79 @@ extension APIProtocol {
     /// - Remark: Generated from `#/paths//v1/api-tokens/post(create_api_token_v1_api_tokens_post)`.
     internal func createApiTokenV1ApiTokensPost(headers: Operations.CreateApiTokenV1ApiTokensPost.Input.Headers = .init()) async throws -> Operations.CreateApiTokenV1ApiTokensPost.Output {
         try await createApiTokenV1ApiTokensPost(Operations.CreateApiTokenV1ApiTokensPost.Input(headers: headers))
+    }
+    /// Start Link
+    ///
+    /// Begin linking the signed-in user's account to an Auth0 identity.
+    ///
+    /// Generates a PKCE ``code_verifier`` + CSRF ``state``, stashes them in a
+    /// short-lived signed httponly cookie (no server-side store, so the flow is
+    /// stateless across replicas), and 302-redirects the browser to Auth0's
+    /// ``/authorize`` for an authorization-code + PKCE login requesting only the
+    /// ``openid`` scope. The matching callback completes the bind.
+    ///
+    /// Requires an established fortymm session (the link is bound to *you*). Returns
+    /// a clean ``404`` when Auth0 linking is not configured for this deployment,
+    /// never a ``500``.
+    ///
+    /// - Remark: HTTP `GET /v1/auth0/link/start`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/start/get(start_link_v1_auth0_link_start_get)`.
+    internal func startLinkV1Auth0LinkStartGet(headers: Operations.StartLinkV1Auth0LinkStartGet.Input.Headers = .init()) async throws -> Operations.StartLinkV1Auth0LinkStartGet.Output {
+        try await startLinkV1Auth0LinkStartGet(Operations.StartLinkV1Auth0LinkStartGet.Input(headers: headers))
+    }
+    /// Link Callback
+    ///
+    /// Complete the Auth0 account link and redirect back to settings.
+    ///
+    /// Validates the returned ``state`` against the signed PKCE cookie, exchanges the
+    /// ``code`` for an id_token at Auth0, verifies it (RS256 via the tenant JWKS,
+    /// ``aud`` = the link client id, ``iss`` = the tenant), and binds its ``sub`` to
+    /// the **current session user** (one-to-one; a ``sub`` already held by a
+    /// different live user is rejected ``409`` and left in place — see
+    /// ``_bind_auth0_sub``). On success it 302-redirects to ``/settings?linked=1``.
+    ///
+    /// Requires an established fortymm session. Rejects a missing / mismatched /
+    /// expired ``state`` with ``400``, an exchange or id_token-verification failure
+    /// with ``400``, and returns ``404`` when linking is unconfigured.
+    ///
+    /// - Remark: HTTP `GET /v1/auth0/link/callback`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/callback/get(link_callback_v1_auth0_link_callback_get)`.
+    internal func linkCallbackV1Auth0LinkCallbackGet(
+        query: Operations.LinkCallbackV1Auth0LinkCallbackGet.Input.Query,
+        headers: Operations.LinkCallbackV1Auth0LinkCallbackGet.Input.Headers = .init()
+    ) async throws -> Operations.LinkCallbackV1Auth0LinkCallbackGet.Output {
+        try await linkCallbackV1Auth0LinkCallbackGet(Operations.LinkCallbackV1Auth0LinkCallbackGet.Input(
+            query: query,
+            headers: headers
+        ))
+    }
+    /// Link Status
+    ///
+    /// Whether the signed-in user has an Auth0 identity bound.
+    ///
+    /// ``linked`` is true once the user has completed the link flow (their
+    /// ``users.auth0_sub`` is set). Requires an established fortymm session; needs no
+    /// Auth0 configuration (it only reads local state).
+    ///
+    /// - Remark: HTTP `GET /v1/auth0/link`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/get(link_status_v1_auth0_link_get)`.
+    internal func linkStatusV1Auth0LinkGet(headers: Operations.LinkStatusV1Auth0LinkGet.Input.Headers = .init()) async throws -> Operations.LinkStatusV1Auth0LinkGet.Output {
+        try await linkStatusV1Auth0LinkGet(Operations.LinkStatusV1Auth0LinkGet.Input(headers: headers))
+    }
+    /// Unlink
+    ///
+    /// Clear the signed-in user's Auth0 binding.
+    ///
+    /// Drops ``users.auth0_sub`` so the identity can be re-linked (here or to a
+    /// different account) and any agent authenticating as that ``sub`` stops
+    /// resolving to this user. Idempotent — clearing an already-unlinked account is a
+    /// no-op ``linked=false``. Requires an established fortymm session; needs no Auth0
+    /// configuration.
+    ///
+    /// - Remark: HTTP `DELETE /v1/auth0/link`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/delete(unlink_v1_auth0_link_delete)`.
+    internal func unlinkV1Auth0LinkDelete(headers: Operations.UnlinkV1Auth0LinkDelete.Input.Headers = .init()) async throws -> Operations.UnlinkV1Auth0LinkDelete.Output {
+        try await unlinkV1Auth0LinkDelete(Operations.UnlinkV1Auth0LinkDelete.Input(headers: headers))
     }
     /// List Matches
     ///
@@ -3865,6 +3997,25 @@ internal enum Components {
                 case redis
                 case database
                 case solver
+            }
+        }
+        /// Whether the current user has an Auth0 identity bound. The GET status body
+        /// and the DELETE (now-cleared) body both use it, so a client updates the same
+        /// shape either way.
+        ///
+        /// - Remark: Generated from `#/components/schemas/LinkStatus`.
+        internal struct LinkStatus: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/LinkStatus/linked`.
+            internal var linked: Swift.Bool
+            /// Creates a new `LinkStatus`.
+            ///
+            /// - Parameters:
+            ///   - linked:
+            internal init(linked: Swift.Bool) {
+                self.linked = linked
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case linked
             }
         }
         /// 202 body for the magic-link request endpoint. Always echoes the
@@ -14864,6 +15015,682 @@ internal enum Operations {
             /// - Throws: An error if `self` is not `.unprocessableContent`.
             /// - SeeAlso: `.unprocessableContent`.
             internal var unprocessableContent: Operations.CreateApiTokenV1ApiTokensPost.Output.UnprocessableContent {
+                get throws {
+                    switch self {
+                    case let .unprocessableContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        internal enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            internal init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            internal var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            internal static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Start Link
+    ///
+    /// Begin linking the signed-in user's account to an Auth0 identity.
+    ///
+    /// Generates a PKCE ``code_verifier`` + CSRF ``state``, stashes them in a
+    /// short-lived signed httponly cookie (no server-side store, so the flow is
+    /// stateless across replicas), and 302-redirects the browser to Auth0's
+    /// ``/authorize`` for an authorization-code + PKCE login requesting only the
+    /// ``openid`` scope. The matching callback completes the bind.
+    ///
+    /// Requires an established fortymm session (the link is bound to *you*). Returns
+    /// a clean ``404`` when Auth0 linking is not configured for this deployment,
+    /// never a ``500``.
+    ///
+    /// - Remark: HTTP `GET /v1/auth0/link/start`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/start/get(start_link_v1_auth0_link_start_get)`.
+    internal enum StartLinkV1Auth0LinkStartGet {
+        internal static let id: Swift.String = "start_link_v1_auth0_link_start_get"
+        internal struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/v1/auth0/link/start/GET/header`.
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.StartLinkV1Auth0LinkStartGet.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.StartLinkV1Auth0LinkStartGet.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            internal var headers: Operations.StartLinkV1Auth0LinkStartGet.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - headers:
+            internal init(headers: Operations.StartLinkV1Auth0LinkStartGet.Input.Headers = .init()) {
+                self.headers = headers
+            }
+        }
+        internal enum Output: Sendable, Hashable {
+            internal struct TemporaryRedirect: Sendable, Hashable {
+                /// Creates a new `TemporaryRedirect`.
+                internal init() {}
+            }
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/auth0/link/start/get(start_link_v1_auth0_link_start_get)/responses/307`.
+            ///
+            /// HTTP response code: `307 temporaryRedirect`.
+            case temporaryRedirect(Operations.StartLinkV1Auth0LinkStartGet.Output.TemporaryRedirect)
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/auth0/link/start/get(start_link_v1_auth0_link_start_get)/responses/307`.
+            ///
+            /// HTTP response code: `307 temporaryRedirect`.
+            internal static var temporaryRedirect: Self {
+                .temporaryRedirect(.init())
+            }
+            /// The associated value of the enum case if `self` is `.temporaryRedirect`.
+            ///
+            /// - Throws: An error if `self` is not `.temporaryRedirect`.
+            /// - SeeAlso: `.temporaryRedirect`.
+            internal var temporaryRedirect: Operations.StartLinkV1Auth0LinkStartGet.Output.TemporaryRedirect {
+                get throws {
+                    switch self {
+                    case let .temporaryRedirect(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "temporaryRedirect",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct UnprocessableContent: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/auth0/link/start/GET/responses/422/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/auth0/link/start/GET/responses/422/content/application\/json`.
+                    case json(Components.Schemas.HTTPValidationError)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.HTTPValidationError {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.StartLinkV1Auth0LinkStartGet.Output.UnprocessableContent.Body
+                /// Creates a new `UnprocessableContent`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.StartLinkV1Auth0LinkStartGet.Output.UnprocessableContent.Body) {
+                    self.body = body
+                }
+            }
+            /// Validation Error
+            ///
+            /// - Remark: Generated from `#/paths//v1/auth0/link/start/get(start_link_v1_auth0_link_start_get)/responses/422`.
+            ///
+            /// HTTP response code: `422 unprocessableContent`.
+            case unprocessableContent(Operations.StartLinkV1Auth0LinkStartGet.Output.UnprocessableContent)
+            /// The associated value of the enum case if `self` is `.unprocessableContent`.
+            ///
+            /// - Throws: An error if `self` is not `.unprocessableContent`.
+            /// - SeeAlso: `.unprocessableContent`.
+            internal var unprocessableContent: Operations.StartLinkV1Auth0LinkStartGet.Output.UnprocessableContent {
+                get throws {
+                    switch self {
+                    case let .unprocessableContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        internal enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            internal init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            internal var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            internal static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Link Callback
+    ///
+    /// Complete the Auth0 account link and redirect back to settings.
+    ///
+    /// Validates the returned ``state`` against the signed PKCE cookie, exchanges the
+    /// ``code`` for an id_token at Auth0, verifies it (RS256 via the tenant JWKS,
+    /// ``aud`` = the link client id, ``iss`` = the tenant), and binds its ``sub`` to
+    /// the **current session user** (one-to-one; a ``sub`` already held by a
+    /// different live user is rejected ``409`` and left in place — see
+    /// ``_bind_auth0_sub``). On success it 302-redirects to ``/settings?linked=1``.
+    ///
+    /// Requires an established fortymm session. Rejects a missing / mismatched /
+    /// expired ``state`` with ``400``, an exchange or id_token-verification failure
+    /// with ``400``, and returns ``404`` when linking is unconfigured.
+    ///
+    /// - Remark: HTTP `GET /v1/auth0/link/callback`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/callback/get(link_callback_v1_auth0_link_callback_get)`.
+    internal enum LinkCallbackV1Auth0LinkCallbackGet {
+        internal static let id: Swift.String = "link_callback_v1_auth0_link_callback_get"
+        internal struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/v1/auth0/link/callback/GET/query`.
+            internal struct Query: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/auth0/link/callback/GET/query/code`.
+                internal var code: Swift.String
+                /// - Remark: Generated from `#/paths/v1/auth0/link/callback/GET/query/state`.
+                internal var state: Swift.String
+                /// Creates a new `Query`.
+                ///
+                /// - Parameters:
+                ///   - code:
+                ///   - state:
+                internal init(
+                    code: Swift.String,
+                    state: Swift.String
+                ) {
+                    self.code = code
+                    self.state = state
+                }
+            }
+            internal var query: Operations.LinkCallbackV1Auth0LinkCallbackGet.Input.Query
+            /// - Remark: Generated from `#/paths/v1/auth0/link/callback/GET/header`.
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.LinkCallbackV1Auth0LinkCallbackGet.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.LinkCallbackV1Auth0LinkCallbackGet.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            internal var headers: Operations.LinkCallbackV1Auth0LinkCallbackGet.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - query:
+            ///   - headers:
+            internal init(
+                query: Operations.LinkCallbackV1Auth0LinkCallbackGet.Input.Query,
+                headers: Operations.LinkCallbackV1Auth0LinkCallbackGet.Input.Headers = .init()
+            ) {
+                self.query = query
+                self.headers = headers
+            }
+        }
+        internal enum Output: Sendable, Hashable {
+            internal struct TemporaryRedirect: Sendable, Hashable {
+                /// Creates a new `TemporaryRedirect`.
+                internal init() {}
+            }
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/auth0/link/callback/get(link_callback_v1_auth0_link_callback_get)/responses/307`.
+            ///
+            /// HTTP response code: `307 temporaryRedirect`.
+            case temporaryRedirect(Operations.LinkCallbackV1Auth0LinkCallbackGet.Output.TemporaryRedirect)
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/auth0/link/callback/get(link_callback_v1_auth0_link_callback_get)/responses/307`.
+            ///
+            /// HTTP response code: `307 temporaryRedirect`.
+            internal static var temporaryRedirect: Self {
+                .temporaryRedirect(.init())
+            }
+            /// The associated value of the enum case if `self` is `.temporaryRedirect`.
+            ///
+            /// - Throws: An error if `self` is not `.temporaryRedirect`.
+            /// - SeeAlso: `.temporaryRedirect`.
+            internal var temporaryRedirect: Operations.LinkCallbackV1Auth0LinkCallbackGet.Output.TemporaryRedirect {
+                get throws {
+                    switch self {
+                    case let .temporaryRedirect(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "temporaryRedirect",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct UnprocessableContent: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/auth0/link/callback/GET/responses/422/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/auth0/link/callback/GET/responses/422/content/application\/json`.
+                    case json(Components.Schemas.HTTPValidationError)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.HTTPValidationError {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.LinkCallbackV1Auth0LinkCallbackGet.Output.UnprocessableContent.Body
+                /// Creates a new `UnprocessableContent`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.LinkCallbackV1Auth0LinkCallbackGet.Output.UnprocessableContent.Body) {
+                    self.body = body
+                }
+            }
+            /// Validation Error
+            ///
+            /// - Remark: Generated from `#/paths//v1/auth0/link/callback/get(link_callback_v1_auth0_link_callback_get)/responses/422`.
+            ///
+            /// HTTP response code: `422 unprocessableContent`.
+            case unprocessableContent(Operations.LinkCallbackV1Auth0LinkCallbackGet.Output.UnprocessableContent)
+            /// The associated value of the enum case if `self` is `.unprocessableContent`.
+            ///
+            /// - Throws: An error if `self` is not `.unprocessableContent`.
+            /// - SeeAlso: `.unprocessableContent`.
+            internal var unprocessableContent: Operations.LinkCallbackV1Auth0LinkCallbackGet.Output.UnprocessableContent {
+                get throws {
+                    switch self {
+                    case let .unprocessableContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        internal enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            internal init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            internal var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            internal static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Link Status
+    ///
+    /// Whether the signed-in user has an Auth0 identity bound.
+    ///
+    /// ``linked`` is true once the user has completed the link flow (their
+    /// ``users.auth0_sub`` is set). Requires an established fortymm session; needs no
+    /// Auth0 configuration (it only reads local state).
+    ///
+    /// - Remark: HTTP `GET /v1/auth0/link`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/get(link_status_v1_auth0_link_get)`.
+    internal enum LinkStatusV1Auth0LinkGet {
+        internal static let id: Swift.String = "link_status_v1_auth0_link_get"
+        internal struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/v1/auth0/link/GET/header`.
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.LinkStatusV1Auth0LinkGet.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.LinkStatusV1Auth0LinkGet.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            internal var headers: Operations.LinkStatusV1Auth0LinkGet.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - headers:
+            internal init(headers: Operations.LinkStatusV1Auth0LinkGet.Input.Headers = .init()) {
+                self.headers = headers
+            }
+        }
+        internal enum Output: Sendable, Hashable {
+            internal struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/auth0/link/GET/responses/200/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/auth0/link/GET/responses/200/content/application\/json`.
+                    case json(Components.Schemas.LinkStatus)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.LinkStatus {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.LinkStatusV1Auth0LinkGet.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.LinkStatusV1Auth0LinkGet.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/auth0/link/get(link_status_v1_auth0_link_get)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.LinkStatusV1Auth0LinkGet.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            internal var ok: Operations.LinkStatusV1Auth0LinkGet.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct UnprocessableContent: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/auth0/link/GET/responses/422/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/auth0/link/GET/responses/422/content/application\/json`.
+                    case json(Components.Schemas.HTTPValidationError)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.HTTPValidationError {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.LinkStatusV1Auth0LinkGet.Output.UnprocessableContent.Body
+                /// Creates a new `UnprocessableContent`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.LinkStatusV1Auth0LinkGet.Output.UnprocessableContent.Body) {
+                    self.body = body
+                }
+            }
+            /// Validation Error
+            ///
+            /// - Remark: Generated from `#/paths//v1/auth0/link/get(link_status_v1_auth0_link_get)/responses/422`.
+            ///
+            /// HTTP response code: `422 unprocessableContent`.
+            case unprocessableContent(Operations.LinkStatusV1Auth0LinkGet.Output.UnprocessableContent)
+            /// The associated value of the enum case if `self` is `.unprocessableContent`.
+            ///
+            /// - Throws: An error if `self` is not `.unprocessableContent`.
+            /// - SeeAlso: `.unprocessableContent`.
+            internal var unprocessableContent: Operations.LinkStatusV1Auth0LinkGet.Output.UnprocessableContent {
+                get throws {
+                    switch self {
+                    case let .unprocessableContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        internal enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            internal init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            internal var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            internal static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Unlink
+    ///
+    /// Clear the signed-in user's Auth0 binding.
+    ///
+    /// Drops ``users.auth0_sub`` so the identity can be re-linked (here or to a
+    /// different account) and any agent authenticating as that ``sub`` stops
+    /// resolving to this user. Idempotent — clearing an already-unlinked account is a
+    /// no-op ``linked=false``. Requires an established fortymm session; needs no Auth0
+    /// configuration.
+    ///
+    /// - Remark: HTTP `DELETE /v1/auth0/link`.
+    /// - Remark: Generated from `#/paths//v1/auth0/link/delete(unlink_v1_auth0_link_delete)`.
+    internal enum UnlinkV1Auth0LinkDelete {
+        internal static let id: Swift.String = "unlink_v1_auth0_link_delete"
+        internal struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/v1/auth0/link/DELETE/header`.
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.UnlinkV1Auth0LinkDelete.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.UnlinkV1Auth0LinkDelete.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            internal var headers: Operations.UnlinkV1Auth0LinkDelete.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - headers:
+            internal init(headers: Operations.UnlinkV1Auth0LinkDelete.Input.Headers = .init()) {
+                self.headers = headers
+            }
+        }
+        internal enum Output: Sendable, Hashable {
+            internal struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/auth0/link/DELETE/responses/200/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/auth0/link/DELETE/responses/200/content/application\/json`.
+                    case json(Components.Schemas.LinkStatus)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.LinkStatus {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.UnlinkV1Auth0LinkDelete.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.UnlinkV1Auth0LinkDelete.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/auth0/link/delete(unlink_v1_auth0_link_delete)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.UnlinkV1Auth0LinkDelete.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            internal var ok: Operations.UnlinkV1Auth0LinkDelete.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct UnprocessableContent: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/auth0/link/DELETE/responses/422/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/auth0/link/DELETE/responses/422/content/application\/json`.
+                    case json(Components.Schemas.HTTPValidationError)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.HTTPValidationError {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.UnlinkV1Auth0LinkDelete.Output.UnprocessableContent.Body
+                /// Creates a new `UnprocessableContent`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.UnlinkV1Auth0LinkDelete.Output.UnprocessableContent.Body) {
+                    self.body = body
+                }
+            }
+            /// Validation Error
+            ///
+            /// - Remark: Generated from `#/paths//v1/auth0/link/delete(unlink_v1_auth0_link_delete)/responses/422`.
+            ///
+            /// HTTP response code: `422 unprocessableContent`.
+            case unprocessableContent(Operations.UnlinkV1Auth0LinkDelete.Output.UnprocessableContent)
+            /// The associated value of the enum case if `self` is `.unprocessableContent`.
+            ///
+            /// - Throws: An error if `self` is not `.unprocessableContent`.
+            /// - SeeAlso: `.unprocessableContent`.
+            internal var unprocessableContent: Operations.UnlinkV1Auth0LinkDelete.Output.UnprocessableContent {
                 get throws {
                     switch self {
                     case let .unprocessableContent(response):

--- a/nginx/dev.conf
+++ b/nginx/dev.conf
@@ -49,6 +49,25 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # RFC 9728 protected-resource metadata for the MCP OAuth Resource Server.
+    # The server advertises this URL at the PUBLIC ORIGIN ROOT via the 401
+    # `WWW-Authenticate: Bearer resource_metadata="…"` challenge on /mcp/, in the
+    # RFC 9728 path-insertion form (e.g. /.well-known/oauth-protected-resource/api/mcp/).
+    # The `/api` there is MID-path (part of the resource identifier), NOT a
+    # strippable prefix, so the /api/ rewrite above can't reach it. Internally
+    # FastMCP serves the metadata UNDER its mount
+    # (/mcp/.well-known/oauth-protected-resource/…), so prepend /mcp to the
+    # origin-root path. Unauthenticated by design — discovery precedes any token.
+    location /.well-known/oauth-protected-resource {
+        rewrite ^(.*)$ /mcp$1 break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         proxy_pass http://web_upstream;
         proxy_http_version 1.1;

--- a/nginx/uat.conf
+++ b/nginx/uat.conf
@@ -55,6 +55,25 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # RFC 9728 protected-resource metadata for the MCP OAuth Resource Server.
+    # The server advertises this URL at the PUBLIC ORIGIN ROOT via the 401
+    # `WWW-Authenticate: Bearer resource_metadata="…"` challenge on /mcp/, e.g.
+    # https://uat.fortymm.com/.well-known/oauth-protected-resource/api/mcp/ — the
+    # RFC 9728 path-insertion form. The `/api` there is MID-path (part of the
+    # resource identifier), NOT a strippable prefix, so the /api/ rewrite above
+    # can't reach it. Internally FastMCP serves the metadata UNDER its mount
+    # (/mcp/.well-known/oauth-protected-resource/…), so prepend /mcp to the
+    # origin-root path. Unauthenticated by design — discovery precedes any token.
+    location /.well-known/oauth-protected-resource {
+        rewrite ^(.*)$ /mcp$1 break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Direct API paths — FastAPI mounts routes at /v1/*; /openapi.json,
     # /docs, /redoc are FastAPI's defaults. Useful for curl / API docs.
     location ~ ^/(v1|openapi\.json|docs|redoc)(/|$) {

--- a/web-client/src/api/auth0.ts
+++ b/web-client/src/api/auth0.ts
@@ -1,0 +1,62 @@
+import {
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import { z } from 'zod'
+import { api, resolveBaseUrl, unwrap } from './client'
+
+// Whether the current user has an Auth0 identity bound (see the `LinkStatus`
+// schema). Both `GET /v1/auth0/link` and the `DELETE` reply with this shape, so
+// a client updates the same cache entry either way.
+const linkStatusSchema = z.object({ linked: z.boolean() })
+export type Auth0LinkStatus = z.infer<typeof linkStatusSchema>
+
+export const AUTH0_LINK_QUERY_KEY = ['auth0', 'link'] as const
+
+/** The current user's Auth0 (agent-access) link status. Parsed at the boundary
+ * so a malformed payload fails loudly rather than priming a bad cache entry. */
+export function auth0LinkQueryOptions() {
+  return queryOptions({
+    queryKey: AUTH0_LINK_QUERY_KEY,
+    queryFn: async (): Promise<Auth0LinkStatus> =>
+      linkStatusSchema.parse(
+        unwrap('load agent link status', await api.GET('/v1/auth0/link')),
+      ),
+  })
+}
+
+export function useAuth0LinkStatus() {
+  return useQuery(auth0LinkQueryOptions())
+}
+
+/**
+ * Drop the user's Auth0 identity binding. The 200 body is the freshly-cleared
+ * status (`{ linked: false }`), so we seed the cache with it directly instead of
+ * round-tripping a refetch — the section flips to "not connected" immediately.
+ * Callers await via `mutateAsync` and surface their own errors.
+ */
+export function useUnlinkAuth0() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (): Promise<Auth0LinkStatus> =>
+      linkStatusSchema.parse(
+        unwrap('unlink agent access', await api.DELETE('/v1/auth0/link')),
+      ),
+    onSuccess: (status) => {
+      qc.setQueryData(AUTH0_LINK_QUERY_KEY, status)
+    },
+  })
+}
+
+/**
+ * The full-navigation target that *begins* the Auth0 login/link redirect flow.
+ * This is an OAuth redirect (a 302 from the API), not a fetch — the browser must
+ * navigate to it. Built off the API base URL (nginx serves the API under `/api`,
+ * and `VITE_API_URL` can override it), so the browser lands on the real endpoint
+ * rather than the SPA router.
+ */
+export function auth0LinkStartUrl(): string {
+  return `${resolveBaseUrl()}/v1/auth0/link/start`
+}

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -372,6 +372,101 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/auth0/link/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Start Link
+         * @description Begin linking the signed-in user's account to an Auth0 identity.
+         *
+         *     Generates a PKCE ``code_verifier`` + CSRF ``state``, stashes them in a
+         *     short-lived signed httponly cookie (no server-side store, so the flow is
+         *     stateless across replicas), and 302-redirects the browser to Auth0's
+         *     ``/authorize`` for an authorization-code + PKCE login requesting only the
+         *     ``openid`` scope. The matching callback completes the bind.
+         *
+         *     Requires an established fortymm session (the link is bound to *you*). Returns
+         *     a clean ``404`` when Auth0 linking is not configured for this deployment,
+         *     never a ``500``.
+         */
+        get: operations["start_link_v1_auth0_link_start_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth0/link/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Link Callback
+         * @description Complete the Auth0 account link and redirect back to settings.
+         *
+         *     Validates the returned ``state`` against the signed PKCE cookie, exchanges the
+         *     ``code`` for an id_token at Auth0, verifies it (RS256 via the tenant JWKS,
+         *     ``aud`` = the link client id, ``iss`` = the tenant), and binds its ``sub`` to
+         *     the **current session user** (one-to-one; a ``sub`` already held by a
+         *     different live user is rejected ``409`` and left in place — see
+         *     ``_bind_auth0_sub``). On success it 302-redirects to ``/settings?linked=1``.
+         *
+         *     Requires an established fortymm session. Rejects a missing / mismatched /
+         *     expired ``state`` with ``400``, an exchange or id_token-verification failure
+         *     with ``400``, and returns ``404`` when linking is unconfigured.
+         */
+        get: operations["link_callback_v1_auth0_link_callback_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/auth0/link": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Link Status
+         * @description Whether the signed-in user has an Auth0 identity bound.
+         *
+         *     ``linked`` is true once the user has completed the link flow (their
+         *     ``users.auth0_sub`` is set). Requires an established fortymm session; needs no
+         *     Auth0 configuration (it only reads local state).
+         */
+        get: operations["link_status_v1_auth0_link_get"];
+        put?: never;
+        post?: never;
+        /**
+         * Unlink
+         * @description Clear the signed-in user's Auth0 binding.
+         *
+         *     Drops ``users.auth0_sub`` so the identity can be re-linked (here or to a
+         *     different account) and any agent authenticating as that ``sub`` stops
+         *     resolving to this user. Idempotent — clearing an already-unlinked account is a
+         *     no-op ``linked=false``. Requires an established fortymm session; needs no Auth0
+         *     configuration.
+         */
+        delete: operations["unlink_v1_auth0_link_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/matches": {
         parameters: {
             query?: never;
@@ -2128,6 +2223,16 @@ export interface components {
             redis: components["schemas"]["ComponentHealth"];
             database: components["schemas"]["ComponentHealth"];
             solver: components["schemas"]["ComponentHealth"];
+        };
+        /**
+         * LinkStatus
+         * @description Whether the current user has an Auth0 identity bound. The GET status body
+         *     and the DELETE (now-cleared) body both use it, so a client updates the same
+         *     shape either way.
+         */
+        LinkStatus: {
+            /** Linked */
+            linked: boolean;
         };
         /**
          * LoginRequestAccepted
@@ -5528,6 +5633,138 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiTokenCreated"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    start_link_v1_auth0_link_start_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            307: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    link_callback_v1_auth0_link_callback_get: {
+        parameters: {
+            query: {
+                code: string;
+                state: string;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: {
+                auth0_link_pkce?: string | null;
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            307: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    link_status_v1_auth0_link_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LinkStatus"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unlink_v1_auth0_link_delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LinkStatus"];
                 };
             };
             /** @description Validation Error */

--- a/web-client/src/components/settings/agent-access-section.factory.tsx
+++ b/web-client/src/components/settings/agent-access-section.factory.tsx
@@ -1,0 +1,13 @@
+import type { components } from '@/api/schema'
+
+type LinkStatus = components['schemas']['LinkStatus']
+
+/**
+ * The `GET`/`DELETE /v1/auth0/link` wire payload. Defaults to the **linked**
+ * scenario (a user whose Auth0 identity is bound) — the state that shows the
+ * Connected badge + Unlink control. Pass `{ linked: false }` for the
+ * not-connected/Connect state.
+ */
+export function buildLinkStatus(overrides: Partial<LinkStatus> = {}): LinkStatus {
+  return { linked: true, ...overrides }
+}

--- a/web-client/src/components/settings/agent-access-section.page.tsx
+++ b/web-client/src/components/settings/agent-access-section.page.tsx
@@ -4,7 +4,10 @@ import { render, screen, type Container } from '@/test/utilities'
 import { server } from '@/mocks/server'
 import { sessionResponse } from '@/test/factories'
 import { SessionProbe } from '@/test/session-probe'
-import { mockAuth0LinkStatusEndpoint } from '@/mocks/endpoints/auth0/auth0-link.endpoint'
+import {
+  mockAuth0LinkStatusEndpoint,
+  mockAuth0UnlinkEndpoint,
+} from '@/mocks/endpoints/auth0/auth0-link.endpoint'
 
 import { AgentAccessSection } from './agent-access-section'
 import { buildLinkStatus } from './agent-access-section.factory'
@@ -75,12 +78,10 @@ export const agentAccessSectionPage = {
    * the calls, so a test can assert the Unlink click hit the endpoint. */
   stubUnlink() {
     unlinkCallCount = 0
-    server.use(
-      http.delete('*/v1/auth0/link', () => {
-        unlinkCallCount += 1
-        return HttpResponse.json(buildLinkStatus({ linked: false }))
-      }),
-    )
+    mockAuth0UnlinkEndpoint(server, () => {
+      unlinkCallCount += 1
+      return HttpResponse.json(buildLinkStatus({ linked: false }))
+    })
   },
 
   unlinkCallCount() {

--- a/web-client/src/components/settings/agent-access-section.page.tsx
+++ b/web-client/src/components/settings/agent-access-section.page.tsx
@@ -1,0 +1,95 @@
+import { http, HttpResponse } from 'msw'
+
+import { render, screen, type Container } from '@/test/utilities'
+import { server } from '@/mocks/server'
+import { sessionResponse } from '@/test/factories'
+import { SessionProbe } from '@/test/session-probe'
+import { mockAuth0LinkStatusEndpoint } from '@/mocks/endpoints/auth0/auth0-link.endpoint'
+
+import { AgentAccessSection } from './agent-access-section'
+import { buildLinkStatus } from './agent-access-section.factory'
+
+const scoped = (container: Container) => ({
+  /** The whole section — absent for a user without `mcp.access`. */
+  querySection() {
+    return container.queryByRole('region', { name: /agent access/i })
+  },
+  /** The "Connected" badge shown in the linked state's header. */
+  queryConnectedBadge() {
+    return container.queryByText('Connected')
+  },
+  /** The Unlink control — present only in the linked state. */
+  queryUnlinkButton() {
+    return container.queryByRole('button', { name: /unlink/i })
+  },
+  findUnlinkButton() {
+    return container.findByRole('button', { name: /unlink/i })
+  },
+  /** The Connect affordance — a real link (full navigation to the OAuth
+   * redirect), present only in the not-connected state. */
+  queryConnectLink() {
+    return container.queryByRole('link', { name: /connect/i })
+  },
+  findConnectLink() {
+    return container.findByRole('link', { name: /connect/i })
+  },
+  /** The signal that `GET /v1/session` has resolved — `await` it before
+   * asserting the section's *absence*, or a still-loading session reads as
+   * "no permission" and the assertion proves nothing. */
+  findSessionReady() {
+    return container.findByTestId('session-ready')
+  },
+})
+
+/** Bumped each time `DELETE /v1/auth0/link` is hit — proves the Unlink click
+ * actually calls the endpoint. */
+let unlinkCallCount = 0
+
+export const agentAccessSectionPage = {
+  render() {
+    render(
+      <>
+        <AgentAccessSection />
+        <SessionProbe />
+      </>,
+    )
+  },
+
+  /** Make `GET /v1/session` return a user with the given permission list. */
+  signInWithPermissions(permissions: string[]) {
+    server.use(
+      http.get('*/v1/session', () =>
+        HttpResponse.json(sessionResponse({ user: { permissions } })),
+      ),
+    )
+  },
+
+  /** Stub `GET /v1/auth0/link` to report a fixed link status. */
+  mockLinkStatus(linked: boolean) {
+    mockAuth0LinkStatusEndpoint(server, () =>
+      HttpResponse.json(buildLinkStatus({ linked })),
+    )
+  },
+
+  /** Stub `DELETE /v1/auth0/link` to return the now-cleared status and count
+   * the calls, so a test can assert the Unlink click hit the endpoint. */
+  stubUnlink() {
+    unlinkCallCount = 0
+    server.use(
+      http.delete('*/v1/auth0/link', () => {
+        unlinkCallCount += 1
+        return HttpResponse.json(buildLinkStatus({ linked: false }))
+      }),
+    )
+  },
+
+  unlinkCallCount() {
+    return unlinkCallCount
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/settings/agent-access-section.test.tsx
+++ b/web-client/src/components/settings/agent-access-section.test.tsx
@@ -1,0 +1,57 @@
+import userEvent from '@testing-library/user-event'
+
+import { waitFor } from '@/test/utilities'
+import { PERM } from '@/lib/permissions'
+
+import { agentAccessSectionPage as page } from './agent-access-section.page'
+
+describe('AgentAccessSection', () => {
+  it('renders nothing for a user without mcp.access', async () => {
+    page.signInWithPermissions([])
+    page.mockLinkStatus(false)
+    page.render()
+
+    // Wait for the session to actually resolve — otherwise the absence is just
+    // the still-loading state and proves nothing.
+    await page.findSessionReady()
+    expect(page.querySection()).not.toBeInTheDocument()
+  })
+
+  it('shows a Connect link to the Auth0 start flow when the user is permitted but unlinked', async () => {
+    page.signInWithPermissions([PERM.MCP_ACCESS])
+    page.mockLinkStatus(false)
+    page.render()
+
+    const connect = await page.findConnectLink()
+    // A real navigation to the API's OAuth-redirect endpoint, not a fetch.
+    expect(connect.getAttribute('href')).toContain('/v1/auth0/link/start')
+    expect(page.queryUnlinkButton()).not.toBeInTheDocument()
+    expect(page.queryConnectedBadge()).not.toBeInTheDocument()
+  })
+
+  it('shows Connected status and an Unlink control when the user is linked', async () => {
+    page.signInWithPermissions([PERM.MCP_ACCESS])
+    page.mockLinkStatus(true)
+    page.render()
+
+    expect(await page.findUnlinkButton()).toBeInTheDocument()
+    expect(page.queryConnectedBadge()).toBeInTheDocument()
+    expect(page.queryConnectLink()).not.toBeInTheDocument()
+  })
+
+  it('calls DELETE and flips to the unlinked state when Unlink is clicked', async () => {
+    page.signInWithPermissions([PERM.MCP_ACCESS])
+    page.mockLinkStatus(true)
+    page.stubUnlink()
+    page.render()
+
+    const unlink = await page.findUnlinkButton()
+    await userEvent.click(unlink)
+
+    // The Connect link is the tell that the section flipped to "not connected".
+    const connect = await page.findConnectLink()
+    expect(connect).toBeInTheDocument()
+    expect(page.queryUnlinkButton()).not.toBeInTheDocument()
+    await waitFor(() => expect(page.unlinkCallCount()).toBe(1))
+  })
+})

--- a/web-client/src/components/settings/agent-access-section.tsx
+++ b/web-client/src/components/settings/agent-access-section.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { Bot, Check } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { toast } from 'sonner'
 
 import {
@@ -108,104 +109,109 @@ export function AgentAccessSection() {
             Couldn't load your agent-access status. Reload to try again.
           </div>
         ) : status.data.linked ? (
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 14,
-              padding: '14px 16px',
-              background: 'rgba(0,226,154,0.06)',
-              border: '1px solid rgba(0,226,154,0.3)',
-              borderRadius: 'var(--r-md)',
-            }}
-          >
-            <div
-              style={{
-                width: 28,
-                height: 28,
-                borderRadius: '50%',
-                background: 'rgba(0,226,154,0.18)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexShrink: 0,
-              }}
-            >
-              <Check size={16} color="var(--serve-500)" />
-            </div>
-            <div
-              style={{ flex: 1, fontSize: 'var(--text-sm)', color: 'var(--fg-2)' }}
-            >
-              <div style={{ fontWeight: 600, color: 'var(--fg-1)' }}>
-                Agent access is connected.
-              </div>
-              <div style={{ color: 'var(--fg-3)', marginTop: 2 }}>
-                An agent signed in with your linked identity can reach the MCP
-                server on your behalf.
-              </div>
-            </div>
-            <button
-              type="button"
-              className="fmm-btn fmm-btn--quiet fmm-btn--sm"
-              onClick={onUnlink}
-              disabled={unlink.isPending}
-            >
-              {unlink.isPending ? (
-                <>
-                  <span className="fmm-spinner" /> Disconnecting…
-                </>
-              ) : (
-                'Unlink'
-              )}
-            </button>
-          </div>
+          <StatusRow
+            wrapperBackground="rgba(0,226,154,0.06)"
+            wrapperBorder="1px solid rgba(0,226,154,0.3)"
+            badgeBackground="rgba(0,226,154,0.18)"
+            icon={<Check size={16} color="var(--serve-500)" />}
+            title="Agent access is connected."
+            body="An agent signed in with your linked identity can reach the MCP server on your behalf."
+            action={
+              <button
+                type="button"
+                className="fmm-btn fmm-btn--quiet fmm-btn--sm"
+                onClick={onUnlink}
+                disabled={unlink.isPending}
+              >
+                {unlink.isPending ? (
+                  <>
+                    <span className="fmm-spinner" /> Disconnecting…
+                  </>
+                ) : (
+                  'Unlink'
+                )}
+              </button>
+            }
+          />
         ) : (
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 14,
-              padding: '14px 16px',
-              background: 'var(--bg-panel)',
-              border: '1px solid var(--border-subtle)',
-              borderRadius: 'var(--r-md)',
-            }}
-          >
-            <div
-              style={{
-                width: 28,
-                height: 28,
-                borderRadius: '50%',
-                background: 'var(--bg-elev)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                flexShrink: 0,
-              }}
-            >
-              <Bot size={16} color="var(--fg-muted)" />
-            </div>
-            <div
-              style={{ flex: 1, fontSize: 'var(--text-sm)', color: 'var(--fg-2)' }}
-            >
-              <div style={{ fontWeight: 600, color: 'var(--fg-1)' }}>
-                No agent access connected.
-              </div>
-              <div style={{ color: 'var(--fg-3)', marginTop: 2 }}>
-                Connect an Auth0 identity to let an agent act for you.
-              </div>
-            </div>
-            {/* A full-page navigation, not a fetch — this begins an OAuth
-                redirect the API answers with a 302 (see `auth0LinkStartUrl`). */}
-            <a
-              className="fmm-btn fmm-btn--primary fmm-btn--sm"
-              href={auth0LinkStartUrl()}
-            >
-              Connect
-            </a>
-          </div>
+          <StatusRow
+            wrapperBackground="var(--bg-panel)"
+            wrapperBorder="1px solid var(--border-subtle)"
+            badgeBackground="var(--bg-elev)"
+            icon={<Bot size={16} color="var(--fg-muted)" />}
+            title="No agent access connected."
+            body="Connect an Auth0 identity to let an agent act for you."
+            action={
+              /* A full-page navigation, not a fetch — this begins an OAuth
+                 redirect the API answers with a 302 (see `auth0LinkStartUrl`). */
+              <a
+                className="fmm-btn fmm-btn--primary fmm-btn--sm"
+                href={auth0LinkStartUrl()}
+              >
+                Connect
+              </a>
+            }
+          />
         )}
       </div>
     </section>
+  )
+}
+
+/**
+ * The connection-status row shared by the linked ("Connected") and
+ * not-connected states: a flex row wrapping a 28px circular icon badge, a
+ * title + body text block, and a trailing action. Only the tone (wrapper /
+ * badge colors), icon, copy, and action differ between the two states.
+ */
+function StatusRow({
+  wrapperBackground,
+  wrapperBorder,
+  badgeBackground,
+  icon,
+  title,
+  body,
+  action,
+}: {
+  wrapperBackground: string
+  wrapperBorder: string
+  badgeBackground: string
+  icon: ReactNode
+  title: string
+  body: string
+  action: ReactNode
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+        padding: '14px 16px',
+        background: wrapperBackground,
+        border: wrapperBorder,
+        borderRadius: 'var(--r-md)',
+      }}
+    >
+      <div
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: '50%',
+          background: badgeBackground,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        {icon}
+      </div>
+      <div style={{ flex: 1, fontSize: 'var(--text-sm)', color: 'var(--fg-2)' }}>
+        <div style={{ fontWeight: 600, color: 'var(--fg-1)' }}>{title}</div>
+        <div style={{ color: 'var(--fg-3)', marginTop: 2 }}>{body}</div>
+      </div>
+      {action}
+    </div>
   )
 }

--- a/web-client/src/components/settings/agent-access-section.tsx
+++ b/web-client/src/components/settings/agent-access-section.tsx
@@ -1,0 +1,211 @@
+import { useQuery } from '@tanstack/react-query'
+import { Bot, Check } from 'lucide-react'
+import { toast } from 'sonner'
+
+import {
+  auth0LinkQueryOptions,
+  auth0LinkStartUrl,
+  useUnlinkAuth0,
+} from '@/api/auth0'
+import { ApiError } from '@/api/client'
+import { useHasPermission, useSession } from '@/api/session'
+import { PERM } from '@/lib/permissions'
+
+/**
+ * The Settings page's **Agent access** section — the Auth0 identity link that
+ * lets an AI agent reach the MCP server on the user's behalf.
+ *
+ * The whole section is gated on `mcp.access`: a user without the grant sees
+ * nothing at all. Hiding it is a UX decision, never a security boundary — the
+ * API independently enforces the same permission on `/v1/auth0/link*`.
+ *
+ * `useHasPermission` reads `false` while the session is still loading, so we wait
+ * the session out (`isPending`) before deciding, exactly like `ApiTokensPage` —
+ * otherwise a permitted user would flash an empty section on first paint.
+ */
+export function AgentAccessSection() {
+  const { isPending: sessionPending } = useSession()
+  const canAccess = useHasPermission(PERM.MCP_ACCESS)
+  const status = useQuery({
+    ...auth0LinkQueryOptions(),
+    // Don't fetch link status for a user who will never see the section.
+    enabled: canAccess,
+  })
+  const unlink = useUnlinkAuth0()
+
+  if (sessionPending || !canAccess) return null
+
+  const onUnlink = async () => {
+    try {
+      await unlink.mutateAsync()
+      toast.success('Agent access disconnected.')
+    } catch (err) {
+      toast.error(
+        err instanceof ApiError && err.detail
+          ? err.detail
+          : "Couldn't disconnect agent access. Try again.",
+      )
+    }
+  }
+
+  return (
+    <section
+      id="sec-agent-access"
+      className="fmm-card"
+      aria-labelledby="agent-access-title"
+      data-screen-label="04 Agent access"
+    >
+      <header style={{ padding: '24px 28px 0' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            marginBottom: 6,
+          }}
+        >
+          <span className="fmm-section-num">04</span>
+          <span className="fmm-overline" style={{ color: 'var(--fg-muted)' }}>
+            Integrations
+          </span>
+          {status.data?.linked && (
+            <span className="fmm-tag fmm-tag--ok">Connected</span>
+          )}
+        </div>
+        <h2
+          id="agent-access-title"
+          style={{
+            fontFamily: 'var(--font-ui)',
+            fontSize: 'var(--text-xl)',
+            fontWeight: 600,
+            letterSpacing: '-0.01em',
+            color: 'var(--fg-1)',
+            margin: '0 0 6px',
+          }}
+        >
+          Agent access
+        </h2>
+        <p
+          style={{
+            fontSize: 'var(--text-sm)',
+            color: 'var(--fg-3)',
+            margin: 0,
+            maxWidth: 560,
+            lineHeight: 'var(--lh-snug)',
+          }}
+        >
+          Connect an Auth0 identity so an AI agent can act on your behalf through
+          the FortyMM MCP server. You can disconnect it any time.
+        </p>
+      </header>
+      <div className="fmm-card-body" style={{ padding: '24px 28px 28px' }}>
+        {status.isPending ? (
+          <div className="fmm-help" role="status">
+            <span className="fmm-spinner" /> Checking connection…
+          </div>
+        ) : status.isError ? (
+          <div className="fmm-help fmm-help--err" role="status">
+            Couldn't load your agent-access status. Reload to try again.
+          </div>
+        ) : status.data.linked ? (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 14,
+              padding: '14px 16px',
+              background: 'rgba(0,226,154,0.06)',
+              border: '1px solid rgba(0,226,154,0.3)',
+              borderRadius: 'var(--r-md)',
+            }}
+          >
+            <div
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: '50%',
+                background: 'rgba(0,226,154,0.18)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <Check size={16} color="var(--serve-500)" />
+            </div>
+            <div
+              style={{ flex: 1, fontSize: 'var(--text-sm)', color: 'var(--fg-2)' }}
+            >
+              <div style={{ fontWeight: 600, color: 'var(--fg-1)' }}>
+                Agent access is connected.
+              </div>
+              <div style={{ color: 'var(--fg-3)', marginTop: 2 }}>
+                An agent signed in with your linked identity can reach the MCP
+                server on your behalf.
+              </div>
+            </div>
+            <button
+              type="button"
+              className="fmm-btn fmm-btn--quiet fmm-btn--sm"
+              onClick={onUnlink}
+              disabled={unlink.isPending}
+            >
+              {unlink.isPending ? (
+                <>
+                  <span className="fmm-spinner" /> Disconnecting…
+                </>
+              ) : (
+                'Unlink'
+              )}
+            </button>
+          </div>
+        ) : (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 14,
+              padding: '14px 16px',
+              background: 'var(--bg-panel)',
+              border: '1px solid var(--border-subtle)',
+              borderRadius: 'var(--r-md)',
+            }}
+          >
+            <div
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: '50%',
+                background: 'var(--bg-elev)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <Bot size={16} color="var(--fg-muted)" />
+            </div>
+            <div
+              style={{ flex: 1, fontSize: 'var(--text-sm)', color: 'var(--fg-2)' }}
+            >
+              <div style={{ fontWeight: 600, color: 'var(--fg-1)' }}>
+                No agent access connected.
+              </div>
+              <div style={{ color: 'var(--fg-3)', marginTop: 2 }}>
+                Connect an Auth0 identity to let an agent act for you.
+              </div>
+            </div>
+            {/* A full-page navigation, not a fetch — this begins an OAuth
+                redirect the API answers with a 302 (see `auth0LinkStartUrl`). */}
+            <a
+              className="fmm-btn fmm-btn--primary fmm-btn--sm"
+              href={auth0LinkStartUrl()}
+            >
+              Connect
+            </a>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/web-client/src/lib/permissions.ts
+++ b/web-client/src/lib/permissions.ts
@@ -30,6 +30,12 @@ export const PERM = {
   // RBAC-management keys. Mirrors the server's `api_token.manage` permission,
   // which fronts `POST /v1/api-tokens`.
   API_TOKEN_MANAGE: 'api_token.manage',
+  // Gates the Settings page's **Agent access** section — the Auth0 identity link
+  // that lets an AI agent reach the MCP server on the user's behalf. Its own
+  // grant, like the other feature-scoped perms above, so an operator can hand out
+  // agent access without the RBAC-management keys. Mirrors the `mcp.access`
+  // permission the server enforces on the `/v1/auth0/link*` endpoints.
+  MCP_ACCESS: 'mcp.access',
 } as const
 
 export type PermissionName = (typeof PERM)[keyof typeof PERM]

--- a/web-client/src/mocks/endpoints/auth0/auth0-link.endpoint.ts
+++ b/web-client/src/mocks/endpoints/auth0/auth0-link.endpoint.ts
@@ -1,0 +1,25 @@
+import { type HttpResponseResolver, http } from 'msw'
+
+import type { components } from '@/api/schema'
+
+import type { worker } from '../../browser'
+import type { server } from '../../server'
+
+type Backend = typeof server | typeof worker
+type LinkStatus = components['schemas']['LinkStatus']
+
+export type Auth0LinkResolver = HttpResponseResolver<never, never, LinkStatus>
+
+/** Stub `GET /v1/auth0/link` — whether the current user has an Auth0 identity
+ * bound. Drives the Settings "Agent access" section's Connect/Connected split. */
+export const mockAuth0LinkStatusEndpoint = (
+  backend: Backend,
+  resolver: Auth0LinkResolver,
+) => backend.use(http.get('*/v1/auth0/link', resolver))
+
+/** Stub `DELETE /v1/auth0/link` — the Unlink action. Replies with the
+ * now-cleared status. */
+export const mockAuth0UnlinkEndpoint = (
+  backend: Backend,
+  resolver: Auth0LinkResolver,
+) => backend.use(http.delete('*/v1/auth0/link', resolver))

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -100,10 +100,16 @@ export const mockSession = sessionResponse({
       PERM.NOTIFICATIONS_BROADCAST,
       PERM.SCHEDULING_VIEW,
       PERM.API_TOKEN_MANAGE,
+      // MCP_ACCESS so the Settings page's "Agent access" section (Auth0 identity
+      // link) renders under `npm run dev`.
+      PERM.MCP_ACCESS,
     ],
   },
 })
 export const mockHealthy = healthCheck()
+
+// Dev-world Auth0 agent-access link state (see the `/v1/auth0/link` handlers).
+let mockAuth0Linked = true
 
 /** The dev world's cross-tournament solve ledger (see the handler below). */
 const mockAdminSolveLedger = buildAdminSolveLedgerSeed()
@@ -1065,6 +1071,21 @@ export const handlers = [
   http.post('*/v1/api-tokens', async () => {
     await delay(300)
     return HttpResponse.json(apiTokenCreated(), { status: 201 })
+  }),
+  // ----- Auth0 agent-access link (Settings → Agent access) ----------------
+  // Whether the dev user's Auth0 identity is bound. Starts linked so the
+  // "Connected" + Unlink state is demoable under `npm run dev`; the DELETE
+  // flips it, so the Unlink interaction actually drives the section back to
+  // "not connected". (The Connect flow is an OAuth *redirect* to the real API,
+  // which MSW can't stand in for — it only works against a live backend.)
+  http.get('*/v1/auth0/link', async () => {
+    await delay(200)
+    return HttpResponse.json({ linked: mockAuth0Linked })
+  }),
+  http.delete('*/v1/auth0/link', async () => {
+    await delay(200)
+    mockAuth0Linked = false
+    return HttpResponse.json({ linked: mockAuth0Linked })
   }),
   // ----- /v1/players list + per-player profile + per-player matches ------
   // BFF endpoints — each returns exactly what its consumer page needs. The

--- a/web-client/src/routes/_app/settings.tsx
+++ b/web-client/src/routes/_app/settings.tsx
@@ -37,6 +37,7 @@ import {
   useUpdateUsername,
   type EmailStatus,
 } from '@/api/session'
+import { AgentAccessSection } from '@/components/settings/agent-access-section'
 import { Turnstile, type TurnstileHandle } from '@/components/turnstile'
 import {
   Tooltip,
@@ -1105,6 +1106,9 @@ function SettingsPage() {
                 onDirtyChange={setEmailDirty}
               />
               <NotificationsSection />
+              {/* Self-gates on `mcp.access` — renders nothing for a user
+                  without the grant, so it's mounted unconditionally here. */}
+              <AgentAccessSection />
             </div>
 
             <ComingSoon>


### PR DESCRIPTION
## What & why

Agents can now connect to the FortyMM MCP server via the **standard MCP 2025 OAuth flow**, with **Auth0** as the authorization server. This replaces the operator-only opaque bearer token *on the MCP surface* and broadens who can connect (resolves the long-standing "MCP is operator-only until token minting is broadened" gap).

Design recorded in `docs/adr/20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0.md`.

## How it works

- **MCP server = stateless OAuth Resource Server.** FastMCP `RemoteAuthProvider` + a `JWTVerifier` subclass validates Auth0 JWTs (RS256/JWKS/`iss`/`aud`/`exp`), maps the token `sub` to a linked user, and gates on a new `mcp.access` permission. **Not** the stateful `Auth0Provider` — incompatible with `stateless_http` + 2 replicas.
- **Auth0 = authentication only; authorization stays in fortymm RBAC.** `mcp.access` is seeded onto the **Beta tester** role; revoking it cuts an agent off even with a live token.
- **Explicit account linking.** New unique `users.auth0_sub` column. A logged-in user links once via a server-side confidential OAuth code flow (`/v1/auth0/link/{start,callback}`, PKCE, id_token verification, one-to-one binding with collision rejection). `sub`-only, no PII stored. Surfaced as an "Agent access" section on `/settings`, shown only to `mcp.access` holders.
- **Fails closed:** with `AUTH0_*` unset (local/qa/e2e), the api still boots and MCP just 401s.
- **HTTP bearer untouched:** the opaque `context="api"` token, `POST /v1/api-tokens`, and the admin UI stay for the iOS app; only the MCP surface moved to Auth0.
- **nginx** forwards the RFC 9728 protected-resource metadata (advertised at the origin-root path-insertion URL) to the `/mcp` mount so client discovery + DCR work through the public path.

## Testing

- api: ruff + mypy + **pytest 1647 passed** (incl. rewritten MCP transport-auth suite: valid/missing/bad-sig/bad-aud/bad-iss/unlinked/no-permission/tombstoned; link-flow collision→409; merge handling; fail-closed boot).
- web: **vitest 2907 passed**, build clean, settings e2e green.
- iOS: BUILD SUCCEEDED against regenerated `Types.swift`. OpenAPI drift: none.
- nginx discovery verified end-to-end (401 challenge → 200 metadata JSON through nginx).

## Operator follow-up (post-merge, UAT)

The live browser + agent-connect round-trip needs a real Auth0 tenant — **not exercised in CI**:
1. Create an Auth0 **API/Resource Server** (identifier = `https://uat.fortymm.com/api/mcp`) and a **Regular Web Application** (confidential, callback `https://uat.fortymm.com/api/auth0/link/callback`); enable an interactive login connection + Dynamic Client Registration.
2. Set `AUTH0_DOMAIN`, `AUTH0_AUDIENCE`, `AUTH0_LINK_CLIENT_ID` in `deploy/uat/values.yaml`; add `AUTH0_LINK_CLIENT_SECRET` to `.env`.
3. Grant yourself the **Beta tester** role on UAT, link your account on `/settings`, then add the MCP server to an agent host as an OAuth connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
