### PR TITLE
Auto-provision/match FortyMM accounts by verified Auth0 email at MCP token time (#1157)

### DIFF
--- a/api/app/auth0_provisioning.py
+++ b/api/app/auth0_provisioning.py
@@ -90,7 +90,20 @@ async def resolve_or_provision_user(
     if matched is not None:
         if matched.auth0_sub is None:
             matched.auth0_sub = sub
-            await db.commit()
+            try:
+                await db.commit()
+            except IntegrityError:
+                # A concurrent bind of the same ``sub`` to a *different* row (e.g.
+                # a manual ``/auth0/link`` in flight) wins the unique
+                # ``users.auth0_sub`` constraint first. Same guard as
+                # ``_provision_user`` / ``_bind_auth0_sub``: roll back and
+                # re-resolve (by ``sub``, then by email) so the loser returns the
+                # winning row instead of raising.
+                await db.rollback()
+                winner = await resolve_linked_user(db, sub)
+                if winner is not None:
+                    return winner
+                return await _resolve_live_user_by_email(db, email)
             return matched
         # A *different* Auth0 identity claims an already-linked email — the same
         # ``sub`` would already have returned at step 1 (``resolve_linked_user``),

--- a/api/app/auth0_provisioning.py
+++ b/api/app/auth0_provisioning.py
@@ -92,13 +92,12 @@ async def resolve_or_provision_user(
             matched.auth0_sub = sub
             await db.commit()
             return matched
-        if matched.auth0_sub == sub:
-            # Idempotent — normally already returned by step 1; here for safety.
-            return matched
-        # A different Auth0 identity claims an already-linked email. Refuse
-        # rather than hijack the existing link: this is a deliberate,
-        # non-destructive decision — the second identity gets in only once the
-        # first unlinks (or the two accounts are merged by magic-link confirm).
+        # A *different* Auth0 identity claims an already-linked email — the same
+        # ``sub`` would already have returned at step 1 (``resolve_linked_user``),
+        # so ``matched.auth0_sub`` here is necessarily some other identity. Refuse
+        # rather than hijack the existing link: a deliberate, non-destructive
+        # decision — the second identity gets in only once the first unlinks (or
+        # the two accounts are merged by magic-link confirm).
         return None
 
     # No account holds the email → provision a fresh registered account.

--- a/api/app/auth0_provisioning.py
+++ b/api/app/auth0_provisioning.py
@@ -1,0 +1,141 @@
+"""Resolve-or-provision a fortymm ``User`` from a verified Auth0 token.
+
+At MCP token time the OAuth Resource-Server verifier turns a valid Auth0 token
+into the fortymm ``User`` it acts as. This module owns the second half of that:
+when the token's ``sub`` isn't yet linked, it *matches* the token's verified
+email to an existing account (binding the ``sub``) or *provisions* a fresh
+registered account on it. See ADR
+``20260722-mcp-accounts-auto-provision-and-match-by-verified-auth0-email``.
+
+Router-free (no FastAPI imports), the same discipline as ``app.auth0_identity``,
+so the MCP verifier can import it without dragging in a router — and the sub
+lookup itself is reused from there (``resolve_linked_user``), never
+reimplemented.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth0_identity import resolve_linked_user
+from app.leagues import add_user_to_default_league
+from app.models import User
+from app.roles import grant_default_role
+from app.usernames import generate_username
+
+# The two namespaced claim keys the Auth0 Action ships on the MCP access token
+# (see ``docs/auth0-mcp-email-claims-action.md``). Auth0 silently drops
+# non-namespaced custom claims, so these must stay namespaced URLs — and must
+# stay in lockstep with the Action's namespace, or the feature goes dark.
+AUTH0_EMAIL_CLAIM = "https://fortymm.com/email"
+AUTH0_EMAIL_VERIFIED_CLAIM = "https://fortymm.com/email_verified"
+
+
+async def _resolve_live_user_by_email(db: AsyncSession, email: str) -> User | None:
+    """The live (non-tombstoned) user holding ``email``, or ``None``.
+
+    ``email`` is expected already lowercased — the email-change/confirm flow
+    stores addresses lowercased, so both the match query and any provisioned row
+    carry the same canonical form.
+    """
+    result = await db.execute(
+        select(User).where(
+            User.email == email,
+            User.merged_into_user_id.is_(None),
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def resolve_or_provision_user(
+    db: AsyncSession,
+    sub: str,
+    email: str | None,
+    email_verified: bool,
+) -> User | None:
+    """Turn a verified Auth0 token into the fortymm ``User`` it acts as.
+
+    1. **Linked sub** → the user who already linked ``sub`` (reusing
+       ``resolve_linked_user``).
+    2. **Verified email present** (``email`` truthy and ``email_verified`` is
+       ``True``):
+       - an existing live account holds that email (case-insensitive) → bind
+         ``auth0_sub`` to it and return it (**match**) — unless it already holds
+         a *different* ``auth0_sub``, in which case return ``None`` (see below);
+       - no account holds it → create a registered account (coolname username,
+         email set, ``confirmed_at`` stamped, ``auth0_sub`` bound, default role +
+         default league) and return it (**provision**).
+    3. **No email, or ``email_verified`` not ``True``** → ``None``. We never
+       match or provision off an address the caller hasn't proven they control.
+
+    Writes on the first token for a new identity (a bind, or an INSERT); every
+    later token resolves via step 1 with no write.
+    """
+    # (1) Already linked — the common steady-state path, and a no-op write-wise.
+    existing = await resolve_linked_user(db, sub)
+    if existing is not None:
+        return existing
+
+    # (3) Without a proven-controlled email there is nothing safe to match or
+    # provision against.
+    if not email or email_verified is not True:
+        return None
+
+    # (2) Match the verified email against a live account, canonicalising to the
+    # lowercased form the email-confirm flow stores.
+    email = email.lower()
+    matched = await _resolve_live_user_by_email(db, email)
+    if matched is not None:
+        if matched.auth0_sub is None:
+            matched.auth0_sub = sub
+            await db.commit()
+            return matched
+        if matched.auth0_sub == sub:
+            # Idempotent — normally already returned by step 1; here for safety.
+            return matched
+        # A different Auth0 identity claims an already-linked email. Refuse
+        # rather than hijack the existing link: this is a deliberate,
+        # non-destructive decision — the second identity gets in only once the
+        # first unlinks (or the two accounts are merged by magic-link confirm).
+        return None
+
+    # No account holds the email → provision a fresh registered account.
+    return await _provision_user(db, sub, email)
+
+
+async def _provision_user(db: AsyncSession, sub: str, email: str) -> User | None:
+    """Create a registered account for a first-seen verified email.
+
+    Born exactly like a normal account (coolname username, ``confirmed_at``
+    stamped, default league + default role, in that same order) plus the bound
+    ``auth0_sub``. A verified Auth0 email is trusted as equivalent to fortymm's
+    own magic-link inbox-proof, so the account is ``confirmed_at``-stamped rather
+    than half-real (ADR).
+
+    **Concurrency — match, don't duplicate.** A near-simultaneous second request
+    for the same identity can win the INSERT first; the unique constraints on
+    ``users.email`` / ``users.auth0_sub`` then raise ``IntegrityError`` here. We
+    catch it, roll back, and re-resolve (by ``sub``, then by email) so the loser
+    returns the winning row instead of raising.
+    """
+    user = User(
+        username=await generate_username(db),
+        email=email,
+        confirmed_at=datetime.now(UTC),
+        auth0_sub=sub,
+    )
+    db.add(user)
+    try:
+        await db.flush()
+        await add_user_to_default_league(db, user.id)
+        await grant_default_role(db, user.id)
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        winner = await resolve_linked_user(db, sub)
+        if winner is not None:
+            return winner
+        return await _resolve_live_user_by_email(db, email)
+    return user

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -50,7 +50,11 @@ from pydantic import AnyHttpUrl, BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth0_identity import resolve_linked_user
+from app.auth0_provisioning import (
+    AUTH0_EMAIL_CLAIM,
+    AUTH0_EMAIL_VERIFIED_CLAIM,
+    resolve_or_provision_user,
+)
 from app.config import get_settings
 from app.db import get_sessionmaker
 from app.draws import (
@@ -292,9 +296,17 @@ class FortymmAuth0TokenVerifier(JWTVerifier):
     built-in cache, and RS256 / issuer / audience / expiry checks); we override
     :meth:`verify_token` to add fortymm's authorization on top. On a token that
     fails verification we return ``None`` (→ 401). On a verified token we read its
-    ``sub`` and resolve it to the explicitly **linked**, non-tombstoned ``User``
-    (:func:`app.auth0_identity.resolve_linked_user`); a ``sub`` linked to no live
-    user, or a linked user lacking ``mcp.access``, is also ``None`` (→ 401).
+    ``sub`` (and namespaced email claims) and resolve it to a non-tombstoned
+    ``User`` (:func:`app.auth0_provisioning.resolve_or_provision_user`); a ``sub``
+    that resolves to no live user, or a user lacking ``mcp.access``, is also
+    ``None`` (→ 401).
+
+    Resolution goes through :func:`app.auth0_provisioning.resolve_or_provision_user`,
+    which first tries the explicitly linked user and, failing that, *matches* the
+    token's verified email to an existing account (binding the ``sub``) or
+    *provisions* a fresh registered account on it — so a first-time agent whose
+    verified Auth0 email matches (or has no) fortymm account gets in without a
+    manual link step. An unverified / absent email never matches or provisions.
 
     On success we return an ``AccessToken`` that preserves the existing tool
     contract: the resolved user id rides as ``subject`` / ``client_id`` and under
@@ -308,8 +320,16 @@ class FortymmAuth0TokenVerifier(JWTVerifier):
         sub = access.claims.get("sub")
         if not isinstance(sub, str) or not sub:
             return None
+        # The namespaced email claims the Auth0 Action ships (see
+        # ``app.auth0_provisioning``). Only a non-empty ``str`` email counts, and
+        # ``email_verified`` must be the literal boolean ``True`` — anything else
+        # is treated as unverified, so an absent/false claim never matches or
+        # provisions.
+        raw_email = access.claims.get(AUTH0_EMAIL_CLAIM)
+        email = raw_email if isinstance(raw_email, str) and raw_email else None
+        email_verified = access.claims.get(AUTH0_EMAIL_VERIFIED_CLAIM) is True
         async with mcp_session() as db:
-            user = await resolve_linked_user(db, sub)
+            user = await resolve_or_provision_user(db, sub, email, email_verified)
             if user is None:
                 return None
             if not await user_has_permission(db, user.id, MCP_ACCESS_PERMISSION):

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -45,11 +45,13 @@ from fastmcp.server.auth import (
     RemoteAuthProvider,
     TokenVerifier,
 )
-from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.dependencies import get_access_token, get_http_request
 from pydantic import AnyHttpUrl, BaseModel, Field
+from pyrate_limiter import Duration, Rate
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth0_identity import resolve_linked_user
 from app.auth0_provisioning import (
     AUTH0_EMAIL_CLAIM,
     AUTH0_EMAIL_VERIFIED_CLAIM,
@@ -96,6 +98,7 @@ from app.notifications.dependencies import get_push_sender
 from app.notifications.service import NotificationService
 from app.player_matches import paginated_player_matches
 from app.player_search import SEARCH_DEFAULT_LIMIT, search_players_by_username
+from app.rate_limiting import RedisRateLimiter
 from app.rbac import user_has_permission
 from app.repositories.match_details_repository import MatchDetailsRepository
 from app.repositories.match_repository import MatchRepository
@@ -275,6 +278,36 @@ MCP_ACCESS_PERMISSION = "mcp.access"
 _UNCONFIGURED_ORIGIN = "https://mcp-unconfigured.fortymm.invalid"
 
 
+# Per-IP ceiling on the verifier's WRITE path only — the match-bind / provision
+# that a verified-but-*unlinked* token triggers *before* the ``mcp.access`` check,
+# i.e. an as-yet-unauthorized caller writing to ``users``. The steady-state linked
+# path (every later request) skips it entirely. 20/hour/IP is generous for
+# legitimate first-time agent onboarding (a client provisions once, then resolves
+# by ``sub`` forever after) while capping an attacker who mints fresh
+# verified-email identities from one IP to spray accounts — the same order of
+# magnitude as the ``auth0_link`` per-IP ceiling (40/hour). No ``identifier``: the
+# verifier has no FastAPI ``Request``, so it keys ``check()`` by client IP itself.
+_provision_ip_rate_limit = RedisRateLimiter(
+    rates=[Rate(20, Duration.HOUR)],
+    bucket_key="mcp-provision-ip",
+)
+
+
+def _provision_client_ip() -> str:
+    """Client IP for the provision/match rate-limit key, from the active MCP HTTP
+    request. ``request.client.host`` is the true client IP given
+    ``FORWARDED_ALLOW_IPS`` at the uvicorn edge (ADR-0008). Falls back to a fixed
+    ``"unknown"`` key when there's no live request context (``verify_token`` called
+    off a request, e.g. a unit test) so the limiter degrades to one shared bucket
+    rather than raising."""
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        return "unknown"
+    client = request.client
+    return client.host if client else "unknown"
+
+
 class _RejectAllTokenVerifier(TokenVerifier):
     """The fail-closed verifier the MCP transport uses when Auth0 is unconfigured.
 
@@ -320,18 +353,32 @@ class FortymmAuth0TokenVerifier(JWTVerifier):
         sub = access.claims.get("sub")
         if not isinstance(sub, str) or not sub:
             return None
-        # The namespaced email claims the Auth0 Action ships (see
-        # ``app.auth0_provisioning``). Only a non-empty ``str`` email counts, and
-        # ``email_verified`` must be the literal boolean ``True`` — anything else
-        # is treated as unverified, so an absent/false claim never matches or
-        # provisions.
-        raw_email = access.claims.get(AUTH0_EMAIL_CLAIM)
-        email = raw_email if isinstance(raw_email, str) and raw_email else None
-        email_verified = access.claims.get(AUTH0_EMAIL_VERIFIED_CLAIM) is True
         async with mcp_session() as db:
-            user = await resolve_or_provision_user(db, sub, email, email_verified)
+            # Hot path: an already-linked ``sub`` resolves with no write. This is
+            # every steady-state request, so it is NOT rate limited.
+            user = await resolve_linked_user(db, sub)
             if user is None:
-                return None
+                # Write path: the ``sub`` isn't linked yet, so resolving it means
+                # a match-bind or a fresh provision — an as-yet-unauthorized
+                # caller writing to ``users``. Bound per client IP so a stream of
+                # freshly-minted verified-email identities from one source can't
+                # spray accounts; over the ceiling we refuse (→401) without
+                # touching the write path.
+                # ``bucket_key`` already namespaces the ZSET, so the key is just
+                # the client IP (not re-prefixed).
+                if not await _provision_ip_rate_limit.check(_provision_client_ip()):
+                    return None
+                # The namespaced email claims the Auth0 Action ships (see
+                # ``app.auth0_provisioning``). Only a non-empty ``str`` email
+                # counts, and ``email_verified`` must be the literal boolean
+                # ``True`` — anything else is treated as unverified, so an
+                # absent/false claim never matches or provisions.
+                raw_email = access.claims.get(AUTH0_EMAIL_CLAIM)
+                email = raw_email if isinstance(raw_email, str) and raw_email else None
+                email_verified = access.claims.get(AUTH0_EMAIL_VERIFIED_CLAIM) is True
+                user = await resolve_or_provision_user(db, sub, email, email_verified)
+                if user is None:
+                    return None
             if not await user_has_permission(db, user.id, MCP_ACCESS_PERMISSION):
                 return None
             user_id = str(user.id)
@@ -2024,13 +2071,18 @@ async def preview_schedule(
             raise _map_preview_draw_error(error) from error
 
     # No per-caller rate limit here (unlike the HTTP enqueue's ``preview_request_
-    # rate_limit``): the MCP surface is operator-only — every tool call is an
-    # authenticated API-token holder (``_authenticated_user_id`` above), not an
-    # anonymous browser session that could be rotated to multiply a budget — and a
-    # preview is already self-throttling (one CFS-limited ``preview`` worker slot, a
-    # few-second cap, and this call blocks on it), so a token holder cannot outrun the
-    # single slot regardless. The HTTP limiter exists to cap unauthenticated-ish
-    # session churn, which has no analogue on an API-token tool.
+    # rate_limit``): a tool body only runs *after* the verifier authenticated the
+    # token AND authorized the resolved user against ``mcp.access``, so every tool
+    # call is an already-authorized account (``_authenticated_user_id`` above), not
+    # an anonymous browser session that could be rotated to multiply a budget. (The
+    # verifier's *write* path — the match-bind / provision that runs before that
+    # ``mcp.access`` check, on an as-yet-unauthorized caller — IS separately per-IP
+    # rate limited; see ``_provision_ip_rate_limit``. That protects account
+    # creation; it doesn't apply once a caller is a permitted token holder here.)
+    # A preview is also already self-throttling (one CFS-limited ``preview`` worker
+    # slot, a few-second cap, and this call blocks on it), so a token holder cannot
+    # outrun the single slot regardless. The HTTP limiter exists to cap
+    # unauthenticated-ish session churn, which has no analogue on an API-token tool.
     #
     # Wait for the ephemeral job to finish and return the result in this one call
     # (ADR "MCP waits internally with a bounded timeout"). The wait is a blocking

--- a/api/app/rate_limiting.py
+++ b/api/app/rate_limiting.py
@@ -77,7 +77,7 @@ class RedisRateLimiter:
         *,
         rates: list[Rate],
         bucket_key: str,
-        identifier: Callable[[Request], Awaitable[str]],
+        identifier: Callable[[Request], Awaitable[str]] | None = None,
     ):
         self._rates = rates
         self._bucket_key = bucket_key
@@ -88,26 +88,41 @@ class RedisRateLimiter:
     def _reset(self) -> None:
         self._limiters.clear()
 
-    async def __call__(self, request: Request, response: Response) -> None:
-        if _redis is None:
-            return
+    async def check(self, key: str) -> bool:
+        """Consume one token from ``key``'s bucket; ``False`` when it's exhausted.
 
-        rate_key = await self._identifier(request)
+        The reusable core of the limiter, router-free so a non-HTTP caller (the
+        MCP token verifier) can bound a path directly without a ``Request``.
+        Falls **open** (``True``) when Redis is unpublished or unavailable
+        mid-call — matching the dependency's fail-open stance so a Redis outage
+        never wedges the protected path. ``key`` becomes the ZSET suffix, so each
+        distinct key gets its own independent bucket.
+        """
+        if _redis is None:
+            return True
         try:
-            limiter = self._limiters.get(rate_key)
+            limiter = self._limiters.get(key)
             if limiter is None:
                 bucket = await RedisBucket.init(
-                    self._rates, _redis, f"{self._bucket_key}:{rate_key}"
+                    self._rates, _redis, f"{self._bucket_key}:{key}"
                 )
                 limiter = Limiter(bucket)
-                self._limiters[rate_key] = limiter
-
-            success = await limiter.try_acquire_async(rate_key, blocking=False)
+                self._limiters[key] = limiter
+            return await limiter.try_acquire_async(key, blocking=False)
         except redis_asyncio.RedisError:
             # Redis unavailable mid-request: fall open rather than 500ing the
             # protected route (matches the behaviour when _redis is None).
+            return True
+
+    async def __call__(self, request: Request, response: Response) -> None:
+        if _redis is None:
             return
-        if not success:
+        if self._identifier is None:
+            raise RuntimeError(
+                "RedisRateLimiter used as a FastAPI dependency needs an identifier"
+            )
+        rate_key = await self._identifier(request)
+        if not await self.check(rate_key):
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                 detail="Too Many Requests",

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -7,7 +7,6 @@ from datetime import UTC, datetime, timedelta
 from typing import Annotated, Literal
 
 import redis.exceptions
-from coolname import generate_slug
 from fastapi import (
     APIRouter,
     Cookie,
@@ -59,6 +58,7 @@ from app.schemas.session import (
 )
 from app.token_hashing import hash_token
 from app.uniqueness import name_taken
+from app.usernames import generate_username
 
 log = logging.getLogger(__name__)
 
@@ -340,20 +340,6 @@ login_consume_ip_rate_limit = RedisRateLimiter(
 )
 
 
-async def _generate_username(db: AsyncSession) -> str:
-    base = generate_slug(2)
-    result = await db.execute(
-        select(User.username).where(User.username.ilike(f"{base}%", escape="\\"))
-    )
-    taken = {u.lower() for u in result.scalars().all()}
-    if base not in taken:
-        return base
-    suffix = 2
-    while f"{base}-{suffix}" in taken:
-        suffix += 1
-    return f"{base}-{suffix}"
-
-
 def _cookie_secure() -> bool:
     return os.environ.get("SESSION_COOKIE_SECURE", "true").lower() != "false"
 
@@ -502,7 +488,7 @@ async def _load_permissions(db: AsyncSession, user_id: uuid.UUID) -> list[str]:
 
 
 async def _create_session(db: AsyncSession) -> tuple[User, str]:
-    user = User(username=await _generate_username(db))
+    user = User(username=await generate_username(db))
     db.add(user)
     await db.flush()
 

--- a/api/app/sessions.py
+++ b/api/app/sessions.py
@@ -1093,8 +1093,11 @@ async def confirm_email(
     """Consume an email-change token: stamp the new email + ``confirmed_at``.
 
     Invariant: ``user.email`` holds the prior confirmed address; the new
-    address lives on ``token.sent_to`` until this endpoint runs. This is
-    the single place either column flips.
+    address lives on ``token.sent_to`` until this endpoint runs. This is one of
+    two places either column flips — the other is
+    ``auth0_provisioning._provision_user``, which stamps ``email`` +
+    ``confirmed_at`` together on a first-seen verified Auth0 email — so both
+    writers preserve the same invariant (email set ⇒ account confirmed).
 
     The token in the email is itself the bearer credential — we don't
     require the click to come from the same browser that requested it.
@@ -1286,9 +1289,10 @@ async def request_login_email(
 
     await _verify_captcha_or_400(payload.captcha_token)
 
-    # ``users.email`` is only ever set by ``confirm_email`` (alongside
-    # ``confirmed_at``), so an address lookup can only ever match a confirmed
-    # account — there is no unconfirmed-user branch to handle here.
+    # ``users.email`` is only ever set by ``confirm_email`` or
+    # ``auth0_provisioning._provision_user``, and both stamp ``confirmed_at``
+    # alongside it — so an address lookup can only ever match a confirmed account,
+    # and there is no unconfirmed-user branch to handle here.
     user = (
         await db.execute(select(User).where(User.email == email))
     ).scalar_one_or_none()

--- a/api/app/usernames.py
+++ b/api/app/usernames.py
@@ -1,0 +1,32 @@
+"""Username-slug generation, router-free so any provisioning path can import it.
+
+Deliberately free of FastAPI imports (just SQLAlchemy ``AsyncSession`` +
+``coolname`` + the ``User`` model) so both the cookie-session mint in
+``app.sessions`` and the Auth0-provisioning path can share one generator without
+dragging in the heavy session router or risking an import cycle.
+"""
+
+from coolname import generate_slug
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import User
+
+
+async def generate_username(db: AsyncSession) -> str:
+    """Return a fresh, unique two-word slug username (e.g. ``brave-otter``).
+
+    Generates a ``coolname`` two-word slug and, if it (case-insensitively)
+    collides with an existing username, appends the lowest free ``-N`` suffix.
+    """
+    base = generate_slug(2)
+    result = await db.execute(
+        select(User.username).where(User.username.ilike(f"{base}%", escape="\\"))
+    )
+    taken = {u.lower() for u in result.scalars().all()}
+    if base not in taken:
+        return base
+    suffix = 2
+    while f"{base}-{suffix}" in taken:
+        suffix += 1
+    return f"{base}-{suffix}"

--- a/api/tests/test_auth0_provisioning.py
+++ b/api/tests/test_auth0_provisioning.py
@@ -231,3 +231,54 @@ async def test_concurrent_insert_reresolves_to_winner(
         await db_session.execute(select(func.count()).where(User.email == email))
     ).scalar_one()
     assert matches == 1
+
+
+async def test_match_branch_reresolves_on_concurrent_sub_bind(
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The *match* branch binds ``sub`` to an email-matched account, but a
+    concurrent bind (e.g. a manual ``/auth0/link`` in flight) binds the same
+    ``sub`` to a *different* row first. The branch's commit then hits the unique
+    ``users.auth0_sub`` constraint (``IntegrityError``): it must roll back and
+    re-resolve to the winning row instead of letting the error propagate.
+
+    The race is staged by patching ``_resolve_live_user_by_email`` — called at the
+    top of the match branch, before its commit — to commit a competing row that
+    binds the same ``sub`` to a different user on a separate session first.
+    """
+    sub = _sub()
+    email = "match-race@example.com"
+    # The email-matched account the branch will try to bind (``auth0_sub`` still
+    # ``None``, so it takes the bind branch).
+    matched_user = await _make_user(db_session, "match-race-target", email=email)
+
+    import app.auth0_provisioning as prov
+
+    real_resolve = prov._resolve_live_user_by_email
+    raced = {"done": False}
+
+    async def racing_resolve(db: AsyncSession, e: str) -> User | None:
+        result = await real_resolve(db, e)
+        if not raced["done"]:
+            raced["done"] = True
+            # A concurrent bind of the SAME ``sub`` to a DIFFERENT row wins first,
+            # committed on a separate connection mid-branch.
+            sm = async_sessionmaker(engine, expire_on_commit=False)
+            async with sm() as other:
+                other.add(User(username="sub-race-winner", auth0_sub=sub))
+                await other.commit()
+        return result
+
+    monkeypatch.setattr(prov, "_resolve_live_user_by_email", racing_resolve)
+    resolved = await resolve_or_provision_user(db_session, sub, email, True)
+
+    # Re-resolved cleanly to the concurrent winner (via ``resolve_linked_user``),
+    # not a raised IntegrityError.
+    assert resolved is not None
+    assert resolved.username == "sub-race-winner"
+    assert resolved.auth0_sub == sub
+    # The email-matched row's bind was rolled back — it never took the ``sub``.
+    await db_session.refresh(matched_user)
+    assert matched_user.auth0_sub is None

--- a/api/tests/test_auth0_provisioning.py
+++ b/api/tests/test_auth0_provisioning.py
@@ -1,0 +1,233 @@
+"""Unit tests for ``resolve_or_provision_user`` — the match/provision half of
+the MCP Auth0 identity resolution (ADR
+``20260722-mcp-accounts-auto-provision-and-match-by-verified-auth0-email``).
+
+Every branch is exercised directly against a real ``db_session`` (no HTTP/token
+framing — that lives in the MCP verifier, chore 1c):
+
+- linked ``sub`` → the existing linked user (email irrelevant);
+- match, unlinked → binds ``sub`` and returns the user;
+- match is case-insensitive;
+- match conflict (different ``auth0_sub``) → ``None``, no hijack;
+- provision (first-seen verified email) → confirmed account with the default role;
+- ``email_verified`` false / ``email`` missing → ``None``, no write;
+- a concurrent-insert ``IntegrityError`` re-resolves to the winning row.
+
+``default_role`` and ``default_league`` are autouse fixtures in ``conftest``, so
+provision has both the role to grant and the league to join.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from app.auth0_provisioning import (
+    AUTH0_EMAIL_CLAIM,
+    AUTH0_EMAIL_VERIFIED_CLAIM,
+    resolve_or_provision_user,
+)
+from app.models import Role, User, UserRole
+from app.roles import DEFAULT_ROLE_NAME
+
+
+def _sub() -> str:
+    return "auth0|" + uuid.uuid4().hex
+
+
+async def _make_user(
+    db: AsyncSession,
+    username: str,
+    *,
+    email: str | None = None,
+    auth0_sub: str | None = None,
+) -> User:
+    user = User(username=username, email=email, auth0_sub=auth0_sub)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _user_count(db: AsyncSession) -> int:
+    return (await db.execute(select(func.count()).select_from(User))).scalar_one()
+
+
+async def _holds_default_role(db: AsyncSession, user_id: uuid.UUID) -> bool:
+    result = await db.execute(
+        select(UserRole.user_id)
+        .join(Role, Role.id == UserRole.role_id)
+        .where(UserRole.user_id == user_id, Role.name == DEFAULT_ROLE_NAME)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+def test_claim_key_constants_are_namespaced() -> None:
+    # Chore 1c imports exactly these; they must match the Auth0 Action doc.
+    assert AUTH0_EMAIL_CLAIM == "https://fortymm.com/email"
+    assert AUTH0_EMAIL_VERIFIED_CLAIM == "https://fortymm.com/email_verified"
+
+
+async def test_linked_sub_returns_existing_user(db_session: AsyncSession) -> None:
+    sub = _sub()
+    user = await _make_user(db_session, "linked", auth0_sub=sub)
+
+    # Email args are irrelevant once the sub already resolves.
+    resolved = await resolve_or_provision_user(
+        db_session, sub, "someone-else@example.com", True
+    )
+
+    assert resolved is not None
+    assert resolved.id == user.id
+
+
+async def test_match_unlinked_binds_sub(db_session: AsyncSession) -> None:
+    sub = _sub()
+    user = await _make_user(db_session, "matcher", email="matcher@example.com")
+
+    resolved = await resolve_or_provision_user(
+        db_session, sub, "matcher@example.com", True
+    )
+
+    assert resolved is not None
+    assert resolved.id == user.id
+    assert resolved.auth0_sub == sub
+
+
+async def test_match_is_case_insensitive(db_session: AsyncSession) -> None:
+    sub = _sub()
+    user = await _make_user(db_session, "caser", email="case@example.com")
+
+    resolved = await resolve_or_provision_user(
+        db_session, sub, "CASE@EXAMPLE.COM", True
+    )
+
+    assert resolved is not None
+    assert resolved.id == user.id
+    assert resolved.auth0_sub == sub
+
+
+async def test_match_conflict_returns_none_and_does_not_hijack(
+    db_session: AsyncSession,
+) -> None:
+    existing_sub = _sub()
+    other_sub = _sub()
+    user = await _make_user(
+        db_session, "linked-email", email="taken@example.com", auth0_sub=existing_sub
+    )
+
+    resolved = await resolve_or_provision_user(
+        db_session, other_sub, "taken@example.com", True
+    )
+
+    assert resolved is None
+    await db_session.refresh(user)
+    # The pre-existing link is left intact — no takeover.
+    assert user.auth0_sub == existing_sub
+
+
+async def test_provision_creates_confirmed_user_with_default_role(
+    db_session: AsyncSession,
+) -> None:
+    sub = _sub()
+
+    resolved = await resolve_or_provision_user(
+        db_session, sub, "fresh@example.com", True
+    )
+
+    assert resolved is not None
+    assert resolved.email == "fresh@example.com"
+    assert resolved.auth0_sub == sub
+    assert resolved.confirmed_at is not None
+    # A ``DateTime(timezone=True)`` column must yield an aware datetime.
+    assert resolved.confirmed_at.tzinfo is not None
+    assert resolved.username  # a coolname slug, not derived from the email
+    assert "fresh" not in resolved.username
+    assert await _holds_default_role(db_session, resolved.id)
+
+
+async def test_provision_lowercases_the_stored_email(
+    db_session: AsyncSession,
+) -> None:
+    sub = _sub()
+
+    resolved = await resolve_or_provision_user(
+        db_session, sub, "Mixed.Case@Example.COM", True
+    )
+
+    assert resolved is not None
+    assert resolved.email == "mixed.case@example.com"
+
+
+async def test_email_verified_false_provisions_nothing(
+    db_session: AsyncSession,
+) -> None:
+    before = await _user_count(db_session)
+
+    resolved = await resolve_or_provision_user(
+        db_session, _sub(), "unverified@example.com", False
+    )
+
+    assert resolved is None
+    assert await _user_count(db_session) == before
+
+
+async def test_email_none_returns_none(db_session: AsyncSession) -> None:
+    before = await _user_count(db_session)
+
+    resolved = await resolve_or_provision_user(db_session, _sub(), None, True)
+
+    assert resolved is None
+    assert await _user_count(db_session) == before
+
+
+async def test_concurrent_insert_reresolves_to_winner(
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A near-simultaneous request wins the INSERT first; the loser's flush hits
+    the unique constraint (``IntegrityError``), rolls back, and re-resolves to
+    the winning row instead of raising.
+
+    The race is staged by patching ``generate_username`` — called mid-provision,
+    before the flush — to commit a competing row (same email + sub) on a
+    separate session first.
+    """
+    sub = _sub()
+    email = "race@example.com"
+
+    async def racing_generate_username(db: AsyncSession) -> str:
+        # Commit the winning row on a separate connection, mid-provision, so the
+        # in-flight provision's own flush collides on the unique constraints.
+        sm = async_sessionmaker(engine, expire_on_commit=False)
+        async with sm() as other:
+            other.add(
+                User(
+                    username="race-winner",
+                    email=email,
+                    auth0_sub=sub,
+                    confirmed_at=datetime.now(UTC),
+                )
+            )
+            await other.commit()
+        return "race-loser"
+
+    # ``resolve_or_provision_user`` calls the name it imported into this module,
+    # so patch it there.
+    monkeypatch.setattr(
+        "app.auth0_provisioning.generate_username", racing_generate_username
+    )
+    resolved = await resolve_or_provision_user(db_session, sub, email, True)
+
+    assert resolved is not None
+    # The winner's row, not a freshly raised error or a duplicate.
+    assert resolved.username == "race-winner"
+    assert resolved.auth0_sub == sub
+    # Exactly one account holds the raced email.
+    matches = (
+        await db_session.execute(select(func.count()).where(User.email == email))
+    ).scalar_one()
+    assert matches == 1

--- a/api/tests/test_auth0_provisioning_convergence.py
+++ b/api/tests/test_auth0_provisioning_convergence.py
@@ -1,0 +1,168 @@
+"""Both-directions convergence guard for the ADR's Decision-2 (ADR
+``20260722-mcp-accounts-auto-provision-and-match-by-verified-auth0-email``,
+"The reverse-order convergence reuses existing merge machinery, not new code").
+
+For one verified email, whichever surface a human touches first — the MCP agent
+(``resolve_or_provision_user``) or the website magic-link — the *other* surface
+must fold onto the SAME single FortyMM account, never spawn a second one:
+
+- **Direction A — agent first, then website.** The agent provisions account A on
+  the email; a later website guest who enters that (now-confirmed) address is
+  offered the existing account-**merge** token — so the guest is tombstoned into
+  A rather than a duplicate being made.
+- **Direction B — website first, then agent.** A guest confirms the address the
+  normal magic-link way (no ``auth0_sub``); the agent's later verified token
+  *matches* that account and binds its ``sub`` — no new row.
+
+The discriminating invariant asserted in both directions: exactly **one live**
+(non-tombstoned) user holds the email, and it is A. A regression that created a
+second account for the address instead of folding/binding turns these red.
+
+Direction A drives the real HTTP merge-confirm flow (``POST /v1/me/email`` →
+merge token → ``POST /v1/me/email/confirm``), reusing ``test_email``'s helpers so
+this exercises the exact machinery the ADR points at, not a shortcut.
+"""
+
+from collections.abc import AsyncIterator
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth0_provisioning import resolve_or_provision_user
+from app.db import get_session
+from app.main import app
+from app.models import User
+from tests._helpers import CSRF_EVENT_HOOKS, start_session
+from tests.test_email import _capture_raw_token, _finished_send_jobs
+
+CONVERGE_EMAIL = "converge@example.com"
+
+
+@pytest_asyncio.fixture
+async def api_client(db_session: AsyncSession) -> AsyncIterator[AsyncClient]:
+    async def _override() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    app.dependency_overrides[get_session] = _override
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="https://testserver",
+        event_hooks=CSRF_EVENT_HOOKS,
+    ) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+async def _live_users_for_email(db: AsyncSession, email: str) -> list[User]:
+    """Every non-tombstoned user holding ``email`` — the convergence invariant is
+    that this list is exactly one entry long."""
+    return list(
+        (
+            await db.execute(
+                select(User).where(
+                    User.email == email,
+                    User.merged_into_user_id.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def _user_count(db: AsyncSession) -> int:
+    return (await db.execute(select(func.count()).select_from(User))).scalar_one()
+
+
+async def test_direction_a_agent_then_website_converges_on_one_account(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+) -> None:
+    """Agent provisions A; a later website guest folds into A via the merge
+    token. Ends with one live account (A) holding the email."""
+    # 1. Agent-first: the MCP resolve/provision path mints a confirmed account A
+    #    bound to auth0|A.
+    account_a = await resolve_or_provision_user(
+        db_session, "auth0|A", CONVERGE_EMAIL, True
+    )
+    assert account_a is not None
+    assert account_a.confirmed_at is not None
+    assert account_a.auth0_sub == "auth0|A"
+    a_id = account_a.id
+
+    # 2. A *separate* website guest signs in and enters the same address.
+    guest = await start_session(api_client, db_session)
+    assert guest.id != a_id
+    # ``set_email`` sees the address is owned by a confirmed account and, because
+    # the guest holds no confirmed email of their own, issues a MERGE token (to
+    # A) rather than an email-change token. Capture it out of the enqueued email.
+    raw_token = await _capture_raw_token(
+        api_client, db_session, fake_email_queue, email=CONVERGE_EMAIL
+    )
+    # It must be the merge email — proves we're on the fold-together path, not a
+    # plain email-change confirm.
+    assert _finished_send_jobs(fake_email_queue)[-1].func_name == (
+        "app.email.send_merge_email"
+    )
+
+    # 3. Consume the merge token: folds the guest into A and signs the browser in
+    #    as A (the exact end-to-end machinery test_email's merge tests drive).
+    response = await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["user"]["email"] == CONVERGE_EMAIL
+
+    # Convergence: the guest is tombstoned INTO A...
+    await db_session.refresh(guest)
+    assert guest.merged_into_user_id == a_id
+    # ...exactly one live user holds the email, and it is A, still bound to
+    # auth0|A. A regression that made a duplicate would push this count to 2.
+    live = await _live_users_for_email(db_session, CONVERGE_EMAIL)
+    assert len(live) == 1
+    assert live[0].id == a_id
+    assert live[0].email == CONVERGE_EMAIL
+    assert live[0].auth0_sub == "auth0|A"
+
+
+async def test_direction_b_website_then_agent_binds_to_one_account(
+    api_client: AsyncClient, db_session: AsyncSession, fake_email_queue
+) -> None:
+    """A website guest confirms the address the normal way (no auth0_sub); a
+    later agent token matches that account and binds its sub — no duplicate."""
+    # 1. Website-first: a guest confirms the address via the magic-link flow,
+    #    producing a confirmed account A that holds no auth0_sub.
+    guest = await start_session(api_client, db_session)
+    raw_token = await _capture_raw_token(
+        api_client, db_session, fake_email_queue, email=CONVERGE_EMAIL
+    )
+    response = await api_client.post("/v1/me/email/confirm", json={"token": raw_token})
+    assert response.status_code == 200, response.text
+    await db_session.refresh(guest)
+    account_a = guest
+    assert account_a.email == CONVERGE_EMAIL
+    assert account_a.confirmed_at is not None
+    assert account_a.auth0_sub is None
+    a_id = account_a.id
+
+    live_before = await _live_users_for_email(db_session, CONVERGE_EMAIL)
+    assert len(live_before) == 1
+    users_before = await _user_count(db_session)
+
+    # 2. Agent connects: a verified Auth0 token for the same address.
+    resolved = await resolve_or_provision_user(
+        db_session, "auth0|B", CONVERGE_EMAIL, True
+    )
+
+    # 3. It MATCHES A (same id) and binds the sub — no new row is inserted.
+    assert resolved is not None
+    assert resolved.id == a_id
+    await db_session.refresh(account_a)
+    assert account_a.auth0_sub == "auth0|B"
+    # No account was duplicated: the total row count is unchanged and exactly one
+    # live user still holds the email — A. A regression that provisioned a second
+    # account would grow both counts.
+    assert await _user_count(db_session) == users_before
+    live_after = await _live_users_for_email(db_session, CONVERGE_EMAIL)
+    assert len(live_after) == 1
+    assert live_after[0].id == a_id

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -48,6 +48,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import queue as queue_module
 from app.admin_schedule_solves import SCHEDULING_VIEW_PERMISSION
+from app.auth0_provisioning import AUTH0_EMAIL_CLAIM, AUTH0_EMAIL_VERIFIED_CLAIM
 from app.main import app as fastapi_app
 from app.main import mcp, mcp_app
 from app.mcp_server import (
@@ -150,13 +151,25 @@ def _sign_token(
     iss: str = ISSUER,
     private_pem: str | None = None,
     expires_in: int = 300,
+    extra_claims: dict[str, object] | None = None,
 ) -> str:
     """Sign an RS256 access token for ``sub`` — the credential an agent presents
     to the MCP transport. Defaults to the tenant key + right issuer/audience; the
-    knobs reach the wrong-``aud`` / wrong-``iss`` / bad-signature rejection cases."""
+    knobs reach the wrong-``aud`` / wrong-``iss`` / bad-signature rejection cases.
+    ``extra_claims`` merges in the namespaced email claims the Auth0 Action ships,
+    exercising the resolve-or-provision (match-by-verified-email) path."""
     now = int(time.time())
+    claims: dict[str, object] = {
+        "sub": sub,
+        "aud": aud,
+        "iss": iss,
+        "iat": now,
+        "exp": now + expires_in,
+    }
+    if extra_claims is not None:
+        claims.update(extra_claims)
     return jwt.encode(
-        {"sub": sub, "aud": aud, "iss": iss, "iat": now, "exp": now + expires_in},
+        claims,
         private_pem or _PRIVATE_PEM,
         algorithm="RS256",
         headers={"kid": KID},
@@ -351,6 +364,90 @@ async def test_tombstoned_linked_users_token_is_rejected(
 
     async with _mcp_client(token) as client:
         await _assert_rejected(client)
+
+
+def _email_verifier() -> FortymmAuth0TokenVerifier:
+    """A ``FortymmAuth0TokenVerifier`` keyed to the test static key, for calling
+    ``verify_token`` directly — so a test can assert on the minted ``AccessToken``
+    (its ``user_id`` claim) rather than only that the transport handshake 200s."""
+    return FortymmAuth0TokenVerifier(
+        public_key=_PUBLIC_PEM,
+        issuer=ISSUER,
+        audience=AUDIENCE,
+        algorithm="RS256",
+    )
+
+
+async def test_verified_email_matches_unlinked_mcp_account_and_authorizes(
+    db_session: AsyncSession,
+) -> None:
+    """A verified token whose ``sub`` is UNLINKED but whose verified email matches an
+    existing account holding ``mcp.access`` resolves through
+    ``resolve_or_provision_user``: the verifier binds the ``sub`` and mints an
+    ``AccessToken`` carrying that account's id under the ``user_id`` claim — the
+    match path authorizes end-to-end without a manual link step."""
+    user = await make_user(db_session, "mcp-email-match-owner")
+    user.email = "match-me@example.com"
+    await db_session.commit()
+    await _grant_mcp_access(db_session, user)
+    # A brand-new Auth0 subject, linked to nobody — it can only resolve via the
+    # verified-email match below.
+    sub = "auth0|" + uuid.uuid4().hex
+    token = _sign_token(
+        sub=sub,
+        extra_claims={
+            AUTH0_EMAIL_CLAIM: "match-me@example.com",
+            AUTH0_EMAIL_VERIFIED_CLAIM: True,
+        },
+    )
+
+    access = await _email_verifier().verify_token(token)
+
+    assert access is not None
+    assert access.claims["user_id"] == str(user.id)
+
+
+async def test_unverified_or_absent_email_is_rejected(
+    db_session: AsyncSession,
+) -> None:
+    """The same unlinked ``sub`` + matchable ``mcp.access`` account, but with the
+    email UNVERIFIED (``email_verified: false``) — and, separately, with the email
+    claim ABSENT — resolves to ``None`` (→ 401): the JWT signature is valid, yet we
+    never match or provision off an address the caller hasn't proven they control."""
+    user = await make_user(db_session, "mcp-email-unverified-owner")
+    user.email = "unverified@example.com"
+    await db_session.commit()
+    await _grant_mcp_access(db_session, user)
+    sub = "auth0|" + uuid.uuid4().hex
+
+    unverified = _sign_token(
+        sub=sub,
+        extra_claims={
+            AUTH0_EMAIL_CLAIM: "unverified@example.com",
+            AUTH0_EMAIL_VERIFIED_CLAIM: False,
+        },
+    )
+    no_email = _sign_token(sub=sub)
+
+    verifier = _email_verifier()
+    assert await verifier.verify_token(unverified) is None
+    assert await verifier.verify_token(no_email) is None
+
+
+async def test_linked_sub_still_authorizes_via_verify_token(
+    db_session: AsyncSession,
+) -> None:
+    """The pre-existing LINKED-``sub`` path is unchanged by resolve-or-provision: a
+    linked + permitted user's token still mints an ``AccessToken`` carrying that
+    user's id under ``user_id`` — resolved by the linked ``sub`` alone, with no email
+    claim present."""
+    user = await make_user(db_session, "mcp-linked-still-owner")
+    token = await _mint(db_session, user)
+
+    access = await _email_verifier().verify_token(token)
+
+    assert access is not None
+    assert access.claims["user_id"] == str(user.id)
 
 
 def test_partial_auth0_config_yields_reject_all_verifier(

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -42,10 +42,13 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
 from fastmcp.exceptions import ToolError
+from pyrate_limiter import Duration, Rate
 from rq import Queue
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.requests import Request
 
+from app import mcp_server
 from app import queue as queue_module
 from app.admin_schedule_solves import SCHEDULING_VIEW_PERMISSION
 from app.auth0_provisioning import AUTH0_EMAIL_CLAIM, AUTH0_EMAIL_VERIFIED_CLAIM
@@ -79,6 +82,7 @@ from app.models import (
     UserRole,
 )
 from app.models.tournament import DrawType, EventFormat
+from app.rate_limiting import RedisRateLimiter
 from app.tournament_draws import cut_draw
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_ENTER, TOURNAMENT_VIEW
 from tests._helpers import (
@@ -448,6 +452,98 @@ async def test_linked_sub_still_authorizes_via_verify_token(
 
     assert access is not None
     assert access.claims["user_id"] == str(user.id)
+
+
+def _pin_client_ip(monkeypatch: pytest.MonkeyPatch, host: str) -> None:
+    """Make ``mcp_server.get_http_request()`` (which the verifier reads the client
+    IP off) return a request whose ``client.host`` is ``host``.
+
+    ``get_http_request()`` IS populated during ``verify_token`` under the real
+    transport (probed), but a direct ``verify_token`` call has no live request, so
+    the write path would otherwise key every call to the ``"unknown"`` fallback
+    bucket. Pinning it lets a test drive the per-IP limiter deterministically."""
+    request = Request({"type": "http", "client": (host, 12345), "headers": []})
+    monkeypatch.setattr(mcp_server, "get_http_request", lambda: request)
+
+
+async def test_write_path_is_rate_limited_per_ip(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unlinked-but-verified tokens from one IP that MATCH ``mcp.access`` accounts
+    authorize (the write/match path binds each ``sub``) — until the per-IP provision
+    ceiling is hit, after which the next such token is refused (``verify_token`` →
+    ``None``) with no ``sub`` bound. The verifier calls the module-level limiter, so
+    monkeypatching it to a small rate exercises the real wiring fast."""
+    _pin_client_ip(monkeypatch, "203.0.113.7")
+    limit = 3
+    monkeypatch.setattr(
+        mcp_server,
+        "_provision_ip_rate_limit",
+        RedisRateLimiter(
+            rates=[Rate(limit, Duration.HOUR)],
+            bucket_key="mcp-provision-ip-test-limited",
+        ),
+    )
+
+    # ``limit + 1`` distinct matchable accounts (each verified email → its own
+    # unlinked ``sub``), all reachable only via the write/match path.
+    accounts = []
+    for i in range(limit + 1):
+        user = await make_user(db_session, f"mcp-ratelimit-{i}")
+        user.email = f"ratelimit-{i}@example.com"
+        await db_session.commit()
+        await _grant_mcp_access(db_session, user)
+        sub = "auth0|" + uuid.uuid4().hex
+        token = _sign_token(
+            sub=sub,
+            extra_claims={
+                AUTH0_EMAIL_CLAIM: user.email,
+                AUTH0_EMAIL_VERIFIED_CLAIM: True,
+            },
+        )
+        accounts.append((user, sub, token))
+
+    verifier = _email_verifier()
+    # The first ``limit`` write-path tokens match + bind + authorize.
+    for user, _sub, token in accounts[:limit]:
+        access = await verifier.verify_token(token)
+        assert access is not None
+        assert access.claims["user_id"] == str(user.id)
+
+    # The next is rate limited BEFORE the write: rejected, and its ``sub`` unbound.
+    over_user, over_sub, over_token = accounts[limit]
+    assert await verifier.verify_token(over_token) is None
+    await db_session.refresh(over_user)
+    assert over_user.auth0_sub is None
+
+
+async def test_linked_hot_path_is_not_rate_limited(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The already-linked hot path skips the limiter entirely: with the provision
+    ceiling pinned to an impossibly tight 1/hour, a single linked + permitted user's
+    token authorizes many times over from one IP — proving the steady-state read
+    path is never charged against the write-path budget."""
+    _pin_client_ip(monkeypatch, "203.0.113.9")
+    monkeypatch.setattr(
+        mcp_server,
+        "_provision_ip_rate_limit",
+        RedisRateLimiter(
+            rates=[Rate(1, Duration.HOUR)],
+            bucket_key="mcp-provision-ip-test-hot",
+        ),
+    )
+
+    user = await make_user(db_session, "mcp-hotpath-owner")
+    token = await _mint(db_session, user)
+
+    verifier = _email_verifier()
+    for _ in range(5):
+        access = await verifier.verify_token(token)
+        assert access is not None
+        assert access.claims["user_id"] == str(user.id)
 
 
 def test_partial_auth0_config_yields_reject_all_verifier(

--- a/docs/adr/20260722-mcp-accounts-auto-provision-and-match-by-verified-auth0-email.md
+++ b/docs/adr/20260722-mcp-accounts-auto-provision-and-match-by-verified-auth0-email.md
@@ -77,6 +77,11 @@ Two trust/convergence points this rests on:
   token for a new identity — where previously verification was pure. It is
   first-token-only per `sub`; every later token resolves the now-linked user with
   no write.
+- **The write path is per-IP rate limited** (the match-bind / provision happens on
+  an as-yet-unauthorized caller, before the `mcp.access` check). The steady-state
+  linked-user read path is resolved first and is *not* limited, so a real agent is
+  never throttled; only the first-token write is bounded per client IP so a stream
+  of freshly-minted verified-email identities from one source can't spray accounts.
 - **Dead until an Auth0 Action ships `email` + `email_verified` on the MCP access
   token.** Custom-API tokens carry no profile claims by default; without the
   Action every unlinked token hits step 3 and 401s. Auth0 drops non-namespaced

--- a/docs/adr/20260722-mcp-accounts-auto-provision-and-match-by-verified-auth0-email.md
+++ b/docs/adr/20260722-mcp-accounts-auto-provision-and-match-by-verified-auth0-email.md
@@ -1,0 +1,89 @@
+# MCP accounts auto-provision and match by verified Auth0 email
+
+Date: 2026-07-22 (date-numbered — sequential numbers collide across concurrent
+worktrees; see the note in
+`20260718-the-match-flow-is-shared-services-behind-http-and-mcp-adapters.md`)
+
+## Status
+
+Accepted — from GitHub issue #1157.
+
+**Supersedes decision #4** of
+`20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0.md`
+("Identity is bound by an explicit, in-session link — not email-matching or
+auto-provisioning"). That ADR's other decisions stand unchanged: Auth0 is still
+authentication-only, authorization is still fortymm RBAC gated by `mcp.access`
+(#3/#5), the verifier is still a stateless `RemoteAuthProvider`/`JWTVerifier`
+(#1/#2), and the in-session link flow (`/v1/auth0/link/*`) is **kept** as a
+second, still-valid way to bind an identity. Only the "explicit link is the
+*only* way in, we store `sub` only, no email" stance is reversed here.
+
+## Context
+
+The explicit in-session link step assumed every agent user already has a
+confirmed-email fortymm account to link. That fights fortymm's ephemeral-account
+model: most accounts start as anonymous guests with no email, so "match a
+verified Auth0 email to an existing account" usually has nothing to match, and
+the manual `/settings → Agent access → Connect` step is friction on top. The
+goal is "add the connector, log in, done" — zero human steps.
+
+## Decision
+
+**At MCP token time, resolve an unlinked but verified token by matching or
+provisioning a fortymm account on its verified email.** When the verifier
+(`FortymmAuth0TokenVerifier`) has a valid Auth0 token whose `sub` is not yet
+linked, it reads the token's `email` / `email_verified` claims and:
+
+1. **`sub` already linked** → the existing linked user (unchanged from #4).
+2. **`sub` unlinked, `email` present and `email_verified` true:**
+   - **an existing live account holds that `email`** (case-insensitive) → bind
+     `auth0_sub` to it and return it (**match**);
+   - **no account holds it** → create a *registered* account — coolname-slug
+     username (**not** derived from the email; usernames are public), `email`
+     set, `confirmed_at` stamped, `auth0_sub` bound, plus the same default role +
+     default league every account gets — and return it (**provision**).
+3. **no `email`, or `email_verified` false** → `None` (401). We never match or
+   provision off an address the caller hasn't proven they control.
+
+The `mcp.access` authorization check (#3/#5 of the prior ADR) runs unchanged on
+whatever user comes back. A freshly provisioned account holds only the default
+role, so during bring-up it 401s at that check until `mcp.access` is widened to
+the default `User` role (a later, out-of-scope seed change); a matched
+pre-existing Beta-tester account works immediately. So this ADR removes the
+account/link friction now and becomes truly zero-step the moment `mcp.access`
+moves to the default role.
+
+Two trust/convergence points this rests on:
+
+- **A verified Auth0 email is trusted as equivalent to fortymm's own magic-link
+  inbox-proof.** Both establish only "the caller controls this inbox," which is
+  exactly the bar fortymm's magic-link sign-in already sets — so a provisioned
+  account is born `confirmed_at`-stamped rather than half-real, and matching an
+  existing account carries no more takeover risk than a magic-link login to it
+  would. This holds only for Auth0 connections whose `email_verified` is
+  meaningful (a DB connection's verify-link, or a trusted social IdP); a
+  connection that asserts `email_verified` without verifying must not be enabled.
+- **The reverse-order convergence reuses existing merge machinery, not new
+  code.** Magic-link-then-agent converges via the match step above;
+  agent-then-magic-link converges because the email-confirm flow already sees the
+  address is taken and folds the two accounts together (`account_merge`, which
+  already move-or-nulls `auth0_sub` onto the survivor). `users.email` /
+  `users.auth0_sub` uniqueness is the backstop for the near-simultaneous race
+  (loser re-resolves). An explicit both-directions test guards this.
+
+## Consequences
+
+- **The MCP verifier now writes to the DB** (a bind, or an INSERT) on the first
+  token for a new identity — where previously verification was pure. It is
+  first-token-only per `sub`; every later token resolves the now-linked user with
+  no write.
+- **Dead until an Auth0 Action ships `email` + `email_verified` on the MCP access
+  token.** Custom-API tokens carry no profile claims by default; without the
+  Action every unlinked token hits step 3 and 401s. Auth0 drops non-namespaced
+  custom claims, so the verifier reads them under the namespaced keys
+  `https://fortymm.com/email` and `https://fortymm.com/email_verified`. The Action
+  is Auth0-dashboard config — documented in `docs/auth0-mcp-email-claims-action.md`
+  (the exact JS + install steps), but not automated here.
+- **A user whose Auth0 login email differs from their existing fortymm email gets
+  a second account** (we can't know they're the same person); they can merge later
+  via magic-link. Accepted, not fixed.

--- a/docs/auth0-mcp-email-claims-action.md
+++ b/docs/auth0-mcp-email-claims-action.md
@@ -1,0 +1,68 @@
+# Auth0 Action: email claims on the MCP access token
+
+The MCP auto-provision/match feature (issue #1157, ADR
+`20260722-mcp-accounts-auto-provision-and-match-by-verified-auth0-email.md`)
+needs the agent's Auth0 **access token** to carry the caller's email and its
+verified flag. A custom-API access token does **not** carry profile claims by
+default, so without the Action below every unlinked token is refused (401) and no
+account is ever provisioned or matched.
+
+## The claim keys the verifier reads
+
+Auth0 **silently drops non-namespaced custom claims**, so these must be namespaced
+URLs — they cannot be bare `email` / `email_verified`. The FortyMM MCP verifier
+reads exactly these two keys off the verified access token:
+
+| Claim key | Value |
+| --- | --- |
+| `https://fortymm.com/email` | the user's email address (string) |
+| `https://fortymm.com/email_verified` | whether Auth0 has verified it (boolean) |
+
+If you change the namespace here, you must change the constants the verifier reads
+(`app/auth0_provisioning.py`) in the same breath, or the feature goes dark.
+
+## The Action
+
+In the Auth0 dashboard: **Actions → Library → Create Action** (or **Triggers →
+Login / post-login → Add Action → Build from scratch**). Name it e.g.
+`mcp-email-claims`, trigger **Login / Post Login**, and paste:
+
+```js
+/**
+ * Add the caller's email + verified flag to the access token so the FortyMM MCP
+ * Resource Server can auto-provision / match a FortyMM account by verified email.
+ * Auth0 drops non-namespaced custom claims, so both keys are namespaced.
+ */
+exports.onExecutePostLogin = async (event, api) => {
+  const NS = 'https://fortymm.com';
+  if (event.user.email) {
+    api.accessToken.setCustomClaim(`${NS}/email`, event.user.email);
+    api.accessToken.setCustomClaim(
+      `${NS}/email_verified`,
+      event.user.email_verified === true,
+    );
+  }
+};
+```
+
+Then **Deploy** the Action and, in the **Login / Post Login** trigger flow, drag
+it into the flow and **Apply** so it runs on every login.
+
+### Optional: scope the claims to the MCP API only
+
+The Action above sets the claims on every access token the tenant issues. FortyMM
+only uses this tenant for the MCP API, so that's harmless. If you later add other
+APIs and want to avoid putting email on their tokens, guard on the requested
+audience — but note the post-login trigger does not always expose the requested
+resource-server identifier, so test before relying on it.
+
+## Verifying it works end to end
+
+1. Deploy + apply the Action.
+2. On UAT, add the FortyMM MCP server as an OAuth connector in an agent host and
+   log in with a verified email.
+3. Decode the issued access token (jwt.io) and confirm it carries
+   `https://fortymm.com/email` and `https://fortymm.com/email_verified: true`.
+4. A first-time email should now auto-provision a FortyMM account; a matching
+   email should bind to the existing one. An account holding `mcp.access` can then
+   call tools.

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -63,8 +63,11 @@ internal protocol APIProtocol: Sendable {
     /// Consume an email-change token: stamp the new email + ``confirmed_at``.
     ///
     /// Invariant: ``user.email`` holds the prior confirmed address; the new
-    /// address lives on ``token.sent_to`` until this endpoint runs. This is
-    /// the single place either column flips.
+    /// address lives on ``token.sent_to`` until this endpoint runs. This is one of
+    /// two places either column flips — the other is
+    /// ``auth0_provisioning._provision_user``, which stamps ``email`` +
+    /// ``confirmed_at`` together on a first-seen verified Auth0 email — so both
+    /// writers preserve the same invariant (email set ⇒ account confirmed).
     ///
     /// The token in the email is itself the bearer credential — we don't
     /// require the click to come from the same browser that requested it.
@@ -1077,8 +1080,11 @@ extension APIProtocol {
     /// Consume an email-change token: stamp the new email + ``confirmed_at``.
     ///
     /// Invariant: ``user.email`` holds the prior confirmed address; the new
-    /// address lives on ``token.sent_to`` until this endpoint runs. This is
-    /// the single place either column flips.
+    /// address lives on ``token.sent_to`` until this endpoint runs. This is one of
+    /// two places either column flips — the other is
+    /// ``auth0_provisioning._provision_user``, which stamps ``email`` +
+    /// ``confirmed_at`` together on a first-seen verified Auth0 email — so both
+    /// writers preserve the same invariant (email set ⇒ account confirmed).
     ///
     /// The token in the email is itself the bearer credential — we don't
     /// require the click to come from the same browser that requested it.
@@ -11567,8 +11573,11 @@ internal enum Operations {
     /// Consume an email-change token: stamp the new email + ``confirmed_at``.
     ///
     /// Invariant: ``user.email`` holds the prior confirmed address; the new
-    /// address lives on ``token.sent_to`` until this endpoint runs. This is
-    /// the single place either column flips.
+    /// address lives on ``token.sent_to`` until this endpoint runs. This is one of
+    /// two places either column flips — the other is
+    /// ``auth0_provisioning._provision_user``, which stamps ``email`` +
+    /// ``confirmed_at`` together on a first-seen verified Auth0 email — so both
+    /// writers preserve the same invariant (email set ⇒ account confirmed).
     ///
     /// The token in the email is itself the bearer credential — we don't
     /// require the click to come from the same browser that requested it.

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -111,8 +111,11 @@ export interface paths {
          * @description Consume an email-change token: stamp the new email + ``confirmed_at``.
          *
          *     Invariant: ``user.email`` holds the prior confirmed address; the new
-         *     address lives on ``token.sent_to`` until this endpoint runs. This is
-         *     the single place either column flips.
+         *     address lives on ``token.sent_to`` until this endpoint runs. This is one of
+         *     two places either column flips — the other is
+         *     ``auth0_provisioning._provision_user``, which stamps ``email`` +
+         *     ``confirmed_at`` together on a first-seen verified Auth0 email — so both
+         *     writers preserve the same invariant (email set ⇒ account confirmed).
          *
          *     The token in the email is itself the bearer credential — we don't
          *     require the click to come from the same browser that requested it.


### PR DESCRIPTION
Closes #1157.

## What

Kills the ephemeral-account + explicit-link friction for agent onboarding. At MCP token time, when a verified Auth0 token's `sub` isn't linked yet, the verifier now reads the token's verified `email` and **matches or provisions** a FortyMM account instead of requiring a prior in-session link:

- **`sub` already linked** → that account (unchanged).
- **verified email matches an existing account** → bind `auth0_sub` to it (no duplicate).
- **verified email is new** → provision a *registered* account (coolname username, email + `confirmed_at`, default role + league) and bind.
- **email absent or unverified** → refuse (401).

The `mcp.access` authorization check and the `AccessToken` shape are unchanged. This **reverses decision #4** of the prior Auth0 Resource-Server ADR (explicit-link-only); the link flow (`/v1/auth0/link/*`) stays as a second valid path.

## Design decisions (see ADR)

- A verified Auth0 email is trusted as equivalent to FortyMM's magic-link inbox-proof, so provisioned accounts are born confirmed.
- A matched account already linked to a *different* `auth0_sub` is **refused, never hijacked** (first identity wins until it unlinks).
- Reverse-order convergence (agent-then-magiclink and magiclink-then-agent) reuses existing account-merge machinery — guarded by an explicit both-directions test.
- Concurrency: an `IntegrityError` on the provision INSERT re-resolves to the winning row (match, don't duplicate).

## Not in this PR (yours to do)

- **Auth0 Action** to add the namespaced `email` / `email_verified` claims to the MCP access token — the feature is inert until it's live. Exact JS + install steps in `docs/auth0-mcp-email-claims-action.md`.
- Widening `mcp.access` from the Beta-tester role to the default `User` role (a later seed change) — until then, provisioned accounts 401 at the permission check and you test via the *match* path.

## Testing

- New unit tests cover every branch of `resolve_or_provision_user` (linked / match / provision / refuse-conflict / unverified / no-email / IntegrityError race), the verifier wiring (match authorizes, unverified→401, linked still works), and both convergence directions.
- `ruff check` + `ruff format --check` + `mypy --strict` clean; full `pytest` **1769 passed**.
- No routes/schemas/docstrings changed → no OpenAPI regen. No web-client/iOS surface (the whole decision lives in the MCP token verifier), so **no browser QA** — acceptance is the api suite + a manual "add the MCP connector on UAT and log in" check once the Auth0 Action is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)