### PR TITLE
Serve MCP protected-resource metadata without a trailing-slash redirect

### DIFF
--- a/deploy/uat/templates/_helpers.tpl
+++ b/deploy/uat/templates/_helpers.tpl
@@ -126,7 +126,17 @@ server {
     # can't reach it. Internally FastMCP serves the metadata UNDER its mount
     # (/mcp/.well-known/oauth-protected-resource/…), so prepend /mcp to the
     # origin-root path. Unauthenticated by design — discovery precedes any token.
+    # Both spellings of the path must answer 200 directly. FastMCP registers the
+    # metadata route WITH a trailing slash, so a client that normalizes it away
+    # would otherwise get Starlette's `redirect_slashes` 307 — and that Location
+    # is built from the INTERNAL mount, so it comes back as
+    # `http://host/mcp/.well-known/…` (scheme downgraded, `/api` missing), the
+    # app having no idea nginx stripped a prefix. OAuth clients don't follow
+    # redirects during discovery; they fall back to the bare
+    # /.well-known/oauth-protected-resource, get a 404, and give up without ever
+    # finding the authorization server. So normalize the slash here instead.
     location /.well-known/oauth-protected-resource {
+        rewrite ^(.*[^/])$ /mcp$1/ break;
         rewrite ^(.*)$ /mcp$1 break;
         proxy_pass http://api_upstream;
         proxy_http_version 1.1;

--- a/nginx/dev.conf
+++ b/nginx/dev.conf
@@ -58,7 +58,17 @@ server {
     # FastMCP serves the metadata UNDER its mount
     # (/mcp/.well-known/oauth-protected-resource/…), so prepend /mcp to the
     # origin-root path. Unauthenticated by design — discovery precedes any token.
+    # Both spellings of the path must answer 200 directly. FastMCP registers the
+    # metadata route WITH a trailing slash, so a client that normalizes it away
+    # would otherwise get Starlette's `redirect_slashes` 307 — and that Location
+    # is built from the INTERNAL mount, so it comes back as
+    # `http://host/mcp/.well-known/…` (scheme downgraded, `/api` missing), the
+    # app having no idea nginx stripped a prefix. OAuth clients don't follow
+    # redirects during discovery; they fall back to the bare
+    # /.well-known/oauth-protected-resource, get a 404, and give up without ever
+    # finding the authorization server. So normalize the slash here instead.
     location /.well-known/oauth-protected-resource {
+        rewrite ^(.*[^/])$ /mcp$1/ break;
         rewrite ^(.*)$ /mcp$1 break;
         proxy_pass http://api_upstream;
         proxy_http_version 1.1;

--- a/nginx/uat.conf
+++ b/nginx/uat.conf
@@ -64,7 +64,17 @@ server {
     # can't reach it. Internally FastMCP serves the metadata UNDER its mount
     # (/mcp/.well-known/oauth-protected-resource/…), so prepend /mcp to the
     # origin-root path. Unauthenticated by design — discovery precedes any token.
+    # Both spellings of the path must answer 200 directly. FastMCP registers the
+    # metadata route WITH a trailing slash, so a client that normalizes it away
+    # would otherwise get Starlette's `redirect_slashes` 307 — and that Location
+    # is built from the INTERNAL mount, so it comes back as
+    # `http://host/mcp/.well-known/…` (scheme downgraded, `/api` missing), the
+    # app having no idea nginx stripped a prefix. OAuth clients don't follow
+    # redirects during discovery; they fall back to the bare
+    # /.well-known/oauth-protected-resource, get a 404, and give up without ever
+    # finding the authorization server. So normalize the slash here instead.
     location /.well-known/oauth-protected-resource {
+        rewrite ^(.*[^/])$ /mcp$1/ break;
         rewrite ^(.*)$ /mcp$1 break;
         proxy_pass http://api_upstream;
         proxy_http_version 1.1;


### PR DESCRIPTION
## The bug

The Claude connector could not complete OAuth discovery against UAT. Observed in the api access log (`160.79.106.35` is Anthropic's connector infra):

```
GET /mcp/.well-known/oauth-protected-resource/api/mcp   307 Temporary Redirect
GET /mcp/.well-known/oauth-protected-resource           404 Not Found
```

FastMCP registers the RFC 9728 metadata route **with** a trailing slash. A client that normalizes the slash away gets Starlette's `redirect_slashes` 307 — and that `Location` is built from the *internal* mount, so it comes back as:

```
location: http://uat.fortymm.com/mcp/.well-known/oauth-protected-resource/api/mcp/
```

Both the scheme (`https` → `http`) and the path (`/api` missing) are wrong, because the app has no idea nginx stripped a prefix. OAuth clients don't follow redirects during metadata discovery, so the connector fell back to the bare `/.well-known/oauth-protected-resource`, got a 404, and never found the authorization server.

Nothing reached token verification — `users.auth0_sub` stayed null throughout, confirming this is purely a discovery-path failure and not RBAC or provisioning.

## The fix

Normalize the trailing slash in nginx so both spellings proxy straight to the metadata route and answer 200, keeping the discovery path redirect-free:

```nginx
rewrite ^(.*[^/])$ /mcp$1/ break;
rewrite ^(.*)$ /mcp$1 break;
```

Applied to all three copies of the block, per the `deploy/CLAUDE.md` note that the k8s routing nginx renders its own inline copy rather than reading `uat.conf`:

- `nginx/uat.conf` (mounted by the QA compose stack)
- `nginx/dev.conf`
- `deploy/uat/templates/_helpers.tpl` (what the k8s nginx actually renders)

## Verification

- Reproduced the 307 and captured the malformed `Location` header against live UAT.
- Confirmed the redirect target *does* resolve to valid JSON when followed — so the redirect itself, not the metadata, is what breaks the connector.
- `nginx -t` passes on the rendered ConfigMap (`helm template` → extract `default.conf` → stub upstreams → nginx:1.27-alpine).

**Not yet deployed to UAT** — the shared-cluster `helm upgrade` needs operator approval. Deploy with:

```bash
export KUBECONFIG=$(k3d kubeconfig write fortymm-uat)
helm upgrade --install fortymm-uat deploy/uat -n fortymm-uat \
  -f deploy/uat/values.yaml \
  --set images.api.tag=e7e45b2-1784818498 \
  --set images.web.tag=e7e45b2-1784818498 --wait
```

Then confirm the no-slash spelling returns 200 rather than 307:

```bash
curl -so /dev/null -w '%{http_code}\n' \
  https://uat.fortymm.com/.well-known/oauth-protected-resource/api/mcp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VV3c1f6wgJs9K3Vbr7KCe