### PR TITLE
iOS: navigation-driven refetch fixes stale data (#1133)

### DIFF
--- a/docs/adr/0010-ios-freshness-is-navigation-driven-not-realtime.md
+++ b/docs/adr/0010-ios-freshness-is-navigation-driven-not-realtime.md
@@ -1,0 +1,57 @@
+# iOS data freshness is navigation-driven, not realtime
+
+The native app was showing stale data "for too long": returning to the Home
+tab from Matches left the dashboard showing an already-resolved "needs your
+attention" row, and returning to the matches list from a match detail left the
+tapped row stale. The data-bearing screens (`DashboardView`, `MatchesListView`)
+own an in-place-refreshing store/state and *try* to refetch on re-appearance,
+but they hang that refetch off SwiftUI `.onAppear`, which fires **unreliably on
+`TabView` tab-return** (Matches→Home reproducibly did not refetch the dashboard,
+even though the symmetric Home→Matches did). The store itself is correct —
+`DashboardStore.load(force: true)` always refetches in place — so the defect is
+the *trigger*, not the fetch.
+
+We decided freshness on iOS is, for now, **navigation- and visibility-driven,
+made deterministic** — not realtime:
+
+- **Tab-return refetch is driven off the `TabView` `selection` binding**, which
+  `MainTabView` owns, rather than `.onAppear`. "The selected tab just became
+  Home → reload the dashboard" (and the same for the matches list) fires every
+  time, on a signal the app controls, instead of relying on `.onAppear`'s
+  `TabView` quirk. First-load moves to `.task`; tab-returns ride the selection
+  change, so there is exactly one refetch per return and no double-fetch.
+- **The matches list refetches when a match-detail cover is dismissed**, mirror-
+  ing the hook `DashboardView` already has on its detail/resume covers. This is
+  a *separate* fix from the selection-driven one: the detail is a
+  `fullScreenCover` presented *over* the matches list within the same tab, so
+  returning from it never changes tab selection.
+
+## Considered options
+
+- **Deterministic navigation/visibility refetch (chosen).** Refetch on the
+  signals the app already controls — tab selection and cover dismissal. Fixes
+  the observed staleness with no server changes and no ongoing request cost, and
+  removes the dependency on `.onAppear`'s unreliable tab-return behavior.
+- **Lightweight foreground polling.** Refetch the visible tab every ~20s while
+  active. Would additionally cover *cross-device* changes to a screen you are
+  actively looking at (the opponent posts a result while you sit on the
+  dashboard). **Deferred** — see below.
+- **Just make `.onAppear` fire reliably.** Rejected: `.onAppear`-on-tab-return
+  in `TabView` is the exact flakiness that caused the bug; it is not a
+  foundation to rest a freshness guarantee on.
+- **Full live channel (SSE/WebSocket) now.** Rejected as out of scope for a
+  staleness bugfix; it is the right long-term answer but a large, cross-platform
+  effort (see below).
+
+## Consequence
+
+The two reported staleness bugs are fixed deterministically. What this
+**explicitly does not do** is keep a *visible* screen fresh against changes made
+on another device — if you sit on the dashboard and your opponent posts a
+result, you still won't see it until you leave and return, pull to refresh, or
+background/foreground. That "live" gap is a **deliberate non-goal here**: it is
+slated for a dedicated, cross-platform realtime effort (web **and** iOS,
+in-progress matches, iOS Live Activity) rather than an iOS-only polling
+stopgap. Anyone tempted to add polling to close the gap should do it as part of
+that effort, not bolt it on here — that is why this refetch is navigation-driven
+and stops there.

--- a/ios/Fortymm/Components/ViewModifiers.swift
+++ b/ios/Fortymm/Components/ViewModifiers.swift
@@ -18,6 +18,17 @@ extension View {
         modifier(RefetchOnForeground(action: action))
     }
 
+    /// Run `action` when this view's tab becomes the selected tab — the tab-return
+    /// sibling of `.refetchOnForeground`. `isSelected` is derived by `MainTabView`
+    /// from the `TabView` selection it owns (so the tab identity lives in one
+    /// place, next to the `.tag`). `.onChange` skips the initial value, so this
+    /// fires only on the transition *into* selected — a real tab-return — not on
+    /// first appearance, which rides `.task`. Deterministic where `.onAppear` on
+    /// `TabView` tab-return is not (ADR 0010).
+    func refetchWhenSelected(_ isSelected: Bool, _ action: @escaping () -> Void) -> some View {
+        modifier(RefetchWhenSelected(isSelected: isSelected, action: action))
+    }
+
     /// Present the resume-scoring flow over this view, driven by `item`. On
     /// dismissal it clears `item` and runs `onFinish` (the surface's refetch),
     /// so a resumed/posted match is reflected instead of the stale pre-resume
@@ -42,6 +53,17 @@ private struct RefetchOnForeground: ViewModifier {
     func body(content: Content) -> some View {
         content.onChange(of: scenePhase) { _, phase in
             if phase == .active { action() }
+        }
+    }
+}
+
+private struct RefetchWhenSelected: ViewModifier {
+    let isSelected: Bool
+    let action: () -> Void
+
+    func body(content: Content) -> some View {
+        content.onChange(of: isSelected) { _, selected in
+            if selected { action() }
         }
     }
 }

--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -15,6 +15,10 @@ struct DashboardView: View {
     /// to the Matches tab, filtered to their matches. The argument is the
     /// current username, used as the list's search filter. Nil in previews.
     var onViewAll: ((String?) -> Void)? = nil
+    /// The tab currently selected in `MainTabView`'s `TabView`. Passed down so
+    /// tab-return refetch can ride the deterministic selection change rather than
+    /// `.onAppear`, which fires unreliably on `TabView` tab-return (ADR 0010).
+    var selectedTab: FMTab = .home
 
     /// Non-nil while the resume-scoring flow is presented over the dashboard;
     /// `resumeLoading` covers the brief fetch of the full match (the attention
@@ -46,11 +50,18 @@ struct DashboardView: View {
             }
             .background(FMColor.bgApp.ignoresSafeArea())
             .refreshable { await store.load(force: true) }
-            // onAppear (not task) so returning to the Home tab after posting /
-            // resuming a match re-fetches — clearing a stale "Score needed"
-            // banner and refreshing recent results. force: true silently
-            // refreshes in place once content is loaded.
-            .onAppear { Task { await store.load(force: true) } }
+            // First load rides .task; the non-force load() no-ops once loaded, so
+            // if .task re-fires on a tab return it costs nothing — the actual
+            // tab-return refetch is the selection-driven .onChange below.
+            .task { await store.load() }
+            // Returning to the Home tab must re-fetch (clearing a stale "Score
+            // needed" banner, refreshing recent results). Drive it off the
+            // TabView selection MainTabView owns — this fires deterministically
+            // when selection transitions to .home, unlike .onAppear on tab-return
+            // (ADR 0010). force: true refreshes in place once content is loaded.
+            .onChange(of: selectedTab) { _, tab in
+                if tab == .home { Task { await store.load(force: true) } }
+            }
             // Returning to the foreground may surface cross-device changes (a
             // match the other player just accepted) — refetch in place.
             .refetchOnForeground { Task { await store.load(force: true) } }

--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -15,10 +15,11 @@ struct DashboardView: View {
     /// to the Matches tab, filtered to their matches. The argument is the
     /// current username, used as the list's search filter. Nil in previews.
     var onViewAll: ((String?) -> Void)? = nil
-    /// The tab currently selected in `MainTabView`'s `TabView`. Passed down so
-    /// tab-return refetch can ride the deterministic selection change rather than
-    /// `.onAppear`, which fires unreliably on `TabView` tab-return (ADR 0010).
-    var selectedTab: FMTab = .home
+    /// Whether Home is the currently-selected tab (derived by `MainTabView` from
+    /// the `TabView` selection it owns). Drives `.refetchWhenSelected` so tab-return
+    /// refetch rides the deterministic selection change rather than `.onAppear`,
+    /// which fires unreliably on `TabView` tab-return (ADR 0010).
+    var isSelected: Bool = false
 
     /// Non-nil while the resume-scoring flow is presented over the dashboard;
     /// `resumeLoading` covers the brief fetch of the full match (the attention
@@ -52,16 +53,12 @@ struct DashboardView: View {
             .refreshable { await store.load(force: true) }
             // First load rides .task; the non-force load() no-ops once loaded, so
             // if .task re-fires on a tab return it costs nothing — the actual
-            // tab-return refetch is the selection-driven .onChange below.
+            // tab-return refetch is `.refetchWhenSelected` below.
             .task { await store.load() }
             // Returning to the Home tab must re-fetch (clearing a stale "Score
-            // needed" banner, refreshing recent results). Drive it off the
-            // TabView selection MainTabView owns — this fires deterministically
-            // when selection transitions to .home, unlike .onAppear on tab-return
-            // (ADR 0010). force: true refreshes in place once content is loaded.
-            .onChange(of: selectedTab) { _, tab in
-                if tab == .home { Task { await store.load(force: true) } }
-            }
+            // needed" banner, refreshing recent results). force: true refreshes
+            // in place once content is loaded.
+            .refetchWhenSelected(isSelected) { Task { await store.load(force: true) } }
             // Returning to the foreground may surface cross-device changes (a
             // match the other player just accepted) — refetch in place.
             .refetchOnForeground { Task { await store.load(force: true) } }

--- a/ios/Fortymm/Matches/MatchesListView.swift
+++ b/ios/Fortymm/Matches/MatchesListView.swift
@@ -16,6 +16,10 @@ struct MatchesListView: View {
     var service: MatchService = .shared
     /// Set by another tab to pre-apply a filter on arrival; cleared once applied.
     var pendingFilter: Binding<MatchesFilter?> = .constant(nil)
+    /// The tab currently selected in `MainTabView`'s `TabView`. Passed down so the
+    /// tab-return refetch can ride the deterministic selection change rather than
+    /// `.onAppear`, which fires unreliably on `TabView` tab-return (ADR 0010).
+    var selectedTab: FMTab = .matches
 
     @State private var statusTab: StatusTab = .all
     @State private var query = ""
@@ -39,6 +43,11 @@ struct MatchesListView: View {
     /// that programmatically changing `query` would otherwise schedule on top of
     /// `applyPendingFilter`'s own reload.
     @State private var suppressQueryReload = false
+    /// Guards the `.task` first-load so it fetches exactly once. `.task` restarts
+    /// on tab re-appearance the same unreliable way `.onAppear` does, so gating it
+    /// keeps tab-returns solely on the deterministic selection `.onChange` below —
+    /// exactly one fetch per return, no double-fetch (ADR 0010).
+    @State private var didInitialLoad = false
 
     var body: some View {
         ZStack {
@@ -54,14 +63,26 @@ struct MatchesListView: View {
             }
             .background(FMColor.bgApp.ignoresSafeArea())
             .refreshable { await load() }
-            // onAppear (not task) so returning to the tab after posting a match
-            // re-fetches and surfaces it at the top. A queued cross-tab filter is
-            // applied here rather than via .onChange, because TabView renders this
-            // tab lazily — .onChange isn't observing when the value is set on the
-            // other tab, but .onAppear fires when the tab becomes visible.
-            .onAppear {
+            // First load rides .task (once, via the didInitialLoad guard). A
+            // queued cross-tab filter is applied here rather than via .onChange,
+            // because TabView renders this tab lazily on first visit — .onChange
+            // isn't observing when the value is set on the other tab, but .task
+            // fires when the tab first becomes visible.
+            .task {
+                guard !didInitialLoad else { return }
+                didInitialLoad = true
                 if pendingFilter.wrappedValue != nil { applyPendingFilter() }
                 else { reload() }
+            }
+            // Returning to the Matches tab must re-fetch (surfacing a match just
+            // posted at the top). Drive it off the TabView selection MainTabView
+            // owns — fires deterministically on the transition to .matches, unlike
+            // .onAppear on tab-return (ADR 0010). Skip when a cross-tab filter is
+            // queued: the pendingFilter .onChange below owns that reload, so this
+            // guard keeps it to exactly one fetch.
+            .onChange(of: selectedTab) { _, tab in
+                guard tab == .matches else { return }
+                if pendingFilter.wrappedValue == nil { reload() }
             }
             // Foregrounding may surface cross-device changes (a match the opponent
             // just accepted/countered) — re-fetch the feed.
@@ -79,8 +100,16 @@ struct MatchesListView: View {
                     if !Task.isCancelled { reload() }
                 }
             }
+            // The match's state may have changed while in detail (a result
+            // posted, an acceptance, a new proposal). The cover *covers* the list
+            // rather than removing it, so the list's re-appearance triggers don't
+            // fire on dismissal — refetch in place here, mirroring the dashboard
+            // (ADR 0010).
             .fullScreenCover(item: $selected) { match in
-                MatchDetailView(initial: match, onBack: { selected = nil })
+                MatchDetailView(initial: match, onBack: {
+                    selected = nil
+                    reload()
+                })
             }
             // The list now has a stale row for the resumed match (it just gained a
             // posted result / more games) — refetch so it reflects reality.

--- a/ios/Fortymm/Matches/MatchesListView.swift
+++ b/ios/Fortymm/Matches/MatchesListView.swift
@@ -16,10 +16,11 @@ struct MatchesListView: View {
     var service: MatchService = .shared
     /// Set by another tab to pre-apply a filter on arrival; cleared once applied.
     var pendingFilter: Binding<MatchesFilter?> = .constant(nil)
-    /// The tab currently selected in `MainTabView`'s `TabView`. Passed down so the
-    /// tab-return refetch can ride the deterministic selection change rather than
-    /// `.onAppear`, which fires unreliably on `TabView` tab-return (ADR 0010).
-    var selectedTab: FMTab = .matches
+    /// Whether Matches is the currently-selected tab (derived by `MainTabView` from
+    /// the `TabView` selection it owns). Drives `.refetchWhenSelected` so tab-return
+    /// refetch rides the deterministic selection change rather than `.onAppear`,
+    /// which fires unreliably on `TabView` tab-return (ADR 0010).
+    var isSelected: Bool = false
 
     @State private var statusTab: StatusTab = .all
     @State private var query = ""
@@ -45,7 +46,7 @@ struct MatchesListView: View {
     @State private var suppressQueryReload = false
     /// Guards the `.task` first-load so it fetches exactly once. `.task` restarts
     /// on tab re-appearance the same unreliable way `.onAppear` does, so gating it
-    /// keeps tab-returns solely on the deterministic selection `.onChange` below —
+    /// keeps tab-returns solely on the deterministic `.refetchWhenSelected` below —
     /// exactly one fetch per return, no double-fetch (ADR 0010).
     @State private var didInitialLoad = false
 
@@ -75,20 +76,17 @@ struct MatchesListView: View {
                 else { reload() }
             }
             // Returning to the Matches tab must re-fetch (surfacing a match just
-            // posted at the top). Drive it off the TabView selection MainTabView
-            // owns — fires deterministically on the transition to .matches, unlike
-            // .onAppear on tab-return (ADR 0010). Skip when a cross-tab filter is
-            // queued: the pendingFilter .onChange below owns that reload, so this
-            // guard keeps it to exactly one fetch.
-            .onChange(of: selectedTab) { _, tab in
-                guard tab == .matches else { return }
+            // posted at the top). Skip when a cross-tab filter is queued: the
+            // pendingFilter .onChange below owns that reload, so this guard keeps
+            // it to exactly one fetch.
+            .refetchWhenSelected(isSelected) {
                 if pendingFilter.wrappedValue == nil { reload() }
             }
             // Foregrounding may surface cross-device changes (a match the opponent
             // just accepted/countered) — re-fetch the feed.
             .refetchOnForeground { reload() }
             // Also handle the case where this tab is already visible when the
-            // filter is set (no fresh .onAppear) — apply it live.
+            // filter is set (no fresh `.task`) — apply it live.
             .onChange(of: pendingFilter.wrappedValue) { _, filter in
                 if filter != nil { applyPendingFilter() }
             }

--- a/ios/Fortymm/Navigation/MainTabView.swift
+++ b/ios/Fortymm/Navigation/MainTabView.swift
@@ -33,12 +33,12 @@ struct MainTabView: View {
             DashboardView(onViewAll: { username in
                 matchesFilter = MatchesFilter(status: nil, query: username ?? "")
                 selection = .matches
-            })
+            }, selectedTab: selection)
                 .fmTopBar(FMTab.home.title)
                 .tabItem { Label("Home", systemImage: "house") }
                 .tag(FMTab.home)
 
-            MatchesListView(pendingFilter: $matchesFilter)
+            MatchesListView(pendingFilter: $matchesFilter, selectedTab: selection)
                 .fmTopBar(FMTab.matches.title)
                 .tabItem { Label("Matches", systemImage: "sportscourt") }
                 .tag(FMTab.matches)

--- a/ios/Fortymm/Navigation/MainTabView.swift
+++ b/ios/Fortymm/Navigation/MainTabView.swift
@@ -33,12 +33,12 @@ struct MainTabView: View {
             DashboardView(onViewAll: { username in
                 matchesFilter = MatchesFilter(status: nil, query: username ?? "")
                 selection = .matches
-            }, selectedTab: selection)
+            }, isSelected: selection == .home)
                 .fmTopBar(FMTab.home.title)
                 .tabItem { Label("Home", systemImage: "house") }
                 .tag(FMTab.home)
 
-            MatchesListView(pendingFilter: $matchesFilter, selectedTab: selection)
+            MatchesListView(pendingFilter: $matchesFilter, isSelected: selection == .matches)
                 .fmTopBar(FMTab.matches.title)
                 .tabItem { Label("Matches", systemImage: "sportscourt") }
                 .tag(FMTab.matches)


### PR DESCRIPTION
## What

Fixes iOS screens showing **stale data after navigation** (#1133). The dashboard and matches list hung their tab-return refetch off SwiftUI `.onAppear`, which fires **unreliably on `TabView` tab-return** — so Matches→Home left the dashboard's "needs your attention" row stale, and returning from a match detail left the tapped row stale. The stores refetch correctly; the *trigger* was the bug.

## Changes

- **Tab-return refetch driven off the `TabView` selection** (not `.onAppear`). `MainTabView` owns the selection and passes a derived `isSelected: Bool` into each data screen; first-load moves to `.task`, tab-returns ride the selection change — exactly one fetch per return, no residual `.onAppear` double-fetch. Pull-to-refresh and foreground hooks unchanged.
- **Matches list refetches on match-detail dismissal**, mirroring the hook `DashboardView` already had.
- **Extracted a `.refetchWhenSelected` view modifier** (sibling to the existing `.refetchOnForeground`) so both screens share one trigger and tab identity lives in one place next to the `.tag`.

## Explicitly out of scope (deferred)

Keeping a *visible* screen fresh against another device's changes (opponent posts while you watch the dashboard) — no polling / SSE / Live Activity here. That's the dedicated cross-platform realtime effort (**#1063**). Rationale recorded in `docs/adr/0010-ios-freshness-is-navigation-driven-not-realtime.md`.

## Testing

- iOS clean simulator build (`rm -rf build/sim` + `xcodebuild … CODE_SIGNING_ALLOWED=NO`) → `** BUILD SUCCEEDED **`. iOS ships no XCTest target; the compile is the automated gate.
- Each chore independently verified by a fresh verifier agent (code-level: deterministic trigger, single fetch per return, scope held).
- **Behavioral confirmation** (tab-return / back-nav / pull-to-refresh against a real QA-stack API) is done in the Simulator QA pass below — it's the load-bearing check for this fix, since the bug was "a trigger that looked wired but didn't fire."

🤖 Generated with [Claude Code](https://claude.com/claude-code)