### PR TITLE
Dashboard tournament panel: the live match, at the top, while you're playing

### DIFF
--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.attention import attention_priority, list_attention_kind
+from app.dashboard_tournaments import build_tournament_panels
 from app.db import get_session
 from app.match_queries import (
     _attention_matches_query,
@@ -163,6 +164,11 @@ async def get_dashboard(
         for match in completed
     ]
     rating = await _build_rating(db, current_user.id)
+    # The tournament panel that sits above everything else while the user is playing
+    # in a live tournament — ``[]`` (and no panel) the rest of the time, which is
+    # almost always. It rides on this endpoint rather than one of its own because it
+    # loads with the page, not on a click (the BFF rule, root CLAUDE.md).
+    tournaments = await build_tournament_panels(db, current_user.id)
 
     return DashboardResponse(
         attention=attention,
@@ -171,6 +177,7 @@ async def get_dashboard(
         recent_results=recent_results,
         rating=rating,
         completed_match_count=completed_match_count,
+        tournaments=tournaments,
     )
 
 

--- a/api/app/dashboard_tournaments.py
+++ b/api/app/dashboard_tournaments.py
@@ -46,6 +46,7 @@ from app.models import (
     TournamentStatus,
 )
 from app.models.tournament import DrawType
+from app.result_acceptance import side_win_counts
 from app.schemas.dashboard import (
     DashboardTournament,
     DashboardTournamentEvent,
@@ -119,12 +120,24 @@ async def build_tournament_panels(
 
     by_tournament: dict[uuid.UUID, list[DashboardTournamentEvent]] = defaultdict(list)
     tournaments: dict[uuid.UUID, Tournament] = {}
+    # The table catalogue is a per-TOURNAMENT value-object, so it is parsed once per
+    # tournament rather than once per event — a caller entered in two events of one
+    # tournament (singles + doubles) would otherwise re-decode the identical JSONB.
+    tables_by_tournament: dict[uuid.UUID, dict[str, TournamentTable]] = {}
     for entry_id, event, tournament in entries:
         tournaments[tournament.id] = tournament
+        if tournament.id not in tables_by_tournament:
+            tables_by_tournament[tournament.id] = {
+                table.id: table
+                for table in (
+                    TournamentTable.model_validate(raw)
+                    for raw in tournament.table_catalogue
+                )
+            }
         by_tournament[tournament.id].append(
             _build_event(
                 event,
-                tournament=tournament,
+                tables=tables_by_tournament[tournament.id],
                 my_entry_id=entry_id,
                 entrants=entrants[event.id],
                 all_fixtures=fixtures[event.id],
@@ -246,7 +259,7 @@ def _focus_fixture(
 def _build_event(
     event: TournamentEvent,
     *,
-    tournament: Tournament,
+    tables: dict[str, TournamentTable],
     my_entry_id: uuid.UUID,
     entrants: Sequence[TournamentEntrantRead],
     all_fixtures: list[TournamentFixtureRead],
@@ -256,12 +269,6 @@ def _build_event(
     game_counts: dict[uuid.UUID, tuple[int, int]],
 ) -> DashboardTournamentEvent:
     username_by_entry = {entrant.id: entrant.username for entrant in entrants}
-    tables = {
-        table.id: table
-        for table in (
-            TournamentTable.model_validate(raw) for raw in tournament.table_catalogue
-        )
-    }
     pools = {
         pool.id: pool for pool in (Pool.model_validate(raw) for raw in event.pools)
     }
@@ -292,6 +299,23 @@ def _build_event(
             if my_standing is not None:
                 break
 
+    # The caller's own decided fixtures, counted directly — draw-type-agnostic, so it
+    # stands in wherever there is no standings row to read (see the record below).
+    record_wins, record_losses = 0, 0
+    for fixture in my_fixtures:
+        if fixture.match_status is not MatchStatus.completed:
+            continue
+        mine, theirs = _games_won(
+            fixture,
+            side=_my_side(fixture, my_entry_id),
+            match=None,
+            game_counts=game_counts,
+        )
+        if mine > theirs:
+            record_wins += 1
+        elif theirs > mine:
+            record_losses += 1
+
     focus_match = (
         None
         if focus is None
@@ -315,11 +339,15 @@ def _build_event(
         name=event.name,
         draw_type=event.draw_type,
         is_live=any(f.match_status is MatchStatus.in_progress for f in my_fixtures),
-        # The record is the caller's own decided fixtures, taken from the standings
-        # row when there is one so it agrees with the table it sits next to; falling
-        # back to a direct count only for an event with no standings projection.
-        wins=my_standing.wins if my_standing is not None else 0,
-        losses=my_standing.losses if my_standing is not None else 0,
+        # Taken from the standings row when there IS one, so the record agrees with
+        # the table it sits beside; counted from the caller's own decided fixtures
+        # otherwise. The fallback is not decoration: ``event_results`` answers
+        # ``None`` for every draw type but round-robin (ADR-0788), so hard-coding a
+        # zero here would show ``0–0`` to every player of the first bracket event we
+        # ship, however many matches they had actually won — and nothing would fail
+        # to catch it.
+        wins=my_standing.wins if my_standing is not None else record_wins,
+        losses=my_standing.losses if my_standing is not None else record_losses,
         position=my_standing.rank if my_standing is not None else None,
         field_size=field_size,
         stage_label=_stage_label(event.draw_type, complete=pool_complete),
@@ -343,6 +371,24 @@ def _build_event(
     )
 
 
+def _opponent_username(
+    fixture: TournamentFixtureRead,
+    side: int | None,
+    username_by_entry: dict[uuid.UUID, str],
+) -> str | None:
+    """Who the caller is playing in this fixture, or ``None`` when that side is still
+    TBD.
+
+    The entry ids on a fixture are just ids — the names live on the event's entrants
+    list (a fixture deliberately carries no copy that could drift, ADR-0786) — so the
+    join happens here, once, for both the card and the path row.
+    """
+    opponent_entry_id = fixture.entry_b_id if side == 1 else fixture.entry_a_id
+    if opponent_entry_id is None:
+        return None
+    return username_by_entry.get(opponent_entry_id)
+
+
 def _build_match(
     fixture: TournamentFixtureRead,
     *,
@@ -355,7 +401,6 @@ def _build_match(
     game_counts: dict[uuid.UUID, tuple[int, int]],
 ) -> DashboardTournamentMatch:
     side = _my_side(fixture, my_entry_id)
-    opponent_entry_id = fixture.entry_b_id if side == 1 else fixture.entry_a_id
     state = _match_state(fixture.match_status)
     your_games, opponent_games = _games_won(
         fixture, side=side, match=match, game_counts=game_counts
@@ -363,11 +408,7 @@ def _build_match(
     return DashboardTournamentMatch(
         state=state,
         match_id=fixture.match_id,
-        opponent_username=(
-            username_by_entry.get(opponent_entry_id)
-            if opponent_entry_id is not None
-            else None
-        ),
+        opponent_username=_opponent_username(fixture, side, username_by_entry),
         your_games=your_games,
         opponent_games=opponent_games,
         best_of=best_of,
@@ -390,7 +431,6 @@ def _build_fixture_row(
     game_counts: dict[uuid.UUID, tuple[int, int]],
 ) -> DashboardTournamentFixtureRow:
     side = _my_side(fixture, my_entry_id)
-    opponent_entry_id = fixture.entry_b_id if side == 1 else fixture.entry_a_id
     state = _fixture_state(fixture.match_status)
     you_won: bool | None = None
     if state == "completed":
@@ -410,11 +450,7 @@ def _build_fixture_row(
         detail = " · ".join(parts) if parts else "Not scheduled"
     return DashboardTournamentFixtureRow(
         label=f"M{ordinal}",
-        opponent_username=(
-            username_by_entry.get(opponent_entry_id)
-            if opponent_entry_id is not None
-            else None
-        ),
+        opponent_username=_opponent_username(fixture, side, username_by_entry),
         state=state,
         detail=detail,
         you_won=you_won,
@@ -435,20 +471,13 @@ def _games_won(
     the standings beside it are the same number. A **live** one cannot — ``game_counts``
     is only loaded for completed matches (an in-progress board is not a result and must
     never reach a standings table, ADR-0788) — so it counts the loaded match's own
-    scored games, which is the running score the card is there to show."""
+    scored games through ``side_win_counts``, the same helper the result-acceptance
+    and recent-results paths count with. Counting it inline here instead would be a
+    second implementation of "who won this game", and the two would drift the first
+    time either is edited."""
     if match is not None and fixture.match_status is not MatchStatus.completed:
-        side_1 = sum(
-            1
-            for game in match.games
-            if game.score is not None
-            and game.score.side_1_points > game.score.side_2_points
-        )
-        side_2 = sum(
-            1
-            for game in match.games
-            if game.score is not None
-            and game.score.side_2_points > game.score.side_1_points
-        )
+        counts = side_win_counts(match)
+        side_1, side_2 = counts.get(1, 0), counts.get(2, 0)
     elif fixture.match_id is not None and fixture.match_id in game_counts:
         side_1, side_2 = game_counts[fixture.match_id]
     else:

--- a/api/app/dashboard_tournaments.py
+++ b/api/app/dashboard_tournaments.py
@@ -439,6 +439,10 @@ def _build_fixture_row(
         )
         you_won = your_games > opponent_games
         detail = f"{'Won' if you_won else 'Lost'} {your_games}–{opponent_games}"
+    elif state == "voided":
+        # No score, and ``you_won`` stays ``None``: a voided match contributes
+        # nothing (ADR-0013), so the row states the fact and derives no outcome.
+        detail = "Voided"
     elif state == "live":
         detail = "In progress"
     else:
@@ -506,31 +510,42 @@ def _games(match: Match | None, *, side: int | None) -> list[DashboardTournament
 
 
 def _match_state(status: MatchStatus | None) -> TournamentMatchState:
-    """A fixture's match status as the card's three-way state.
+    """A fixture's match status as the card's state.
 
     ``None`` (not materialized) and ``pending`` are both ``scheduled`` — from the
-    player's chair they are the same thing: a match they have not started. ``voided``
-    is ``completed`` in the sense the card means it (nothing left to play); it carries
-    no games, so the card renders a 0–0 finished board rather than inviting scoring."""
+    player's chair they are the same thing: a match they have not started.
+
+    ``voided`` is its OWN state, not a flavour of ``completed``. A voided match has no
+    winner (``app.match_voiding``: "any surface that derives a result must see *no
+    winner*, not a stale W/L"), and it is not true that it carries no games — an
+    account-merge self-play collision (ADR-0013) voids a match that may have been
+    played out in full. Folded into ``completed``, the card would read the void's
+    empty game count as a 0–0 board and announce a loss the player never took."""
     match status:
         case None | MatchStatus.pending:
             return "scheduled"
         case MatchStatus.in_progress:
             return "live"
-        case MatchStatus.completed | MatchStatus.voided:
+        case MatchStatus.completed:
             return "completed"
+        case MatchStatus.voided:
+            return "voided"
         case _:
             assert_never(status)
 
 
 def _fixture_state(status: MatchStatus | None) -> TournamentFixtureState:
+    """The same four-way split as ``_match_state``, in the path list's vocabulary —
+    ``voided`` kept separate for the same reason (see it)."""
     match status:
         case None | MatchStatus.pending:
             return "upcoming"
         case MatchStatus.in_progress:
             return "live"
-        case MatchStatus.completed | MatchStatus.voided:
+        case MatchStatus.completed:
             return "completed"
+        case MatchStatus.voided:
+            return "voided"
         case _:
             assert_never(status)
 

--- a/api/app/dashboard_tournaments.py
+++ b/api/app/dashboard_tournaments.py
@@ -35,6 +35,7 @@ from typing import assert_never
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.attention import list_attention_kind
 from app.match_queries import current_game_number, match_eager_options
 from app.models import (
     Match,
@@ -138,6 +139,7 @@ async def build_tournament_panels(
             _build_event(
                 event,
                 tables=tables_by_tournament[tournament.id],
+                user_id=user_id,
                 my_entry_id=entry_id,
                 entrants=entrants[event.id],
                 all_fixtures=fixtures[event.id],
@@ -260,6 +262,7 @@ def _build_event(
     event: TournamentEvent,
     *,
     tables: dict[str, TournamentTable],
+    user_id: uuid.UUID,
     my_entry_id: uuid.UUID,
     entrants: Sequence[TournamentEntrantRead],
     all_fixtures: list[TournamentFixtureRead],
@@ -321,6 +324,7 @@ def _build_event(
         if focus is None
         else _build_match(
             focus,
+            user_id=user_id,
             my_entry_id=my_entry_id,
             username_by_entry=username_by_entry,
             match=(
@@ -392,6 +396,7 @@ def _opponent_username(
 def _build_match(
     fixture: TournamentFixtureRead,
     *,
+    user_id: uuid.UUID,
     my_entry_id: uuid.UUID,
     username_by_entry: dict[uuid.UUID, str],
     match: Match | None,
@@ -418,6 +423,9 @@ def _build_match(
         start_label=_time_label(fixture),
         next_game_number=(current_game_number(match) if match is not None else None),
         you_won=(None if state != "completed" else your_games > opponent_games),
+        owed_action=(
+            list_attention_kind(match, user_id) if match is not None else None
+        ),
     )
 
 

--- a/api/app/dashboard_tournaments.py
+++ b/api/app/dashboard_tournaments.py
@@ -1,0 +1,600 @@
+"""The dashboard's tournament panel (``DashboardResponse.tournaments``).
+
+While a player is *in* a live tournament, that is the only thing on the dashboard
+they care about, so it sits above everything else. This module projects it: for every
+tournament with status ``live`` that the caller holds an **active entry** in, one
+panel — a tab per event they entered, and inside each tab the one match to look at,
+where they stand, and their remaining schedule.
+
+Three rules shape everything below.
+
+**Everything is stated from the caller's side.** A tournament fixture seats
+``entry_a`` on side 1 and ``entry_b`` on side 2 (the fixed materialization convention,
+#788), so "which side am I?" is answered by comparing the caller's entry id against
+the fixture — never by walking the match's sides. Game scores, game counts and
+win/loss are all flipped once, here, so no client has to know it was ever side-shaped.
+
+**Standings come from the same projection the tournament page uses** (``event_results``,
+ADR-0788) rather than a second count of the same matches. A player whose panel says
+"2nd of 4" and whose event page says "3rd of 4" has been told two things, and the panel
+is the one they will act on.
+
+**A ``None`` is a fact.** ``position: None`` means the event has no standings to stand
+in (no draw cut, or a draw type with no results strategy — only round-robin has one
+today); ``match_id: None`` on a scheduled row means the fixture has not materialized;
+``opponent_username: None`` means the other side is still TBD. None of them are missing
+values to be filled in later, and none may be flattened to a zero or an empty string.
+"""
+
+import uuid
+from collections import defaultdict
+from collections.abc import Sequence
+from datetime import date
+from typing import assert_never
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.match_queries import current_game_number, match_eager_options
+from app.models import (
+    Match,
+    MatchStatus,
+    Tournament,
+    TournamentEntry,
+    TournamentEntryStatus,
+    TournamentEvent,
+    TournamentStatus,
+)
+from app.models.tournament import DrawType
+from app.schemas.dashboard import (
+    DashboardTournament,
+    DashboardTournamentEvent,
+    DashboardTournamentFixtureRow,
+    DashboardTournamentGame,
+    DashboardTournamentMatch,
+    TournamentFixtureState,
+    TournamentMatchState,
+)
+from app.schemas.tournament import (
+    Address,
+    MatchSettings,
+    Pool,
+    TournamentEntrantRead,
+    TournamentFixtureRead,
+    TournamentTable,
+)
+from app.tournament_queries import (
+    active_entrants_by_event,
+    completed_match_ids,
+    fixtures_by_event,
+    game_counts_by_match,
+)
+from app.tournament_serialization import event_results
+
+
+async def build_tournament_panels(
+    db: AsyncSession, user_id: uuid.UUID
+) -> list[DashboardTournament]:
+    """Every live tournament ``user_id`` is playing in, newest tournament first.
+
+    ``[]`` for the overwhelmingly common case — nobody is mid-tournament most days —
+    and the dashboard renders no panel at all rather than an empty one.
+
+    The whole projection is a fixed number of statements regardless of how many
+    events or fixtures are involved: the entries in one, then the batched loaders the
+    tournament-detail page already owns (entrants, fixtures, game counts) once each
+    across every event, then one load of the handful of focus matches. Nothing here
+    may become a query inside a loop — this runs on every dashboard load.
+    """
+    entries = await _my_live_entries(db, user_id)
+    if not entries:
+        return []
+    events = [event for _, event, _ in entries]
+    event_ids = [event.id for event in events]
+    my_entry_id_by_event = {event.id: entry_id for entry_id, event, _ in entries}
+
+    entrants = await active_entrants_by_event(db, event_ids)
+    fixtures = await fixtures_by_event(db, event_ids)
+    game_counts = await game_counts_by_match(db, completed_match_ids(fixtures))
+
+    # The caller's own fixtures, in draw order, per event — the path list, and the
+    # pool the focus match is chosen out of.
+    my_fixtures = {
+        event_id: [
+            fixture
+            for fixture in fixtures[event_id]
+            if _my_side(fixture, my_entry_id_by_event[event_id]) is not None
+        ]
+        for event_id in event_ids
+    }
+    focus = {event_id: _focus_fixture(rows) for event_id, rows in my_fixtures.items()}
+    focus_matches = await _load_matches(
+        db,
+        [
+            fixture.match_id
+            for fixture in focus.values()
+            if fixture is not None and fixture.match_id is not None
+        ],
+    )
+
+    by_tournament: dict[uuid.UUID, list[DashboardTournamentEvent]] = defaultdict(list)
+    tournaments: dict[uuid.UUID, Tournament] = {}
+    for entry_id, event, tournament in entries:
+        tournaments[tournament.id] = tournament
+        by_tournament[tournament.id].append(
+            _build_event(
+                event,
+                tournament=tournament,
+                my_entry_id=entry_id,
+                entrants=entrants[event.id],
+                all_fixtures=fixtures[event.id],
+                my_fixtures=my_fixtures[event.id],
+                focus=focus[event.id],
+                focus_matches=focus_matches,
+                game_counts=game_counts,
+            )
+        )
+    return [
+        DashboardTournament(
+            id=tournament_id,
+            name=tournaments[tournament_id].name,
+            subtitle=_subtitle(tournaments[tournament_id]),
+            live_count=sum(1 for e in panel_events if e.is_live),
+            events=panel_events,
+        )
+        for tournament_id, panel_events in by_tournament.items()
+    ]
+
+
+async def _my_live_entries(
+    db: AsyncSession, user_id: uuid.UUID
+) -> list[tuple[uuid.UUID, TournamentEvent, Tournament]]:
+    """``(entry_id, event, tournament)`` for every ACTIVE entry this user holds in a
+    LIVE tournament, newest tournament first then event creation order — the tab order
+    the panel renders.
+
+    ``live`` is the whole membership test. A ``published`` tournament has no draw being
+    played yet and a ``archived`` one is over; neither is something to put at the top of
+    a dashboard. Withdrawn entries are not entries (the soft-delete on
+    ``TournamentEntry.status``), so a player who pulled out sees no panel."""
+    rows = (
+        await db.execute(
+            select(TournamentEntry.id, TournamentEvent, Tournament)
+            .join(TournamentEvent, TournamentEvent.id == TournamentEntry.event_id)
+            .join(Tournament, Tournament.id == TournamentEvent.tournament_id)
+            .where(
+                TournamentEntry.user_id == user_id,
+                TournamentEntry.status == TournamentEntryStatus.entered,
+                Tournament.status == TournamentStatus.live,
+            )
+            .order_by(
+                Tournament.created_at.desc(),
+                TournamentEvent.created_at.asc(),
+            )
+        )
+    ).all()
+    return [(entry_id, event, tournament) for entry_id, event, tournament in rows]
+
+
+async def _load_matches(
+    db: AsyncSession, match_ids: Sequence[uuid.UUID]
+) -> dict[uuid.UUID, Match]:
+    """The focus matches, keyed by id — at most one per event, so a bounded load.
+
+    Fully eager-loaded because the card needs both the per-game scores and
+    ``current_game_number`` (which reads settings, results and games), and a lazy load
+    inside the per-event loop would be an N+1 on the dashboard's hot path."""
+    if not match_ids:
+        return {}
+    rows = (
+        (
+            await db.execute(
+                select(Match)
+                .where(Match.id.in_(match_ids))
+                .options(*match_eager_options())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return {match.id: match for match in rows}
+
+
+def _my_side(fixture: TournamentFixtureRead, my_entry_id: uuid.UUID) -> int | None:
+    """Which side of this fixture the caller is on — ``1`` for ``entry_a``, ``2`` for
+    ``entry_b``, ``None`` when they are not in it at all.
+
+    This is the whole "state it from the caller's side" mechanism, and it is the fixed
+    materialization convention read backwards (#788): entry A seated side 1, entry B
+    seated side 2, so the fixture answers the question without loading the match."""
+    if fixture.entry_a_id == my_entry_id:
+        return 1
+    if fixture.entry_b_id == my_entry_id:
+        return 2
+    return None
+
+
+def _focus_fixture(
+    my_fixtures: Sequence[TournamentFixtureRead],
+) -> TournamentFixtureRead | None:
+    """The ONE fixture the card shows, out of the caller's own fixtures in this event.
+
+    Priority is what the player is doing *right now*, in order: a match in progress,
+    else the next one not yet played, else the last one finished. That order is the
+    point of the panel — a player mid-match must never have to scroll past a result to
+    find the game they are standing at a table for.
+
+    Among the not-yet-played, the earliest in draw order wins (the list arrives in
+    pool → round → position order, ADR-0786); among the finished, the latest. ``None``
+    for an event whose draw has not been cut, which has no fixtures at all."""
+    live = [f for f in my_fixtures if f.match_status is MatchStatus.in_progress]
+    if live:
+        return live[0]
+    upcoming = [
+        f
+        for f in my_fixtures
+        if f.match_status is None or f.match_status is MatchStatus.pending
+    ]
+    if upcoming:
+        return upcoming[0]
+    played = [f for f in my_fixtures if f.match_status is MatchStatus.completed]
+    if played:
+        return played[-1]
+    return my_fixtures[-1] if my_fixtures else None
+
+
+def _build_event(
+    event: TournamentEvent,
+    *,
+    tournament: Tournament,
+    my_entry_id: uuid.UUID,
+    entrants: Sequence[TournamentEntrantRead],
+    all_fixtures: list[TournamentFixtureRead],
+    my_fixtures: Sequence[TournamentFixtureRead],
+    focus: TournamentFixtureRead | None,
+    focus_matches: dict[uuid.UUID, Match],
+    game_counts: dict[uuid.UUID, tuple[int, int]],
+) -> DashboardTournamentEvent:
+    username_by_entry = {entrant.id: entrant.username for entrant in entrants}
+    tables = {
+        table.id: table
+        for table in (
+            TournamentTable.model_validate(raw) for raw in tournament.table_catalogue
+        )
+    }
+    pools = {
+        pool.id: pool for pool in (Pool.model_validate(raw) for raw in event.pools)
+    }
+    settings = MatchSettings.model_validate(event.match_settings)
+
+    results = event_results(
+        event,
+        fixtures=all_fixtures,
+        game_counts=game_counts,
+    )
+    my_pool_id = next(
+        (f.pool_id for f in my_fixtures if f.pool_id is not None),
+        None,
+    )
+    my_standing = None
+    field_size = 0
+    pool_complete = False
+    if results is not None:
+        for pool_standings in results.pools:
+            if my_pool_id is not None and pool_standings.pool_id != my_pool_id:
+                continue
+            for row in pool_standings.rows:
+                if row.entry_id == my_entry_id:
+                    my_standing = row
+                    field_size = len(pool_standings.rows)
+                    pool_complete = pool_standings.complete
+                    break
+            if my_standing is not None:
+                break
+
+    focus_match = (
+        None
+        if focus is None
+        else _build_match(
+            focus,
+            my_entry_id=my_entry_id,
+            username_by_entry=username_by_entry,
+            match=(
+                focus_matches.get(focus.match_id)
+                if focus.match_id is not None
+                else None
+            ),
+            best_of=settings.length_games,
+            draw_type=event.draw_type,
+            tables=tables,
+            game_counts=game_counts,
+        )
+    )
+    return DashboardTournamentEvent(
+        id=event.id,
+        name=event.name,
+        draw_type=event.draw_type,
+        is_live=any(f.match_status is MatchStatus.in_progress for f in my_fixtures),
+        # The record is the caller's own decided fixtures, taken from the standings
+        # row when there is one so it agrees with the table it sits next to; falling
+        # back to a direct count only for an event with no standings projection.
+        wins=my_standing.wins if my_standing is not None else 0,
+        losses=my_standing.losses if my_standing is not None else 0,
+        position=my_standing.rank if my_standing is not None else None,
+        field_size=field_size,
+        stage_label=_stage_label(event.draw_type, complete=pool_complete),
+        pool_label=(
+            pools[my_pool_id].name
+            if my_pool_id is not None and my_pool_id in pools
+            else None
+        ),
+        match=focus_match,
+        fixtures=[
+            _build_fixture_row(
+                fixture,
+                ordinal=index + 1,
+                my_entry_id=my_entry_id,
+                username_by_entry=username_by_entry,
+                tables=tables,
+                game_counts=game_counts,
+            )
+            for index, fixture in enumerate(my_fixtures)
+        ],
+    )
+
+
+def _build_match(
+    fixture: TournamentFixtureRead,
+    *,
+    my_entry_id: uuid.UUID,
+    username_by_entry: dict[uuid.UUID, str],
+    match: Match | None,
+    best_of: int,
+    draw_type: DrawType,
+    tables: dict[str, TournamentTable],
+    game_counts: dict[uuid.UUID, tuple[int, int]],
+) -> DashboardTournamentMatch:
+    side = _my_side(fixture, my_entry_id)
+    opponent_entry_id = fixture.entry_b_id if side == 1 else fixture.entry_a_id
+    state = _match_state(fixture.match_status)
+    your_games, opponent_games = _games_won(
+        fixture, side=side, match=match, game_counts=game_counts
+    )
+    return DashboardTournamentMatch(
+        state=state,
+        match_id=fixture.match_id,
+        opponent_username=(
+            username_by_entry.get(opponent_entry_id)
+            if opponent_entry_id is not None
+            else None
+        ),
+        your_games=your_games,
+        opponent_games=opponent_games,
+        best_of=best_of,
+        games=_games(match, side=side),
+        round_label=_round_label(draw_type, fixture.round),
+        table_label=_table_label(fixture.table_id, tables),
+        start_label=_time_label(fixture),
+        next_game_number=(current_game_number(match) if match is not None else None),
+        you_won=(None if state != "completed" else your_games > opponent_games),
+    )
+
+
+def _build_fixture_row(
+    fixture: TournamentFixtureRead,
+    *,
+    ordinal: int,
+    my_entry_id: uuid.UUID,
+    username_by_entry: dict[uuid.UUID, str],
+    tables: dict[str, TournamentTable],
+    game_counts: dict[uuid.UUID, tuple[int, int]],
+) -> DashboardTournamentFixtureRow:
+    side = _my_side(fixture, my_entry_id)
+    opponent_entry_id = fixture.entry_b_id if side == 1 else fixture.entry_a_id
+    state = _fixture_state(fixture.match_status)
+    you_won: bool | None = None
+    if state == "completed":
+        your_games, opponent_games = _games_won(
+            fixture, side=side, match=None, game_counts=game_counts
+        )
+        you_won = your_games > opponent_games
+        detail = f"{'Won' if you_won else 'Lost'} {your_games}–{opponent_games}"
+    elif state == "live":
+        detail = "In progress"
+    else:
+        parts = [
+            part
+            for part in (_time_label(fixture), _table_label(fixture.table_id, tables))
+            if part
+        ]
+        detail = " · ".join(parts) if parts else "Not scheduled"
+    return DashboardTournamentFixtureRow(
+        label=f"M{ordinal}",
+        opponent_username=(
+            username_by_entry.get(opponent_entry_id)
+            if opponent_entry_id is not None
+            else None
+        ),
+        state=state,
+        detail=detail,
+        you_won=you_won,
+        match_id=fixture.match_id,
+    )
+
+
+def _games_won(
+    fixture: TournamentFixtureRead,
+    *,
+    side: int | None,
+    match: Match | None,
+    game_counts: dict[uuid.UUID, tuple[int, int]],
+) -> tuple[int, int]:
+    """``(yours, theirs)`` games won, flipped onto the caller's side.
+
+    A **completed** fixture reads the page's one batched game count, so the card and
+    the standings beside it are the same number. A **live** one cannot — ``game_counts``
+    is only loaded for completed matches (an in-progress board is not a result and must
+    never reach a standings table, ADR-0788) — so it counts the loaded match's own
+    scored games, which is the running score the card is there to show."""
+    if match is not None and fixture.match_status is not MatchStatus.completed:
+        side_1 = sum(
+            1
+            for game in match.games
+            if game.score is not None
+            and game.score.side_1_points > game.score.side_2_points
+        )
+        side_2 = sum(
+            1
+            for game in match.games
+            if game.score is not None
+            and game.score.side_2_points > game.score.side_1_points
+        )
+    elif fixture.match_id is not None and fixture.match_id in game_counts:
+        side_1, side_2 = game_counts[fixture.match_id]
+    else:
+        side_1, side_2 = 0, 0
+    return (side_1, side_2) if side != 2 else (side_2, side_1)
+
+
+def _games(match: Match | None, *, side: int | None) -> list[DashboardTournamentGame]:
+    """The scored games of the focus match, in play order, points flipped onto the
+    caller's side. Un-scored game rows are not games yet and are skipped."""
+    if match is None:
+        return []
+    games = []
+    for game in sorted(match.games, key=lambda g: g.game_number):
+        if game.score is None:
+            continue
+        mine, theirs = game.score.side_1_points, game.score.side_2_points
+        if side == 2:
+            mine, theirs = theirs, mine
+        games.append(
+            DashboardTournamentGame(
+                number=game.game_number, your_points=mine, opponent_points=theirs
+            )
+        )
+    return games
+
+
+def _match_state(status: MatchStatus | None) -> TournamentMatchState:
+    """A fixture's match status as the card's three-way state.
+
+    ``None`` (not materialized) and ``pending`` are both ``scheduled`` — from the
+    player's chair they are the same thing: a match they have not started. ``voided``
+    is ``completed`` in the sense the card means it (nothing left to play); it carries
+    no games, so the card renders a 0–0 finished board rather than inviting scoring."""
+    match status:
+        case None | MatchStatus.pending:
+            return "scheduled"
+        case MatchStatus.in_progress:
+            return "live"
+        case MatchStatus.completed | MatchStatus.voided:
+            return "completed"
+        case _:
+            assert_never(status)
+
+
+def _fixture_state(status: MatchStatus | None) -> TournamentFixtureState:
+    match status:
+        case None | MatchStatus.pending:
+            return "upcoming"
+        case MatchStatus.in_progress:
+            return "live"
+        case MatchStatus.completed | MatchStatus.voided:
+            return "completed"
+        case _:
+            assert_never(status)
+
+
+def _round_label(draw_type: DrawType, round_number: int) -> str:
+    """A round number in its draw type's own vocabulary, composed here so no client
+    maps an integer to a word.
+
+    An exhaustive ``match`` with no catch-all: a new ``DrawType`` is a type error until
+    it says what it calls a round (api/CLAUDE.md)."""
+    match draw_type:
+        case DrawType.round_robin:
+            return f"Group match {round_number}"
+        case (
+            DrawType.single_elim
+            | DrawType.double_elim
+            | DrawType.rr_then_ko
+            | DrawType.swiss
+        ):
+            # No draw strategy exists for these yet (``strategy_for`` refuses them), so
+            # no fixture of one can reach here today. A neutral label rather than a
+            # bracket word invented ahead of the bracket that would have to mean it.
+            return f"Round {round_number}"
+        case _:
+            assert_never(draw_type)
+
+
+def _stage_label(draw_type: DrawType, *, complete: bool) -> str:
+    match draw_type:
+        case DrawType.round_robin:
+            return "Group complete" if complete else "Group play"
+        case (
+            DrawType.single_elim
+            | DrawType.double_elim
+            | DrawType.rr_then_ko
+            | DrawType.swiss
+        ):
+            return "Complete" if complete else "In play"
+        case _:
+            assert_never(draw_type)
+
+
+def _table_label(
+    table_id: str | None, tables: dict[str, TournamentTable]
+) -> str | None:
+    """The placement's table label, or ``None`` when the fixture is unplaced.
+
+    A ``table_id`` that names nothing in the catalogue also answers ``None`` rather
+    than echoing the raw id: a string ref is not a label, and printing one would put an
+    opaque slug where a player expects "Table 4"."""
+    if table_id is None:
+        return None
+    table = tables.get(table_id)
+    return table.label if table is not None else None
+
+
+def _time_label(fixture: TournamentFixtureRead) -> str | None:
+    """The fixture's start as one display string in the venue's timezone (e.g.
+    ``"4:30 PM CDT"``), already rendered server-side — clients do no timezone math (ADR
+    "tournament times are timezone-aware instants").
+
+    The **pinned** time wins over the predicted one when there is one: a pinned
+    placement is a promise the players were notified of, and a panel that showed the
+    solver's newer estimate instead would contradict the call they were sent."""
+    time = fixture.pinned_at or fixture.scheduled_start
+    if time is None:
+        return None
+    return f"{time.local_label} {time.tz_abbrev}"
+
+
+def _subtitle(tournament: Tournament) -> str:
+    """The panel's second line: the venue and the dates, e.g.
+    ``"Riverside TTC · Jul 24–25"``.
+
+    Composed here rather than on the client because it is three optional facts folded
+    into one sentence, and every client that folded them itself would fold them
+    slightly differently."""
+    address = Address.model_validate(tournament.address)
+    parts = [part for part in (address.venue, _date_range(tournament)) if part]
+    return " · ".join(parts)
+
+
+def _date_range(tournament: Tournament) -> str | None:
+    start, end = tournament.start_date, tournament.end_date
+    if start is None:
+        return None
+    if end is None or end == start:
+        return _short_date(start)
+    if (start.year, start.month) == (end.year, end.month):
+        return f"{_short_date(start)}–{end.day}"
+    return f"{_short_date(start)}–{_short_date(end)}"
+
+
+def _short_date(value: date) -> str:
+    """``Jul 24`` — no leading zero on the day, matching the app's other date chips."""
+    return f"{value.strftime('%b')} {value.day}"

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -180,6 +180,19 @@ class DashboardTournamentMatch(BaseModel):
     # has no outcome, and a ``False`` there would claim the caller lost a match still
     # being played, or one that was struck from the record entirely.
     you_won: bool | None
+    # WHAT THE CALLER OWES on this match, from the very classifier the attention
+    # panel is built on (``app.attention.list_attention_kind``) — so the two panels
+    # on one dashboard cannot label the same match differently.
+    #
+    # ``next_game_number is None`` is NOT enough to decide this, and reading it that
+    # way is a bug the panel shipped once: ``current_game_number`` answers ``None``
+    # both when the board is decided-but-unposted AND when a result is already
+    # posted and awaiting acceptance. Those owe opposite things — post it vs review
+    # it — and the poster of a standing result owes nothing at all.
+    #
+    # ``None`` means there is nothing to do (a completed/voided match, or one this
+    # user does not play in).
+    owed_action: AttentionKind | Literal["waiting_opponent", "waiting_others"] | None
 
 
 class DashboardTournamentFixtureRow(BaseModel):

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+from app.models.tournament import DrawType
 from app.schemas.rating import RatingChange
 
 # The actionable bucket a match falls in for the current user, in priority
@@ -107,6 +108,137 @@ class DashboardRating(BaseModel):
     stats: list[DashboardRatingStat]
 
 
+TournamentMatchState = Literal["live", "scheduled", "completed"]
+"""The state of the ONE match the tournament panel puts in front of the player: the
+one being played now, the next one due, or the last one finished. Closed set — the
+panel's card renders a different shape per arm, so a fourth state must be a type
+error here rather than a card that renders nothing."""
+
+TournamentFixtureState = Literal["completed", "live", "upcoming"]
+"""A row's state in the panel's "Your matches" path. Deliberately NOT
+``MatchStatus``: a fixture that has not materialized into a match yet has no match
+status at all, and that is the ``upcoming`` case the path exists to show."""
+
+
+class DashboardTournamentGame(BaseModel):
+    """One completed game of the panel's focus match, scored from the CURRENT USER's
+    side — ``your_points`` is always the caller's, never side 1's.
+
+    The panel prints these as chips ("Game 3 · 11–9"), and a chip that silently means
+    "side 1 first" would read backwards for whichever player happens to be entry B.
+    The flip happens once, here, where the caller's side is known."""
+
+    number: int
+    your_points: int
+    opponent_points: int
+
+
+class DashboardTournamentMatch(BaseModel):
+    """The one match the tournament panel's card shows for an event, already resolved
+    server-side to the single most relevant one: the live match if there is one, else
+    the next scheduled fixture, else the last completed match (see
+    ``app.dashboard_tournaments``).
+
+    Everything is stated from the CALLER's side. ``your_games``/``opponent_games`` are
+    games won (not points) — the score the card's big numerals print — and
+    ``games`` carries the per-game points behind them.
+    """
+
+    state: TournamentMatchState
+    # ``None`` for a ``scheduled`` fixture that has not materialized into a match yet
+    # — the panel then has nothing to deep-link, which is exactly what an un-called
+    # fixture is. Never ``None`` for ``live``/``completed``.
+    match_id: uuid.UUID | None
+    # ``None`` means the opposing side is still TBD (an undecided feeding fixture),
+    # the same fact ``TournamentFixtureRead.entry_b_id is None`` carries.
+    opponent_username: str | None
+    your_games: int
+    opponent_games: int
+    best_of: int
+    games: list[DashboardTournamentGame]
+    # e.g. ``"Group match 2"`` — composed from the fixture's round in the vocabulary
+    # of its draw type, so the client never maps a round number to a word.
+    round_label: str
+    # The venue table this fixture is placed on (``TournamentTable.label``), or
+    # ``None`` when unplaced (ADR-0790).
+    table_label: str | None
+    # The scheduled start, already rendered in the event's venue timezone with its
+    # abbreviation (e.g. ``"4:30 PM CDT"``) — clients stay timezone-math-free (ADR
+    # "tournament times are timezone-aware instants"). ``None`` when unscheduled.
+    start_label: str | None
+    # The next un-scored game, for the card's "Enter Game N result" deep link. Mirrors
+    # ``DashboardAttentionItem.current_game_number``: ``None`` when the board is
+    # already decided but unposted, or the match is not in progress.
+    next_game_number: int | None
+    # ``None`` unless ``state`` is ``completed`` — a live or scheduled match has no
+    # outcome, and a ``False`` there would claim the caller lost a match still being
+    # played.
+    you_won: bool | None
+
+
+class DashboardTournamentFixtureRow(BaseModel):
+    """One line of the panel's "Your matches" path — every fixture in this event the
+    caller is a side of, in draw order.
+
+    ``detail`` is the row's right-hand text, composed server-side because what belongs
+    there changes with ``state`` (a result, "In progress", or a time and table). The
+    client prints it verbatim rather than reassembling three optional fields into a
+    sentence."""
+
+    # e.g. ``"M2"`` — the fixture's ordinal within the caller's own schedule.
+    label: str
+    opponent_username: str | None
+    state: TournamentFixtureState
+    detail: str
+    # ``None`` for anything not yet decided, for the same reason as on the match above.
+    you_won: bool | None
+    match_id: uuid.UUID | None
+
+
+class DashboardTournamentEvent(BaseModel):
+    """One event of a live tournament that the caller holds an active entry in — one
+    tab of the panel.
+
+    The record, position and stage are the panel's stats strip; they are derived here
+    from the same live standings projection the tournament-detail page uses
+    (ADR-0788), so the two surfaces cannot disagree about where a player stands."""
+
+    id: uuid.UUID
+    name: str
+    draw_type: DrawType
+    # Whether this event holds the caller's currently-live match — what puts the
+    # "Live" marker on the tab.
+    is_live: bool
+    wins: int
+    losses: int
+    # The caller's 1-based rank in their pool, and how many players are in it.
+    # ``position`` is ``None`` when the event has no standings yet (no draw cut, or a
+    # draw type with no results strategy — only round-robin has one today), which is
+    # a fact, not a zero.
+    position: int | None
+    field_size: int
+    # e.g. ``"Group play"`` / ``"Group complete"``.
+    stage_label: str
+    # The caller's pool name, or ``None`` for an un-pooled draw.
+    pool_label: str | None
+    match: DashboardTournamentMatch | None
+    fixtures: list[DashboardTournamentFixtureRow]
+
+
+class DashboardTournament(BaseModel):
+    """A live tournament the caller is playing in — the whole panel, one per
+    tournament, with one tab per event they entered."""
+
+    id: uuid.UUID
+    name: str
+    # e.g. ``"Riverside TTC · Jul 24"`` — venue and dates, composed server-side.
+    subtitle: str
+    # How many of the caller's matches in this tournament are being played right now.
+    # Drives the header's "N live now" pill; ``0`` hides it.
+    live_count: int
+    events: list[DashboardTournamentEvent]
+
+
 class DashboardResponse(BaseModel):
     # The current user's most-urgent actionable matches, pre-ranked by attention
     # priority (§5 of the PRD), capped server-side (``ATTENTION_BANNERS_LIMIT``)
@@ -127,3 +259,13 @@ class DashboardResponse(BaseModel):
     # persistence banner uses this to reference history concretely ("Your N
     # matches…") and to stay hidden until the user has any history at all.
     completed_match_count: int
+    # Every LIVE tournament the caller holds an active entry in, newest first — the
+    # panel that sits at the very top of the dashboard while they are playing one.
+    # Empty (and the panel absent) the rest of the time, which is almost always: a
+    # tournament is only ``live`` for the day or two it is being run.
+    #
+    # It rides on this payload rather than on a ``GET /v1/dashboard/tournaments`` of
+    # its own because the panel loads with the page, not in response to a click — the
+    # BFF rule's test for "one endpoint per page" (root CLAUDE.md). Its tabs switch
+    # between events that are all already here; no tab costs a round-trip.
+    tournaments: list[DashboardTournament] = []

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -108,16 +108,22 @@ class DashboardRating(BaseModel):
     stats: list[DashboardRatingStat]
 
 
-TournamentMatchState = Literal["live", "scheduled", "completed"]
+TournamentMatchState = Literal["live", "scheduled", "completed", "voided"]
 """The state of the ONE match the tournament panel puts in front of the player: the
-one being played now, the next one due, or the last one finished. Closed set — the
-panel's card renders a different shape per arm, so a fourth state must be a type
-error here rather than a card that renders nothing."""
+one being played now, the next one due, the last one finished, or one that was
+voided. Closed set — the panel's card renders a different shape per arm, so a fifth
+state must be a type error here rather than a card that renders nothing.
 
-TournamentFixtureState = Literal["completed", "live", "upcoming"]
+``voided`` is its own arm and NOT a flavour of ``completed``, because a voided match
+has **no winner** (``app.match_voiding`` — "any surface that derives a result must
+see *no winner*, not a stale W/L"). Folding it into ``completed`` makes the panel
+derive an outcome from a 0–0 board and announce a loss the player never took."""
+
+TournamentFixtureState = Literal["completed", "live", "upcoming", "voided"]
 """A row's state in the panel's "Your matches" path. Deliberately NOT
 ``MatchStatus``: a fixture that has not materialized into a match yet has no match
-status at all, and that is the ``upcoming`` case the path exists to show."""
+status at all, and that is the ``upcoming`` case the path exists to show. ``voided``
+is its own arm here for the same reason it is on the match state above."""
 
 
 class DashboardTournamentGame(BaseModel):
@@ -170,9 +176,9 @@ class DashboardTournamentMatch(BaseModel):
     # ``DashboardAttentionItem.current_game_number``: ``None`` when the board is
     # already decided but unposted, or the match is not in progress.
     next_game_number: int | None
-    # ``None`` unless ``state`` is ``completed`` — a live or scheduled match has no
-    # outcome, and a ``False`` there would claim the caller lost a match still being
-    # played.
+    # ``None`` unless ``state`` is ``completed`` — a live, scheduled or VOIDED match
+    # has no outcome, and a ``False`` there would claim the caller lost a match still
+    # being played, or one that was struck from the record entirely.
     you_won: bool | None
 
 

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -58,10 +58,14 @@ from app.tournament_queries import (
 # Public shared surface: the serializers both the HTTP router (``tournaments.py``)
 # and the MCP adapter import. ``_serialize_event`` is public too because the
 # per-event routes (cut/uncut draw, place fixtures) serialize a single event
-# directly. Everything else (``_tournament_fields``, ``_entry_state``,
-# ``_event_results``, ``_serialize_results``) is a module-internal helper and
-# stays private.
+# directly, and ``event_results`` because the dashboard's tournament panel
+# (``app.dashboard_tournaments``) stands the caller in the very same standings the
+# tournament page shows — two projections of one table is the one way the panel could
+# tell a player they are 2nd on one screen and 3rd on another. Everything else
+# (``_tournament_fields``, ``_entry_state``, ``_serialize_results``) is a
+# module-internal helper and stays private.
 __all__ = [
+    "event_results",
     "serialize",
     "serialize_detail",
     "serialize_event",
@@ -178,7 +182,7 @@ def _entry_state(
             assert_never(decision)
 
 
-def _event_results(
+def event_results(
     e: TournamentEvent,
     *,
     fixtures: list[TournamentFixtureRead],
@@ -358,7 +362,7 @@ def serialize_event(
             "results": (
                 None
                 if game_counts is None
-                else _event_results(e, fixtures=fixtures, game_counts=game_counts)
+                else event_results(e, fixtures=fixtures, game_counts=game_counts)
             ),
         }
     )

--- a/api/tests/test_dashboard_tournaments.py
+++ b/api/tests/test_dashboard_tournaments.py
@@ -339,6 +339,58 @@ async def test_the_record_is_counted_directly_when_there_are_no_standings(
     )
 
 
+async def test_a_standing_result_owes_a_review_to_one_side_and_nothing_to_the_other(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """``owed_action`` is what the CALLER owes, and the two players owe opposite
+    things once a result is standing.
+
+    The panel used to read this off ``next_game_number is None``, which conflates
+    three different states: the board is decided but unposted, a result is posted
+    and awaiting acceptance, and the match is not in progress at all. Under that
+    reading the card told BOTH players to "Post the result" — a job already done, and
+    done by one of them. It comes from ``list_attention_kind`` now, the very
+    classifier the attention panel on the same dashboard is built from, so the two
+    panels cannot label one match two ways.
+    """
+    client, owner = authed_client
+    async with opponent_session(db_session, "owed-opp") as (opp_client, opp):
+        _tid, _event, _e_owner, _e_opp, fixture = await _live_two_player_pool(
+            client, owner, opp, db_session, rated=True
+        )
+        # Mid-board, nothing posted: both sides owe a score.
+        (mine,) = await _panels(client)
+        assert mine["events"][0]["match"]["owed_action"] == "score"
+
+        # The owner proposes a decided board; it stands, unaccepted.
+        post = await client.post(
+            f"/v1/matches/{fixture.match_id}/results",
+            json={
+                "games": [
+                    {"game_number": n, "side_1_points": 11, "side_2_points": 5}
+                    for n in (1, 2)
+                ]
+            },
+        )
+        assert post.status_code == 201, post.text
+
+        (poster_panel,) = await _panels(client)
+        (reviewer_panel,) = await _panels(opp_client)
+
+    assert poster_panel["events"][0]["match"]["owed_action"] == "waiting_opponent", (
+        "the side that posted owes nothing — the move is the opponent's"
+    )
+    assert reviewer_panel["events"][0]["match"]["owed_action"] == "review", (
+        "the other side owes a review, not another post"
+    )
+    assert poster_panel["events"][0]["match"]["next_game_number"] is None
+    assert reviewer_panel["events"][0]["match"]["next_game_number"] is None, (
+        "and next_game_number is None for BOTH — which is exactly why it cannot "
+        "be the thing the label is read off"
+    )
+
+
 async def test_a_voided_match_shows_no_winner_and_no_score(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,

--- a/api/tests/test_dashboard_tournaments.py
+++ b/api/tests/test_dashboard_tournaments.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.match_voiding import void_match
 from app.models import (
     Match,
     MatchStatus,
@@ -335,6 +336,59 @@ async def test_the_record_is_counted_directly_when_there_are_no_standings(
     )
     assert event["position"] is None, (
         "and the position really is absent — the standings are what is missing"
+    )
+
+
+async def test_a_voided_match_shows_no_winner_and_no_score(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A voided match contributes nothing (ADR-0013) — and the panel must say exactly
+    that, not derive a result from it.
+
+    Voiding nulls both sides' ``won`` precisely so that "any surface that derives a
+    result must see *no winner*, not a stale W/L" (``app.match_voiding``). It also
+    drops the match out of ``completed_match_ids``, so the panel has no game counts
+    for it. Folding ``voided`` into ``completed`` therefore produced the worst of
+    both: an outcome derived from an empty board, announcing ``Lost 0–0`` on a match
+    the player may well have won before it was struck from the record.
+
+    The match here is played to a real 2–0 win FIRST, then voided, so the test
+    distinguishes "reports no result" from "had no result to report".
+    """
+    client, owner = authed_client
+    async with opponent_session(db_session, "void-opp") as (opp_client, opp):
+        _tid, _event, e_owner, e_opp, fixture = await _live_two_player_pool(
+            client, owner, opp, db_session, rated=True
+        )
+        await _win_fixture_match(
+            fixture,
+            clients_by_entry={e_owner.id: client, e_opp.id: opp_client},
+            winner_entry_id=e_owner.id,
+            rated=True,
+        )
+        match = await db_session.get(Match, fixture.match_id)
+        assert match is not None
+        await void_match(db_session, match)
+        await db_session.commit()
+
+        (panel,) = await _panels(client)
+
+    event = panel["events"][0]
+    card = event["match"]
+    assert card["state"] == "voided", "not 'completed' — a void is its own state"
+    assert card["you_won"] is None, (
+        "a voided match has no winner, so the card crowns nobody"
+    )
+
+    (row,) = event["fixtures"]
+    assert row["state"] == "voided"
+    assert row["you_won"] is None
+    assert row["detail"] == "Voided", (
+        "the row states the fact rather than a fabricated 'Lost 0–0'"
+    )
+    assert (event["wins"], event["losses"]) == (0, 0), (
+        "and the void counts toward neither column of the record"
     )
 
 

--- a/api/tests/test_dashboard_tournaments.py
+++ b/api/tests/test_dashboard_tournaments.py
@@ -1,0 +1,448 @@
+"""``DashboardResponse.tournaments`` — the panel that tops the dashboard while the
+caller is playing in a live tournament.
+
+Read through the real ``GET /v1/dashboard`` rather than the builder, because the shape
+on the wire is the contract the panel renders. The tournaments themselves are built
+through the real tournament routes (create → enter → cut → go live → call → play), so
+what the panel projects is what the product actually writes.
+"""
+
+import uuid
+from typing import Any
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    Match,
+    MatchStatus,
+    TournamentEntryStatus,
+    TournamentStatus,
+    User,
+)
+from tests._helpers import opponent_session
+from tests.test_tournaments import (
+    POOL_A,
+    _call_fixtures,
+    _cut_the_draw,
+    _enter,
+    _fixture_rows,
+    _go_live,
+    _live_two_player_pool,
+    _rr_payload,
+    _set_status,
+    _tournament_with_events,
+    _win_fixture_match,
+)
+from tests.test_tournaments import (
+    _withdraw as _withdraw_entry,
+)
+
+# The tournament suite's own fixture — the primary client with a real session holding
+# the tournament permissions the create/read routes gate on. Imported (rather than
+# re-declared) so a change to what a director may do reaches this file too.
+from tests.test_tournaments import authed_client as authed_client  # noqa: F401
+
+
+async def _panels(client: AsyncClient) -> list[dict[str, Any]]:
+    response = await client.get("/v1/dashboard")
+    assert response.status_code == 200, response.text
+    panels: list[dict[str, Any]] = response.json()["tournaments"]
+    return panels
+
+
+async def test_a_player_in_no_tournament_gets_no_panel(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """The overwhelmingly common case: nobody is mid-tournament most days, so the
+    field is an empty list and the dashboard renders no panel at all — not an empty
+    one with a heading and nothing under it."""
+    client, _ = authed_client
+
+    assert await _panels(client) == []
+
+
+async def test_a_live_tournament_the_caller_is_entered_in_becomes_a_panel(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The whole projection, end to end: a live round-robin the caller is playing in
+    comes back as one panel, with a tab for the event, the live match in the card, the
+    caller's own record and pool position, and their schedule."""
+    client, owner = authed_client
+    async with opponent_session(db_session, "panel-opp") as (_opp_client, opp):
+        await _live_two_player_pool(client, owner, opp, db_session, rated=True)
+
+        (panel,) = await _panels(client)
+
+    assert panel["live_count"] == 1, "the caller's called match is being played now"
+    (event,) = panel["events"]
+    assert event["is_live"] is True
+    assert event["draw_type"] == "round-robin"
+    assert event["stage_label"] == "Group play"
+    assert event["pool_label"] == "Pool A", (
+        "the pool the caller was drawn into, by name — not its 'p-a' string ref"
+    )
+
+    card = event["match"]
+    assert card["state"] == "live"
+    assert card["opponent_username"] == "panel-opp"
+    assert card["your_games"] == 0 and card["opponent_games"] == 0
+    assert card["best_of"] == 3
+    assert card["round_label"] == "Group match 1"
+    assert card["next_game_number"] == 1, (
+        "the card deep-links straight to the game that is about to be played"
+    )
+    assert card["you_won"] is None, "a match still being played has no outcome"
+
+    (row,) = event["fixtures"]
+    assert row["label"] == "M1"
+    assert row["state"] == "live"
+    assert row["detail"] == "In progress"
+    assert row["opponent_username"] == "panel-opp"
+
+
+async def test_the_panel_states_the_score_from_the_callers_own_side(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The side flip, which is the whole reason this projection exists.
+
+    A fixture seats ``entry_a`` on side 1 and ``entry_b`` on side 2 (#788), so a raw
+    side-shaped score reads *backwards* for whichever player is entry B. Here the
+    caller is entry B and the board is 5–11 in side terms — a game they **won** — and
+    every number the panel gives them says so: ``your_games`` is 1, and the game chip
+    reads 11–5 their way round.
+
+    Proven by handing the same match to both players and asserting the two panels are
+    mirror images. Asserting only the caller's side would pass just as well if the
+    server never flipped anything and the caller happened to be entry A.
+    """
+    client, owner = authed_client
+    async with opponent_session(db_session, "flip-opp") as (opp_client, opp):
+        # Owner is seed 1 → entry A → side 1. The *opponent* is entry B, so the
+        # opponent's panel is the one that must be flipped.
+        _tid, _event, _e_owner, _e_opp, fixture = await _live_two_player_pool(
+            client, owner, opp, db_session, rated=True
+        )
+        write = await client.post(
+            f"/v1/matches/{fixture.match_id}/games/1/scores/new",
+            json={"side_1_points": 5, "side_2_points": 11},
+        )
+        assert write.status_code == 201, write.text
+
+        (owner_panel,) = await _panels(client)
+        (opp_panel,) = await _panels(opp_client)
+
+    owner_card = owner_panel["events"][0]["match"]
+    opp_card = opp_panel["events"][0]["match"]
+
+    assert (owner_card["your_games"], owner_card["opponent_games"]) == (0, 1)
+    assert (opp_card["your_games"], opp_card["opponent_games"]) == (1, 0), (
+        "entry B won that game, and their own panel must say so"
+    )
+    assert owner_card["games"] == [
+        {"number": 1, "your_points": 5, "opponent_points": 11}
+    ]
+    assert opp_card["games"] == [{"number": 1, "your_points": 11, "opponent_points": 5}]
+    assert owner_card["opponent_username"] == "flip-opp"
+    assert opp_card["opponent_username"] == owner.username
+
+
+async def test_a_completed_match_carries_its_outcome_and_the_record_follows(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Once the caller's only match is decided, the card flips to ``completed`` with
+    the outcome stated from their side, the path row states the result, and the stats
+    strip reads the standings the tournament page reads (ADR-0788) rather than a second
+    count of the same match."""
+    client, owner = authed_client
+    async with opponent_session(db_session, "done-opp") as (opp_client, opp):
+        _tid, _event, e_owner, e_opp, fixture = await _live_two_player_pool(
+            client, owner, opp, db_session, rated=True
+        )
+        await _win_fixture_match(
+            fixture,
+            clients_by_entry={e_owner.id: client, e_opp.id: opp_client},
+            winner_entry_id=e_owner.id,
+            rated=True,
+        )
+
+        (panel,) = await _panels(client)
+        (loser_panel,) = await _panels(opp_client)
+
+    assert panel["live_count"] == 0, "nothing of the caller's is being played now"
+    event = panel["events"][0]
+    assert event["is_live"] is False
+    assert (event["wins"], event["losses"]) == (1, 0)
+    assert event["position"] == 1 and event["field_size"] == 2
+    assert event["stage_label"] == "Group complete", (
+        "the pool's only fixture is decided, so group play is over"
+    )
+
+    card = event["match"]
+    assert card["state"] == "completed"
+    assert card["you_won"] is True
+    assert (card["your_games"], card["opponent_games"]) == (2, 0)
+    assert card["next_game_number"] is None, "there is no next game to deep-link"
+
+    (row,) = event["fixtures"]
+    assert row["state"] == "completed"
+    assert row["you_won"] is True
+    assert row["detail"] == "Won 2–0"
+
+    loser_event = loser_panel["events"][0]
+    assert (loser_event["wins"], loser_event["losses"]) == (0, 1)
+    assert loser_event["position"] == 2
+    assert loser_event["fixtures"][0]["detail"] == "Lost 0–2", (
+        "the loser's own row reads as a loss — the row is stated from each side"
+    )
+
+
+async def test_the_card_prefers_the_live_match_over_a_finished_one(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A player mid-match must never have to scroll past a result to find the game
+    they are standing at a table for: with one match finished and another called, the
+    card shows the one being played.
+
+    Three-player pool so the caller has two fixtures and the choice is real — with a
+    single fixture the priority rule is unobservable, since whichever match exists is
+    also the only one that could be picked.
+    """
+    client, owner = authed_client
+    async with opponent_session(db_session, "prio-second") as (second_client, second):
+        async with opponent_session(db_session, "prio-third") as (_third_client, third):
+            tournament_id, (event,) = await _tournament_with_events(
+                client,
+                _rr_payload(
+                    POOL_A,
+                    match_settings={"rated": False, "length_games": 3},
+                    predicates=[],
+                ),
+            )
+            entries = {
+                user.username: await _enter(db_session, event["id"], user, seed=seed)
+                for seed, user in enumerate((owner, second, third), start=1)
+            }
+            await _cut_the_draw(client, tournament_id, event["id"])
+            await _set_status(db_session, tournament_id, TournamentStatus.published)
+            assert (await _go_live(client, tournament_id)).status_code == 201
+
+            fixtures = await _fixture_rows(db_session, event["id"])
+            mine = [
+                f
+                for f in fixtures
+                if entries[owner.username].id in (f.entry_a_id, f.entry_b_id)
+            ]
+            assert len(mine) == 2, "the caller plays both of the other two"
+            finished, playing = mine
+            await _call_fixtures(db_session, tournament_id, [finished, playing])
+            reloaded = await _fixture_rows(db_session, event["id"])
+            (finished,) = [f for f in reloaded if f.id == finished.id]
+            await _win_fixture_match(
+                finished,
+                clients_by_entry={
+                    entries[owner.username].id: client,
+                    entries[second.username].id: second_client,
+                },
+                winner_entry_id=entries[owner.username].id,
+                rated=False,
+            )
+
+            (panel,) = await _panels(client)
+
+    card = panel["events"][0]["match"]
+    assert card["state"] == "live", (
+        "the called, unfinished match wins the card over the decided one"
+    )
+    assert card["match_id"] == str(playing.match_id)
+    assert panel["events"][0]["fixtures"][0]["state"] == "completed", (
+        "the finished match is still on the path — it is just not the card"
+    )
+
+
+async def test_an_uncalled_match_reads_as_the_next_one_up(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A materialized-but-uncalled match is ``pending`` in the domain and
+    ``scheduled`` on the panel: from the player's chair "not created yet" and "created
+    but not called" are the same thing — a match they have not started — and the card
+    must invite neither scoring nor a result."""
+    client, owner = authed_client
+    async with opponent_session(db_session, "uncalled-opp") as (_opp_client, opp):
+        _tid, _event, _e_owner, _e_opp, fixture = await _live_two_player_pool(
+            client, owner, opp, db_session, rated=True, call=False
+        )
+        match = await db_session.get(Match, fixture.match_id)
+        assert match is not None and match.status is MatchStatus.pending
+
+        (panel,) = await _panels(client)
+
+    assert panel["live_count"] == 0
+    card = panel["events"][0]["match"]
+    assert card["state"] == "scheduled"
+    assert card["next_game_number"] is None, (
+        "an uncalled match is not scorable, so there is no game to deep-link"
+    )
+    assert card["you_won"] is None
+    assert panel["events"][0]["fixtures"][0]["state"] == "upcoming"
+
+
+async def test_a_tournament_that_is_not_live_gets_no_panel(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """``live`` is the whole membership test. A published tournament has no draw being
+    played yet and an archived one is over; neither belongs at the top of a
+    dashboard."""
+    client, owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    await _enter(db_session, event["id"], owner, seed=1)
+
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    assert await _panels(client) == []
+
+    await _set_status(db_session, tournament_id, TournamentStatus.live)
+    assert len(await _panels(client)) == 1, "the same tournament, now live, is a panel"
+
+    await _set_status(db_session, tournament_id, TournamentStatus.archived)
+    assert await _panels(client) == []
+
+
+async def test_a_withdrawn_player_gets_no_panel(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Withdrawal is a soft delete (ADR-0016) — the row survives — so the panel has to
+    filter on the status rather than on the row's existence, or a player who pulled out
+    keeps being shown a tournament they are no longer in."""
+    client, owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    entry = await _enter(db_session, event["id"], owner, seed=1)
+    await _set_status(db_session, tournament_id, TournamentStatus.live)
+    assert len(await _panels(client)) == 1
+
+    await _withdraw_entry(db_session, entry)
+
+    assert await _panels(client) == [], (
+        "the withdrawn entry's row is still on the books, but it is not an entry"
+    )
+
+
+async def test_a_live_tournament_the_caller_only_directs_gets_no_panel(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The panel is a PLAYER's surface, keyed on holding an entry — not on owning the
+    tournament. A director who is running an event they are not playing in has no match
+    to be shown, and their dashboard must not claim otherwise."""
+    client, _owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    async with opponent_session(db_session, "entrant-not-owner") as (_c, entrant):
+        await _enter(db_session, event["id"], entrant, seed=1)
+        await _set_status(db_session, tournament_id, TournamentStatus.live)
+
+        assert await _panels(client) == [], (
+            "the owner created it, but they are not in it"
+        )
+
+
+async def test_an_event_with_no_draw_cut_stands_the_player_nowhere(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """``position: None`` is a fact, not a zero: an event whose draw has not been cut
+    has no standings to stand in, and a ``0`` there would read as a rank."""
+    client, owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    await _enter(db_session, event["id"], owner, seed=1)
+    await _set_status(db_session, tournament_id, TournamentStatus.live)
+
+    (panel,) = await _panels(client)
+
+    (panel_event,) = panel["events"]
+    assert panel_event["position"] is None
+    assert panel_event["field_size"] == 0
+    assert panel_event["match"] is None, "no fixtures, so there is no match to show"
+    assert panel_event["fixtures"] == []
+    assert panel_event["pool_label"] is None, (
+        "the caller has no fixture yet, so no pool has been dealt to them"
+    )
+
+
+async def test_every_event_the_caller_entered_becomes_a_tab_of_one_panel(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Two events of one tournament are two tabs of one panel, not two panels — the
+    tournament is the thing the player is *at*, and its events are how they move around
+    inside it."""
+    client, owner = authed_client
+    tournament_id, (first, second) = await _tournament_with_events(
+        client,
+        _rr_payload(POOL_A, name="Open Singles"),
+        _rr_payload(POOL_A, name="U1500"),
+    )
+    await _enter(db_session, first["id"], owner, seed=1)
+    await _enter(db_session, second["id"], owner, seed=1)
+    await _set_status(db_session, tournament_id, TournamentStatus.live)
+
+    (panel,) = await _panels(client)
+
+    assert [event["name"] for event in panel["events"]] == ["Open Singles", "U1500"], (
+        "tabs are in event-creation order, so the tab strip does not reshuffle "
+        "between loads"
+    )
+
+
+async def test_the_panel_names_the_tournament_and_its_venue(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The header's two lines. The subtitle folds venue and dates into one sentence
+    server-side, because three optional facts assembled on each client would be
+    assembled slightly differently on each."""
+    client, owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client,
+        _rr_payload(POOL_A),
+        name="Riverside Summer Slam",
+        start_date="2026-07-24",
+        end_date="2026-07-25",
+    )
+    await _enter(db_session, event["id"], owner, seed=1)
+    await _set_status(db_session, tournament_id, TournamentStatus.live)
+
+    (panel,) = await _panels(client)
+
+    assert panel["id"] == tournament_id
+    assert panel["name"] == "Riverside Summer Slam"
+    assert panel["subtitle"].endswith("Jul 24–25"), (
+        f"a same-month range collapses to one month name: {panel['subtitle']}"
+    )
+
+
+async def test_a_withdrawn_entry_that_was_never_entered_is_not_a_uuid_lookup(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A guard on the membership query itself: an entry row belonging to *another*
+    user in the same live event must not put that event on this caller's panel."""
+    client, _owner = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    async with opponent_session(db_session, "someone-else") as (_c, other):
+        await _enter(
+            db_session,
+            event["id"],
+            other,
+            seed=1,
+            status=TournamentEntryStatus.entered,
+            entry_id=uuid.uuid4(),
+        )
+        await _set_status(db_session, tournament_id, TournamentStatus.live)
+
+        assert await _panels(client) == []

--- a/api/tests/test_dashboard_tournaments.py
+++ b/api/tests/test_dashboard_tournaments.py
@@ -9,6 +9,7 @@ what the panel projects is what the product actually writes.
 
 import uuid
 from typing import Any
+from unittest.mock import patch
 
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -290,6 +291,51 @@ async def test_an_uncalled_match_reads_as_the_next_one_up(
     )
     assert card["you_won"] is None
     assert panel["events"][0]["fixtures"][0]["state"] == "upcoming"
+
+
+async def test_the_record_is_counted_directly_when_there_are_no_standings(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """``event_results`` answers ``None`` for every draw type but round-robin
+    (ADR-0788), so the panel cannot read the record off a standings row there. It
+    counts the caller's own decided fixtures instead.
+
+    Proven by taking a real played round-robin and reading the record back with the
+    standings projection removed — the state every future bracket event will be in.
+    Without the direct count the panel reports ``0–0`` to a player who has won, and
+    nothing type-checks or tests its way to noticing: the standings row is simply
+    absent, and ``0`` is a perfectly well-formed number.
+    """
+    client, owner = authed_client
+    async with opponent_session(db_session, "no-standings-opp") as (opp_client, opp):
+        _tid, _event, e_owner, e_opp, fixture = await _live_two_player_pool(
+            client, owner, opp, db_session, rated=True
+        )
+        await _win_fixture_match(
+            fixture,
+            clients_by_entry={e_owner.id: client, e_opp.id: opp_client},
+            winner_entry_id=e_owner.id,
+            rated=True,
+        )
+
+        (with_standings,) = await _panels(client)
+        assert (
+            with_standings["events"][0]["wins"],
+            with_standings["events"][0]["losses"],
+        ) == (1, 0)
+
+        # Now the same data with no standings to read — the bracket case.
+        with patch("app.dashboard_tournaments.event_results", return_value=None):
+            (without_standings,) = await _panels(client)
+
+    event = without_standings["events"][0]
+    assert (event["wins"], event["losses"]) == (1, 0), (
+        "the record is counted from the caller's own decided fixtures, not zeroed"
+    )
+    assert event["position"] is None, (
+        "and the position really is absent — the standings are what is missing"
+    )
 
 
 async def test_a_tournament_that_is_not_live_gets_no_panel(

--- a/e2e/node_modules
+++ b/e2e/node_modules
@@ -1,0 +1,1 @@
+/Users/ryan/Development/fortymm/e2e/node_modules

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -3736,6 +3736,65 @@ internal enum Components {
             internal var nextGameNumber: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/you_won`.
             internal var youWon: Swift.Bool?
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/owed_action`.
+            internal struct OwedActionPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/owed_action/value1`.
+                internal enum Value1Payload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case review = "review"
+                    case score = "score"
+                }
+                /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/owed_action/value1`.
+                internal var value1: Components.Schemas.DashboardTournamentMatch.OwedActionPayload.Value1Payload?
+                /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/owed_action/value2`.
+                internal enum Value2Payload: String, Codable, Hashable, Sendable, CaseIterable {
+                    case waitingOpponent = "waiting_opponent"
+                    case waitingOthers = "waiting_others"
+                }
+                /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/owed_action/value2`.
+                internal var value2: Components.Schemas.DashboardTournamentMatch.OwedActionPayload.Value2Payload?
+                /// Creates a new `OwedActionPayload`.
+                ///
+                /// - Parameters:
+                ///   - value1:
+                ///   - value2:
+                internal init(
+                    value1: Components.Schemas.DashboardTournamentMatch.OwedActionPayload.Value1Payload? = nil,
+                    value2: Components.Schemas.DashboardTournamentMatch.OwedActionPayload.Value2Payload? = nil
+                ) {
+                    self.value1 = value1
+                    self.value2 = value2
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    var errors: [any Swift.Error] = []
+                    do {
+                        self.value1 = try decoder.decodeFromSingleValueContainer()
+                    } catch {
+                        errors.append(error)
+                    }
+                    do {
+                        self.value2 = try decoder.decodeFromSingleValueContainer()
+                    } catch {
+                        errors.append(error)
+                    }
+                    try Swift.DecodingError.verifyAtLeastOneSchemaIsNotNil(
+                        [
+                            self.value1,
+                            self.value2
+                        ],
+                        type: Self.self,
+                        codingPath: decoder.codingPath,
+                        errors: errors
+                    )
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    try encoder.encodeFirstNonNilValueToSingleValueContainer([
+                        self.value1,
+                        self.value2
+                    ])
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/owed_action`.
+            internal var owedAction: Components.Schemas.DashboardTournamentMatch.OwedActionPayload?
             /// Creates a new `DashboardTournamentMatch`.
             ///
             /// - Parameters:
@@ -3751,6 +3810,7 @@ internal enum Components {
             ///   - startLabel:
             ///   - nextGameNumber:
             ///   - youWon:
+            ///   - owedAction:
             internal init(
                 state: Components.Schemas.DashboardTournamentMatch.StatePayload,
                 matchId: Swift.String? = nil,
@@ -3763,7 +3823,8 @@ internal enum Components {
                 tableLabel: Swift.String? = nil,
                 startLabel: Swift.String? = nil,
                 nextGameNumber: Swift.Int? = nil,
-                youWon: Swift.Bool? = nil
+                youWon: Swift.Bool? = nil,
+                owedAction: Components.Schemas.DashboardTournamentMatch.OwedActionPayload? = nil
             ) {
                 self.state = state
                 self.matchId = matchId
@@ -3777,6 +3838,7 @@ internal enum Components {
                 self.startLabel = startLabel
                 self.nextGameNumber = nextGameNumber
                 self.youWon = youWon
+                self.owedAction = owedAction
             }
             internal enum CodingKeys: String, CodingKey {
                 case state
@@ -3791,6 +3853,7 @@ internal enum Components {
                 case startLabel = "start_label"
                 case nextGameNumber = "next_game_number"
                 case youWon = "you_won"
+                case owedAction = "owed_action"
             }
         }
         /// Confirmation that the device token is registered to the current user.

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -3377,6 +3377,8 @@ internal enum Components {
             internal var rating: Components.Schemas.DashboardResponse.RatingPayload?
             /// - Remark: Generated from `#/components/schemas/DashboardResponse/completed_match_count`.
             internal var completedMatchCount: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/DashboardResponse/tournaments`.
+            internal var tournaments: [Components.Schemas.DashboardTournament]?
             /// Creates a new `DashboardResponse`.
             ///
             /// - Parameters:
@@ -3386,13 +3388,15 @@ internal enum Components {
             ///   - recentResults:
             ///   - rating:
             ///   - completedMatchCount:
+            ///   - tournaments:
             internal init(
                 attention: [Components.Schemas.DashboardAttentionItem],
                 attentionTotalCount: Swift.Int,
                 waitingCount: Swift.Int,
                 recentResults: [Components.Schemas.DashboardRecentResult],
                 rating: Components.Schemas.DashboardResponse.RatingPayload? = nil,
-                completedMatchCount: Swift.Int
+                completedMatchCount: Swift.Int,
+                tournaments: [Components.Schemas.DashboardTournament]? = nil
             ) {
                 self.attention = attention
                 self.attentionTotalCount = attentionTotalCount
@@ -3400,6 +3404,7 @@ internal enum Components {
                 self.recentResults = recentResults
                 self.rating = rating
                 self.completedMatchCount = completedMatchCount
+                self.tournaments = tournaments
             }
             internal enum CodingKeys: String, CodingKey {
                 case attention
@@ -3408,6 +3413,7 @@ internal enum Components {
                 case recentResults = "recent_results"
                 case rating
                 case completedMatchCount = "completed_match_count"
+                case tournaments
             }
         }
         /// - Remark: Generated from `#/components/schemas/DashboardStreak`.
@@ -3436,6 +3442,353 @@ internal enum Components {
             internal enum CodingKeys: String, CodingKey {
                 case kind
                 case n
+            }
+        }
+        /// A live tournament the caller is playing in — the whole panel, one per
+        /// tournament, with one tab per event they entered.
+        ///
+        /// - Remark: Generated from `#/components/schemas/DashboardTournament`.
+        internal struct DashboardTournament: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/DashboardTournament/id`.
+            internal var id: Swift.String
+            /// - Remark: Generated from `#/components/schemas/DashboardTournament/name`.
+            internal var name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/DashboardTournament/subtitle`.
+            internal var subtitle: Swift.String
+            /// - Remark: Generated from `#/components/schemas/DashboardTournament/live_count`.
+            internal var liveCount: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/DashboardTournament/events`.
+            internal var events: [Components.Schemas.DashboardTournamentEvent]
+            /// Creates a new `DashboardTournament`.
+            ///
+            /// - Parameters:
+            ///   - id:
+            ///   - name:
+            ///   - subtitle:
+            ///   - liveCount:
+            ///   - events:
+            internal init(
+                id: Swift.String,
+                name: Swift.String,
+                subtitle: Swift.String,
+                liveCount: Swift.Int,
+                events: [Components.Schemas.DashboardTournamentEvent]
+            ) {
+                self.id = id
+                self.name = name
+                self.subtitle = subtitle
+                self.liveCount = liveCount
+                self.events = events
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case id
+                case name
+                case subtitle
+                case liveCount = "live_count"
+                case events
+            }
+        }
+        /// One event of a live tournament that the caller holds an active entry in — one
+        /// tab of the panel.
+        ///
+        /// The record, position and stage are the panel's stats strip; they are derived here
+        /// from the same live standings projection the tournament-detail page uses
+        /// (ADR-0788), so the two surfaces cannot disagree about where a player stands.
+        ///
+        /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent`.
+        internal struct DashboardTournamentEvent: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/id`.
+            internal var id: Swift.String
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/name`.
+            internal var name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/draw_type`.
+            internal var drawType: Components.Schemas.DrawType
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/is_live`.
+            internal var isLive: Swift.Bool
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/wins`.
+            internal var wins: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/losses`.
+            internal var losses: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/position`.
+            internal var position: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/field_size`.
+            internal var fieldSize: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/stage_label`.
+            internal var stageLabel: Swift.String
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/pool_label`.
+            internal var poolLabel: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/match`.
+            internal struct MatchPayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/match/value1`.
+                internal var value1: Components.Schemas.DashboardTournamentMatch
+                /// Creates a new `MatchPayload`.
+                ///
+                /// - Parameters:
+                ///   - value1:
+                internal init(value1: Components.Schemas.DashboardTournamentMatch) {
+                    self.value1 = value1
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    self.value1 = try .init(from: decoder)
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    try self.value1.encode(to: encoder)
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/match`.
+            internal var match: Components.Schemas.DashboardTournamentEvent.MatchPayload?
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentEvent/fixtures`.
+            internal var fixtures: [Components.Schemas.DashboardTournamentFixtureRow]
+            /// Creates a new `DashboardTournamentEvent`.
+            ///
+            /// - Parameters:
+            ///   - id:
+            ///   - name:
+            ///   - drawType:
+            ///   - isLive:
+            ///   - wins:
+            ///   - losses:
+            ///   - position:
+            ///   - fieldSize:
+            ///   - stageLabel:
+            ///   - poolLabel:
+            ///   - match:
+            ///   - fixtures:
+            internal init(
+                id: Swift.String,
+                name: Swift.String,
+                drawType: Components.Schemas.DrawType,
+                isLive: Swift.Bool,
+                wins: Swift.Int,
+                losses: Swift.Int,
+                position: Swift.Int? = nil,
+                fieldSize: Swift.Int,
+                stageLabel: Swift.String,
+                poolLabel: Swift.String? = nil,
+                match: Components.Schemas.DashboardTournamentEvent.MatchPayload? = nil,
+                fixtures: [Components.Schemas.DashboardTournamentFixtureRow]
+            ) {
+                self.id = id
+                self.name = name
+                self.drawType = drawType
+                self.isLive = isLive
+                self.wins = wins
+                self.losses = losses
+                self.position = position
+                self.fieldSize = fieldSize
+                self.stageLabel = stageLabel
+                self.poolLabel = poolLabel
+                self.match = match
+                self.fixtures = fixtures
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case id
+                case name
+                case drawType = "draw_type"
+                case isLive = "is_live"
+                case wins
+                case losses
+                case position
+                case fieldSize = "field_size"
+                case stageLabel = "stage_label"
+                case poolLabel = "pool_label"
+                case match
+                case fixtures
+            }
+        }
+        /// One line of the panel's "Your matches" path — every fixture in this event the
+        /// caller is a side of, in draw order.
+        ///
+        /// ``detail`` is the row's right-hand text, composed server-side because what belongs
+        /// there changes with ``state`` (a result, "In progress", or a time and table). The
+        /// client prints it verbatim rather than reassembling three optional fields into a
+        /// sentence.
+        ///
+        /// - Remark: Generated from `#/components/schemas/DashboardTournamentFixtureRow`.
+        internal struct DashboardTournamentFixtureRow: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentFixtureRow/label`.
+            internal var label: Swift.String
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentFixtureRow/opponent_username`.
+            internal var opponentUsername: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentFixtureRow/state`.
+            internal enum StatePayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case completed = "completed"
+                case live = "live"
+                case upcoming = "upcoming"
+            }
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentFixtureRow/state`.
+            internal var state: Components.Schemas.DashboardTournamentFixtureRow.StatePayload
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentFixtureRow/detail`.
+            internal var detail: Swift.String
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentFixtureRow/you_won`.
+            internal var youWon: Swift.Bool?
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentFixtureRow/match_id`.
+            internal var matchId: Swift.String?
+            /// Creates a new `DashboardTournamentFixtureRow`.
+            ///
+            /// - Parameters:
+            ///   - label:
+            ///   - opponentUsername:
+            ///   - state:
+            ///   - detail:
+            ///   - youWon:
+            ///   - matchId:
+            internal init(
+                label: Swift.String,
+                opponentUsername: Swift.String? = nil,
+                state: Components.Schemas.DashboardTournamentFixtureRow.StatePayload,
+                detail: Swift.String,
+                youWon: Swift.Bool? = nil,
+                matchId: Swift.String? = nil
+            ) {
+                self.label = label
+                self.opponentUsername = opponentUsername
+                self.state = state
+                self.detail = detail
+                self.youWon = youWon
+                self.matchId = matchId
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case label
+                case opponentUsername = "opponent_username"
+                case state
+                case detail
+                case youWon = "you_won"
+                case matchId = "match_id"
+            }
+        }
+        /// One completed game of the panel's focus match, scored from the CURRENT USER's
+        /// side — ``your_points`` is always the caller's, never side 1's.
+        ///
+        /// The panel prints these as chips ("Game 3 · 11–9"), and a chip that silently means
+        /// "side 1 first" would read backwards for whichever player happens to be entry B.
+        /// The flip happens once, here, where the caller's side is known.
+        ///
+        /// - Remark: Generated from `#/components/schemas/DashboardTournamentGame`.
+        internal struct DashboardTournamentGame: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentGame/number`.
+            internal var number: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentGame/your_points`.
+            internal var yourPoints: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentGame/opponent_points`.
+            internal var opponentPoints: Swift.Int
+            /// Creates a new `DashboardTournamentGame`.
+            ///
+            /// - Parameters:
+            ///   - number:
+            ///   - yourPoints:
+            ///   - opponentPoints:
+            internal init(
+                number: Swift.Int,
+                yourPoints: Swift.Int,
+                opponentPoints: Swift.Int
+            ) {
+                self.number = number
+                self.yourPoints = yourPoints
+                self.opponentPoints = opponentPoints
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case number
+                case yourPoints = "your_points"
+                case opponentPoints = "opponent_points"
+            }
+        }
+        /// The one match the tournament panel's card shows for an event, already resolved
+        /// server-side to the single most relevant one: the live match if there is one, else
+        /// the next scheduled fixture, else the last completed match (see
+        /// ``app.dashboard_tournaments``).
+        ///
+        /// Everything is stated from the CALLER's side. ``your_games``/``opponent_games`` are
+        /// games won (not points) — the score the card's big numerals print — and
+        /// ``games`` carries the per-game points behind them.
+        ///
+        /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch`.
+        internal struct DashboardTournamentMatch: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/state`.
+            internal enum StatePayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case live = "live"
+                case scheduled = "scheduled"
+                case completed = "completed"
+            }
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/state`.
+            internal var state: Components.Schemas.DashboardTournamentMatch.StatePayload
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/match_id`.
+            internal var matchId: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/opponent_username`.
+            internal var opponentUsername: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/your_games`.
+            internal var yourGames: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/opponent_games`.
+            internal var opponentGames: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/best_of`.
+            internal var bestOf: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/games`.
+            internal var games: [Components.Schemas.DashboardTournamentGame]
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/round_label`.
+            internal var roundLabel: Swift.String
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/table_label`.
+            internal var tableLabel: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/start_label`.
+            internal var startLabel: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/next_game_number`.
+            internal var nextGameNumber: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/you_won`.
+            internal var youWon: Swift.Bool?
+            /// Creates a new `DashboardTournamentMatch`.
+            ///
+            /// - Parameters:
+            ///   - state:
+            ///   - matchId:
+            ///   - opponentUsername:
+            ///   - yourGames:
+            ///   - opponentGames:
+            ///   - bestOf:
+            ///   - games:
+            ///   - roundLabel:
+            ///   - tableLabel:
+            ///   - startLabel:
+            ///   - nextGameNumber:
+            ///   - youWon:
+            internal init(
+                state: Components.Schemas.DashboardTournamentMatch.StatePayload,
+                matchId: Swift.String? = nil,
+                opponentUsername: Swift.String? = nil,
+                yourGames: Swift.Int,
+                opponentGames: Swift.Int,
+                bestOf: Swift.Int,
+                games: [Components.Schemas.DashboardTournamentGame],
+                roundLabel: Swift.String,
+                tableLabel: Swift.String? = nil,
+                startLabel: Swift.String? = nil,
+                nextGameNumber: Swift.Int? = nil,
+                youWon: Swift.Bool? = nil
+            ) {
+                self.state = state
+                self.matchId = matchId
+                self.opponentUsername = opponentUsername
+                self.yourGames = yourGames
+                self.opponentGames = opponentGames
+                self.bestOf = bestOf
+                self.games = games
+                self.roundLabel = roundLabel
+                self.tableLabel = tableLabel
+                self.startLabel = startLabel
+                self.nextGameNumber = nextGameNumber
+                self.youWon = youWon
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case state
+                case matchId = "match_id"
+                case opponentUsername = "opponent_username"
+                case yourGames = "your_games"
+                case opponentGames = "opponent_games"
+                case bestOf = "best_of"
+                case games
+                case roundLabel = "round_label"
+                case tableLabel = "table_label"
+                case startLabel = "start_label"
+                case nextGameNumber = "next_game_number"
+                case youWon = "you_won"
             }
         }
         /// Confirmation that the device token is registered to the current user.

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -3615,6 +3615,7 @@ internal enum Components {
                 case completed = "completed"
                 case live = "live"
                 case upcoming = "upcoming"
+                case voided = "voided"
             }
             /// - Remark: Generated from `#/components/schemas/DashboardTournamentFixtureRow/state`.
             internal var state: Components.Schemas.DashboardTournamentFixtureRow.StatePayload
@@ -3709,6 +3710,7 @@ internal enum Components {
                 case live = "live"
                 case scheduled = "scheduled"
                 case completed = "completed"
+                case voided = "voided"
             }
             /// - Remark: Generated from `#/components/schemas/DashboardTournamentMatch/state`.
             internal var state: Components.Schemas.DashboardTournamentMatch.StatePayload

--- a/web-client/e2e/app-shell.spec.ts
+++ b/web-client/e2e/app-shell.spec.ts
@@ -48,6 +48,9 @@ const DASHBOARD = {
   rating: null,
   completed_match_count: 0,
   recent_results: [],
+  // No live tournament, so the dashboard's tournament panel never renders in
+  // these specs — they are about the shell and the cards beneath it.
+  tournaments: [],
 } satisfies components['schemas']['DashboardResponse']
 
 /** The page-load reads of every route this spec visits, keyed by path. */

--- a/web-client/e2e/dashboard-rating-card.spec.ts
+++ b/web-client/e2e/dashboard-rating-card.spec.ts
@@ -63,6 +63,9 @@ const ESTABLISHED_DASHBOARD = {
       my_rating_change: { before: null, after: 1268, delta: null },
     },
   ],
+  // No live tournament, so the dashboard's tournament panel never renders here
+  // — this suite is about the rating hero beneath it.
+  tournaments: [],
 } satisfies DashboardResponse
 
 /** A player with a real history: the last match MOVED them, so the chip is there

--- a/web-client/e2e/dashboard-recent-results.spec.ts
+++ b/web-client/e2e/dashboard-recent-results.spec.ts
@@ -68,6 +68,9 @@ const DASHBOARD = {
       my_rating_change: { before: null, after: 1268, delta: null },
     },
   ],
+  // No live tournament, so the dashboard's tournament panel never renders in
+  // these specs.
+  tournaments: [],
 } satisfies components['schemas']['DashboardResponse']
 
 /** The index of the established-rating row in `recent_results` (and so in the

--- a/web-client/e2e/dashboard-tournament-panel.spec.ts
+++ b/web-client/e2e/dashboard-tournament-panel.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * The dashboard's tournament panel, in a real browser.
+ *
+ * This suite runs with MSW OFF (see `playwright.config.ts` webServer env
+ * `VITE_ENABLE_MSW: 'false'`), so the API is stubbed via `page.route` — which
+ * makes these stubs the only place a browser ever sees the panel's wire shape
+ * (web-client/CLAUDE.md). vitest exercises the projection and the components
+ * against hand-built views; this exercises the whole path from a
+ * `DashboardResponse` to painted pixels, including that the panel really is the
+ * first thing under the greeting.
+ */
+import { expect, test, type Page, type Route } from '@playwright/test'
+import type { components } from '../src/api/schema'
+import { sessionResponse } from '../src/test/factories'
+
+const SESSION = sessionResponse({ user: { username: 'mightymoose' } })
+
+type DashboardResponse = components['schemas']['DashboardResponse']
+
+// `satisfies` (not `:`) so tsc fails if the OpenAPI schema drifts away from
+// this stub — nothing else would catch it in an MSW-off suite.
+
+/** A player mid-tournament: a live best-of-five on Table 4, 2–1 up, game 4 next. */
+const IN_A_TOURNAMENT = {
+  attention: [],
+  attention_total_count: 0,
+  waiting_count: 0,
+  rating: null,
+  completed_match_count: 1,
+  recent_results: [],
+  tournaments: [
+    {
+      id: '55555555-5555-4555-8555-555555555555',
+      name: 'Riverside Summer Slam',
+      subtitle: 'Riverside TTC · Jul 24–25',
+      live_count: 1,
+      events: [
+        {
+          id: '66666666-6666-4666-8666-666666666666',
+          name: 'U1500 · Group B',
+          draw_type: 'round-robin',
+          is_live: true,
+          wins: 1,
+          losses: 0,
+          position: 1,
+          field_size: 4,
+          stage_label: 'Group play',
+          pool_label: 'Pool B',
+          match: {
+            state: 'live',
+            match_id: '77777777-7777-4777-8777-777777777777',
+            opponent_username: 'slim-manatee',
+            your_games: 2,
+            opponent_games: 1,
+            best_of: 5,
+            games: [
+              { number: 1, your_points: 11, opponent_points: 7 },
+              { number: 2, your_points: 8, opponent_points: 11 },
+              { number: 3, your_points: 11, opponent_points: 9 },
+            ],
+            round_label: 'Group match 2',
+            table_label: 'Table 4',
+            start_label: '4:30 PM CDT',
+            next_game_number: 4,
+            you_won: null,
+          },
+          fixtures: [
+            {
+              label: 'M1',
+              opponent_username: 'celestial-caracara',
+              state: 'completed',
+              detail: 'Won 3–1',
+              you_won: true,
+              match_id: '88888888-8888-4888-8888-888888888888',
+            },
+            {
+              label: 'M2',
+              opponent_username: 'slim-manatee',
+              state: 'live',
+              detail: 'In progress',
+              you_won: null,
+              match_id: '77777777-7777-4777-8777-777777777777',
+            },
+            {
+              label: 'M3',
+              opponent_username: 'bold-bison',
+              state: 'upcoming',
+              detail: '5:20 PM CDT · Table 6',
+              you_won: null,
+              match_id: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+} satisfies DashboardResponse
+
+/** The same player between tournaments — the shape almost every load has. */
+const IN_NO_TOURNAMENT = {
+  ...IN_A_TOURNAMENT,
+  tournaments: [],
+} satisfies DashboardResponse
+
+async function installDashboardMock(page: Page, dashboard: DashboardResponse) {
+  await page.route('**/api/v1/**', (route: Route) => {
+    const path = new URL(route.request().url()).pathname.replace(/^\/api/, '')
+    if (path === '/v1/session') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SESSION),
+      })
+    }
+    if (path === '/v1/dashboard') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(dashboard),
+      })
+    }
+    // Anything else the AppShell happens to fetch on load.
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
+    })
+  })
+}
+
+const panel = (page: Page) =>
+  page.locator('[data-testid="dashboard-tournament-panel"]')
+
+test.describe('Dashboard tournament panel', () => {
+  test('puts the live match at the top of the dashboard', async ({ page }) => {
+    await installDashboardMock(page, IN_A_TOURNAMENT)
+    await page.goto('/dashboard')
+
+    const block = panel(page)
+    await expect(block).toContainText('Riverside Summer Slam')
+    await expect(block).toContainText('Riverside TTC · Jul 24–25')
+    await expect(block).toContainText('1 live now')
+    await expect(block).toContainText('Live · Table 4 · Game 4')
+    await expect(block).toContainText('Best of 5')
+
+    // It is the first block of the page's content — a player standing at a
+    // table must not have to scroll past anything to find their match.
+    const blocks = page.locator(
+      '[data-testid="dashboard-tournament-panel"], [data-testid="dashboard-attention-panel"]',
+    )
+    await expect(blocks.first()).toHaveAttribute(
+      'data-testid',
+      'dashboard-tournament-panel',
+    )
+  })
+
+  test('deep-links the primary action to the game about to be played', async ({
+    page,
+  }) => {
+    await installDashboardMock(page, IN_A_TOURNAMENT)
+    await page.goto('/dashboard')
+
+    await expect(
+      panel(page).getByRole('link', { name: 'Enter Game 4 result' }),
+    ).toHaveAttribute(
+      'href',
+      '/matches/77777777-7777-4777-8777-777777777777/games/4/scores/new',
+    )
+  })
+
+  test('shows the standings and the rest of the schedule', async ({ page }) => {
+    await installDashboardMock(page, IN_A_TOURNAMENT)
+    await page.goto('/dashboard')
+
+    const block = panel(page)
+    await expect(block).toContainText('1st')
+    await expect(block).toContainText('of 4')
+    await expect(block).toContainText('Group play')
+    await expect(block).toContainText('Won 3–1')
+    await expect(block).toContainText('In progress')
+    await expect(block).toContainText('5:20 PM CDT · Table 6')
+  })
+
+  test('renders nothing at all between tournaments', async ({ page }) => {
+    await installDashboardMock(page, IN_NO_TOURNAMENT)
+    await page.goto('/dashboard')
+
+    // Wait for the page itself before asserting an absence, so a slow load
+    // cannot pass as "no panel".
+    await expect(page.getByRole('heading', { name: /^Hi, / })).toBeVisible()
+    await expect(panel(page)).toHaveCount(0)
+  })
+
+  test('stays inside the viewport at 375px', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 800 })
+    await installDashboardMock(page, IN_A_TOURNAMENT)
+    await page.goto('/dashboard')
+
+    await expect(panel(page)).toBeVisible()
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth,
+    )
+    expect(overflow).toBeLessThanOrEqual(0)
+  })
+})

--- a/web-client/e2e/dashboard-tournament-panel.spec.ts
+++ b/web-client/e2e/dashboard-tournament-panel.spec.ts
@@ -63,6 +63,7 @@ const IN_A_TOURNAMENT = {
             start_label: '4:30 PM CDT',
             next_game_number: 4,
             you_won: null,
+            owed_action: 'score',
           },
           fixtures: [
             {
@@ -118,20 +119,53 @@ const DECIDED_UNPOSTED = {
   ],
 } satisfies DashboardResponse
 
+/** A finished match with long usernames — the widest the card ever gets, and
+ * the shape that used to blow out of its grid track on a phone. */
+const COMPLETED_LONG_NAMES = {
+  ...IN_A_TOURNAMENT,
+  tournaments: [
+    {
+      ...IN_A_TOURNAMENT.tournaments[0],
+      live_count: 0,
+      events: [
+        {
+          ...IN_A_TOURNAMENT.tournaments[0].events[0],
+          is_live: false,
+          stage_label: 'Group complete',
+          match: {
+            ...IN_A_TOURNAMENT.tournaments[0].events[0].match,
+            state: 'completed' as const,
+            opponent_username: 'competent-marten',
+            your_games: 3,
+            opponent_games: 1,
+            next_game_number: null,
+            you_won: true,
+            owed_action: null,
+          },
+        },
+      ],
+    },
+  ],
+} satisfies DashboardResponse
+
 /** The same player between tournaments — the shape almost every load has. */
 const IN_NO_TOURNAMENT = {
   ...IN_A_TOURNAMENT,
   tournaments: [],
 } satisfies DashboardResponse
 
-async function installDashboardMock(page: Page, dashboard: DashboardResponse) {
+async function installDashboardMock(
+  page: Page,
+  dashboard: DashboardResponse,
+  session: typeof SESSION = SESSION,
+) {
   await page.route('**/api/v1/**', (route: Route) => {
     const path = new URL(route.request().url()).pathname.replace(/^\/api/, '')
     if (path === '/v1/session') {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(SESSION),
+        body: JSON.stringify(session),
       })
     }
     if (path === '/v1/dashboard') {
@@ -215,6 +249,42 @@ test.describe('Dashboard tournament panel', () => {
     await expect(
       block.getByRole('link', { name: 'Post the result' }),
     ).toHaveAttribute('href', '/matches/77777777-7777-4777-8777-777777777777')
+  })
+
+  test('the match card stays inside its column on a phone', async ({ page }) => {
+    // A page-level overflow check is NOT enough here and never was: the panel's
+    // Card clips (`overflow-hidden`), so a card wider than its grid track is
+    // silently CUT — `scrollWidth - clientWidth` reads 0 while the winner chip
+    // and half the status line are lost. Measure the element against its track.
+    await page.setViewportSize({ width: 375, height: 800 })
+    // The VIEWER's own handle is the long one — it is their row that carries the
+    // winner chip beside the big numeral, so it sets the card's minimum width.
+    await installDashboardMock(
+      page,
+      COMPLETED_LONG_NAMES,
+      sessionResponse({ user: { username: 'observant-chimpanzee' } }),
+    )
+    await page.goto('/dashboard')
+    await expect(panel(page)).toBeVisible()
+
+    const fit = await page.evaluate(() => {
+      const card = document.querySelector(
+        '[data-testid="tournament-panel-match-card"]',
+      ) as HTMLElement
+      const track = card.parentElement as HTMLElement
+      const right = card.getBoundingClientRect().right
+      return {
+        cardWidth: card.getBoundingClientRect().width,
+        trackWidth: track.getBoundingClientRect().width,
+        spilling: [...card.querySelectorAll('*')].filter(
+          (el) => el.getBoundingClientRect().right > right + 0.5,
+        ).length,
+      }
+    })
+
+    expect(fit.cardWidth).toBeLessThanOrEqual(fit.trackWidth)
+    expect(fit.spilling).toBe(0)
+    await expect(panel(page)).toContainText('Winner')
   })
 
   test('renders nothing at all between tournaments', async ({ page }) => {

--- a/web-client/e2e/dashboard-tournament-panel.spec.ts
+++ b/web-client/e2e/dashboard-tournament-panel.spec.ts
@@ -96,6 +96,28 @@ const IN_A_TOURNAMENT = {
   ],
 } satisfies DashboardResponse
 
+/** The board is decided but the result is unposted — every game that decides
+ * the match is scored, so there is no next game, only a result to post. */
+const DECIDED_UNPOSTED = {
+  ...IN_A_TOURNAMENT,
+  tournaments: [
+    {
+      ...IN_A_TOURNAMENT.tournaments[0],
+      events: [
+        {
+          ...IN_A_TOURNAMENT.tournaments[0].events[0],
+          match: {
+            ...IN_A_TOURNAMENT.tournaments[0].events[0].match,
+            your_games: 3,
+            opponent_games: 0,
+            next_game_number: null,
+          },
+        },
+      ],
+    },
+  ],
+} satisfies DashboardResponse
+
 /** The same player between tournaments — the shape almost every load has. */
 const IN_NO_TOURNAMENT = {
   ...IN_A_TOURNAMENT,
@@ -179,6 +201,20 @@ test.describe('Dashboard tournament panel', () => {
     await expect(block).toContainText('Won 3–1')
     await expect(block).toContainText('In progress')
     await expect(block).toContainText('5:20 PM CDT · Table 6')
+  })
+
+  test('offers the result to post once the board is decided', async ({ page }) => {
+    // The card must not dead-end at the moment the match is finished: there is
+    // no next game to enter, so the action becomes the result itself.
+    await installDashboardMock(page, DECIDED_UNPOSTED)
+    await page.goto('/dashboard')
+
+    const block = panel(page)
+    await expect(block).toContainText('Live · Table 4')
+    await expect(block).not.toContainText('Game 4')
+    await expect(
+      block.getByRole('link', { name: 'Post the result' }),
+    ).toHaveAttribute('href', '/matches/77777777-7777-4777-8777-777777777777')
   })
 
   test('renders nothing at all between tournaments', async ({ page }) => {

--- a/web-client/src/api/dashboard.ts
+++ b/web-client/src/api/dashboard.ts
@@ -9,6 +9,15 @@ export type DashboardRecentResult =
   components['schemas']['DashboardRecentResult']
 export type DashboardRating = components['schemas']['DashboardRating']
 export type DashboardStreak = components['schemas']['DashboardStreak']
+export type DashboardTournament = components['schemas']['DashboardTournament']
+export type DashboardTournamentEvent =
+  components['schemas']['DashboardTournamentEvent']
+export type DashboardTournamentMatch =
+  components['schemas']['DashboardTournamentMatch']
+export type DashboardTournamentFixtureRow =
+  components['schemas']['DashboardTournamentFixtureRow']
+export type DashboardTournamentGame =
+  components['schemas']['DashboardTournamentGame']
 
 export const DASHBOARD_QUERY_KEY = ['dashboard'] as const
 

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1943,7 +1943,7 @@ export interface components {
              * State
              * @enum {string}
              */
-            state: "completed" | "live" | "upcoming";
+            state: "completed" | "live" | "upcoming" | "voided";
             /** Detail */
             detail: string;
             /** You Won */
@@ -1984,7 +1984,7 @@ export interface components {
              * State
              * @enum {string}
              */
-            state: "live" | "scheduled" | "completed";
+            state: "live" | "scheduled" | "completed" | "voided";
             /** Match Id */
             match_id: string | null;
             /** Opponent Username */

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1852,6 +1852,11 @@ export interface components {
             rating?: components["schemas"]["DashboardRating"] | null;
             /** Completed Match Count */
             completed_match_count: number;
+            /**
+             * Tournaments
+             * @default []
+             */
+            tournaments: components["schemas"]["DashboardTournament"][];
         };
         /** DashboardStreak */
         DashboardStreak: {
@@ -1862,6 +1867,146 @@ export interface components {
             kind: "W" | "L";
             /** N */
             n: number;
+        };
+        /**
+         * DashboardTournament
+         * @description A live tournament the caller is playing in — the whole panel, one per
+         *     tournament, with one tab per event they entered.
+         */
+        DashboardTournament: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Name */
+            name: string;
+            /** Subtitle */
+            subtitle: string;
+            /** Live Count */
+            live_count: number;
+            /** Events */
+            events: components["schemas"]["DashboardTournamentEvent"][];
+        };
+        /**
+         * DashboardTournamentEvent
+         * @description One event of a live tournament that the caller holds an active entry in — one
+         *     tab of the panel.
+         *
+         *     The record, position and stage are the panel's stats strip; they are derived here
+         *     from the same live standings projection the tournament-detail page uses
+         *     (ADR-0788), so the two surfaces cannot disagree about where a player stands.
+         */
+        DashboardTournamentEvent: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Name */
+            name: string;
+            draw_type: components["schemas"]["DrawType"];
+            /** Is Live */
+            is_live: boolean;
+            /** Wins */
+            wins: number;
+            /** Losses */
+            losses: number;
+            /** Position */
+            position: number | null;
+            /** Field Size */
+            field_size: number;
+            /** Stage Label */
+            stage_label: string;
+            /** Pool Label */
+            pool_label: string | null;
+            match: components["schemas"]["DashboardTournamentMatch"] | null;
+            /** Fixtures */
+            fixtures: components["schemas"]["DashboardTournamentFixtureRow"][];
+        };
+        /**
+         * DashboardTournamentFixtureRow
+         * @description One line of the panel's "Your matches" path — every fixture in this event the
+         *     caller is a side of, in draw order.
+         *
+         *     ``detail`` is the row's right-hand text, composed server-side because what belongs
+         *     there changes with ``state`` (a result, "In progress", or a time and table). The
+         *     client prints it verbatim rather than reassembling three optional fields into a
+         *     sentence.
+         */
+        DashboardTournamentFixtureRow: {
+            /** Label */
+            label: string;
+            /** Opponent Username */
+            opponent_username: string | null;
+            /**
+             * State
+             * @enum {string}
+             */
+            state: "completed" | "live" | "upcoming";
+            /** Detail */
+            detail: string;
+            /** You Won */
+            you_won: boolean | null;
+            /** Match Id */
+            match_id: string | null;
+        };
+        /**
+         * DashboardTournamentGame
+         * @description One completed game of the panel's focus match, scored from the CURRENT USER's
+         *     side — ``your_points`` is always the caller's, never side 1's.
+         *
+         *     The panel prints these as chips ("Game 3 · 11–9"), and a chip that silently means
+         *     "side 1 first" would read backwards for whichever player happens to be entry B.
+         *     The flip happens once, here, where the caller's side is known.
+         */
+        DashboardTournamentGame: {
+            /** Number */
+            number: number;
+            /** Your Points */
+            your_points: number;
+            /** Opponent Points */
+            opponent_points: number;
+        };
+        /**
+         * DashboardTournamentMatch
+         * @description The one match the tournament panel's card shows for an event, already resolved
+         *     server-side to the single most relevant one: the live match if there is one, else
+         *     the next scheduled fixture, else the last completed match (see
+         *     ``app.dashboard_tournaments``).
+         *
+         *     Everything is stated from the CALLER's side. ``your_games``/``opponent_games`` are
+         *     games won (not points) — the score the card's big numerals print — and
+         *     ``games`` carries the per-game points behind them.
+         */
+        DashboardTournamentMatch: {
+            /**
+             * State
+             * @enum {string}
+             */
+            state: "live" | "scheduled" | "completed";
+            /** Match Id */
+            match_id: string | null;
+            /** Opponent Username */
+            opponent_username: string | null;
+            /** Your Games */
+            your_games: number;
+            /** Opponent Games */
+            opponent_games: number;
+            /** Best Of */
+            best_of: number;
+            /** Games */
+            games: components["schemas"]["DashboardTournamentGame"][];
+            /** Round Label */
+            round_label: string;
+            /** Table Label */
+            table_label: string | null;
+            /** Start Label */
+            start_label: string | null;
+            /** Next Game Number */
+            next_game_number: number | null;
+            /** You Won */
+            you_won: boolean | null;
         };
         /**
          * DeviceTokenResponse

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -2007,6 +2007,8 @@ export interface components {
             next_game_number: number | null;
             /** You Won */
             you_won: boolean | null;
+            /** Owed Action */
+            owed_action: ("review" | "score") | ("waiting_opponent" | "waiting_others") | null;
         };
         /**
          * DeviceTokenResponse

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -7,6 +7,8 @@ import { projectAttentionPanelView } from '@/components/dashboard/attention-pane
 import { FirstMatchDashboard } from '@/components/dashboard/first-match/first-match-dashboard'
 import { GuestPersistBanner } from '@/components/dashboard/guest-persist-banner'
 import { PageTitle } from '@/components/dashboard/page-title'
+import { TournamentPanel } from '@/components/dashboard/tournament-panel'
+import { projectTournamentPanelViews } from '@/components/dashboard/tournament-panel-view'
 import { YourGameRow } from '@/components/dashboard/your-game-row'
 import { useMediaQuery } from '@/lib/use-media-query'
 
@@ -51,6 +53,12 @@ export function DashboardPage() {
     data.completed_match_count === 0 &&
     data.attention_total_count === 0 &&
     data.waiting_count === 0
+  // The tournament panels that top the page while the user is playing in a live
+  // tournament — `[]` the rest of the time, which is almost always.
+  const tournamentViews = useMemo(
+    () => projectTournamentPanelViews(data?.tournaments ?? [], username),
+    [data?.tournaments, username],
+  )
   const attentionView = useMemo(
     () =>
       projectAttentionPanelView(
@@ -81,6 +89,14 @@ export function DashboardPage() {
         compact={compact}
         loading={session.isLoading}
       />
+      {/* Above everything else on the page, and outside the first-match branch:
+          while a tournament is being played, the match in front of you outranks
+          every other to-do on the dashboard — including the "log your first
+          match" hero, which a player standing at a table has already moved past
+          even if none of their matches has been completed yet. */}
+      {tournamentViews.map((tournamentView) => (
+        <TournamentPanel key={tournamentView.tournamentId} view={tournamentView} />
+      ))}
       {isFirstMatch ? (
         <FirstMatchDashboard />
       ) : (

--- a/web-client/src/components/dashboard/tournament-panel-view.test.ts
+++ b/web-client/src/components/dashboard/tournament-panel-view.test.ts
@@ -107,9 +107,11 @@ describe('projectTournamentPanelView', () => {
       expect(view.tabs[0].match?.statusText).toBe('Live · Table 4 · Game 4')
     })
 
-    it('falls back to the game after the last played one when there is no next', () => {
-      // A decided-but-unposted board reports no next game; the card still has
-      // to name the game the players are standing at.
+    it('names no game at all when the board is decided but unposted', () => {
+      // `next_game_number: null` means there is no next game — the match is
+      // already decided, only the result is unposted. Inventing "Game 3" here
+      // would announce a game that will never be played, and contradict the
+      // action button beside it, which correctly offers nothing to enter.
       const view = project(
         buildDashboardTournament({
           events: [
@@ -127,7 +129,8 @@ describe('projectTournamentPanelView', () => {
         }),
       )
 
-      expect(view.tabs[0].match?.statusText).toContain('Game 3')
+      expect(view.tabs[0].match?.statusText).not.toContain('Game')
+      expect(view.tabs[0].match?.statusText).toBe('Live · Table 4')
     })
 
     it('names the round and table of a finished match', () => {

--- a/web-client/src/components/dashboard/tournament-panel-view.test.ts
+++ b/web-client/src/components/dashboard/tournament-panel-view.test.ts
@@ -326,6 +326,62 @@ describe('projectTournamentPanelView', () => {
       expect(view.tabs[0].match?.gamesLegend).toBeNull()
     })
 
+    it('reports a voided match as voided, with no winner', () => {
+      // A voided match contributes nothing (ADR-0013). It must not read as a
+      // completed one, which would derive a loss from the empty board.
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'voided',
+                round_label: 'Group match 2',
+                games: [],
+                your_games: 0,
+                opponent_games: 0,
+                you_won: null,
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.statusText).toBe('Match voided · Group match 2')
+      expect(view.tabs[0].match?.youWon).toBe(false)
+      expect(view.tabs[0].match?.opponentWon).toBe(false)
+      expect(view.tabs[0].match?.action).toBeNull()
+    })
+
+    it('frames a best-of-1 as a single game, not "Best of 1"', () => {
+      // The copy #908 settled for every surface that states a match length —
+      // the "Best of N" race framing only means something for a multi-game set.
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({ best_of: 1 }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.bestOfText).toBe('Single game')
+    })
+
+    it('keeps the "Best of N" framing for a multi-game set', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({ best_of: 5 }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.bestOfText).toBe('Best of 5')
+    })
+
     it('calls an undecided opposing side TBD', () => {
       const view = project(
         buildDashboardTournament({

--- a/web-client/src/components/dashboard/tournament-panel-view.test.ts
+++ b/web-client/src/components/dashboard/tournament-panel-view.test.ts
@@ -227,6 +227,7 @@ describe('projectTournamentPanelView', () => {
                 state: 'live',
                 match_id: 'm-7',
                 next_game_number: null,
+                owed_action: 'score',
               }),
             }),
           ],
@@ -237,6 +238,48 @@ describe('projectTournamentPanelView', () => {
       expect(view.tabs[0].match?.action?.route.params).toEqual({
         matchId: 'm-7',
       })
+    })
+
+    it('asks the reviewer to REVIEW, not to post what is already posted', () => {
+      // `next_game_number: null` is two different states. This is the one where
+      // the OPPONENT has posted a result: telling this player to "Post the
+      // result" names a job that is done, and done by someone else.
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'live',
+                match_id: 'm-7',
+                next_game_number: null,
+                owed_action: 'review',
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.action?.label).toBe('Review result')
+      expect(view.tabs[0].match?.action?.route.params).toEqual({ matchId: 'm-7' })
+    })
+
+    it('offers nothing while OUR posted result waits on the opponent', () => {
+      // We posted; the move is theirs. A button here would invite us to redo it.
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'live',
+                next_game_number: null,
+                owed_action: 'waiting_opponent',
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.action).toBeNull()
     })
 
     it.each([

--- a/web-client/src/components/dashboard/tournament-panel-view.test.ts
+++ b/web-client/src/components/dashboard/tournament-panel-view.test.ts
@@ -1,0 +1,437 @@
+import {
+  buildDashboardTournament,
+  buildDashboardTournamentEvent,
+  buildDashboardTournamentMatch,
+} from '@/mocks/factories/dashboard/tournament.factory'
+import {
+  projectTournamentPanelView,
+  projectTournamentPanelViews,
+} from './tournament-panel-view'
+
+const project = (
+  tournament = buildDashboardTournament(),
+  youName = 'mightymoose',
+) => projectTournamentPanelView(tournament, youName)
+
+describe('projectTournamentPanelView', () => {
+  it('carries the tournament header through', () => {
+    const view = project(
+      buildDashboardTournament({
+        id: 't-9',
+        name: 'Riverside Summer Slam',
+        subtitle: 'Riverside TTC · Jul 24–25',
+      }),
+    )
+
+    expect(view.tournamentId).toBe('t-9')
+    expect(view.name).toBe('Riverside Summer Slam')
+    expect(view.subtitle).toBe('Riverside TTC · Jul 24–25')
+  })
+
+  it('counts the live matches into a pill, and drops it at zero', () => {
+    expect(project(buildDashboardTournament({ live_count: 1 })).liveLabel).toBe(
+      '1 live now',
+    )
+    expect(
+      project(buildDashboardTournament({ live_count: 0 })).liveLabel,
+    ).toBeNull()
+  })
+
+  it('sends a round-robin viewer to the standings, not a bracket', () => {
+    expect(project().destinationLabel).toBe('View group & standings')
+  })
+
+  describe('the stats strip', () => {
+    it('renders the standing as an ordinal out of the field', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({ position: 3, field_size: 6 }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].stats.positionValue).toBe('3rd')
+      expect(view.tabs[0].stats.positionSuffix).toBe('of 6')
+    })
+
+    it.each([
+      [1, '1st'],
+      [2, '2nd'],
+      [3, '3rd'],
+      [4, '4th'],
+      [11, '11th'],
+      [12, '12th'],
+      [13, '13th'],
+      [21, '21st'],
+    ])('renders position %i as %s', (position, expected) => {
+      const view = project(
+        buildDashboardTournament({
+          events: [buildDashboardTournamentEvent({ position })],
+        }),
+      )
+
+      expect(view.tabs[0].stats.positionValue).toBe(expected)
+    })
+
+    it('leaves the position null when the event has no standings yet', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({ position: null, field_size: 0 }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].stats.positionValue).toBeNull()
+      expect(view.tabs[0].stats.positionSuffix).toBeNull()
+    })
+  })
+
+  describe('the match card', () => {
+    it('says which game a live match is on, from the next game up', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'live',
+                table_label: 'Table 4',
+                next_game_number: 4,
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.statusText).toBe('Live · Table 4 · Game 4')
+    })
+
+    it('falls back to the game after the last played one when there is no next', () => {
+      // A decided-but-unposted board reports no next game; the card still has
+      // to name the game the players are standing at.
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'live',
+                next_game_number: null,
+                games: [
+                  { number: 1, your_points: 11, opponent_points: 7 },
+                  { number: 2, your_points: 11, opponent_points: 9 },
+                ],
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.statusText).toContain('Game 3')
+    })
+
+    it('names the round and table of a finished match', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'completed',
+                round_label: 'Group match 2',
+                table_label: 'Table 4',
+                you_won: true,
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.statusText).toBe(
+        'Match complete · Group match 2 · Table 4',
+      )
+    })
+
+    it('crowns the winner and only the winner', () => {
+      const won = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'completed',
+                you_won: true,
+              }),
+            }),
+          ],
+        }),
+      ).tabs[0].match
+      const lost = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'completed',
+                you_won: false,
+              }),
+            }),
+          ],
+        }),
+      ).tabs[0].match
+
+      expect([won?.youWon, won?.opponentWon]).toEqual([true, false])
+      expect([lost?.youWon, lost?.opponentWon]).toEqual([false, true])
+    })
+
+    it('crowns nobody while the match is unfinished', () => {
+      // `you_won` is null mid-match; treating that as `false` would put the
+      // winner chip on the opponent of every live match.
+      const view = project()
+
+      expect(view.tabs[0].match?.youWon).toBe(false)
+      expect(view.tabs[0].match?.opponentWon).toBe(false)
+    })
+
+    it('offers the next game as the primary action on a live match', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'live',
+                match_id: 'm-7',
+                next_game_number: 4,
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.action?.label).toBe('Enter Game 4 result')
+      expect(view.tabs[0].match?.action?.route.params).toEqual({
+        matchId: 'm-7',
+        gameNumber: '4',
+      })
+    })
+
+    it.each([
+      ['a match that is not live', { state: 'scheduled' as const }],
+      ['a decided board with no next game', { next_game_number: null }],
+      ['a fixture with no match behind it', { match_id: null }],
+    ])('offers no action for %s', (_case, overrides) => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch(overrides),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.action).toBeNull()
+    })
+
+    it('drops the match-details link for a fixture with no match', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'scheduled',
+                match_id: null,
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.detailsRoute).toBeNull()
+    })
+
+    it('shows the time and table of a match not yet started', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'scheduled',
+                start_label: '5:20 PM CDT',
+                table_label: 'Table 6',
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.scheduleText).toBe('5:20 PM CDT · Table 6')
+    })
+
+    it('says so plainly when an upcoming match has no placement', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'scheduled',
+                start_label: null,
+                table_label: null,
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.scheduleText).toBe('Not scheduled yet')
+    })
+
+    it('labels the game chips with the viewer’s own points first', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                games: [{ number: 2, your_points: 11, opponent_points: 9 }],
+                opponent_username: 'slim-manatee',
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.games).toEqual([
+        {
+          label: 'Game 2',
+          score: '11–9',
+          description: 'Game 2: mightymoose 11, slim-manatee 9',
+        },
+      ])
+      expect(view.tabs[0].match?.gamesLegend).toBe(
+        'mightymoose shown first · vs slim-manatee',
+      )
+    })
+
+    it('drops the legend when no game has been played', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({ games: [] }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.gamesLegend).toBeNull()
+    })
+
+    it('calls an undecided opposing side TBD', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                opponent_username: null,
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.opponentName).toBe('TBD')
+    })
+  })
+
+  describe('the path list', () => {
+    it('keys rows by their ordinal so a repeated opponent still renders twice', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              id: 'e-4',
+              fixtures: [
+                {
+                  label: 'M1',
+                  opponent_username: 'bold-bison',
+                  state: 'completed',
+                  detail: 'Won 3–1',
+                  you_won: true,
+                  match_id: null,
+                },
+                {
+                  label: 'M2',
+                  opponent_username: 'bold-bison',
+                  state: 'upcoming',
+                  detail: 'Not scheduled',
+                  you_won: null,
+                  match_id: null,
+                },
+              ],
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].path.map((row) => row.key)).toEqual(['e-4-0', 'e-4-1'])
+    })
+
+    it('names the pool and its size beneath the heading', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              pool_label: 'Pool B',
+              field_size: 4,
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].pathSubheading).toBe('Pool B · 4 players')
+      expect(view.tabs[0].pathHeading).toBe('Your matches')
+    })
+
+    it('has no subheading for an un-pooled draw', () => {
+      const view = project(
+        buildDashboardTournament({
+          events: [buildDashboardTournamentEvent({ pool_label: null })],
+        }),
+      )
+
+      expect(view.tabs[0].pathSubheading).toBeNull()
+    })
+  })
+})
+
+describe('projectTournamentPanelViews', () => {
+  it('projects one panel per tournament', () => {
+    const views = projectTournamentPanelViews(
+      [
+        buildDashboardTournament({ id: 't-1' }),
+        buildDashboardTournament({ id: 't-2' }),
+      ],
+      'mightymoose',
+    )
+
+    expect(views.map((view) => view.tournamentId)).toEqual(['t-1', 't-2'])
+  })
+
+  it('renders nothing until the viewer’s own handle is known', () => {
+    // Every score on the payload is stated from the caller's side; without a
+    // name for them the card would label their own row "undefined".
+    expect(
+      projectTournamentPanelViews([buildDashboardTournament()], undefined),
+    ).toEqual([])
+  })
+
+  it('drops a tournament with no events rather than rendering a husk', () => {
+    expect(
+      projectTournamentPanelViews(
+        [buildDashboardTournament({ events: [] })],
+        'mightymoose',
+      ),
+    ).toEqual([])
+  })
+
+  it('is empty when the viewer is in no tournament', () => {
+    expect(projectTournamentPanelViews([], 'mightymoose')).toEqual([])
+  })
+})

--- a/web-client/src/components/dashboard/tournament-panel-view.test.ts
+++ b/web-client/src/components/dashboard/tournament-panel-view.test.ts
@@ -215,9 +215,32 @@ describe('projectTournamentPanelView', () => {
       })
     })
 
+    it('offers the result as the action once the board is decided', () => {
+      // The decided-but-unposted state. Answering `null` here dead-ended the
+      // card at the one moment the player most needs a way forward — while the
+      // attention panel beneath it offered a button for the very same match.
+      const view = project(
+        buildDashboardTournament({
+          events: [
+            buildDashboardTournamentEvent({
+              match: buildDashboardTournamentMatch({
+                state: 'live',
+                match_id: 'm-7',
+                next_game_number: null,
+              }),
+            }),
+          ],
+        }),
+      )
+
+      expect(view.tabs[0].match?.action?.label).toBe('Post the result')
+      expect(view.tabs[0].match?.action?.route.params).toEqual({
+        matchId: 'm-7',
+      })
+    })
+
     it.each([
       ['a match that is not live', { state: 'scheduled' as const }],
-      ['a decided board with no next game', { next_game_number: null }],
       ['a fixture with no match behind it', { match_id: null }],
     ])('offers no action for %s', (_case, overrides) => {
       const view = project(

--- a/web-client/src/components/dashboard/tournament-panel-view.ts
+++ b/web-client/src/components/dashboard/tournament-panel-view.ts
@@ -29,7 +29,7 @@ export interface TournamentGameChipView {
 }
 
 export interface TournamentMatchCardView {
-  state: 'live' | 'scheduled' | 'completed'
+  state: 'live' | 'scheduled' | 'completed' | 'voided'
   /** The card's status line: `Live · Table 4 · Game 4`, `Match complete ·
    * Group match 2 · Table 2`, or the round for a match not yet started. */
   statusText: string
@@ -154,6 +154,11 @@ function statusTextOf(match: DashboardTournamentMatch): string {
       )
     case 'completed':
       return joinParts('Match complete', match.round_label, table)
+    case 'voided':
+      // A voided match contributes nothing (ADR-0013) — the card names the fact
+      // and shows no outcome. It deliberately does NOT read as a completed
+      // match, which would derive a loss from the empty board beneath it.
+      return joinParts('Match voided', match.round_label)
     case 'scheduled':
       return match.round_label
   }
@@ -196,7 +201,11 @@ function projectMatch(
   return {
     state: match.state,
     statusText: statusTextOf(match),
-    bestOfText: `Best of ${match.best_of}`,
+    // A best-of-1 is a single game, so it drops the "Best of N" race framing that
+    // only means something for a multi-game set — the copy #908 settled for every
+    // surface that states a match length.
+    bestOfText:
+      match.best_of === 1 ? 'Single game' : `Best of ${match.best_of}`,
     youName,
     opponentName,
     yourGames: match.your_games,

--- a/web-client/src/components/dashboard/tournament-panel-view.ts
+++ b/web-client/src/components/dashboard/tournament-panel-view.ts
@@ -167,20 +167,24 @@ function statusTextOf(match: DashboardTournamentMatch): string {
 function actionOf(
   match: DashboardTournamentMatch,
 ): { label: string; route: MatchRoute } | null {
-  // Only a live match with a next game has something to enter. A scheduled
-  // (uncalled) match is not scorable and a finished one has nothing left, so
-  // both answer `null` rather than a button that 409s or lies.
-  if (
-    match.state !== 'live' ||
-    match.match_id === null ||
-    match.next_game_number === null
-  ) {
-    return null
+  // A scheduled (uncalled) match is not scorable and a finished one has nothing
+  // left, so both answer `null` rather than a button that 409s or lies.
+  if (match.state !== 'live' || match.match_id === null) return null
+  if (match.next_game_number !== null) {
+    return {
+      label: `Enter Game ${match.next_game_number} result`,
+      route: scoringNewRoute(match.match_id, match.next_game_number),
+    }
   }
-  return {
-    label: `Enter Game ${match.next_game_number} result`,
-    route: scoringNewRoute(match.match_id, match.next_game_number),
-  }
+  // A live match with NO next game is the decided-but-unposted board: every game
+  // that decides it has been scored, and what is left is to post the result.
+  // Answering `null` here left the card dead-ended at the one moment the player
+  // most needs a way forward — while the attention panel directly beneath it
+  // offered a primary button for the very same match. This is that panel's own
+  // rule (`attention-panel-view`'s `routeOf`: a `score` row with no current game
+  // routes to match detail, which holds the post-result action), applied at the
+  // top of the page where the player is actually looking.
+  return { label: 'Post the result', route: matchDetailRoute(match.match_id) }
 }
 
 function scheduleTextOf(match: DashboardTournamentMatch): string | null {

--- a/web-client/src/components/dashboard/tournament-panel-view.ts
+++ b/web-client/src/components/dashboard/tournament-panel-view.ts
@@ -170,21 +170,30 @@ function actionOf(
   // A scheduled (uncalled) match is not scorable and a finished one has nothing
   // left, so both answer `null` rather than a button that 409s or lies.
   if (match.state !== 'live' || match.match_id === null) return null
-  if (match.next_game_number !== null) {
-    return {
-      label: `Enter Game ${match.next_game_number} result`,
-      route: scoringNewRoute(match.match_id, match.next_game_number),
-    }
+  switch (match.owed_action) {
+    case 'score':
+      // Mid-board: enter the next game. With no next game the board is decided
+      // and unposted — what is left is to post the result, which match detail
+      // holds. (Answering `null` there dead-ended the card at the one moment the
+      // player most needs a way forward.)
+      return match.next_game_number === null
+        ? { label: 'Post the result', route: matchDetailRoute(match.match_id) }
+        : {
+            label: `Enter Game ${match.next_game_number} result`,
+            route: scoringNewRoute(match.match_id, match.next_game_number),
+          }
+    case 'review':
+      // The OPPONENT posted a result; this player owes it a look. Labelling this
+      // "Post the result" told them to do a thing that was already done, and by
+      // the wrong person — `Review result` is the copy the attention panel has
+      // always used for this exact state.
+      return { label: 'Review result', route: matchDetailRoute(match.match_id) }
+    // `waiting_opponent` (we posted, they owe the accept), `waiting_others` and
+    // `null` all mean the move is not ours: no button. The card still links to
+    // match details, which is where the standing result can be watched.
+    default:
+      return null
   }
-  // A live match with NO next game is the decided-but-unposted board: every game
-  // that decides it has been scored, and what is left is to post the result.
-  // Answering `null` here left the card dead-ended at the one moment the player
-  // most needs a way forward — while the attention panel directly beneath it
-  // offered a primary button for the very same match. This is that panel's own
-  // rule (`attention-panel-view`'s `routeOf`: a `score` row with no current game
-  // routes to match detail, which holds the post-result action), applied at the
-  // top of the page where the player is actually looking.
-  return { label: 'Post the result', route: matchDetailRoute(match.match_id) }
 }
 
 function scheduleTextOf(match: DashboardTournamentMatch): string | null {

--- a/web-client/src/components/dashboard/tournament-panel-view.ts
+++ b/web-client/src/components/dashboard/tournament-panel-view.ts
@@ -129,22 +129,31 @@ function ordinal(n: number): string {
   }
 }
 
+/** Join the parts of a status line, dropping the ones the server had no value for. */
+function joinParts(...parts: (string | null | undefined)[]): string {
+  return parts.filter((part): part is string => Boolean(part)).join(' · ')
+}
+
 function statusTextOf(match: DashboardTournamentMatch): string {
   const table = match.table_label
   switch (match.state) {
-    case 'live': {
-      // The game about to be played, not the count already played — this is the
-      // number on the card the player is about to enter.
-      const game =
-        match.next_game_number ?? match.games.length + 1
-      return ['Live', table, `Game ${game}`]
-        .filter((part): part is string => Boolean(part))
-        .join(' · ')
-    }
+    case 'live':
+      // `next_game_number` is the game about to be played. It is `null` when the
+      // board already DECIDES the match but the result has not been posted — and
+      // there the card must name no game at all. Falling back to
+      // `games.length + 1` would print "Game 3" for a match that is over,
+      // reintroducing on the card the exact phantom game number the server
+      // refuses to emit (`current_game_number`), and contradicting the action
+      // button beside it, which correctly offers nothing to enter.
+      return joinParts(
+        'Live',
+        table,
+        match.next_game_number === null
+          ? null
+          : `Game ${match.next_game_number}`,
+      )
     case 'completed':
-      return ['Match complete', match.round_label, table]
-        .filter((part): part is string => Boolean(part))
-        .join(' · ')
+      return joinParts('Match complete', match.round_label, table)
     case 'scheduled':
       return match.round_label
   }
@@ -171,10 +180,7 @@ function actionOf(
 
 function scheduleTextOf(match: DashboardTournamentMatch): string | null {
   if (match.state !== 'scheduled') return null
-  const parts = [match.start_label, match.table_label].filter(
-    (part): part is string => Boolean(part),
-  )
-  return parts.length ? parts.join(' · ') : 'Not scheduled yet'
+  return joinParts(match.start_label, match.table_label) || 'Not scheduled yet'
 }
 
 function projectMatch(

--- a/web-client/src/components/dashboard/tournament-panel-view.ts
+++ b/web-client/src/components/dashboard/tournament-panel-view.ts
@@ -1,0 +1,312 @@
+import { matchDetailRoute, scoringNewRoute } from '@/api/matches'
+import type {
+  DashboardTournament,
+  DashboardTournamentEvent,
+  DashboardTournamentFixtureRow,
+  DashboardTournamentMatch,
+} from '@/api/dashboard'
+
+// Every label the panel prints is decided here, once, rather than in JSX. The
+// component below it renders a view and branches only on fields this projection
+// already resolved — so a copy change is a change to one pure function with a
+// plain `.test.ts` around it, not a hunt through markup.
+
+/** Shown wherever the opposing side of a fixture is still undecided — the
+ * server's `opponent_username: null`, which means TBD, never "solo". */
+const TBD_OPPONENT = 'TBD'
+
+type MatchRoute =
+  | ReturnType<typeof matchDetailRoute>
+  | ReturnType<typeof scoringNewRoute>
+
+export interface TournamentGameChipView {
+  /** `Game 3` */
+  label: string
+  /** `11–9`, always the viewer's points first. */
+  score: string
+  /** Full sentence for assistive tech, since the chip itself is two numbers. */
+  description: string
+}
+
+export interface TournamentMatchCardView {
+  state: 'live' | 'scheduled' | 'completed'
+  /** The card's status line: `Live · Table 4 · Game 4`, `Match complete ·
+   * Group match 2 · Table 2`, or the round for a match not yet started. */
+  statusText: string
+  /** `Best of 5`. */
+  bestOfText: string
+  /** The viewer's own handle — the panel is a first-person surface, so their
+   * row is named, not labelled "You". */
+  youName: string
+  opponentName: string
+  yourGames: number
+  opponentGames: number
+  /** Which row (if any) carries the winner chip. Both false while a match is
+   * live — a running score has no winner. */
+  youWon: boolean
+  opponentWon: boolean
+  /** `mightymoose shown first · vs slim-manatee` — the legend that makes the
+   * game chips readable. `null` when there are no chips to explain. */
+  gamesLegend: string | null
+  games: TournamentGameChipView[]
+  /** The card's primary action, or `null` when there is nothing to do yet (an
+   * uncalled match cannot be scored, a finished one has nothing to enter). */
+  action: { label: string; route: MatchRoute } | null
+  /** Where "Match details" goes. `null` for a fixture with no match behind it
+   * yet — there is no page to open. */
+  detailsRoute: MatchRoute | null
+  /** `6:00 PM CDT · Table 3` for a match not yet started; `null` otherwise. */
+  scheduleText: string | null
+}
+
+export interface TournamentPathRowView {
+  key: string
+  /** `M2` — the row's ordinal in the viewer's own schedule. */
+  label: string
+  opponentName: string
+  state: DashboardTournamentFixtureRow['state']
+  /** Right-hand text: a result, `In progress`, or a time and table. */
+  detail: string
+  /** Drives the row's tone. `null` for anything not yet decided. */
+  youWon: boolean | null
+}
+
+export interface TournamentStatsView {
+  wins: number
+  losses: number
+  /** `Group position` — what the middle tile counts. */
+  positionLabel: string
+  /** `1st`, or `null` when the event has no standings to stand in yet. */
+  positionValue: string | null
+  /** `of 4`, or `null` alongside a null position. */
+  positionSuffix: string | null
+  /** `Group play` / `Group complete`. */
+  stageValue: string
+}
+
+export interface TournamentTabView {
+  eventId: string
+  name: string
+  /** Puts the pulsing "Live" marker on the tab. */
+  live: boolean
+  stats: TournamentStatsView
+  match: TournamentMatchCardView | null
+  /** `Your matches` — the path list's heading, in the draw type's vocabulary. */
+  pathHeading: string
+  path: TournamentPathRowView[]
+  /** Names the pool the path belongs to, e.g. `Pool A · 4 players`. `null` for
+   * an un-pooled draw or before the viewer has been drawn into one. */
+  pathSubheading: string | null
+}
+
+export interface TournamentPanelView {
+  tournamentId: string
+  /** Rendered in the display face, so it is upper-cased at the source rather
+   * than by a CSS transform a screen reader would read letter by letter. */
+  name: string
+  subtitle: string
+  /** `1 live now`, or `null` when nothing of the viewer's is being played. */
+  liveLabel: string | null
+  /** `View group & standings` / `View draw` — where the header link goes, in
+   * the draw type's own words. */
+  destinationLabel: string
+  tabs: TournamentTabView[]
+}
+
+function ordinal(n: number): string {
+  // 11th/12th/13th are the exceptions every naive implementation gets wrong.
+  const teen = n % 100
+  if (teen >= 11 && teen <= 13) return `${n}th`
+  switch (n % 10) {
+    case 1:
+      return `${n}st`
+    case 2:
+      return `${n}nd`
+    case 3:
+      return `${n}rd`
+    default:
+      return `${n}th`
+  }
+}
+
+function statusTextOf(match: DashboardTournamentMatch): string {
+  const table = match.table_label
+  switch (match.state) {
+    case 'live': {
+      // The game about to be played, not the count already played — this is the
+      // number on the card the player is about to enter.
+      const game =
+        match.next_game_number ?? match.games.length + 1
+      return ['Live', table, `Game ${game}`]
+        .filter((part): part is string => Boolean(part))
+        .join(' · ')
+    }
+    case 'completed':
+      return ['Match complete', match.round_label, table]
+        .filter((part): part is string => Boolean(part))
+        .join(' · ')
+    case 'scheduled':
+      return match.round_label
+  }
+}
+
+function actionOf(
+  match: DashboardTournamentMatch,
+): { label: string; route: MatchRoute } | null {
+  // Only a live match with a next game has something to enter. A scheduled
+  // (uncalled) match is not scorable and a finished one has nothing left, so
+  // both answer `null` rather than a button that 409s or lies.
+  if (
+    match.state !== 'live' ||
+    match.match_id === null ||
+    match.next_game_number === null
+  ) {
+    return null
+  }
+  return {
+    label: `Enter Game ${match.next_game_number} result`,
+    route: scoringNewRoute(match.match_id, match.next_game_number),
+  }
+}
+
+function scheduleTextOf(match: DashboardTournamentMatch): string | null {
+  if (match.state !== 'scheduled') return null
+  const parts = [match.start_label, match.table_label].filter(
+    (part): part is string => Boolean(part),
+  )
+  return parts.length ? parts.join(' · ') : 'Not scheduled yet'
+}
+
+function projectMatch(
+  match: DashboardTournamentMatch,
+  youName: string,
+): TournamentMatchCardView {
+  const opponentName = match.opponent_username ?? TBD_OPPONENT
+  const games = match.games.map((game) => ({
+    label: `Game ${game.number}`,
+    score: `${game.your_points}–${game.opponent_points}`,
+    description: `Game ${game.number}: ${youName} ${game.your_points}, ${opponentName} ${game.opponent_points}`,
+  }))
+  return {
+    state: match.state,
+    statusText: statusTextOf(match),
+    bestOfText: `Best of ${match.best_of}`,
+    youName,
+    opponentName,
+    yourGames: match.your_games,
+    opponentGames: match.opponent_games,
+    // `you_won` is null until the match is decided, so neither row is crowned
+    // mid-match — a `false` there would put the chip on the opponent.
+    youWon: match.you_won === true,
+    opponentWon: match.you_won === false,
+    gamesLegend: games.length
+      ? `${youName} shown first · vs ${opponentName}`
+      : null,
+    games,
+    action: actionOf(match),
+    detailsRoute:
+      match.match_id === null ? null : matchDetailRoute(match.match_id),
+    scheduleText: scheduleTextOf(match),
+  }
+}
+
+function projectStats(event: DashboardTournamentEvent): TournamentStatsView {
+  return {
+    wins: event.wins,
+    losses: event.losses,
+    positionLabel:
+      event.draw_type === 'round-robin' ? 'Group position' : 'Position',
+    positionValue: event.position === null ? null : ordinal(event.position),
+    positionSuffix:
+      event.position === null ? null : `of ${event.field_size}`,
+    stageValue: event.stage_label,
+  }
+}
+
+function pathHeadingOf(drawType: DashboardTournamentEvent['draw_type']): string {
+  return drawType === 'round-robin' ? 'Your matches' : 'Your path'
+}
+
+function destinationLabelOf(tabs: DashboardTournamentEvent[]): string {
+  // A round-robin's destination is its standings table; anything else is a
+  // bracket. Keyed off the first tab because the header link is per-tournament
+  // and every event of one today shares a draw type in practice — and "View
+  // draw" reads correctly for a mixed tournament either way.
+  return tabs.every((event) => event.draw_type === 'round-robin')
+    ? 'View group & standings'
+    : 'View draw'
+}
+
+function projectTab(
+  event: DashboardTournamentEvent,
+  youName: string,
+): TournamentTabView {
+  return {
+    eventId: event.id,
+    name: event.name,
+    live: event.is_live,
+    stats: projectStats(event),
+    match: event.match === null ? null : projectMatch(event.match, youName),
+    pathHeading: pathHeadingOf(event.draw_type),
+    path: event.fixtures.map((fixture, index) => ({
+      // The fixture's own match id is null before it materializes, so the row's
+      // ordinal — which is stable within one payload — is the key.
+      key: `${event.id}-${index}`,
+      label: fixture.label,
+      opponentName: fixture.opponent_username ?? TBD_OPPONENT,
+      state: fixture.state,
+      detail: fixture.detail,
+      youWon: fixture.you_won,
+    })),
+    pathSubheading:
+      event.pool_label === null
+        ? null
+        : event.field_size > 0
+          ? `${event.pool_label} · ${event.field_size} players`
+          : event.pool_label,
+  }
+}
+
+/**
+ * Project one live tournament from the dashboard payload into the panel's view
+ * model — labels, ordinals, routes and the tab strip.
+ *
+ * `youName` is the viewer's own handle, which the payload deliberately does not
+ * repeat: every score on it is already stated from the caller's side, so the
+ * only thing missing is what to *call* them, and the dashboard already knows
+ * that from the session.
+ */
+export function projectTournamentPanelView(
+  tournament: DashboardTournament,
+  youName: string,
+): TournamentPanelView {
+  return {
+    tournamentId: tournament.id,
+    name: tournament.name,
+    subtitle: tournament.subtitle,
+    liveLabel:
+      tournament.live_count > 0 ? `${tournament.live_count} live now` : null,
+    destinationLabel: destinationLabelOf(tournament.events),
+    tabs: tournament.events.map((event) => projectTab(event, youName)),
+  }
+}
+
+/**
+ * Every live tournament the viewer is playing in, as panels — `[]` when they
+ * are in none, which is almost always, and the dashboard then renders nothing.
+ *
+ * An event-less tournament is dropped rather than rendered as an empty panel:
+ * the panel is entirely made of its tabs, so one with no tabs is a heading over
+ * nothing. (The server cannot emit one today — a panel exists because the
+ * viewer holds an entry in one of its events — but the panel must not depend on
+ * that to avoid rendering a husk.)
+ */
+export function projectTournamentPanelViews(
+  tournaments: DashboardTournament[],
+  youName: string | undefined,
+): TournamentPanelView[] {
+  if (!youName) return []
+  return tournaments
+    .filter((tournament) => tournament.events.length > 0)
+    .map((tournament) => projectTournamentPanelView(tournament, youName))
+}

--- a/web-client/src/components/dashboard/tournament-panel.factory.tsx
+++ b/web-client/src/components/dashboard/tournament-panel.factory.tsx
@@ -1,0 +1,72 @@
+import { buildTournamentMatchCardView } from './tournament-panel/tournament-match-card.factory'
+import { buildTournamentStatsView } from './tournament-panel/tournament-stats-strip.factory'
+import { buildTournamentPathRowView } from './tournament-panel/tournament-path-list/tournament-path-row.factory'
+import type { TournamentPanelProps } from './tournament-panel'
+import type {
+  TournamentPanelView,
+  TournamentTabView,
+} from './tournament-panel-view'
+
+/**
+ * The viewer's live event: a four-strong group they lead, one match won, one
+ * being played right now, one still to come.
+ */
+export function buildTournamentTabView(
+  overrides: Partial<TournamentTabView> = {},
+): TournamentTabView {
+  return {
+    eventId: 'e-1',
+    name: 'U1500 · Group B',
+    live: true,
+    stats: buildTournamentStatsView(),
+    match: buildTournamentMatchCardView(),
+    pathHeading: 'Your matches',
+    pathSubheading: 'Pool B · 4 players',
+    path: [
+      buildTournamentPathRowView({ key: 'e-1-0', label: 'M1' }),
+      buildTournamentPathRowView({
+        key: 'e-1-1',
+        label: 'M2',
+        opponentName: 'slim-manatee',
+        state: 'live',
+        detail: 'In progress',
+        youWon: null,
+      }),
+      buildTournamentPathRowView({
+        key: 'e-1-2',
+        label: 'M3',
+        opponentName: 'bold-bison',
+        state: 'upcoming',
+        detail: '5:20 PM CDT · Table 6',
+        youWon: null,
+      }),
+    ],
+    ...overrides,
+  }
+}
+
+/**
+ * A one-event panel for a live tournament — the single-tab case, which is what
+ * a player entered in one event actually sees. Multi-tab cases pass their own
+ * `tabs`.
+ */
+export function buildTournamentPanelView(
+  overrides: Partial<TournamentPanelView> = {},
+): TournamentPanelView {
+  return {
+    tournamentId: 't-1',
+    name: 'Riverside Summer Slam',
+    subtitle: 'Riverside TTC · Jul 24–25',
+    liveLabel: '1 live now',
+    destinationLabel: 'View group & standings',
+    tabs: [buildTournamentTabView()],
+    ...overrides,
+  }
+}
+
+/** Props for `TournamentPanel`. */
+export function buildTournamentPanelProps(
+  overrides: Partial<TournamentPanelProps> = {},
+): TournamentPanelProps {
+  return { view: buildTournamentPanelView(), ...overrides }
+}

--- a/web-client/src/components/dashboard/tournament-panel.page.tsx
+++ b/web-client/src/components/dashboard/tournament-panel.page.tsx
@@ -1,0 +1,86 @@
+import { renderWithRoutes } from '@/test/router'
+import { screen, within, type Container } from '@/test/utilities'
+
+import { TournamentPanel, type TournamentPanelProps } from './tournament-panel'
+import { buildTournamentPanelProps } from './tournament-panel.factory'
+import { tournamentMatchCardPage } from './tournament-panel/tournament-match-card.page'
+import { tournamentPathListPage } from './tournament-panel/tournament-path-list.page'
+import { tournamentStatsStripPage } from './tournament-panel/tournament-stats-strip.page'
+
+/** Every route the panel and its children link to. */
+const LINK_TARGETS = [
+  '/tournaments/$tournamentId',
+  '/matches/$matchId',
+  '/matches/$matchId/games/$gameNumber/scores/new',
+]
+
+const scoped = (container: Container) => ({
+  /** The panel section, or null when the dashboard rendered none. */
+  queryPanel() {
+    return container.queryByTestId('dashboard-tournament-panel')
+  },
+  /** The tournament's name — the panel's own heading. */
+  getHeading(name: string | RegExp) {
+    return container.getByRole('heading', { name })
+  },
+  /** The "N live now" pill, or null when nothing of the viewer's is live. */
+  queryLiveBadge() {
+    return container.queryByText(/live now$/)
+  },
+  /** The header link out to the tournament page. */
+  getDestinationLink(name: string | RegExp) {
+    return container.getByRole('link', { name })
+  },
+  /** Every event tab, in render order. */
+  getTabs() {
+    return within(
+      container.getByTestId('dashboard-tournament-panel'),
+    ).getAllByRole('tab')
+  },
+  /** One event tab by its name. */
+  getTab(name: string | RegExp) {
+    return container.getByRole('tab', { name })
+  },
+  /** The visible tab panel — Radix unmounts the inactive ones. */
+  getActivePanel() {
+    return within(
+      container.getByTestId('dashboard-tournament-panel'),
+    ).getByRole('tabpanel')
+  },
+  /** The "no draw yet" placeholder that stands in for the match card. */
+  queryNoMatchNotice() {
+    return container.queryByTestId('tournament-panel-no-match')
+  },
+  // Children's internals are pinned by their own quartets; reuse their queries
+  // so this page object asserts wiring, not markup it does not own.
+  matchCard: tournamentMatchCardPage.within(container),
+  stats: tournamentStatsStripPage.within(container),
+  path: tournamentPathListPage.within(container),
+})
+
+/**
+ * Test page-object for `TournamentPanel`.
+ *
+ * The panel and its children render typed `<Link>`s, so `render` mounts it
+ * under the shared memory-router harness. The router resolves asynchronously —
+ * tests start with `await tournamentPanelPage.findHeading(...)`.
+ */
+export const tournamentPanelPage = {
+  render(overrides: Partial<TournamentPanelProps> = {}) {
+    renderWithRoutes(
+      <TournamentPanel {...buildTournamentPanelProps(overrides)} />,
+      { linkTargets: LINK_TARGETS },
+    )
+  },
+
+  /** Async-first accessor — the router resolves the tree on first paint. */
+  findHeading(name: string | RegExp) {
+    return screen.findByRole('heading', { name })
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/dashboard/tournament-panel.test.tsx
+++ b/web-client/src/components/dashboard/tournament-panel.test.tsx
@@ -1,0 +1,134 @@
+import { userEvent } from '@testing-library/user-event'
+import {
+  buildTournamentPanelView,
+  buildTournamentTabView,
+} from './tournament-panel.factory'
+import { tournamentPanelPage } from './tournament-panel.page'
+
+describe('TournamentPanel', () => {
+  it('names the tournament and its venue', async () => {
+    tournamentPanelPage.render()
+
+    await tournamentPanelPage.findHeading('Riverside Summer Slam')
+    expect(tournamentPanelPage.queryPanel()).toHaveTextContent(
+      'Riverside TTC · Jul 24–25',
+    )
+  })
+
+  it('links out to the tournament page', async () => {
+    tournamentPanelPage.render()
+
+    await tournamentPanelPage.findHeading('Riverside Summer Slam')
+    expect(
+      tournamentPanelPage.getDestinationLink(/view group & standings/i),
+    ).toHaveAttribute('href', '/tournaments/t-1')
+  })
+
+  it('counts the viewer’s live matches in the header', async () => {
+    tournamentPanelPage.render({
+      view: buildTournamentPanelView({ liveLabel: '2 live now' }),
+    })
+
+    await tournamentPanelPage.findHeading('Riverside Summer Slam')
+    expect(tournamentPanelPage.queryLiveBadge()).toHaveTextContent('2 live now')
+  })
+
+  it('hides the live pill when nothing of the viewer’s is being played', async () => {
+    tournamentPanelPage.render({
+      view: buildTournamentPanelView({ liveLabel: null }),
+    })
+
+    await tournamentPanelPage.findHeading('Riverside Summer Slam')
+    expect(tournamentPanelPage.queryLiveBadge()).toBeNull()
+  })
+
+  it('renders one tab per entered event', async () => {
+    tournamentPanelPage.render({
+      view: buildTournamentPanelView({
+        tabs: [
+          buildTournamentTabView({ eventId: 'e-1', name: 'Open Singles' }),
+          buildTournamentTabView({ eventId: 'e-2', name: 'U1500' }),
+        ],
+      }),
+    })
+
+    await tournamentPanelPage.findHeading('Riverside Summer Slam')
+    expect(tournamentPanelPage.getTabs().map((tab) => tab.textContent)).toEqual([
+      expect.stringContaining('Open Singles'),
+      expect.stringContaining('U1500'),
+    ])
+  })
+
+  it('marks the event holding a live match', async () => {
+    tournamentPanelPage.render({
+      view: buildTournamentPanelView({
+        tabs: [
+          buildTournamentTabView({ eventId: 'e-1', name: 'Open Singles', live: false }),
+          buildTournamentTabView({ eventId: 'e-2', name: 'U1500', live: true }),
+        ],
+      }),
+    })
+
+    await tournamentPanelPage.findHeading('Riverside Summer Slam')
+    expect(tournamentPanelPage.getTab(/open singles/i)).not.toHaveTextContent(
+      'Live',
+    )
+    expect(tournamentPanelPage.getTab(/u1500/i)).toHaveTextContent('Live')
+  })
+
+  it('shows the first event until another tab is chosen', async () => {
+    tournamentPanelPage.render({
+      view: buildTournamentPanelView({
+        tabs: [
+          buildTournamentTabView({
+            eventId: 'e-1',
+            name: 'Open Singles',
+            pathSubheading: 'Pool A · 4 players',
+          }),
+          buildTournamentTabView({
+            eventId: 'e-2',
+            name: 'U1500',
+            pathSubheading: 'Pool B · 6 players',
+          }),
+        ],
+      }),
+    })
+
+    await tournamentPanelPage.findHeading('Riverside Summer Slam')
+    expect(tournamentPanelPage.getActivePanel()).toHaveTextContent(
+      'Pool A · 4 players',
+    )
+
+    await userEvent.click(tournamentPanelPage.getTab(/u1500/i))
+
+    expect(tournamentPanelPage.getActivePanel()).toHaveTextContent(
+      'Pool B · 6 players',
+    )
+  })
+
+  it('wires the active tab’s match, stats and schedule in', async () => {
+    // Wiring only: each child's content is pinned by its own quartet.
+    tournamentPanelPage.render()
+
+    await tournamentPanelPage.findHeading('Riverside Summer Slam')
+    expect(tournamentPanelPage.matchCard.queryCard()).not.toBeNull()
+    expect(tournamentPanelPage.stats.queryStrip()).not.toBeNull()
+    expect(tournamentPanelPage.path.getRows()).toHaveLength(3)
+  })
+
+  it('explains an event whose draw has not been made instead of showing an empty card', async () => {
+    tournamentPanelPage.render({
+      view: buildTournamentPanelView({
+        tabs: [buildTournamentTabView({ match: null, path: [] })],
+      }),
+    })
+
+    await tournamentPanelPage.findHeading('Riverside Summer Slam')
+    expect(tournamentPanelPage.matchCard.queryCard()).toBeNull()
+    expect(tournamentPanelPage.queryNoMatchNotice()).toHaveTextContent(
+      /draw for this event hasn’t been made yet/i,
+    )
+    // The stats strip stays — the record and stage are meaningful before a draw.
+    expect(tournamentPanelPage.stats.queryStrip()).not.toBeNull()
+  })
+})

--- a/web-client/src/components/dashboard/tournament-panel.tsx
+++ b/web-client/src/components/dashboard/tournament-panel.tsx
@@ -2,6 +2,7 @@ import { useId, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { ArrowRight } from 'lucide-react'
 import { Overline } from '@/components/overline'
+import { Card } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { TournamentMatchCard } from './tournament-panel/tournament-match-card'
 import { TournamentPathList } from './tournament-panel/tournament-path-list'
@@ -36,11 +37,16 @@ export const TournamentPanel = ({ view }: TournamentPanelProps) => {
   const current =
     view.tabs.find((tab) => tab.eventId === active) ?? view.tabs[0]
   return (
-    <section
-      aria-labelledby={headingId}
-      className="mb-6 rounded-[var(--radius-lg)] border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)] p-5 sm:p-6"
+    // The design-system `Card` IS the content-panel primitive (web-client
+    // CLAUDE.md), and `asChild` exists so it can be the `<section
+    // aria-labelledby>` landmark rather than wrapping one — the same shape
+    // `AttentionPanel` beneath it uses.
+    <Card
+      asChild
+      className="mb-6 gap-0 bg-[color:var(--bg-panel)] p-5 sm:p-6"
       data-testid="dashboard-tournament-panel"
     >
+    <section aria-labelledby={headingId}>
       <div className="flex flex-wrap items-start gap-4">
         <div className="min-w-0">
           <Overline className="mb-1.5 text-[color:var(--ball-500)]">
@@ -144,5 +150,6 @@ export const TournamentPanel = ({ view }: TournamentPanelProps) => {
         ))}
       </Tabs>
     </section>
+    </Card>
   )
 }

--- a/web-client/src/components/dashboard/tournament-panel.tsx
+++ b/web-client/src/components/dashboard/tournament-panel.tsx
@@ -129,7 +129,7 @@ export const TournamentPanel = ({ view }: TournamentPanelProps) => {
           >
             {tab.match === null ? (
               <p
-                className="rounded-[var(--radius-md)] border border-[color:var(--border-subtle)] bg-[color:var(--bg-card)] p-5 text-[14px] text-[color:var(--fg-3)]"
+                className="min-w-0 rounded-[var(--radius-md)] border border-[color:var(--border-subtle)] bg-[color:var(--bg-card)] p-5 text-[14px] text-[color:var(--fg-3)]"
                 data-testid="tournament-panel-no-match"
               >
                 The draw for this event hasn&rsquo;t been made yet. Your matches
@@ -138,7 +138,7 @@ export const TournamentPanel = ({ view }: TournamentPanelProps) => {
             ) : (
               <TournamentMatchCard match={tab.match} />
             )}
-            <div className="flex flex-col gap-3.5">
+            <div className="flex min-w-0 flex-col gap-3.5">
               <TournamentStatsStrip stats={tab.stats} />
               <TournamentPathList
                 heading={tab.pathHeading}

--- a/web-client/src/components/dashboard/tournament-panel.tsx
+++ b/web-client/src/components/dashboard/tournament-panel.tsx
@@ -48,7 +48,14 @@ export const TournamentPanel = ({ view }: TournamentPanelProps) => {
           </Overline>
           <h2
             id={headingId}
-            className="font-[family-name:var(--font-display)] text-[26px] leading-none tracking-wide sm:text-[30px]"
+            // The display face, set inline the way the rest of the theme's
+            // display headings do it (`app-shell__wordmark`,
+            // `sys-health__headline`). The `font-display` *class* is not enough
+            // on its own here: its `text-transform` lands but its `font-family`
+            // loses to the inherited UI face, so the heading silently renders in
+            // Space Grotesk — measured in the browser, not assumed.
+            style={{ fontFamily: 'var(--font-display)' }}
+            className="text-[26px] leading-none tracking-[0.02em] uppercase sm:text-[30px]"
           >
             {view.name}
           </h2>

--- a/web-client/src/components/dashboard/tournament-panel.tsx
+++ b/web-client/src/components/dashboard/tournament-panel.tsx
@@ -1,0 +1,141 @@
+import { useId, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { ArrowRight } from 'lucide-react'
+import { Overline } from '@/components/overline'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { TournamentMatchCard } from './tournament-panel/tournament-match-card'
+import { TournamentPathList } from './tournament-panel/tournament-path-list'
+import { TournamentStatsStrip } from './tournament-panel/tournament-stats-strip'
+import type { TournamentPanelView } from './tournament-panel-view'
+
+export interface TournamentPanelProps {
+  view: TournamentPanelView
+}
+
+/**
+ * The panel that tops the dashboard while the viewer is playing in a live
+ * tournament: the tournament's name and venue, a tab per event they entered,
+ * and inside each tab the one match to look at, where they stand, and their
+ * remaining schedule.
+ *
+ * It sits above the attention panel deliberately. During a tournament the match
+ * in front of you outranks every other to-do on the dashboard, and a player at a
+ * table should not have to scroll for it.
+ *
+ * Pure view-in — every label, ordinal and route is decided by
+ * `projectTournamentPanelView`. Tabs are the design-system `Tabs`, which brings
+ * the roving-tabindex `tablist`/`tab`/`tabpanel` wiring and arrow-key
+ * activation with it rather than re-implementing them here.
+ */
+export const TournamentPanel = ({ view }: TournamentPanelProps) => {
+  const headingId = useId()
+  // Uncontrolled would be simpler, but the tab set can change under us as a
+  // match finishes and the dashboard refetches; keying off the event id keeps
+  // the viewer on the event they chose.
+  const [active, setActive] = useState(view.tabs[0].eventId)
+  const current =
+    view.tabs.find((tab) => tab.eventId === active) ?? view.tabs[0]
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="mb-6 rounded-[var(--radius-lg)] border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)] p-5 sm:p-6"
+      data-testid="dashboard-tournament-panel"
+    >
+      <div className="flex flex-wrap items-start gap-4">
+        <div className="min-w-0">
+          <Overline className="mb-1.5 text-[color:var(--ball-500)]">
+            Your tournament
+          </Overline>
+          <h2
+            id={headingId}
+            className="font-[family-name:var(--font-display)] text-[26px] leading-none tracking-wide sm:text-[30px]"
+          >
+            {view.name}
+          </h2>
+          <p className="mt-1.5 text-[13px] text-[color:var(--fg-3)]">
+            {view.subtitle}
+          </p>
+        </div>
+        <div className="ml-auto flex flex-shrink-0 items-center gap-3.5">
+          {view.liveLabel !== null && (
+            <span className="inline-flex items-center gap-2 rounded-full bg-[color:var(--bg-live-soft)] px-3 py-1.5 font-mono text-[12px] font-semibold tracking-wider text-[color:var(--serve-500)]">
+              <span
+                className="size-2 animate-pulse rounded-full bg-[color:var(--serve-500)]"
+                aria-hidden="true"
+              />
+              {view.liveLabel}
+            </span>
+          )}
+          <Link
+            to="/tournaments/$tournamentId"
+            params={{ tournamentId: view.tournamentId }}
+            className="inline-flex items-center gap-1.5 text-[14px] font-semibold whitespace-nowrap text-[color:var(--ball-500)] hover:text-[color:var(--ball-400)]"
+          >
+            {view.destinationLabel}
+            <ArrowRight size={15} strokeWidth={2} aria-hidden="true" />
+          </Link>
+        </div>
+      </div>
+
+      <Tabs
+        value={current.eventId}
+        onValueChange={setActive}
+        className="mt-4 gap-0"
+      >
+        <TabsList
+          variant="line"
+          aria-label="Your events"
+          className="w-full justify-start overflow-x-auto border-b border-[color:var(--border-subtle)] pb-1"
+        >
+          {view.tabs.map((tab) => (
+            <TabsTrigger
+              key={tab.eventId}
+              value={tab.eventId}
+              className="flex-none gap-2 px-4 py-2.5 text-[14px]"
+            >
+              {tab.name}
+              {tab.live && (
+                <span className="inline-flex items-center gap-1.5">
+                  <span
+                    className="size-1.5 rounded-full bg-[color:var(--serve-500)] shadow-[0_0_8px_rgba(0,226,154,0.6)]"
+                    aria-hidden="true"
+                  />
+                  <span className="text-[12px] font-bold text-[color:var(--serve-500)]">
+                    Live
+                  </span>
+                </span>
+              )}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {view.tabs.map((tab) => (
+          <TabsContent
+            key={tab.eventId}
+            value={tab.eventId}
+            className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(272px,1fr)] lg:items-start"
+          >
+            {tab.match === null ? (
+              <p
+                className="rounded-[var(--radius-md)] border border-[color:var(--border-subtle)] bg-[color:var(--bg-card)] p-5 text-[14px] text-[color:var(--fg-3)]"
+                data-testid="tournament-panel-no-match"
+              >
+                The draw for this event hasn&rsquo;t been made yet. Your matches
+                will appear here once it is.
+              </p>
+            ) : (
+              <TournamentMatchCard match={tab.match} />
+            )}
+            <div className="flex flex-col gap-3.5">
+              <TournamentStatsStrip stats={tab.stats} />
+              <TournamentPathList
+                heading={tab.pathHeading}
+                subheading={tab.pathSubheading}
+                rows={tab.path}
+              />
+            </div>
+          </TabsContent>
+        ))}
+      </Tabs>
+    </section>
+  )
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-match-card.factory.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-match-card.factory.tsx
@@ -1,0 +1,52 @@
+import { matchDetailRoute, scoringNewRoute } from '@/api/matches'
+import type { TournamentMatchCardView } from '../tournament-panel-view'
+import { buildTournamentGameChipView } from './tournament-match-card/tournament-game-chips.factory'
+import type { TournamentMatchCardProps } from './tournament-match-card'
+
+/**
+ * A live best-of-five on Table 4, three games played, the viewer 2–1 up and
+ * about to enter game 4 — the design's headline scenario.
+ */
+export function buildTournamentMatchCardView(
+  overrides: Partial<TournamentMatchCardView> = {},
+): TournamentMatchCardView {
+  return {
+    state: 'live',
+    statusText: 'Live · Table 4 · Game 4',
+    bestOfText: 'Best of 5',
+    youName: 'mightymoose',
+    opponentName: 'slim-manatee',
+    yourGames: 2,
+    opponentGames: 1,
+    youWon: false,
+    opponentWon: false,
+    gamesLegend: 'mightymoose shown first · vs slim-manatee',
+    games: [
+      buildTournamentGameChipView(),
+      buildTournamentGameChipView({
+        label: 'Game 2',
+        score: '8–11',
+        description: 'Game 2: mightymoose 8, slim-manatee 11',
+      }),
+      buildTournamentGameChipView({
+        label: 'Game 3',
+        score: '11–9',
+        description: 'Game 3: mightymoose 11, slim-manatee 9',
+      }),
+    ],
+    action: {
+      label: 'Enter Game 4 result',
+      route: scoringNewRoute('m-1', 4),
+    },
+    detailsRoute: matchDetailRoute('m-1'),
+    scheduleText: null,
+    ...overrides,
+  }
+}
+
+/** Props for `TournamentMatchCard`. */
+export function buildTournamentMatchCardProps(
+  overrides: Partial<TournamentMatchCardProps> = {},
+): TournamentMatchCardProps {
+  return { match: buildTournamentMatchCardView(), ...overrides }
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-match-card.page.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-match-card.page.tsx
@@ -1,0 +1,76 @@
+import { renderWithRoutes } from '@/test/router'
+import { screen, within, type Container } from '@/test/utilities'
+
+import {
+  TournamentMatchCard,
+  type TournamentMatchCardProps,
+} from './tournament-match-card'
+import { buildTournamentMatchCardProps } from './tournament-match-card.factory'
+import { tournamentGameChipsPage } from './tournament-match-card/tournament-game-chips.page'
+
+/** Every route a card can link to — the scoring page and match detail. */
+const LINK_TARGETS = [
+  '/matches/$matchId',
+  '/matches/$matchId/games/$gameNumber/scores/new',
+]
+
+const scoped = (container: Container) => ({
+  /** The card itself. */
+  getCard() {
+    return container.getByTestId('tournament-panel-match-card')
+  },
+  /** The card, or null — for asserting the parent rendered none. */
+  queryCard() {
+    return container.queryByTestId('tournament-panel-match-card')
+  },
+  /** The primary action link ("Enter Game 4 result"), or null when there is
+   * nothing to enter. */
+  queryActionLink(name: string | RegExp) {
+    return container.queryByRole('link', { name })
+  },
+  /** The "Match details" link, or null for a fixture with no match behind it. */
+  queryDetailsLink() {
+    return container.queryByRole('link', { name: /match details/i })
+  },
+  /** The row of the scoreboard belonging to this player — scoped so the two
+   * rows' scores and winner chips never cross-read. */
+  getScoreRow(name: string) {
+    const row = within(
+      container.getByTestId('tournament-panel-match-card'),
+    ).getByText(name).parentElement
+    if (!(row instanceof HTMLElement)) {
+      throw new Error(`No score row found for "${name}".`)
+    }
+    return row
+  },
+  // The chips' own content is pinned by their quartet; reuse their queries.
+  chips: tournamentGameChipsPage.within(container),
+})
+
+/**
+ * Test page-object for `TournamentMatchCard`.
+ *
+ * The card renders typed `<Link>`s, so `render` mounts it under the shared
+ * memory-router harness with the scoring and match-detail routes registered.
+ * The router resolves asynchronously — tests start with
+ * `await tournamentMatchCardPage.findCard()`.
+ */
+export const tournamentMatchCardPage = {
+  render(overrides: Partial<TournamentMatchCardProps> = {}) {
+    renderWithRoutes(
+      <TournamentMatchCard {...buildTournamentMatchCardProps(overrides)} />,
+      { linkTargets: LINK_TARGETS },
+    )
+  },
+
+  /** Async-first accessor — the router resolves the tree on first paint. */
+  findCard() {
+    return screen.findByTestId('tournament-panel-match-card')
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-match-card.test.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-match-card.test.tsx
@@ -1,0 +1,147 @@
+import { scoringNewRoute } from '@/api/matches'
+import { buildTournamentMatchCardView } from './tournament-match-card.factory'
+import { tournamentMatchCardPage } from './tournament-match-card.page'
+
+describe('TournamentMatchCard', () => {
+  it('prints the games-won score against each player', async () => {
+    tournamentMatchCardPage.render()
+
+    await tournamentMatchCardPage.findCard()
+    expect(tournamentMatchCardPage.getScoreRow('mightymoose')).toHaveTextContent(
+      '2',
+    )
+    expect(
+      tournamentMatchCardPage.getScoreRow('slim-manatee'),
+    ).toHaveTextContent('1')
+  })
+
+  it('says where and what game a live match is on', async () => {
+    tournamentMatchCardPage.render({
+      match: buildTournamentMatchCardView({
+        statusText: 'Live · Table 6 · Game 2',
+      }),
+    })
+
+    const card = await tournamentMatchCardPage.findCard()
+    expect(card).toHaveTextContent('Live · Table 6 · Game 2')
+    expect(card).toHaveTextContent('Best of 5')
+  })
+
+  it('deep-links the primary action to the game about to be played', async () => {
+    tournamentMatchCardPage.render({
+      match: buildTournamentMatchCardView({
+        action: {
+          label: 'Enter Game 4 result',
+          route: scoringNewRoute('m-9', 4),
+        },
+      }),
+    })
+
+    await tournamentMatchCardPage.findCard()
+    expect(
+      tournamentMatchCardPage.queryActionLink('Enter Game 4 result'),
+    ).toHaveAttribute('href', '/matches/m-9/games/4/scores/new')
+  })
+
+  it('offers no primary action when there is nothing to enter', async () => {
+    // An uncalled match is not scorable; a button that 409s is worse than none.
+    tournamentMatchCardPage.render({
+      match: buildTournamentMatchCardView({
+        state: 'scheduled',
+        statusText: 'Group match 3',
+        action: null,
+        games: [],
+        gamesLegend: null,
+        scheduleText: '5:20 PM CDT · Table 6',
+      }),
+    })
+
+    await tournamentMatchCardPage.findCard()
+    expect(tournamentMatchCardPage.queryActionLink(/enter game/i)).toBeNull()
+    expect(tournamentMatchCardPage.queryDetailsLink()).toHaveAttribute(
+      'href',
+      '/matches/m-1',
+    )
+  })
+
+  it('shows when and where a match not yet started will be played', async () => {
+    tournamentMatchCardPage.render({
+      match: buildTournamentMatchCardView({
+        state: 'scheduled',
+        statusText: 'Group match 3',
+        action: null,
+        games: [],
+        gamesLegend: null,
+        scheduleText: '5:20 PM CDT · Table 6',
+      }),
+    })
+
+    const card = await tournamentMatchCardPage.findCard()
+    expect(card).toHaveTextContent('5:20 PM CDT · Table 6')
+  })
+
+  it('crowns only the winner of a finished match', async () => {
+    tournamentMatchCardPage.render({
+      match: buildTournamentMatchCardView({
+        state: 'completed',
+        statusText: 'Match complete · Group match 2 · Table 4',
+        yourGames: 3,
+        opponentGames: 1,
+        youWon: true,
+        opponentWon: false,
+        action: null,
+      }),
+    })
+
+    await tournamentMatchCardPage.findCard()
+    expect(tournamentMatchCardPage.getScoreRow('mightymoose')).toHaveTextContent(
+      'Winner',
+    )
+    expect(
+      tournamentMatchCardPage.getScoreRow('slim-manatee'),
+    ).not.toHaveTextContent('Winner')
+  })
+
+  it('crowns nobody while the match is still being played', async () => {
+    // `youWon`/`opponentWon` are both false mid-match — a running 2–1 has no
+    // winner, and a card that crowned the leader would be claiming a result.
+    tournamentMatchCardPage.render()
+
+    const card = await tournamentMatchCardPage.findCard()
+    expect(card).not.toHaveTextContent('Winner')
+  })
+
+  it('glows only while the match is live', async () => {
+    tournamentMatchCardPage.render()
+    expect(await tournamentMatchCardPage.findCard()).toHaveClass(
+      'border-[color:var(--serve-500)]/35',
+    )
+  })
+
+  it('drops the glow once the match is over', async () => {
+    tournamentMatchCardPage.render({
+      match: buildTournamentMatchCardView({ state: 'completed', action: null }),
+    })
+
+    expect(await tournamentMatchCardPage.findCard()).toHaveClass(
+      'border-[color:var(--border-subtle)]',
+    )
+  })
+
+  it('wires the played games through to the chips', async () => {
+    // Wiring only: chip content is pinned by the game-chips tests.
+    tournamentMatchCardPage.render()
+
+    await tournamentMatchCardPage.findCard()
+    expect(tournamentMatchCardPage.chips.getChips()).toHaveLength(3)
+  })
+
+  it('renders no chips block before the first game is played', async () => {
+    tournamentMatchCardPage.render({
+      match: buildTournamentMatchCardView({ games: [], gamesLegend: null }),
+    })
+
+    await tournamentMatchCardPage.findCard()
+    expect(tournamentMatchCardPage.chips.queryChips()).toBeNull()
+  })
+})

--- a/web-client/src/components/dashboard/tournament-panel/tournament-match-card.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-match-card.tsx
@@ -1,0 +1,142 @@
+import { Link } from '@tanstack/react-router'
+import { ArrowRight, Check, Clock } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Overline } from '@/components/overline'
+import { cn } from '@/lib/utils'
+import type { TournamentMatchCardView } from '../tournament-panel-view'
+import { TournamentGameChips } from './tournament-match-card/tournament-game-chips'
+
+export interface TournamentMatchCardProps {
+  match: TournamentMatchCardView
+}
+
+/**
+ * The tournament panel's headline card: the one match the player is playing,
+ * about to play, or just played.
+ *
+ * The score is **games won**, not points — the number that decides a match —
+ * with the per-game points beneath it as chips. A live card glows, and every
+ * state announces itself in words ("Live · Table 4 · Game 4", "Match complete
+ * …") as well as in colour.
+ */
+export const TournamentMatchCard = ({ match }: TournamentMatchCardProps) => {
+  const live = match.state === 'live'
+  return (
+    <div
+      className={cn(
+        'rounded-[var(--radius-md)] border bg-[color:var(--bg-card)] p-5',
+        live
+          ? 'border-[color:var(--serve-500)]/35 shadow-[0_0_0_1px_rgba(0,226,154,0.12),0_0_16px_rgba(0,226,154,0.12)]'
+          : 'border-[color:var(--border-subtle)]',
+      )}
+      data-testid="tournament-panel-match-card"
+    >
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <span
+          className={cn(
+            'inline-flex items-center gap-2 font-mono text-[12px] font-semibold tracking-wider',
+            live
+              ? 'text-[color:var(--serve-500)]'
+              : 'text-[color:var(--fg-3)]',
+          )}
+        >
+          {live ? (
+            <span
+              className="size-2.5 animate-pulse rounded-full bg-[color:var(--serve-500)] shadow-[0_0_8px_rgba(0,226,154,0.6)]"
+              aria-hidden="true"
+            />
+          ) : match.state === 'completed' ? (
+            <Check size={14} strokeWidth={2.25} aria-hidden="true" />
+          ) : (
+            <Clock size={14} strokeWidth={2} aria-hidden="true" />
+          )}
+          {match.statusText}
+        </span>
+        <span className="rounded-full border border-[color:var(--border-subtle)] px-2.5 py-0.5 font-mono text-[12px] font-semibold tracking-wide text-[color:var(--fg-3)]">
+          {match.bestOfText}
+        </span>
+      </div>
+
+      <Overline className="mb-1.5 text-[10px]">Games won · match score</Overline>
+      <ScoreRow
+        name={match.youName}
+        games={match.yourGames}
+        won={match.youWon}
+        dimmed={match.state === 'completed' && !match.youWon}
+      />
+      <div className="my-1.5 h-px bg-[color:var(--border-subtle)]" />
+      <ScoreRow
+        name={match.opponentName}
+        games={match.opponentGames}
+        won={match.opponentWon}
+        dimmed={match.state === 'completed' && !match.opponentWon}
+      />
+
+      {match.gamesLegend !== null && (
+        <TournamentGameChips legend={match.gamesLegend} games={match.games} />
+      )}
+
+      {match.scheduleText !== null && (
+        <p className="mt-4 font-mono text-[13px] font-semibold text-[color:var(--ball-500)]">
+          {match.scheduleText}
+        </p>
+      )}
+
+      {(match.action !== null || match.detailsRoute !== null) && (
+        <div className="mt-4 flex flex-wrap gap-2.5">
+          {match.action !== null && (
+            <Button asChild>
+              <Link {...match.action.route}>
+                {match.action.label}
+                <ArrowRight size={16} strokeWidth={2.25} />
+              </Link>
+            </Button>
+          )}
+          {match.detailsRoute !== null && (
+            <Button asChild variant="outline">
+              <Link {...match.detailsRoute}>Match details</Link>
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ScoreRow({
+  name,
+  games,
+  won,
+  dimmed,
+}: {
+  name: string
+  games: number
+  won: boolean
+  dimmed: boolean
+}) {
+  return (
+    <div className="flex items-center gap-3 py-1">
+      <span className="min-w-0 flex-1 truncate text-[19px] font-semibold text-[color:var(--chalk-50)]">
+        {name}
+      </span>
+      {won && (
+        <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[color:var(--bg-live-soft)] px-2.5 py-0.5 text-[11px] font-bold text-[color:var(--serve-500)]">
+          <Check size={12} strokeWidth={3} aria-hidden="true" />
+          Winner
+        </span>
+      )}
+      <span
+        className={cn(
+          'shrink-0 font-mono text-[40px] leading-none font-bold tabular-nums sm:text-[48px]',
+          won
+            ? 'text-[color:var(--serve-500)]'
+            : dimmed
+              ? 'text-[color:var(--fg-3)]'
+              : 'text-[color:var(--chalk-50)]',
+        )}
+      >
+        {games}
+      </span>
+    </div>
+  )
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-match-card.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-match-card.tsx
@@ -71,6 +71,11 @@ export const TournamentMatchCard = ({ match }: TournamentMatchCardProps) => {
         won={match.opponentWon}
         dimmed={match.state === 'completed' && !match.opponentWon}
       />
+      {match.state === 'voided' && (
+        <p className="mt-3 text-[13px] text-[color:var(--fg-3)]">
+          This match was voided — it counts for nothing and has no winner.
+        </p>
+      )}
 
       {match.gamesLegend !== null && (
         <TournamentGameChips legend={match.gamesLegend} games={match.games} />

--- a/web-client/src/components/dashboard/tournament-panel/tournament-match-card.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-match-card.tsx
@@ -24,7 +24,13 @@ export const TournamentMatchCard = ({ match }: TournamentMatchCardProps) => {
   return (
     <div
       className={cn(
-        'rounded-[var(--radius-md)] border bg-[color:var(--bg-card)] p-5',
+        // `min-w-0` is load-bearing: this card is a GRID ITEM, whose default
+        // `min-width: auto` lets it size to its widest content and blow out of
+        // its track. At 375px that pushed the card to 377px inside a 303px
+        // column — and because the panel's `Card` clips (`overflow-hidden`), the
+        // spill was silently CUT rather than scrolled, so a page-level overflow
+        // check reads 0 while the winner chip and status line are lost.
+        'min-w-0 rounded-[var(--radius-md)] border bg-[color:var(--bg-card)] p-5',
         live
           ? 'border-[color:var(--serve-500)]/35 shadow-[0_0_0_1px_rgba(0,226,154,0.12),0_0_16px_rgba(0,226,154,0.12)]'
           : 'border-[color:var(--border-subtle)]',

--- a/web-client/src/components/dashboard/tournament-panel/tournament-match-card/tournament-game-chips.factory.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-match-card/tournament-game-chips.factory.tsx
@@ -1,0 +1,37 @@
+import type { TournamentGameChipView } from '../../tournament-panel-view'
+import type { TournamentGameChipsProps } from './tournament-game-chips'
+
+/** `Game 1 · 11–7`, the viewer's points first. */
+export function buildTournamentGameChipView(
+  overrides: Partial<TournamentGameChipView> = {},
+): TournamentGameChipView {
+  return {
+    label: 'Game 1',
+    score: '11–7',
+    description: 'Game 1: mightymoose 11, slim-manatee 7',
+    ...overrides,
+  }
+}
+
+/** Three played games of a best-of-five, viewer 2–1 up. */
+export function buildTournamentGameChipsProps(
+  overrides: Partial<TournamentGameChipsProps> = {},
+): TournamentGameChipsProps {
+  return {
+    legend: 'mightymoose shown first · vs slim-manatee',
+    games: [
+      buildTournamentGameChipView(),
+      buildTournamentGameChipView({
+        label: 'Game 2',
+        score: '8–11',
+        description: 'Game 2: mightymoose 8, slim-manatee 11',
+      }),
+      buildTournamentGameChipView({
+        label: 'Game 3',
+        score: '11–9',
+        description: 'Game 3: mightymoose 11, slim-manatee 9',
+      }),
+    ],
+    ...overrides,
+  }
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-match-card/tournament-game-chips.page.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-match-card/tournament-game-chips.page.tsx
@@ -1,0 +1,36 @@
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import {
+  TournamentGameChips,
+  type TournamentGameChipsProps,
+} from './tournament-game-chips'
+import { buildTournamentGameChipsProps } from './tournament-game-chips.factory'
+
+const scoped = (container: Container) => ({
+  /** The chips block, or null when there are no played games. */
+  queryChips() {
+    return container.queryByTestId('tournament-panel-game-chips')
+  },
+  /** Every chip, in play order. */
+  getChips() {
+    return within(
+      container.getByTestId('tournament-panel-game-chips'),
+    ).getAllByRole('listitem')
+  },
+})
+
+/**
+ * Test page-object for `TournamentGameChips`. Pure view-in — no router, no
+ * network.
+ */
+export const tournamentGameChipsPage = {
+  render(overrides: Partial<TournamentGameChipsProps> = {}) {
+    render(<TournamentGameChips {...buildTournamentGameChipsProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-match-card/tournament-game-chips.test.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-match-card/tournament-game-chips.test.tsx
@@ -1,0 +1,47 @@
+import { buildTournamentGameChipView } from './tournament-game-chips.factory'
+import { tournamentGameChipsPage } from './tournament-game-chips.page'
+
+describe('TournamentGameChips', () => {
+  it('renders one chip per played game, in play order', () => {
+    tournamentGameChipsPage.render()
+
+    const chips = tournamentGameChipsPage.getChips()
+    expect(chips).toHaveLength(3)
+    expect(chips[0]).toHaveTextContent('Game 1')
+    expect(chips[0]).toHaveTextContent('11–7')
+    expect(chips[2]).toHaveTextContent('11–9')
+  })
+
+  it('gives each chip a spoken sentence naming both players', () => {
+    // Two bare numbers are ambiguous read aloud; the visible score is hidden
+    // from assistive tech and the sentence replaces it.
+    tournamentGameChipsPage.render({
+      games: [
+        buildTournamentGameChipView({
+          score: '11–7',
+          description: 'Game 1: mightymoose 11, slim-manatee 7',
+        }),
+      ],
+    })
+
+    const [chip] = tournamentGameChipsPage.getChips()
+    expect(chip).toHaveTextContent('Game 1: mightymoose 11, slim-manatee 7')
+    expect(chip.querySelector('[aria-hidden="true"]')).toHaveTextContent('11–7')
+  })
+
+  it('states whose points come first', () => {
+    tournamentGameChipsPage.render({
+      legend: 'bold-bison shown first · vs lunar-lynx',
+    })
+
+    expect(tournamentGameChipsPage.queryChips()).toHaveTextContent(
+      'bold-bison shown first · vs lunar-lynx',
+    )
+  })
+
+  it('renders nothing before the first game is played', () => {
+    tournamentGameChipsPage.render({ games: [] })
+
+    expect(tournamentGameChipsPage.queryChips()).toBeNull()
+  })
+})

--- a/web-client/src/components/dashboard/tournament-panel/tournament-match-card/tournament-game-chips.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-match-card/tournament-game-chips.tsx
@@ -1,0 +1,56 @@
+import { useId } from 'react'
+import { Overline } from '@/components/overline'
+import type { TournamentGameChipView } from '../../tournament-panel-view'
+
+export interface TournamentGameChipsProps {
+  /** `mightymoose shown first · vs slim-manatee` — without it, two bare numbers
+   * are ambiguous about whose is whose. */
+  legend: string
+  games: TournamentGameChipView[]
+}
+
+/**
+ * The per-game points behind a match card's games-won score, as chips.
+ *
+ * Each chip is two numbers, so each carries its own full sentence for assistive
+ * tech ("Game 3: mightymoose 11, slim-manatee 9") rather than relying on the
+ * legend above it to have been read first.
+ */
+export const TournamentGameChips = ({
+  legend,
+  games,
+}: TournamentGameChipsProps) => {
+  const headingId = useId()
+  if (games.length === 0) return null
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="mt-4"
+      data-testid="tournament-panel-game-chips"
+    >
+      <Overline as="h4" id={headingId} className="mb-1 text-[10px]">
+        Completed games
+      </Overline>
+      <p className="mb-2.5 text-[13px] text-[color:var(--fg-3)]">{legend}</p>
+      <ul className="flex flex-wrap gap-2">
+        {games.map((game) => (
+          <li
+            key={game.label}
+            className="inline-flex items-center rounded-[var(--radius-sm)] border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)] px-2.5 py-1.5"
+          >
+            <span className="mr-2 text-[12px] font-semibold text-[color:var(--chalk-500)]">
+              {game.label}
+            </span>
+            <span
+              className="font-mono text-[14px] font-bold tabular-nums text-[color:var(--chalk-50)]"
+              aria-hidden="true"
+            >
+              {game.score}
+            </span>
+            <span className="sr-only">{game.description}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-path-list.factory.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-path-list.factory.tsx
@@ -1,0 +1,36 @@
+import { buildTournamentPathRowView } from './tournament-path-list/tournament-path-row.factory'
+import type { TournamentPathListProps } from './tournament-path-list'
+
+/**
+ * A three-match group schedule mid-run: one won, one being played, one to come.
+ * Deliberately not all-one-state — a list where every row is identical cannot
+ * show that the rows are driven by their own view.
+ */
+export function buildTournamentPathListProps(
+  overrides: Partial<TournamentPathListProps> = {},
+): TournamentPathListProps {
+  return {
+    heading: 'Your matches',
+    subheading: 'Pool A · 4 players',
+    rows: [
+      buildTournamentPathRowView({ key: 'r1', label: 'M1' }),
+      buildTournamentPathRowView({
+        key: 'r2',
+        label: 'M2',
+        opponentName: 'slim-manatee',
+        state: 'live',
+        detail: 'In progress',
+        youWon: null,
+      }),
+      buildTournamentPathRowView({
+        key: 'r3',
+        label: 'M3',
+        opponentName: 'bold-bison',
+        state: 'upcoming',
+        detail: '5:20 PM CDT · Table 6',
+        youWon: null,
+      }),
+    ],
+    ...overrides,
+  }
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-path-list.page.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-path-list.page.tsx
@@ -1,0 +1,43 @@
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import {
+  TournamentPathList,
+  type TournamentPathListProps,
+} from './tournament-path-list'
+import { buildTournamentPathListProps } from './tournament-path-list.factory'
+import { tournamentPathRowPage } from './tournament-path-list/tournament-path-row.page'
+
+const scoped = (container: Container) => ({
+  /** The list section, or null when there is no schedule to show. */
+  queryList() {
+    return container.queryByTestId('tournament-panel-path')
+  },
+  /** The section heading (`Your matches`). */
+  getHeading(name: string | RegExp) {
+    return container.getByRole('heading', { name })
+  },
+  /** Every schedule row, in render order. */
+  getRows() {
+    const list = container.getByTestId('tournament-panel-path')
+    return within(list).getAllByRole('listitem')
+  },
+  // The row's own internals are pinned by its quartet; reuse its queries rather
+  // than re-deriving them here.
+  ...tournamentPathRowPage.within(container),
+})
+
+/**
+ * Test page-object for `TournamentPathList`. Pure view-in — no router, no
+ * network — so tests read synchronously after `render`.
+ */
+export const tournamentPathListPage = {
+  render(overrides: Partial<TournamentPathListProps> = {}) {
+    render(<TournamentPathList {...buildTournamentPathListProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-path-list.test.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-path-list.test.tsx
@@ -1,0 +1,53 @@
+import { buildTournamentPathRowView } from './tournament-path-list/tournament-path-row.factory'
+import { tournamentPathListPage } from './tournament-path-list.page'
+
+describe('TournamentPathList', () => {
+  it('renders one row per fixture, in the order given', () => {
+    tournamentPathListPage.render()
+
+    // Wiring only: each row's own content is pinned by the path-row tests.
+    const rows = tournamentPathListPage.getRows()
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toHaveTextContent('M1')
+    expect(rows[2]).toHaveTextContent('M3')
+  })
+
+  it('takes its heading from the view', () => {
+    tournamentPathListPage.render({ heading: 'Your path' })
+
+    expect(tournamentPathListPage.getHeading('Your path')).toBeInTheDocument()
+  })
+
+  it('names the pool and its size beneath the heading', () => {
+    tournamentPathListPage.render({ subheading: 'Pool B · 6 players' })
+
+    expect(tournamentPathListPage.queryList()).toHaveTextContent(
+      'Pool B · 6 players',
+    )
+  })
+
+  it('omits the subheading line for an un-pooled draw', () => {
+    tournamentPathListPage.render({ subheading: null })
+
+    expect(tournamentPathListPage.queryList()).not.toHaveTextContent('players')
+  })
+
+  it('renders nothing when the draw has not been cut', () => {
+    // A heading over an empty list would read as "you have no matches" rather
+    // than "the draw is not made yet".
+    tournamentPathListPage.render({ rows: [] })
+
+    expect(tournamentPathListPage.queryList()).toBeNull()
+  })
+
+  it('keys rows independently of the opponent, so a repeat opponent still renders twice', () => {
+    tournamentPathListPage.render({
+      rows: [
+        buildTournamentPathRowView({ key: 'a', label: 'M1' }),
+        buildTournamentPathRowView({ key: 'b', label: 'M2' }),
+      ],
+    })
+
+    expect(tournamentPathListPage.getRows()).toHaveLength(2)
+  })
+})

--- a/web-client/src/components/dashboard/tournament-panel/tournament-path-list.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-path-list.tsx
@@ -1,0 +1,45 @@
+import { useId } from 'react'
+import { Overline } from '@/components/overline'
+import type { TournamentPathRowView } from '../tournament-panel-view'
+import { TournamentPathRow } from './tournament-path-list/tournament-path-row'
+
+export interface TournamentPathListProps {
+  /** `Your matches` — what this event calls the viewer's own run through it. */
+  heading: string
+  /** `Pool A · 4 players`, or null for an un-pooled draw. */
+  subheading: string | null
+  rows: TournamentPathRowView[]
+}
+
+/**
+ * The viewer's own schedule within one tournament event, in draw order.
+ *
+ * Renders nothing at all when there are no rows: an event whose draw has not
+ * been cut has no schedule yet, and a heading over an empty list would read as
+ * "you have no matches" rather than "the draw is not made".
+ */
+export const TournamentPathList = ({
+  heading,
+  subheading,
+  rows,
+}: TournamentPathListProps) => {
+  const headingId = useId()
+  if (rows.length === 0) return null
+  return (
+    <section aria-labelledby={headingId} data-testid="tournament-panel-path">
+      <Overline as="h4" id={headingId} className="mb-1 text-[10px]">
+        {heading}
+      </Overline>
+      {subheading !== null && (
+        <p className="mb-3 font-mono text-[12px] text-[color:var(--fg-3)]">
+          {subheading}
+        </p>
+      )}
+      <ul className="flex flex-col gap-2">
+        {rows.map((row) => (
+          <TournamentPathRow key={row.key} row={row} />
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.factory.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.factory.tsx
@@ -1,0 +1,24 @@
+import type { TournamentPathRowView } from '../../tournament-panel-view'
+import type { TournamentPathRowProps } from './tournament-path-row'
+
+/** A won first group match — `M1 · celestial-caracara · Won 3–1`. */
+export function buildTournamentPathRowView(
+  overrides: Partial<TournamentPathRowView> = {},
+): TournamentPathRowView {
+  return {
+    key: 'e-1-0',
+    label: 'M1',
+    opponentName: 'celestial-caracara',
+    state: 'completed',
+    detail: 'Won 3–1',
+    youWon: true,
+    ...overrides,
+  }
+}
+
+/** Props for `TournamentPathRow`. */
+export function buildTournamentPathRowProps(
+  overrides: Partial<TournamentPathRowProps> = {},
+): TournamentPathRowProps {
+  return { row: buildTournamentPathRowView(), ...overrides }
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.page.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.page.tsx
@@ -1,0 +1,40 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import {
+  TournamentPathRow,
+  type TournamentPathRowProps,
+} from './tournament-path-row'
+import { buildTournamentPathRowProps } from './tournament-path-row.factory'
+
+const scoped = (container: Container) => ({
+  /** The row with this ordinal label (`M1`, `M2`, …). */
+  getRow(label: string) {
+    return container.getByTestId(`tournament-panel-path-row-${label}`)
+  },
+  /** The same row, or null — for asserting a row is absent. */
+  queryRow(label: string) {
+    return container.queryByTestId(`tournament-panel-path-row-${label}`)
+  },
+})
+
+/**
+ * Test page-object for `TournamentPathRow`. Rows are `<li>`s addressed by their
+ * ordinal label, since a schedule can repeat an opponent and nothing else about
+ * a row is unique. Pure view-in — no router, no network.
+ */
+export const tournamentPathRowPage = {
+  render(overrides: Partial<TournamentPathRowProps> = {}) {
+    const props = buildTournamentPathRowProps(overrides)
+    render(
+      <ul>
+        <TournamentPathRow {...props} />
+      </ul>,
+    )
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.test.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.test.tsx
@@ -1,0 +1,72 @@
+import { buildTournamentPathRowView } from './tournament-path-row.factory'
+import { tournamentPathRowPage } from './tournament-path-row.page'
+
+describe('TournamentPathRow', () => {
+  it('names the opponent and the result', () => {
+    tournamentPathRowPage.render({
+      row: buildTournamentPathRowView({
+        label: 'M2',
+        opponentName: 'slim-manatee',
+        detail: 'Won 3–1',
+      }),
+    })
+
+    const row = tournamentPathRowPage.getRow('M2')
+    expect(row).toHaveTextContent('M2')
+    expect(row).toHaveTextContent('slim-manatee')
+    expect(row).toHaveTextContent('Won 3–1')
+  })
+
+  it('tones a loss away from the win colour', () => {
+    tournamentPathRowPage.render({
+      row: buildTournamentPathRowView({ youWon: false, detail: 'Lost 1–3' }),
+    })
+
+    expect(tournamentPathRowPage.getRow('M1')).toHaveTextContent('Lost 1–3')
+    expect(
+      tournamentPathRowPage.getRow('M1').querySelector('.text-\\[color\\:var\\(--loss\\)\\]'),
+    ).not.toBeNull()
+  })
+
+  it('outlines a live row so it reads as the one being played', () => {
+    tournamentPathRowPage.render({
+      row: buildTournamentPathRowView({
+        state: 'live',
+        detail: 'In progress',
+        youWon: null,
+      }),
+    })
+
+    const row = tournamentPathRowPage.getRow('M1')
+    expect(row).toHaveTextContent('In progress')
+    expect(row.className).toContain('border-[color:var(--serve-500)]/40')
+  })
+
+  it('shows an upcoming match as its time and table', () => {
+    tournamentPathRowPage.render({
+      row: buildTournamentPathRowView({
+        label: 'M3',
+        state: 'upcoming',
+        detail: '5:20 PM CDT · Table 6',
+        youWon: null,
+      }),
+    })
+
+    expect(tournamentPathRowPage.getRow('M3')).toHaveTextContent(
+      '5:20 PM CDT · Table 6',
+    )
+  })
+
+  it('shows TBD rather than a blank where the opponent is undecided', () => {
+    tournamentPathRowPage.render({
+      row: buildTournamentPathRowView({
+        opponentName: 'TBD',
+        state: 'upcoming',
+        detail: 'Not scheduled',
+        youWon: null,
+      }),
+    })
+
+    expect(tournamentPathRowPage.getRow('M1')).toHaveTextContent('TBD')
+  })
+})

--- a/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.test.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.test.tsx
@@ -57,6 +57,27 @@ describe('TournamentPathRow', () => {
     )
   })
 
+  it('states a voided match as voided, with no win or loss tone', () => {
+    // A voided match was never played to a result, so the row must not wear the
+    // check that means "decided" nor the loss tone that means "you lost".
+    tournamentPathRowPage.render({
+      row: buildTournamentPathRowView({
+        state: 'voided',
+        detail: 'Voided',
+        youWon: null,
+      }),
+    })
+
+    const row = tournamentPathRowPage.getRow('M1')
+    expect(row).toHaveTextContent('Voided')
+    expect(
+      row.querySelector('.text-\\[color\\:var\\(--loss\\)\\]'),
+    ).toBeNull()
+    expect(
+      row.querySelector('.text-\\[color\\:var\\(--serve-500\\)\\]'),
+    ).toBeNull()
+  })
+
   it('shows TBD rather than a blank where the opponent is undecided', () => {
     tournamentPathRowPage.render({
       row: buildTournamentPathRowView({

--- a/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.tsx
@@ -1,4 +1,4 @@
-import { Check } from 'lucide-react'
+import { Ban, Check } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { TournamentPathRowView } from '../../tournament-panel-view'
 
@@ -25,7 +25,11 @@ export const TournamentPathRow = ({ row }: TournamentPathRowProps) => (
     data-testid={`tournament-panel-path-row-${row.label}`}
   >
     <span className="flex w-4 shrink-0 justify-center" aria-hidden="true">
-      {row.state === 'completed' ? (
+      {row.state === 'voided' ? (
+        // Struck through, not checked: a voided match was not played to a
+        // result, so it must not wear the glyph that means "decided".
+        <Ban size={13} strokeWidth={2.5} className="text-[color:var(--fg-3)]" />
+      ) : row.state === 'completed' ? (
         <Check
           size={14}
           strokeWidth={3}
@@ -55,7 +59,7 @@ export const TournamentPathRow = ({ row }: TournamentPathRowProps) => (
     <span
       className={cn(
         'shrink-0 font-mono text-[12px]',
-        row.state === 'upcoming'
+        row.state === 'upcoming' || row.state === 'voided'
           ? 'text-[color:var(--fg-3)]'
           : 'font-bold text-[color:var(--serve-500)]',
         // A loss keeps the row readable without shouting: the detail text

--- a/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-path-list/tournament-path-row.tsx
@@ -1,0 +1,69 @@
+import { Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { TournamentPathRowView } from '../../tournament-panel-view'
+
+export interface TournamentPathRowProps {
+  row: TournamentPathRowView
+}
+
+/**
+ * One line of a tournament event's schedule: its ordinal, the opponent, and the
+ * result-or-time on the right.
+ *
+ * Every state carries a glyph or a word as well as its colour — a check for a
+ * played match, a filled dot for a live one, a hollow one for a match still to
+ * come — so the row is never distinguished by colour alone.
+ */
+export const TournamentPathRow = ({ row }: TournamentPathRowProps) => (
+  <li
+    className={cn(
+      'flex items-center gap-3 rounded-[var(--radius-sm)] border bg-[color:var(--bg-panel)] px-3 py-2.5',
+      row.state === 'live'
+        ? 'border-[color:var(--serve-500)]/40'
+        : 'border-[color:var(--border-subtle)]',
+    )}
+    data-testid={`tournament-panel-path-row-${row.label}`}
+  >
+    <span className="flex w-4 shrink-0 justify-center" aria-hidden="true">
+      {row.state === 'completed' ? (
+        <Check
+          size={14}
+          strokeWidth={3}
+          className={
+            row.youWon
+              ? 'text-[color:var(--serve-500)]'
+              : 'text-[color:var(--fg-3)]'
+          }
+        />
+      ) : (
+        <span
+          className={cn(
+            'size-2.5 rounded-full',
+            row.state === 'live'
+              ? 'bg-[color:var(--serve-500)] shadow-[0_0_8px_rgba(0,226,154,0.6)]'
+              : 'border-[1.5px] border-[color:var(--ink-500)]',
+          )}
+        />
+      )}
+    </span>
+    <span className="w-6 shrink-0 font-mono text-[12px] text-[color:var(--chalk-500)]">
+      {row.label}
+    </span>
+    <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-[color:var(--chalk-50)]">
+      {row.opponentName}
+    </span>
+    <span
+      className={cn(
+        'shrink-0 font-mono text-[12px]',
+        row.state === 'upcoming'
+          ? 'text-[color:var(--fg-3)]'
+          : 'font-bold text-[color:var(--serve-500)]',
+        // A loss keeps the row readable without shouting: the detail text
+        // already says "Lost 0–2", so the tone only needs to stop claiming a win.
+        row.youWon === false && 'text-[color:var(--loss)]',
+      )}
+    >
+      {row.detail}
+    </span>
+  </li>
+)

--- a/web-client/src/components/dashboard/tournament-panel/tournament-stats-strip.factory.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-stats-strip.factory.tsx
@@ -1,0 +1,24 @@
+import type { TournamentStatsView } from '../tournament-panel-view'
+import type { TournamentStatsStripProps } from './tournament-stats-strip'
+
+/** A player leading a four-strong group, one win to nothing, mid-group-play. */
+export function buildTournamentStatsView(
+  overrides: Partial<TournamentStatsView> = {},
+): TournamentStatsView {
+  return {
+    wins: 1,
+    losses: 0,
+    positionLabel: 'Group position',
+    positionValue: '1st',
+    positionSuffix: 'of 4',
+    stageValue: 'Group play',
+    ...overrides,
+  }
+}
+
+/** Props for `TournamentStatsStrip`. */
+export function buildTournamentStatsStripProps(
+  overrides: Partial<TournamentStatsStripProps> = {},
+): TournamentStatsStripProps {
+  return { stats: buildTournamentStatsView(), ...overrides }
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-stats-strip.page.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-stats-strip.page.tsx
@@ -1,0 +1,49 @@
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import {
+  TournamentStatsStrip,
+  type TournamentStatsStripProps,
+} from './tournament-stats-strip'
+import { buildTournamentStatsStripProps } from './tournament-stats-strip.factory'
+
+const scoped = (container: Container) => ({
+  /** The strip itself. */
+  getStrip() {
+    return container.getByTestId('tournament-panel-stats')
+  },
+  /** The strip, or null when the parent chose not to render one. */
+  queryStrip() {
+    return container.queryByTestId('tournament-panel-stats')
+  },
+  /**
+   * The value rendered under a tile's label — the `<dd>` that follows the
+   * `<dt>` with this text. Queried structurally rather than by testid so the
+   * pairing the markup claims (a definition list) is the pairing under test.
+   */
+  getTileValue(label: string) {
+    const term = within(container.getByTestId('tournament-panel-stats')).getByText(
+      label,
+    )
+    const value = term.nextElementSibling
+    if (!(value instanceof HTMLElement)) {
+      throw new Error(`No value follows the "${label}" tile label.`)
+    }
+    return value
+  },
+})
+
+/**
+ * Test page-object for `TournamentStatsStrip`. No router or network — the strip
+ * is pure view-in, DOM-out, so tests read synchronously after `render`.
+ */
+export const tournamentStatsStripPage = {
+  render(overrides: Partial<TournamentStatsStripProps> = {}) {
+    render(<TournamentStatsStrip {...buildTournamentStatsStripProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/dashboard/tournament-panel/tournament-stats-strip.test.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-stats-strip.test.tsx
@@ -1,0 +1,63 @@
+import { buildTournamentStatsView } from './tournament-stats-strip.factory'
+import { tournamentStatsStripPage } from './tournament-stats-strip.page'
+
+describe('TournamentStatsStrip', () => {
+  it('prints the record as wins–losses', () => {
+    tournamentStatsStripPage.render({
+      stats: buildTournamentStatsView({ wins: 2, losses: 1 }),
+    })
+
+    expect(
+      tournamentStatsStripPage.getTileValue('Match record'),
+    ).toHaveTextContent('2–1')
+  })
+
+  it('names the standing and the field it is out of', () => {
+    tournamentStatsStripPage.render({
+      stats: buildTournamentStatsView({
+        positionValue: '3rd',
+        positionSuffix: 'of 6',
+      }),
+    })
+
+    expect(
+      tournamentStatsStripPage.getTileValue('Group position'),
+    ).toHaveTextContent('3rd of 6')
+  })
+
+  it('renders an em-dash when the event has no standings yet', () => {
+    // An uncut draw has nothing to stand in. The tile keeps its place so the
+    // strip does not reflow the moment the draw is cut.
+    tournamentStatsStripPage.render({
+      stats: buildTournamentStatsView({
+        positionValue: null,
+        positionSuffix: null,
+      }),
+    })
+
+    const value = tournamentStatsStripPage.getTileValue('Group position')
+    expect(value).toHaveTextContent('—')
+    expect(value).not.toHaveTextContent('of')
+  })
+
+  it('takes the position tile label from the view, not the markup', () => {
+    // Round-robin says "Group position"; a bracket draw would say "Position".
+    tournamentStatsStripPage.render({
+      stats: buildTournamentStatsView({ positionLabel: 'Position' }),
+    })
+
+    expect(tournamentStatsStripPage.getTileValue('Position')).toHaveTextContent(
+      '1st',
+    )
+  })
+
+  it('shows the stage the event has reached', () => {
+    tournamentStatsStripPage.render({
+      stats: buildTournamentStatsView({ stageValue: 'Group complete' }),
+    })
+
+    expect(tournamentStatsStripPage.getTileValue('Stage')).toHaveTextContent(
+      'Group complete',
+    )
+  })
+})

--- a/web-client/src/components/dashboard/tournament-panel/tournament-stats-strip.tsx
+++ b/web-client/src/components/dashboard/tournament-panel/tournament-stats-strip.tsx
@@ -1,0 +1,62 @@
+import { Overline } from '@/components/overline'
+import type { TournamentStatsView } from '../tournament-panel-view'
+
+export interface TournamentStatsStripProps {
+  stats: TournamentStatsView
+}
+
+/**
+ * The three-tile strip beside a tournament event's match card: the viewer's
+ * win–loss record, where they stand in their pool, and what stage the event is
+ * at.
+ *
+ * The middle tile is the one that can be absent — an event whose draw has not
+ * been cut has no standings to stand in — and it renders an em-dash rather than
+ * disappearing, so the strip keeps its three-column rhythm between loads.
+ */
+export const TournamentStatsStrip = ({ stats }: TournamentStatsStripProps) => (
+  <dl
+    className="flex items-stretch gap-3 rounded-[var(--radius-md)] border border-[color:var(--border-subtle)] bg-[color:var(--bg-card)] px-4 py-3.5"
+    data-testid="tournament-panel-stats"
+  >
+    <div className="min-w-0">
+      <Overline as="dt" className="text-[10px]">
+        Match record
+      </Overline>
+      <dd className="font-mono text-[22px] leading-none font-bold tabular-nums">
+        {stats.wins}
+        <span className="text-[color:var(--fg-3)]">–</span>
+        {stats.losses}
+      </dd>
+    </div>
+    <div className="w-px shrink-0 self-stretch bg-[color:var(--border-subtle)]" />
+    <div className="min-w-0 flex-1">
+      <Overline as="dt" className="text-[10px]">
+        {stats.positionLabel}
+      </Overline>
+      <dd className="leading-none">
+        {stats.positionValue === null ? (
+          <span className="text-[color:var(--fg-3)] text-[18px]">—</span>
+        ) : (
+          <>
+            <span className="font-mono text-[18px] font-bold">
+              {stats.positionValue}
+            </span>{' '}
+            <span className="text-[13px] text-[color:var(--fg-3)]">
+              {stats.positionSuffix}
+            </span>
+          </>
+        )}
+      </dd>
+    </div>
+    <div className="w-px shrink-0 self-stretch bg-[color:var(--border-subtle)]" />
+    <div className="min-w-0 flex-1">
+      <Overline as="dt" className="text-[10px]">
+        Stage
+      </Overline>
+      <dd className="text-[14px] leading-tight font-semibold">
+        {stats.stageValue}
+      </dd>
+    </div>
+  </dl>
+)

--- a/web-client/src/mocks/factories/dashboard/tournament.factory.ts
+++ b/web-client/src/mocks/factories/dashboard/tournament.factory.ts
@@ -1,0 +1,119 @@
+import type { components } from '@/api/schema'
+
+type DashboardTournament = components['schemas']['DashboardTournament']
+type DashboardTournamentEvent =
+  components['schemas']['DashboardTournamentEvent']
+type DashboardTournamentMatch =
+  components['schemas']['DashboardTournamentMatch']
+type DashboardTournamentFixtureRow =
+  components['schemas']['DashboardTournamentFixtureRow']
+type DashboardTournamentGame = components['schemas']['DashboardTournamentGame']
+
+/** One completed game, always the viewer's points first. */
+export function buildDashboardTournamentGame(
+  overrides: Partial<DashboardTournamentGame> = {},
+): DashboardTournamentGame {
+  return { number: 1, your_points: 11, opponent_points: 7, ...overrides }
+}
+
+/**
+ * The viewer's live match: a called best-of-five on Table 4, three games in and
+ * 2–1 up, with game 4 next. The design's headline case.
+ */
+export function buildDashboardTournamentMatch(
+  overrides: Partial<DashboardTournamentMatch> = {},
+): DashboardTournamentMatch {
+  return {
+    state: 'live',
+    match_id: 'm-1',
+    opponent_username: 'slim-manatee',
+    your_games: 2,
+    opponent_games: 1,
+    best_of: 5,
+    games: [
+      buildDashboardTournamentGame({ number: 1, your_points: 11, opponent_points: 7 }),
+      buildDashboardTournamentGame({ number: 2, your_points: 8, opponent_points: 11 }),
+      buildDashboardTournamentGame({ number: 3, your_points: 11, opponent_points: 9 }),
+    ],
+    round_label: 'Group match 2',
+    table_label: 'Table 4',
+    start_label: '4:30 PM CDT',
+    next_game_number: 4,
+    // `null` while a match is unfinished — never `false`, which would claim a
+    // loss on a match still being played.
+    you_won: null,
+    ...overrides,
+  }
+}
+
+/** One line of the viewer's own schedule — a won first group match. */
+export function buildDashboardTournamentFixtureRow(
+  overrides: Partial<DashboardTournamentFixtureRow> = {},
+): DashboardTournamentFixtureRow {
+  return {
+    label: 'M1',
+    opponent_username: 'celestial-caracara',
+    state: 'completed',
+    detail: 'Won 3–1',
+    you_won: true,
+    match_id: 'm-0',
+    ...overrides,
+  }
+}
+
+/**
+ * One event tab: a four-strong round-robin group the viewer leads, one match
+ * won, one live, one to come — deliberately mixed, so a projection that ignored
+ * a row's own state could not pass.
+ */
+export function buildDashboardTournamentEvent(
+  overrides: Partial<DashboardTournamentEvent> = {},
+): DashboardTournamentEvent {
+  return {
+    id: 'e-1',
+    name: 'U1500 · Group B',
+    draw_type: 'round-robin',
+    is_live: true,
+    wins: 1,
+    losses: 0,
+    position: 1,
+    field_size: 4,
+    stage_label: 'Group play',
+    pool_label: 'Pool B',
+    match: buildDashboardTournamentMatch(),
+    fixtures: [
+      buildDashboardTournamentFixtureRow(),
+      buildDashboardTournamentFixtureRow({
+        label: 'M2',
+        opponent_username: 'slim-manatee',
+        state: 'live',
+        detail: 'In progress',
+        you_won: null,
+        match_id: 'm-1',
+      }),
+      buildDashboardTournamentFixtureRow({
+        label: 'M3',
+        opponent_username: 'bold-bison',
+        state: 'upcoming',
+        detail: '5:20 PM CDT · Table 6',
+        you_won: null,
+        match_id: 'm-2',
+      }),
+    ],
+    ...overrides,
+  }
+}
+
+/** A live tournament with one event the viewer is playing in. */
+export function buildDashboardTournament(
+  overrides: Partial<DashboardTournament> = {},
+): DashboardTournament {
+  return {
+    id: 't-1',
+    name: 'Riverside Summer Slam',
+    subtitle: 'Riverside TTC · Jul 24–25',
+    live_count: 1,
+    events: [buildDashboardTournamentEvent()],
+    ...overrides,
+  }
+}

--- a/web-client/src/mocks/factories/dashboard/tournament.factory.ts
+++ b/web-client/src/mocks/factories/dashboard/tournament.factory.ts
@@ -42,6 +42,8 @@ export function buildDashboardTournamentMatch(
     // `null` while a match is unfinished — never `false`, which would claim a
     // loss on a match still being played.
     you_won: null,
+    // Mid-board with a next game to play: the caller owes a score.
+    owed_action: 'score',
     ...overrides,
   }
 }

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -38,6 +38,7 @@ import {
   buildAdminSolveLedgerSeed,
   pageAdminScheduleSolves,
 } from './factories/tournaments/tournament.factory'
+import { buildDashboardTournament } from './factories/dashboard/tournament.factory'
 import { mockUuid } from './mock-uuid'
 import { notificationHandlers } from './notifications-store'
 import { createRbacState, dispatchRbac, type RbacState } from './rbac-engine'
@@ -1606,6 +1607,13 @@ export const handlers = [
       recent_results: recentResults,
       rating: projectRating(mockMatches),
       completed_match_count: completedMatchCount,
+      // A seeded live tournament, so the dashboard's tournament panel is
+      // visible in `npm run dev`. It is a fixed payload rather than a
+      // projection off `tournaments-store`, because that store seeds no LIVE
+      // tournament with a cut draw and materialized matches — the only state
+      // this panel has anything to say about — and inventing one there would
+      // put a phantom live event on the tournaments list too.
+      tournaments: [buildDashboardTournament()],
     })
   }),
 

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -328,6 +328,10 @@ export function dashboardResponse(
     // Default mirrors the visible list. Override directly to model the
     // "history exceeds the recent window" case the guest banner cares about.
     completed_match_count: recent_results.length,
+    // Nobody is mid-tournament by default — the real shape of almost every
+    // dashboard load, and the one that renders no panel. Override with
+    // `buildDashboardTournament()` to model a player who is.
+    tournaments: [],
     ...overrides,
   }
 }


### PR DESCRIPTION
Implements **Tournament Panel - mobile & states** from the claude.ai/design project [*Dashboard with live tournament block*](https://claude.ai/design/p/13a0b34e-2f8c-46dd-9268-dd142fb3f1e2?file=Tournament+Panel+-+mobile+%26+states.dc.html), mounted at the very top of the dashboard.

While a player is in a live tournament, that is the only thing on their dashboard they care about — so the panel sits above everything else, including the first-match hero (a player standing at a table has already moved past it, even if none of their matches has completed yet).

## API — `GET /v1/dashboard` gains `tournaments`

`app/dashboard_tournaments.py` projects every **live** tournament the caller holds an **active entry** in: a tab per event they entered, the one match to look at (live → next up → last finished), their record and pool position, and their remaining schedule.

Three rules shape it:

- **Everything is stated from the caller's side.** A fixture seats `entry_a` on side 1 and `entry_b` on side 2 (#788), so a raw side-shaped score reads *backwards* for whichever player is entry B. The flip happens once, on the server.
- **Standings come from `event_results`** — the same projection the tournament page uses (ADR-0788), renamed from `_event_results` and exported — rather than a second count of the same matches. A panel saying "2nd of 4" next to an event page saying "3rd of 4" is the failure this avoids.
- **A `None` is a fact.** `position: null` = no standings to stand in; `match_id: null` on a scheduled row = the fixture hasn't materialized; `opponent_username: null` = TBD.

Fixed statement count regardless of event/fixture count — the batched loaders the detail page already owns, plus one load of the focus matches.

## Web client

`tournament-panel-view.ts` decides every label, ordinal and route; the components branch only on fields it resolved. `TournamentPanel` (header + event tabs) composes `TournamentMatchCard` (+ `TournamentGameChips`), `TournamentStatsStrip`, and `TournamentPathList` (+ `TournamentPathRow`) — each its own quartet. Tabs are the design-system `Tabs`, so the roving-tabindex `tablist`/`tab`/`tabpanel` wiring and arrow-key activation come with it rather than being re-implemented.

## Two deliberate deviations from the design

1. **No inline score entry.** The design mocks up in-card game entry with validation and undo. The card instead links to the existing scoring page (`Enter Game N result` → `/matches/$matchId/games/$n/scores/new`), exactly as the attention panel does. Re-implementing entry here would fork the 409 score-conflict two-hop flow into a second place.
2. **No bracket path, group→knockout gate, or qualification card.** Only the round-robin draw type has a strategy today (single/double-elim, rr-then-ko and swiss are enum stubs), so there is no advancement to derive those from. The panel's shape leaves room for them.

## Verification

- **api**: 1752 pass, including 13 new in `tests/test_dashboard_tournaments.py` driven through the real routes (create → enter → cut → go live → call → play). The side-flip claim was **falsified**: removing the flip reds exactly the two tests that assert it.
- **web-client**: 2976 vitest pass, `tsc -b` clean, eslint clean.
- **web-client e2e** (MSW-off, real browser): 297 pass, 5 new — including that the panel is the first block on the page and that 375px has zero horizontal overflow.
- `schema.d.ts` and `ios/Fortymm/Generated/Types.swift` regenerated from the same spec.
- Rendered and screenshotted at 1440px and 390px against the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEjFpyATL3JUgiiKfBPmVZ