### PR TITLE
Fix MCP OAuth discovery: no-slash redirects were scheme-downgraded to http

### DIFF
--- a/deploy/uat/templates/_helpers.tpl
+++ b/deploy/uat/templates/_helpers.tpl
@@ -73,6 +73,13 @@ server {
     listen 80;
     server_name _;
 
+    # This nginx listens on :80 behind TLS-terminating host Caddy. With the
+    # default `absolute_redirect on` it can't see the external https scheme, so
+    # any nginx-generated redirect (e.g. the slash-append 301 on a no-slash
+    # location) emits a scheme-DOWNGRADED http:// Location that OAuth/MCP clients
+    # refuse to follow. Relative redirects can't downgrade the scheme.
+    absolute_redirect off;
+
     client_max_body_size 25m;
 
     # /api/* — strip /api and forward to the FastAPI service.
@@ -80,6 +87,21 @@ server {
         rewrite ^/api/(.*)$ /$1 break;
         proxy_pass http://api_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Tolerate clients that strip the trailing slash (e.g. Claude): serve the
+    # bare /api/mcp straight from the /mcp/ mount instead of emitting a
+    # slash-append 301 that a POST client won't follow.
+    location = /api/mcp {
+        rewrite ^ /mcp/ break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -126,14 +148,45 @@ server {
     # can't reach it. Internally FastMCP serves the metadata UNDER its mount
     # (/mcp/.well-known/oauth-protected-resource/…), so prepend /mcp to the
     # origin-root path. Unauthenticated by design — discovery precedes any token.
-    location /.well-known/oauth-protected-resource {
-        rewrite ^(.*)$ /mcp$1 break;
+    #
+    # The connector requests the NO-slash form (MCP_PUBLIC_RESOURCE_URL has no
+    # trailing slash); mapping it straight to the WITH-slash internal path serves
+    # 200 directly, so Starlette's redirect_slashes never emits the 307 that was
+    # coming back as a scheme-downgraded http:// Location the client won't follow.
+    location = /.well-known/oauth-protected-resource/api/mcp {
+        rewrite ^ /mcp/.well-known/oauth-protected-resource/api/mcp/ break;
         proxy_pass http://api_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /.well-known/oauth-protected-resource {
+        rewrite ^(.*)$ /mcp$1 break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        # Belt-and-suspenders: rewrite any upstream redirect that leaks the
+        # internal /mcp mount prefix (and, via Caddy, an http:// downgrade) back
+        # into a followable public https URL.
+        proxy_redirect ~^https?://([^/]+)/mcp(/.*)$ https://$1$2;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # The MCP server is a Resource Server, NOT an Authorization Server — it does
+    # not host AS metadata (Auth0 does). Without these, the paths fall through to
+    # `location /` and the SPA answers 200 + index.html, which a strict client
+    # mis-reads as metadata. 404 forces the client to use the `authorization_servers`
+    # (Auth0) named in the protected-resource metadata above.
+    location /.well-known/oauth-authorization-server {
+        return 404;
+    }
+    location /.well-known/openid-configuration {
+        return 404;
     }
 
     # Browser telemetry (Grafana Faro) -> Alloy faro.receiver in the

--- a/nginx/dev.conf
+++ b/nginx/dev.conf
@@ -10,12 +10,34 @@ server {
     listen 80;
     server_name _;
 
+    # This nginx listens on :80 behind TLS-terminating host Caddy. With the
+    # default `absolute_redirect on` it can't see the external https scheme, so
+    # any nginx-generated redirect (e.g. the slash-append 301 on a no-slash
+    # location) emits a scheme-DOWNGRADED http:// Location that OAuth/MCP clients
+    # refuse to follow. Relative redirects can't downgrade the scheme.
+    absolute_redirect off;
+
     client_max_body_size 25m;
 
     location /api/ {
         rewrite ^/api/(.*)$ /$1 break;
         proxy_pass http://api_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Tolerate clients that strip the trailing slash (e.g. Claude): serve the
+    # bare /api/mcp straight from the /mcp/ mount instead of emitting a
+    # slash-append 301 that a POST client won't follow.
+    location = /api/mcp {
+        rewrite ^ /mcp/ break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -58,14 +80,45 @@ server {
     # FastMCP serves the metadata UNDER its mount
     # (/mcp/.well-known/oauth-protected-resource/…), so prepend /mcp to the
     # origin-root path. Unauthenticated by design — discovery precedes any token.
-    location /.well-known/oauth-protected-resource {
-        rewrite ^(.*)$ /mcp$1 break;
+    #
+    # The connector requests the NO-slash form (MCP_PUBLIC_RESOURCE_URL has no
+    # trailing slash); mapping it straight to the WITH-slash internal path serves
+    # 200 directly, so Starlette's redirect_slashes never emits the 307 that was
+    # coming back as a scheme-downgraded http:// Location the client won't follow.
+    location = /.well-known/oauth-protected-resource/api/mcp {
+        rewrite ^ /mcp/.well-known/oauth-protected-resource/api/mcp/ break;
         proxy_pass http://api_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /.well-known/oauth-protected-resource {
+        rewrite ^(.*)$ /mcp$1 break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        # Belt-and-suspenders: rewrite any upstream redirect that leaks the
+        # internal /mcp mount prefix (and, via Caddy, an http:// downgrade) back
+        # into a followable public https URL.
+        proxy_redirect ~^https?://([^/]+)/mcp(/.*)$ https://$1$2;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # The MCP server is a Resource Server, NOT an Authorization Server — it does
+    # not host AS metadata (Auth0 does). Without these, the paths fall through to
+    # `location /` and the SPA answers 200 + index.html, which a strict client
+    # mis-reads as metadata. 404 forces the client to use the `authorization_servers`
+    # (Auth0) named in the protected-resource metadata above.
+    location /.well-known/oauth-authorization-server {
+        return 404;
+    }
+    location /.well-known/openid-configuration {
+        return 404;
     }
 
     location / {

--- a/nginx/uat.conf
+++ b/nginx/uat.conf
@@ -10,6 +10,13 @@ server {
     listen 80;
     server_name _;
 
+    # This nginx listens on :80 behind TLS-terminating host Caddy. With the
+    # default `absolute_redirect on` it can't see the external https scheme, so
+    # any nginx-generated redirect (e.g. the slash-append 301 on a no-slash
+    # location) emits a scheme-DOWNGRADED http:// Location that OAuth/MCP clients
+    # refuse to follow. Relative redirects can't downgrade the scheme.
+    absolute_redirect off;
+
     client_max_body_size 25m;
 
     # /api/* — strip /api and forward to the FastAPI service.
@@ -19,6 +26,21 @@ server {
         rewrite ^/api/(.*)$ /$1 break;
         proxy_pass http://api_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Tolerate clients that strip the trailing slash (e.g. Claude): serve the
+    # bare /api/mcp straight from the /mcp/ mount instead of emitting a
+    # slash-append 301 that a POST client won't follow.
+    location = /api/mcp {
+        rewrite ^ /mcp/ break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -64,14 +86,45 @@ server {
     # can't reach it. Internally FastMCP serves the metadata UNDER its mount
     # (/mcp/.well-known/oauth-protected-resource/…), so prepend /mcp to the
     # origin-root path. Unauthenticated by design — discovery precedes any token.
-    location /.well-known/oauth-protected-resource {
-        rewrite ^(.*)$ /mcp$1 break;
+    #
+    # The connector requests the NO-slash form (MCP_PUBLIC_RESOURCE_URL has no
+    # trailing slash); mapping it straight to the WITH-slash internal path serves
+    # 200 directly, so Starlette's redirect_slashes never emits the 307 that was
+    # coming back as a scheme-downgraded http:// Location the client won't follow.
+    location = /.well-known/oauth-protected-resource/api/mcp {
+        rewrite ^ /mcp/.well-known/oauth-protected-resource/api/mcp/ break;
         proxy_pass http://api_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /.well-known/oauth-protected-resource {
+        rewrite ^(.*)$ /mcp$1 break;
+        proxy_pass http://api_upstream;
+        proxy_http_version 1.1;
+        # Belt-and-suspenders: rewrite any upstream redirect that leaks the
+        # internal /mcp mount prefix (and, via Caddy, an http:// downgrade) back
+        # into a followable public https URL.
+        proxy_redirect ~^https?://([^/]+)/mcp(/.*)$ https://$1$2;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # The MCP server is a Resource Server, NOT an Authorization Server — it does
+    # not host AS metadata (Auth0 does). Without these, the paths fall through to
+    # `location /` and the SPA answers 200 + index.html, which a strict client
+    # mis-reads as metadata. 404 forces the client to use the `authorization_servers`
+    # (Auth0) named in the protected-resource metadata above.
+    location /.well-known/oauth-authorization-server {
+        return 404;
+    }
+    location /.well-known/openid-configuration {
+        return 404;
     }
 
     # Direct API paths — FastAPI mounts routes at /v1/*; /openapi.json,


### PR DESCRIPTION
## Problem

The claude.ai MCP connector could not complete the Auth0 OAuth handshake against UAT. The browser landed on `https://uat.fortymm.com/authorize?...` which **404s** — FortyMM is an OAuth *Resource* Server, not the *Authorization* Server (Auth0 is). Symptom looked exactly like an expired token / broken auth, but nothing was wrong with Auth0, the token, or RBAC.

## Root cause

The routing nginx does `listen 80` behind TLS-terminating host Caddy:

- With the default `absolute_redirect on`, nginx can't see the external `https` scheme, so any redirect it emits (a slash-append 301, or an upstream Starlette `redirect_slashes` 307 proxied back through it) carries a **scheme-downgraded `http://` Location** that OAuth/MCP clients refuse to follow.
- The connector fetches RFC 9728 protected-resource metadata at the **no-trailing-slash** path (`/.well-known/oauth-protected-resource/api/mcp` — `MCP_PUBLIC_RESOURCE_URL` has no slash). That hit the prefix rewrite → Starlette 307 → `http://` downgrade → dead end, so the client never learned Auth0 is the authorization server.
- It then fell back to `/.well-known/oauth-authorization-server`, which the SPA catch-all answered with **200 + `index.html`** (not metadata), so discovery failed entirely and the client guessed `{origin}/authorize` → 404.

## Fix

Applied to all three committed nginx copies — the k8s ConfigMap rendered from `deploy/uat/templates/_helpers.tpl`, plus `nginx/uat.conf` and `nginx/dev.conf` (kept in sync per `deploy/CLAUDE.md`):

1. `absolute_redirect off;` — no nginx redirect can downgrade the scheme.
2. Exact-match `location = /api/mcp` and `location = /.well-known/oauth-protected-resource/api/mcp` serving the no-slash forms straight from the with-slash internal path, so Starlette never 307s.
3. `proxy_redirect` on the protected-resource block to rewrite any leaked internal `/mcp` prefix / `http://` downgrade back to a followable public `https` URL.
4. `404` for `/.well-known/oauth-authorization-server` and `/.well-known/openid-configuration` so AS-metadata probes don't fall through to the SPA.

Extends #1162, which fixed only the discovery path's *with-slash* form.

## Verification

- **Live-verified on UAT** via a ConfigMap hotpatch before landing this: the connector completed the OAuth handshake and the MCP tools work (`list_my_matches` etc. return data).
- Four server-side probes flipped as expected: no-slash protected-resource metadata `307→http` ⇒ **200** (JSON naming Auth0); `/.well-known/oauth-authorization-server` `200 HTML` ⇒ **404**; no-slash `POST /api/mcp` `301` ⇒ **401**; with-slash forms unchanged (**200 / 401**).
- `nginx -t` passes for `nginx/uat.conf` and `nginx/dev.conf`; `helm template deploy/uat` renders and the resulting ConfigMap `default.conf` passes `nginx -t`.

## Deploy note

The nginx pod rolls on next `redeploy-uat`/`helm upgrade` because the Deployment carries `checksum/config: {{ include "fortymm-uat.nginxConf" . | sha256sum }}` and this changes it. No schema wipe / cluster op required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)