### PR TITLE
Workflow audit: collect the garbage, cut the CI waste, fix three skill-file bugs

### DIFF
--- a/.claude/commands/land-the-plane.md
+++ b/.claude/commands/land-the-plane.md
@@ -28,7 +28,7 @@ Run each suite the project ships. Use the project root as cwd. Run independent s
 - **Web client unit tests (vitest):** `cd web-client && npm run test:run`
 - **Web client lint + typecheck/build:** `cd web-client && npm run lint && npm run build` (the `build` script is `tsc -b && vite build` — it's the only typecheck.)
 - **Web client e2e (Playwright):** `cd web-client && npm run test:e2e`. Playwright defaults to port 5174 which collides with the dev compose web-client; set `PLAYWRIGHT_PORT` to a free port when the dev compose stack is up.
-- **Root e2e (Playwright + docker stack):** `cd e2e && npm test`. This suite drives the full docker compose stack; it self-manages the stack, so just run it. It is the *only* coverage for the tournament create → go-live → play → crown lifecycle (a QA-stack browser pass can't create tournaments at all — no role, 403).
+- **Root e2e (Playwright + docker stack):** `cd e2e && npm test`. This suite drives the full docker compose stack; it self-manages the stack, so just run it. It is the only **automated** coverage for the tournament create → go-live → play → crown lifecycle. A browser QA pass can reach those flows once it grants itself the Beta tester role (see `qa-review.md` §2b), but that is a hand-driven exploratory pass, not a regression gate — it proves the flow worked once, for one operator, on one stack.
 
   **Never scope it out because "the branch didn't touch `e2e/`".** A web-client-only or api-only change absolutely can break it; that is precisely what it is for, and skipping it on that reasoning once already shipped a break that CI then caught, costing a full merge cycle. Run it whenever the branch touches **`api/`, `web-client/`, `ios/`, `e2e/`, `deploy/`, `nginx/`, or any `docker-compose*.yml`**.
 

--- a/.claude/commands/land-the-plane.md
+++ b/.claude/commands/land-the-plane.md
@@ -28,7 +28,11 @@ Run each suite the project ships. Use the project root as cwd. Run independent s
 - **Web client unit tests (vitest):** `cd web-client && npm run test:run`
 - **Web client lint + typecheck/build:** `cd web-client && npm run lint && npm run build` (the `build` script is `tsc -b && vite build` — it's the only typecheck.)
 - **Web client e2e (Playwright):** `cd web-client && npm run test:e2e`. Playwright defaults to port 5174 which collides with the dev compose web-client; set `PLAYWRIGHT_PORT` to a free port when the dev compose stack is up.
-- **Root e2e (Playwright + docker stack):** `cd e2e && npm test`. This suite drives the full docker compose stack; ensure it's running first (or skip if not applicable to this branch's changes).
+- **Root e2e (Playwright + docker stack):** `cd e2e && npm test`. This suite drives the full docker compose stack; it self-manages the stack, so just run it. It is the *only* coverage for the tournament create → go-live → play → crown lifecycle (a QA-stack browser pass can't create tournaments at all — no role, 403).
+
+  **Never scope it out because "the branch didn't touch `e2e/`".** A web-client-only or api-only change absolutely can break it; that is precisely what it is for, and skipping it on that reasoning once already shipped a break that CI then caught, costing a full merge cycle. Run it whenever the branch touches **`api/`, `web-client/`, `ios/`, `e2e/`, `deploy/`, `nginx/`, or any `docker-compose*.yml`**.
+
+  The one case you may skip: a branch that touches **only** `*.md`, `docs/`, or `.claude/` — no application code, no stack config. Charging a cold docker stack build to a README edit buys nothing. Say explicitly that you skipped it and why.
 - **OpenAPI schema drift:** if `api/**` or `web-client/src/api/**` changed, run `mise run regen-api-types` then `git diff --exit-code web-client/src/api/schema.d.ts`. A non-empty diff means the committed schema is stale — commit the regenerated file.
 - **iOS app build (xcodebuild):** if `ios/**` changed, the compile is the gate (the app ships no XCTest target). Clean-build for the simulator **from the worktree's own `ios/` dir** (a worktree has its own checkout — building the main repo's `ios/` tests the wrong code): `rm -rf ios/build/sim && xcodebuild -project ios/Fortymm.xcodeproj -scheme Fortymm -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath ios/build/sim build`. The `rm -rf` matters — incremental builds report `BUILD SUCCEEDED` while serving a stale dylib. A non-`** BUILD SUCCEEDED **` result stops the workflow.
 
@@ -135,6 +139,21 @@ gh pr merge --squash --delete-branch
 ```
 
 Use `--squash` unless the user asked for a different merge strategy. If the merge is blocked (required checks still running, conflicts, branch protection), report exactly why and stop — do not override protections.
+
+Note: run from a worktree, `--delete-branch` prints `fatal: 'main' already used by worktree` **after the remote merge has already succeeded**. That is not a failed merge — verify with `gh pr view <n> --json state,mergedAt` before reacting, and clean up the branch by hand rather than retrying the merge.
+
+## Step 9 — Collect the garbage
+
+Only after the merge is confirmed. `--delete-branch` removes the *branch*; nothing has ever removed the *worktree*. Left alone this accumulates fast — it reached 311 worktrees and 82 GB, 77% of them on already-merged branches, and that sprawl is what causes `/epic` to resume into a stale checkout, ADR numbers to be computed against old trees, and QA stacks to OOM a host with no headroom.
+
+```bash
+scripts/reap-worktrees.sh            # dry run: what would go
+scripts/reap-worktrees.sh --force    # reap worktrees whose PR has merged
+```
+
+The script only ever removes a worktree whose PR is **merged** and which holds nothing that isn't already in `main` (no modified tracked files, no source-looking untracked files, no commits added after the merge); anything else it lists as REVIEW and leaves alone. It records branch/sha/path to `.claude/reaped-worktrees.tsv` first, so any reap can be undone with `git worktree add -b <branch> <path> <sha>`.
+
+You are standing in the worktree that was just merged, so the script will skip it as "current" — that one is the user's to remove after they've moved on. Report the counts; don't push past a REVIEW entry on the user's behalf.
 
 ## Reporting
 

--- a/.claude/commands/qa-review.md
+++ b/.claude/commands/qa-review.md
@@ -69,24 +69,95 @@ so launch **two** Chromes on two ports. Run this with
 `dangerouslyDisableSandbox: true` — the detached launch is what the sandbox
 otherwise blocks:
 
+**Never hardcode the CDP ports, and never pick them yourself.** Two QA passes
+running out of two worktrees at once used to land on the same 9222/9223 and
+silently drive each other's browser. Picking a different fixed "non-default" port
+is not a fix (the next run reads the same note and picks the same one), and
+neither is hashing a slug then probing for a free pair — that's check-then-act,
+so two runs starting in the same second still collide.
+
+**Let the kernel assign the port.** `--remote-debugging-port=0` binds an
+ephemeral port atomically; Chrome writes it to `DevToolsActivePort` in its
+profile dir. No race, no hash, no probe loop.
+
+**Write the ports and PIDs to a file, not to shell variables.** Each step below
+runs in its own Bash tool call and **shell state does not persist between them** —
+a `$CDP_POSTER` set here is empty by Step 4, which would degrade that step's
+`pkill -f "remote-debugging-port=$CDP_POSTER"` into a pattern matching *every*
+CDP Chrome on the machine, including a sibling worktree's mid-flow.
+
 ```bash
 CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 
-launch_cdp() {  # $1=port  $2=label
-  if curl -sf -o /dev/null "http://localhost:$1/json/version"; then
-    echo "$2: CDP already up on $1 — reusing"; return
+# Key everything to this run's stack. $QA_PROJECT comes from scripts/qa-up.sh;
+# fall back to the branch name. The profile dir is keyed the same way, so two
+# runs never share a cookie jar either.
+QA_SLUG="${QA_PROJECT:-fortymm-qa-$(git rev-parse --abbrev-ref HEAD)}"
+RUN_DIR=".qa-review/$QA_SLUG"; mkdir -p "$RUN_DIR"
+
+launch_cdp() {  # $1=label
+  local dir="/tmp/qa-chrome-$QA_SLUG-$1" port
+  # Reuse this run's own browser if it's still alive (a resumed session), but
+  # never adopt a stranger's: the port came from OUR profile dir.
+  if [ -s "$dir/DevToolsActivePort" ]; then
+    port="$(head -1 "$dir/DevToolsActivePort")"
+    if curl -sf -o /dev/null "http://localhost:$port/json/version"; then
+      echo "$1: reusing CDP on $port"; echo "$port" > "$RUN_DIR/$1.port"; return
+    fi
   fi
-  nohup "$CHROME" --remote-debugging-port="$1" \
-    --user-data-dir="/tmp/qa-chrome-$2" \
+  rm -f "$dir/DevToolsActivePort"
+  nohup "$CHROME" --remote-debugging-port=0 --user-data-dir="$dir" \
     --no-first-run --no-default-browser-check about:blank >/dev/null 2>&1 &
+  echo $! > "$RUN_DIR/$1.pid"
   disown
-  until curl -sf -o /dev/null "http://localhost:$1/json/version"; do sleep 1; done
-  echo "$2: CDP up on $1"
+  for _ in $(seq 1 60); do [ -s "$dir/DevToolsActivePort" ] && break; sleep 1; done
+  port="$(head -1 "$dir/DevToolsActivePort")"
+  echo "$port" > "$RUN_DIR/$1.port"
+  echo "$1: CDP up on $port (pid $(cat "$RUN_DIR/$1.pid"))"
 }
 
-launch_cdp 9222 poster
-launch_cdp 9223 opponent
+launch_cdp poster
+launch_cdp opponent
+echo "poster=$(cat "$RUN_DIR/poster.port")  opponent=$(cat "$RUN_DIR/opponent.port")"
 ```
+
+Steps 3 and 4 read `.qa-review/$QA_SLUG/{poster,opponent}.port` and `.pid` — read
+them fresh in each step rather than carrying a variable across tool calls.
+
+## 2b. Grant the QA user a role that can actually do anything
+
+The QA stack seeds roles but assigns them to **nobody**, and the default `User`
+role carries no permissions (`api/scripts/seed_rbac.py`). So a guest or freshly
+minted user 403s on every tournament write, and Quinn reports "can't create a
+tournament" as a bug on every single run. There is no HTTP endpoint to
+self-assign a role, so the sanctioned seam is the database — the same one
+`e2e/support/rbac-grant.ts` uses for the composed suite.
+
+After the stack is up, grant **"Beta tester"** (`tournament.view` / `.create` /
+`.enter`) to the user Quinn will drive. Substitute the username Quinn signs in as:
+
+`-v ON_ERROR_STOP=1` is not optional: without it `psql` does not reliably signal
+a SQL error in its exit status, so a renamed role or a reshaped `user_roles`
+would leave the grant silently unapplied — and Quinn would then report the
+resulting 403s as a product bug, which is the exact false positive this step
+exists to prevent. Check the exit code.
+
+```bash
+docker compose -p "$QA_PROJECT" -f docker-compose.qa.yml exec -T postgres \
+  psql -v ON_ERROR_STOP=1 -U postgres -d fortymm -c "
+    INSERT INTO user_roles (user_id, role_id)
+    SELECT u.id, r.id FROM users u CROSS JOIN roles r
+    WHERE u.username = '<USERNAME>' AND r.name = 'Beta tester'
+      AND NOT EXISTS (SELECT 1 FROM user_roles ur
+                      WHERE ur.user_id = u.id AND ur.role_id = r.id);"
+```
+
+Idempotent, so re-running is safe. The user must exist first — grant *after*
+Quinn has signed in, or after seeding the account.
+
+**Keep one un-granted identity if the branch touches permission gating**: with
+every user granted, the "no permission" path becomes untestable. Say which
+identity holds which role when you brief Quinn.
 
 The launched Chrome is **headless** — Quinn drives it blind and reads the page
 via `snapshot` (the a11y tree), screenshotting only as bug evidence.
@@ -95,7 +166,8 @@ via `snapshot` (the a11y tree), screenshotting only as bug evidence.
 
 Use the Agent tool (general-purpose). Tell Quinn it has the `playwright-cli`
 skill available. Pass it the base URL, the absolute screenshots dir, the two CDP
-ports (poster 9222, opponent 9223), and the flows to exercise (derive these from
+ports (read them now with `cat .qa-review/$QA_SLUG/{poster,opponent}.port` and
+substitute the actual numbers — they differ every run), and the flows to exercise (derive these from
 what the user asked to QA; if they didn't say, give Quinn the app's primary
 flows — sign-in, create a match, enter scores). Give Quinn the identity and rules
 verbatim below as its prompt.
@@ -124,8 +196,8 @@ NON-NEGOTIABLE RULES
 BROWSER ACCESS — ATTACH, DON'T OPEN. Two headless Chromes are already running
 for you. Do NOT run `playwright-cli open` (the sandbox will kill it). Attach each
 named session to its CDP port instead:
-  playwright-cli -s=poster attach --cdp=http://localhost:9222
-  playwright-cli -s=opponent attach --cdp=http://localhost:9223
+  playwright-cli -s=poster attach --cdp=http://localhost:<CDP_POSTER>
+  playwright-cli -s=opponent attach --cdp=http://localhost:<CDP_OPPONENT>
 Every playwright-cli call must run with dangerouslyDisableSandbox: true. The
 browsers are headless, so use `snapshot` (the a11y tree) as your eyes and reserve
 screenshots for bug evidence. When finished, `detach` each session — do NOT
@@ -154,9 +226,26 @@ when there are bugs worth showing.
 Close the Chromes you launched in Step 2 — Quinn only detaches, so the processes
 are still running:
 
+Kill **this run's** browsers by PID. Do not `pkill -f remote-debugging-port=…`:
+this step runs in a fresh Bash call where any variable from Step 2 is empty, so
+the pattern would collapse to a prefix that matches a sibling worktree's Chrome
+too. Re-derive the slug and read the PIDs back from the file Step 2 wrote:
+
 ```bash
-pkill -f 'remote-debugging-port=9222'
-pkill -f 'remote-debugging-port=9223'
+QA_SLUG="${QA_PROJECT:-fortymm-qa-$(git rev-parse --abbrev-ref HEAD)}"
+RUN_DIR=".qa-review/$QA_SLUG"
+
+for label in poster opponent; do
+  pidfile="$RUN_DIR/$label.pid"
+  [ -f "$pidfile" ] || continue
+  pid="$(cat "$pidfile")"
+  kill "$pid" 2>/dev/null
+  # Wait for it to actually exit before removing the profile — Chrome writes on
+  # its way down, so an immediate `rm -rf` races it and leaves the dir behind.
+  for _ in $(seq 1 15); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+  rm -rf "/tmp/qa-chrome-$QA_SLUG-$label"
+done
+rm -f "$RUN_DIR"/*.pid "$RUN_DIR"/*.port
 ```
 
 Tear down the stack unless the user wants it left up for their own poking. Use

--- a/.claude/rules/verify-the-artifact-under-test.md
+++ b/.claude/rules/verify-the-artifact-under-test.md
@@ -1,0 +1,48 @@
+# Verify the artifact under test is the one you changed
+
+A green result is a claim about **some** artifact. It is only evidence about **your** change
+if the thing that ran was built from it. In this repo that has been false often enough, and
+in enough different ways, that it deserves its own rule: nearly every "it passed locally but
+broke in CI" and every "the demo proved nothing" traced back to a layer serving something
+older than the edit.
+
+## The rule
+
+Before you believe a green run, establish two things:
+
+1. **Provenance** — the bundle, image, container, module or binary that ran was produced
+   from the working tree you just edited.
+2. **Coverage** — the number of tests/specs that *ran* matches the number *collected*. A
+   suite that silently skipped a whole project is not a green suite.
+
+If you can't establish both, the result is `INCONCLUSIVE`, not `PASS`.
+
+## The caches that lie
+
+Each of these has produced a false green here at least once. They fail *silently* — no
+error, just stale output.
+
+| Layer | How it lies | How to defeat it |
+| --- | --- | --- |
+| **Docker BuildKit** | `up --build` serves a cached image without your change | Check the *served* asset (bundle, `openapi.json`) actually contains the feature; `--no-cache` if not |
+| **PWA service worker** | Browser keeps the old `index.html` after a rebuild | Unregister the service worker + clear caches, or you QA the previous commit |
+| **Vite dev server** | A reused server serves the old transform, so a fail-then-pass demo passes in *both* states | Restart vite between the red and green states of a regression proof |
+| **Xcode incremental build** | Reports `BUILD SUCCEEDED` while serving a stale dylib | `rm -rf ios/build/sim` before the build that counts, or check the dylib mtime |
+| **MSW** | Left on, it intercepts the `page.route` stubs an e2e run depends on, false-redding unrelated specs | A hand-started vite reused by Playwright must set `VITE_ENABLE_MSW=false` |
+| **Playwright reporter** | "N passed" can under-report — a whole project (e.g. mobile) never ran | Check "N passed" against `--list`'s collected total |
+| **Worktree tooling** | An untrusted `mise.toml` makes `npx` exit 127; the step "passes" having run nothing | Call `node_modules/.bin/<tool>` directly and **check the exit code** |
+
+## Corollaries
+
+- **A test you have not seen fail is not evidence.** Run the falsification: break the
+  implementation deliberately and confirm the test reds *for the stated reason*. This is the
+  only way to distinguish a real assertion from one that was weakened to fit the code.
+- **An undiscriminated timeout-red proves nothing.** "Timed out after 5000ms" cannot
+  distinguish "the guard worked" from "the harness never got there". Vary one thing at a
+  time, or probe state at failure time.
+- **A green suite and a working product are different claims.** Neither discharges the
+  other; this is why the work order carries `## Testing notes` separately from each chore's
+  `Verify` command.
+
+The per-layer tooling that implements this lives in each unit's `CLAUDE.md`; this file is
+the *why*.

--- a/.claude/skills/domain-modeling/ADR-FORMAT.md
+++ b/.claude/skills/domain-modeling/ADR-FORMAT.md
@@ -1,6 +1,7 @@
 # ADR Format
 
-ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+ADRs live in `docs/adr/` and are **date-prefixed**: `YYYYMMDD-slug.md` — e.g.
+`20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0.md`.
 
 Create the `docs/adr/` directory lazily — only when the first ADR is needed.
 
@@ -22,9 +23,27 @@ Only include these when they add genuine value. Most ADRs won't need them.
 - **Considered Options** — only when the rejected alternatives are worth remembering
 - **Consequences** — only when non-obvious downstream effects need to be called out
 
-## Numbering
+## Naming — date prefix, never a sequential number
 
-Scan `docs/adr/` for the highest existing number and increment by one.
+**`docs/adr/YYYYMMDD-slug.md`.** The date is the date the decision was made;
+the slug is lowercase words joined by hyphens, and should read as the decision
+itself ("a-null-player-cap-means-no-cap"), not as a topic.
+
+**Do not scan for "the highest number and increment".** That is what this repo
+used to say, and it produced ten duplicated prefixes — including four different
+`0008-*.md` files — because every worktree numbers off a `main` that has already
+moved on, and two agents working in parallel both pick the same "next" number.
+Issue numbers (`0783-`, `0915-`) collide the same way when one issue produces
+several ADRs. A calendar date is assigned by the world rather than raced for, so
+it cannot collide by construction; several ADRs may legitimately share one date,
+and the slug distinguishes them.
+
+The legacy `NNNN-` ADRs stay as they are — their numbers are cited from PR
+bodies and commit messages, so renaming them would break those links. Refer to
+any ADR by its **full filename**, not by a bare number.
+
+`scripts/check-adr-numbering.sh` enforces this on new files in CI (it only ever
+looks at ADRs a branch *adds*, so the legacy names are grandfathered).
 
 ## When to offer an ADR
 

--- a/.claude/skills/domain-modeling/ADR-FORMAT.md
+++ b/.claude/skills/domain-modeling/ADR-FORMAT.md
@@ -30,7 +30,7 @@ the slug is lowercase words joined by hyphens, and should read as the decision
 itself ("a-null-player-cap-means-no-cap"), not as a topic.
 
 **Do not scan for "the highest number and increment".** That is what this repo
-used to say, and it produced ten duplicated prefixes — including four different
+used to say, and it produced seven duplicated numeric prefixes — including four different
 `0008-*.md` files — because every worktree numbers off a `main` that has already
 moved on, and two agents working in parallel both pick the same "next" number.
 Issue numbers (`0783-`, `0915-`) collide the same way when one issue produces

--- a/.claude/skills/domain-modeling/SKILL.md
+++ b/.claude/skills/domain-modeling/SKILL.md
@@ -16,8 +16,8 @@ Most repos have a single context:
 ├── CONTEXT.md
 ├── docs/
 │   └── adr/
-│       ├── 0001-event-sourced-orders.md
-│       └── 0002-postgres-for-write-model.md
+│       ├── 20260716-event-sourced-orders.md
+│       └── 20260718-postgres-for-write-model.md
 └── src/
 ```
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,6 +15,7 @@
 #
 # Escape hatches:
 #   SKIP_OPENAPI_CHECK=1 git push       # skip the whole hook
+#   SKIP_WEB_OPENAPI_CHECK=1 git push   # skip only the web half (schema.d.ts)
 #   SKIP_IOS_OPENAPI_CHECK=1 git push   # skip only the (slow) Swift half
 #   git push --no-verify                # skip every pre-push hook
 #
@@ -96,6 +97,13 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
 
   if [ -n "$base" ]; then
     files="$(git diff --name-only "$base" "$local_sha" 2>/dev/null || true)"
+    # Fail toward CHECKING, per the note above: an unresolvable base (force-push,
+    # rewritten remote, partial fetch) makes `git diff` error into an empty list,
+    # which would otherwise read as "nothing relevant changed" and skip silently.
+    if [ -z "$files" ] && [ -n "$base" ]; then
+      echo "pre-push: cannot diff against '$base' — checking anyway." >&2
+      relevant=1; break
+    fi
   else
     files="$(git show --pretty=format: --name-only "$local_sha" 2>/dev/null || true)"
   fi
@@ -110,8 +118,10 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
 $files
 EOF
 
-  # NB: `[ ... ] && break` as the last command of a loop body would trip
-  # `set -e` when the test is false. Keep it an `if`.
+  # NB: an `if`, not `[ "$relevant" -eq 1 ] && break`. Not because the latter
+  # trips `set -e` — it doesn't; a failing non-final member of an `&&` list is
+  # exempt — but because the loop's own exit status would then become 1, which
+  # does matter when a loop is the last command of a function or an `&&` chain.
   if [ "$relevant" -eq 1 ]; then
     break
   fi
@@ -121,7 +131,7 @@ if [ "$relevant" -ne 1 ]; then
   exit 0
 fi
 
-echo "pre-push: this push touches api/ — checking generated OpenAPI types..." >&2
+echo "pre-push: this push touches api/ or ios/openapi/ — checking generated OpenAPI types..." >&2
 
 # --- Regenerate, reusing the same machinery as the mise tasks / CI ---------
 #
@@ -221,6 +231,8 @@ fi
   echo " To regenerate by hand instead:"
   echo "     mise run regen-api-types"
   echo "     mise run regen-ios-api-types"
+  echo
+  echo " Skip just one half with SKIP_WEB_OPENAPI_CHECK=1 / SKIP_IOS_OPENAPI_CHECK=1."
   echo
   echo " If the diff is not yours (e.g. unrelated uncommitted work under api/),"
   echo " bypass with:  SKIP_OPENAPI_CHECK=1 git push"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# pre-push: catch OpenAPI type drift before CI does.
+#
+# The tax this pays down: `web-client/src/api/schema.d.ts` and
+# `ios/Fortymm/Generated/Types.swift` are generated from the API's
+# `openapi.json`, and `.github/workflows/openapi-schema.yml` fails the build
+# when either drifts. Forgetting `mise run regen-api-types` after touching a
+# route — or even just a docstring, which becomes an OpenAPI `description` —
+# accounted for half of all PRs that ever went red. That is a ~15-minute round
+# trip (push, wait for CI, regen, push again) to learn something the local
+# machine can tell you in seconds.
+#
+# Runs ONLY when the commits being pushed touch `api/**` (or the iOS generator
+# config), so a web-only or docs-only push pays nothing.
+#
+# Escape hatches:
+#   SKIP_OPENAPI_CHECK=1 git push       # skip the whole hook
+#   SKIP_IOS_OPENAPI_CHECK=1 git push   # skip only the (slow) Swift half
+#   git push --no-verify                # skip every pre-push hook
+#
+# Enabled by `git config core.hooksPath .githooks` (scripts/install_tools.sh
+# does this for you). NOTE FOR WORKTREES: `core.hooksPath` set without
+# `--worktree` lands in the SHARED `.git/config`, so setting it from any one
+# worktree enables these hooks for the main checkout and every other worktree at
+# once — which is what we want here. The value is a RELATIVE path, and git
+# resolves a relative `core.hooksPath` against the top level of the *current*
+# working tree, so every worktree runs its own checked-out copy of this file
+# rather than the main checkout's.
+
+set -euo pipefail
+
+if [ "${SKIP_OPENAPI_CHECK:-}" = "1" ]; then
+  echo "pre-push: SKIP_OPENAPI_CHECK=1 — skipping the OpenAPI drift check." >&2
+  exit 0
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+# All-zeros sha (git's "this ref does not exist" sentinel). Written as a glob
+# test rather than `expr`/regex so it works the same on BSD and GNU userland,
+# and so it tolerates both the 40-char sha1 and 64-char sha256 forms.
+is_zero_sha() {
+  case "${1:-}" in
+    "") return 1 ;;
+    *[!0]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Paths whose contents can change the generated OpenAPI output. `api/**` covers
+# routes, pydantic schemas and docstrings; `ios/openapi/**` is the nullable
+# fixer + generator config, which shape Types.swift independently of the spec.
+#
+# The exclusions matter as much as the matches: this hook boots the API and (on
+# the iOS half) builds a Swift toolchain, so firing it for a change that cannot
+# possibly move the spec is exactly the friction it exists to remove. Markdown
+# under api/ (CLAUDE.md and friends) and the test suite are never part of the
+# served OpenAPI document. Migrations aren't either — the spec comes from the
+# pydantic models, not the schema.
+is_relevant() {
+  case "$1" in
+    *.md)                 return 1 ;;   # docs, incl. api/CLAUDE.md
+    api/tests/*)          return 1 ;;   # tests don't shape the spec
+    api/migrations/*)     return 1 ;;   # the spec comes from the models
+    api/*)                return 0 ;;
+    ios/openapi/*)        return 0 ;;
+    *)                    return 1 ;;
+  esac
+}
+
+# --- Work out what is actually being pushed -------------------------------
+#
+# git's pre-push protocol feeds us one line per ref on stdin:
+#   <local ref> <local sha> <remote ref> <remote sha>
+# A local sha of all zeros means the ref is being DELETED — nothing to verify.
+# A remote sha of all zeros means the remote has no such branch yet, so there is
+# no "since" commit to diff against; fall back to the merge-base with
+# origin/main, which is exactly the set of commits this push would add.
+
+relevant=0
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ -n "${local_sha:-}" ] || continue
+  if is_zero_sha "$local_sha"; then
+    continue  # branch deletion
+  fi
+
+  if is_zero_sha "${remote_sha:-}" || [ -z "${remote_sha:-}" ]; then
+    # New branch. If origin/main is unknown (fresh clone, unusual remote) the
+    # base stays empty and we fall back to inspecting the tip commit alone —
+    # fail toward checking rather than toward silently skipping.
+    base="$(git merge-base "$local_sha" origin/main 2>/dev/null || true)"
+  else
+    base="$remote_sha"
+  fi
+
+  if [ -n "$base" ]; then
+    files="$(git diff --name-only "$base" "$local_sha" 2>/dev/null || true)"
+  else
+    files="$(git show --pretty=format: --name-only "$local_sha" 2>/dev/null || true)"
+  fi
+
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    if is_relevant "$f"; then
+      relevant=1
+      break
+    fi
+  done <<EOF
+$files
+EOF
+
+  # NB: `[ ... ] && break` as the last command of a loop body would trip
+  # `set -e` when the test is false. Keep it an `if`.
+  if [ "$relevant" -eq 1 ]; then
+    break
+  fi
+done
+
+if [ "$relevant" -ne 1 ]; then
+  exit 0
+fi
+
+echo "pre-push: this push touches api/ — checking generated OpenAPI types..." >&2
+
+# --- Regenerate, reusing the same machinery as the mise tasks / CI ---------
+#
+# scripts/ensure-api-up.sh boots the API only if one isn't already listening and
+# hands back $API_URL plus $API_STARTED_PID (empty when it reused a running
+# server). Assign-then-eval through `tail -n1`: only the final stdout line is
+# the machine-readable handoff, and a bare `eval "$(cmd)"` would hide a failure
+# from `set -e`. Same convention as mise.toml's regen-api-types.
+API_STATUS="$("$ROOT/scripts/ensure-api-up.sh" | tail -n1)"
+eval "$API_STATUS"
+TMP_SPEC=""
+# Registered before `mktemp` so a started-but-uncleaned server can't leak if
+# `mktemp` itself fails. Single-quoted on purpose: expands at trap time.
+trap 'rm -f "$TMP_SPEC"; [ -n "${API_STARTED_PID:-}" ] && kill "$API_STARTED_PID" 2>/dev/null || true' EXIT
+
+# Plain string, not an array: macOS still ships bash 3.2, where `"${arr[@]}"` on
+# an EMPTY array is an unbound-variable error under `set -u`.
+drifted_files=""
+
+# Compare against HEAD, not the index: HEAD is what the push actually sends, so
+# a regenerated-but-only-staged file must still count as drift.
+has_drift() { ! git diff --quiet HEAD -- "$1"; }
+
+# --- web-client/src/api/schema.d.ts ---------------------------------------
+#
+# Degrade the same way the iOS half below does. Most worktrees have no
+# `web-client/node_modules` (it is not shared between worktrees), and a bare
+# `npm ci` here would silently write ~525 MB into every fresh worktree, inside
+# `git push`, on the most latency-sensitive step of the loop. A push must never
+# turn into a half-gigabyte install: warn, skip, and let CI's `verify` catch it.
+if [ "${SKIP_WEB_OPENAPI_CHECK:-}" = "1" ]; then
+  echo "pre-push: SKIP_WEB_OPENAPI_CHECK=1 — skipping the schema.d.ts check." >&2
+elif [ ! -x "$ROOT/web-client/node_modules/.bin/openapi-typescript" ]; then
+  echo "pre-push: WARNING — web-client/node_modules is missing, so the" >&2
+  echo "          schema.d.ts check is skipped rather than triggering a large" >&2
+  echo "          'npm ci' during a push. CI's 'verify' job still catches drift;" >&2
+  echo "          run 'npm ci' in web-client/ (or 'mise run regen-api-types')." >&2
+else
+  ( cd "$ROOT/web-client" && API_URL="$API_URL" npm run gen:api )
+  if has_drift web-client/src/api/schema.d.ts; then
+    drifted_files="$drifted_files web-client/src/api/schema.d.ts"
+  fi
+fi
+
+# --- ios/Fortymm/Generated/Types.swift ------------------------------------
+#
+# `swift run swift-openapi-generator` needs a Swift toolchain and, on a cold
+# cache, a multi-minute build. A machine without Swift (or someone who doesn't
+# want to pay for it right now) must never be blocked from pushing — warn and
+# move on. CI's `verify-ios` job is still the backstop.
+if [ "${SKIP_IOS_OPENAPI_CHECK:-}" = "1" ]; then
+  echo "pre-push: SKIP_IOS_OPENAPI_CHECK=1 — skipping the iOS Types.swift check." >&2
+elif ! command -v swift >/dev/null 2>&1 || ! swift --version >/dev/null 2>&1; then
+  echo "pre-push: WARNING — no working Swift toolchain; skipping the iOS" >&2
+  echo "          Types.swift check. CI's 'verify-ios' job still catches drift;" >&2
+  echo "          run 'mise run regen-ios-api-types' on a machine with Xcode." >&2
+else
+  TMP_SPEC="$(mktemp)"
+  curl -fs "$API_URL/openapi.json" -o "$TMP_SPEC"
+  # swift-openapi-generator silently DROPS `Optional[T]` fields encoded the way
+  # FastAPI emits OpenAPI 3.1 (`anyOf: [T, {type: null}]`); this rewrites them
+  # into the older `nullable: true` form it understands. Same step as CI.
+  python3 "$ROOT/ios/openapi/fix_openapi_nullable.py" "$TMP_SPEC" "$TMP_SPEC"
+
+  cd "$ROOT/ios/Tools/OpenAPIGeneratorCLI"
+  swift run swift-openapi-generator generate "$TMP_SPEC" \
+    --config "$ROOT/ios/openapi/openapi-generator-config.yaml" \
+    --output-directory "$ROOT/ios/Fortymm/Generated"
+  cd "$ROOT"
+  if has_drift ios/Fortymm/Generated/Types.swift; then
+    drifted_files="$drifted_files ios/Fortymm/Generated/Types.swift"
+  fi
+fi
+
+if [ -z "$drifted_files" ]; then
+  echo "pre-push: generated OpenAPI types are up to date." >&2
+  exit 0
+fi
+
+# The regenerated files are left ON DISK on purpose: recovery is `git add` +
+# commit + push, with nothing to re-run.
+{
+  echo
+  echo "================================================================"
+  echo " PUSH BLOCKED — generated OpenAPI types are out of date."
+  echo "================================================================"
+  for f in $drifted_files; do
+    echo "  - $f"
+  done
+  echo
+  echo " They have already been regenerated in your working tree, so:"
+  echo
+  echo "     git add$drifted_files"
+  echo "     git commit --amend --no-edit    # or a fresh commit"
+  echo "     git push"
+  echo
+  echo " To regenerate by hand instead:"
+  echo "     mise run regen-api-types"
+  echo "     mise run regen-ios-api-types"
+  echo
+  echo " If the diff is not yours (e.g. unrelated uncommitted work under api/),"
+  echo " bypass with:  SKIP_OPENAPI_CHECK=1 git push"
+  echo "================================================================"
+} >&2
+exit 1

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,5 +1,21 @@
 name: api
 
+# The triggers here are deliberately NOT path-filtered, even though 39 of the
+# last 60 PRs touch at most one unit and most never go near `api/`.
+#
+# `pytest` is a REQUIRED status check on `main`. A path-filtered workflow that
+# doesn't trigger never reports its check, so a web-only PR would sit on
+# "Expected — waiting for status to be reported" forever. (Contrast `ios.yml`,
+# which *is* path-filtered precisely because its `build` job is deliberately
+# not in the required-contexts list.)
+#
+# So the job always runs and always reports — it just short-circuits the
+# expensive steps when nothing that can affect the API changed. A web-only PR
+# costs ~30s of runner instead of ~4 minutes and 1,490 tests.
+#
+# Fail safe: if the base commit can't be resolved (force-push, first push,
+# shallow history), we run everything rather than skip.
+
 on:
   push:
     branches: [main]
@@ -13,20 +29,66 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
+      # Full history so the base commit is present to diff against.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Does this change affect the API?
+        id: changes
+        working-directory: .
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+
+          run_all() {
+            echo "Running everything: $1"
+            echo "api=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          # No usable base — empty, all-zeros (branch creation / force-push), or
+          # simply not in this clone. Any of those and we run everything.
+          case "$BASE_SHA" in
+            *[!0]*) ;;                      # contains a non-zero char: plausible sha
+            *) run_all "no base commit to diff against (got '${BASE_SHA}')" ;;
+          esac
+          git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null \
+            || run_all "base commit ${BASE_SHA} not present locally"
+
+          # Three-dot: only what this branch changed, ignoring what landed on
+          # main after it was cut.
+          changed="$(git diff --name-only "${BASE_SHA}...HEAD" -- \
+            api .github/workflows/api.yml)"
+
+          if [ -n "$changed" ]; then
+            echo "API-affecting files changed:"
+            echo "$changed"
+            echo "api=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Nothing under api/ changed — skipping lint, typecheck and tests."
+            echo "api=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/setup-python@v6
+        if: steps.changes.outputs.api == 'true'
         with:
           python-version: '3.13'
           cache: pip
           cache-dependency-path: api/pyproject.toml
 
       - run: pip install -e '.[dev]'
+        if: steps.changes.outputs.api == 'true'
 
       - run: ruff check app tests
+        if: steps.changes.outputs.api == 'true'
 
       - run: ruff format --check app tests
+        if: steps.changes.outputs.api == 'true'
 
       - run: mypy
+        if: steps.changes.outputs.api == 'true'
 
       - run: pytest
+        if: steps.changes.outputs.api == 'true'

--- a/.github/workflows/openapi-schema.yml
+++ b/.github/workflows/openapi-schema.yml
@@ -1,35 +1,118 @@
 name: openapi-schema
 
+# Repo-wide consistency guards. Primarily the generated-types drift checks
+# (`verify`, `verify-ios`), plus `adr-numbering` — see the comment on that job
+# for why it lives here rather than in its own workflow file.
+
 on:
   push:
     branches: [main]
   pull_request:
 
 jobs:
+  # Housed in this workflow on purpose: it is the repo's cross-cutting
+  # "consistency" workflow — the only one that isn't scoped to a single
+  # deployable unit and that deliberately runs unfiltered on every PR. A
+  # one-second bash check doesn't justify a seventh workflow file, and putting
+  # it in web-client/api/e2e would tie a docs rule to an unrelated unit's
+  # trigger (and, if that workflow ever gets path-filtered, silently stop it
+  # running). It's a separate JOB rather than a step so a naming failure reads
+  # as "adr-numbering", not as OpenAPI drift.
+  #
+  # Not a required status check, so it reports red on the PR without blocking.
+  # To make it blocking, add "adr-numbering" to the branch-protection contexts.
+  adr-numbering:
+    runs-on: ubuntu-latest
+    steps:
+      # Full history: the check diffs the branch against its merge base to find
+      # only the ADRs this branch ADDS (legacy names are grandfathered).
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: New ADRs use the YYYYMMDD-slug.md scheme
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          scripts/check-adr-numbering.sh "${base:-origin/main}"
+
+  # Can this branch possibly move the generated types? Only a small closed set of
+  # paths can: the spec comes from the API's pydantic models, and the generators'
+  # own versions come from the lockfiles. Everything else — docs, web-client
+  # components, e2e specs, .claude/ — provably cannot, and on those branches
+  # `verify` + `verify-ios` are ~143s of pure waste (verify-ios downloads a Swift
+  # toolchain to prove a file didn't change).
+  #
+  # One job, consumed by both, so the path list has a single definition.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      openapi: ${{ steps.check.outputs.openapi }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - id: check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+
+          # Fail safe: if the base can't be resolved, regenerate and check.
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "No usable base commit (got '${BASE_SHA}') — checking anyway."
+            echo "openapi=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          changed="$(git diff --name-only "${BASE_SHA}...HEAD" -- \
+            api ios/openapi ios/Tools/OpenAPIGeneratorCLI \
+            scripts/ensure-api-up.sh \
+            web-client/package-lock.json web-client/src/api/schema.d.ts \
+            ios/Fortymm/Generated/Types.swift \
+            .github/workflows/openapi-schema.yml \
+            | grep -v '\.md$' || true)"
+
+          if [ -n "$changed" ]; then
+            echo "Type-affecting files changed:"; echo "$changed"
+            echo "openapi=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Nothing that can move the generated types — skipping regeneration."
+            echo "openapi=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # `verify` is a REQUIRED status check, so it must always run and report. Only
+  # its expensive steps are gated — see api.yml for the same pattern and why a
+  # trigger-level `paths:` filter would hang every PR instead.
   verify:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
+        if: needs.changes.outputs.openapi == 'true'
         with:
           python-version: '3.13'
           cache: pip
           cache-dependency-path: api/pyproject.toml
 
       - uses: actions/setup-node@v7
+        if: needs.changes.outputs.openapi == 'true'
         with:
           node-version: '26.1.0'
           cache: npm
           cache-dependency-path: web-client/package-lock.json
 
       - run: pip install -e '.[dev]'
+        if: needs.changes.outputs.openapi == 'true'
         working-directory: api
 
       - run: npm ci
+        if: needs.changes.outputs.openapi == 'true'
         working-directory: web-client
 
       - name: Regenerate OpenAPI types
+        if: needs.changes.outputs.openapi == 'true'
         run: |
           API_STATUS="$(scripts/ensure-api-up.sh | tail -n1)"
           eval "$API_STATUS"
@@ -39,6 +122,7 @@ jobs:
           API_URL="$API_URL" npm run gen:api
 
       - name: Verify committed schema is up to date
+        if: needs.changes.outputs.openapi == 'true'
         run: |
           if ! git diff --exit-code web-client/src/api/schema.d.ts; then
             echo "::error::web-client/src/api/schema.d.ts is out of date. Run 'mise run regen-api-types' locally and commit the result."
@@ -46,17 +130,20 @@ jobs:
           fi
 
   verify-ios:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
+        if: needs.changes.outputs.openapi == 'true'
         with:
           python-version: '3.13'
           cache: pip
           cache-dependency-path: api/pyproject.toml
 
       - name: Cache Swift toolchain
+        if: needs.changes.outputs.openapi == 'true'
         id: swift-cache
         uses: actions/cache@v6
         with:
@@ -64,6 +151,7 @@ jobs:
           key: ${{ runner.os }}-swift-6.1-RELEASE-ubuntu24.04
 
       - name: Install Swift toolchain
+        if: needs.changes.outputs.openapi == 'true'
         if: steps.swift-cache.outputs.cache-hit != 'true'
         run: |
           # Not swift-actions/setup-swift: its Swiftly installer verifies a
@@ -74,17 +162,21 @@ jobs:
           tar xzf /tmp/swift.tar.gz -C /tmp
 
       - run: echo "/tmp/swift-6.1-RELEASE-ubuntu24.04/usr/bin" >> "$GITHUB_PATH"
+        if: needs.changes.outputs.openapi == 'true'
 
       - run: pip install -e '.[dev]'
+        if: needs.changes.outputs.openapi == 'true'
         working-directory: api
 
       - name: Cache swift-openapi-generator build
+        if: needs.changes.outputs.openapi == 'true'
         uses: actions/cache@v6
         with:
           path: ios/Tools/OpenAPIGeneratorCLI/.build
           key: ${{ runner.os }}-openapi-generator-cli-${{ hashFiles('ios/Tools/OpenAPIGeneratorCLI/Package.resolved') }}
 
       - name: Regenerate iOS OpenAPI types
+        if: needs.changes.outputs.openapi == 'true'
         run: |
           API_STATUS="$(scripts/ensure-api-up.sh | tail -n1)"
           eval "$API_STATUS"
@@ -101,6 +193,7 @@ jobs:
             --output-directory ../../Fortymm/Generated
 
       - name: Verify committed Types.swift is up to date
+        if: needs.changes.outputs.openapi == 'true'
         run: |
           if ! git diff --exit-code ios/Fortymm/Generated/Types.swift; then
             echo "::error::ios/Fortymm/Generated/Types.swift is out of date. Run 'mise run regen-ios-api-types' locally and commit the result."

--- a/.github/workflows/openapi-schema.yml
+++ b/.github/workflows/openapi-schema.yml
@@ -151,8 +151,7 @@ jobs:
           key: ${{ runner.os }}-swift-6.1-RELEASE-ubuntu24.04
 
       - name: Install Swift toolchain
-        if: needs.changes.outputs.openapi == 'true'
-        if: steps.swift-cache.outputs.cache-hit != 'true'
+        if: needs.changes.outputs.openapi == 'true' && steps.swift-cache.outputs.cache-hit != 'true'
         run: |
           # Not swift-actions/setup-swift: its Swiftly installer verifies a
           # GPG signature against a key the runner's keyring doesn't have,

--- a/.github/workflows/openapi-schema.yml
+++ b/.github/workflows/openapi-schema.yml
@@ -67,7 +67,7 @@ jobs:
           changed="$(git diff --name-only "${BASE_SHA}...HEAD" -- \
             api ios/openapi ios/Tools/OpenAPIGeneratorCLI \
             scripts/ensure-api-up.sh \
-            web-client/package-lock.json web-client/src/api/schema.d.ts \
+            web-client/package.json web-client/package-lock.json web-client/src/api/schema.d.ts \
             ios/Fortymm/Generated/Types.swift \
             .github/workflows/openapi-schema.yml \
             | grep -v '\.md$' || true)"
@@ -85,34 +85,38 @@ jobs:
   # trigger-level `paths:` filter would hang every PR instead.
   verify:
     needs: changes
+    # `always()` so a failure in `changes` cannot SKIP this job: GitHub reports a
+    # skipped required check as SUCCESSFUL, which would turn the drift guard
+    # into a silent pass — the exact inversion this gating was meant to avoid.
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         with:
           python-version: '3.13'
           cache: pip
           cache-dependency-path: api/pyproject.toml
 
       - uses: actions/setup-node@v7
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         with:
           node-version: '26.1.0'
           cache: npm
           cache-dependency-path: web-client/package-lock.json
 
       - run: pip install -e '.[dev]'
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         working-directory: api
 
       - run: npm ci
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         working-directory: web-client
 
       - name: Regenerate OpenAPI types
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         run: |
           API_STATUS="$(scripts/ensure-api-up.sh | tail -n1)"
           eval "$API_STATUS"
@@ -122,7 +126,7 @@ jobs:
           API_URL="$API_URL" npm run gen:api
 
       - name: Verify committed schema is up to date
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         run: |
           if ! git diff --exit-code web-client/src/api/schema.d.ts; then
             echo "::error::web-client/src/api/schema.d.ts is out of date. Run 'mise run regen-api-types' locally and commit the result."
@@ -131,19 +135,20 @@ jobs:
 
   verify-ios:
     needs: changes
+    if: always()          # see the note on `verify`
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         with:
           python-version: '3.13'
           cache: pip
           cache-dependency-path: api/pyproject.toml
 
       - name: Cache Swift toolchain
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         id: swift-cache
         uses: actions/cache@v6
         with:
@@ -151,7 +156,7 @@ jobs:
           key: ${{ runner.os }}-swift-6.1-RELEASE-ubuntu24.04
 
       - name: Install Swift toolchain
-        if: needs.changes.outputs.openapi == 'true' && steps.swift-cache.outputs.cache-hit != 'true'
+        if: needs.changes.outputs.openapi != 'false' && steps.swift-cache.outputs.cache-hit != 'true'
         run: |
           # Not swift-actions/setup-swift: its Swiftly installer verifies a
           # GPG signature against a key the runner's keyring doesn't have,
@@ -161,21 +166,21 @@ jobs:
           tar xzf /tmp/swift.tar.gz -C /tmp
 
       - run: echo "/tmp/swift-6.1-RELEASE-ubuntu24.04/usr/bin" >> "$GITHUB_PATH"
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
 
       - run: pip install -e '.[dev]'
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         working-directory: api
 
       - name: Cache swift-openapi-generator build
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         uses: actions/cache@v6
         with:
           path: ios/Tools/OpenAPIGeneratorCLI/.build
           key: ${{ runner.os }}-openapi-generator-cli-${{ hashFiles('ios/Tools/OpenAPIGeneratorCLI/Package.resolved') }}
 
       - name: Regenerate iOS OpenAPI types
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         run: |
           API_STATUS="$(scripts/ensure-api-up.sh | tail -n1)"
           eval "$API_STATUS"
@@ -192,7 +197,7 @@ jobs:
             --output-directory ../../Fortymm/Generated
 
       - name: Verify committed Types.swift is up to date
-        if: needs.changes.outputs.openapi == 'true'
+        if: needs.changes.outputs.openapi != 'false'
         run: |
           if ! git diff --exit-code ios/Fortymm/Generated/Types.swift; then
             echo "::error::ios/Fortymm/Generated/Types.swift is out of date. Run 'mise run regen-ios-api-types' locally and commit the result."

--- a/.github/workflows/web-client-mutation.yml
+++ b/.github/workflows/web-client-mutation.yml
@@ -1,19 +1,37 @@
 name: web-client-mutation
 
-# Mutation testing (StrykerJS) for the web client. Separate from the blocking
-# `web-client` workflow on purpose: mutation runs are slower, and the score is
-# advisory — `thresholds.break` is null in stryker.config.mjs, so this job
-# reports a score but never fails the build. Make it gating later by setting a
-# `break` threshold and dropping `continue-on-error`.
+# Mutation testing (StrykerJS) for the web client — NIGHTLY, not on PRs.
+#
+# Why it is off the PR critical path: the score is advisory (`thresholds.break`
+# is null in stryker.config.mjs, so Stryker exits 0 whatever the score) and the
+# job carried `continue-on-error: true`, so it could never fail a build — yet it
+# was the single most expensive thing in CI, ~47% of all PR wall-minutes
+# (median ~20 min, p90 ~86 min). On several PRs it was still running after the
+# PR had already merged, so its output was never even read. A check that cannot
+# gate a merge does not belong on the merge path.
+#
+# So it now runs once a night against the default branch, plus on demand via
+# workflow_dispatch (use that to get a score for a specific branch before you
+# merge it). There is deliberately NO push-to-main trigger: `schedule` already
+# covers main, and a per-push trigger would re-run an 80-minute job on every
+# merge for a number nobody reads between nightlies.
+#
+# It also no longer runs the changed-files variant (`test:mutation:changed`,
+# web-client/scripts/mutation-changed.ts) — that script diffs against a base
+# ref, and neither `schedule` nor `workflow_dispatch` has a `github.base_ref`.
+# The script stays for local use: `npm run test:mutation:changed -- origin/main`.
+#
+# Make it gating later by setting a `break` threshold in stryker.config.mjs and
+# moving it back onto `pull_request` — but only once it is fast enough to finish
+# before a PR merges.
 
 on:
-  # On PRs, mutate only the source files that changed vs. the base branch — fast
-  # and relevant. scripts/mutation-changed.sh diffs against the base, so we need
-  # full history + the base ref fetched (see fetch-depth + git fetch below).
-  pull_request:
-    paths:
-      - 'web-client/**'
-  # Manual full-suite run (mutates everything in stryker.config.mjs's `mutate`).
+  # 08:17 UTC ≈ 02:17/03:17 America/Chicago — off-peak for this project, and off
+  # the top of the hour, where GitHub's scheduler is most congested (a job
+  # queued at :00 can be delayed by many minutes).
+  schedule:
+    - cron: '17 8 * * *'
+  # On-demand full run against whatever ref you pick in the Actions UI.
   workflow_dispatch:
 
 defaults:
@@ -23,13 +41,14 @@ defaults:
 jobs:
   mutation:
     runs-on: ubuntu-latest
-    continue-on-error: true
+    # p90 of the historical runs is ~86 min; 120 bounds a runaway without
+    # tripping on a normal slow night. (The 6h default would burn a runner.)
+    timeout-minutes: 120
     steps:
+      # Shallow checkout is fine now: the full run mutates the `mutate` globs
+      # from stryker.config.mjs, so there is no diff against a base ref and no
+      # need for `fetch-depth: 0`.
       - uses: actions/checkout@v7
-        with:
-          # The changed-files diff needs the base branch and full history, not
-          # the default shallow checkout.
-          fetch-depth: 0
 
       - uses: actions/setup-node@v7
         with:
@@ -39,18 +58,11 @@ jobs:
 
       - run: npm ci
 
-      # PR: mutate only files changed vs. the base (skips cleanly with exit 0
-      # when no mutatable source changed). StrykerJS has no native "since" flag,
-      # so scripts/mutation-changed.sh computes the set with git and feeds it to
-      # `--mutate`.
-      - name: Run mutation tests (changed files)
-        if: github.event_name == 'pull_request'
-        run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1
-          npm run test:mutation:changed -- "origin/${{ github.base_ref }}"
-
+      # Full run. `continue-on-error` is deliberately gone: off the merge path,
+      # a red run is informational rather than blocking, and swallowing the exit
+      # code would hide a genuinely broken harness (crash / OOM / bad config).
+      # A merely-low score still exits 0 while `thresholds.break` is null.
       - name: Run mutation tests (full)
-        if: github.event_name == 'workflow_dispatch'
         run: npm run test:mutation
 
       - name: Upload HTML report

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ secrets
 # scaffolding, not a deliverable — checkboxes are the run state.
 .claude/work-order.md
 
+# scripts/reap-worktrees.sh records branch/sha/path here before removing a
+# worktree, so any reap can be undone. Local machine state, not a deliverable.
+.claude/reaped-worktrees.tsv
+
 # Helm chart dependencies are vendored at deploy time (helm dependency build
 # reads Chart.lock, which IS committed). Don't commit the downloaded tarballs.
 deploy/observability/charts/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,4 +92,8 @@ The iOS app mirrors this with `ios/Fortymm/Generated/Types.swift`, generated fro
 
 **Parse untrusted data at every boundary** — see `.claude/rules/parse-at-boundaries.md`.
 
+**Verify the artifact under test is the one you changed** — see `.claude/rules/verify-the-artifact-under-test.md`. Stale bundles, cached images, live service workers and reused dev servers all fail *silently* green.
+
+**Collect the garbage you create.** `land-the-plane` Step 9 runs `scripts/reap-worktrees.sh` after a merge. Worktrees are never removed by `gh pr merge --delete-branch`, and left alone they accumulate into stale-checkout bugs (`/epic` resuming onto a squash-merged branch, ADR numbers computed off an old tree) long before they become a disk problem.
+
 Layer-specific architecture and conventions live in `api/CLAUDE.md` and `web-client/CLAUDE.md` (loaded automatically when working in those directories).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,8 @@ The iOS app mirrors this with `ios/Fortymm/Generated/Types.swift`, generated fro
 
 **Parse untrusted data at every boundary** — see `.claude/rules/parse-at-boundaries.md`.
 
-**Verify the artifact under test is the one you changed** — see `.claude/rules/verify-the-artifact-under-test.md`. Stale bundles, cached images, live service workers and reused dev servers all fail *silently* green.
+**Verify the artifact under test is the one you changed** — see `.claude/rules/verify-the-artifact-under-test.md`.
 
-**Collect the garbage you create.** `land-the-plane` Step 9 runs `scripts/reap-worktrees.sh` after a merge. Worktrees are never removed by `gh pr merge --delete-branch`, and left alone they accumulate into stale-checkout bugs (`/epic` resuming onto a squash-merged branch, ADR numbers computed off an old tree) long before they become a disk problem.
+**Collect the garbage you create** — `land-the-plane` Step 9 runs `scripts/reap-worktrees.sh` (see its header for why).
 
 Layer-specific architecture and conventions live in `api/CLAUDE.md` and `web-client/CLAUDE.md` (loaded automatically when working in those directories).

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -49,6 +49,10 @@ the `db_session` fixture, which truncates all tables after each test.
 - **Models:** every `Mapped[datetime]` column must explicitly pass
   `DateTime(timezone=True)` to `mapped_column(...)`. Import `DateTime` from
   `sqlalchemy`. SQLAlchemy's default is naïve — do not rely on it.
+- **Test seeds too, not just columns.** `tournament_fixtures.scheduled_start` /
+  `pinned_at` are `timestamptz` (since #1152); a naïve `datetime` seeded by a test
+  reads back in the *session* timezone, so it passes on a Central-time dev box and
+  fails in UTC CI. Seed aware — `datetime.now(UTC)`, `tzinfo=UTC`.
 - Pydantic / response schemas are exempt unless they emit a naïve datetime.
 
 ## Table naming: `<singular_parent>_<plural_child>`
@@ -98,6 +102,50 @@ docstring, the generated types must be regenerated: `mise run regen-api-types`
 (`ios/Fortymm/Generated/Types.swift`), committed in the same change — the
 `openapi-schema` CI job fails on drift. (See the root `CLAUDE.md` for the full
 invariant.)
+
+## Testing gotchas
+
+**`pytest` never runs the migrations.** The `engine` fixture in `tests/conftest.py`
+builds the schema with `Base.metadata.create_all`; Alembic is never invoked. Models
+and migrations are two independent descriptions of the schema and only the models are
+under test — the whole suite goes green against a migration that is broken, missing a
+column, or would fail outright on a real database. That matters most here because of
+the edit-in-place rule above, which leaves every rewritten migration unverified. **Any
+change touching a migration must run `alembic upgrade head` against a fresh empty
+Postgres** and inspect the result (`\d+ <table>`, `information_schema`) for the
+column, its nullability and its FK. A green `pytest` is not evidence. (`alembic check`
+reports pre-existing drift on `users` / `roles` / `permissions` — the models say
+`unique=True, index=True` where the migrations create a `UniqueConstraint`. That noise
+is background, not a finding.)
+
+**A race test written the obvious way passes against a broken implementation.**
+`asyncio.Barrier` + `asyncio.gather` over two sessions both hitting the endpoint only
+reds when the scheduler happens to interleave the damning way: with the capacity
+`COUNT(*)` hoisted above the tournament row lock — a genuinely broken guard that lets
+two entrants take the same last slot — the gather-based version stayed green. **Stage
+the contention instead of hoping for it:** a gatekeeper session takes the row lock and
+holds it, both contenders are launched into the handler, the test asserts they *block*
+(`pytest.fail` if either finished — an unlocked read never waits), then the gatekeeper
+releases. Now a count above the lock necessarily reds. Copy the harness in
+`tests/test_tournament_entries.py` —
+`test_two_entrants_racing_for_the_last_slot_yield_exactly_one_entry`, plus
+`_hold_the_go_live_lock` beside it for the ADR-0017 go-live races. Why the lock is the
+whole enforcement: capacity is a count on one table compared against a column on
+another, so unlike the duplicate-entry partial unique index it *cannot* be a database
+constraint — nothing underneath catches a loser that slipped through.
+
+Concurrency is where the repo-wide "a test you have not seen fail is not evidence"
+corollary bites hardest — **run the falsification**: hoist the count above the lock,
+confirm the test reds *for the stated reason*, put it back. See
+`.claude/rules/verify-the-artifact-under-test.md`.
+
+**Some display strings are DB seed data, not app code.** Notification category and
+channel display names are seed rows: migration `0009` inserts them (`0015` adds
+`match_calls`), `tests/conftest.py` re-seeds them by hand
+(`NOTIFICATION_TYPE_LABELS` / `NOTIFICATION_CHANNEL_LABELS`, because `create_all`
+skips the migration), and `web-client/src/test/factories.ts` mirrors them for MSW.
+Three places that must change together — and a copy/wording sweep that greps `app/`
+finds none of them.
 
 ## Make illegal states unrepresentable
 

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -15,8 +15,8 @@ Infra has no single directory — it spans:
   optional tailscale proxy; migrate+seed as a `post-install,post-upgrade` hook Job).
 - `deploy/observability/` — umbrella chart (kube-prometheus-stack + loki-stack
   + tempo) in the `monitoring` namespace, tailnet-only.
-- `docker-compose.{dev,qa,e2e,uat}.yml` — compose stacks (UAT compose is a
-  documented fallback; the live UAT is k3d/Helm, above).
+- `docker-compose.{dev,qa,e2e}.yml` — the compose stacks. There is **no**
+  `docker-compose.uat.yml`: UAT is k3d/Helm only (the chart above).
 - `nginx/` — `dev.conf` (web upstream :5173) and `uat.conf` (web upstream :80);
   `uat.conf` is mounted by the QA compose stack. The k8s routing nginx does NOT
   read this file — it renders an **inline copy** in
@@ -120,9 +120,9 @@ unprompted.**
 - **Cause:** The compose nginx resolves `api:8000` / `web-client:80` to IPs
   **once at startup** and caches them; recreated containers get new IPs.
 - **Fix:** `docker compose -f docker-compose.<stack>.yml restart nginx`.
-- **Scope:** compose stacks only (dev / qa / compose-uat fallback). The **k3d
-  UAT is immune** — its nginx upstreams are Kubernetes Services, so this
-  specific stale-IP 502 doesn't apply there.
+- **Scope:** compose stacks only — **dev / qa / e2e**. The **k3d UAT is
+  immune** (and has no compose stack to restart): its nginx upstreams are
+  Kubernetes Services, so this specific stale-IP 502 doesn't apply there.
 
 ### QA `up --build` serves STALE code (two independent caches)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,7 +10,7 @@ Format and "when is a decision worth an ADR" live in
 ## Why dates and not `0019-`, `0020-`, …
 
 This directory used to say "scan for the highest number and increment". That
-produced **ten duplicated numeric prefixes**, including four different
+produced **seven duplicated numeric prefixes**, including four different
 `0008-*.md` files, because work happens in parallel worktrees: each one numbers
 off a `main` that has already moved on, so two branches confidently pick the
 same next number and both land. Issue-number prefixes (`0783-`, `0915-`) collide

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,49 @@
+# Architecture Decision Records
+
+**New ADRs are named `YYYYMMDD-slug.md`** — the date the decision was made, then
+the decision itself in lowercase hyphenated words. Example:
+`20260722-the-mcp-server-is-an-oauth-resource-server-trusting-auth0.md`.
+
+Format and "when is a decision worth an ADR" live in
+`.claude/skills/domain-modeling/ADR-FORMAT.md`.
+
+## Why dates and not `0019-`, `0020-`, …
+
+This directory used to say "scan for the highest number and increment". That
+produced **ten duplicated numeric prefixes**, including four different
+`0008-*.md` files, because work happens in parallel worktrees: each one numbers
+off a `main` that has already moved on, so two branches confidently pick the
+same next number and both land. Issue-number prefixes (`0783-`, `0915-`) collide
+for the same reason whenever one issue yields several ADRs.
+
+A calendar date is assigned by the world instead of raced for, so it cannot
+collide by construction. Several ADRs may share a date — that's fine and already
+the case; the slug is what identifies the decision.
+
+## The legacy files stay put
+
+The existing `NNNN-` ADRs are **not** being renumbered: their numbers are cited
+from PR bodies and commit messages, and renaming would break those references.
+They are grandfathered forever.
+
+The corollary: **refer to an ADR by its full filename, never by a bare number.**
+"ADR 0008" is ambiguous — there are four.
+
+## The CI check
+
+`scripts/check-adr-numbering.sh` runs in CI (the `adr-numbering` job in
+`.github/workflows/openapi-schema.yml`). It inspects only the ADRs a branch
+*adds* versus `origin/main`, so it can never fail on the legacy names.
+
+**It reports, it does not block** — `adr-numbering` is deliberately not in the
+branch-protection required contexts, so a badly-named ADR shows a red check
+while the merge still proceeds. Treat it as a prompt to rename, not a gate. (Add
+`adr-numbering` to the required contexts if you want it blocking; it is a
+one-second check, so there is no cost argument against it.)
+
+Run it locally the same way:
+
+```bash
+scripts/check-adr-numbering.sh            # vs origin/main
+scripts/check-adr-numbering.sh <base-ref>
+```

--- a/scripts/check-adr-numbering.sh
+++ b/scripts/check-adr-numbering.sh
@@ -2,7 +2,7 @@
 # Reject NEW ADRs that don't use the date-prefixed naming scheme.
 #
 # docs/adr/ carries three historical numbering schemes — sequential (0001-0018),
-# issue-number (0783, 0915, 1001) and date (20260716+) — and ten duplicated
+# issue-number (0783, 0915, 1001) and date (20260716+) — and seven duplicated
 # numeric prefixes, including FOUR different `0008-*.md` files. Cause: parallel
 # worktrees each number off a `main` that has already moved on, so two branches
 # pick the same "next" number and both land. `YYYYMMDD-slug.md` cannot collide
@@ -22,16 +22,22 @@ adr_dir="docs/adr"
 
 cd "$(git rev-parse --show-toplevel)"
 
-if ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
-  echo "check-adr-numbering: base ref '$base' not found — skipping." >&2
-  exit 0
+if git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+  # Three-dot: compare against the merge base, so unrelated ADRs that landed on
+  # main after this branch was cut don't read as "added by this branch".
+  # --diff-filter=A: additions only. A push straight to main degenerates to an
+  # empty range, which passes.
+  added="$(git diff --name-only --diff-filter=A "$base...HEAD" -- "$adr_dir" || true)"
+else
+  # Fail toward CHECKING, matching api.yml and openapi-schema.yml's `changes`.
+  # Exiting 0 here would let any badly-named ADR through, and an empty `$base`
+  # would silently degenerate to `...HEAD` — an empty range that passes
+  # everything. Inspect the whole directory instead: noisier on a legacy name,
+  # but it cannot wave a bad one through.
+  echo "check-adr-numbering: base ref '$base' not resolvable — inspecting every" >&2
+  echo "  ADR in the tree rather than only the ones this branch adds." >&2
+  added="$(git ls-files "$adr_dir" || true)"
 fi
-
-# Three-dot: compare against the merge base, so unrelated ADRs that landed on
-# main after this branch was cut don't read as "added by this branch".
-# --diff-filter=A: additions only. A push straight to main degenerates to an
-# empty range, which passes.
-added="$(git diff --name-only --diff-filter=A "$base...HEAD" -- "$adr_dir" || true)"
 
 bad=""
 while IFS= read -r path; do

--- a/scripts/check-adr-numbering.sh
+++ b/scripts/check-adr-numbering.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Reject NEW ADRs that don't use the date-prefixed naming scheme.
+#
+# docs/adr/ carries three historical numbering schemes — sequential (0001-0018),
+# issue-number (0783, 0915, 1001) and date (20260716+) — and ten duplicated
+# numeric prefixes, including FOUR different `0008-*.md` files. Cause: parallel
+# worktrees each number off a `main` that has already moved on, so two branches
+# pick the same "next" number and both land. `YYYYMMDD-slug.md` cannot collide
+# that way, because the date is assigned by the calendar rather than raced for.
+#
+# This check deliberately looks ONLY at files a branch *adds* relative to its
+# base. The legacy names are grandfathered forever — their numbers are cited
+# from PR bodies and commit messages, so renaming them would break those links.
+# It therefore passes against the repo exactly as it stands today.
+#
+# Usage: scripts/check-adr-numbering.sh [base-ref]     (default: origin/main)
+
+set -euo pipefail
+
+base="${1:-origin/main}"
+adr_dir="docs/adr"
+
+cd "$(git rev-parse --show-toplevel)"
+
+if ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+  echo "check-adr-numbering: base ref '$base' not found — skipping." >&2
+  exit 0
+fi
+
+# Three-dot: compare against the merge base, so unrelated ADRs that landed on
+# main after this branch was cut don't read as "added by this branch".
+# --diff-filter=A: additions only. A push straight to main degenerates to an
+# empty range, which passes.
+added="$(git diff --name-only --diff-filter=A "$base...HEAD" -- "$adr_dir" || true)"
+
+bad=""
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  name="${path#"$adr_dir"/}"
+
+  # Directory furniture, not a decision record.
+  case "$name" in
+    README.md) continue ;;
+  esac
+
+  # YYYYMMDD-lower-hyphen-slug.md, with a sane-looking date.
+  if [[ "$name" =~ ^(20[0-9]{2})(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])-[a-z0-9]+(-[a-z0-9]+)*\.md$ ]]; then
+    continue
+  fi
+
+  bad="$bad$path
+"
+done <<EOF
+$added
+EOF
+
+if [ -z "$bad" ]; then
+  exit 0
+fi
+
+{
+  echo "::error::New ADRs must be named docs/adr/YYYYMMDD-slug.md"
+  echo
+  echo "These added files don't match the date-prefixed scheme:"
+  printf '%s' "$bad" | sed 's/^/  - /'
+  echo
+  echo "Rename them, e.g.:"
+  echo "    git mv $adr_dir/<file> $adr_dir/$(date -u +%Y%m%d)-<lowercase-hyphenated-decision>.md"
+  echo
+  echo "Why: sequential numbering raced across worktrees and produced ten"
+  echo "duplicated prefixes (four different 0008-*.md). A calendar date can't"
+  echo "collide that way. Existing ADRs keep their legacy names on purpose —"
+  echo "this check only ever inspects files your branch ADDS."
+  echo "See $adr_dir/README.md."
+} >&2
+exit 1

--- a/scripts/install_tools.sh
+++ b/scripts/install_tools.sh
@@ -1,6 +1,43 @@
 #!/bin/bash
 set -e
 
+# --- Runs on LOCAL machines too (above the CLAUDE_CODE_REMOTE gate) --------
+#
+# Point git at the repo's checked-in hooks. Git deliberately never enables
+# hooks from a clone, so `.githooks/pre-push` (the OpenAPI-drift guard) is inert
+# until core.hooksPath is set. This is the local-side counterpart to
+# check-main-freshness.sh: the thing it protects — a wasted 15-minute CI round
+# trip on forgotten `mise run regen-api-types` — only ever bites locally, so it
+# must run before the remote-only early exit below.
+#
+# Best-effort and non-fatal: `set -e` is in force, so every git call is guarded.
+#
+# WORKTREE NOTE: `git config` without `--worktree` writes to the SHARED
+# `.git/config`, so running this from any one worktree enables the hooks for the
+# main checkout and every other worktree at once — intended. The value stays
+# RELATIVE because git resolves a relative core.hooksPath against the top level
+# of the *current* working tree, so each worktree runs its own copy of the hook.
+setup_git_hooks() {
+  local root current
+  root="$(git -C "${CLAUDE_PROJECT_DIR:-.}" rev-parse --show-toplevel 2>/dev/null)" || return 0
+  [ -d "$root/.githooks" ] || return 0
+
+  current="$(git -C "$root" config --get core.hooksPath 2>/dev/null || true)"
+  case "$current" in
+    .githooks)
+      return 0 ;;                       # already wired — idempotent no-op
+    "" | .git/hooks | */.git/hooks)
+      # Unset, or git's own default written out longhand: safe to take over.
+      git -C "$root" config core.hooksPath .githooks 2>/dev/null \
+        && echo "[hooks] core.hooksPath -> .githooks (repo hooks enabled)" \
+        || true ;;
+    *)
+      echo "[hooks] core.hooksPath is '$current' (not ours) — leaving it alone." \
+           "Run: git config core.hooksPath .githooks" ;;
+  esac
+}
+setup_git_hooks || true
+
 # Skip on local machines — you already have your own mise/asdf setup
 if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
   exit 0

--- a/scripts/reap-worktrees.sh
+++ b/scripts/reap-worktrees.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+# Reap worktrees whose PR has already merged.
+#
+# The tax this pays down: nothing in the workflow ever collected the garbage it
+# created. `land-the-plane` Step 8 runs `gh pr merge --delete-branch`, which
+# deletes the *branch* and never the *worktree* — so every shipped change left a
+# ~270 MB tombstone behind. At the time this script was written that was 311
+# worktrees / 82 GB, 236 of them (77%) on branches whose PR had long since
+# merged, plus 439 local branches.
+#
+# That sprawl is not just disk. It is the root cause of a family of recurring
+# failures: `/epic` resuming into a stale worktree whose branch was already
+# squash-merged, ADR numbers computed by "increment the max" against a stale
+# checkout, `gh pr merge --delete-branch` erroring out from inside a worktree,
+# and QA stacks OOMing a host with no headroom left.
+#
+# SAFETY MODEL — this script deletes work, so it is paranoid by design:
+#
+#   * Dry run is the DEFAULT. Nothing is removed without `--force`.
+#   * A worktree is only ever a candidate if its branch has a MERGED pull
+#     request. Squash merges do not leave ancestry, so `--merged` /
+#     `merge-base --is-ancestor` both under-report; the PR state is the only
+#     honest signal. No PR, or a closed-unmerged PR, means KEEP.
+#   * Even then it is only auto-reaped when nothing would be lost: no modified
+#     tracked files, no unpushed commits beyond what the PR merged, and no
+#     untracked file that looks like source rather than build junk.
+#   * Anything merged-but-not-clean is reported as REVIEW and skipped, unless
+#     you explicitly pass `--include-review`.
+#   * The main checkout, the worktree you are standing in, and any worktree
+#     git has marked `locked` are never touched.
+#
+# Usage:
+#   scripts/reap-worktrees.sh                      # dry run: show what would go
+#   scripts/reap-worktrees.sh --force              # reap the SAFE ones
+#   scripts/reap-worktrees.sh --force --include-review
+#   scripts/reap-worktrees.sh --docker             # also report docker residue
+#   scripts/reap-worktrees.sh --force --docker     # ...and prune it
+#
+set -euo pipefail
+
+FORCE=0
+INCLUDE_REVIEW=0
+DO_DOCKER=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force|-f)        FORCE=1 ;;
+    --include-review)  INCLUDE_REVIEW=1 ;;
+    --docker)          DO_DOCKER=1 ;;
+    # Print the header block, stopping at the first non-comment line. A
+    # hardcoded line range silently rots every time the header grows.
+    -h|--help)         awk 'NR>1 && !/^#/{exit} NR>1{sub(/^# ?/,""); print}' "$0"; exit 0 ;;
+    *) echo "unknown flag: $1 (try --help)" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# Capture the invoking worktree BEFORE we move — we must never reap the tree the
+# caller is standing in.
+CALLED_FROM="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+# Always operate from the MAIN checkout: `git worktree remove` must not be run
+# from inside the worktree being removed, and a relative path would resolve
+# against whichever worktree invoked us.
+#
+# `substr($0,10)` not `$2` — awk's $2 splits on whitespace, so a checkout path
+# containing a space would be truncated to its first word. That matters more
+# here than anywhere else in this script: MAIN_ROOT is what we `cd` into, and
+# it is what every "is this the main checkout?" comparison below tests against.
+# A truncated value makes those comparisons fail, which would make the main
+# checkout itself look reapable.
+MAIN_ROOT="$(git worktree list --porcelain | awk 'NR==1{print substr($0,10)}')"
+cd "$MAIN_ROOT"
+
+command -v gh >/dev/null 2>&1 || { echo "gh CLI required (PR state is the only safe merge signal)" >&2; exit 1; }
+
+echo "Fetching merged PR head refs..."
+# One temp dir, one trap, registered once — so there is no ordering question
+# about which temp files a given trap covers.
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+MERGED="$TMP/merged"; LOCKED="$TMP/locked"
+# `headRefName<TAB>headRefOid` — the oid is the commit GitHub actually merged.
+# Comparing the local branch tip to it is the only reliable "did I commit
+# anything the PR never saw?" test: `git cherry` compares patch-ids, and a
+# SQUASH merge collapses N commits into one, so every commit on every
+# squash-merged branch reads as unmerged. That false positive is what makes the
+# naive check useless here — this repo squash-merges everything.
+#
+# `--state merged` (not `--state all` filtered locally): the closed/open rows
+# would be fetched over the same ~6 paginated round trips and then thrown away,
+# and nothing below acts on them.
+gh pr list --state merged --limit 2000 --json headRefName,headRefOid \
+  -q '.[] | [.headRefName, .headRefOid] | @tsv' | sort -u > "$MERGED"
+echo "  $(wc -l < "$MERGED" | tr -d ' ') merged head refs known"
+echo
+
+# An untracked path is "junk" if it is build output / tooling residue. Anything
+# else is treated as possible work and forces REVIEW.
+#
+# This list is deliberately SHORT, because it is only the residue: the caller
+# feeds us `git ls-files --others --exclude-standard`, which has already applied
+# .gitignore, so node_modules/.venv/dist/.env/.DS_Store and friends never reach
+# here from a current branch. What this covers is the stale-branch case — a
+# worktree checked out from a commit whose .gitignore predates an entry — plus
+# the few paths no .gitignore lists. Keep it minimal: a long list here is a
+# second, divergent definition of "junk" governing a destructive decision.
+is_junk() {
+  case "$1" in
+    .venv/*|.venv)                        return 0 ;;   # only api/.gitignore has it
+    */.vite/*|*/xcshareddata/*)           return 0 ;;
+    .qa-artifacts/*|.playwright-cli/*|*/.playwright-cli/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Precompute the locked set once — a `locked` line follows its `worktree` line
+# in the porcelain stream, so a single pass is both cheaper and less fragile
+# than re-grepping with the path (which may contain regex metacharacters).
+git worktree list --porcelain | awk '
+  /^worktree /{ w=substr($0,10) }
+  /^locked/   { print w }
+' > "$LOCKED"
+
+# Both arrays use the same packed "path|branch|reason" encoding, so nothing has
+# to keep two parallel arrays in step.
+safe=(); review=(); keep_n=0
+
+while IFS= read -r line; do
+  case "$line" in worktree\ *) wt="${line#worktree }" ;; *) continue ;; esac
+
+  # Never the main checkout.
+  [ "$wt" = "$MAIN_ROOT" ] && continue
+
+  # Never the worktree we were invoked from.
+  if [ -n "$CALLED_FROM" ] && [ "$wt" = "$CALLED_FROM" ]; then
+    echo "SKIP  (current worktree)  $wt"; continue
+  fi
+
+  # Never a locked worktree — the lock is an explicit "leave this alone".
+  if grep -qxF "$wt" "$LOCKED"; then
+    echo "SKIP  (locked)           $wt"; continue
+  fi
+
+  branch="$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  if [ -z "$branch" ]; then
+    keep_n=$((keep_n+1)); continue          # detached HEAD: no PR to check against
+  fi
+
+  merged_oid="$(awk -F'\t' -v b="$branch" '$1==b{print $2; exit}' "$MERGED")"
+  if [ -z "$merged_oid" ]; then
+    keep_n=$((keep_n+1)); continue
+  fi
+
+  # --- merged: now decide whether anything would be lost -------------------
+  why=""
+
+  # 1. Modified/staged TRACKED files.
+  if [ -n "$(git -C "$wt" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+    why="modified tracked files"
+  fi
+
+  # 2. Untracked files that don't look like build junk.
+  if [ -z "$why" ]; then
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      if ! is_junk "$f"; then why="untracked: $f"; break; fi
+    done < <(git -C "$wt" ls-files --others --exclude-standard 2>/dev/null | head -200)
+  fi
+
+  # 3. Commits made AFTER the PR merged — the only way a merged branch can still
+  #    hold work. If the local tip is the exact commit GitHub merged, everything
+  #    on this branch is in main by definition.
+  if [ -z "$why" ]; then
+    local_tip="$(git -C "$wt" rev-parse HEAD 2>/dev/null || true)"
+    if [ -z "$local_tip" ]; then
+      why="cannot resolve local HEAD"
+    elif [ "$local_tip" != "$merged_oid" ]; then
+      # The merged commit may not be in the local object DB at all (never
+      # fetched, or gc'd). FAIL CLOSED: an unanswerable question is a REVIEW,
+      # never a SAFE. Getting this backwards silently deletes real work.
+      if ! git cat-file -e "${merged_oid}^{commit}" 2>/dev/null; then
+        why="merged commit ${merged_oid:0:12} not in local object db — cannot prove nothing is lost"
+      else
+        # Tip differs but both are known. Only a problem if the tip carries
+        # commits the merge never saw; a branch sitting *behind* its own merge
+        # is fine (its content is a subset of what shipped).
+        ahead="$(git -C "$wt" rev-list --count "${merged_oid}..${local_tip}" 2>/dev/null || echo unknown)"
+        if [ "$ahead" = "unknown" ]; then
+          why="cannot compare tip to merged commit"
+        elif [ "$ahead" -gt 0 ]; then
+          why="$ahead commit(s) added after the PR merged"
+        fi
+      fi
+    fi
+  fi
+
+  if [ -n "$why" ]; then
+    review+=("$wt|$branch|$why")
+  else
+    safe+=("$wt|$branch")
+  fi
+done < <(git worktree list --porcelain)
+
+echo
+echo "=========================================================="
+echo "  SAFE to reap (PR merged, nothing to lose): ${#safe[@]}"
+echo "  REVIEW (PR merged, but something is there): ${#review[@]}"
+echo "  KEEP (no merged PR): $keep_n"
+echo "=========================================================="
+
+if [ "${#review[@]}" -gt 0 ]; then
+  echo
+  echo "REVIEW — not touched unless you pass --include-review:"
+  # `${arr[@]+"${arr[@]}"}`: under `set -u`, macOS's bash 3.2 treats a plain
+  # "${arr[@]}" on an EMPTY array as an unbound variable and aborts.
+  for r in ${review[@]+"${review[@]}"}; do
+    rest="${r#*|}"; echo "    ${rest%%|*} — ${rest#*|}"
+  done
+fi
+
+# Recoverability: record branch -> sha -> path before anything is removed, so a
+# reap can always be undone with `git worktree add -b <branch> <path> <sha>`.
+# The shas are all reachable (they are what the merged PRs contain), but making
+# the mapping durable means you never have to go spelunking for one.
+MANIFEST="${MAIN_ROOT}/.claude/reaped-worktrees.tsv"
+
+reap_one() {
+  local wt="$1" branch="$2"
+  if [ "$FORCE" -eq 1 ]; then
+    printf '%s\t%s\t%s\n' "$branch" "$(git -C "$wt" rev-parse HEAD 2>/dev/null || echo '?')" "$wt" \
+      >> "$MANIFEST"
+    git worktree remove --force "$wt" 2>/dev/null \
+      || { echo "    ! could not remove $wt"; return; }
+    # Branch is only deleted once its worktree is gone; -D because a
+    # squash-merged branch never looks "merged" to git.
+    git branch -D "$branch" >/dev/null 2>&1 || true
+    echo "    reaped $branch"
+  else
+    echo "    would reap $branch  ($wt)"
+  fi
+}
+
+echo
+if [ "$FORCE" -eq 1 ]; then echo "Reaping..."; else echo "DRY RUN — nothing will be removed. Re-run with --force."; fi
+for entry in ${safe[@]+"${safe[@]}"}; do
+  reap_one "${entry%%|*}" "${entry#*|}"
+done
+if [ "$INCLUDE_REVIEW" -eq 1 ]; then
+  echo "  (--include-review)"
+  for entry in ${review[@]+"${review[@]}"}; do
+    rest="${entry#*|}"
+    reap_one "${entry%%|*}" "${rest%%|*}"
+  done
+fi
+
+if [ "$FORCE" -eq 1 ]; then
+  git worktree prune
+  echo
+  echo "Local branches remaining: $(git branch | wc -l | tr -d ' ')"
+fi
+
+if [ "$DO_DOCKER" -eq 1 ]; then
+  echo
+  echo "=== docker residue ==="
+  docker system df 2>/dev/null || { echo "docker unavailable"; exit 0; }
+  if [ "$FORCE" -eq 1 ]; then
+    echo "Pruning build cache and dangling images (images in use are untouched)..."
+    docker builder prune -f >/dev/null 2>&1 || true
+    docker image prune -f  >/dev/null 2>&1 || true
+    echo "After:"; docker system df 2>/dev/null
+  else
+    echo "(dry run — pass --force to prune build cache + dangling images)"
+  fi
+fi

--- a/scripts/reap-worktrees.sh
+++ b/scripts/reap-worktrees.sh
@@ -106,7 +106,7 @@ echo
 # second, divergent definition of "junk" governing a destructive decision.
 is_junk() {
   case "$1" in
-    .venv/*|.venv)                        return 0 ;;   # only api/.gitignore has it
+    .venv/*|*/.venv/*|.venv)              return 0 ;;   # api/.venv is the real one
     */.vite/*|*/xcshareddata/*)           return 0 ;;
     .qa-artifacts/*|.playwright-cli/*|*/.playwright-cli/*) return 0 ;;
     *) return 1 ;;
@@ -121,8 +121,10 @@ git worktree list --porcelain | awk '
   /^locked/   { print w }
 ' > "$LOCKED"
 
-# Both arrays use the same packed "path|branch|reason" encoding, so nothing has
-# to keep two parallel arrays in step.
+# Both arrays pack their fields into one string, TAB-separated, so nothing has to
+# keep two parallel arrays in step. Tab (not `|`) because a `|` is legal in a git
+# branch name while a control character is not — so the delimiter can never
+# appear in the data. `safe` carries path+branch; `review` adds the reason.
 safe=(); review=(); keep_n=0
 
 while IFS= read -r line; do
@@ -161,10 +163,18 @@ while IFS= read -r line; do
 
   # 2. Untracked files that don't look like build junk.
   if [ -z "$why" ]; then
+    # Read one MORE than the cap so truncation is detectable. A bounded scan
+    # that silently stops is worse than no scan: the one path that can lose work
+    # is a file we never looked at being classified SAFE and force-removed.
+    n=0
     while IFS= read -r f; do
       [ -n "$f" ] || continue
+      n=$((n+1))
+      if [ "$n" -gt 200 ]; then
+        why="more than 200 untracked files — not audited, review by hand"; break
+      fi
       if ! is_junk "$f"; then why="untracked: $f"; break; fi
-    done < <(git -C "$wt" ls-files --others --exclude-standard 2>/dev/null | head -200)
+    done < <(git -C "$wt" ls-files --others --exclude-standard 2>/dev/null | head -201)
   fi
 
   # 3. Commits made AFTER the PR merged — the only way a merged branch can still
@@ -195,9 +205,9 @@ while IFS= read -r line; do
   fi
 
   if [ -n "$why" ]; then
-    review+=("$wt|$branch|$why")
+    review+=("$wt	$branch	$why")
   else
-    safe+=("$wt|$branch")
+    safe+=("$wt	$branch")
   fi
 done < <(git worktree list --porcelain)
 
@@ -214,14 +224,19 @@ if [ "${#review[@]}" -gt 0 ]; then
   # `${arr[@]+"${arr[@]}"}`: under `set -u`, macOS's bash 3.2 treats a plain
   # "${arr[@]}" on an EMPTY array as an unbound variable and aborts.
   for r in ${review[@]+"${review[@]}"}; do
-    rest="${r#*|}"; echo "    ${rest%%|*} — ${rest#*|}"
+    IFS=$'\t' read -r _ b w <<<"$r"; echo "    $b — $w"
   done
 fi
 
 # Recoverability: record branch -> sha -> path before anything is removed, so a
-# reap can always be undone with `git worktree add -b <branch> <path> <sha>`.
-# The shas are all reachable (they are what the merged PRs contain), but making
-# the mapping durable means you never have to go spelunking for one.
+# reap can be undone with `git worktree add -b <branch> <path> <sha>`.
+#
+# Be honest about the shelf life. Because this repo SQUASH-merges, the recorded
+# sha is NOT an ancestor of main (see the note on $MERGED), so once the branch is
+# deleted its only local anchors are the reflog and gc's grace period. After that
+# the commit is recoverable from the remote — `git fetch origin refs/pull/<N>/head`
+# — but not from this clone. The content itself is never at risk: it is in main,
+# squashed.
 MANIFEST="${MAIN_ROOT}/.claude/reaped-worktrees.tsv"
 
 reap_one() {
@@ -243,13 +258,12 @@ reap_one() {
 echo
 if [ "$FORCE" -eq 1 ]; then echo "Reaping..."; else echo "DRY RUN — nothing will be removed. Re-run with --force."; fi
 for entry in ${safe[@]+"${safe[@]}"}; do
-  reap_one "${entry%%|*}" "${entry#*|}"
+  IFS=$'\t' read -r wt_ br_ <<<"$entry"; reap_one "$wt_" "$br_"
 done
 if [ "$INCLUDE_REVIEW" -eq 1 ]; then
   echo "  (--include-review)"
   for entry in ${review[@]+"${review[@]}"}; do
-    rest="${entry#*|}"
-    reap_one "${entry%%|*}" "${rest%%|*}"
+    IFS=$'\t' read -r wt_ br_ _ <<<"$entry"; reap_one "$wt_" "$br_"
   done
 fi
 

--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -37,6 +37,97 @@ Reach for the `react-component` skill (component + page-object + factory + vites
 quartet) and the `fetching-data` skill (TanStack Query `queryOptions` factories)
 for the file-layout conventions — they're not otherwise written down here.
 
+### `throwOnError` also throws on a *background* refetch
+
+React Query v5 sets `status: 'error'` on a failed refetch **even when data is
+already cached** (the reducer's `error` case is unconditional), and
+`getHasError` (`react-query/errorBoundaryUtils`) throws during render whenever
+`isError && !isFetching && throwOnError`. So `throwOnError: true` does **not**
+mean "throw if the initial load fails" — it means "throw whenever the last fetch
+failed". The moment a *success* path invalidates a query, a transient GET blip
+after a write that actually **succeeded** replaces a working, rendered screen
+with the error boundary. That shipped: `invalidateMatchViews` added
+`invalidateQueries(matchQueryKey(...))` to the save path (#843), so every
+successful score save refetched the match — and a blip threw the user out
+mid-scoring.
+
+Where the screen has data worth keeping, predicate it instead:
+
+```ts
+throwOnError: (_error, query) => query.state.data === undefined
+```
+
+An initial load (no cached data) still throws, so the boundary renders its
+retry; a background failure leaves last-good data on screen and the next good
+refetch heals it. Live in `matchQueryOptions` (`src/api/matches.ts`) and
+`tournamentDetailQuery` (`src/components/tournaments/data/api.ts`, which also
+excludes an expected 404).
+
+**The test trap:** a background error changes neither `data` nor `isLoading`, so
+a tracked-props observer that reads only those never notifies — the component
+doesn't re-render, and the throw lands on the *next* render (in production,
+whatever else re-renders the screen, e.g. the save mutation settling). A test
+must force that render — `rerender(...)` after the failed refetch — or it passes
+just as happily against a bare `throwOnError: true`. See the #843 regression
+pair in `src/api/matches.test.ts` ("keeps last-good data…" / "throws to the
+boundary when the initial match load fails").
+
+Related: `invalidateQueries` defaults to `cancelRefetch: true`, but query-core's
+`Query.fetch` only cancels when `state.data !== undefined`. On a cold cache the
+second fetch **joins** the in-flight one, so a stale initial fetch can be the
+one that wins.
+
+### StrictMode latches a cleanup-only mounted ref
+
+The app root is wrapped in `<StrictMode>` (`src/main.tsx`), so effects fire
+mount → cleanup → remount. An is-mounted ref written cleanup-only
+(`useRef(true)` + `useEffect(() => () => { ref.current = false }, [])`) latches
+`false` on that first simulated unmount and **never recovers**, permanently
+disabling whatever it guards — e.g. the post-`await` `navigate()` in
+`useStartMatch` (`src/components/matches/match-setup/use-start-match.ts`), which
+silently stopped redirecting after a match was created.
+
+Both routine verifications passed while it was broken: `vite build` is a
+production build (no double-invoke), and the vitest harness used a plain
+`render` (no StrictMode). Only the e2e suite went red — on 10 new-match-flow
+specs. Hence:
+
+- **Any is-mounted ref sets `true` in the effect body**, not just `false` in
+  cleanup. Same rule for anything else a StrictMode remount has to re-arm.
+- **When a vitest harness exercises effect-lifecycle behaviour, wrap the render
+  in `<StrictMode>`** so the double-invoke is reproduced — see
+  `use-start-match.test.tsx`.
+- **Run `npm run test:e2e` even when you've reasoned "no schema change, no stubs
+  affected".** Note it only catches this **locally**: `playwright.config.ts`
+  serves `vite dev` locally but `vite preview` (production build, no
+  double-invoke) on CI.
+
+### The vitest timeout collision produces an opaque red
+
+`src/test/setup.ts` sets Testing Library's `asyncUtilTimeout: 5000`. Left at
+vitest's *default* `testTimeout` — also 5000 — a bare `await waitFor(...)` gets a
+wait budget equal to the whole test budget: when the async chain is slow both
+expire at the same instant and the test dies with `Test timed out in 5000ms`
+instead of Testing Library's diagnosable "Unable to find <element>" —
+intermittent red CI with zero actionable output.
+
+**`vite.config.ts` therefore sets `testTimeout: 10000`, and these two numbers
+must stay unequal.** Don't "tidy" them back to matching: the outer bound exists
+so the inner one can expire first and report *what* it was waiting for. This is
+the fix for all ~410 `waitFor` call sites at once — only 4 pass a bound of their
+own, so per-call discipline was never going to cover it.
+
+- A `waitFor` following a `fireEvent` may still want its own tighter bound, e.g.
+  `{ timeout: 2000 }`. (`fireEvent` returns synchronously without flushing
+  `act`, unlike `user.click`, so the whole async chain runs inside that window.)
+  Examples in `src/components/matches/score-entry.test.tsx`.
+- Reproduce flakes with `--no-file-parallelism`, repeatedly; warm runs hide it.
+- **Corollary: a 5000ms timeout is not a discriminating "red".** It can't tell
+  "the guard blocked the navigation" from "the harness never landed the
+  refetch", so a red built on one proves nothing. Discriminate by holding the
+  harness, handlers and fixtures byte-identical and varying only the thing under
+  test, or by probing the DOM at failure time.
+
 ## Conventions
 
 - Path alias: `@/*` → `src/*` (see `vite.config.ts`, `components.json`).

--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -124,9 +124,11 @@ own, so per-call discipline was never going to cover it.
 - Reproduce flakes with `--no-file-parallelism`, repeatedly; warm runs hide it.
 - **Corollary: a 5000ms timeout is not a discriminating "red".** It can't tell
   "the guard blocked the navigation" from "the harness never landed the
-  refetch", so a red built on one proves nothing. Discriminate by holding the
-  harness, handlers and fixtures byte-identical and varying only the thing under
-  test, or by probing the DOM at failure time.
+  refetch", so a red built on one proves nothing — the local case of the
+  repo-wide "an undiscriminated red proves nothing" rule
+  (`.claude/rules/verify-the-artifact-under-test.md`). Discriminate by holding
+  the harness, handlers and fixtures byte-identical and varying only the thing
+  under test, or by probing the DOM at failure time.
 
 ## Conventions
 

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -9,46 +9,42 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as AppRouteRouteImport } from './routes/_app/route'
-import { Route as ConfirmEmailRouteImport } from './routes/confirm-email'
 import { Route as DesignSystemRouteImport } from './routes/design-system'
-import { Route as AppAdminRouteImport } from './routes/_app/admin'
-import { Route as AppDashboardRouteImport } from './routes/_app/dashboard'
-import { Route as AppNotificationsRouteImport } from './routes/_app/notifications'
-import { Route as AppSettingsRouteImport } from './routes/_app/settings'
-import { Route as AppTournamentsRouteImport } from './routes/_app/tournaments'
+import { Route as ConfirmEmailRouteImport } from './routes/confirm-email'
+import { Route as AppRouteRouteImport } from './routes/_app/route'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as LoginIndexRouteImport } from './routes/login.index'
-import { Route as LoginSentRouteImport } from './routes/login.sent'
-import { Route as LoginVerifyingRouteImport } from './routes/login.verifying'
 import { Route as LoginWelcomeRouteImport } from './routes/login.welcome'
-import { Route as AppAdminIndexRouteImport } from './routes/_app/admin.index'
-import { Route as AppAdminBroadcastRouteImport } from './routes/_app/admin.broadcast'
-import { Route as AppAdminPermissionsRouteImport } from './routes/_app/admin.permissions'
-import { Route as AppAdminRolesRouteImport } from './routes/_app/admin.roles'
-import { Route as AppAdminScheduleSolvesRouteImport } from './routes/_app/admin.schedule-solves'
-import { Route as AppAdminUsersRouteImport } from './routes/_app/admin.users'
-import { Route as AppMatchesIndexRouteImport } from './routes/_app/matches/index'
-import { Route as AppMatchesNewRouteImport } from './routes/_app/matches/new'
-import { Route as AppNotificationsIndexRouteImport } from './routes/_app/notifications.index'
-import { Route as AppNotificationsSettingsRouteImport } from './routes/_app/notifications.settings'
-import { Route as AppPlayersIndexRouteImport } from './routes/_app/players/index'
-import { Route as AppPlayersUserIdRouteImport } from './routes/_app/players/$userId'
+import { Route as LoginVerifyingRouteImport } from './routes/login.verifying'
+import { Route as LoginSentRouteImport } from './routes/login.sent'
+import { Route as AppTournamentsRouteImport } from './routes/_app/tournaments'
+import { Route as AppSettingsRouteImport } from './routes/_app/settings'
+import { Route as AppNotificationsRouteImport } from './routes/_app/notifications'
+import { Route as AppDashboardRouteImport } from './routes/_app/dashboard'
+import { Route as AppAdminRouteImport } from './routes/_app/admin'
 import { Route as AppTournamentsIndexRouteImport } from './routes/_app/tournaments/index'
+import { Route as AppPlayersIndexRouteImport } from './routes/_app/players/index'
+import { Route as AppNotificationsIndexRouteImport } from './routes/_app/notifications.index'
+import { Route as AppMatchesIndexRouteImport } from './routes/_app/matches/index'
+import { Route as AppAdminIndexRouteImport } from './routes/_app/admin.index'
 import { Route as AppTournamentsTournamentIdRouteImport } from './routes/_app/tournaments.$tournamentId'
+import { Route as AppPlayersUserIdRouteImport } from './routes/_app/players/$userId'
+import { Route as AppNotificationsSettingsRouteImport } from './routes/_app/notifications.settings'
+import { Route as AppMatchesNewRouteImport } from './routes/_app/matches/new'
+import { Route as AppAdminUsersRouteImport } from './routes/_app/admin.users'
+import { Route as AppAdminScheduleSolvesRouteImport } from './routes/_app/admin.schedule-solves'
+import { Route as AppAdminRolesRouteImport } from './routes/_app/admin.roles'
+import { Route as AppAdminPermissionsRouteImport } from './routes/_app/admin.permissions'
+import { Route as AppAdminBroadcastRouteImport } from './routes/_app/admin.broadcast'
 import { Route as AppMatchesMatchIdIndexRouteImport } from './routes/_app/matches.$matchId.index'
 import { Route as AppPlayersUserIdMatchesRouteImport } from './routes/_app/players/$userId_.matches'
 import { Route as AppMatchesMatchIdResultsNewRouteImport } from './routes/_app/matches.$matchId.results.new'
-import { Route as AppMatchesMatchIdGamesGameNumberScoresEditRouteImport } from './routes/_app/matches.$matchId.games.$gameNumber.scores.edit'
 import { Route as AppMatchesMatchIdGamesGameNumberScoresNewRouteImport } from './routes/_app/matches.$matchId.games.$gameNumber.scores.new'
+import { Route as AppMatchesMatchIdGamesGameNumberScoresEditRouteImport } from './routes/_app/matches.$matchId.games.$gameNumber.scores.edit'
 
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AppRouteRoute = AppRouteRouteImport.update({
-  id: '/_app',
+const DesignSystemRoute = DesignSystemRouteImport.update({
+  id: '/design-system',
+  path: '/design-system',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ConfirmEmailRoute = ConfirmEmailRouteImport.update({
@@ -56,49 +52,18 @@ const ConfirmEmailRoute = ConfirmEmailRouteImport.update({
   path: '/confirm-email',
   getParentRoute: () => rootRouteImport,
 } as any)
-const DesignSystemRoute = DesignSystemRouteImport.update({
-  id: '/design-system',
-  path: '/design-system',
+const AppRouteRoute = AppRouteRouteImport.update({
+  id: '/_app',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AppAdminRoute = AppAdminRouteImport.update({
-  id: '/admin',
-  path: '/admin',
-  getParentRoute: () => AppRouteRoute,
-} as any)
-const AppDashboardRoute = AppDashboardRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
-  getParentRoute: () => AppRouteRoute,
-} as any)
-const AppNotificationsRoute = AppNotificationsRouteImport.update({
-  id: '/notifications',
-  path: '/notifications',
-  getParentRoute: () => AppRouteRoute,
-} as any)
-const AppSettingsRoute = AppSettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => AppRouteRoute,
-} as any)
-const AppTournamentsRoute = AppTournamentsRouteImport.update({
-  id: '/tournaments',
-  path: '/tournaments',
-  getParentRoute: () => AppRouteRoute,
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const LoginIndexRoute = LoginIndexRouteImport.update({
   id: '/login/',
   path: '/login/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LoginSentRoute = LoginSentRouteImport.update({
-  id: '/login/sent',
-  path: '/login/sent',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LoginVerifyingRoute = LoginVerifyingRouteImport.update({
-  id: '/login/verifying',
-  path: '/login/verifying',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginWelcomeRoute = LoginWelcomeRouteImport.update({
@@ -106,65 +71,39 @@ const LoginWelcomeRoute = LoginWelcomeRouteImport.update({
   path: '/login/welcome',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AppAdminIndexRoute = AppAdminIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => AppAdminRoute,
+const LoginVerifyingRoute = LoginVerifyingRouteImport.update({
+  id: '/login/verifying',
+  path: '/login/verifying',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const AppAdminBroadcastRoute = AppAdminBroadcastRouteImport.update({
-  id: '/broadcast',
-  path: '/broadcast',
-  getParentRoute: () => AppAdminRoute,
+const LoginSentRoute = LoginSentRouteImport.update({
+  id: '/login/sent',
+  path: '/login/sent',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const AppAdminPermissionsRoute = AppAdminPermissionsRouteImport.update({
-  id: '/permissions',
-  path: '/permissions',
-  getParentRoute: () => AppAdminRoute,
-} as any)
-const AppAdminRolesRoute = AppAdminRolesRouteImport.update({
-  id: '/roles',
-  path: '/roles',
-  getParentRoute: () => AppAdminRoute,
-} as any)
-const AppAdminScheduleSolvesRoute = AppAdminScheduleSolvesRouteImport.update({
-  id: '/schedule-solves',
-  path: '/schedule-solves',
-  getParentRoute: () => AppAdminRoute,
-} as any)
-const AppAdminUsersRoute = AppAdminUsersRouteImport.update({
-  id: '/users',
-  path: '/users',
-  getParentRoute: () => AppAdminRoute,
-} as any)
-const AppMatchesIndexRoute = AppMatchesIndexRouteImport.update({
-  id: '/matches/',
-  path: '/matches/',
+const AppTournamentsRoute = AppTournamentsRouteImport.update({
+  id: '/tournaments',
+  path: '/tournaments',
   getParentRoute: () => AppRouteRoute,
 } as any)
-const AppMatchesNewRoute = AppMatchesNewRouteImport.update({
-  id: '/matches/new',
-  path: '/matches/new',
+const AppSettingsRoute = AppSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => AppRouteRoute,
 } as any)
-const AppNotificationsIndexRoute = AppNotificationsIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => AppNotificationsRoute,
-} as any)
-const AppNotificationsSettingsRoute =
-  AppNotificationsSettingsRouteImport.update({
-    id: '/settings',
-    path: '/settings',
-    getParentRoute: () => AppNotificationsRoute,
-  } as any)
-const AppPlayersIndexRoute = AppPlayersIndexRouteImport.update({
-  id: '/players/',
-  path: '/players/',
+const AppNotificationsRoute = AppNotificationsRouteImport.update({
+  id: '/notifications',
+  path: '/notifications',
   getParentRoute: () => AppRouteRoute,
 } as any)
-const AppPlayersUserIdRoute = AppPlayersUserIdRouteImport.update({
-  id: '/players/$userId',
-  path: '/players/$userId',
+const AppDashboardRoute = AppDashboardRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
+  getParentRoute: () => AppRouteRoute,
+} as any)
+const AppAdminRoute = AppAdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
   getParentRoute: () => AppRouteRoute,
 } as any)
 const AppTournamentsIndexRoute = AppTournamentsIndexRouteImport.update({
@@ -172,12 +111,73 @@ const AppTournamentsIndexRoute = AppTournamentsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => AppTournamentsRoute,
 } as any)
+const AppPlayersIndexRoute = AppPlayersIndexRouteImport.update({
+  id: '/players/',
+  path: '/players/',
+  getParentRoute: () => AppRouteRoute,
+} as any)
+const AppNotificationsIndexRoute = AppNotificationsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AppNotificationsRoute,
+} as any)
+const AppMatchesIndexRoute = AppMatchesIndexRouteImport.update({
+  id: '/matches/',
+  path: '/matches/',
+  getParentRoute: () => AppRouteRoute,
+} as any)
+const AppAdminIndexRoute = AppAdminIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AppAdminRoute,
+} as any)
 const AppTournamentsTournamentIdRoute =
   AppTournamentsTournamentIdRouteImport.update({
     id: '/$tournamentId',
     path: '/$tournamentId',
     getParentRoute: () => AppTournamentsRoute,
   } as any)
+const AppPlayersUserIdRoute = AppPlayersUserIdRouteImport.update({
+  id: '/players/$userId',
+  path: '/players/$userId',
+  getParentRoute: () => AppRouteRoute,
+} as any)
+const AppNotificationsSettingsRoute =
+  AppNotificationsSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AppNotificationsRoute,
+  } as any)
+const AppMatchesNewRoute = AppMatchesNewRouteImport.update({
+  id: '/matches/new',
+  path: '/matches/new',
+  getParentRoute: () => AppRouteRoute,
+} as any)
+const AppAdminUsersRoute = AppAdminUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => AppAdminRoute,
+} as any)
+const AppAdminScheduleSolvesRoute = AppAdminScheduleSolvesRouteImport.update({
+  id: '/schedule-solves',
+  path: '/schedule-solves',
+  getParentRoute: () => AppAdminRoute,
+} as any)
+const AppAdminRolesRoute = AppAdminRolesRouteImport.update({
+  id: '/roles',
+  path: '/roles',
+  getParentRoute: () => AppAdminRoute,
+} as any)
+const AppAdminPermissionsRoute = AppAdminPermissionsRouteImport.update({
+  id: '/permissions',
+  path: '/permissions',
+  getParentRoute: () => AppAdminRoute,
+} as any)
+const AppAdminBroadcastRoute = AppAdminBroadcastRouteImport.update({
+  id: '/broadcast',
+  path: '/broadcast',
+  getParentRoute: () => AppAdminRoute,
+} as any)
 const AppMatchesMatchIdIndexRoute = AppMatchesMatchIdIndexRouteImport.update({
   id: '/matches/$matchId/',
   path: '/matches/$matchId/',
@@ -194,16 +194,16 @@ const AppMatchesMatchIdResultsNewRoute =
     path: '/matches/$matchId/results/new',
     getParentRoute: () => AppRouteRoute,
   } as any)
-const AppMatchesMatchIdGamesGameNumberScoresEditRoute =
-  AppMatchesMatchIdGamesGameNumberScoresEditRouteImport.update({
-    id: '/matches/$matchId/games/$gameNumber/scores/edit',
-    path: '/matches/$matchId/games/$gameNumber/scores/edit',
-    getParentRoute: () => AppRouteRoute,
-  } as any)
 const AppMatchesMatchIdGamesGameNumberScoresNewRoute =
   AppMatchesMatchIdGamesGameNumberScoresNewRouteImport.update({
     id: '/matches/$matchId/games/$gameNumber/scores/new',
     path: '/matches/$matchId/games/$gameNumber/scores/new',
+    getParentRoute: () => AppRouteRoute,
+  } as any)
+const AppMatchesMatchIdGamesGameNumberScoresEditRoute =
+  AppMatchesMatchIdGamesGameNumberScoresEditRouteImport.update({
+    id: '/matches/$matchId/games/$gameNumber/scores/edit',
+    path: '/matches/$matchId/games/$gameNumber/scores/edit',
     getParentRoute: () => AppRouteRoute,
   } as any)
 
@@ -418,18 +418,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_app': {
-      id: '/_app'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof AppRouteRouteImport
+    '/design-system': {
+      id: '/design-system'
+      path: '/design-system'
+      fullPath: '/design-system'
+      preLoaderRoute: typeof DesignSystemRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/confirm-email': {
@@ -439,67 +432,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ConfirmEmailRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/design-system': {
-      id: '/design-system'
-      path: '/design-system'
-      fullPath: '/design-system'
-      preLoaderRoute: typeof DesignSystemRouteImport
+    '/_app': {
+      id: '/_app'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof AppRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_app/admin': {
-      id: '/_app/admin'
-      path: '/admin'
-      fullPath: '/admin'
-      preLoaderRoute: typeof AppAdminRouteImport
-      parentRoute: typeof AppRouteRoute
-    }
-    '/_app/dashboard': {
-      id: '/_app/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof AppDashboardRouteImport
-      parentRoute: typeof AppRouteRoute
-    }
-    '/_app/notifications': {
-      id: '/_app/notifications'
-      path: '/notifications'
-      fullPath: '/notifications'
-      preLoaderRoute: typeof AppNotificationsRouteImport
-      parentRoute: typeof AppRouteRoute
-    }
-    '/_app/settings': {
-      id: '/_app/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof AppSettingsRouteImport
-      parentRoute: typeof AppRouteRoute
-    }
-    '/_app/tournaments': {
-      id: '/_app/tournaments'
-      path: '/tournaments'
-      fullPath: '/tournaments'
-      preLoaderRoute: typeof AppTournamentsRouteImport
-      parentRoute: typeof AppRouteRoute
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/login/': {
       id: '/login/'
       path: '/login'
       fullPath: '/login/'
       preLoaderRoute: typeof LoginIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/login/sent': {
-      id: '/login/sent'
-      path: '/login/sent'
-      fullPath: '/login/sent'
-      preLoaderRoute: typeof LoginSentRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/login/verifying': {
-      id: '/login/verifying'
-      path: '/login/verifying'
-      fullPath: '/login/verifying'
-      preLoaderRoute: typeof LoginVerifyingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login/welcome': {
@@ -509,88 +460,53 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginWelcomeRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_app/admin/': {
-      id: '/_app/admin/'
-      path: '/'
-      fullPath: '/admin/'
-      preLoaderRoute: typeof AppAdminIndexRouteImport
-      parentRoute: typeof AppAdminRoute
+    '/login/verifying': {
+      id: '/login/verifying'
+      path: '/login/verifying'
+      fullPath: '/login/verifying'
+      preLoaderRoute: typeof LoginVerifyingRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/_app/admin/broadcast': {
-      id: '/_app/admin/broadcast'
-      path: '/broadcast'
-      fullPath: '/admin/broadcast'
-      preLoaderRoute: typeof AppAdminBroadcastRouteImport
-      parentRoute: typeof AppAdminRoute
+    '/login/sent': {
+      id: '/login/sent'
+      path: '/login/sent'
+      fullPath: '/login/sent'
+      preLoaderRoute: typeof LoginSentRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/_app/admin/permissions': {
-      id: '/_app/admin/permissions'
-      path: '/permissions'
-      fullPath: '/admin/permissions'
-      preLoaderRoute: typeof AppAdminPermissionsRouteImport
-      parentRoute: typeof AppAdminRoute
-    }
-    '/_app/admin/roles': {
-      id: '/_app/admin/roles'
-      path: '/roles'
-      fullPath: '/admin/roles'
-      preLoaderRoute: typeof AppAdminRolesRouteImport
-      parentRoute: typeof AppAdminRoute
-    }
-    '/_app/admin/schedule-solves': {
-      id: '/_app/admin/schedule-solves'
-      path: '/schedule-solves'
-      fullPath: '/admin/schedule-solves'
-      preLoaderRoute: typeof AppAdminScheduleSolvesRouteImport
-      parentRoute: typeof AppAdminRoute
-    }
-    '/_app/admin/users': {
-      id: '/_app/admin/users'
-      path: '/users'
-      fullPath: '/admin/users'
-      preLoaderRoute: typeof AppAdminUsersRouteImport
-      parentRoute: typeof AppAdminRoute
-    }
-    '/_app/matches/': {
-      id: '/_app/matches/'
-      path: '/matches'
-      fullPath: '/matches/'
-      preLoaderRoute: typeof AppMatchesIndexRouteImport
+    '/_app/tournaments': {
+      id: '/_app/tournaments'
+      path: '/tournaments'
+      fullPath: '/tournaments'
+      preLoaderRoute: typeof AppTournamentsRouteImport
       parentRoute: typeof AppRouteRoute
     }
-    '/_app/matches/new': {
-      id: '/_app/matches/new'
-      path: '/matches/new'
-      fullPath: '/matches/new'
-      preLoaderRoute: typeof AppMatchesNewRouteImport
-      parentRoute: typeof AppRouteRoute
-    }
-    '/_app/notifications/': {
-      id: '/_app/notifications/'
-      path: '/'
-      fullPath: '/notifications/'
-      preLoaderRoute: typeof AppNotificationsIndexRouteImport
-      parentRoute: typeof AppNotificationsRoute
-    }
-    '/_app/notifications/settings': {
-      id: '/_app/notifications/settings'
+    '/_app/settings': {
+      id: '/_app/settings'
       path: '/settings'
-      fullPath: '/notifications/settings'
-      preLoaderRoute: typeof AppNotificationsSettingsRouteImport
-      parentRoute: typeof AppNotificationsRoute
-    }
-    '/_app/players/': {
-      id: '/_app/players/'
-      path: '/players'
-      fullPath: '/players/'
-      preLoaderRoute: typeof AppPlayersIndexRouteImport
+      fullPath: '/settings'
+      preLoaderRoute: typeof AppSettingsRouteImport
       parentRoute: typeof AppRouteRoute
     }
-    '/_app/players/$userId': {
-      id: '/_app/players/$userId'
-      path: '/players/$userId'
-      fullPath: '/players/$userId'
-      preLoaderRoute: typeof AppPlayersUserIdRouteImport
+    '/_app/notifications': {
+      id: '/_app/notifications'
+      path: '/notifications'
+      fullPath: '/notifications'
+      preLoaderRoute: typeof AppNotificationsRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/dashboard': {
+      id: '/_app/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof AppDashboardRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/admin': {
+      id: '/_app/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AppAdminRouteImport
       parentRoute: typeof AppRouteRoute
     }
     '/_app/tournaments/': {
@@ -600,12 +516,96 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppTournamentsIndexRouteImport
       parentRoute: typeof AppTournamentsRoute
     }
+    '/_app/players/': {
+      id: '/_app/players/'
+      path: '/players'
+      fullPath: '/players/'
+      preLoaderRoute: typeof AppPlayersIndexRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/notifications/': {
+      id: '/_app/notifications/'
+      path: '/'
+      fullPath: '/notifications/'
+      preLoaderRoute: typeof AppNotificationsIndexRouteImport
+      parentRoute: typeof AppNotificationsRoute
+    }
+    '/_app/matches/': {
+      id: '/_app/matches/'
+      path: '/matches'
+      fullPath: '/matches/'
+      preLoaderRoute: typeof AppMatchesIndexRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/admin/': {
+      id: '/_app/admin/'
+      path: '/'
+      fullPath: '/admin/'
+      preLoaderRoute: typeof AppAdminIndexRouteImport
+      parentRoute: typeof AppAdminRoute
+    }
     '/_app/tournaments/$tournamentId': {
       id: '/_app/tournaments/$tournamentId'
       path: '/$tournamentId'
       fullPath: '/tournaments/$tournamentId'
       preLoaderRoute: typeof AppTournamentsTournamentIdRouteImport
       parentRoute: typeof AppTournamentsRoute
+    }
+    '/_app/players/$userId': {
+      id: '/_app/players/$userId'
+      path: '/players/$userId'
+      fullPath: '/players/$userId'
+      preLoaderRoute: typeof AppPlayersUserIdRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/notifications/settings': {
+      id: '/_app/notifications/settings'
+      path: '/settings'
+      fullPath: '/notifications/settings'
+      preLoaderRoute: typeof AppNotificationsSettingsRouteImport
+      parentRoute: typeof AppNotificationsRoute
+    }
+    '/_app/matches/new': {
+      id: '/_app/matches/new'
+      path: '/matches/new'
+      fullPath: '/matches/new'
+      preLoaderRoute: typeof AppMatchesNewRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/admin/users': {
+      id: '/_app/admin/users'
+      path: '/users'
+      fullPath: '/admin/users'
+      preLoaderRoute: typeof AppAdminUsersRouteImport
+      parentRoute: typeof AppAdminRoute
+    }
+    '/_app/admin/schedule-solves': {
+      id: '/_app/admin/schedule-solves'
+      path: '/schedule-solves'
+      fullPath: '/admin/schedule-solves'
+      preLoaderRoute: typeof AppAdminScheduleSolvesRouteImport
+      parentRoute: typeof AppAdminRoute
+    }
+    '/_app/admin/roles': {
+      id: '/_app/admin/roles'
+      path: '/roles'
+      fullPath: '/admin/roles'
+      preLoaderRoute: typeof AppAdminRolesRouteImport
+      parentRoute: typeof AppAdminRoute
+    }
+    '/_app/admin/permissions': {
+      id: '/_app/admin/permissions'
+      path: '/permissions'
+      fullPath: '/admin/permissions'
+      preLoaderRoute: typeof AppAdminPermissionsRouteImport
+      parentRoute: typeof AppAdminRoute
+    }
+    '/_app/admin/broadcast': {
+      id: '/_app/admin/broadcast'
+      path: '/broadcast'
+      fullPath: '/admin/broadcast'
+      preLoaderRoute: typeof AppAdminBroadcastRouteImport
+      parentRoute: typeof AppAdminRoute
     }
     '/_app/matches/$matchId/': {
       id: '/_app/matches/$matchId/'
@@ -628,18 +628,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppMatchesMatchIdResultsNewRouteImport
       parentRoute: typeof AppRouteRoute
     }
-    '/_app/matches/$matchId/games/$gameNumber/scores/edit': {
-      id: '/_app/matches/$matchId/games/$gameNumber/scores/edit'
-      path: '/matches/$matchId/games/$gameNumber/scores/edit'
-      fullPath: '/matches/$matchId/games/$gameNumber/scores/edit'
-      preLoaderRoute: typeof AppMatchesMatchIdGamesGameNumberScoresEditRouteImport
-      parentRoute: typeof AppRouteRoute
-    }
     '/_app/matches/$matchId/games/$gameNumber/scores/new': {
       id: '/_app/matches/$matchId/games/$gameNumber/scores/new'
       path: '/matches/$matchId/games/$gameNumber/scores/new'
       fullPath: '/matches/$matchId/games/$gameNumber/scores/new'
       preLoaderRoute: typeof AppMatchesMatchIdGamesGameNumberScoresNewRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/matches/$matchId/games/$gameNumber/scores/edit': {
+      id: '/_app/matches/$matchId/games/$gameNumber/scores/edit'
+      path: '/matches/$matchId/games/$gameNumber/scores/edit'
+      fullPath: '/matches/$matchId/games/$gameNumber/scores/edit'
+      preLoaderRoute: typeof AppMatchesMatchIdGamesGameNumberScoresEditRouteImport
       parentRoute: typeof AppRouteRoute
     }
   }

--- a/web-client/src/routeTree.gen.ts
+++ b/web-client/src/routeTree.gen.ts
@@ -9,42 +9,46 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as DesignSystemRouteImport } from './routes/design-system'
-import { Route as ConfirmEmailRouteImport } from './routes/confirm-email'
-import { Route as AppRouteRouteImport } from './routes/_app/route'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as LoginIndexRouteImport } from './routes/login.index'
-import { Route as LoginWelcomeRouteImport } from './routes/login.welcome'
-import { Route as LoginVerifyingRouteImport } from './routes/login.verifying'
-import { Route as LoginSentRouteImport } from './routes/login.sent'
-import { Route as AppTournamentsRouteImport } from './routes/_app/tournaments'
-import { Route as AppSettingsRouteImport } from './routes/_app/settings'
-import { Route as AppNotificationsRouteImport } from './routes/_app/notifications'
-import { Route as AppDashboardRouteImport } from './routes/_app/dashboard'
+import { Route as AppRouteRouteImport } from './routes/_app/route'
+import { Route as ConfirmEmailRouteImport } from './routes/confirm-email'
+import { Route as DesignSystemRouteImport } from './routes/design-system'
 import { Route as AppAdminRouteImport } from './routes/_app/admin'
-import { Route as AppTournamentsIndexRouteImport } from './routes/_app/tournaments/index'
-import { Route as AppPlayersIndexRouteImport } from './routes/_app/players/index'
-import { Route as AppNotificationsIndexRouteImport } from './routes/_app/notifications.index'
-import { Route as AppMatchesIndexRouteImport } from './routes/_app/matches/index'
+import { Route as AppDashboardRouteImport } from './routes/_app/dashboard'
+import { Route as AppNotificationsRouteImport } from './routes/_app/notifications'
+import { Route as AppSettingsRouteImport } from './routes/_app/settings'
+import { Route as AppTournamentsRouteImport } from './routes/_app/tournaments'
+import { Route as LoginIndexRouteImport } from './routes/login.index'
+import { Route as LoginSentRouteImport } from './routes/login.sent'
+import { Route as LoginVerifyingRouteImport } from './routes/login.verifying'
+import { Route as LoginWelcomeRouteImport } from './routes/login.welcome'
 import { Route as AppAdminIndexRouteImport } from './routes/_app/admin.index'
-import { Route as AppTournamentsTournamentIdRouteImport } from './routes/_app/tournaments.$tournamentId'
-import { Route as AppPlayersUserIdRouteImport } from './routes/_app/players/$userId'
-import { Route as AppNotificationsSettingsRouteImport } from './routes/_app/notifications.settings'
-import { Route as AppMatchesNewRouteImport } from './routes/_app/matches/new'
-import { Route as AppAdminUsersRouteImport } from './routes/_app/admin.users'
-import { Route as AppAdminScheduleSolvesRouteImport } from './routes/_app/admin.schedule-solves'
-import { Route as AppAdminRolesRouteImport } from './routes/_app/admin.roles'
-import { Route as AppAdminPermissionsRouteImport } from './routes/_app/admin.permissions'
 import { Route as AppAdminBroadcastRouteImport } from './routes/_app/admin.broadcast'
+import { Route as AppAdminPermissionsRouteImport } from './routes/_app/admin.permissions'
+import { Route as AppAdminRolesRouteImport } from './routes/_app/admin.roles'
+import { Route as AppAdminScheduleSolvesRouteImport } from './routes/_app/admin.schedule-solves'
+import { Route as AppAdminUsersRouteImport } from './routes/_app/admin.users'
+import { Route as AppMatchesIndexRouteImport } from './routes/_app/matches/index'
+import { Route as AppMatchesNewRouteImport } from './routes/_app/matches/new'
+import { Route as AppNotificationsIndexRouteImport } from './routes/_app/notifications.index'
+import { Route as AppNotificationsSettingsRouteImport } from './routes/_app/notifications.settings'
+import { Route as AppPlayersIndexRouteImport } from './routes/_app/players/index'
+import { Route as AppPlayersUserIdRouteImport } from './routes/_app/players/$userId'
+import { Route as AppTournamentsIndexRouteImport } from './routes/_app/tournaments/index'
+import { Route as AppTournamentsTournamentIdRouteImport } from './routes/_app/tournaments.$tournamentId'
 import { Route as AppMatchesMatchIdIndexRouteImport } from './routes/_app/matches.$matchId.index'
 import { Route as AppPlayersUserIdMatchesRouteImport } from './routes/_app/players/$userId_.matches'
 import { Route as AppMatchesMatchIdResultsNewRouteImport } from './routes/_app/matches.$matchId.results.new'
-import { Route as AppMatchesMatchIdGamesGameNumberScoresNewRouteImport } from './routes/_app/matches.$matchId.games.$gameNumber.scores.new'
 import { Route as AppMatchesMatchIdGamesGameNumberScoresEditRouteImport } from './routes/_app/matches.$matchId.games.$gameNumber.scores.edit'
+import { Route as AppMatchesMatchIdGamesGameNumberScoresNewRouteImport } from './routes/_app/matches.$matchId.games.$gameNumber.scores.new'
 
-const DesignSystemRoute = DesignSystemRouteImport.update({
-  id: '/design-system',
-  path: '/design-system',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AppRouteRoute = AppRouteRouteImport.update({
+  id: '/_app',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ConfirmEmailRoute = ConfirmEmailRouteImport.update({
@@ -52,48 +56,14 @@ const ConfirmEmailRoute = ConfirmEmailRouteImport.update({
   path: '/confirm-email',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AppRouteRoute = AppRouteRouteImport.update({
-  id: '/_app',
+const DesignSystemRoute = DesignSystemRouteImport.update({
+  id: '/design-system',
+  path: '/design-system',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LoginIndexRoute = LoginIndexRouteImport.update({
-  id: '/login/',
-  path: '/login/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LoginWelcomeRoute = LoginWelcomeRouteImport.update({
-  id: '/login/welcome',
-  path: '/login/welcome',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LoginVerifyingRoute = LoginVerifyingRouteImport.update({
-  id: '/login/verifying',
-  path: '/login/verifying',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LoginSentRoute = LoginSentRouteImport.update({
-  id: '/login/sent',
-  path: '/login/sent',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AppTournamentsRoute = AppTournamentsRouteImport.update({
-  id: '/tournaments',
-  path: '/tournaments',
-  getParentRoute: () => AppRouteRoute,
-} as any)
-const AppSettingsRoute = AppSettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => AppRouteRoute,
-} as any)
-const AppNotificationsRoute = AppNotificationsRouteImport.update({
-  id: '/notifications',
-  path: '/notifications',
+const AppAdminRoute = AppAdminRouteImport.update({
+  id: '/admin',
+  path: '/admin',
   getParentRoute: () => AppRouteRoute,
 } as any)
 const AppDashboardRoute = AppDashboardRouteImport.update({
@@ -101,76 +71,44 @@ const AppDashboardRoute = AppDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => AppRouteRoute,
 } as any)
-const AppAdminRoute = AppAdminRouteImport.update({
-  id: '/admin',
-  path: '/admin',
+const AppNotificationsRoute = AppNotificationsRouteImport.update({
+  id: '/notifications',
+  path: '/notifications',
   getParentRoute: () => AppRouteRoute,
 } as any)
-const AppTournamentsIndexRoute = AppTournamentsIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => AppTournamentsRoute,
-} as any)
-const AppPlayersIndexRoute = AppPlayersIndexRouteImport.update({
-  id: '/players/',
-  path: '/players/',
+const AppSettingsRoute = AppSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => AppRouteRoute,
 } as any)
-const AppNotificationsIndexRoute = AppNotificationsIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => AppNotificationsRoute,
-} as any)
-const AppMatchesIndexRoute = AppMatchesIndexRouteImport.update({
-  id: '/matches/',
-  path: '/matches/',
+const AppTournamentsRoute = AppTournamentsRouteImport.update({
+  id: '/tournaments',
+  path: '/tournaments',
   getParentRoute: () => AppRouteRoute,
+} as any)
+const LoginIndexRoute = LoginIndexRouteImport.update({
+  id: '/login/',
+  path: '/login/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LoginSentRoute = LoginSentRouteImport.update({
+  id: '/login/sent',
+  path: '/login/sent',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LoginVerifyingRoute = LoginVerifyingRouteImport.update({
+  id: '/login/verifying',
+  path: '/login/verifying',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LoginWelcomeRoute = LoginWelcomeRouteImport.update({
+  id: '/login/welcome',
+  path: '/login/welcome',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AppAdminIndexRoute = AppAdminIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => AppAdminRoute,
-} as any)
-const AppTournamentsTournamentIdRoute =
-  AppTournamentsTournamentIdRouteImport.update({
-    id: '/$tournamentId',
-    path: '/$tournamentId',
-    getParentRoute: () => AppTournamentsRoute,
-  } as any)
-const AppPlayersUserIdRoute = AppPlayersUserIdRouteImport.update({
-  id: '/players/$userId',
-  path: '/players/$userId',
-  getParentRoute: () => AppRouteRoute,
-} as any)
-const AppNotificationsSettingsRoute =
-  AppNotificationsSettingsRouteImport.update({
-    id: '/settings',
-    path: '/settings',
-    getParentRoute: () => AppNotificationsRoute,
-  } as any)
-const AppMatchesNewRoute = AppMatchesNewRouteImport.update({
-  id: '/matches/new',
-  path: '/matches/new',
-  getParentRoute: () => AppRouteRoute,
-} as any)
-const AppAdminUsersRoute = AppAdminUsersRouteImport.update({
-  id: '/users',
-  path: '/users',
-  getParentRoute: () => AppAdminRoute,
-} as any)
-const AppAdminScheduleSolvesRoute = AppAdminScheduleSolvesRouteImport.update({
-  id: '/schedule-solves',
-  path: '/schedule-solves',
-  getParentRoute: () => AppAdminRoute,
-} as any)
-const AppAdminRolesRoute = AppAdminRolesRouteImport.update({
-  id: '/roles',
-  path: '/roles',
-  getParentRoute: () => AppAdminRoute,
-} as any)
-const AppAdminPermissionsRoute = AppAdminPermissionsRouteImport.update({
-  id: '/permissions',
-  path: '/permissions',
   getParentRoute: () => AppAdminRoute,
 } as any)
 const AppAdminBroadcastRoute = AppAdminBroadcastRouteImport.update({
@@ -178,6 +116,68 @@ const AppAdminBroadcastRoute = AppAdminBroadcastRouteImport.update({
   path: '/broadcast',
   getParentRoute: () => AppAdminRoute,
 } as any)
+const AppAdminPermissionsRoute = AppAdminPermissionsRouteImport.update({
+  id: '/permissions',
+  path: '/permissions',
+  getParentRoute: () => AppAdminRoute,
+} as any)
+const AppAdminRolesRoute = AppAdminRolesRouteImport.update({
+  id: '/roles',
+  path: '/roles',
+  getParentRoute: () => AppAdminRoute,
+} as any)
+const AppAdminScheduleSolvesRoute = AppAdminScheduleSolvesRouteImport.update({
+  id: '/schedule-solves',
+  path: '/schedule-solves',
+  getParentRoute: () => AppAdminRoute,
+} as any)
+const AppAdminUsersRoute = AppAdminUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => AppAdminRoute,
+} as any)
+const AppMatchesIndexRoute = AppMatchesIndexRouteImport.update({
+  id: '/matches/',
+  path: '/matches/',
+  getParentRoute: () => AppRouteRoute,
+} as any)
+const AppMatchesNewRoute = AppMatchesNewRouteImport.update({
+  id: '/matches/new',
+  path: '/matches/new',
+  getParentRoute: () => AppRouteRoute,
+} as any)
+const AppNotificationsIndexRoute = AppNotificationsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AppNotificationsRoute,
+} as any)
+const AppNotificationsSettingsRoute =
+  AppNotificationsSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AppNotificationsRoute,
+  } as any)
+const AppPlayersIndexRoute = AppPlayersIndexRouteImport.update({
+  id: '/players/',
+  path: '/players/',
+  getParentRoute: () => AppRouteRoute,
+} as any)
+const AppPlayersUserIdRoute = AppPlayersUserIdRouteImport.update({
+  id: '/players/$userId',
+  path: '/players/$userId',
+  getParentRoute: () => AppRouteRoute,
+} as any)
+const AppTournamentsIndexRoute = AppTournamentsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AppTournamentsRoute,
+} as any)
+const AppTournamentsTournamentIdRoute =
+  AppTournamentsTournamentIdRouteImport.update({
+    id: '/$tournamentId',
+    path: '/$tournamentId',
+    getParentRoute: () => AppTournamentsRoute,
+  } as any)
 const AppMatchesMatchIdIndexRoute = AppMatchesMatchIdIndexRouteImport.update({
   id: '/matches/$matchId/',
   path: '/matches/$matchId/',
@@ -194,16 +194,16 @@ const AppMatchesMatchIdResultsNewRoute =
     path: '/matches/$matchId/results/new',
     getParentRoute: () => AppRouteRoute,
   } as any)
-const AppMatchesMatchIdGamesGameNumberScoresNewRoute =
-  AppMatchesMatchIdGamesGameNumberScoresNewRouteImport.update({
-    id: '/matches/$matchId/games/$gameNumber/scores/new',
-    path: '/matches/$matchId/games/$gameNumber/scores/new',
-    getParentRoute: () => AppRouteRoute,
-  } as any)
 const AppMatchesMatchIdGamesGameNumberScoresEditRoute =
   AppMatchesMatchIdGamesGameNumberScoresEditRouteImport.update({
     id: '/matches/$matchId/games/$gameNumber/scores/edit',
     path: '/matches/$matchId/games/$gameNumber/scores/edit',
+    getParentRoute: () => AppRouteRoute,
+  } as any)
+const AppMatchesMatchIdGamesGameNumberScoresNewRoute =
+  AppMatchesMatchIdGamesGameNumberScoresNewRouteImport.update({
+    id: '/matches/$matchId/games/$gameNumber/scores/new',
+    path: '/matches/$matchId/games/$gameNumber/scores/new',
     getParentRoute: () => AppRouteRoute,
   } as any)
 
@@ -418,18 +418,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/design-system': {
-      id: '/design-system'
-      path: '/design-system'
-      fullPath: '/design-system'
-      preLoaderRoute: typeof DesignSystemRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/confirm-email': {
-      id: '/confirm-email'
-      path: '/confirm-email'
-      fullPath: '/confirm-email'
-      preLoaderRoute: typeof ConfirmEmailRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_app': {
@@ -439,60 +432,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/confirm-email': {
+      id: '/confirm-email'
+      path: '/confirm-email'
+      fullPath: '/confirm-email'
+      preLoaderRoute: typeof ConfirmEmailRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/login/': {
-      id: '/login/'
-      path: '/login'
-      fullPath: '/login/'
-      preLoaderRoute: typeof LoginIndexRouteImport
+    '/design-system': {
+      id: '/design-system'
+      path: '/design-system'
+      fullPath: '/design-system'
+      preLoaderRoute: typeof DesignSystemRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/login/welcome': {
-      id: '/login/welcome'
-      path: '/login/welcome'
-      fullPath: '/login/welcome'
-      preLoaderRoute: typeof LoginWelcomeRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/login/verifying': {
-      id: '/login/verifying'
-      path: '/login/verifying'
-      fullPath: '/login/verifying'
-      preLoaderRoute: typeof LoginVerifyingRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/login/sent': {
-      id: '/login/sent'
-      path: '/login/sent'
-      fullPath: '/login/sent'
-      preLoaderRoute: typeof LoginSentRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_app/tournaments': {
-      id: '/_app/tournaments'
-      path: '/tournaments'
-      fullPath: '/tournaments'
-      preLoaderRoute: typeof AppTournamentsRouteImport
-      parentRoute: typeof AppRouteRoute
-    }
-    '/_app/settings': {
-      id: '/_app/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof AppSettingsRouteImport
-      parentRoute: typeof AppRouteRoute
-    }
-    '/_app/notifications': {
-      id: '/_app/notifications'
-      path: '/notifications'
-      fullPath: '/notifications'
-      preLoaderRoute: typeof AppNotificationsRouteImport
+    '/_app/admin': {
+      id: '/_app/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AppAdminRouteImport
       parentRoute: typeof AppRouteRoute
     }
     '/_app/dashboard': {
@@ -502,40 +460,54 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppDashboardRouteImport
       parentRoute: typeof AppRouteRoute
     }
-    '/_app/admin': {
-      id: '/_app/admin'
-      path: '/admin'
-      fullPath: '/admin'
-      preLoaderRoute: typeof AppAdminRouteImport
+    '/_app/notifications': {
+      id: '/_app/notifications'
+      path: '/notifications'
+      fullPath: '/notifications'
+      preLoaderRoute: typeof AppNotificationsRouteImport
       parentRoute: typeof AppRouteRoute
     }
-    '/_app/tournaments/': {
-      id: '/_app/tournaments/'
-      path: '/'
-      fullPath: '/tournaments/'
-      preLoaderRoute: typeof AppTournamentsIndexRouteImport
-      parentRoute: typeof AppTournamentsRoute
-    }
-    '/_app/players/': {
-      id: '/_app/players/'
-      path: '/players'
-      fullPath: '/players/'
-      preLoaderRoute: typeof AppPlayersIndexRouteImport
+    '/_app/settings': {
+      id: '/_app/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof AppSettingsRouteImport
       parentRoute: typeof AppRouteRoute
     }
-    '/_app/notifications/': {
-      id: '/_app/notifications/'
-      path: '/'
-      fullPath: '/notifications/'
-      preLoaderRoute: typeof AppNotificationsIndexRouteImport
-      parentRoute: typeof AppNotificationsRoute
-    }
-    '/_app/matches/': {
-      id: '/_app/matches/'
-      path: '/matches'
-      fullPath: '/matches/'
-      preLoaderRoute: typeof AppMatchesIndexRouteImport
+    '/_app/tournaments': {
+      id: '/_app/tournaments'
+      path: '/tournaments'
+      fullPath: '/tournaments'
+      preLoaderRoute: typeof AppTournamentsRouteImport
       parentRoute: typeof AppRouteRoute
+    }
+    '/login/': {
+      id: '/login/'
+      path: '/login'
+      fullPath: '/login/'
+      preLoaderRoute: typeof LoginIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login/sent': {
+      id: '/login/sent'
+      path: '/login/sent'
+      fullPath: '/login/sent'
+      preLoaderRoute: typeof LoginSentRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login/verifying': {
+      id: '/login/verifying'
+      path: '/login/verifying'
+      fullPath: '/login/verifying'
+      preLoaderRoute: typeof LoginVerifyingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login/welcome': {
+      id: '/login/welcome'
+      path: '/login/welcome'
+      fullPath: '/login/welcome'
+      preLoaderRoute: typeof LoginWelcomeRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/_app/admin/': {
       id: '/_app/admin/'
@@ -544,53 +516,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppAdminIndexRouteImport
       parentRoute: typeof AppAdminRoute
     }
-    '/_app/tournaments/$tournamentId': {
-      id: '/_app/tournaments/$tournamentId'
-      path: '/$tournamentId'
-      fullPath: '/tournaments/$tournamentId'
-      preLoaderRoute: typeof AppTournamentsTournamentIdRouteImport
-      parentRoute: typeof AppTournamentsRoute
-    }
-    '/_app/players/$userId': {
-      id: '/_app/players/$userId'
-      path: '/players/$userId'
-      fullPath: '/players/$userId'
-      preLoaderRoute: typeof AppPlayersUserIdRouteImport
-      parentRoute: typeof AppRouteRoute
-    }
-    '/_app/notifications/settings': {
-      id: '/_app/notifications/settings'
-      path: '/settings'
-      fullPath: '/notifications/settings'
-      preLoaderRoute: typeof AppNotificationsSettingsRouteImport
-      parentRoute: typeof AppNotificationsRoute
-    }
-    '/_app/matches/new': {
-      id: '/_app/matches/new'
-      path: '/matches/new'
-      fullPath: '/matches/new'
-      preLoaderRoute: typeof AppMatchesNewRouteImport
-      parentRoute: typeof AppRouteRoute
-    }
-    '/_app/admin/users': {
-      id: '/_app/admin/users'
-      path: '/users'
-      fullPath: '/admin/users'
-      preLoaderRoute: typeof AppAdminUsersRouteImport
-      parentRoute: typeof AppAdminRoute
-    }
-    '/_app/admin/schedule-solves': {
-      id: '/_app/admin/schedule-solves'
-      path: '/schedule-solves'
-      fullPath: '/admin/schedule-solves'
-      preLoaderRoute: typeof AppAdminScheduleSolvesRouteImport
-      parentRoute: typeof AppAdminRoute
-    }
-    '/_app/admin/roles': {
-      id: '/_app/admin/roles'
-      path: '/roles'
-      fullPath: '/admin/roles'
-      preLoaderRoute: typeof AppAdminRolesRouteImport
+    '/_app/admin/broadcast': {
+      id: '/_app/admin/broadcast'
+      path: '/broadcast'
+      fullPath: '/admin/broadcast'
+      preLoaderRoute: typeof AppAdminBroadcastRouteImport
       parentRoute: typeof AppAdminRoute
     }
     '/_app/admin/permissions': {
@@ -600,12 +530,82 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppAdminPermissionsRouteImport
       parentRoute: typeof AppAdminRoute
     }
-    '/_app/admin/broadcast': {
-      id: '/_app/admin/broadcast'
-      path: '/broadcast'
-      fullPath: '/admin/broadcast'
-      preLoaderRoute: typeof AppAdminBroadcastRouteImport
+    '/_app/admin/roles': {
+      id: '/_app/admin/roles'
+      path: '/roles'
+      fullPath: '/admin/roles'
+      preLoaderRoute: typeof AppAdminRolesRouteImport
       parentRoute: typeof AppAdminRoute
+    }
+    '/_app/admin/schedule-solves': {
+      id: '/_app/admin/schedule-solves'
+      path: '/schedule-solves'
+      fullPath: '/admin/schedule-solves'
+      preLoaderRoute: typeof AppAdminScheduleSolvesRouteImport
+      parentRoute: typeof AppAdminRoute
+    }
+    '/_app/admin/users': {
+      id: '/_app/admin/users'
+      path: '/users'
+      fullPath: '/admin/users'
+      preLoaderRoute: typeof AppAdminUsersRouteImport
+      parentRoute: typeof AppAdminRoute
+    }
+    '/_app/matches/': {
+      id: '/_app/matches/'
+      path: '/matches'
+      fullPath: '/matches/'
+      preLoaderRoute: typeof AppMatchesIndexRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/matches/new': {
+      id: '/_app/matches/new'
+      path: '/matches/new'
+      fullPath: '/matches/new'
+      preLoaderRoute: typeof AppMatchesNewRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/notifications/': {
+      id: '/_app/notifications/'
+      path: '/'
+      fullPath: '/notifications/'
+      preLoaderRoute: typeof AppNotificationsIndexRouteImport
+      parentRoute: typeof AppNotificationsRoute
+    }
+    '/_app/notifications/settings': {
+      id: '/_app/notifications/settings'
+      path: '/settings'
+      fullPath: '/notifications/settings'
+      preLoaderRoute: typeof AppNotificationsSettingsRouteImport
+      parentRoute: typeof AppNotificationsRoute
+    }
+    '/_app/players/': {
+      id: '/_app/players/'
+      path: '/players'
+      fullPath: '/players/'
+      preLoaderRoute: typeof AppPlayersIndexRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/players/$userId': {
+      id: '/_app/players/$userId'
+      path: '/players/$userId'
+      fullPath: '/players/$userId'
+      preLoaderRoute: typeof AppPlayersUserIdRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/tournaments/': {
+      id: '/_app/tournaments/'
+      path: '/'
+      fullPath: '/tournaments/'
+      preLoaderRoute: typeof AppTournamentsIndexRouteImport
+      parentRoute: typeof AppTournamentsRoute
+    }
+    '/_app/tournaments/$tournamentId': {
+      id: '/_app/tournaments/$tournamentId'
+      path: '/$tournamentId'
+      fullPath: '/tournaments/$tournamentId'
+      preLoaderRoute: typeof AppTournamentsTournamentIdRouteImport
+      parentRoute: typeof AppTournamentsRoute
     }
     '/_app/matches/$matchId/': {
       id: '/_app/matches/$matchId/'
@@ -628,18 +628,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppMatchesMatchIdResultsNewRouteImport
       parentRoute: typeof AppRouteRoute
     }
-    '/_app/matches/$matchId/games/$gameNumber/scores/new': {
-      id: '/_app/matches/$matchId/games/$gameNumber/scores/new'
-      path: '/matches/$matchId/games/$gameNumber/scores/new'
-      fullPath: '/matches/$matchId/games/$gameNumber/scores/new'
-      preLoaderRoute: typeof AppMatchesMatchIdGamesGameNumberScoresNewRouteImport
-      parentRoute: typeof AppRouteRoute
-    }
     '/_app/matches/$matchId/games/$gameNumber/scores/edit': {
       id: '/_app/matches/$matchId/games/$gameNumber/scores/edit'
       path: '/matches/$matchId/games/$gameNumber/scores/edit'
       fullPath: '/matches/$matchId/games/$gameNumber/scores/edit'
       preLoaderRoute: typeof AppMatchesMatchIdGamesGameNumberScoresEditRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/_app/matches/$matchId/games/$gameNumber/scores/new': {
+      id: '/_app/matches/$matchId/games/$gameNumber/scores/new'
+      path: '/matches/$matchId/games/$gameNumber/scores/new'
+      fullPath: '/matches/$matchId/games/$gameNumber/scores/new'
+      preLoaderRoute: typeof AppMatchesMatchIdGamesGameNumberScoresNewRouteImport
       parentRoute: typeof AppRouteRoute
     }
   }

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -66,6 +66,14 @@ export default defineConfig({
     },
     setupFiles: ['./src/test/setup.ts'],
     css: true,
+    // Must stay STRICTLY GREATER than Testing Library's `asyncUtilTimeout`
+    // (5000, set in src/test/setup.ts). Left at vitest's 5000 default the two
+    // budgets are equal, so a slow `waitFor` and the test itself expire at the
+    // same instant and the failure surfaces as an undiagnosable
+    // "Test timed out in 5000ms" instead of Testing Library's "Unable to find
+    // <element>". Raising the outer bound fixes that for all ~410 `waitFor`
+    // call sites at once; only 4 pass a timeout of their own.
+    testTimeout: 10000,
     // Dates render in the reader's LOCAL zone (a match is played on a local day),
     // so an unpinned runner would date the same fixture differently on a laptop in
     // Chicago and on a CI box in UTC. Pin the suite to one zone — the one CI


### PR DESCRIPTION
A measured audit of this repo's development workflow, plus the fixes it found.

**The merge gate is healthy and nothing here loosens it** — `main` is 240/240 green post-merge, 0 reverts in 400 commits, 90% same-day merge, and no PR ever merged before blocking CI finished. The problems were *cost* and *residue* around the gate.

## Garbage collection — nothing ever collected any

`gh pr merge --delete-branch` removes the branch and never the worktree, so every shipped change left a ~270 MB tombstone: **311 worktrees / 82 GB, 77% on already-merged branches**, plus 439 local branches. That sprawl is upstream of a family of recurring bugs — `/epic` resuming into a stale checkout, ADR numbers computed against an old tree, QA stacks OOMing a host with no headroom.

`scripts/reap-worktrees.sh` + `land-the-plane` Step 9. Dry-run by default; only reaps a worktree whose PR is **merged** and which holds nothing not already in `main`. Squash merges defeat both `git cherry` (patch-ids) and `--is-ancestor`, so it compares the local tip to the PR's actual `headRefOid`, and **fails closed** when that commit isn't in the local object db. Writes a manifest first, so any reap is undoable.

## CI cost

- **`web-client-mutation` → nightly.** It burned **1,344 of 2,856 PR wall-minutes (47%)** while carrying `continue-on-error` *and* a null `break` threshold — it could never fail a build, and on 5 of 22 PRs it finished *after* the merge.
- **`api.yml` / `openapi-schema.yml` short-circuit** their expensive steps when nothing that can affect them changed. Deliberately **not** a trigger-level `paths:` filter: `pytest` and `verify` are required checks, and a workflow that never triggers never reports, hanging every PR on "Expected — waiting for status".

## OpenAPI drift — the #1 avoidable red

The two drift guards caused **5 of 17 failed CI steps across 3 PRs** (#1153, #1158, #1165) — half of all PRs that ever went red. `.githooks/pre-push` regenerates and compares when the pushed range touches `api/`. Advisory, and degrades gracefully with no Swift toolchain **and** with no `web-client/node_modules` — a push must never turn into a 525 MB `npm ci`.

## Three skill files that were themselves the bug

- **`qa-review.md` hardcoded CDP 9222/9223**, so concurrent QA runs drove each other's browser. The kernel now assigns the port (`--remote-debugging-port=0`, read back from `DevToolsActivePort`), and ports/PIDs go to a run-scoped file — shell state does not survive between steps, which had made the teardown match *every* CDP Chrome on the box.
- **`qa-review.md` gained the RBAC grant step.** The QA stack seeds roles but assigns them to nobody, so every gated feature 403s and reads as a product bug.
- **`land-the-plane.md`'s "skip root e2e if not applicable" escape hatch is gone** (it's the only tournament-lifecycle coverage), scoped so a docs-only branch still needn't build a stack.

## Documentation promoted out of personal notes, so it's versioned

`.claude/rules/verify-the-artifact-under-test.md` (the caches that silently lie), testing-gotchas sections in `api/CLAUDE.md` and `web-client/CLAUDE.md`, and `docs/adr/README.md` + `scripts/check-adr-numbering.sh`. The ADR root cause was `ADR-FORMAT.md` instructing agents to increment the highest number, which raced across worktrees into **four different `0008-*.md`**; legacy names are grandfathered and the check only inspects ADRs a branch *adds*.

`vite.config.ts` sets `testTimeout: 10000` — it exactly matched Testing Library's `asyncUtilTimeout`, so both budgets expired together and a slow `waitFor` died as an undiagnosable "Test timed out in 5000ms" instead of naming the missing element. Fixes **all ~410 `waitFor` call sites**; only 4 passed a bound of their own.

## Testing

- vitest **2982 passed** (291 files)
- api: ruff check + format, mypy clean, **1755 pytest passed**
- `tsc -b` and eslint clean (1 pre-existing warning in a generated MSW file)
- web-client e2e **299/299**, root e2e **15/15**

Both Playwright suites were checked **run-count against collected-count** — which is how the root suite was caught *exiting 0 having run nothing* (a self-referential `e2e/node_modules` symlink in the main checkout, since repaired). That's the exact failure mode the new rule file documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)