### PR TITLE
Stop showing users broken strings: tournament not-found, copy fixes, notifications honesty

### DIFF
--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -435,9 +435,12 @@ def _snake(
     # Asked of the dealt pools themselves, not of arithmetic on N and P: the refusal
     # should hold whatever the distribution does.
     if any(len(pool_members) < 2 for pool_members in members):
+        entrant_count = len(ordered_entrants)
+        entrant_noun = "entrant" if entrant_count == 1 else "entrants"
+        pool_noun = "pool" if pool_count == 1 else "pools"
         raise DegenerateDraw(
-            f"{len(ordered_entrants)} entrants across {pool_count} pool(s) would leave "
-            "a pool with fewer than 2 entrants, who would have nobody to play."
+            f"{entrant_count} {entrant_noun} across {pool_count} {pool_noun} would "
+            "leave a pool with fewer than 2 entrants, who would have nobody to play."
         )
 
     return [

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -410,28 +410,28 @@ class TestRoundRobinCut:
             pytest.param(
                 1,
                 1,
-                "1 entrants across 1 pool(s) would leave a pool with fewer than 2 "
+                "1 entrant across 1 pool would leave a pool with fewer than 2 "
                 "entrants, who would have nobody to play.",
                 id="a-lone-entrant-has-nobody-to-play",
             ),
             pytest.param(
                 0,
                 1,
-                "0 entrants across 1 pool(s) would leave a pool with fewer than 2 "
+                "0 entrants across 1 pool would leave a pool with fewer than 2 "
                 "entrants, who would have nobody to play.",
                 id="a-ghost-pool",
             ),
             pytest.param(
                 3,
                 2,
-                "3 entrants across 2 pool(s) would leave a pool with fewer than 2 "
+                "3 entrants across 2 pools would leave a pool with fewer than 2 "
                 "entrants, who would have nobody to play.",
                 id="the-snake-would-leave-pool-B-with-one",
             ),
             pytest.param(
                 5,
                 3,
-                "5 entrants across 3 pool(s) would leave a pool with fewer than 2 "
+                "5 entrants across 3 pools would leave a pool with fewer than 2 "
                 "entrants, who would have nobody to play.",
                 id="...and-pool-C-with-one",
             ),
@@ -447,6 +447,21 @@ class TestRoundRobinCut:
         # Both numbers, because either one of them is a thing the director can move:
         # cut fewer pools, or go and find another player.
         assert str(excinfo.value) == message
+
+    def test_the_refusal_inflects_its_count_nouns(self) -> None:
+        # Singular counts get singular nouns — never "1 entrants" and never the lazy
+        # "pool(s)" — so a one-entrant, one-pool refusal reads like a sentence.
+        with pytest.raises(DegenerateDraw) as singular:
+            RoundRobinStrategy().plan_initial(_config(1), _ordered(1))
+        singular_message = str(singular.value)
+        assert "1 entrant across 1 pool" in singular_message
+        assert "1 entrants" not in singular_message
+        assert "pool(s)" not in singular_message
+
+        # Plural counts stay plural.
+        with pytest.raises(DegenerateDraw) as plural:
+            RoundRobinStrategy().plan_initial(_config(2), _ordered(3))
+        assert "3 entrants across 2 pools" in str(plural.value)
 
     def test_a_draw_with_no_pools_is_refused(self) -> None:
         with pytest.raises(DegenerateDraw) as excinfo:

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -4730,14 +4730,14 @@ async def test_cutting_a_singles_event_is_allowed(
         pytest.param(
             (POOL_A, POOL_B),
             3,
-            "3 entrants across 2 pool(s) would leave a pool with fewer than 2 "
+            "3 entrants across 2 pools would leave a pool with fewer than 2 "
             "entrants, who would have nobody to play.",
             id="a-pool-of-one",
         ),
         pytest.param(
             (POOL_A,),
             0,
-            "0 entrants across 1 pool(s) would leave a pool with fewer than 2 "
+            "0 entrants across 1 pool would leave a pool with fewer than 2 "
             "entrants, who would have nobody to play.",
             id="no-entrants-at-all",
         ),

--- a/docs/adr/20260724-unread-is-a-per-visit-snapshot-over-auto-marked-notifications.md
+++ b/docs/adr/20260724-unread-is-a-per-visit-snapshot-over-auto-marked-notifications.md
@@ -74,10 +74,17 @@ Emitting a notification when a result is accepted, or when a rating changes, is 
 domain-event fan-out feature with its own design surface (what counts as a
 rating-change event, per-match vs digest, copy, read semantics). It is **out of
 scope** here. Until it exists, the `rating_change` category is hidden **client-side
-from both surfaces it renders on** — the filter pills and the preferences matrix —
-so users never see a pill or a channel toggle for a notification that cannot
-arrive. The category remains defined and seeded server-side; the follow-up feature
-un-hides it by flipping one predicate. A tracking issue carries the fan-out work.
+in the taxonomy and preferences query `select`s**, so every surface built from
+those lists drops it — the filter pills and the admin broadcast category picker
+(both render the taxonomy `types`), and the preferences matrix. Filtering at the
+query layer rather than at each render site is deliberate: it is one revert point
+that cannot miss a surface. The trade-off is that the admin broadcast picker also
+loses the category, so an admin cannot send a `rating_change` broadcast while the
+feature is descoped — which is the right call, since such a broadcast would land as
+an un-filterable, un-opt-out-able notification precisely because the user-facing
+pill and pref are gone. The category remains defined and seeded server-side; the
+follow-up feature un-hides it by emptying one list. A tracking issue (#1176)
+carries the fan-out work.
 
 ## Consequences
 
@@ -91,5 +98,6 @@ un-hides it by flipping one predicate. A tracking issue carries the fan-out work
 - **Hiding `rating_change` is a client filter over the server taxonomy**, not a
   taxonomy change. No schema churn, no regen; the follow-up feature reverts it in
   one place. If a `rating_change` notification somehow already exists in a feed, it
-  still renders in the row list — we only suppress the pill and the pref toggle,
-  which are the decorative-when-empty surfaces.
+  still renders in the row list — we only suppress the category *pickers* (the
+  filter pills, the preferences matrix, and the admin broadcast picker), which are
+  the decorative-when-empty surfaces. The feed itself is never filtered.

--- a/docs/adr/20260724-unread-is-a-per-visit-snapshot-over-auto-marked-notifications.md
+++ b/docs/adr/20260724-unread-is-a-per-visit-snapshot-over-auto-marked-notifications.md
@@ -1,0 +1,95 @@
+# Unread is a per-visit snapshot over auto-marked notifications
+
+Date: 2026-07-24
+
+## Status
+
+Accepted
+
+Numbered by date, following the `20260722-*` ADRs, not by incrementing the highest
+file on disk — parallel worktrees each number off a stale main, which has already
+produced four `0008`s.
+
+## Context
+
+Three QA-filed bugs (#996, #999, #1112) and one descope decision (#998) all turn on
+a single unresolved question the notifications feature never answered out loud:
+**when does a notification become "read"?**
+
+Today a notification is marked read the moment its row scrolls ≥50% into view — an
+`IntersectionObserver` (`use-seen-on-screen.ts`) feeds a debounced batch
+mark-read (`use-auto-mark-read.ts`), on both the `/notifications` page and the bell
+dropdown. On a short list, everything visible is read within 800ms of arrival.
+
+That eager auto-mark is *convenient* — you never have to click a notification to
+clear it — and we chose to keep it (a per-item "click to dismiss" was rejected as
+annoying). But it makes a naive **Unread** filter (`read_at IS NULL`) empty by
+construction: by the time you can click the Unread pill, nothing is unread. #762
+added a "sticky unread" mechanism to keep just-auto-read rows visible under Unread,
+but scoped it to *rows seen while the Unread filter was already active* — so
+arriving on the default **All** filter (the normal case) marks everything read
+before the snapshot is ever taken, and Unread is empty anyway.
+
+The related failures:
+
+- **#996** — Unread can never show anything; the pill is decorative.
+- **#1112** — the bell badge goes stale: it does not reliably decrement as rows
+  auto-read.
+- **#999** — the active filter lives in component state, not the URL, so a filtered
+  view can't be linked and doesn't survive reload.
+- **#998** — the `rating_change` category is seeded (pill + preferences row) but
+  **nothing ever emits it**, and the result-poster gets no "accepted" notification.
+  Building that fan-out is its own feature; see the descope below.
+
+## Decision
+
+**Auto-mark-on-view stays. "Unread" is redefined as a per-visit snapshot: the set
+of notifications that were unread at the moment you arrived on this surface.** The
+snapshot is taken on arrival (page mount / bell open) regardless of which filter
+you land on, and those rows remain visible under the Unread filter for the visit
+even after auto-mark flips their `read_at`.
+
+This is #762's sticky mechanism, generalized: the snapshot is no longer gated on
+the Unread filter being active when a row is seen — it is captured up front, once,
+per visit. Leaving and returning (or reloading) takes a fresh snapshot.
+
+Consequences of the redefinition:
+
+- **"Unread" means "new since you got here," not "never opened."** That is what
+  most people already read the pill as, and it is the only meaning compatible with
+  keeping auto-mark. A row read on another device, or on a previous visit, is not
+  in this visit's snapshot and correctly does not appear.
+- **The badge counts true unread (`read_at IS NULL`) and drains as rows auto-read.**
+  It is not driven by the snapshot. #1112 is fixed by making the optimistic
+  decrement / invalidation reliable, independent of this redefinition — the badge
+  and the Unread pill answer two different questions and are allowed to disagree.
+- **The active filter moves into the URL** (`?filter=…`), Zod-parsed at the route
+  boundary via `validateSearch`, per the web-client Boundaries convention (#999).
+  A shared/reloaded `?filter=unread` link takes its snapshot at load time, so it is
+  self-consistent.
+
+### Descope: rating/result-accepted notifications (#998)
+
+Emitting a notification when a result is accepted, or when a rating changes, is a
+domain-event fan-out feature with its own design surface (what counts as a
+rating-change event, per-match vs digest, copy, read semantics). It is **out of
+scope** here. Until it exists, the `rating_change` category is hidden **client-side
+from both surfaces it renders on** — the filter pills and the preferences matrix —
+so users never see a pill or a channel toggle for a notification that cannot
+arrive. The category remains defined and seeded server-side; the follow-up feature
+un-hides it by flipping one predicate. A tracking issue carries the fan-out work.
+
+## Consequences
+
+- **The sticky mechanism is generalized, not deleted.** `use-sticky-unread.ts`
+  keeps pinning auto-read rows under Unread; the change is *when* it starts
+  snapshotting (arrival, any filter) rather than (first seen while on Unread).
+- **"Unread" is explicitly a session/visit concept.** A row does not stay under
+  Unread forever — a return visit re-snapshots. This is deliberate: a durable
+  "never opened" state is incompatible with auto-mark-on-view, and we chose
+  auto-mark.
+- **Hiding `rating_change` is a client filter over the server taxonomy**, not a
+  taxonomy change. No schema churn, no regen; the follow-up feature reverts it in
+  one place. If a `rating_change` notification somehow already exists in a feed, it
+  still renders in the row list — we only suppress the pill and the pref toggle,
+  which are the decorative-when-empty surfaces.

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -86,7 +86,12 @@ const UNREAD_COUNT: UnreadCountResponse = { unread_count: 0 }
  * rather than passing a stale shape into a green spec.
  */
 
-export const TOURNAMENT_ID = 'bay-area-open-2026'
+// A real **uuid**, not a slug: `tournament_id` is a `uuid.UUID` on the API, and
+// since ADR-1001 the detail route Zod-validates the segment as one at the boundary
+// (`tournaments.$tournamentId.tsx`) — a non-uuid URL throws `notFound()` before any
+// fetch. A slug here (the old `bay-area-open-2026`) would make every detail
+// navigation in this suite land on the not-found page instead of the tournament.
+export const TOURNAMENT_ID = 'b0a1e2a0-0000-4000-8000-000000000001'
 
 /** The events the specs drive, named so the specs never hard-code strings that
  * must agree with the seed below. */

--- a/web-client/e2e/tournaments/tournament-not-found.spec.ts
+++ b/web-client/e2e/tournaments/tournament-not-found.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * The tournament detail route's not-found taxonomy, in a real browser (ADR-1001,
+ * #992/#1050/#1090).
+ *
+ * Two different bad URLs must both reach the route's `notFoundComponent`, and the
+ * *malformed* one must do it **without touching the API** — the whole of #992 was
+ * that `/tournaments/abc` hit the server and painted a raw Pydantic "Input should
+ * be a valid UUID" string into the error boundary. Only a real browser exercises
+ * the router wiring (`params.parse` → `notFound()`, and the query's 404 →
+ * `notFound()`), so it is pinned here rather than only in vitest.
+ *
+ * **MSW is OFF in this suite** (`playwright.config.ts` → `VITE_ENABLE_MSW:
+ * 'false'`): the network is stubbed by `TournamentsStore`'s inline `page.route`
+ * interceptors, and the malformed-id assertion reads that store's request log to
+ * prove no detail fetch went out.
+ */
+import { expect, test } from '@playwright/test'
+
+import { TournamentsStore } from '../page-objects/tournaments/tournaments-store'
+
+/** A well-formed uuid that names no tournament — the "valid but unknown" case,
+ * which the store's catch-all answers with a 404 (as the server would). */
+const UNKNOWN_ID = '00000000-0000-4000-8000-000000000000'
+
+/** Did the app fetch a tournament DETAIL (a `/v1/tournaments/{id}` GET, not the
+ * bare list)? The malformed-id case must answer no. */
+function detailFetches(store: TournamentsStore): number {
+  return store.requests.filter(
+    (r) => r.method === 'GET' && /^\/v1\/tournaments\/[^/]+$/.test(r.path),
+  ).length
+}
+
+test.describe('Tournament detail · a missing tournament is a not-found, not an error', () => {
+  test('a MALFORMED id reaches the designed not-found — with no fetch and no validator string', async ({
+    page,
+  }) => {
+    const store = new TournamentsStore()
+    await store.install(page)
+
+    await page.goto('/tournaments/abc')
+
+    await expect(
+      page.getByRole('heading', { name: 'Tournament not found.' }),
+    ).toBeVisible()
+    // #992: the raw Pydantic validator string never reaches the screen…
+    await expect(page.getByText(/valid uuid/i)).toHaveCount(0)
+    // …because the request was never made. The route rejected the id at its edge.
+    expect(detailFetches(store)).toBe(0)
+    // The one recovery action, and it is a real link to the list.
+    const back = page.getByRole('link', { name: 'Back to tournaments' })
+    await expect(back).toBeVisible()
+    await expect(back).toHaveAttribute('href', '/tournaments')
+    // The body renders inside the ONE app shell it already sits under — not a
+    // second one nested by a shell-wrapping 404 (ADR-1001).
+    await expect(page.getByRole('main')).toHaveCount(1)
+  })
+
+  test('a well-formed-but-unknown id (a 404) reaches the same not-found — and this one DID fetch', async ({
+    page,
+  }) => {
+    const store = new TournamentsStore()
+    await store.install(page)
+
+    await page.goto(`/tournaments/${UNKNOWN_ID}`)
+
+    await expect(
+      page.getByRole('heading', { name: 'Tournament not found.' }),
+    ).toBeVisible()
+    // Unlike the malformed case, the client cannot tell valid-unknown from
+    // valid-known without asking — so it really did ask.
+    expect(detailFetches(store)).toBeGreaterThan(0)
+  })
+
+  test('the not-found is not a dead end — “Back to tournaments” lands on the list', async ({
+    page,
+  }) => {
+    const store = new TournamentsStore()
+    await store.install(page)
+
+    await page.goto('/tournaments/abc')
+    await page.getByRole('link', { name: 'Back to tournaments' }).click()
+
+    await expect(page).toHaveURL(/\/tournaments$/)
+    // The list really rendered — a dead-end link that only changed the URL would
+    // still be a dead end.
+    await expect(page.getByRole('heading', { name: 'Tournaments' })).toBeVisible()
+  })
+})

--- a/web-client/src/api/notifications.test.tsx
+++ b/web-client/src/api/notifications.test.tsx
@@ -10,6 +10,7 @@ import {
   type NotificationFeed,
   type UnreadCount,
   useMarkNotificationsRead,
+  useUnreadCount,
 } from './notifications'
 
 const feedKey = [...NOTIFICATIONS_QUERY_KEY, 'feed']
@@ -88,6 +89,46 @@ describe('useMarkNotificationsRead', () => {
       expect(feed?.unread_count).toBe(1)
       expect(queryClient.getQueryData<UnreadCount>(countKey)?.unread_count).toBe(1)
     })
+  })
+
+  it('reconciles the badge to server truth when the optimistic decrement is a no-op', async () => {
+    // #1112: the debounced batch flushes ids that aren't in the on-screen feed
+    // (e.g. rows already scrolled past / not held in this cache), so the
+    // optimistic pass finds newlyRead == 0 and cannot drop the badge. The badge
+    // must still converge to the server's true count promptly — not stick stale
+    // until the 60s poll. The server reports 2 unread until the batch read lands,
+    // then 1; only a post-success reconcile of the count query surfaces that.
+    let read = false
+    server.use(
+      http.post('*/v1/notifications/read', () => {
+        read = true
+        return HttpResponse.json({ marked: 1 })
+      }),
+      http.get('*/v1/notifications/unread-count', () =>
+        HttpResponse.json({ unread_count: read ? 1 : 2 }),
+      ),
+    )
+
+    const { result } = renderHook(
+      () => ({
+        badge: useUnreadCount(),
+        markRead: useMarkNotificationsRead(),
+      }),
+      { wrapper },
+    )
+
+    // The mounted badge settles on the initial server truth (2).
+    await waitFor(() =>
+      expect(result.current.badge.data?.unread_count).toBe(2),
+    )
+
+    // Flush a batch whose ids aren't in the feed: the optimistic decrement is a
+    // no-op, so without a reconcile the badge would stay at 2 until the poll.
+    result.current.markRead.mutate(['not-in-feed'])
+
+    await waitFor(() =>
+      expect(result.current.badge.data?.unread_count).toBe(1),
+    )
   })
 
   it('rolls the count back to server truth when the batch request fails', async () => {

--- a/web-client/src/api/notifications.ts
+++ b/web-client/src/api/notifications.ts
@@ -39,10 +39,15 @@ export const NOTIFICATION_TAXONOMY_QUERY_KEY = [
 
 // Categories that are defined + seeded server-side but that nothing ever emits
 // yet, so their filter pill and preferences toggle would be decorative and
-// misleading. We hide them CLIENT-SIDE from the two surfaces that render the
-// category taxonomy — the notifications filter pills and the preferences matrix —
-// without touching the server taxonomy. The follow-up fan-out feature (#1176)
-// starts emitting `rating_change` and un-hides it by emptying this list (#998).
+// misleading. We hide them CLIENT-SIDE in the taxonomy and preferences query
+// selects — so every surface built from those lists drops them: the notifications
+// filter pills and the admin broadcast category picker (both render the taxonomy
+// `types`), and the preferences matrix. Filtering at the query layer rather than
+// at each render site is deliberate — one revert point that can't miss a surface,
+// at the cost of also dropping the category from the admin broadcast picker (fine:
+// a Rating broadcast would be un-filterable and un-opt-out-able while the pill and
+// pref are gone). The server taxonomy is untouched. The follow-up fan-out feature
+// (#1176) starts emitting `rating_change` and un-hides it by emptying this list.
 export const HIDDEN_NOTIFICATION_CATEGORIES: readonly NotificationCategory[] = [
   'rating_change',
 ]
@@ -244,9 +249,9 @@ export function notificationTaxonomyQueryOptions() {
         await api.GET('/v1/notification-taxonomy'),
       ),
     staleTime: Infinity,
-    // Drop hidden categories from the taxonomy so the filter pills (which map
-    // over `types`) never render one for a notification that can't arrive
-    // (#998). See HIDDEN_NOTIFICATION_CATEGORIES.
+    // Drop hidden categories from the taxonomy so neither the filter pills nor
+    // the admin broadcast category picker (both map over `types`) renders one for
+    // a notification that can't arrive (#998). See HIDDEN_NOTIFICATION_CATEGORIES.
     select: (taxonomy) => ({
       ...taxonomy,
       types: taxonomy.types.filter((type) => !isHiddenCategory(type.key)),

--- a/web-client/src/api/notifications.ts
+++ b/web-client/src/api/notifications.ts
@@ -37,6 +37,20 @@ export const NOTIFICATION_TAXONOMY_QUERY_KEY = [
   'notification-taxonomy',
 ] as const
 
+// Categories that are defined + seeded server-side but that nothing ever emits
+// yet, so their filter pill and preferences toggle would be decorative and
+// misleading. We hide them CLIENT-SIDE from the two surfaces that render the
+// category taxonomy — the notifications filter pills and the preferences matrix —
+// without touching the server taxonomy. The follow-up fan-out feature (#1176)
+// starts emitting `rating_change` and un-hides it by emptying this list (#998).
+export const HIDDEN_NOTIFICATION_CATEGORIES: readonly NotificationCategory[] = [
+  'rating_change',
+]
+
+function isHiddenCategory(category: NotificationCategory): boolean {
+  return HIDDEN_NOTIFICATION_CATEGORIES.includes(category)
+}
+
 // The bell badge polls this lightweight count so a notification that arrives in
 // another tab/device surfaces without a manual refresh. We poll rather than
 // long-poll/WebSocket deliberately: the feed is low-frequency and per-user, so a
@@ -116,9 +130,15 @@ export function useMarkNotificationRead() {
  *
  * We optimistically clear those rows' `read_at` and drop the unread badge so the
  * count falls the instant a notification is seen — the debounce would otherwise
- * leave the badge stale for ~1s. On success we leave the optimistic state in
- * place (the background polls reconcile any drift); only a failed write rolls
- * back and re-syncs to server truth.
+ * leave the badge stale for ~1s. On success we reconcile *only* the cheap
+ * unread-count query against the server, so the badge converges to the true count
+ * even when the optimistic decrement was a no-op or wrong (the count query hadn't
+ * loaded, or the flushed ids weren't in the on-screen feed) — the failure mode of
+ * #1112, where the badge stuck stale until the 60s poll. We deliberately leave the
+ * full feed's optimistic state in place rather than invalidating it: re-fetching
+ * the whole feed on every debounced batch would thrash the list while scrolling,
+ * and the FEED_POLL reconciles any drift there. A failed write rolls the whole
+ * optimistic state back and re-syncs to server truth.
  */
 export function useMarkNotificationsRead() {
   const qc = useQueryClient()
@@ -157,10 +177,14 @@ export function useMarkNotificationsRead() {
       }
       return { prevFeed, prevCount }
     },
-    // On success the optimistic state is already correct and the background
-    // polls reconcile any drift, so we deliberately don't invalidate here —
-    // that would force two refetches per debounced batch while scrolling. Only
-    // a failed write needs to re-sync to server truth.
+    // Reconcile the badge to server truth by invalidating *only* the lightweight
+    // unread-count query (never the full feed — that would thrash the list on
+    // every debounced batch while scrolling). This makes the decrement reliable
+    // even when the optimistic pass couldn't do it: a mounted badge refetches the
+    // real count instead of sticking stale until the poll (#1112).
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: countKey })
+    },
     onError: (_err, _ids, context) => {
       if (context?.prevFeed) qc.setQueryData(feedKey, context.prevFeed)
       if (context?.prevCount) qc.setQueryData(countKey, context.prevCount)
@@ -192,6 +216,15 @@ export function notificationPreferencesQueryOptions() {
         'load notification preferences',
         await api.GET('/v1/notification-preferences'),
       ),
+    // Drop hidden categories from the matrix — its rows come from
+    // `categories`, a separate query from the taxonomy that feeds the pills, so
+    // it has to be filtered here too (#998). See HIDDEN_NOTIFICATION_CATEGORIES.
+    select: (prefs) => ({
+      ...prefs,
+      categories: prefs.categories.filter(
+        (row) => !isHiddenCategory(row.category),
+      ),
+    }),
   })
 }
 
@@ -211,6 +244,13 @@ export function notificationTaxonomyQueryOptions() {
         await api.GET('/v1/notification-taxonomy'),
       ),
     staleTime: Infinity,
+    // Drop hidden categories from the taxonomy so the filter pills (which map
+    // over `types`) never render one for a notification that can't arrive
+    // (#998). See HIDDEN_NOTIFICATION_CATEGORIES.
+    select: (taxonomy) => ({
+      ...taxonomy,
+      types: taxonomy.types.filter((type) => !isHiddenCategory(type.key)),
+    }),
   })
 }
 

--- a/web-client/src/components/matches/match-list.test.tsx
+++ b/web-client/src/components/matches/match-list.test.tsx
@@ -35,10 +35,14 @@ describe('MatchList', () => {
     // MatchListTable: the settled table renders (no aria-busy once loaded).
     expect(matchListPage.table.getTable()).not.toHaveAttribute('aria-busy')
 
-    // PaginationFooter: the range readout reflects the single match.
+    // PaginationFooter: the range readout reflects the single match, inflected
+    // to the singular. "of 1 match" is a substring of the ungrammatical "of 1
+    // matches", so also assert the plural is absent — otherwise this stays
+    // green against a regression back to a fixed plural.
     expect(matchListPage.footer.getInfo()).toHaveTextContent(
-      'Showing 1–1 of 1 matches',
+      'Showing 1–1 of 1 match',
     )
+    expect(matchListPage.footer.getInfo()).not.toHaveTextContent(/of 1 matches/)
   })
 
   it('renders the Attention tab and the action CTA for an attention row when deep-linked', async () => {

--- a/web-client/src/components/matches/match-list.tsx
+++ b/web-client/src/components/matches/match-list.tsx
@@ -229,7 +229,7 @@ export const MatchList = () => {
         total={total}
         pageSize={PAGE_SIZE}
         totalPages={totalPages}
-        noun="matches"
+        noun={{ one: 'match', other: 'matches' }}
       />
     </div>
   )

--- a/web-client/src/components/notifications/notification-preferences-page.test.tsx
+++ b/web-client/src/components/notifications/notification-preferences-page.test.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { render, screen, waitFor } from '@/test/utilities'
+import { Route } from '@/routes/_app/notifications.settings'
+
+// Mount the real settings route (container → preferences query + taxonomy →
+// PreferencesView) so the matrix rows come through the *actual* preferences
+// `select`. The default MSW handlers serve the full server preferences +
+// taxonomy — rating_change included — so any hiding is the client's doing.
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute()
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/notifications/settings',
+    component: Route.options.component!,
+  })
+  // The deep-link target any channel setup-nudge <Link> resolves against.
+  const settingsPageRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/settings',
+    component: () => <div>settings</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([settingsRoute, settingsPageRoute]),
+    history: createMemoryHistory({
+      initialEntries: ['/notifications/settings'],
+    }),
+  })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('NotificationPreferencesPage — the descoped rating_change category is hidden (#998)', () => {
+  it('omits the "Rating changes" matrix row but keeps the other category rows', async () => {
+    renderPage()
+
+    // Wait for the matrix to resolve — another category row proves it rendered
+    // (so this can't pass by rendering an empty matrix).
+    await waitFor(() =>
+      expect(screen.getByText('Match reminders')).toBeInTheDocument(),
+    )
+    expect(screen.getByText('Tournament news')).toBeInTheDocument()
+    expect(screen.getByText('Score acceptances')).toBeInTheDocument()
+
+    // The rating_change row (label "Rating changes") is filtered out of the
+    // preferences `categories` client-side. Fails before the fix, where the
+    // matrix renders every seeded category including this one.
+    expect(screen.queryByText('Rating changes')).not.toBeInTheDocument()
+    // …and so is every one of its per-channel toggle cells.
+    expect(
+      screen.queryByRole('checkbox', { name: /^Rating changes via/ }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/notifications/notifications-page.test.tsx
+++ b/web-client/src/components/notifications/notifications-page.test.tsx
@@ -1,0 +1,224 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { http, HttpResponse } from 'msw'
+import {
+  notificationFeedQueryOptions,
+  type NotificationFeed,
+  type NotificationItem,
+} from '@/api/notifications'
+import { server } from '@/mocks/server'
+import { act, render, screen, waitFor } from '@/test/utilities'
+import { buildNotificationItem } from './notification-row.factory'
+import { notificationsViewPage } from './notifications-page/notifications-view.page'
+import { Route } from '@/routes/_app/notifications.index'
+
+const READ_AT = '2026-07-03T00:00:00.000Z'
+
+// What the feed returns the moment you arrive: two unread rows and one that was
+// already read before you got here.
+function arrivalFeed(): NotificationItem[] {
+  return [
+    buildNotificationItem({
+      id: 'n-a',
+      title: 'Accept your score',
+      read_at: null,
+    }),
+    buildNotificationItem({
+      id: 'n-b',
+      title: 'Match reminder tonight',
+      read_at: null,
+    }),
+    buildNotificationItem({
+      id: 'n-c',
+      title: 'Rating +12',
+      read_at: READ_AT,
+    }),
+  ]
+}
+
+function feedResponse(items: NotificationItem[]): NotificationFeed {
+  return { items, unread_count: items.filter((i) => i.read_at == null).length }
+}
+
+// Mount the real route component under a memory router so the filter lives in
+// the URL exactly as it does in production — `initialEntry` seeds the starting
+// location (e.g. `/notifications?filter=unread` for a deep-link/reload). The
+// taxonomy endpoint is served by the default MSW handlers.
+function renderPage(feed: NotificationFeed, initialEntry = '/notifications') {
+  server.use(http.get('*/v1/notifications', () => HttpResponse.json(feed)))
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute()
+  const notificationsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/notifications/',
+    component: Route.options.component!,
+    validateSearch: Route.options.validateSearch,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([notificationsRoute]),
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+  })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+  return { queryClient, router }
+}
+
+describe('NotificationsPage — Unread is an arrival snapshot (#996)', () => {
+  it('lands on All, auto-reads every row, and still lists the arrival-unread rows under Unread', async () => {
+    const items = arrivalFeed()
+    const { queryClient } = renderPage(feedResponse(items))
+
+    // Arrive on the default All filter; every row (read or not) is listed.
+    await waitFor(() =>
+      expect(
+        notificationsViewPage.queryTitle('Accept your score'),
+      ).toBeInTheDocument(),
+    )
+    expect(notificationsViewPage.getFilter('All')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+
+    // Auto-mark-on-view fires while we sit on All: the optimistic cache write
+    // flips both arrival-unread rows to read in the very feed this page renders.
+    act(() => {
+      queryClient.setQueryData<NotificationFeed>(
+        notificationFeedQueryOptions().queryKey,
+        feedResponse(
+          items.map((item) =>
+            item.id === 'n-c' ? item : { ...item, read_at: READ_AT },
+          ),
+        ),
+      )
+    })
+
+    // Only now do we click Unread. Pre-fix, the snapshot was gated on the Unread
+    // filter being active, so nothing was captured while we were on All and this
+    // list would be empty. Post-fix, the arrival snapshot keeps them visible.
+    await notificationsViewPage.clickFilter('Unread')
+
+    expect(
+      notificationsViewPage.queryTitle('Accept your score'),
+    ).toBeInTheDocument()
+    expect(
+      notificationsViewPage.queryTitle('Match reminder tonight'),
+    ).toBeInTheDocument()
+    // Not the filter-empty state.
+    expect(notificationsViewPage.queryShowAll()).not.toBeInTheDocument()
+
+    // A row already read on arrival was never "new since you got here", so it is
+    // not pinned and does not appear under Unread.
+    expect(notificationsViewPage.queryTitle('Rating +12')).not.toBeInTheDocument()
+  })
+})
+
+describe('NotificationsPage — the descoped rating_change category is hidden (#998)', () => {
+  it('omits the Rating filter pill but keeps the other category pills', async () => {
+    // The default MSW handler serves the full server taxonomy, rating_change
+    // included; the client-side taxonomy `select` is what drops the pill.
+    renderPage(feedResponse(arrivalFeed()))
+    await waitFor(() =>
+      expect(
+        notificationsViewPage.queryTitle('Accept your score'),
+      ).toBeInTheDocument(),
+    )
+
+    // Other server categories still render their pills (so this can't pass by
+    // rendering no pills at all)…
+    expect(notificationsViewPage.getFilter('Tourney')).toBeInTheDocument()
+    expect(notificationsViewPage.getFilter('Scores')).toBeInTheDocument()
+    expect(notificationsViewPage.getFilter('Calls')).toBeInTheDocument()
+    // …but rating_change (short label "Rating") is filtered out client-side.
+    // Fails before the fix, where the taxonomy is rendered unfiltered.
+    expect(
+      screen.queryByRole('button', { name: 'Rating' }),
+    ).not.toBeInTheDocument()
+  })
+})
+
+describe('NotificationsPage — the filter lives in the URL (#999)', () => {
+  it('writes ?filter=unread to the URL when the Unread pill is clicked', async () => {
+    const { router } = renderPage(feedResponse(arrivalFeed()))
+    await waitFor(() =>
+      expect(
+        notificationsViewPage.queryTitle('Accept your score'),
+      ).toBeInTheDocument(),
+    )
+
+    // Fails against useState-only: the pill would flip local state and never
+    // touch the URL, so a filtered view stays unlinkable.
+    await notificationsViewPage.clickFilter('Unread')
+    await waitFor(() =>
+      expect(router.state.location.search).toEqual({ filter: 'unread' }),
+    )
+  })
+
+  it('clears the param back to a clean URL when All is reselected', async () => {
+    const { router } = renderPage(feedResponse(arrivalFeed()), '/notifications?filter=unread')
+    await waitFor(() =>
+      expect(notificationsViewPage.getFilter('Unread')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      ),
+    )
+
+    // Default (All) is represented by an absent param — the URL stays clean.
+    await notificationsViewPage.clickFilter('All')
+    await waitFor(() => expect(router.state.location.search).toEqual({}))
+  })
+
+  it('renders the Unread view when mounted at ?filter=unread (survives reload)', async () => {
+    const items = arrivalFeed()
+    renderPage(feedResponse(items), '/notifications?filter=unread')
+
+    // Fails against useState-only: the initial state is hardcoded 'all', so a
+    // deep-link/reload would land on All and show the already-read row too.
+    await waitFor(() =>
+      expect(notificationsViewPage.getFilter('Unread')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      ),
+    )
+    // The two arrival-unread rows show…
+    expect(
+      notificationsViewPage.queryTitle('Accept your score'),
+    ).toBeInTheDocument()
+    expect(
+      notificationsViewPage.queryTitle('Match reminder tonight'),
+    ).toBeInTheDocument()
+    // …but the row already read before arrival does not.
+    expect(notificationsViewPage.queryTitle('Rating +12')).not.toBeInTheDocument()
+  })
+
+  it('falls back to All for a bogus ?filter value rather than an empty filtered view', async () => {
+    const items = arrivalFeed()
+    renderPage(feedResponse(items), '/notifications?filter=xyz')
+
+    // A slug no category owns degrades to All — not a filter-empty "Show all"
+    // state. Fails against a naive normalize that passes 'xyz' through to the
+    // view's `category === 'xyz'` predicate (which matches nothing).
+    await waitFor(() =>
+      expect(notificationsViewPage.getFilter('All')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      ),
+    )
+    expect(notificationsViewPage.queryShowAll()).not.toBeInTheDocument()
+    // Every row shows, including the one read before arrival.
+    expect(
+      notificationsViewPage.queryTitle('Accept your score'),
+    ).toBeInTheDocument()
+    expect(notificationsViewPage.queryTitle('Rating +12')).toBeInTheDocument()
+  })
+})

--- a/web-client/src/components/notifications/notifications-page.tsx
+++ b/web-client/src/components/notifications/notifications-page.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import {
   useMarkAllNotificationsRead,
   useNotificationFeed,
@@ -9,31 +10,50 @@ import {
   NotificationsView,
   type NotificationFilter,
 } from './notifications-page/notifications-view'
+import {
+  normalizeNotificationFilter,
+  type NotificationsSearch,
+} from './notifications-page/notifications-search'
 import { useAutoMarkRead } from './use-auto-mark-read'
 import { useFollowNotification } from './use-follow-notification'
 import { useStickyUnread } from './use-sticky-unread'
 
 /** Route container for the full notifications page — wires the feed query, the
- * filter state, and the mark-read mutations to the pure view. */
+ * URL-backed filter, and the mark-read mutations to the pure view. */
 export function NotificationsPage() {
   const feed = useNotificationFeed()
   const taxonomy = useNotificationTaxonomy()
-  const [filter, setFilter] = useState<NotificationFilter>('all')
+  // The active filter is URL state (`?filter=…`), validated at the route
+  // boundary. Read it route-agnostically (`strict: false`) so the same
+  // component mounts under both the real `/notifications/` route and a test's
+  // memory-router harness without importing the Route object (import-cycle
+  // guard). Writes go back to the URL via `navigate`, so a filtered view is
+  // linkable, survives reload, and steps through browser Back (#999).
+  const search = useSearch({ strict: false }) as NotificationsSearch
+  const navigate = useNavigate()
   const follow = useFollowNotification()
   const markAll = useMarkAllNotificationsRead()
   const markSeen = useAutoMarkRead()
-  const { pinned: stickyUnread, remember, forget } = useStickyUnread(
-    filter === 'unread',
-  )
+  // The Unread snapshot is captured on arrival (first feed resolve) from the feed
+  // itself, independent of the landing filter — see `useStickyUnread` (#996).
+  // Reading the filter from the URL rather than local state does not change
+  // when/how this snapshot is taken: it still keys off the feed, not the filter.
+  const { pinned: stickyUnread, forget } = useStickyUnread(feed.data?.items)
 
-  // A row that scrolls into view auto-marks-read AND gets pinned, so viewing it
-  // doesn't drop it off the Unread filter mid-read (#762).
-  const handleSeen = useCallback(
-    (id: string) => {
-      remember(id)
-      markSeen(id)
+  const setFilter = useCallback(
+    (next: NotificationFilter) => {
+      void navigate({
+        to: '/notifications',
+        replace: true,
+        // Default (All) drops the param so the URL stays clean; every other
+        // filter is written verbatim.
+        search: (prev) => ({
+          ...prev,
+          filter: next === 'all' ? undefined : next,
+        }),
+      })
     },
-    [remember, markSeen],
+    [navigate],
   )
 
   // "Mark all read" is an explicit bulk dismiss — forget the snapshot so the
@@ -62,6 +82,13 @@ export function NotificationsPage() {
     )
   }
 
+  // Resolve the raw URL slug against the taxonomy now that it's loaded: an
+  // unknown/stale slug degrades to All rather than rendering an empty filter.
+  const filter = normalizeNotificationFilter(
+    search.filter,
+    taxonomy.data.types.map((t) => t.key),
+  )
+
   return (
     <NotificationsView
       items={feed.data.items}
@@ -71,7 +98,7 @@ export function NotificationsPage() {
       onFilterChange={setFilter}
       onActivate={follow}
       onMarkAllRead={handleMarkAllRead}
-      onSeen={handleSeen}
+      onSeen={markSeen}
       stickyUnread={stickyUnread}
     />
   )

--- a/web-client/src/components/notifications/notifications-page.tsx
+++ b/web-client/src/components/notifications/notifications-page.tsx
@@ -84,10 +84,7 @@ export function NotificationsPage() {
 
   // Resolve the raw URL slug against the taxonomy now that it's loaded: an
   // unknown/stale slug degrades to All rather than rendering an empty filter.
-  const filter = normalizeNotificationFilter(
-    search.filter,
-    taxonomy.data.types.map((t) => t.key),
-  )
+  const filter = normalizeNotificationFilter(search.filter, taxonomy.data.types)
 
   return (
     <NotificationsView

--- a/web-client/src/components/notifications/notifications-page/notifications-search.ts
+++ b/web-client/src/components/notifications/notifications-page/notifications-search.ts
@@ -31,12 +31,12 @@ export type NotificationsSearch = z.infer<typeof notificationsSearchSchema>
  */
 export function normalizeNotificationFilter(
   raw: string | undefined,
-  categoryKeys: readonly NotificationCategory[],
+  categories: readonly { key: NotificationCategory }[],
 ): NotificationFilter {
   if (raw === undefined || raw === 'all' || raw === 'unread') {
     return raw ?? 'all'
   }
-  return (categoryKeys as readonly string[]).includes(raw)
+  return categories.some((c) => c.key === raw)
     ? (raw as NotificationCategory)
     : 'all'
 }

--- a/web-client/src/components/notifications/notifications-page/notifications-search.ts
+++ b/web-client/src/components/notifications/notifications-page/notifications-search.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod'
+
+import type { NotificationCategory } from '../notification-meta'
+import type { NotificationFilter } from './notifications-view'
+
+// The active filter lives in the URL (`?filter=…`), Zod-parsed at the route
+// boundary via `validateSearch` — so a filtered view is linkable, survives a
+// reload, and steps through browser Back (#999, per the web-client Boundaries
+// convention).
+//
+// Category slugs are open-ended: they come from the server taxonomy
+// (`/v1/notification-taxonomy`), not a client-side enum, so the boundary can't
+// know the valid set. It therefore accepts any string; a malformed value (a
+// non-string, an array) `.catch('all')`. `.optional()` keeps the default (All)
+// off the URL entirely — an absent param is undefined, not the literal `all`,
+// so reselecting All returns to a clean `/notifications` (the players/matches
+// `.optional().catch(...)` precedent). An unknown *slug* (a syntactically-valid
+// string that no category owns) is degraded to All in the page by
+// `normalizeNotificationFilter`, once the taxonomy is known.
+export const notificationsSearchSchema = z.object({
+  filter: z.string().optional().catch('all'),
+})
+
+export type NotificationsSearch = z.infer<typeof notificationsSearchSchema>
+
+/**
+ * Resolve the raw URL `filter` to a filter the view understands: `all`,
+ * `unread`, or a category slug the server taxonomy actually defines. An absent
+ * param, or a stale/bogus slug, degrades to `all` rather than rendering an
+ * empty "no notifications match" view for a filter that can never match.
+ */
+export function normalizeNotificationFilter(
+  raw: string | undefined,
+  categoryKeys: readonly NotificationCategory[],
+): NotificationFilter {
+  if (raw === undefined || raw === 'all' || raw === 'unread') {
+    return raw ?? 'all'
+  }
+  return (categoryKeys as readonly string[]).includes(raw)
+    ? (raw as NotificationCategory)
+    : 'all'
+}

--- a/web-client/src/components/notifications/use-sticky-unread.test.ts
+++ b/web-client/src/components/notifications/use-sticky-unread.test.ts
@@ -1,52 +1,96 @@
+import type { NotificationItem } from '@/api/notifications'
 import { act, renderHook } from '@/test/utilities'
+import { buildNotificationItem } from './notification-row.factory'
 import { useStickyUnread } from './use-sticky-unread'
 
+const READ_AT = '2026-07-03T00:00:00.000Z'
+
+/** Two unread rows and one already-read row, as a fresh feed would arrive. */
+function arrivalFeed(): NotificationItem[] {
+  return [
+    buildNotificationItem({ id: 'n-1', read_at: null }),
+    buildNotificationItem({ id: 'n-2', read_at: null }),
+    buildNotificationItem({ id: 'n-3', read_at: READ_AT }),
+  ]
+}
+
+/** The same rows with `ids` flipped read — the optimistic auto-mark cache write. */
+function withRead(items: NotificationItem[], ids: string[]): NotificationItem[] {
+  return items.map((item) =>
+    ids.includes(item.id) ? { ...item, read_at: READ_AT } : item,
+  )
+}
+
 describe('useStickyUnread', () => {
-  it('pins ids reported via remember while active', () => {
-    const { result } = renderHook(() => useStickyUnread(true))
-    act(() => result.current.remember('n-1'))
-    expect([...result.current.pinned]).toEqual(['n-1'])
+  it('snapshots the ids that are unread on arrival, ignoring already-read rows', () => {
+    const { result } = renderHook(() => useStickyUnread(arrivalFeed()))
+    // n-1, n-2 were unread on arrival; n-3 was already read and is not pinned.
+    expect([...result.current.pinned].sort()).toEqual(['n-1', 'n-2'])
   })
 
-  it('keeps a pinned id even after the row it names flips to read', () => {
-    // The hook holds ids, not read state — so a row stays pinned through its
-    // optimistic read_at flip. (The view test asserts the visible effect.)
-    const { result } = renderHook(() => useStickyUnread(true))
-    act(() => result.current.remember('n-1'))
-    act(() => result.current.remember('n-1'))
-    expect([...result.current.pinned]).toEqual(['n-1'])
+  it('holds the snapshot after those rows auto-mark-read (the core #996 fix)', () => {
+    const items = arrivalFeed()
+    const { result, rerender } = renderHook(
+      ({ feed }: { feed: NotificationItem[] }) => useStickyUnread(feed),
+      { initialProps: { feed: items } },
+    )
+    // Auto-mark flips both arrival-unread rows to read in the feed cache.
+    rerender({ feed: withRead(items, ['n-1', 'n-2']) })
+    // They stay pinned — the hook holds ids, not live read state.
+    expect([...result.current.pinned].sort()).toEqual(['n-1', 'n-2'])
   })
 
-  it('exposes no pins while inactive, even after remember', () => {
-    const { result } = renderHook(({ active }) => useStickyUnread(active), {
-      initialProps: { active: false },
+  it('does not pin rows that arrive unread only mid-visit (another device)', () => {
+    const items = arrivalFeed()
+    const { result, rerender } = renderHook(
+      ({ feed }: { feed: NotificationItem[] }) => useStickyUnread(feed),
+      { initialProps: { feed: items } },
+    )
+    // A brand-new unread row shows up after arrival; it is not "new since you
+    // got here" for this snapshot, so it is not pinned.
+    rerender({
+      feed: [buildNotificationItem({ id: 'n-9', read_at: null }), ...items],
     })
-    act(() => result.current.remember('n-1'))
+    expect([...result.current.pinned].sort()).toEqual(['n-1', 'n-2'])
+  })
+
+  it('takes no snapshot until the feed resolves', () => {
+    const { result, rerender } = renderHook(
+      ({ feed }: { feed: NotificationItem[] | undefined }) =>
+        useStickyUnread(feed),
+      { initialProps: { feed: undefined as NotificationItem[] | undefined } },
+    )
     expect(result.current.pinned.size).toBe(0)
+    rerender({ feed: arrivalFeed() })
+    expect([...result.current.pinned].sort()).toEqual(['n-1', 'n-2'])
   })
 
   it('forgets the whole snapshot on demand (e.g. Mark all read)', () => {
-    const { result } = renderHook(() => useStickyUnread(true))
-    act(() => result.current.remember('n-1'))
+    const items = arrivalFeed()
+    const { result } = renderHook(() => useStickyUnread(items))
     act(() => result.current.forget())
     expect(result.current.pinned.size).toBe(0)
   })
 
-  it('starts fresh on re-entry: leaving and returning drops earlier pins', () => {
+  it('stays empty after forget — it does not re-snapshot the same visit', () => {
+    const items = arrivalFeed()
     const { result, rerender } = renderHook(
-      ({ active }) => useStickyUnread(active),
-      { initialProps: { active: true } },
+      ({ feed }: { feed: NotificationItem[] }) => useStickyUnread(feed),
+      { initialProps: { feed: items } },
     )
-    act(() => result.current.remember('n-1'))
-    expect(result.current.pinned.has('n-1')).toBe(true)
-
-    // Leave the Unread filter...
-    rerender({ active: false })
+    act(() => result.current.forget())
+    rerender({ feed: items })
     expect(result.current.pinned.size).toBe(0)
+  })
 
-    // ...and come back: n-1 (read in the meantime) is no longer pinned, so it
-    // drops off instead of being resurrected.
-    rerender({ active: true })
-    expect(result.current.pinned.size).toBe(0)
+  it('re-snapshots on a fresh visit (remount)', () => {
+    const first = renderHook(() => useStickyUnread(arrivalFeed()))
+    act(() => first.result.current.forget())
+    expect(first.result.current.pinned.size).toBe(0)
+    first.unmount()
+
+    // A new mount (return visit / reload) takes a fresh snapshot.
+    const second = renderHook(() => useStickyUnread(arrivalFeed()))
+    expect([...second.result.current.pinned].sort()).toEqual(['n-1', 'n-2'])
   })
 })

--- a/web-client/src/components/notifications/use-sticky-unread.ts
+++ b/web-client/src/components/notifications/use-sticky-unread.ts
@@ -1,60 +1,62 @@
 import { useCallback, useState } from 'react'
+import type { NotificationItem } from '@/api/notifications'
 
 const EMPTY: ReadonlySet<string> = new Set()
 
 export interface StickyUnread {
-  /** Ids to keep visible on the Unread filter; empty while the filter is off. */
+  /** Ids to keep visible on the Unread filter for this visit — the rows that
+   * were unread the moment you arrived, even after auto-mark flips them. */
   pinned: ReadonlySet<string>
-  /** Record a row the view just auto-marked-read so it stays put (#762). */
-  remember: (id: string) => void
   /** Drop the whole snapshot — e.g. an explicit "Mark all read" should empty
    * the list rather than leave the just-read rows pinned. */
   forget: () => void
 }
 
 /**
- * Keeps the rows a user is *actively reading* from vanishing out from under
- * them on the Unread filter.
+ * "Unread" is a per-visit snapshot, not a live `read_at IS NULL` query.
  *
  * Rows auto-mark-read after a moment on screen (`use-auto-mark-read`), and the
  * optimistic cache write flips their `read_at` in the very feed this page
- * renders. A naive `read_at == null` filter would then drop each row the instant
- * it's read, emptying the Unread list mid-read even though the user never
- * dismissed anything (#762). The view reports each row it auto-marks via
- * `remember`; those ids stay pinned (they merely lose the unread emphasis) until
- * the filter is left or the snapshot is explicitly `forget`-ten.
+ * renders. On the default **All** filter that happens on arrival, before the
+ * user ever clicks Unread — so a naive `read_at == null` filter is empty by the
+ * time they get there (#996). Gating the snapshot on the Unread filter being
+ * active (the original #762 mechanism) didn't help: nothing was captured while
+ * the user sat on All.
  *
- * Pinning only what this view auto-read — rather than every row that happens to
- * be unread — is deliberate: a bulk "Mark all read" (`forget`) or a row read on
- * another tab/device is not something the user is mid-reading here, so it drops
- * off the Unread filter as expected instead of lingering.
+ * So we snapshot on **arrival** instead, regardless of the landing filter: the
+ * first render where the feed has resolved, we pin exactly the ids that are
+ * unread right then. Those rows stay visible under Unread for the whole visit
+ * even after auto-mark reads them — "new since you got here." Rows already read
+ * on arrival, or created/read on another device mid-visit, are not in the
+ * snapshot and correctly don't appear.
  *
- * `active` is the Unread filter being on. Entering or leaving it starts a fresh
- * snapshot, so re-entering shows only rows read during this visit.
+ * The snapshot is per mount: a fresh visit (remount) or a reload re-snapshots,
+ * and leaving then returning takes a new one. An explicit bulk "Mark all read"
+ * (`forget`) clears it so the Unread list actually empties.
  */
-export function useStickyUnread(active: boolean): StickyUnread {
-  const [pinned, setPinned] = useState<ReadonlySet<string>>(EMPTY)
-  const [wasActive, setWasActive] = useState(active)
+export function useStickyUnread(
+  items: readonly NotificationItem[] | undefined,
+): StickyUnread {
+  // `null` means no snapshot taken yet this visit; a set (possibly empty) means
+  // it has been captured and must not be recomputed.
+  const [snapshot, setSnapshot] = useState<ReadonlySet<string> | null>(null)
 
-  // Reset on any enter/leave of the filter (state-adjustment during render, the
-  // React-recommended alternative to a setState-in-effect). Use the cleared set
-  // for this render too, not just the next one.
-  let current = pinned
-  if (wasActive !== active) {
-    setWasActive(active)
-    if (pinned.size > 0) {
-      current = EMPTY
-      setPinned(EMPTY)
-    }
+  // Snapshot on arrival: the first render where the feed has resolved. This is a
+  // state-adjustment during render (the React-recommended alternative to a
+  // setState-in-effect) — use the fresh set for this render too, not just next.
+  let pinned = snapshot
+  if (snapshot === null && items !== undefined) {
+    pinned = new Set(
+      items.filter((item) => item.read_at == null).map((item) => item.id),
+    )
+    setSnapshot(pinned)
   }
 
-  const remember = useCallback((id: string) => {
-    setPinned((prev) => (prev.has(id) ? prev : new Set(prev).add(id)))
-  }, [])
-
+  // Setting a (non-null) empty set also blocks a re-snapshot for the rest of the
+  // visit, so "Mark all read" stays emptied rather than re-capturing next render.
   const forget = useCallback(() => {
-    setPinned((prev) => (prev.size === 0 ? prev : EMPTY))
+    setSnapshot((prev) => (prev != null && prev.size === 0 ? prev : EMPTY))
   }, [])
 
-  return { pinned: active ? current : EMPTY, remember, forget }
+  return { pinned: pinned ?? EMPTY, forget }
 }

--- a/web-client/src/components/notifications/use-sticky-unread.ts
+++ b/web-client/src/components/notifications/use-sticky-unread.ts
@@ -54,9 +54,7 @@ export function useStickyUnread(
 
   // Setting a (non-null) empty set also blocks a re-snapshot for the rest of the
   // visit, so "Mark all read" stays emptied rather than re-capturing next render.
-  const forget = useCallback(() => {
-    setSnapshot((prev) => (prev != null && prev.size === 0 ? prev : EMPTY))
-  }, [])
+  const forget = useCallback(() => setSnapshot(EMPTY), [])
 
   return { pinned: pinned ?? EMPTY, forget }
 }

--- a/web-client/src/components/pagination-footer.factory.tsx
+++ b/web-client/src/components/pagination-footer.factory.tsx
@@ -10,7 +10,7 @@ export function buildPaginationFooterProps(
     total: 26,
     pageSize: 25,
     totalPages: 2,
-    noun: 'matches',
+    noun: { one: 'match', other: 'matches' },
     ...overrides,
   }
 }

--- a/web-client/src/components/pagination-footer.test.tsx
+++ b/web-client/src/components/pagination-footer.test.tsx
@@ -11,6 +11,26 @@ describe('PaginationFooter', () => {
     )
   })
 
+  it('inflects the noun to the singular at a count of 1', () => {
+    paginationFooterPage.render({ total: 1, pageSize: 25, totalPages: 1 })
+
+    const info = paginationFooterPage.getInfo()
+    // "of 1 matches" is ungrammatical — a lone result reads the singular.
+    expect(info).toHaveTextContent('Showing 1–1 of 1 match')
+    // Discriminating: "of 1 match" is a substring of the ungrammatical "of 1
+    // matches", so the positive check alone stays green against the old
+    // fixed-plural code. Assert the plural is absent so a regression reds.
+    expect(info).not.toHaveTextContent(/of 1 matches/)
+  })
+
+  it('keeps the plural noun for a count above 1', () => {
+    paginationFooterPage.render({ total: 2, pageSize: 25, totalPages: 1 })
+
+    expect(paginationFooterPage.getInfo()).toHaveTextContent(
+      'Showing 1–2 of 2 matches',
+    )
+  })
+
   it('renders an in-range page range correctly', () => {
     // Page 2 of 4, 100 results, 25/page => Showing 26–50.
     paginationFooterPage.render({

--- a/web-client/src/components/pagination-footer.tsx
+++ b/web-client/src/components/pagination-footer.tsx
@@ -23,11 +23,15 @@ export interface PaginationFooterProps {
   pageSize: number
   totalPages: number
   /**
-   * What the readout counts — "…of 26 **matches**", "…of 40 **players**".
-   * Required on purpose: this footer is shared across pages, and a default
-   * would let a new caller silently ship someone else's copy.
+   * The counted noun, in both grammatical numbers — "…of 1 **match**",
+   * "…of 26 **matches**", "…of 40 **players**". The footer prints `one` when
+   * `total` is exactly 1 and `other` otherwise, so a single-row result reads
+   * grammatically ("of 1 match", not the ungrammatical "of 1 matches").
+   *
+   * Both forms are required on purpose: this footer is shared across pages, and
+   * a default would let a new caller silently ship someone else's copy.
    */
-  noun: string
+  noun: { one: string; other: string }
 }
 
 /**
@@ -67,11 +71,16 @@ export const PaginationFooter = ({
   // page-1 token.
   const isEmpty = total === 0
 
+  // Inflect the noun to match the count so a lone result reads grammatically —
+  // "of 1 match", never "of 1 matches" (mirrors the singular special-case in
+  // `recent-matches/recent-matches-query.ts`'s "View match" label).
+  const countedNoun = total === 1 ? noun.one : noun.other
+
   return (
     <div className="footer">
       <div className="footer-info">
         Showing <span className="mono">{first}–{last}</span> of{' '}
-        <span className="mono">{total}</span> {noun}
+        <span className="mono">{total}</span> {countedNoun}
       </div>
       <div className="footer-spacer" />
       {!isEmpty && (

--- a/web-client/src/components/players/player-match-history.tsx
+++ b/web-client/src/components/players/player-match-history.tsx
@@ -227,7 +227,7 @@ function PlayerMatchesSection({
           total={total}
           pageSize={PAGE_SIZE}
           totalPages={totalPages}
-          noun="matches"
+          noun={{ one: 'match', other: 'matches' }}
         />
       )}
     </section>

--- a/web-client/src/components/scheduling/solve-ledger-page.tsx
+++ b/web-client/src/components/scheduling/solve-ledger-page.tsx
@@ -164,9 +164,9 @@ export function SolveLedgerPage({ page, tournamentId }: SolveLedgerPageProps) {
         total={data.total}
         pageSize={SOLVE_LEDGER_PAGE_SIZE}
         totalPages={totalPages}
-        // Inflected at the call site — the shared footer interpolates a fixed
-        // noun and never singularizes it itself (#1028).
-        noun={data.total === 1 ? 'run' : 'runs'}
+        // The shared footer inflects the noun to the count itself — a lone
+        // result reads "of 1 run", the rest "of N runs" (#1028).
+        noun={{ one: 'run', other: 'runs' }}
       />
     </div>
   )

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { isNotFound } from '@tanstack/react-router'
 import {
   act,
   render,
@@ -120,16 +121,36 @@ describe('useTournament', () => {
     expect(result.current.data).toMatchObject({ id: 't-1' })
   })
 
-  it('resolves to null (not an error) when the id 404s', async () => {
+  it('converts a 404 into a router notFound() — never a null, and never an ApiError (ADR-1001)', async () => {
+    // A missing tournament is a designed state, not an error value: the `queryFn`
+    // throws a router `notFound()`, which `throwOnError` re-throws to a boundary
+    // (the route's `notFoundComponent` in production). So it is the plain
+    // `{ isNotFound: true }` object, NOT an `ApiError`, and emphatically not the
+    // `null` the route used to have to model as "missing". A capturing boundary
+    // reads back what was actually thrown.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
     mockTournamentDetailEndpoint(server, () =>
       HttpResponse.json({ detail: 'Tournament not found.' }, { status: 404 }),
     )
 
-    const { result } = renderHook(() => useTournament('missing'))
+    let caught: unknown
+    function Page() {
+      useTournament('missing')
+      return <p>loaded</p>
+    }
+    render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <CaptureBoundary onCatch={(e) => (caught = e)}>
+          <Page />
+        </CaptureBoundary>
+      </QueryClientProvider>,
+    )
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data).toBeNull()
-    expect(result.current.isError).toBe(false)
+    await waitFor(() => expect(caught).toBeDefined())
+    expect(isNotFound(caught)).toBe(true)
+    expect(caught).not.toBeInstanceOf(ApiError)
   })
 })
 
@@ -1490,6 +1511,28 @@ class CatchBoundary extends Component<
 
   static getDerivedStateFromError() {
     return { failed: true }
+  }
+
+  render() {
+    return this.state.failed ? <p>the boundary caught it</p> : this.props.children
+  }
+}
+
+/** Like `CatchBoundary`, but hands the caught value to `onCatch` so a test can
+ * inspect *what* was thrown — a router `notFound()` (`{ isNotFound: true }`) is
+ * not an `Error`, so "did it throw a notFound or an ApiError" is a real question. */
+class CaptureBoundary extends Component<
+  { children: ReactNode; onCatch: (error: unknown) => void },
+  { failed: boolean }
+> {
+  state = { failed: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  componentDidCatch(error: unknown) {
+    this.props.onCatch(error)
   }
 
   render() {

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -12,6 +12,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query'
+import { notFound } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
 import { ApiError, api, unwrap } from '@/api/client'
@@ -325,30 +326,57 @@ type TournamentDetail = {
 
 /** The detail query, shared by `useTournament` and `useTables` so both read one
  * cache entry from a single fetch — and one parse. It resolves to the mapped
- * `TournamentDetail` (or `null` on 404); each consumer selects its own projection. A
- * 403 bubbles to the `RbacBoundary`; any other error throws. */
+ * `TournamentDetail`; each consumer selects its own projection.
+ *
+ * **A 404 is converted to a router `notFound()` right here, in the `queryFn`**
+ * (ADR-1001: `docs/adr/1001-a-missing-resource-is-a-not-found-not-an-error.md`).
+ * A missing tournament is not an error — it is a designed state — so it never
+ * becomes an `ApiError` the error boundary sees. The throw lands in the detail
+ * route's `notFoundComponent`, not its `errorComponent`. Two obligations follow,
+ * both discharged on the route (`tournaments.$tournamentId.tsx`):
+ *
+ * - **the route must declare its own `notFoundComponent`.** A render-thrown
+ *   `notFound` with no boundary of its own escapes to TanStack's generic
+ *   "Something went wrong!" screen — `defaultNotFoundComponent` never sees it.
+ * - **it must not be retried.** A 404 fails identically every time, so a retry
+ *   only makes the user watch the skeleton longer before the not-found paints —
+ *   see `retry` below.
+ *
+ * A 403 (a permitted non-creator the server still gates) is NOT converted: it
+ * stays an `ApiError` and reaches the `RbacBoundary` the route wraps around
+ * itself. Any other error throws too. */
 function tournamentDetailQuery(id: string) {
   return queryOptions({
     queryKey: tournamentKey(id),
-    queryFn: async (): Promise<TournamentDetail | null> => {
-      const result = await api.GET('/v1/tournaments/{tournament_id}', {
-        params: { path: { tournament_id: id } },
-      })
-      // A 404 is an expected "doesn't exist" — resolve to null rather than
-      // throw, so the route renders its own not-found screen.
-      if (result.response?.status === 404) return null
-      const payload: TournamentDetailRead = unwrap('load tournament', result)
-      // The parse boundary: `apiToTournament` runs `parseFixtures` over every event's
-      // draw, so a malformed fixture throws HERE — inside the fetch — and is reported
-      // as a failed query rather than half-entering the app.
+    queryFn: async (): Promise<TournamentDetail> => {
+      let payload: TournamentDetailRead
+      try {
+        // The parse boundary: `apiToTournament` runs `parseFixtures` over every event's
+        // draw, so a malformed fixture throws HERE — inside the fetch — and is reported
+        // as a failed query rather than half-entering the app.
+        payload = unwrap(
+          'load tournament',
+          await api.GET('/v1/tournaments/{tournament_id}', {
+            params: { path: { tournament_id: id } },
+          }),
+        )
+      } catch (error) {
+        // The one status that is not an error. `notFound()` returns a plain object
+        // (`{ isNotFound: true }`), NOT an `Error` — anything that can catch it must
+        // tolerate a non-Error throw (the route's `RbacBoundary` narrows on
+        // `instanceof ApiError`, so it does).
+        if (error instanceof ApiError && error.status === 404) throw notFound()
+        throw error
+      }
       return {
         tournament: apiToTournament(payload),
         tables: payload.table_catalogue,
       }
     },
-    // Bubble everything except a 404 (which resolved to null above and never
-    // reaches here as an error) — but only while there is NOTHING on screen. A
-    // 403 on load still reaches the RbacBoundary.
+    // Throw on a first-load failure so it reaches a boundary — the converted 404
+    // lands in the route's `notFoundComponent`, everything else (5xx, a 403, a
+    // network blip, a malformed-draw parse) in its error boundary — but ONLY
+    // while there is nothing on screen.
     //
     // `throwOnError` fires on *background refetch* failures too, not just the
     // first load. Since the entry mutations now reconcile on settle (see below),
@@ -356,20 +384,29 @@ function tournamentDetailQuery(id: string) {
     // whole rendered tournament away — a network blip on Enter is a toast, not a
     // teardown. With data in hand we keep the last-good view and let the
     // mutation's own error toast carry the failure.
-    throwOnError: (error, query) =>
-      !(error instanceof ApiError && error.status === 404) &&
-      query.state.data === undefined,
-    retry: false,
+    throwOnError: (_error, query) => query.state.data === undefined,
+    // Decline to retry a terminal failure, retry a transient server one (ADR-1001).
+    // A converted 404 (a `notFound()`), any other 4xx (a 403 included), and a parse
+    // failure of an otherwise-OK payload all fail identically every time, so a retry
+    // only delays the boundary. A genuine 5xx may clear, so give it a couple of
+    // tries. Anything that is not an `ApiError` (a `notFound()`, a Zod parse throw)
+    // is terminal here and declined.
+    retry: (failureCount, error) => {
+      if (!(error instanceof ApiError) || error.status < 500) return false
+      return failureCount < 2
+    },
   })
 }
 
-/** A single tournament's detail, as a prototype `Tournament` — or `null` when the id
- * 404s (so the detail route can show its "not found" UI). A projection of the parsed
- * cache entry: the mapping already happened, in the `queryFn`. */
+/** A single tournament's detail, as a prototype `Tournament`. A projection of the
+ * parsed cache entry: the mapping already happened, in the `queryFn`. A 404 no
+ * longer resolves to `null` here — it is converted to a router `notFound()` in the
+ * `queryFn` (ADR-1001), which the detail route's `notFoundComponent` catches, so
+ * this never has to model "missing" as a value. */
 export function useTournament(id: string) {
   return useQuery({
     ...tournamentDetailQuery(id),
-    select: (data) => data?.tournament ?? null,
+    select: (data) => data.tournament,
   })
 }
 
@@ -380,7 +417,7 @@ export function useTournament(id: string) {
 export function useTables(id: string): TournamentTable[] {
   const { data } = useQuery({
     ...tournamentDetailQuery(id),
-    select: (data) => data?.tables ?? [],
+    select: (data) => data.tables,
   })
   return data ?? []
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.page.tsx
@@ -18,6 +18,11 @@ const scoped = (container: Container) => ({
   getCourtInput() {
     return container.getByRole('textbox', { name: 'Court' })
   },
+  /** The Court field's placeholder — must hint a BARE value (e.g. "A"), never
+   * "Court", or a user following it types "Court A" → card "Court Court A". */
+  getCourtPlaceholder() {
+    return this.getCourtInput().getAttribute('placeholder')
+  },
   getAddButton() {
     return container.getByRole('button', { name: 'Add table' })
   },

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from '@testing-library/user-event'
 
-import { buildTables } from '../data/seed.factory'
+import { buildTable, buildTables } from '../data/seed.factory'
 import { tablesTabPage } from './tables-tab.page'
 
 describe('TablesTab', () => {
@@ -21,6 +21,42 @@ describe('TablesTab', () => {
     expect(next[2]).toEqual(
       expect.objectContaining({ label: 'T9', court: '9' }),
     )
+  })
+
+  // The Court field is already labeled "Court" (its aria-label), and the card
+  // renders "Court {court}" — so the value stored is a BARE identifier. The
+  // placeholder must hint that bare value, never "Court", or a user who follows
+  // it types "Court A" and the card reads "Court Court A".
+  it('hints a bare Court value, not "Court", so "Court Court A" is impossible', async () => {
+    const onChangeCatalogue = vi.fn()
+    tablesTabPage.render({
+      catalogue: buildTables(2),
+      onChangeCatalogue,
+    })
+
+    const placeholder = tablesTabPage.getCourtPlaceholder()
+    expect(placeholder).not.toBe('Court')
+    expect(placeholder).not.toMatch(/court/i)
+
+    // A user following the placeholder types just "A".
+    await userEvent.type(tablesTabPage.getLabelInput(), 'T9')
+    await userEvent.type(tablesTabPage.getCourtInput(), 'A')
+    await userEvent.click(tablesTabPage.getAddButton())
+
+    const next = onChangeCatalogue.mock.calls[0][0]
+    // Stored raw as "A" (not "Court A") → the card's "Court " prefix reads "Court A".
+    expect(next[2]).toEqual(expect.objectContaining({ label: 'T9', court: 'A' }))
+  })
+
+  // The card prepends "Court " to the raw value, so a bare "A" reads "Court A"
+  // (and never the "Court Court A" a "Court"-nudged value would produce).
+  it('renders a bare court value as "Court A" on the card', () => {
+    tablesTabPage.render({
+      catalogue: [buildTable({ id: 't1', label: 'T1', court: 'A' })],
+    })
+
+    expect(document.body).toHaveTextContent('Court A')
+    expect(document.body).not.toHaveTextContent('Court Court A')
   })
 
   it('keeps the add button disabled until a label is entered', async () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.tsx
@@ -140,8 +140,13 @@ export const TablesTab = ({
               className="w-36"
             />
             <Input
+              // The card renders "Court {court}", so the field is already
+              // labeled "Court" (aria-label) — the value is a bare identifier.
+              // Placeholder hints a bare value ("A"), never "Court", so a user
+              // following it types "A" → card reads "Court A", not the
+              // "Court Court A" a "Court" placeholder would nudge them into.
               aria-label="Court"
-              placeholder="Court"
+              placeholder="e.g. A"
               value={court}
               onChange={(e) => setCourt(e.target.value)}
               className="w-28"

--- a/web-client/src/components/tournaments/tournament-not-found.tsx
+++ b/web-client/src/components/tournaments/tournament-not-found.tsx
@@ -1,0 +1,47 @@
+import { Link } from '@tanstack/react-router'
+
+import { NotFoundContent } from '@/components/not-found-content'
+
+/**
+ * The tournament detail route's `notFoundComponent` — what a tournament id that
+ * names nothing renders instead of the error boundary. See
+ * `docs/adr/1001-a-missing-resource-is-a-not-found-not-an-error.md`: a missing
+ * resource is a designed state, so it gets copy that names the thing that was
+ * missing and a way back to somewhere the user can find it.
+ *
+ * It catches TWO throws, and the whole point of the route is that they land in
+ * the same place (#992, #1050, #1090):
+ *
+ * - a **well-formed-but-unknown** uuid — the detail query's `queryFn` gets a 404
+ *   and converts it to a router `notFound()`;
+ * - a **malformed** id segment (`abc`, `new`, `%20`) — the route's `params.parse`
+ *   rejects a non-uuid and throws `notFound()` *before any fetch*, so a garbage
+ *   URL never reaches the API and never leaks a Pydantic "Input should be a valid
+ *   UUID" string into the UI.
+ *
+ * **Shell-less on purpose.** The tournament routes already sit under `_app`, which
+ * *is* an `<AppShell>`. This renders `NotFoundContent` directly rather than
+ * reusing `NotFoundPage` (which wraps its own `AppShell`) — nesting a second shell
+ * here would put two `<main>` landmarks, two sidebars and two headers on the page.
+ * The test pins that with a zero-`<main>` assertion; don't add a shell.
+ *
+ * No `meta` line, unlike the root 404. Echoing the requested path is the *root*
+ * 404's affordance: there the URL matched nothing, so the path is the one piece of
+ * evidence the user can act on. Here the URL matched this route perfectly and only
+ * the id is unknown — replaying an opaque uuid back at the reader adds no
+ * information and no recovery. The recovery is the link.
+ */
+export function TournamentNotFound() {
+  return (
+    <NotFoundContent
+      headline="Tournament not found."
+      body={
+        <>
+          No tournament with that id. It may have been deleted, or the link is
+          wrong.
+        </>
+      }
+      action={<Link to="/tournaments">Back to tournaments</Link>}
+    />
+  )
+}

--- a/web-client/src/components/tournaments/tournament-route-error.tsx
+++ b/web-client/src/components/tournaments/tournament-route-error.tsx
@@ -1,0 +1,91 @@
+import { useRouter } from '@tanstack/react-router'
+
+import { ApiError } from '@/api/client'
+import { AccessDenied } from '@/components/rbac/error-fallback'
+
+export interface TournamentRouteErrorProps {
+  error: Error
+  reset: () => void
+}
+
+/**
+ * Route-level fallback for the tournament detail route — **everything that is
+ * genuinely an error**: 5xx, network-down, a malformed-draw parse failure, a
+ * render throw, 401, and a 403.
+ *
+ * It does NOT own "Tournament not found". A 404 is not an error, it is a designed
+ * state: the detail query's `queryFn` converts it into a router `notFound()`, and
+ * the route's `notFoundComponent` (`TournamentNotFound`) renders it with copy that
+ * names the missing thing and a link back to the tournaments list. A malformed id
+ * never reaches here at all — `params.parse` throws `notFound()` before any fetch.
+ * See `docs/adr/1001-a-missing-resource-is-a-not-found-not-an-error.md`.
+ *
+ * **Two branches, and the split is deliberate:**
+ *
+ * - **403** — a permitted non-creator the server still gates. This route used to
+ *   have no error boundary of its own, so its 403 bubbled to the `RbacBoundary`
+ *   the parent `tournaments` layout wraps the `<Outlet>` in, which renders
+ *   `AccessDenied`. Now that the route owns its own boundary (for ADR-1001), that
+ *   boundary catches the 403 first — so it renders the same `AccessDenied` panel,
+ *   keeping the "you don't have access" UX exactly where it was. A 403 is a
+ *   server-side refusal, not a transient failure, so it is not retryable.
+ * - **everything else is retryable.** A 5xx, a dropped network, a bad payload, a
+ *   render crash, a bare 401 — the tournament may well exist and the request
+ *   simply failed, so the one action re-runs it.
+ *
+ * The `error` prop is typed `Error` because that is what TanStack hands an
+ * `errorComponent`, but a `notFound()` is a plain object, not an `Error`; the
+ * `instanceof ApiError` narrowing below tolerates a non-Error throw. (A
+ * `notFound()` should never arrive here — `CatchNotFound` is mounted *inside*
+ * `CatchBoundary`, so it catches first — but this is not the place to be surprised
+ * by it.)
+ *
+ * The styling is the design system's page-level error state (`md-error-state`, in
+ * `src/index.css`), the same treatment `AppError`, `MatchDetailsError` and
+ * `PlayerRouteError` use.
+ */
+export function TournamentRouteError({ error, reset }: TournamentRouteErrorProps) {
+  const router = useRouter()
+
+  // A server-side permission gate — the same panel the parent `RbacBoundary` would
+  // have shown, so direct-navigation to a tournament you can't see reads as
+  // intentional rather than broken.
+  if (error instanceof ApiError && error.status === 403) {
+    return <AccessDenied />
+  }
+
+  return (
+    <div role="alert" className="md-error-state" data-tone="alert">
+      <div className="md-error-state__code">
+        <span className="md-error-state__dot" aria-hidden="true" />
+        Error
+      </div>
+      <h1 className="md-error-state__title">Couldn’t load this tournament.</h1>
+      {/* Deliberately vague about the cause: this branch catches a 5xx, a dropped
+       * network, a bad payload, a bare 401 and a render throw alike. Naming one
+       * cause would be a confident lie in most of the others. Say what is true of
+       * all of them — it didn't load, it may be temporary, here is the retry — and
+       * let the button do the talking. The 404, the one status we CAN name, is not
+       * here at all: it has its own page. */}
+      <p className="md-error-state__sub">
+        The tournament didn’t load. It may be temporary — try again.
+      </p>
+      <div className="md-error-state__actions">
+        <button
+          type="button"
+          className="md-btn md-btn--primary"
+          onClick={() => {
+            // Reset the router's error boundary, then re-run the loaders so the
+            // failed detail query refetches. Both halves matter: `reset()` alone
+            // re-renders the boundary with the same failed query, and
+            // `invalidate()` alone leaves the boundary up.
+            reset()
+            void router.invalidate()
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/routes/_app/notifications.index.tsx
+++ b/web-client/src/routes/_app/notifications.index.tsx
@@ -1,10 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { zodValidator } from '@tanstack/zod-adapter'
 import { NotificationsPage } from '@/components/notifications/notifications-page'
+import { notificationsSearchSchema } from '@/components/notifications/notifications-page/notifications-search'
 import { pageTitle } from '@/lib/page-title'
+
+// Re-exported so deep-link tests can read the search schema off the route module.
+export { notificationsSearchSchema } from '@/components/notifications/notifications-page/notifications-search'
 
 export const Route = createFileRoute('/_app/notifications/')({
   head: () => ({
     meta: [{ title: pageTitle('Notifications') }],
   }),
+  // The active filter lives in the URL (`?filter=…`), Zod-parsed at the route
+  // boundary — a malformed value falls back to All instead of throwing (#999).
+  validateSearch: zodValidator(notificationsSearchSchema),
   component: NotificationsPage,
 })

--- a/web-client/src/routes/_app/players/index.tsx
+++ b/web-client/src/routes/_app/players/index.tsx
@@ -150,7 +150,7 @@ function PlayersPage() {
         total={total}
         pageSize={PAGE_SIZE}
         totalPages={totalPages}
-        noun="players"
+        noun={{ one: 'player', other: 'players' }}
       />
     </div>
   )

--- a/web-client/src/routes/_app/tournaments.$tournamentId.test.tsx
+++ b/web-client/src/routes/_app/tournaments.$tournamentId.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { server } from '@/mocks/server'
+import { Route } from './tournaments.$tournamentId'
+
+// The SHIPPED route options — read off the route rather than re-implemented, so a
+// route that drops its `params.parse`, its `notFoundComponent` or its
+// `errorComponent` reds these tests instead of quietly changing behaviour.
+const TournamentRoute = Route.options.component!
+const TournamentError = Route.options.errorComponent!
+/** The route's OWN not-found boundary (ADR-1001). A route with none of its own has
+ * no not-found boundary at its match at all, so the `notFound()` the query (or
+ * `params.parse`) throws would escape to TanStack's generic screen — which is
+ * exactly what these tests would then render, and go red on. */
+const TournamentNotFound = Route.options.notFoundComponent
+/** The REAL param parser, typed loosely enough to hang off this harness's route
+ * (whose path type differs from the file route's). Nothing here re-implements it —
+ * a route that dropped `params.parse` would send `/tournaments/abc` to the API. */
+const shippedParseParams = (
+  Route.options.params as { parse: (raw: unknown) => { tournamentId: string } }
+).parse
+
+/** A well-formed uuid that names nothing — the "valid but unknown" case. */
+const UNKNOWN_ID = '00000000-0000-4000-8000-000000000000'
+
+/** Count every detail fetch, so a test can prove one happened — or, for a
+ * malformed id, that NONE did (the whole point of validating at the route
+ * boundary: a garbage URL never reaches the API). */
+function mockDetail(status: number, onRequest?: () => void) {
+  server.use(
+    http.get('*/v1/tournaments/:id', () => {
+      onRequest?.()
+      if (status === 200) return HttpResponse.json({ detail: 'unused' })
+      return HttpResponse.json({ detail: 'nope' }, { status })
+    }),
+  )
+}
+
+/**
+ * Mount the real route at its real path under a memory router, with the shipped
+ * boundaries wired, plus a `/tournaments` list stub the not-found page's one
+ * recovery link points at. `retryDelay: 1` keeps the 5xx-retry test fast (the
+ * query's own `retry` predicate retries a 5xx twice, and it overrides the client).
+ */
+function renderRoute(initialEntry: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retryDelay: 1 } },
+  })
+  const rootRoute = createRootRoute()
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/tournaments/$tournamentId',
+    component: TournamentRoute,
+    errorComponent: TournamentError,
+    notFoundComponent: TournamentNotFound,
+    // The REAL param parser — the thing under test. A route that dropped it would
+    // send `/tournaments/abc` to the API and blow up in the error boundary.
+    params: { parse: (raw) => shippedParseParams(raw) },
+  })
+  const listRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/tournaments',
+    component: () => <div>tournaments list</div>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([listRoute, detailRoute]),
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+  })
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    ),
+    router,
+  }
+}
+
+describe('tournament detail route — a missing tournament is a not-found, not an error (ADR-1001)', () => {
+  it('sends a MALFORMED id to the designed not-found — with no fetch and no validator string', async () => {
+    // The #992 fix: `/tournaments/abc` must never reach the API (where it would
+    // 422 with a Pydantic "Input should be a valid UUID" string) — `params.parse`
+    // rejects the non-uuid segment and throws `notFound()` before any request.
+    let requests = 0
+    mockDetail(404, () => {
+      requests += 1
+    })
+
+    renderRoute('/tournaments/abc')
+
+    expect(
+      await screen.findByRole('heading', { name: 'Tournament not found.' }),
+    ).toBeInTheDocument()
+    // Not a single fetch went out — the boundary caught it at the route edge.
+    expect(requests).toBe(0)
+    // And the raw validator string never appears.
+    expect(screen.queryByText(/valid uuid/i)).not.toBeInTheDocument()
+    // Not the error boundary, and not the generic router screen.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument()
+  })
+
+  it('sends a well-formed-but-unknown id (a 404) to the same not-found — and this one DID fetch', async () => {
+    let requests = 0
+    mockDetail(404, () => {
+      requests += 1
+    })
+
+    renderRoute(`/tournaments/${UNKNOWN_ID}`)
+
+    expect(
+      await screen.findByRole('heading', { name: 'Tournament not found.' }),
+    ).toBeInTheDocument()
+    // The client cannot tell valid-unknown from valid-known without the request —
+    // so unlike the malformed case, this one really asked the server. And exactly
+    // ONCE: a 404 is terminal, so the query's `retry` predicate declines it rather
+    // than making the user watch the skeleton through three attempts.
+    expect(requests).toBe(1)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('is not a dead end — the one action lands on the tournaments list', async () => {
+    const user = userEvent.setup()
+    mockDetail(404)
+
+    const { router } = renderRoute('/tournaments/abc')
+    const link = await screen.findByRole('link', { name: 'Back to tournaments' })
+
+    await user.click(link)
+
+    expect(await screen.findByText('tournaments list')).toBeInTheDocument()
+    expect(router.state.location.pathname).toBe('/tournaments')
+  })
+
+  it('still sends a 5xx to the RETRYABLE error boundary — never “Tournament not found.”', async () => {
+    // The regression this change most endangers: a server error is NOT a missing
+    // tournament. It must render the error state, with a working retry, and must
+    // never be reported as a 404.
+    let requests = 0
+    mockDetail(500, () => {
+      requests += 1
+    })
+
+    renderRoute(`/tournaments/${UNKNOWN_ID}`)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Couldn’t load this tournament.')
+    expect(
+      screen.queryByRole('heading', { name: 'Tournament not found.' }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+    // …and, unlike the 404, a 5xx is retried before it gives up (the query's
+    // predicate retries a transient server failure a couple of times).
+    expect(requests).toBeGreaterThan(1)
+  })
+
+  it('sends a 403 to the AccessDenied panel, not the not-found', async () => {
+    // A permitted non-creator the server still gates. It used to reach the parent
+    // layout's `RbacBoundary`; the route's own error boundary now catches it first
+    // and renders the same panel.
+    mockDetail(403)
+
+    renderRoute(`/tournaments/${UNKNOWN_ID}`)
+
+    expect(
+      await screen.findByText("You don't have access to this page"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { name: 'Tournament not found.' }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/web-client/src/routes/_app/tournaments.$tournamentId.tsx
+++ b/web-client/src/routes/_app/tournaments.$tournamentId.tsx
@@ -1,7 +1,9 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, notFound, useNavigate } from '@tanstack/react-router'
+import { z } from 'zod'
 
-import { Button } from '@/components/ui/button'
 import { TournamentDetailPage } from '@/components/tournaments/tournament-detail-page'
+import { TournamentNotFound } from '@/components/tournaments/tournament-not-found'
+import { TournamentRouteError } from '@/components/tournaments/tournament-route-error'
 import {
   eventToCreateBody,
   eventToUpdateBody,
@@ -15,11 +17,43 @@ import {
 } from '@/components/tournaments/data/api'
 import { pageTitle } from '@/lib/page-title'
 
+/** The tournament id segment. The API types `tournament_id` as a `uuid.UUID`, so a
+ * non-uuid segment is a URL that names no resource — never a request to make. */
+const tournamentIdSchema = z.string().uuid()
+
 export const Route = createFileRoute('/_app/tournaments/$tournamentId')({
+  // Validate the id at the route boundary, BEFORE any fetch (ADR-1001). A non-uuid
+  // segment (`new`, `abc`, `%20`) throws `notFound()` here, so it lands in
+  // `notFoundComponent` below rather than hitting the API and leaking a Pydantic
+  // "Input should be a valid UUID" string into the error boundary (#992, #1050,
+  // #1090). A router-thrown `notFound` from `params.parse` is tagged with this
+  // route's id, so it renders THIS route's `notFoundComponent`.
+  params: {
+    parse: (raw) => {
+      const parsed = tournamentIdSchema.safeParse(raw.tournamentId)
+      if (!parsed.success) throw notFound()
+      return { tournamentId: parsed.data }
+    },
+  },
   head: () => ({
     meta: [{ title: pageTitle('Tournament') }],
   }),
   component: TournamentDetailRoute,
+  // The two boundaries, and the split between them is the whole of ADR-1001.
+  // `notFoundComponent` owns the one status that is a designed outcome — a
+  // tournament that does not exist: the detail query's `queryFn` converts a 404
+  // into a router `notFound()`, `params.parse` throws one for a malformed id, and
+  // this is the boundary that catches both. `errorComponent` keeps everything that
+  // is genuinely an error — 5xx, network, a bad payload, a 403 (→ AccessDenied) —
+  // and stays retryable.
+  //
+  // Declaring `notFoundComponent` here is NOT optional and NOT a fallback to the
+  // router's `defaultNotFoundComponent`: a route with none of its own has no
+  // not-found boundary mounted at its match at all, so a render-thrown `notFound`
+  // would sail past every route to TanStack's generic "Something went wrong!"
+  // screen.
+  notFoundComponent: TournamentNotFound,
+  errorComponent: TournamentRouteError,
 })
 
 function TournamentDetailRoute() {
@@ -34,29 +68,16 @@ function TournamentDetailRoute() {
 
   const back = () => navigate({ to: '/tournaments' })
 
-  // First load: the query is pending and `tournament` is still undefined.
-  // Show a loading state rather than the not-found screen (which is only for a
-  // resolved 404).
-  if (isPending) {
+  // First load: the query is pending and `tournament` is still undefined — show a
+  // loading state. A resolved 404 no longer lands here at all: the detail query
+  // converts it to a router `notFound()`, which this route's `notFoundComponent`
+  // catches (ADR-1001), and any genuine error is thrown to `errorComponent`. So a
+  // settled, non-pending render always has a `tournament` (the `!tournament` guard
+  // below is a type narrowing for that unreachable case, not a UI state).
+  if (isPending || !tournament) {
     return (
       <div className="mx-auto flex max-w-[600px] items-center justify-center px-12 py-24 text-center">
         <p className="text-[14px] text-[color:var(--fg-3)]">Loading tournament…</p>
-      </div>
-    )
-  }
-
-  // `useTournament` resolves to `null` on a 404 (a 403 bubbles to the
-  // RbacBoundary instead); show the not-found screen only after loading settles.
-  if (!tournament) {
-    return (
-      <div className="mx-auto flex max-w-[600px] flex-col items-center gap-4 px-12 py-24 text-center">
-        <h1 className="text-[20px] font-semibold text-[color:var(--fg-1)]">
-          Tournament not found
-        </h1>
-        <p className="text-[14px] text-[color:var(--fg-3)]">
-          It may have been deleted, or the link is wrong.
-        </p>
-        <Button onClick={back}>Back to tournaments</Button>
       </div>
     )
   }


### PR DESCRIPTION
Three tight, demoable slices from the open-issue backlog — each is "the app was showing users something broken or dishonest; now it doesn't." No user-facing feature work; one deferred feature was split out to #1176.

## Slice 1 — Tournament detail route: a bad id is a not-found, not a leaked error
Applies the **ADR-1001** not-found pattern (already established on the player route) to `/tournaments/$tournamentId`:
- The id param is Zod-validated at the route boundary — a non-UUID segment (`new`, `abc`, `%20`) throws `notFound()` **before any fetch**, so `/tournaments/new` no longer greedily matches the detail route and leaks a raw `"Input should be a valid UUID"` Pydantic string.
- The detail query converts a 404 → `notFound()` in its `queryFn` (declining retry on 4xx); the route declares a shell-less `notFoundComponent` and keeps a retryable `errorComponent` for genuine 5xx.

Closes #992, closes #1050, closes #1090.

## Slice 2 — Counts and copy read grammatically
- `PaginationFooter` inflects its noun at a count of 1 ("of 1 **match**"), via a `{one, other}` pair; all callers updated. Closes #1028.
- The `DegenerateDraw` draw-refusal pluralizes its count nouns ("1 **entrant** across 1 **pool**"), retiring "1 entrants across 1 pool(s)". Closes #1048, closes #1059.
- The Tables-tab Court field placeholder hints a bare value ("e.g. A") so following it can't render "Court Court A". Closes #1088.

## Slice 3 — Notifications tell the truth
Decision recorded in `docs/adr/20260724-unread-is-a-per-visit-snapshot-over-auto-marked-notifications.md`.
- **Unread is a per-visit snapshot**: the sticky set is captured on arrival regardless of the landing filter, so switching to Unread after auto-mark still lists what was unread when you arrived. Closes #996.
- The bell **unread-count badge** reconciles to the server's true count on the batch/auto-read path (invalidating only the cheap count key), so it no longer sticks stale until the 60s poll. Closes #1112.
- The active filter lives in the **URL** (`?filter=…`), Zod-validated at the route boundary with an `.optional().catch('all')` fallback; deep links/reloads survive, a bogus value degrades to All. Closes #999.
- The **`rating_change` category is hidden** client-side from both the filter pills and the preferences matrix (it never fires) via a single revertable constant.

### Deferred (not closed)
#998 asked for result-accepted + rating-change notifications. That's a domain-event fan-out feature with its own design surface, so it's **descoped** here (the dead Rating pill/pref is hidden) and tracked in **#1176**. Refs #998.

## Testing
- **API:** ruff · ruff format · mypy · pytest **1756 passed** (the full run caught a second stale `DegenerateDraw` assertion in `test_tournaments.py`, now fixed).
- **web-client:** vitest **3001 passed** · eslint clean · tsc · vite build.
- **web-client e2e (Playwright, MSW off):** **302 passed**, including a new `tournament-not-found.spec.ts`.
- No OpenAPI change (the draws fix is a runtime error string; notifications are client-only) — `schema.d.ts` unchanged.
- Every chore was independently verified by a fresh verifier with a reproduced fail-before; `/simplify` applied two cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)