### PR TITLE
Rating & dashboard correctness: #915 fast-follows (honest ranking, snapshot anchor, chart, a11y, notifications)

### DIFF
--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -35,7 +35,9 @@ from app.ratings.stats import (
     current_streak_for_user,
     latest_rated_match_change,
     league_peak_rating,
-    league_percentile,
+    league_percentile_if_ranked,
+    league_rank,
+    league_rated_population,
 )
 from app.result_acceptance import side_win_counts
 from app.retirement import retirement_deadline
@@ -44,6 +46,7 @@ from app.schemas.dashboard import (
     DashboardAttentionItem,
     DashboardRating,
     DashboardRatingStat,
+    DashboardRatingState,
     DashboardRecentResult,
     DashboardResponse,
     DashboardStreak,
@@ -293,40 +296,41 @@ def _build_recent_result(
     )
 
 
-async def _build_rating(db: AsyncSession, user_id: uuid.UUID) -> DashboardRating | None:
-    """Resolve the user's headline rating row — or ``None``, and no card at all.
+async def _build_rating(db: AsyncSession, user_id: uuid.UUID) -> DashboardRating:
+    """The dashboard's rating card — ALWAYS an object now, carrying a ``state``
+    discriminator, never a bare ``None`` (ADR 20260725).
 
-    Picks the default league's rating if they hold one there, otherwise the oldest
-    league they DO hold one in. "Hold" is ``is_rated_member()``: the widget stays
-    hidden until the league is actually scoring you, which is what this docstring
-    has always claimed and what the row filter now makes true.
+    The ``RATED`` arm is the headline rating: picks the default league's rating if
+    the user holds one there, otherwise the oldest league they DO hold one in.
+    "Hold" is ``is_rated_member()`` — the card shows a rating only when a league is
+    actually scoring them, not when they merely hold the 1500 the league seeded on
+    join (that seed is the strategy's prior, not a rating they earned; #382/#952).
 
-    It was not true. Joining a league seeds a 1500 row, so a guest who had never
-    played anything got the full card — current 1500, peak 1500, RD 350, a
-    one-point sparkline — every number of which is the strategy's PRIOR rather than
-    anything they did. The percentile was suppressed for them (#382) precisely
-    because it was the most obviously absurd of the five; the fix is the same one
-    the profile now makes, applied once and to all of them: a player who has never
-    finished a rated match has no rating, so there is no rating card. They see the
-    same "Unrated" story here as on their profile instead of a fabricated one.
+    The three non-rated arms replace what used to be three indistinguishable
+    ``return None`` exits, which the client could only render as one (false-for-two)
+    string:
 
-    (The alternative — keep the card and null out ``peak``/``percentile`` — would
-    make ``DashboardRating.peak`` nullable, i.e. an OpenAPI change, and would still
-    print a rating of 1500 next to a profile that says Unrated. Hiding the card
-    needs no schema change: ``rating`` is already ``DashboardRating | None`` for
-    manual-strategy leagues, and the client already renders that.)
+    * ``UNRATED`` — in a Glicko-2 (automatic) league, no rated match finished yet;
+    * ``AWAITING_IMPORT`` — a manual-strategy league whose import is pending (or a
+      manual member whose imported rating we do not headline as a Glicko-2 card);
+    * ``NOT_RATED_LEAGUE`` — not a member of any rated league at all.
+
+    Which of the three obtains is a fact only the server holds, so it names it here
+    rather than leaving the client to guess from a ``null``.
 
     ``completed_match_count`` is no longer a parameter: it was a PROXY for "is this
-    player rated" (#382), and we now have the predicate itself. A rated player has,
-    by definition, completed a rated match — so the old gate could no longer fire,
-    and a dead guard that looks live is worse than no guard.
+    player rated" (#382), and we now have the predicate itself.
     """
     rating_row = await _resolve_user_rating(db, user_id)
     if rating_row is None or rating_row.rating_value is None:
-        return None
+        # Not a rated member. Name the league they ARE in (and why it does not rate
+        # them), or ``NOT_RATED_LEAGUE`` if they are in none.
+        return await _non_rated_rating(db, user_id)
     strategy = rating_row.league.rating_strategy
     if not strategy.is_automatic:
-        return None
+        # A rated member of a manual-strategy league: an imported number, not a
+        # Glicko-2 card. Its state is the manual-league one.
+        return _non_rated_card(DashboardRatingState.AWAITING_IMPORT, rating_row.league)
 
     current = rating_row.rating_value
     league_id = rating_row.league_id
@@ -339,10 +343,17 @@ async def _build_rating(db: AsyncSession, user_id: uuid.UUID) -> DashboardRating
     # merely stops being computed here.
     change = await latest_rated_match_change(db, user_id, league_id)
     peak = await league_peak_rating(db, user_id, league_id, current)
-    percentile = await league_percentile(db, league_id, current)
+    # Population + rank first, then the percentile ONLY if the ladder clears the
+    # threshold — below it the card renders "#rank of population" and the percentile
+    # is withheld, so the lowest-rated player of a small league never reads "Top
+    # 100%" (#959). The switch is the shared helper both surfaces read.
+    population = await league_rated_population(db, league_id)
+    rank = await league_rank(db, league_id, user_id)
+    percentile = await league_percentile_if_ranked(db, league_id, current, population)
     streak = await current_streak_for_user(db, user_id)
 
     return DashboardRating(
+        state=DashboardRatingState.RATED,
         league_id=league_id,
         league_name=rating_row.league.name,
         strategy_key=strategy.key,
@@ -350,12 +361,96 @@ async def _build_rating(db: AsyncSession, user_id: uuid.UUID) -> DashboardRating
         delta=None if change is None else change.delta,
         peak=peak,
         percentile=percentile,
+        rank=rank,
+        population=population,
         spark_data=spark,
         streak=(
             None if streak is None else DashboardStreak(kind=streak.kind, n=streak.n)
         ),
         stats=_strategy_stats(strategy.key, rating_row.rating_state or {}),
     )
+
+
+async def _non_rated_rating(db: AsyncSession, user_id: uuid.UUID) -> DashboardRating:
+    """The card for a user who is not a rated member: resolve the league they belong
+    to (default first, else oldest membership) and name why it does not rate them.
+
+    ``UNRATED`` for an automatic (Glicko-2) league they have simply not played a
+    rated match in yet; ``AWAITING_IMPORT`` for a manual league; ``NOT_RATED_LEAGUE``
+    when they are a member of no league at all.
+    """
+    league = await _resolve_user_league(db, user_id)
+    if league is None:
+        return _non_rated_card(DashboardRatingState.NOT_RATED_LEAGUE, None)
+    state = (
+        DashboardRatingState.UNRATED
+        if league.rating_strategy.is_automatic
+        else DashboardRatingState.AWAITING_IMPORT
+    )
+    return _non_rated_card(state, league)
+
+
+def _non_rated_card(
+    state: DashboardRatingState, league: League | None
+) -> DashboardRating:
+    """A non-``RATED`` card: it carries the league context it has (``None`` for
+    ``NOT_RATED_LEAGUE``) and leaves every rating-payload field null/empty — there is
+    no rating to report, and a zero or a 1500 seed here is exactly the fabrication
+    the state exists to avoid."""
+    return DashboardRating(
+        state=state,
+        league_id=None if league is None else league.id,
+        league_name=None if league is None else league.name,
+        strategy_key=None if league is None else league.rating_strategy.key,
+        current=None,
+        delta=None,
+        peak=None,
+        percentile=None,
+        rank=None,
+        population=None,
+        spark_data=[],
+        streak=None,
+        stats=[],
+    )
+
+
+async def _resolve_user_league(db: AsyncSession, user_id: uuid.UUID) -> League | None:
+    """The league whose story a NON-rated user's card tells — the default league
+    they belong to, else the oldest one they belong to, else ``None``.
+
+    Unlike ``_resolve_user_rating`` this is NOT gated on ``is_rated_member()``: every
+    member seeds a ``UserLeagueRating`` row on join whether or not anything has moved
+    it, and it is precisely the unrated members this resolves for. Eager-loads the
+    strategy so the caller can read ``is_automatic`` (UNRATED vs AWAITING_IMPORT)
+    without another round trip.
+    """
+    options = (
+        selectinload(UserLeagueRating.league).selectinload(League.rating_strategy),
+    )
+    default = (
+        await db.execute(
+            select(UserLeagueRating)
+            .join(League, League.id == UserLeagueRating.league_id)
+            .where(
+                UserLeagueRating.user_id == user_id,
+                League.is_default.is_(True),
+            )
+            .options(*options)
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if default is not None:
+        return default.league
+    row = (
+        await db.execute(
+            select(UserLeagueRating)
+            .where(UserLeagueRating.user_id == user_id)
+            .options(*options)
+            .order_by(UserLeagueRating.created_at.asc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return None if row is None else row.league
 
 
 async def _resolve_user_rating(

--- a/api/app/dashboard.py
+++ b/api/app/dashboard.py
@@ -414,19 +414,25 @@ def _non_rated_card(
     )
 
 
-async def _resolve_user_league(db: AsyncSession, user_id: uuid.UUID) -> League | None:
-    """The league whose story a NON-rated user's card tells — the default league
-    they belong to, else the oldest one they belong to, else ``None``.
+async def _pick_user_rating_row(
+    db: AsyncSession, user_id: uuid.UUID, *, rated_only: bool
+) -> UserLeagueRating | None:
+    """The user's headline ``UserLeagueRating`` row — their default league's, else
+    the oldest league they belong to, else ``None``. Eager-loads the league and its
+    strategy so callers read ``is_automatic`` without an extra round trip.
 
-    Unlike ``_resolve_user_rating`` this is NOT gated on ``is_rated_member()``: every
-    member seeds a ``UserLeagueRating`` row on join whether or not anything has moved
-    it, and it is precisely the unrated members this resolves for. Eager-loads the
-    strategy so the caller can read ``is_automatic`` (UNRATED vs AWAITING_IMPORT)
-    without another round trip.
+    ``rated_only`` gates both reads on ``is_rated_member()``. The rated card resolver
+    passes ``True`` so "no row" and "a row holding nothing but the seed the league
+    handed them on join" both answer ``None`` (no card); without the gate the
+    default-league branch always hits — every user is seeded there the moment their
+    session is minted — and the oldest-league fallback is dead code. The non-rated
+    resolver passes ``False``, because every member seeds a row on join whether or
+    not anything has moved it, and it is precisely those unrated members it resolves.
     """
     options = (
         selectinload(UserLeagueRating.league).selectinload(League.rating_strategy),
     )
+    gate = (is_rated_member(),) if rated_only else ()
     default = (
         await db.execute(
             select(UserLeagueRating)
@@ -434,49 +440,7 @@ async def _resolve_user_league(db: AsyncSession, user_id: uuid.UUID) -> League |
             .where(
                 UserLeagueRating.user_id == user_id,
                 League.is_default.is_(True),
-            )
-            .options(*options)
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-    if default is not None:
-        return default.league
-    row = (
-        await db.execute(
-            select(UserLeagueRating)
-            .where(UserLeagueRating.user_id == user_id)
-            .options(*options)
-            .order_by(UserLeagueRating.created_at.asc())
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-    return None if row is None else row.league
-
-
-async def _resolve_user_rating(
-    db: AsyncSession, user_id: uuid.UUID
-) -> UserLeagueRating | None:
-    # The default league's rating first; failing that, the oldest league the user
-    # is actually rated in, so a player who only plays on a side ladder still gets
-    # a card — for THAT ladder. Eager-load the league and strategy so the caller
-    # can read is_automatic without an extra round trip.
-    #
-    # Both reads are gated on ``is_rated_member()``, so "no row" and "a row holding
-    # nothing but the seed the league handed them on join" answer the same way:
-    # ``None``, and no card. Without it the default-league branch always hits — every
-    # user is seeded there the moment their session is minted — and the fallback
-    # below was dead code for everyone.
-    options = (
-        selectinload(UserLeagueRating.league).selectinload(League.rating_strategy),
-    )
-    default = (
-        await db.execute(
-            select(UserLeagueRating)
-            .join(League, League.id == UserLeagueRating.league_id)
-            .where(
-                UserLeagueRating.user_id == user_id,
-                League.is_default.is_(True),
-                is_rated_member(),
+                *gate,
             )
             .options(*options)
             .limit(1)
@@ -489,13 +453,31 @@ async def _resolve_user_rating(
             select(UserLeagueRating)
             .where(
                 UserLeagueRating.user_id == user_id,
-                is_rated_member(),
+                *gate,
             )
             .options(*options)
             .order_by(UserLeagueRating.created_at.asc())
             .limit(1)
         )
     ).scalar_one_or_none()
+
+
+async def _resolve_user_league(db: AsyncSession, user_id: uuid.UUID) -> League | None:
+    """The league whose story a NON-rated user's card tells — ungated by
+    ``is_rated_member()`` (the unrated members are exactly who it resolves for; see
+    ``_pick_user_rating_row``)."""
+    row = await _pick_user_rating_row(db, user_id, rated_only=False)
+    return None if row is None else row.league
+
+
+async def _resolve_user_rating(
+    db: AsyncSession, user_id: uuid.UUID
+) -> UserLeagueRating | None:
+    """The user's headline rated card row, gated on ``is_rated_member()`` (see
+    ``_pick_user_rating_row``): the default league's rating first, else the oldest
+    league they are actually rated in, so a side-ladder-only player still gets a
+    card for THAT ladder."""
+    return await _pick_user_rating_row(db, user_id, rated_only=True)
 
 
 async def _spark(

--- a/api/app/match_result_notifications.py
+++ b/api/app/match_result_notifications.py
@@ -93,6 +93,69 @@ def _result_confirmation_copy(
     return "Accept your match result", body
 
 
+def _result_accepted_copy(match: Match, poster_id: uuid.UUID) -> tuple[str, str] | None:
+    """Title + body for the "your reported result was accepted" notice, framed
+    for the *poster* (the side that proposed the now-final result).
+
+    Names the accepting opponent and lists the per-game scores oriented
+    poster-first (so they read the same way the poster entered them). Returns
+    ``None`` when the opposing side isn't a real player (a solo / player-less
+    sentinel side — nothing could have accepted)."""
+    poster_side = my_side(match, poster_id)
+    acceptor_side = opponent_side(match, poster_id)
+    if poster_side is None or acceptor_side is None or not acceptor_side.players:
+        return None
+
+    acceptor_name = acceptor_side.players[0].user.username
+    games = _game_scores_text(match, poster_side.side_number)
+    headline = f"{acceptor_name} accepted your reported result"
+    body = (
+        f"{headline}. Final score {games}. It's now official."
+        if games
+        else f"{headline}. It's now official."
+    )
+    return "Your result was accepted", body
+
+
+async def notify_result_accepted(
+    notifications: NotificationService, match: Match, poster_id: uuid.UUID
+) -> None:
+    """Tell the poster (the side that proposed the standing result) that their
+    result was accepted and the match is now final — closing the loop the
+    propose-side prompt opened.
+
+    The mirror of :func:`notify_result_posted`: propose notifies the side that
+    *owes* a response; accept notifies the side that was *waiting* on one. Filed
+    under the same ``RESULT_CONFIRM`` family and enqueued once per player on the
+    poster's side. Unlike the propose prompt it carries **no** APNs action group
+    or ``push_category`` — the match is finalized, there is nothing left to
+    accept or counter — so it fans out as a plain in-app + push/email notice,
+    matching the retirement notices in ``app.retirement_jobs``. A per-match
+    ``collapse_id`` (distinct from the propose prompt's) replaces any stale
+    accepted-notice on the lock screen. Returns without enqueuing when the
+    poster's side can't be resolved to a real player (a solo / player-less
+    sentinel side)."""
+    poster_side = my_side(match, poster_id)
+    if poster_side is None or not poster_side.players:
+        return
+    copy = _result_accepted_copy(match, poster_id)
+    if copy is None:
+        return
+    title, body = copy
+    for player in poster_side.players:
+        notifications.enqueue_notification(
+            NotificationJob(
+                user_id=player.user_id,
+                category=NotificationCategory.RESULT_CONFIRM,
+                title=title,
+                body=body,
+                link=f"/matches/{match.id}",
+                action_label="View result",
+                collapse_id=f"result-accepted:{match.id}",
+            )
+        )
+
+
 async def notify_result_posted(
     notifications: NotificationService, match: Match, poster_id: uuid.UUID
 ) -> None:

--- a/api/app/match_serialization.py
+++ b/api/app/match_serialization.py
@@ -12,6 +12,7 @@ modules — never a router — so it stays cycle-free.
 
 import uuid
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import select
@@ -593,7 +594,28 @@ async def view_extras(
             match_id=match.id,
             league_id=match.league_id,
             status=match.status,
-            created_at=match.created_at,
+            as_played=as_played_instant(match),
             user_ids=singles_user_ids(match),
         )
     )
+
+
+def as_played_instant(match: Match) -> datetime:
+    """The match's as-played instant, which the pre-match snapshot anchors its
+    strict-``<`` cutoff on (ADR-0012 #951).
+
+    A completed match was *played into* at its ``completed_at`` — the stable axis
+    the rest of the rating timeline uses (rating rows are stamped
+    ``created_at == completed_at``), so the strict ``<`` cutoff excludes this
+    match's own row and its own completed record while including every prior. A
+    match not yet decided (pending/live/awaiting) is being walked into *now*, so
+    "going into this match" means the players' current standing.
+
+    NOT ``match.created_at``: that is the *creation* instant, which diverges from
+    the as-played instant whenever matches are created as a batch (a tournament
+    schedule, or a player queuing several) but completed later — a match's
+    ``created_at`` then predates its own participants' priors' ``completed_at``,
+    filtering every prior out and reporting both players as Unrated · 0."""
+    if match.status == MatchStatus.completed and match.completed_at is not None:
+        return match.completed_at
+    return datetime.now(UTC)

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -50,7 +50,10 @@ from app.match_queries import (
     match_eager_options,
     participant_filter,
 )
-from app.match_result_notifications import notify_result_posted
+from app.match_result_notifications import (
+    notify_result_accepted,
+    notify_result_posted,
+)
 from app.match_scoring import (
     MatchLockUnavailable,
     enter_game_score,
@@ -856,6 +859,7 @@ async def accept_match_result(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_session),
     match_service: MatchService = Depends(get_match_service),
+    notifications: NotificationService = Depends(get_notification_service),
 ) -> MatchDetails:
     """Accept a standing proposal — the second verb of the negotiation. The
     opposing side ratifies the proposing side's board; the match completes,
@@ -899,6 +903,27 @@ async def accept_match_result(
         raise HTTPException(
             status_code=409, detail="The posted games no longer decide this match."
         ) from exc
+
+    # Close the loop for the poster. The propose side told the *opponent* to
+    # review; now that they've accepted, tell the *poster* their result is
+    # final — otherwise their inbox stays empty on a completed match. The poster
+    # is the accepted result's submitter, never the accepting current user.
+    # Best-effort and post-commit — mirrors the propose handler's guard, so a
+    # delivery-side failure can never turn the 201 into a 500; the session is
+    # rolled back so teardown is clean even when the in-app persist was at fault.
+    poster_id = next(
+        (r.submitted_by_user_id for r in reloaded.results if r.id == result_id),
+        None,
+    )
+    if poster_id is not None:
+        try:
+            await notify_result_accepted(notifications, reloaded, poster_id)
+        except Exception:
+            await db.rollback()
+            log.exception(
+                "Failed to record result-accepted notification",
+                extra={"match_id": str(match_id)},
+            )
 
     extras = await view_extras(match_service, reloaded)
     return serialize_details(reloaded, current_user.id, extras)

--- a/api/app/matches.py
+++ b/api/app/matches.py
@@ -904,13 +904,20 @@ async def accept_match_result(
             status_code=409, detail="The posted games no longer decide this match."
         ) from exc
 
+    extras = await view_extras(match_service, reloaded)
+    details = serialize_details(reloaded, current_user.id, extras)
     # Close the loop for the poster. The propose side told the *opponent* to
     # review; now that they've accepted, tell the *poster* their result is
     # final — otherwise their inbox stays empty on a completed match. The poster
     # is the accepted result's submitter, never the accepting current user.
-    # Best-effort and post-commit — mirrors the propose handler's guard, so a
-    # delivery-side failure can never turn the 201 into a 500; the session is
-    # rolled back so teardown is clean even when the in-app persist was at fault.
+    # Built after the response and best-effort — mirrors the propose handler's
+    # guard, so a delivery-side failure can never turn the 201 into a 500; the
+    # session is rolled back so teardown is clean even when the in-app persist
+    # was at fault. Building ``details`` off ``reloaded`` *before* this block is
+    # load-bearing: the ``except``'s ``db.rollback()`` expires the identity map,
+    # so any serialization after it would lazy-load ``reloaded``'s expired
+    # attributes outside the greenlet (``MissingGreenlet`` → the very 500 this
+    # guard exists to prevent).
     poster_id = next(
         (r.submitted_by_user_id for r in reloaded.results if r.id == result_id),
         None,
@@ -925,5 +932,4 @@ async def accept_match_result(
                 extra={"match_id": str(match_id)},
             )
 
-    extras = await view_extras(match_service, reloaded)
-    return serialize_details(reloaded, current_user.id, extras)
+    return details

--- a/api/app/ratings/state.py
+++ b/api/app/ratings/state.py
@@ -31,8 +31,31 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from app.ratings.base import RatingStrategyKey
+from app.ratings.base import RatingStrategyKey, state_rating_value
 from app.ratings.registry import parse_strategy_key
+
+
+class RatingStateValueMismatchError(ValueError):
+    """A parsed ``rating_state`` blob whose own rating disagrees with the
+    ``rating_value`` stored alongside it on the same row.
+
+    Every write sets ``rating_value`` from ``state_rating_value(state)``, so the
+    stored column and the blob's ``rating`` are two copies of one number: the
+    hero renders the column while the confidence card centres its interval on the
+    blob. If they drift (a bad write, an import, a manual DB fix) the two disagree
+    silently. This turns that drift into a loud failure at the parse boundary,
+    naming both numbers so the corrupt row is obvious.
+    """
+
+    def __init__(self, rating_value: float, state_rating: float) -> None:
+        self.rating_value = rating_value
+        self.state_rating = state_rating
+        super().__init__(
+            "rating_state is inconsistent with its stored rating_value: "
+            f"rating_value={rating_value!r} but the parsed state's rating is "
+            f"{state_rating!r} (they must be equal — every write sets "
+            "rating_value from state_rating_value(state))."
+        )
 
 
 class Glicko2State(BaseModel):
@@ -59,7 +82,9 @@ RatingState = Glicko2State | ManualState
 
 
 def parse_rating_state(
-    strategy_key: str, raw: Mapping[str, Any] | None
+    strategy_key: str,
+    raw: Mapping[str, Any] | None,
+    rating_value: float | None = None,
 ) -> RatingState | None:
     """Decode a ``rating_state`` blob into the model for its strategy.
 
@@ -68,13 +93,31 @@ def parse_rating_state(
     strategy, no rating behaviour" the rest of the ratings code takes for an
     unrecognised key (``parse_strategy_key``). Raises on a blob that is present
     but malformed for its strategy.
+
+    ``rating_value`` is the row's own ``rating_value`` column, threaded in so the
+    boundary can assert the invariant that binds the two: every write sets
+    ``rating_value`` from ``state_rating_value(state)``, so a non-null
+    ``rating_value`` MUST equal the parsed state's ``rating``. When it does not,
+    the row is corrupt (a bad write, an import, a manual DB fix) and the hero
+    would show one number while the confidence card centres its interval on
+    another — so this raises ``RatingStateValueMismatchError`` naming both rather
+    than handing back a state that silently disagrees with the column beside it.
+
+    The check is skipped when ``rating_value`` is ``None`` — the legitimate
+    unrated case (a player seeded into a league who has not completed a rated
+    match yet) — and when there is no parsed state to compare it against.
     """
     if raw is None:
         return None
     match parse_strategy_key(strategy_key):
         case RatingStrategyKey.glicko2:
-            return Glicko2State.model_validate(raw)
+            state: RatingState | None = Glicko2State.model_validate(raw)
         case RatingStrategyKey.manual:
-            return ManualState.model_validate(raw)
+            state = ManualState.model_validate(raw)
         case None:
-            return None
+            state = None
+    if state is not None and rating_value is not None:
+        state_rating = state_rating_value(dict(raw))
+        if rating_value != state_rating:
+            raise RatingStateValueMismatchError(rating_value, state_rating)
+    return state

--- a/api/app/ratings/stats.py
+++ b/api/app/ratings/stats.py
@@ -59,13 +59,15 @@ STREAK_SCAN_LIMIT = 100
 # guess — the *principle* (withhold it while the league is too small) is what is
 # settled, so move it freely.
 #
-# Applied in `player_standing` and not inside `league_percentile` itself, so it is
-# the PROFILE's editorial policy about when a percentile is worth printing — not
-# part of the helper's arithmetic. The dashboard's card, the helper's other caller,
-# renders one from the first rated match; whether it should adopt this floor too is
-# a product question, and keeping the floor out of the shared helper is what leaves
-# it answerable. (What the two callers DO now share is the population itself —
-# `is_rated_member()` — which is arithmetic, not policy.)
+# Applied in `league_percentile_if_ranked` and not inside `league_percentile`
+# itself, so the floor is the editorial policy about when a percentile is worth
+# printing — not part of the base helper's arithmetic. Both surfaces that render a
+# standing (the dashboard's card and the profile's hero) read the switch through
+# that one helper, so below the floor they agree on showing RANK ("#N of M")
+# instead of a percentile, and a future move of the provisional 50 moves them
+# together (ADR 20260725). What the callers also share is the population itself —
+# `is_rated_member()`, via `league_rated_population` — which is arithmetic, not
+# policy.
 PERCENTILE_MIN_RATED_PLAYERS = 50
 
 
@@ -221,6 +223,64 @@ async def league_percentile(
     return max(1, round(int(at_or_above) / int(total) * 100))
 
 
+async def league_rank(
+    db: AsyncSession, league_id: uuid.UUID, user_id: uuid.UUID
+) -> int | None:
+    """The user's 1-based position on the league's rating ladder, or ``None`` when
+    they are not a rated member of it.
+
+    STANDARD COMPETITION RANKING (SQL ``RANK()``) over the SAME population
+    ``league_rated_population`` counts and ``league_percentile`` compares against —
+    ``is_rated_member()`` — so the ``#N`` and the ``of M`` beside it are two reads of
+    one ladder, never two WHERE clauses that agree by luck. Ties share a rank; an
+    unrated (seed-only) or tombstoned row is not on the ladder and answers ``None``.
+
+    A single-player read (the dashboard card), so it ranks the whole league and
+    picks out one row, unlike ``_load_player_ranks`` which does a batch for the
+    roster — the window and its predicate are deliberately the same.
+    """
+    ranked = (
+        select(
+            UserLeagueRating.user_id.label("user_id"),
+            func.rank()
+            .over(order_by=UserLeagueRating.rating_value.desc())
+            .label("rank"),
+        ).where(
+            UserLeagueRating.league_id == league_id,
+            is_rated_member(),
+        )
+    ).subquery()
+    rank = (
+        await db.execute(select(ranked.c.rank).where(ranked.c.user_id == user_id))
+    ).scalar_one_or_none()
+    return None if rank is None else int(rank)
+
+
+async def league_percentile_if_ranked(
+    db: AsyncSession,
+    league_id: uuid.UUID,
+    my_rating: float,
+    population: int,
+) -> int | None:
+    """The league percentile — but ONLY once the ladder is big enough for "Top N%"
+    to be a statement rather than a flourish (``PERCENTILE_MIN_RATED_PLAYERS``).
+
+    Below the threshold both the dashboard's rating card and the profile hero render
+    RANK ("#N of M") instead, so this returns ``None`` and the caller shows the rank.
+    THE shared rank-vs-percentile decision (ADR 20260725): the dashboard used to call
+    ``league_percentile`` unconditionally and printed "Top 100%" to the lowest-rated
+    player of a small league (#959). Both surfaces read the switch here so a future
+    move of the provisional 50 moves them together.
+
+    ``population`` is passed in — each caller already counts it
+    (``league_rated_population``) alongside the rank it renders next to the
+    percentile — so the threshold reads that count rather than issuing its own.
+    """
+    if population < PERCENTILE_MIN_RATED_PLAYERS:
+        return None
+    return await league_percentile(db, league_id, my_rating)
+
+
 async def completed_results(
     db: AsyncSession,
     user_id: uuid.UUID,
@@ -336,6 +396,14 @@ async def player_standing(
     unrated player (never finished a rated match) has no rank, and so no peak, no
     ladder position and no percentile: reporting a peak of 1500 for them would
     present the seed rating as an achievement they earned.
+
+    Below ``PERCENTILE_MIN_RATED_PLAYERS`` the ``percentile`` is withheld and the
+    hero renders RANK ("#N of M", ``summary.rank`` out of ``rank_of``) instead —
+    the same rank-vs-percentile switch the dashboard makes, so the two surfaces
+    cannot disagree. That switch is ``league_percentile_if_ranked``: the shared
+    helper reads the threshold once (ADR 20260725), so this no longer applies the
+    floor inline. ``rank`` and ``rank_of`` are populated for any rated player at
+    any league size, so the below-threshold hero shows "#N of M", never a blank.
     """
     rating = summary.rating
     population = await league_rated_population(db, league_id)
@@ -346,9 +414,9 @@ async def player_standing(
         else await league_peak_rating(db, user_id, league_id, rating)
     )
     percentile = (
-        await league_percentile(db, league_id, rating)
-        if rating is not None and population >= PERCENTILE_MIN_RATED_PLAYERS
-        else None
+        None
+        if rating is None
+        else await league_percentile_if_ranked(db, league_id, rating, population)
     )
     return _Standing(
         peak=peak,
@@ -406,7 +474,9 @@ async def player_confidence(
     ).scalar_one_or_none()
     if row is None or row.rating_value is None:
         return None
-    state = parse_rating_state(row.rating_strategy.key, row.rating_state)
+    state = parse_rating_state(
+        row.rating_strategy.key, row.rating_state, row.rating_value
+    )
     if not isinstance(state, Glicko2State):
         return None
     low, high = rating_interval(state.rating, state.rd)

--- a/api/app/repositories/match_details_repository.py
+++ b/api/app/repositories/match_details_repository.py
@@ -113,17 +113,22 @@ class MatchDetailsRepository:
         user_ids: list[uuid.UUID],
         match_id: uuid.UUID,
         league_id: uuid.UUID,
-        created_at: datetime,
+        before: datetime,
     ) -> list[PlayerForm]:
         """Each player's last few completed matches before this one, with the
-        rating + career record they carried into it."""
+        rating + career record they carried into it.
+
+        ``before`` is the match's *as-played* instant (its ``completed_at`` when
+        completed, else *now*) — see ``as_played_instant`` — NOT its
+        ``created_at``, which diverges from as-played time for batch-created
+        matches and filtered every prior out (ADR-0012 #951)."""
         if not user_ids:
             return []
 
         # Batched once for every player, ahead of the loop — one round-trip
         # each, not one per user (issue #195).
-        careers = await self.career_before(user_ids, created_at)
-        ratings = await self.pre_match_ratings(user_ids, league_id, created_at)
+        careers = await self.career_before(user_ids, before)
+        ratings = await self.pre_match_ratings(user_ids, league_id, before)
 
         result: list[PlayerForm] = []
         for user_id in user_ids:
@@ -131,7 +136,7 @@ class MatchDetailsRepository:
                 (
                     await self._db.execute(
                         participant_filter(
-                            history_base_query(match_id, before=created_at),
+                            history_base_query(match_id, before=before),
                             user_id,
                         ).limit(RECENT_FORM_LIMIT)
                     )
@@ -256,13 +261,19 @@ class MatchDetailsRepository:
         before: datetime,
     ) -> dict[uuid.UUID, CareerRecord]:
         """Every cited player's cross-league ``(matches, wins)`` completed strictly
-        before ``before`` (the current match's ``created_at``), in **one**
-        ``GROUP BY user_id`` round-trip rather than one query per user (issue #195).
+        before ``before`` (the current match's *as-played* instant — its
+        ``completed_at`` when completed, else *now*; see ``as_played_instant``), in
+        **one** ``GROUP BY user_id`` round-trip rather than one query per user
+        (issue #195).
 
-        The current match is excluded by the date filter alone: a completed match's
-        ``completed_at`` is always ``>=`` its own ``created_at``, so it can never
-        satisfy ``completed_at < created_at``. No separate ``id`` guard is needed
-        (issue #202).
+        The current match is excluded by the date filter alone: when this match is
+        completed, ``before`` IS its own ``completed_at``, and the strict ``<``
+        excludes ``completed_at < completed_at``; when it isn't completed it has no
+        ``completed_at`` and so matches no row anyway. No separate ``id`` guard is
+        needed (issue #202). Anchoring on ``completed_at`` rather than
+        ``created_at`` is what stops a batch-created match (``created_at`` before
+        its own participants' priors) from filtering every prior out and reporting
+        ``0 career matches`` (ADR-0012 #951).
 
         A player with no prior completed matches has **no row** in the grouped
         result; they are defaulted back in as a zero record, so every requested id
@@ -300,15 +311,19 @@ class MatchDetailsRepository:
         self,
         user_ids: list[uuid.UUID],
         match_id: uuid.UUID,
-        created_at: datetime,
+        before: datetime,
     ) -> HeadToHead | None:
         """The rivalry between this match's two singles players as it stood
-        going into it. ``None`` unless there are exactly two players."""
+        going into it. ``None`` unless there are exactly two players.
+
+        ``before`` is the match's *as-played* instant (its ``completed_at`` when
+        completed, else *now*) — see ``as_played_instant`` — NOT its
+        ``created_at`` (ADR-0012 #951)."""
         if len(user_ids) != 2:
             return None
         user_a, user_b = user_ids
         rows_query = participant_filter(
-            participant_filter(history_base_query(match_id, before=created_at), user_a),
+            participant_filter(history_base_query(match_id, before=before), user_a),
             user_b,
         ).options(selectinload(Match.match_settings))
         rows = (
@@ -362,7 +377,7 @@ class MatchDetailsRepository:
             .where(
                 Match.status == MatchStatus.completed,
                 Match.id != match_id,
-                Match.completed_at < created_at,
+                Match.completed_at < before,
                 a_player.user_id == user_a,
                 b_player.user_id == user_b,
                 a_side.id != b_side.id,

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from enum import StrEnum
 from typing import Literal
 
 from pydantic import BaseModel
@@ -66,17 +67,50 @@ class DashboardRatingStat(BaseModel):
     value: str
 
 
+class DashboardRatingState(StrEnum):
+    """WHICH rating story the card tells — server-authoritative, because it is the
+    API that knows which of the four situations obtains, not the client guessing
+    from a ``null`` (ADR 20260725).
+
+    A bare ``rating: None`` used to collapse three distinct non-rated facts into one
+    signal, and the client rendered a single string — *"Not in a rated league
+    yet."* — that was a lie for the player who IS in a rated league but has not
+    finished a rated match. The state names the situation so the client can say the
+    true thing per arm.
+    """
+
+    # Has a rating: the value + delta, plus the rank-or-percentile line below.
+    RATED = "RATED"
+    # In a Glicko-2 (automatic-strategy) league but has not finished a rated match
+    # yet — the seed 1500 is the strategy's prior, not a rating they earned.
+    UNRATED = "UNRATED"
+    # Manual-strategy league whose external ratings have not been imported yet.
+    AWAITING_IMPORT = "AWAITING_IMPORT"
+    # Not a member of any rated league at all.
+    NOT_RATED_LEAGUE = "NOT_RATED_LEAGUE"
+
+
 class DashboardRating(BaseModel):
     """Per-league rating snapshot for the dashboard RatingCard.
 
-    Emitted only when the user has a rated row in an automatic-strategy league
-    (Glicko-2 today). Manual leagues and unrated users get ``rating: None``.
+    ALWAYS emitted for a signed-in user — the parent is no longer ``| None``. The
+    ``state`` discriminator says which of four stories the card tells; only the
+    ``RATED`` arm carries the rating payload below (``current`` / ``delta`` /
+    ``peak`` / the rank-or-percentile line / ``spark_data`` / ``streak`` /
+    ``stats``). The three non-rated arms carry the league context they have
+    (``UNRATED`` / ``AWAITING_IMPORT`` name a league; ``NOT_RATED_LEAGUE`` has
+    none) and leave the payload fields null/empty (ADR 20260725).
     """
 
-    league_id: uuid.UUID
-    league_name: str
-    strategy_key: str
-    current: float
+    # Which story this card tells — the client renders copy + payload per arm.
+    state: DashboardRatingState
+    # The league context. Present for RATED / UNRATED / AWAITING_IMPORT; ``None``
+    # for NOT_RATED_LEAGUE (there is no league to name).
+    league_id: uuid.UUID | None
+    league_name: str | None
+    strategy_key: str | None
+    # The headline rating — ``None`` on every non-RATED arm.
+    current: float | None
     # What the player's last rated match DID to them — the "+12 last match" chip.
     #
     # ``None`` means THERE IS NO MOVE TO REPORT, and the client must render nothing
@@ -97,12 +131,25 @@ class DashboardRating(BaseModel):
     # claims a rated match moved the rating by nothing, which is a different (and
     # false) statement.
     delta: float | None
-    peak: float
+    # ``None`` on every non-RATED arm — a peak is a rating they held, and they hold
+    # none.
+    peak: float | None
+    # "Top N%" — but ONLY once the rated population reaches
+    # ``PERCENTILE_MIN_RATED_PLAYERS`` (50). Below that the card shows RANK instead
+    # (``#N of M`` from ``rank`` + ``population``), because "Top 8% of 12" is "you
+    # are first" in a costume and "Top 100%" is the lowest-rated player being
+    # congratulated (ADR 20260725, #959). ``None`` below the threshold and on every
+    # non-RATED arm.
     percentile: int | None
+    # The player's 1-based position among the league's rated members, and how many
+    # rated members there are. The client renders "#N of M" from the pair. Populated
+    # on the RATED arm; ``None`` on every non-RATED arm.
+    rank: int | None
+    population: int | None
     # The rating changes of the last 30 days, oldest-first — and NOT the ``initial``
     # seed row, which is the prior the league hands out on join, not a rating anyone
     # held. So a player one rated match old has a ONE-POINT spark (their result), not
-    # a two-point line sloping out of 1500.
+    # a two-point line sloping out of 1500. Empty on every non-RATED arm.
     spark_data: list[float]
     streak: DashboardStreak | None
     stats: list[DashboardRatingStat]
@@ -273,7 +320,9 @@ class DashboardResponse(BaseModel):
     # as footer text only — never a row.
     waiting_count: int
     recent_results: list[DashboardRecentResult]
-    rating: DashboardRating | None = None
+    # ALWAYS present now — the ``state`` discriminator carries the unrated/awaiting
+    # cases that used to be a bare parent ``null`` (ADR 20260725).
+    rating: DashboardRating
     # Total completed matches the current user participated in. The guest
     # persistence banner uses this to reference history concretely ("Your N
     # matches…") and to stay hidden until the user has any history at all.

--- a/api/app/services/match_service.py
+++ b/api/app/services/match_service.py
@@ -32,7 +32,7 @@ class MatchService:
         match_id: uuid.UUID,
         league_id: uuid.UUID,
         status: MatchStatus,
-        created_at: datetime,
+        as_played: datetime,
         user_ids: list[uuid.UUID],
     ) -> MatchViewExtras:
         """The participant-only extras block for a match the caller has already
@@ -41,13 +41,20 @@ class MatchService:
         Takes primitives rather than a loaded row so the repository stays free of
         the ORM hierarchy. Callers that must *not* show the extras (anonymous or
         spectator viewers — see #515) pass none of this and use
-        ``MatchViewExtras.empty()`` instead."""
+        ``MatchViewExtras.empty()`` instead.
+
+        ``as_played`` is the match's as-played instant — its ``completed_at`` when
+        completed, else *now* — and is the strict-``<`` cutoff the pre-match
+        snapshot (form, rating trail, career, H2H) anchors on. NOT ``created_at``:
+        a match created in a batch (a tournament schedule, or a player queuing
+        several) but completed later has a ``created_at`` that predates its own
+        participants' priors, filtering every prior out (ADR-0012 #951)."""
         return MatchViewExtras(
             rating_changes=await self._details.rating_changes(match_id, status),
             recent_form=await self._details.recent_form(
-                user_ids, match_id, league_id, created_at
+                user_ids, match_id, league_id, as_played
             ),
             head_to_head=await self._details.head_to_head(
-                user_ids, match_id, created_at
+                user_ids, match_id, as_played
             ),
         )

--- a/api/tests/test_dashboard.py
+++ b/api/tests/test_dashboard.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dashboard import _strategy_stats
+from app.dashboard import _build_rating, _strategy_stats
 from app.models import (
     League,
     LeagueMembership,
@@ -19,6 +19,7 @@ from app.models import (
     UserLeagueRating,
 )
 from app.ratings.stats import league_percentile
+from app.schemas.dashboard import DashboardRatingState
 from tests._helpers import (
     accept_standing_result,
     make_client,
@@ -76,14 +77,25 @@ async def test_dashboard_empty_when_user_has_no_matches(
     assert body["waiting_count"] == 0
     assert body["recent_results"] == []
     assert body["completed_match_count"] == 0
-    # NO RATING CARD. A fresh signup is auto-joined to the default Glicko-2 league,
-    # which seeds them a 1500 row — but a seed is a prior, not a rating (CONTEXT.md:
-    # a player who has never finished a rated match has no rating). The card used to
-    # light up here with current 1500, peak 1500, RD 350 and a one-point sparkline:
-    # five numbers, every one of them the strategy's starting state rather than
-    # anything this player did. The widget stays hidden until the league is actually
-    # scoring you — which is what `_build_rating` always said it did.
-    assert body["rating"] is None
+    # UNRATED, not a fabricated card. A fresh signup is auto-joined to the default
+    # Glicko-2 league, which seeds them a 1500 row — but a seed is a prior, not a
+    # rating (CONTEXT.md: a player who has never finished a rated match has no
+    # rating). The card used to light up with current 1500, peak 1500, RD 350 and a
+    # one-point sparkline; then it collapsed to a bare `null` indistinguishable from
+    # "not in a rated league". Now the card is present with `state="UNRATED"` — they
+    # ARE in a rated league, just not scored yet — and carries no rating payload
+    # (ADR 20260725).
+    rating = body["rating"]
+    assert rating["state"] == "UNRATED"
+    assert rating["current"] is None
+    assert rating["peak"] is None
+    assert rating["percentile"] is None
+    assert rating["rank"] is None
+    assert rating["population"] is None
+    assert rating["spark_data"] == []
+    # It still names the (Glicko-2, default) league they are unrated IN.
+    assert rating["league_name"] == "FortyMM"
+    assert rating["strategy_key"] == "glicko2"
 
 
 async def test_dashboard_returns_score_attention_for_in_progress_match(
@@ -217,9 +229,9 @@ async def test_dashboard_scoped_to_current_user(
     # Bob's completed match must not bleed into Alice's history total.
     assert body["completed_match_count"] == 0
     # Alice has her own seeded league row but has never finished a rated match, so
-    # she is unrated and has no rating card — and Bob's match cannot conjure her
-    # one either.
-    assert body["rating"] is None
+    # she is UNRATED — and Bob's match cannot conjure her a rating either.
+    assert body["rating"]["state"] == "UNRATED"
+    assert body["rating"]["current"] is None
 
 
 async def _post_result(client: AsyncClient, match_id: str, *, best_of: int = 1) -> None:
@@ -617,30 +629,40 @@ async def _seed_rated_peers(db_session: AsyncSession) -> League:
     return default_league
 
 
-async def test_dashboard_no_rating_card_for_an_unplayed_user_with_peers(
+async def test_dashboard_rating_unrated_for_an_unplayed_user_with_peers(
     api_client: AsyncClient, db_session: AsyncSession
 ):
     """A never-played user sits at the seed rating (1500, RD 350) — fully unrated.
-    Surrounded by rated peers, they get NO RATING CARD at all.
+    Surrounded by rated peers, they get an UNRATED card with no rating payload.
 
     #382 suppressed only the *percentile* here, on the grounds that ranking the
     unrankable reads as placeholder data. It was right, and it did not go far
     enough: `current`, `peak`, `delta`, the RD tile and the sparkline were the same
     placeholder — the strategy's initial state, printed as if it were this player's.
-    The percentile was just the one that said it out loud."""
+    Now the whole payload is withheld and the card says `state="UNRATED"` (ADR
+    20260725)."""
     await start_session(api_client, db_session)
     await _seed_rated_peers(db_session)
 
     body = (await api_client.get("/v1/dashboard")).json()
     assert body["completed_match_count"] == 0
-    assert body["rating"] is None
+    assert body["rating"]["state"] == "UNRATED"
+    assert body["rating"]["current"] is None
+    assert body["rating"]["percentile"] is None
 
 
-async def test_dashboard_percentile_shown_once_user_has_played(
+async def test_dashboard_rating_shows_rank_not_percentile_below_the_threshold(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    """Once the user has completed a match they're genuinely rated, so the
-    percentile against league peers comes back. (#382)"""
+    """Once the user has completed a rated match they are genuinely RATED — but in a
+    small league (well under ``PERCENTILE_MIN_RATED_PLAYERS``) the card conveys RANK,
+    not percentile.
+
+    This is the #959 fix: the dashboard used to call ``league_percentile``
+    unconditionally, so the lowest-rated player of a twelve-player alpha read "Top
+    100%" — literally true, reads like a compliment, the one percentile value that
+    should never show. Now `percentile` is withheld below the threshold and
+    `rank`/`population` carry an honest "#N of M" instead (ADR 20260725)."""
     await start_session(api_client, db_session)
     await _seed_rated_peers(db_session)
     async with opponent_session(db_session, "rival") as (opp_client, opp):
@@ -658,9 +680,13 @@ async def test_dashboard_percentile_shown_once_user_has_played(
 
     body = (await api_client.get("/v1/dashboard")).json()
     assert body["completed_match_count"] == 1
-    percentile = body["rating"]["percentile"]
-    assert percentile is not None
-    assert 0 <= percentile <= 100
+    rating = body["rating"]
+    assert rating["state"] == "RATED"
+    # 4 seeded peers + the winner + the rival, all now rated members.
+    assert rating["population"] == 6
+    assert 1 <= rating["rank"] <= 6
+    # The whole point: NO percentile below the threshold — no "Top 100%".
+    assert rating["percentile"] is None
 
 
 async def test_league_percentile_ranks_against_rated_members(
@@ -773,11 +799,12 @@ async def test_dashboard_sparkline_returns_most_recent_points(
     assert spark == [float(v) for v in range(1510, 1540)]
 
 
-async def test_dashboard_rating_is_null_for_manual_league(
+async def test_dashboard_rating_awaiting_import_for_manual_league(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    # Move the seeded league over to the manual strategy and null the user's
-    # rating row — the widget should disappear instead of showing a stale 1500.
+    # Move the seeded league over to the manual strategy: the member holds a NULL
+    # rating awaiting its import. The card is present with `state="AWAITING_IMPORT"`
+    # (never a stale 1500, and no longer an indistinguishable bare `null`).
     manual = (
         await db_session.execute(
             select(RatingStrategy).where(RatingStrategy.key == "manual")
@@ -791,7 +818,9 @@ async def test_dashboard_rating_is_null_for_manual_league(
 
     await start_session(api_client, db_session)
     body = (await api_client.get("/v1/dashboard")).json()
-    assert body["rating"] is None
+    assert body["rating"]["state"] == "AWAITING_IMPORT"
+    assert body["rating"]["current"] is None
+    assert body["rating"]["strategy_key"] == "manual"
 
 
 async def test_dashboard_and_profile_agree_that_a_never_played_user_is_unrated(
@@ -803,15 +832,17 @@ async def test_dashboard_and_profile_agree_that_a_never_played_user_is_unrated(
     The dashboard used to say `1500 / peak 1500 / RD 350` about a player whose
     profile said "Unrated" — two pages of the same app disagreeing about whether
     someone has a rating. They cannot now: both read `app.ratings.rated`, so the
-    card is absent and every rating field on the profile is `null`.
+    dashboard card says `state="UNRATED"` (no rating payload) and every rating field
+    on the profile is `null`.
 
-    (A weaker fix — hide the profile's rating but keep the dashboard's card —
-    passes every other test in this file. It reds here.)"""
+    (A weaker fix — narrate a rating on the dashboard's card while the profile says
+    Unrated — passes every other test in this file. It reds here.)"""
     await start_session(api_client, db_session)
     await _seed_rated_peers(db_session)
 
     body = (await api_client.get("/v1/dashboard")).json()
-    assert body["rating"] is None
+    assert body["rating"]["state"] == "UNRATED"
+    assert body["rating"]["current"] is None
     assert body["completed_match_count"] == 0
 
     me = (await api_client.get("/v1/session")).json()["data"]["user"]
@@ -855,3 +886,80 @@ async def test_dashboard_peak_is_the_best_rating_earned_not_the_seed(
     assert after_two["peak"] < 1500.0
     # The sparkline says the same thing: two results, no seed point rising into them.
     assert after_two["spark_data"] == [after_one_loss["current"], after_two["current"]]
+
+
+# --- The `state` discriminator: `_build_rating` returns an object for every
+# situation, named, instead of a bare `None` that collapsed three of them
+# (ADR 20260725). Exercised directly (like `_strategy_stats`) so each arm is
+# checked in isolation without threading a session through the endpoint. ---
+
+
+async def test_dashboard_rating_last_place_shows_rank_not_percentile(
+    db_session: AsyncSession,
+):
+    """A RATED player at the BOTTOM of a small ladder is the #959 poster child: they
+    are #M of M, and the old unconditional percentile called that "Top 100%".
+
+    Seeded peers at 1200/1400/1600/1800 and the player last of all at 1000, so the
+    rank IS the population and every rated member sits above them. The card is RATED,
+    carries `rank == population`, and `percentile is None` — the honest "#5 of 5"
+    with no costume."""
+    me = await make_user(db_session, "wooden.spoon")
+    default_league = await _seed_rated_peers(db_session)
+    await _rate_member(db_session, me, default_league, 1000.0)
+    await db_session.commit()
+
+    rating = await _build_rating(db_session, me.id)
+    assert rating.state is DashboardRatingState.RATED
+    assert rating.population == 5
+    assert rating.rank == 5
+    assert rating.rank == rating.population
+    assert rating.percentile is None
+    assert rating.current == 1000.0
+
+
+async def test_dashboard_rating_state_unrated_for_seeded_glicko2_member(
+    db_session: AsyncSession,
+):
+    """A member of the default Glicko-2 league who holds only the seeded 1500 (no
+    rated match yet) is UNRATED — in a rated league, just not scored — with the
+    league named and no rating payload."""
+    default_league = (
+        await db_session.execute(select(League).where(League.is_default.is_(True)))
+    ).scalar_one()
+    me = await make_user(db_session, "just.joined")
+    db_session.add(LeagueMembership(league_id=default_league.id, user_id=me.id))
+    db_session.add(
+        UserLeagueRating(
+            league_id=default_league.id,
+            user_id=me.id,
+            rating_strategy_id=default_league.rating_strategy_id,
+            rating_value=1500.0,
+            rating_state={"rating": 1500.0, "rd": 350.0, "volatility": 0.06},
+        )
+    )
+    await db_session.commit()
+
+    rating = await _build_rating(db_session, me.id)
+    assert rating.state is DashboardRatingState.UNRATED
+    assert rating.league_id == default_league.id
+    assert rating.strategy_key == "glicko2"
+    assert rating.current is None
+    assert rating.rank is None
+    assert rating.population is None
+
+
+async def test_dashboard_rating_state_not_rated_league_without_any_membership(
+    db_session: AsyncSession,
+):
+    """A user who is a member of NO league at all gets NOT_RATED_LEAGUE — the only
+    arm with no league to name. `make_user` creates a bare user with no membership,
+    which is exactly that state."""
+    me = await make_user(db_session, "no.league")
+
+    rating = await _build_rating(db_session, me.id)
+    assert rating.state is DashboardRatingState.NOT_RATED_LEAGUE
+    assert rating.league_id is None
+    assert rating.league_name is None
+    assert rating.strategy_key is None
+    assert rating.current is None

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -4316,6 +4316,7 @@ async def test_concurrent_accept_and_counter_serialize(
                 actor = (
                     await session.execute(select(User).where(User.id == me_id))
                 ).scalar_one()
+                notifications = NotificationService(session, FakeSender())
                 try:
                     await accept_match_result(
                         match_id,
@@ -4323,6 +4324,7 @@ async def test_concurrent_accept_and_counter_serialize(
                         actor,
                         session,
                         get_match_service(session),
+                        notifications,
                     )
                     return "ok-accept"
                 except HTTPException as exc:
@@ -4589,6 +4591,56 @@ async def test_unrated_result_enqueues_no_confirmation(
         assert response.status_code == 201
 
     assert enqueued_notification_jobs(fake_notifications_queue) == []
+
+
+async def test_accepting_result_notifies_the_poster(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    fake_notifications_queue: Queue,
+):
+    """Accepting a standing proposal closes the loop for the poster: the side
+    that proposed the now-final result gets an in-app notice that their result
+    was accepted (category ``result_confirm``), addressed to them and not the
+    acceptor, and framed with the accepting opponent's name + the final score.
+
+    This is the gap chore 7a fills — before it, accepting completed the match
+    and settled ratings but the poster's inbox stayed empty; only the opponent
+    (asked to confirm) was ever told anything. Removing the
+    ``notify_result_accepted`` call in ``accept_match_result`` reds the
+    ``accept_jobs`` assertion below."""
+    me = await start_session(api_client, db_session)
+    me.username = "poster"
+    await db_session.commit()
+
+    async with opponent_session(db_session, "rival") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        # The propose step notifies only the opponent (asked to confirm); the
+        # poster's inbox is still empty at this point.
+        proposed_jobs = enqueued_notification_jobs(fake_notifications_queue)
+        assert [job.user_id for job in proposed_jobs] == [opp.id]
+
+        await accept_standing_result(opp_client, match["id"])
+
+    # The accept step adds the result-accepted notice — to the poster, never the
+    # accepting opponent.
+    accept_jobs = [
+        job
+        for job in enqueued_notification_jobs(fake_notifications_queue)
+        if job.collapse_id == f"result-accepted:{match['id']}"
+    ]
+    assert [job.user_id for job in accept_jobs] == [me.id]
+    job = accept_jobs[0]
+    assert job.category.value == "result_confirm"
+    assert job.title == "Your result was accepted"
+    assert job.link == f"/matches/{match['id']}"
+    assert "rival accepted your reported result" in job.body
+    # Final score is oriented poster-first (poster won 11–4, 11–4).
+    assert "11–4" in job.body
+    # No stale propose action group: the match is final, nothing to accept or
+    # counter, so this fans out as a plain notice (no APNs action category).
+    assert job.push_category is None
 
 
 # ----- voiding a match (#750, ADR 0013) -----------------------------------

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -4643,6 +4643,46 @@ async def test_accepting_result_notifies_the_poster(
     assert job.push_category is None
 
 
+async def test_accept_survives_notification_failure_with_201(
+    api_client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch,
+):
+    """A notify-side failure on the accept path must NOT turn the already-
+    committed accept into a 500. The result is finalized before the best-effort
+    ``notify_result_accepted`` runs, so a raised exception there — swallowed by
+    the blanket guard, which rolls the session back — must still yield the 201
+    with the completed match.
+
+    Regression for the ordering bug: when the response was serialized *after*
+    the notify/``db.rollback()`` block, the rollback expired ``reloaded``'s
+    identity map and serialization lazy-loaded outside the greenlet
+    (``MissingGreenlet`` → 500). Reverting the reorder reds this with a 500."""
+
+    async def boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("notification persistence exploded")
+
+    monkeypatch.setattr(matches_mod, "notify_result_accepted", boom)
+
+    await start_session(api_client, db_session)
+    async with opponent_session(db_session, "notify-boom-opp") as (opp_client, opp):
+        match = await _create_match(api_client, opp.id, best_of=3)
+        await _post_results(api_client, match["id"])
+
+        details = (await opp_client.get(f"/v1/matches/{match['id']}")).json()
+        standing = details["negotiation"]["standing_result"]
+        assert standing is not None
+        response = await opp_client.post(
+            f"/v1/matches/{match['id']}/results/{standing['id']}/acceptance"
+        )
+
+    # The commit already happened; the notify blow-up is best-effort. So the
+    # caller still gets a 201 with a completed match, never a 500.
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["status"] == "completed"
+
+
 # ----- voiding a match (#750, ADR 0013) -----------------------------------
 
 

--- a/api/tests/test_matches.py
+++ b/api/tests/test_matches.py
@@ -3012,21 +3012,25 @@ async def test_details_recent_form_excludes_the_current_match(
 async def test_details_recent_form_excludes_matches_after_this_one(
     api_client: AsyncClient, db_session: AsyncSession
 ):
-    """Viewing an older match shows form as it stood then: a match completed
-    before this one was created counts; one completed after it does not."""
+    """Viewing a COMPLETED match shows form as it stood at its as-played instant:
+    a match completed before it counts; one completed after it does not. The
+    cutoff is the viewed match's ``completed_at`` (ADR-0012 #951), so this holds
+    even though the later match completed before the *request* is served."""
     me = await start_session(api_client, db_session)
-    opp = await make_user(db_session, "after-rival")
     async with opponent_session(db_session, "after-third-party") as (
         other_client,
         other,
     ):
-        # A match I finished *before* the viewed match is created.
+        # A match I finished *before* the viewed match.
         earlier = await _play_match_to_completion(
             api_client, other_client, other.id, best_of=3, side_1_wins=True
         )
-        # The match we'll view (in progress, so it stays "current" in time).
-        current = await _create_match(api_client, opp.id, best_of=3)
-        # A match I finish *after* the viewed match was created.
+        # The match we'll view, played to completion — its completed_at is the
+        # anchor the snapshot freezes on.
+        current = await _play_match_to_completion(
+            api_client, other_client, other.id, best_of=3, side_1_wins=True
+        )
+        # A match I finish *after* the viewed match completed.
         later = await _play_match_to_completion(
             api_client, other_client, other.id, best_of=3, side_1_wins=False
         )
@@ -3362,6 +3366,95 @@ async def test_details_career_counts_are_per_player(
     assert forms[str(me.id)]["career_wins_before"] == 2
     assert forms[str(opp.id)]["career_matches_before"] == 1
     assert forms[str(opp.id)]["career_wins_before"] == 0
+
+
+async def test_details_pre_match_snapshot_anchors_on_completed_not_created(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The pre-match snapshot of a COMPLETED match anchors its cutoff on the
+    as-played instant (``completed_at``), not the creation instant (ADR-0012
+    #951).
+
+    Batch creation — a tournament schedule, or a player queuing several — creates
+    a match well before it is played, so its ``created_at`` can predate its own
+    participants' priors' ``completed_at``. Anchored on ``created_at`` the snapshot
+    filtered every one of those priors out and reported both players as
+    "Unrated · 0 career matches" on a match they walked into with real histories.
+    We reproduce that by backdating the current match's ``created_at`` to long
+    before its priors completed, leaving its ``completed_at`` (as-played) intact."""
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "as-played-opp") as (opp_client, opp):
+        # Two decided priors between the same pair build career + rating history.
+        await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
+        await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
+        # The match under view, also played to completion (its completed_at is
+        # the latest of the three).
+        current = await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
+
+    # Simulate batch creation: the current match was *created* long before the
+    # priors finished. Its completed_at (the as-played anchor) is untouched, so a
+    # correct snapshot still sees the priors; the old created_at anchor would
+    # filter every prior out.
+    await db_session.execute(
+        update(Match)
+        .where(Match.id == uuid.UUID(current["id"]))
+        .values(created_at=datetime(2020, 1, 1, tzinfo=UTC))
+    )
+    await db_session.commit()
+
+    detail = (await api_client.get(f"/v1/matches/{current['id']}")).json()
+    forms = {f["user_id"]: f for f in detail["recent_form"]}
+    mine = forms[str(me.id)]
+    # Two priors count (the current match itself is excluded by the strict `<`
+    # on completed_at, since its own rating row / completed record sit at the
+    # anchor exactly).
+    assert mine["career_matches_before"] == 2
+    assert mine["career_wins_before"] == 2
+    assert mine["rating_before"] is not None
+    assert len(mine["rating_history"]) == 2
+    assert mine["rating_history"][-1] == mine["rating_before"]
+    # The head-to-head aggregates anchor on the same instant, so both priors
+    # count and the current meeting excludes itself.
+    assert detail["head_to_head"]["total_meetings"] == 2
+
+
+async def test_details_pre_match_snapshot_for_a_live_match_uses_current_standing(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """A not-yet-decided match is being walked into *now*, so "going into this
+    match" means the players' CURRENT standing — the snapshot anchors on the
+    current instant, not the (earlier) creation instant (ADR-0012 #951).
+
+    Created first, then left live while two priors are played to completion: the
+    priors complete *after* this match's ``created_at``, so the old created_at
+    anchor would exclude them and report Unrated · 0; anchoring on *now* counts
+    them. No timestamp surgery is needed — the natural ordering is the bug."""
+    me = await start_session(api_client, db_session)
+    async with opponent_session(db_session, "live-standing-opp") as (opp_client, opp):
+        # The live match is created first, so its created_at precedes the priors.
+        current = await _create_match(api_client, opp.id, best_of=3)
+        await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
+        await _play_match_to_completion(
+            api_client, opp_client, opp.id, best_of=3, side_1_wins=True
+        )
+
+    detail = (await api_client.get(f"/v1/matches/{current['id']}")).json()
+    assert detail["status"] != "completed"
+    forms = {f["user_id"]: f for f in detail["recent_form"]}
+    mine = forms[str(me.id)]
+    # Current standing going into a live match: both priors count.
+    assert mine["career_matches_before"] == 2
+    assert mine["career_wins_before"] == 2
+    assert mine["rating_before"] is not None
+    assert len(mine["rating_history"]) == 2
 
 
 async def test_career_before_batches_every_user_into_one_statement(
@@ -3711,7 +3804,7 @@ async def test_view_extras_issues_a_pinned_number_of_statements(
             match_id=match.id,
             league_id=match.league_id,
             status=match.status,
-            created_at=match.created_at,
+            as_played=match.completed_at,
             user_ids=[me.id, opp.id],
         )
 

--- a/api/tests/test_players.py
+++ b/api/tests/test_players.py
@@ -1536,6 +1536,37 @@ async def test_get_player_withholds_percentile_until_the_ladder_is_big_enough(
     assert body["percentile"] == 2
 
 
+async def test_get_player_shows_rank_not_percentile_at_the_bottom_of_a_small_ladder(
+    api_client: AsyncClient, db_session: AsyncSession
+):
+    """The #959 shape, on the profile: the LOWEST-rated player of a below-floor
+    league. Their percentile would be "Top 100%" — literally true, reads like a
+    compliment, and the one value that should never be shown. Below
+    ``PERCENTILE_MIN_RATED_PLAYERS`` the hero withholds it and renders RANK
+    instead, and rank is honest at the very bottom: "#N of N" is a fact, not a
+    congratulation.
+
+    So ``percentile`` is ``null`` while ``rank`` and ``rank_of`` are populated and
+    EQUAL — the client renders "#N of M" with N == M. A mutant that emitted the
+    percentile below the floor would read 100 here; one that blanked ``rank`` /
+    ``rank_of`` below the floor would leave the hero with nothing to show."""
+    await start_session(api_client, db_session)
+    target = await make_user(db_session, "bottom.target")
+    # A cohort seated ABOVE the target (base 1400 > 1300), one short of the floor,
+    # so the whole ladder — target included — stays below it. The target is dead
+    # last, so their rank equals the population.
+    await _earn_rating(db_session, target, 1300.0)
+    await _rated_cohort(
+        db_session, "bottom.peer", PERCENTILE_MIN_RATED_PLAYERS - 2, base=1400.0
+    )
+
+    body = (await api_client.get(f"/v1/players/{target.id}")).json()
+    assert body["rank_of"] == PERCENTILE_MIN_RATED_PLAYERS - 1
+    # Dead last: "#49 of 49" — rank == rank_of, the honest bottom of the ladder.
+    assert body["rank"] == body["rank_of"]
+    assert body["percentile"] is None
+
+
 async def test_get_player_form_is_ten_results_long(
     api_client: AsyncClient, db_session: AsyncSession
 ):

--- a/api/tests/test_rating_state.py
+++ b/api/tests/test_rating_state.py
@@ -1,0 +1,90 @@
+"""The ``rating_state`` parse boundary (``app.ratings.state``).
+
+The confidence card centres its interval on the parsed state's ``rating`` while
+the hero renders the row's ``rating_value`` column — they agree only because
+every write sets ``rating_value`` from ``state_rating_value(state)``. These tests
+pin the boundary that turns a drift between those two copies into a loud failure
+rather than a silent one-number-here / different-range-there.
+"""
+
+import pytest
+
+from app.ratings.state import (
+    Glicko2State,
+    ManualState,
+    RatingStateValueMismatchError,
+    parse_rating_state,
+)
+
+
+def test_parse_rating_state_consistent_glicko2_value_parses_cleanly():
+    """A blob whose ``rating`` matches the stored ``rating_value`` decodes to a
+    typed ``Glicko2State`` with no raise."""
+    state = parse_rating_state(
+        "glicko2",
+        {"rating": 1500.0, "rd": 350.0, "volatility": 0.06},
+        1500.0,
+    )
+    assert isinstance(state, Glicko2State)
+    assert state.rating == 1500.0
+
+
+def test_parse_rating_state_null_rating_value_skips_the_invariant():
+    """The unrated carve-out: a player seeded into a league who has not
+    completed a rated match has a parsed seed state but a NULL ``rating_value``.
+    The invariant must NOT fire — passing ``None`` parses cleanly."""
+    state = parse_rating_state(
+        "glicko2",
+        {"rating": 1500.0, "rd": 350.0, "volatility": 0.06},
+        None,
+    )
+    assert isinstance(state, Glicko2State)
+    assert state.rating == 1500.0
+
+
+def test_parse_rating_state_omitted_rating_value_skips_the_invariant():
+    """``rating_value`` defaults to ``None`` — a caller that has no column value
+    to check against (and manual/awaiting-import rows) parses without a raise."""
+    state = parse_rating_state(
+        "glicko2",
+        {"rating": 1500.0, "rd": 350.0, "volatility": 0.06},
+    )
+    assert isinstance(state, Glicko2State)
+
+
+def test_parse_rating_state_mismatched_value_raises_naming_both_numbers():
+    """A non-null ``rating_value`` that disagrees with the blob's ``rating`` is
+    corruption: the boundary raises, and the exception names BOTH numbers so the
+    inconsistent row is obvious."""
+    with pytest.raises(RatingStateValueMismatchError) as excinfo:
+        parse_rating_state(
+            "glicko2",
+            {"rating": 1500.0, "rd": 350.0, "volatility": 0.06},
+            1490.0,
+        )
+    err = excinfo.value
+    assert err.rating_value == 1490.0
+    assert err.state_rating == 1500.0
+    message = str(err)
+    assert "1490.0" in message
+    assert "1500.0" in message
+
+
+def test_parse_rating_state_mismatched_manual_value_also_raises():
+    """The invariant holds for every strategy that stores a ``rating`` — a
+    manual (imported) row whose column drifted from its blob raises too."""
+    with pytest.raises(RatingStateValueMismatchError):
+        parse_rating_state("manual", {"rating": 1750.0}, 1751.0)
+
+
+def test_parse_rating_state_consistent_manual_value_parses_cleanly():
+    """A consistent manual row decodes to a ``ManualState`` with no raise."""
+    state = parse_rating_state("manual", {"rating": 1750.0}, 1750.0)
+    assert isinstance(state, ManualState)
+    assert state.rating == 1750.0
+
+
+def test_parse_rating_state_none_blob_is_never_checked():
+    """No blob, no state, no invariant — a manual-league member awaiting an
+    import parses to ``None`` even if a stray ``rating_value`` is passed."""
+    assert parse_rating_state("glicko2", None, 1500.0) is None

--- a/docs/adr/0012-the-rating-timeline-is-anchored-on-completed-at.md
+++ b/docs/adr/0012-the-rating-timeline-is-anchored-on-completed-at.md
@@ -78,3 +78,25 @@ completed.
   ("reads current state and rewrites it deterministically") true for *every* input.
 - `matches.py` (rating history) and `dashboard.py` (the sparkline) both order by
   `rating_history.created_at`; they inherit the stable axis for free.
+
+## Amendment (2026-07-25, #951): the pre-match snapshot obeys the rule too
+
+This ADR claims "history/form/H2H queries anchor on `completed_at`, not the mutable
+`updated_at`." The match-detail **pre-match snapshot** — "Players · going into this
+match" — did not. `pre_match_ratings`, `career_before`, and `head_to_head`
+(`match_details_repository.py`) all took `before = match.created_at` as their
+cutoff. `created_at` is the match's *creation* instant, not its as-played instant,
+and the two diverge whenever matches are created as a batch (a tournament schedule,
+or a player queuing several) but completed later: a match's `created_at` then
+predates its own participants' priors' `completed_at`, so every prior is filtered
+out. Both players read **"Unrated · 0 career matches"** on a match they walked into
+with real histories — the reported symptom, on both fields for both players at once,
+because both the rating trail and the career count share the wrong cutoff.
+
+The fix anchors the snapshot on the **as-played** instant this ADR already
+established: `before = match.completed_at` when the match is completed, else *now*
+for a match not yet decided ("going in" then means the players' current standing).
+Because rating rows are stamped `created_at == completed_at` (this ADR), the strict
+`<` cutoff still excludes the match's own rating row and includes every prior — the
+snapshot becomes historically frozen and correct, and the timeline axis is finally
+uniform across every reader the ADR named.

--- a/docs/adr/0915-the-rating-chart-is-a-calendar-window-with-a-carry-in-anchor.md
+++ b/docs/adr/0915-the-rating-chart-is-a-calendar-window-with-a-carry-in-anchor.md
@@ -61,3 +61,29 @@ first paint still costs one request. It is therefore also the one card that owns
 its own error state — a failed range flip renders "Couldn't load that range · Try
 again" inside the card and leaves the rest of the painted page alone, rather than
 throwing to the route boundary the way a bundle failure does.
+
+## Amendment (2026-07-25, #957): the domain zooms to fit a collapsed span
+
+The calendar axis has a sharp edge the original decision did not address. When a
+player's entire history falls within a tiny fraction of the selected range — a
+brand-new player after one evening of matches — every point shares almost the same
+`x`, and the series collapses to a **1px vertical spike hard against the right
+edge**, ~99% of the plot empty. It is the *honest* rendering of a calendar axis
+over one instant, and it is unusable — and it is exactly the shape a new player
+sees, which is exactly when they are most likely to look.
+
+The fix keeps the calendar axis (this ADR's choice stands) and adds a
+degenerate-case rule: **when the data's own span is a small fraction of the
+selected range, the x-domain zooms to the data's span** (padded out to a
+minimum-span floor) instead of running window-start → now. An evening's six matches
+then fan out across the plot on a real time axis, rather than compressing to a
+sub-pixel line. The range tab becomes "show me *at most* this window, zoomed to
+fit" rather than "stretch the data across the whole window".
+
+The one case the zoom cannot rescue is genuinely identical timestamps (every point
+at the same instant). There the minimum-span floor fans them out; if that is still
+degenerate, the card degrades to a **"N matches today"** label rather than drawing
+a spike. This is the match-indexed axis's one advantage (it needs no anchor and
+degrades gracefully on sparse data) recovered *without* reintroducing it — the
+axis never silently switches its meaning from time to sequence, which is the thing
+this ADR rejected the sequence axis to avoid.

--- a/docs/adr/0915-the-rating-chart-is-a-calendar-window-with-a-carry-in-anchor.md
+++ b/docs/adr/0915-the-rating-chart-is-a-calendar-window-with-a-carry-in-anchor.md
@@ -80,10 +80,16 @@ then fan out across the plot on a real time axis, rather than compressing to a
 sub-pixel line. The range tab becomes "show me *at most* this window, zoomed to
 fit" rather than "stretch the data across the whole window".
 
-The one case the zoom cannot rescue is genuinely identical timestamps (every point
-at the same instant). There the minimum-span floor fans them out; if that is still
-degenerate, the card degrades to a **"N matches today"** label rather than drawing
-a spike. This is the match-indexed axis's one advantage (it needs no anchor and
-degrades gracefully on sparse data) recovered *without* reintroducing it — the
-axis never silently switches its meaning from time to sequence, which is the thing
-this ADR rejected the sequence axis to avoid.
+The zoom-to-fit is the whole fix; there is **no single-instant label**. Even
+genuinely identical timestamps (every point at the same instant) draw fine under
+it: the coincident instant pins to the domain's left edge and the line runs flat to
+today — a plain horizontal line, which is the honest picture of a history that is
+one moment old, and needs no words. An earlier version of this amendment guarded
+that case with an **"N matches today"** label, gated on a fixed-floor domain
+(`[now − 3h, now]`). That floor misfired: it clustered close-but-*distinct* recent
+points — a freshly-rated player's `initial` seed rating plus their first match,
+seconds apart — against the right edge, where their drawn extent fell below a
+viewBox unit and the label fired for a line that should have been drawn. Fitting the
+domain to the data's own span (rather than to a fixed floor) fans distinct points
+out and collapses only truly-coincident ones onto the left edge, so the label had
+nothing left to guard and was removed.

--- a/docs/adr/20260725-a-rating-block-names-its-state-and-shows-rank-below-threshold.md
+++ b/docs/adr/20260725-a-rating-block-names-its-state-and-shows-rank-below-threshold.md
@@ -1,0 +1,95 @@
+# A rating block names its unrated state, and shows rank below the percentile threshold
+
+Date: 2026-07-25
+
+## Status
+
+Accepted
+
+Numbered by date, following the `20260724-*` ADR, not by incrementing the highest
+file on disk — parallel worktrees each number off a stale main (see the ADR
+README).
+
+## Context
+
+Two QA-filed bugs against the #915 rating rollout (#956, #959) turn on the same
+root cause: the dashboard's rating block collapses distinct facts into a single
+signal, and then says something false about the collapsed result.
+
+**`null` conflates three states (#956).** `DashboardRating` is `| None`, and
+`_build_rating()` (`dashboard.py`) has three `return None` exits that the client
+cannot tell apart:
+
+1. the player is **unrated in a glicko2 league** — in a rated league, but has not
+   finished a rated match yet (the real state #915 introduced),
+2. the player is in a **manual-strategy league awaiting an import**,
+3. the player is **not in a rated league at all**.
+
+The client renders one hardcoded string for all three — *"Not in a rated league
+yet."* — which is a lie for state 1: that player *is* in a rated league. No single
+string is true for all three, and the wire carries no way to distinguish them.
+
+**Percentile lies at the bottom of a small ladder (#959).** `league_percentile`
+returns `max(1, round(at_or_above / total * 100))`. For the lowest-rated player,
+`at_or_above == total`, so the card reads **"Top 100% in FortyMM"** — literally
+true, reads like a compliment, and is the one percentile value that should never
+be shown. The profile already gates percentile behind
+`PERCENTILE_MIN_RATED_PLAYERS` (50, provisional); the dashboard had no such gate,
+which is how "Top 100%" surfaced. And below that threshold — a twelve-player alpha
+— "Top 8% of 12" is not a statistic, it is "you are first" in a costume.
+
+## Decision
+
+**The rating block always returns an object carrying a `state` discriminator; the
+client says the true thing per state.** `_build_rating()` no longer returns bare
+`null` for the unrated/awaiting cases. It returns a `DashboardRating` whose `state`
+is one of:
+
+- `RATED` — has a rating; carries the rating value, delta, and the rank-or-percentile line below.
+- `UNRATED` — in a glicko2 league, no rated match finished yet. Copy: *"Unrated — finish a rated match to start your rating."*
+- `AWAITING_IMPORT` — manual-strategy league, import pending. Copy: *"Ratings haven't been imported for this league yet."*
+- `NOT_RATED_LEAGUE` — not in a rated league at all. Copy: *"Not in a rated league yet."* (the existing string, now shown only when it is true).
+
+The enum is server-authoritative — it is the API that knows which of the three
+non-rated situations obtains, so it names it rather than leaving the client to
+guess from a `null`.
+
+**Below the percentile threshold, both surfaces show rank, not percentile.** When
+the rated population is below `PERCENTILE_MIN_RATED_PLAYERS`, the dashboard *and*
+the profile render **rank — "#N of M"** — instead of a percentile. At or above the
+threshold, they render the percentile. Rank is honest at any position and any
+league size ("#5 of 5" is not a compliment or an insult, it is a fact), and it
+keeps a meaningful signal on screen during the alpha instead of blanking the card.
+This unifies the two surfaces, which previously disagreed: the profile suppressed
+the percentile below threshold (showing nothing), the dashboard showed it anyway
+(showing "Top 100%").
+
+The threshold constant stays **50** — #915 marked the number provisional and this
+decision does not add evidence to move it. What changes is that below-threshold is
+no longer "show nothing" but "show rank", and the switch is driven by the one
+constant on both surfaces.
+
+## Considered options
+
+- **Keep returning `null`, add a sibling `reason` field.** Rejected: a nullable
+  block with an out-of-band reason is exactly the shape that let the three states
+  drift apart. A discriminated object keeps the state and its payload together, and
+  parses as one thing at the boundary.
+- **Suppress the percentile only at the bottom of the ladder (#959 option).**
+  Rejected as a targeted hack: it fixes "Top 100%" but leaves "Top 8% of 12" — a
+  meaningless-but-not-wrong statistic — on everyone else in a small league.
+- **Just apply the profile's min-population gate to the dashboard.** Rejected as
+  half a fix: it unifies the two surfaces but blanks the rating card's ranking line
+  entirely during the whole alpha, where rank would have been useful and honest.
+
+## Consequences
+
+- `DashboardRating` is no longer nullable at the parent for the unrated/awaiting
+  cases — a `state` discriminator replaces the `| None`. The OpenAPI regen carries
+  the enum to `schema.d.ts` and `Types.swift`; the client renders copy per state.
+- The rank-vs-percentile switch is a single threshold read shared by
+  `dashboard.py` and the profile's `player_standing`; a future change to the
+  provisional 50 moves both surfaces at once.
+- `PERCENTILE_MIN_RATED_PLAYERS` remains provisional. Rank below it is the honest
+  default until a real threshold is chosen; that choice is still open and out of
+  scope here.

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -3215,25 +3215,36 @@ internal enum Components {
         }
         /// Per-league rating snapshot for the dashboard RatingCard.
         ///
-        /// Emitted only when the user has a rated row in an automatic-strategy league
-        /// (Glicko-2 today). Manual leagues and unrated users get ``rating: None``.
+        /// ALWAYS emitted for a signed-in user — the parent is no longer ``| None``. The
+        /// ``state`` discriminator says which of four stories the card tells; only the
+        /// ``RATED`` arm carries the rating payload below (``current`` / ``delta`` /
+        /// ``peak`` / the rank-or-percentile line / ``spark_data`` / ``streak`` /
+        /// ``stats``). The three non-rated arms carry the league context they have
+        /// (``UNRATED`` / ``AWAITING_IMPORT`` name a league; ``NOT_RATED_LEAGUE`` has
+        /// none) and leave the payload fields null/empty (ADR 20260725).
         ///
         /// - Remark: Generated from `#/components/schemas/DashboardRating`.
         internal struct DashboardRating: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/DashboardRating/state`.
+            internal var state: Components.Schemas.DashboardRatingState
             /// - Remark: Generated from `#/components/schemas/DashboardRating/league_id`.
-            internal var leagueId: Swift.String
+            internal var leagueId: Swift.String?
             /// - Remark: Generated from `#/components/schemas/DashboardRating/league_name`.
-            internal var leagueName: Swift.String
+            internal var leagueName: Swift.String?
             /// - Remark: Generated from `#/components/schemas/DashboardRating/strategy_key`.
-            internal var strategyKey: Swift.String
+            internal var strategyKey: Swift.String?
             /// - Remark: Generated from `#/components/schemas/DashboardRating/current`.
-            internal var current: Swift.Double
+            internal var current: Swift.Double?
             /// - Remark: Generated from `#/components/schemas/DashboardRating/delta`.
             internal var delta: Swift.Double?
             /// - Remark: Generated from `#/components/schemas/DashboardRating/peak`.
-            internal var peak: Swift.Double
+            internal var peak: Swift.Double?
             /// - Remark: Generated from `#/components/schemas/DashboardRating/percentile`.
             internal var percentile: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/DashboardRating/rank`.
+            internal var rank: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/DashboardRating/population`.
+            internal var population: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/DashboardRating/spark_data`.
             internal var sparkData: [Swift.Double]
             /// - Remark: Generated from `#/components/schemas/DashboardRating/streak`.
@@ -3261,6 +3272,7 @@ internal enum Components {
             /// Creates a new `DashboardRating`.
             ///
             /// - Parameters:
+            ///   - state:
             ///   - leagueId:
             ///   - leagueName:
             ///   - strategyKey:
@@ -3268,21 +3280,27 @@ internal enum Components {
             ///   - delta:
             ///   - peak:
             ///   - percentile:
+            ///   - rank:
+            ///   - population:
             ///   - sparkData:
             ///   - streak:
             ///   - stats:
             internal init(
-                leagueId: Swift.String,
-                leagueName: Swift.String,
-                strategyKey: Swift.String,
-                current: Swift.Double,
+                state: Components.Schemas.DashboardRatingState,
+                leagueId: Swift.String? = nil,
+                leagueName: Swift.String? = nil,
+                strategyKey: Swift.String? = nil,
+                current: Swift.Double? = nil,
                 delta: Swift.Double? = nil,
-                peak: Swift.Double,
+                peak: Swift.Double? = nil,
                 percentile: Swift.Int? = nil,
+                rank: Swift.Int? = nil,
+                population: Swift.Int? = nil,
                 sparkData: [Swift.Double],
                 streak: Components.Schemas.DashboardRating.StreakPayload? = nil,
                 stats: [Components.Schemas.DashboardRatingStat]
             ) {
+                self.state = state
                 self.leagueId = leagueId
                 self.leagueName = leagueName
                 self.strategyKey = strategyKey
@@ -3290,11 +3308,14 @@ internal enum Components {
                 self.delta = delta
                 self.peak = peak
                 self.percentile = percentile
+                self.rank = rank
+                self.population = population
                 self.sparkData = sparkData
                 self.streak = streak
                 self.stats = stats
             }
             internal enum CodingKeys: String, CodingKey {
+                case state
                 case leagueId = "league_id"
                 case leagueName = "league_name"
                 case strategyKey = "strategy_key"
@@ -3302,6 +3323,8 @@ internal enum Components {
                 case delta
                 case peak
                 case percentile
+                case rank
+                case population
                 case sparkData = "spark_data"
                 case streak
                 case stats
@@ -3335,6 +3358,23 @@ internal enum Components {
                 case label
                 case value
             }
+        }
+        /// WHICH rating story the card tells — server-authoritative, because it is the
+        /// API that knows which of the four situations obtains, not the client guessing
+        /// from a ``null`` (ADR 20260725).
+        ///
+        /// A bare ``rating: None`` used to collapse three distinct non-rated facts into one
+        /// signal, and the client rendered a single string — *"Not in a rated league
+        /// yet."* — that was a lie for the player who IS in a rated league but has not
+        /// finished a rated match. The state names the situation so the client can say the
+        /// true thing per arm.
+        ///
+        /// - Remark: Generated from `#/components/schemas/DashboardRatingState`.
+        internal enum DashboardRatingState: String, Codable, Hashable, Sendable, CaseIterable {
+            case rated = "RATED"
+            case unrated = "UNRATED"
+            case awaitingImport = "AWAITING_IMPORT"
+            case notRatedLeague = "NOT_RATED_LEAGUE"
         }
         /// - Remark: Generated from `#/components/schemas/DashboardRecentResult`.
         internal struct DashboardRecentResult: Codable, Hashable, Sendable {
@@ -3418,25 +3458,7 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/DashboardResponse/recent_results`.
             internal var recentResults: [Components.Schemas.DashboardRecentResult]
             /// - Remark: Generated from `#/components/schemas/DashboardResponse/rating`.
-            internal struct RatingPayload: Codable, Hashable, Sendable {
-                /// - Remark: Generated from `#/components/schemas/DashboardResponse/rating/value1`.
-                internal var value1: Components.Schemas.DashboardRating
-                /// Creates a new `RatingPayload`.
-                ///
-                /// - Parameters:
-                ///   - value1:
-                internal init(value1: Components.Schemas.DashboardRating) {
-                    self.value1 = value1
-                }
-                internal init(from decoder: any Swift.Decoder) throws {
-                    self.value1 = try .init(from: decoder)
-                }
-                internal func encode(to encoder: any Swift.Encoder) throws {
-                    try self.value1.encode(to: encoder)
-                }
-            }
-            /// - Remark: Generated from `#/components/schemas/DashboardResponse/rating`.
-            internal var rating: Components.Schemas.DashboardResponse.RatingPayload?
+            internal var rating: Components.Schemas.DashboardRating
             /// - Remark: Generated from `#/components/schemas/DashboardResponse/completed_match_count`.
             internal var completedMatchCount: Swift.Int
             /// - Remark: Generated from `#/components/schemas/DashboardResponse/tournaments`.
@@ -3456,7 +3478,7 @@ internal enum Components {
                 attentionTotalCount: Swift.Int,
                 waitingCount: Swift.Int,
                 recentResults: [Components.Schemas.DashboardRecentResult],
-                rating: Components.Schemas.DashboardResponse.RatingPayload? = nil,
+                rating: Components.Schemas.DashboardRating,
                 completedMatchCount: Swift.Int,
                 tournaments: [Components.Schemas.DashboardTournament]? = nil
             ) {

--- a/web-client/e2e/app-shell.spec.ts
+++ b/web-client/e2e/app-shell.spec.ts
@@ -26,6 +26,7 @@ import {
   notificationPreferences,
   notificationTaxonomy,
   sessionResponse,
+  unratedDashboardRating,
 } from '../src/test/factories'
 import { fulfillParkedStream, STREAM_PATH } from './support/realtime'
 
@@ -46,7 +47,9 @@ const DASHBOARD = {
   attention: [],
   attention_total_count: 0,
   waiting_count: 0,
-  rating: null,
+  // The rating block is always present now; these specs are about the shell, so
+  // any valid non-RATED shape does (ADR 20260725).
+  rating: unratedDashboardRating(),
   completed_match_count: 0,
   recent_results: [],
   // No live tournament, so the dashboard's tournament panel never renders in

--- a/web-client/e2e/dashboard-rating-card.spec.ts
+++ b/web-client/e2e/dashboard-rating-card.spec.ts
@@ -39,6 +39,7 @@ const ESTABLISHED_DASHBOARD = {
   waiting_count: 0,
   completed_match_count: 1,
   rating: {
+    state: 'RATED',
     league_id: '44444444-4444-4444-8444-444444444444',
     league_name: 'FortyMM',
     strategy_key: 'glicko2',
@@ -46,6 +47,8 @@ const ESTABLISHED_DASHBOARD = {
     delta: null,
     peak: 1268,
     percentile: 22,
+    rank: null,
+    population: null,
     spark_data: [1268],
     streak: { kind: 'L', n: 1 },
     stats: [

--- a/web-client/e2e/dashboard-recent-results.spec.ts
+++ b/web-client/e2e/dashboard-recent-results.spec.ts
@@ -15,7 +15,10 @@
  */
 import { expect, test, type Page, type Route } from '@playwright/test'
 import type { components } from '../src/api/schema'
-import { sessionResponse } from '../src/test/factories'
+import {
+  sessionResponse,
+  unratedDashboardRating,
+} from '../src/test/factories'
 import { fulfillParkedStream, STREAM_PATH } from './support/realtime'
 
 const SESSION = sessionResponse({ user: { username: 'rita.kovac' } })
@@ -33,7 +36,9 @@ const DASHBOARD = {
   attention: [],
   attention_total_count: 0,
   waiting_count: 0,
-  rating: null,
+  // Rating block is always present now; this spec is about the recent-results
+  // card, so any valid non-RATED shape does (ADR 20260725).
+  rating: unratedDashboardRating(),
   completed_match_count: 3,
   recent_results: [
     {

--- a/web-client/e2e/dashboard-tournament-panel.spec.ts
+++ b/web-client/e2e/dashboard-tournament-panel.spec.ts
@@ -11,7 +11,10 @@
  */
 import { expect, test, type Page, type Route } from '@playwright/test'
 import type { components } from '../src/api/schema'
-import { sessionResponse } from '../src/test/factories'
+import {
+  sessionResponse,
+  unratedDashboardRating,
+} from '../src/test/factories'
 import { fulfillParkedStream, STREAM_PATH } from './support/realtime'
 
 const SESSION = sessionResponse({ user: { username: 'mightymoose' } })
@@ -26,7 +29,9 @@ const IN_A_TOURNAMENT = {
   attention: [],
   attention_total_count: 0,
   waiting_count: 0,
-  rating: null,
+  // Rating block is always present now; this spec is about the tournament panel,
+  // so any valid non-RATED shape does (ADR 20260725).
+  rating: unratedDashboardRating(),
   completed_match_count: 1,
   recent_results: [],
   tournaments: [

--- a/web-client/src/api/dashboard.ts
+++ b/web-client/src/api/dashboard.ts
@@ -8,6 +8,8 @@ export type DashboardAttentionItem =
 export type DashboardRecentResult =
   components['schemas']['DashboardRecentResult']
 export type DashboardRating = components['schemas']['DashboardRating']
+export type DashboardRatingState =
+  components['schemas']['DashboardRatingState']
 export type DashboardStreak = components['schemas']['DashboardStreak']
 export type DashboardTournament = components['schemas']['DashboardTournament']
 export type DashboardTournamentEvent =

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1819,27 +1819,34 @@ export interface components {
          * DashboardRating
          * @description Per-league rating snapshot for the dashboard RatingCard.
          *
-         *     Emitted only when the user has a rated row in an automatic-strategy league
-         *     (Glicko-2 today). Manual leagues and unrated users get ``rating: None``.
+         *     ALWAYS emitted for a signed-in user — the parent is no longer ``| None``. The
+         *     ``state`` discriminator says which of four stories the card tells; only the
+         *     ``RATED`` arm carries the rating payload below (``current`` / ``delta`` /
+         *     ``peak`` / the rank-or-percentile line / ``spark_data`` / ``streak`` /
+         *     ``stats``). The three non-rated arms carry the league context they have
+         *     (``UNRATED`` / ``AWAITING_IMPORT`` name a league; ``NOT_RATED_LEAGUE`` has
+         *     none) and leave the payload fields null/empty (ADR 20260725).
          */
         DashboardRating: {
-            /**
-             * League Id
-             * Format: uuid
-             */
-            league_id: string;
+            state: components["schemas"]["DashboardRatingState"];
+            /** League Id */
+            league_id: string | null;
             /** League Name */
-            league_name: string;
+            league_name: string | null;
             /** Strategy Key */
-            strategy_key: string;
+            strategy_key: string | null;
             /** Current */
-            current: number;
+            current: number | null;
             /** Delta */
             delta: number | null;
             /** Peak */
-            peak: number;
+            peak: number | null;
             /** Percentile */
             percentile: number | null;
+            /** Rank */
+            rank: number | null;
+            /** Population */
+            population: number | null;
             /** Spark Data */
             spark_data: number[];
             streak: components["schemas"]["DashboardStreak"] | null;
@@ -1860,6 +1867,20 @@ export interface components {
             /** Value */
             value: string;
         };
+        /**
+         * DashboardRatingState
+         * @description WHICH rating story the card tells — server-authoritative, because it is the
+         *     API that knows which of the four situations obtains, not the client guessing
+         *     from a ``null`` (ADR 20260725).
+         *
+         *     A bare ``rating: None`` used to collapse three distinct non-rated facts into one
+         *     signal, and the client rendered a single string — *"Not in a rated league
+         *     yet."* — that was a lie for the player who IS in a rated league but has not
+         *     finished a rated match. The state names the situation so the client can say the
+         *     true thing per arm.
+         * @enum {string}
+         */
+        DashboardRatingState: "RATED" | "UNRATED" | "AWAITING_IMPORT" | "NOT_RATED_LEAGUE";
         /** DashboardRecentResult */
         DashboardRecentResult: {
             /**
@@ -1892,7 +1913,7 @@ export interface components {
             waiting_count: number;
             /** Recent Results */
             recent_results: components["schemas"]["DashboardRecentResult"][];
-            rating?: components["schemas"]["DashboardRating"] | null;
+            rating: components["schemas"]["DashboardRating"];
             /** Completed Match Count */
             completed_match_count: number;
             /**

--- a/web-client/src/components/dashboard/dashboard-page.test.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.test.tsx
@@ -18,7 +18,9 @@ import {
   dashboardRecentResult,
   dashboardResponse,
   establishedDashboardRating,
+  notRatedLeagueDashboardRating,
   sessionResponse,
+  unratedDashboardRating,
 } from '@/test/factories'
 import { GUEST_PERSIST_DISMISS_KEY } from './guest-persist-banner'
 import { DashboardPage } from './dashboard-page'
@@ -320,7 +322,10 @@ describe('DashboardPage', () => {
         // At least one completed match keeps this on the normal dashboard
         // path (see the "first-match" describe block below).
         HttpResponse.json(
-          dashboardResponse({ rating: null, completed_match_count: 1 }),
+          dashboardResponse({
+            rating: notRatedLeagueDashboardRating(),
+            completed_match_count: 1,
+          }),
         ),
       ),
     )
@@ -341,7 +346,9 @@ describe('DashboardPage · first-match (zero completed matches, nothing pending)
         HttpResponse.json(
           dashboardResponse({
             completed_match_count: 0,
-            rating: null,
+            // First-match hero renders regardless of the rating block; a
+            // glicko2-unrated shape stands in for "joined, no rated match yet".
+            rating: unratedDashboardRating(),
             recent_results: [],
             attention: [],
             attention_total_count: 0,
@@ -369,8 +376,8 @@ describe('DashboardPage · first-match (zero completed matches, nothing pending)
     // player's own profile, the roster, their leagues card and the opponent
     // picker all — correctly — said Unrated. Joining a league seeds
     // `rating_value = 1500` on session-mint, before a ball is hit; that seed is
-    // the strategy's prior, not a rating anyone earned, and the API now sends
-    // `rating: null` here (CONTEXT.md § Rating).
+    // the strategy's prior, not a rating anyone earned, and the API now sends an
+    // UNRATED rating block (no `current`) here, not that prior (ADR 20260725).
     //
     // The assertion is on the *shape*, not on the literal 1500: any run of 3-4
     // digits is rating-shaped, so re-hardcoding 1600 — or quoting a league's
@@ -380,7 +387,9 @@ describe('DashboardPage · first-match (zero completed matches, nothing pending)
         HttpResponse.json(
           dashboardResponse({
             completed_match_count: 0,
-            rating: null,
+            // First-match hero renders regardless of the rating block; a
+            // glicko2-unrated shape stands in for "joined, no rated match yet".
+            rating: unratedDashboardRating(),
             recent_results: [],
             attention: [],
             attention_total_count: 0,
@@ -404,7 +413,9 @@ describe('DashboardPage · first-match (zero completed matches, nothing pending)
         HttpResponse.json(
           dashboardResponse({
             completed_match_count: 0,
-            rating: null,
+            // First-match hero renders regardless of the rating block; a
+            // glicko2-unrated shape stands in for "joined, no rated match yet".
+            rating: unratedDashboardRating(),
             recent_results: [],
             attention: [
               dashboardAttentionItem({
@@ -435,7 +446,9 @@ describe('DashboardPage · first-match (zero completed matches, nothing pending)
         HttpResponse.json(
           dashboardResponse({
             completed_match_count: 0,
-            rating: null,
+            // First-match hero renders regardless of the rating block; a
+            // glicko2-unrated shape stands in for "joined, no rated match yet".
+            rating: unratedDashboardRating(),
             recent_results: [],
             attention: [],
             attention_total_count: 0,
@@ -463,7 +476,9 @@ describe('DashboardPage · first-match (zero completed matches, nothing pending)
         HttpResponse.json(
           dashboardResponse({
             completed_match_count: 0,
-            rating: null,
+            // First-match hero renders regardless of the rating block; a
+            // glicko2-unrated shape stands in for "joined, no rated match yet".
+            rating: unratedDashboardRating(),
             recent_results: [],
             attention: [],
             attention_total_count: 0,
@@ -520,7 +535,10 @@ describe('DashboardPage · guest persistence banner', () => {
     server.use(
       http.get('*/v1/dashboard', () =>
         HttpResponse.json(
-          dashboardResponse({ completed_match_count: 1, rating: null }),
+          dashboardResponse({
+            completed_match_count: 1,
+            rating: notRatedLeagueDashboardRating(),
+          }),
         ),
       ),
     )
@@ -535,7 +553,10 @@ describe('DashboardPage · guest persistence banner', () => {
     server.use(
       http.get('*/v1/dashboard', () =>
         HttpResponse.json(
-          dashboardResponse({ completed_match_count: 0, rating: null }),
+          dashboardResponse({
+            completed_match_count: 0,
+            rating: unratedDashboardRating(),
+          }),
         ),
       ),
     )

--- a/web-client/src/components/dashboard/dashboard-page.tsx
+++ b/web-client/src/components/dashboard/dashboard-page.tsx
@@ -81,7 +81,13 @@ export function DashboardPage() {
       {showGuestPersistBanner && data && (
         <GuestPersistBanner
           matchCount={data.completed_match_count}
-          rating={data.rating ? Math.round(data.rating.current) : null}
+          // The rating block is always present now, but only the RATED arm
+          // carries a `current`; drop the rating fragment when it's null.
+          rating={
+            data.rating.current !== null
+              ? Math.round(data.rating.current)
+              : null
+          }
         />
       )}
       <PageTitle

--- a/web-client/src/components/dashboard/your-game-row.factory.tsx
+++ b/web-client/src/components/dashboard/your-game-row.factory.tsx
@@ -5,7 +5,8 @@ import type { YourGameRowProps } from './your-game-row'
 /**
  * Props for `YourGameRow` — the loaded, fully-rated case: a Glicko-2 rating and
  * a couple of recent results for the signed-in user "rita.kovac". Override
- * `isLoading` for the skeletons or `rating: null` for the unrated empty state.
+ * `isLoading` for the skeletons, or pass a non-RATED rating block
+ * (`unratedDashboardRating()` etc.) to drive the per-state empty card.
  */
 export function buildYourGameRowProps(
   overrides: Partial<YourGameRowProps> = {},

--- a/web-client/src/components/dashboard/your-game-row.test.tsx
+++ b/web-client/src/components/dashboard/your-game-row.test.tsx
@@ -1,4 +1,9 @@
-import { dashboardRating } from '@/test/factories'
+import {
+  awaitingImportDashboardRating,
+  dashboardRating,
+  notRatedLeagueDashboardRating,
+  unratedDashboardRating,
+} from '@/test/factories'
 
 import { yourGameRowPage } from './your-game-row.page'
 
@@ -21,14 +26,44 @@ describe('YourGameRow', () => {
     expect(yourGameRowPage.recentResults.queryTable()).not.toBeNull()
   })
 
-  it('falls back to the unrated empty state when there is no rating', async () => {
-    yourGameRowPage.render({ rating: null })
+  // The four `state` arms — the client says the true thing per state instead of
+  // the old one-string-fits-all "Not in a rated league yet." (ADR 20260725).
+  it('shows the UNRATED line for a glicko2 player with no rated match yet', async () => {
+    yourGameRowPage.render({ rating: unratedDashboardRating() })
+
+    await yourGameRowPage.findHeading()
+    expect(
+      yourGameRowPage.emptyCard.getBody(
+        'Unrated — finish a rated match to start your rating',
+      ),
+    ).toBeInTheDocument()
+    // Crucially NOT the "not in a rated league" lie — this player IS in one.
+    expect(
+      yourGameRowPage.emptyCard.queryBody('Not in a rated league yet.'),
+    ).toBeNull()
+    // The full rating card is gone — its Peak tile confirms we didn't render it.
+    expect(yourGameRowPage.ratingCard.queryStatLabel('Peak')).toBeNull()
+  })
+
+  it('shows the AWAITING_IMPORT line for a manual league pending its import', async () => {
+    yourGameRowPage.render({ rating: awaitingImportDashboardRating() })
+
+    await yourGameRowPage.findHeading()
+    expect(
+      yourGameRowPage.emptyCard.getBody(
+        "Ratings haven't been imported for this league yet",
+      ),
+    ).toBeInTheDocument()
+    expect(yourGameRowPage.ratingCard.queryStatLabel('Peak')).toBeNull()
+  })
+
+  it('shows the NOT_RATED_LEAGUE line only when the player is in no rated league', async () => {
+    yourGameRowPage.render({ rating: notRatedLeagueDashboardRating() })
 
     await yourGameRowPage.findHeading()
     expect(
       yourGameRowPage.emptyCard.getBody('Not in a rated league yet.'),
     ).toBeInTheDocument()
-    // The rating card's Peak tile is gone — we fell through to the empty state.
     expect(yourGameRowPage.ratingCard.queryStatLabel('Peak')).toBeNull()
   })
 

--- a/web-client/src/components/dashboard/your-game-row.tsx
+++ b/web-client/src/components/dashboard/your-game-row.tsx
@@ -1,4 +1,8 @@
-import type { DashboardRating, DashboardRecentResult } from '@/api/dashboard'
+import type {
+  DashboardRating,
+  DashboardRatingState,
+  DashboardRecentResult,
+} from '@/api/dashboard'
 
 import { EmptyCard } from './your-game-row/empty-card'
 import { RatingCard } from './your-game-row/rating-card'
@@ -11,6 +15,30 @@ function ratingStrategyLabel(key: string): string {
   if (key === 'glicko2') return 'Glicko-2'
   if (key === 'manual') return 'Manual'
   return key
+}
+
+// Per-state copy for the non-RATED arms. The server's `state` discriminator —
+// not a `null` rating — decides which line the empty card shows, so the client
+// says the true thing for each situation instead of the old one-string-fits-all
+// "Not in a rated league yet." that lied to a glicko2-unrated player (#956,
+// ADR 20260725). RATED never reaches this map (it renders the RatingCard).
+const EMPTY_RATING_COPY: Record<
+  Exclude<DashboardRatingState, 'RATED'>,
+  string
+> = {
+  UNRATED: 'Unrated — finish a rated match to start your rating',
+  AWAITING_IMPORT: "Ratings haven't been imported for this league yet",
+  NOT_RATED_LEAGUE: 'Not in a rated league yet.',
+}
+
+function emptyRatingBody(rating: DashboardRating | null): string {
+  // A missing rating is not a wire state the server emits (the block is always
+  // present now); default to the "no rated league" copy for the null-prop edge
+  // (e.g. data still resolving) rather than inventing a fourth string.
+  if (rating === null || rating.state === 'RATED') {
+    return EMPTY_RATING_COPY.NOT_RATED_LEAGUE
+  }
+  return EMPTY_RATING_COPY[rating.state]
 }
 
 export interface YourGameRowProps {
@@ -37,7 +65,9 @@ export const YourGameRow = ({
       <SectionHeader
         title="Your game"
         subtitle={
-          rating
+          // The strategy label rides on the RATED arm's `strategy_key`; the
+          // non-rated arms may not carry one, so fall back to the bare window.
+          rating?.strategy_key
             ? `${ratingStrategyLabel(rating.strategy_key)} · last 30 days`
             : 'Last 30 days'
         }
@@ -48,12 +78,12 @@ export const YourGameRow = ({
       <div className="your-game-grid">
         {isLoading ? (
           <RatingCardSkeleton />
-        ) : rating ? (
+        ) : rating?.state === 'RATED' ? (
           <RatingCard rating={rating} />
         ) : (
           <EmptyCard
             overline="Current rating"
-            body="Not in a rated league yet."
+            body={emptyRatingBody(rating)}
           />
         )}
         {isLoading ? (

--- a/web-client/src/components/dashboard/your-game-row/empty-card.page.tsx
+++ b/web-client/src/components/dashboard/your-game-row/empty-card.page.tsx
@@ -14,6 +14,12 @@ const scoped = (container: Container) => ({
   getBody(text: string | RegExp) {
     return container.getByText(text)
   },
+  /** The muted body line carrying `text`, or null when absent — for asserting a
+   * particular copy string is NOT shown (e.g. the old "not in a rated league"
+   * lie under an UNRATED player). */
+  queryBody(text: string | RegExp) {
+    return container.queryByText(text)
+  },
 })
 
 /**

--- a/web-client/src/components/dashboard/your-game-row/rating-card.page.tsx
+++ b/web-client/src/components/dashboard/your-game-row/rating-card.page.tsx
@@ -32,6 +32,12 @@ const scoped = (container: Container) => ({
   queryPercentile(text: string | RegExp) {
     return container.queryByText(text)
   },
+  /** The rank line shown below the percentile threshold ("#N of M"). Pass a
+   * regex — the line reads "#N of M in <league>" as one span, so an exact string
+   * won't match the whole node. Null when rank isn't shown. */
+  queryRank(text: RegExp) {
+    return container.queryByText(text)
+  },
   /** A stat tile resolved by its label (e.g. "Peak", "RD"); null when absent. */
   queryStatLabel(label: string) {
     return container.queryByText(label)

--- a/web-client/src/components/dashboard/your-game-row/rating-card.test.tsx
+++ b/web-client/src/components/dashboard/your-game-row/rating-card.test.tsx
@@ -84,13 +84,53 @@ describe('RatingCard', () => {
     expect(ratingCardPage.queryPercentile(/FortyMM/)).toBeInTheDocument()
   })
 
-  it('shows just the league name when there is no percentile', () => {
+  it('shows just the league name when there is no percentile and no rank', () => {
     ratingCardPage.render({
-      rating: dashboardRating({ percentile: null, league_name: 'FortyMM' }),
+      rating: dashboardRating({
+        percentile: null,
+        rank: null,
+        population: null,
+        league_name: 'FortyMM',
+      }),
     })
 
     expect(ratingCardPage.queryPercentile('78%')).toBeNull()
     expect(ratingCardPage.queryPercentile('FortyMM')).toBeInTheDocument()
+  })
+
+  // #959. Below the percentile threshold the server suppresses the percentile
+  // and sends rank instead, so the card shows the honest "#N of M" — never the
+  // "Top 100%" that a last-place player used to see when `at_or_above == total`.
+  it('shows rank "#N of M" — not a percentile — when percentile is null but rank is set', () => {
+    ratingCardPage.render({
+      rating: dashboardRating({
+        percentile: null,
+        rank: 3,
+        population: 12,
+        league_name: 'FortyMM',
+      }),
+    })
+
+    expect(ratingCardPage.queryRank(/#3 of 12/)).toBeInTheDocument()
+    expect(ratingCardPage.queryRank(/FortyMM/)).toBeInTheDocument()
+    expect(ratingCardPage.queryPercentile(/Top/)).toBeNull()
+  })
+
+  it('shows the LAST-place player "#5 of 5" and never "Top 100%"', () => {
+    ratingCardPage.render({
+      rating: dashboardRating({
+        percentile: null,
+        rank: 5,
+        population: 5,
+        current: 1200,
+        league_name: 'FortyMM',
+      }),
+    })
+
+    expect(ratingCardPage.queryRank(/#5 of 5/)).toBeInTheDocument()
+    // The one percentile value that should never be shown.
+    expect(ratingCardPage.queryText('100%')).toBeNull()
+    expect(ratingCardPage.queryText(/Top 100%/)).toBeNull()
   })
 
   it('leads the stat tiles with the rounded peak', () => {

--- a/web-client/src/components/dashboard/your-game-row/rating-card.tsx
+++ b/web-client/src/components/dashboard/your-game-row/rating-card.tsx
@@ -14,7 +14,13 @@ export interface RatingCardProps {
 }
 
 export const RatingCard = ({ rating }: RatingCardProps) => {
-  const { current, delta, peak, percentile, spark_data, streak, stats } = rating
+  const { delta, percentile, rank, population, spark_data, streak, stats } =
+    rating
+  // The RATED arm always carries these; the `?? 0` only satisfies the type,
+  // which is nullable across all four states (YourGameRow renders this card for
+  // RATED only, ADR 20260725).
+  const current = rating.current ?? 0
+  const peak = rating.peak ?? 0
   // Sparkline needs ≥2 points to draw a line; pad a single point so the
   // freshly-rated case still shows a level baseline.
   const sparkPoints =
@@ -69,6 +75,17 @@ export const RatingCard = ({ rating }: RatingCardProps) => {
               Top{' '}
               <Mono size={11} color={C.chalk300}>
                 {percentile}%
+              </Mono>{' '}
+              in {rating.league_name}
+            </span>
+          ) : rank !== null && population !== null ? (
+            // Below the percentile threshold the server suppresses percentile
+            // and sends rank instead: "#N of M" is honest at any position and
+            // league size, where "Top 100%" for the last-place player was a
+            // compliment-shaped lie (#959, ADR 20260725).
+            <span style={{ font: `400 11px ${UI}`, color: C.chalk500 }}>
+              <Mono size={11} color={C.chalk300}>
+                {`#${rank} of ${population}`}
               </Mono>{' '}
               in {rating.league_name}
             </span>

--- a/web-client/src/components/dashboard/your-game-row/rating-card.tsx
+++ b/web-client/src/components/dashboard/your-game-row/rating-card.tsx
@@ -1,4 +1,5 @@
 import type { DashboardRating } from '@/api/dashboard'
+import { formatRankOfPopulation } from '@/lib/rating'
 import { Overline } from '@/components/overline'
 import { C, MONO, UI } from '@/components/dashboard/dashboard-tokens'
 
@@ -85,7 +86,7 @@ export const RatingCard = ({ rating }: RatingCardProps) => {
             // compliment-shaped lie (#959, ADR 20260725).
             <span style={{ font: `400 11px ${UI}`, color: C.chalk500 }}>
               <Mono size={11} color={C.chalk300}>
-                {`#${rank} of ${population}`}
+                {formatRankOfPopulation(rank, population)}
               </Mono>{' '}
               in {rating.league_name}
             </span>

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card.test.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card.test.tsx
@@ -50,21 +50,27 @@ describe('RecentResultsCard', () => {
     expect(row.getByLabelText('Gained 24 rating')).toBeInTheDocument()
   })
 
-  it('shows an em dash when the match carries no rating change', () => {
+  it('shows an em dash, named "No rating change", when the match moved no rating', () => {
+    // The bare em dash had no accessible name at all on the dashboard, so a
+    // screen reader heard nothing here. It now names the state.
     recentResultsCardPage.render()
 
-    expect(recentResultsCardPage.getRow('patel.m').getByText('—')).toBeInTheDocument()
+    const row = recentResultsCardPage.getRow('patel.m')
+    expect(row.getByText('—')).toBeInTheDocument()
+    expect(row.getByLabelText('No rating change')).toBeInTheDocument()
   })
 
-  it('shows an em dash — never a signed number — for the match that ESTABLISHED the rating', () => {
+  it('shows an em dash, named "Rating established", for the match that ESTABLISHED the rating', () => {
     // The change is *present* here; only its `delta` is null. Before the fix the
     // column read the delta straight, and `null >= 0` is `true` in JS — so this
     // row would have painted a green "+null"/"+0"-ish chip for a player whose
-    // rating had just come into existence (#952).
+    // rating had just come into existence (#952). And a screen reader must hear
+    // that this is a first rated match, not the same "nothing" as an unrated one.
     recentResultsCardPage.render()
 
     const row = recentResultsCardPage.getRow('invisible-sloth')
     expect(row.getByText('—')).toBeInTheDocument()
+    expect(row.getByLabelText('Rating established')).toBeInTheDocument()
     expect(row.queryByText(/^[+-]/)).toBeNull()
     expect(row.queryByText(/1500|null|NaN/)).toBeNull()
   })

--- a/web-client/src/components/dashboard/your-game-row/recent-results-card.tsx
+++ b/web-client/src/components/dashboard/your-game-row/recent-results-card.tsx
@@ -2,7 +2,11 @@ import type { DashboardRecentResult } from '@/api/dashboard'
 import { UserAvatar } from '@/components/ui/user-avatar'
 import { Overline } from '@/components/overline'
 import { fmtDateShort } from '@/lib/dates'
-import { formatRatingDelta, formatRatingDeltaAria } from '@/lib/rating'
+import {
+  emptyRatingDeltaAria,
+  formatRatingDelta,
+  formatRatingDeltaAria,
+} from '@/lib/rating'
 import { C, UI } from '@/components/dashboard/dashboard-tokens'
 
 import { Card } from './card'
@@ -96,7 +100,10 @@ export const RecentResultsCard = ({ rows }: RecentResultsCardProps) => {
               // moved no rating at all; a *present* change with a null `delta` is
               // the player's FIRST rated match — it established their rating
               // rather than moving it, so there is no movement to report here
-              // either. Never a signed figure off the seeded 1500 (#952).
+              // either. Never a signed figure off the seeded 1500 (#952). The two
+              // read the same glyph but are different facts, so the em-dash cell
+              // takes a truthful accessible name (`emptyRatingDeltaAria`) — these
+              // rows are always completed matches, so they are always "decided".
               const delta = r.my_rating_change?.delta ?? null
               return (
                 <tr
@@ -156,7 +163,11 @@ export const RecentResultsCard = ({ rows }: RecentResultsCardProps) => {
                         {formatRatingDelta(delta)}
                       </Mono>
                     ) : (
-                      <Mono size={12} color={C.chalk500}>
+                      <Mono
+                        size={12}
+                        color={C.chalk500}
+                        ariaLabel={emptyRatingDeltaAria(r.my_rating_change, true)}
+                      >
                         —
                       </Mono>
                     )}

--- a/web-client/src/components/players/player-profile.css
+++ b/web-client/src/components/players/player-profile.css
@@ -2054,6 +2054,19 @@
   display: block;
 }
 
+/* The whole history is one instant (#957): a calendar axis can't fan N matches
+ * played at the same moment, so the plot states the fact rather than draw a
+ * sub-pixel spike. Sized like the pending slot so the card doesn't jump. */
+.rating-chart__single-instant {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 120px;
+  margin: 0;
+  font-size: 14px;
+  color: var(--fg-3);
+}
+
 /* No rating, no chart (CONTEXT.md, "Rating"): the slot says what would end that,
  * rather than drawing an axis with nothing on it. */
 .rating-chart__unrated {

--- a/web-client/src/components/players/player-profile.css
+++ b/web-client/src/components/players/player-profile.css
@@ -2054,19 +2054,6 @@
   display: block;
 }
 
-/* The whole history is one instant (#957): a calendar axis can't fan N matches
- * played at the same moment, so the plot states the fact rather than draw a
- * sub-pixel spike. Sized like the pending slot so the card doesn't jump. */
-.rating-chart__single-instant {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 120px;
-  margin: 0;
-  font-size: 14px;
-  color: var(--fg-3);
-}
-
 /* No rating, no chart (CONTEXT.md, "Rating"): the slot says what would end that,
  * rather than drawing an axis with nothing on it. */
 .rating-chart__unrated {

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.factory.tsx
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.factory.tsx
@@ -1,6 +1,7 @@
 import {
   buildEmptyRatingWindow,
   buildRatingHistoryWindow,
+  buildRatingPoint,
 } from '@/mocks/factories/players/rating-history.factory'
 
 import type { RatingChartDisplayProps } from './rating-chart-display'
@@ -25,6 +26,35 @@ export function buildChartView(window = buildRatingHistoryWindow()): ChartView {
  * chip at all. Never a "+0". */
 export function buildEmptyChartView(): ChartView {
   return selectRatingChart(buildEmptyRatingWindow(), '90d')
+}
+
+/**
+ * A brand-new player whose whole history is **one instant** (#957): `matchCount`
+ * matches all recorded at the same moment, ≈ now, with no carry-in anchor. The
+ * calendar axis cannot fan them out, so the projected view carries
+ * `singleInstant` set — the card renders an "N matches today" label rather than a
+ * spike.
+ *
+ * Built by running the real projection over a fixed `now` that equals the
+ * matches' instant, so the collapse is deterministic rather than racing the wall
+ * clock.
+ */
+export function buildSingleInstantChartView(matchCount = 6): ChartView {
+  const now = Date.now()
+  const instant = new Date(now).toISOString()
+  const points = Array.from({ length: matchCount }, (_, i) =>
+    buildRatingPoint({ at: instant, rating: 1500 + i * 4, match_id: `m-${i}` }),
+  )
+  return selectRatingChart(
+    {
+      anchor: null,
+      points,
+      peak: points.at(-1) ?? null,
+      change: matchCount * 4,
+    },
+    '90d',
+    now,
+  )
 }
 
 /** Props for `RatingChartDisplay` — the settled, painted card. */

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.factory.tsx
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.factory.tsx
@@ -1,7 +1,6 @@
 import {
   buildEmptyRatingWindow,
   buildRatingHistoryWindow,
-  buildRatingPoint,
 } from '@/mocks/factories/players/rating-history.factory'
 
 import type { RatingChartDisplayProps } from './rating-chart-display'
@@ -26,35 +25,6 @@ export function buildChartView(window = buildRatingHistoryWindow()): ChartView {
  * chip at all. Never a "+0". */
 export function buildEmptyChartView(): ChartView {
   return selectRatingChart(buildEmptyRatingWindow(), '90d')
-}
-
-/**
- * A brand-new player whose whole history is **one instant** (#957): `matchCount`
- * matches all recorded at the same moment, ≈ now, with no carry-in anchor. The
- * calendar axis cannot fan them out, so the projected view carries
- * `singleInstant` set — the card renders an "N matches today" label rather than a
- * spike.
- *
- * Built by running the real projection over a fixed `now` that equals the
- * matches' instant, so the collapse is deterministic rather than racing the wall
- * clock.
- */
-export function buildSingleInstantChartView(matchCount = 6): ChartView {
-  const now = Date.now()
-  const instant = new Date(now).toISOString()
-  const points = Array.from({ length: matchCount }, (_, i) =>
-    buildRatingPoint({ at: instant, rating: 1500 + i * 4, match_id: `m-${i}` }),
-  )
-  return selectRatingChart(
-    {
-      anchor: null,
-      points,
-      peak: points.at(-1) ?? null,
-      change: matchCount * 4,
-    },
-    '90d',
-    now,
-  )
 }
 
 /** Props for `RatingChartDisplay` — the settled, painted card. */

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.page.tsx
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.page.tsx
@@ -46,6 +46,12 @@ const scoped = (container: Container) => ({
   queryChangeChip(): HTMLElement | null {
     return this.getChartCard().querySelector('.rating-chart__chip')
   },
+  /** The single-instant fallback's label — "N matches today", rendered *in place
+   * of the SVG* when the whole history is one instant and a calendar axis cannot
+   * fan it out (#957). `null` in every drawable case. */
+  querySingleInstantLabel(): HTMLElement | null {
+    return this.getChartCard().querySelector('.rating-chart__single-instant')
+  },
   /** The in-card failure — "Couldn't load that range", *in place of the SVG*, with
    * the rest of the profile still painted around it. */
   findChartError() {

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.page.tsx
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.page.tsx
@@ -46,12 +46,6 @@ const scoped = (container: Container) => ({
   queryChangeChip(): HTMLElement | null {
     return this.getChartCard().querySelector('.rating-chart__chip')
   },
-  /** The single-instant fallback's label — "N matches today", rendered *in place
-   * of the SVG* when the whole history is one instant and a calendar axis cannot
-   * fan it out (#957). `null` in every drawable case. */
-  querySingleInstantLabel(): HTMLElement | null {
-    return this.getChartCard().querySelector('.rating-chart__single-instant')
-  },
   /** The in-card failure — "Couldn't load that range", *in place of the SVG*, with
    * the rest of the profile still painted around it. */
   findChartError() {

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.test.tsx
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.test.tsx
@@ -1,6 +1,7 @@
 import {
   buildChartView,
   buildEmptyChartView,
+  buildSingleInstantChartView,
 } from './rating-chart-display.factory'
 import { ratingChartDisplayPage } from './rating-chart-display.page'
 
@@ -28,6 +29,29 @@ describe('RatingChartDisplay', () => {
     )
     // …and it still draws: a flat line at their current rating, not an empty box.
     expect(ratingChartDisplayPage.queryChartLine()).toBeInTheDocument()
+  })
+
+  it('shows an "N matches today" label instead of a spike when the whole history is one instant', async () => {
+    // #957: a brand-new player who played several matches at one moment cannot be
+    // drawn on a calendar axis — the line would be a sub-pixel spike hard against
+    // the right edge. The card states the real count in words instead.
+    ratingChartDisplayPage.render({ chart: buildSingleInstantChartView(6) })
+
+    await ratingChartDisplayPage.findChartCard()
+    expect(ratingChartDisplayPage.querySingleInstantLabel()).toHaveTextContent(
+      '6 matches today',
+    )
+    // …and it does NOT draw the line: no SVG, no spike.
+    expect(ratingChartDisplayPage.queryChartLine()).not.toBeInTheDocument()
+  })
+
+  it('pluralises the single-instant label — "1 match today", not "1 matches today"', async () => {
+    ratingChartDisplayPage.render({ chart: buildSingleInstantChartView(1) })
+
+    await ratingChartDisplayPage.findChartCard()
+    expect(ratingChartDisplayPage.querySingleInstantLabel()).toHaveTextContent(
+      '1 match today',
+    )
   })
 
   it('puts a failed range IN the card — the SVG goes, the card stays', async () => {

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.test.tsx
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.test.tsx
@@ -1,7 +1,6 @@
 import {
   buildChartView,
   buildEmptyChartView,
-  buildSingleInstantChartView,
 } from './rating-chart-display.factory'
 import { ratingChartDisplayPage } from './rating-chart-display.page'
 
@@ -29,29 +28,6 @@ describe('RatingChartDisplay', () => {
     )
     // …and it still draws: a flat line at their current rating, not an empty box.
     expect(ratingChartDisplayPage.queryChartLine()).toBeInTheDocument()
-  })
-
-  it('shows an "N matches today" label instead of a spike when the whole history is one instant', async () => {
-    // #957: a brand-new player who played several matches at one moment cannot be
-    // drawn on a calendar axis — the line would be a sub-pixel spike hard against
-    // the right edge. The card states the real count in words instead.
-    ratingChartDisplayPage.render({ chart: buildSingleInstantChartView(6) })
-
-    await ratingChartDisplayPage.findChartCard()
-    expect(ratingChartDisplayPage.querySingleInstantLabel()).toHaveTextContent(
-      '6 matches today',
-    )
-    // …and it does NOT draw the line: no SVG, no spike.
-    expect(ratingChartDisplayPage.queryChartLine()).not.toBeInTheDocument()
-  })
-
-  it('pluralises the single-instant label — "1 match today", not "1 matches today"', async () => {
-    ratingChartDisplayPage.render({ chart: buildSingleInstantChartView(1) })
-
-    await ratingChartDisplayPage.findChartCard()
-    expect(ratingChartDisplayPage.querySingleInstantLabel()).toHaveTextContent(
-      '1 match today',
-    )
   })
 
   it('puts a failed range IN the card — the SVG goes, the card stays', async () => {

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.tsx
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.tsx
@@ -27,11 +27,6 @@ export interface RatingChartDisplayProps {
   onRetry: () => void
 }
 
-/** "1 match today" / "6 matches today" — the single-instant fallback's copy
- * (#957), pluralised on the real in-window match count. */
-const matchesTodayLabel = (count: number): string =>
-  `${count} ${count === 1 ? 'match' : 'matches'} today`
-
 /**
  * The rating chart's card: a heading, the signed change, the range tabs, a
  * sentence, and the line.
@@ -112,14 +107,6 @@ export const RatingChartDisplay = ({
               Try again
             </Button>
           </div>
-        ) : chart?.singleInstant ? (
-          // The whole history is one instant (#957): N matches recorded at the
-          // same moment, ≈ now. A calendar axis cannot fan them out — the line
-          // would be a sub-pixel spike against the right edge — so the card states
-          // the fact in words instead of drawing a spike.
-          <p className="rating-chart__single-instant" role="status">
-            {matchesTodayLabel(chart.singleInstant.matchCount)}
-          </p>
         ) : chart ? (
           <div
             className={cn(

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.tsx
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-display.tsx
@@ -27,6 +27,11 @@ export interface RatingChartDisplayProps {
   onRetry: () => void
 }
 
+/** "1 match today" / "6 matches today" — the single-instant fallback's copy
+ * (#957), pluralised on the real in-window match count. */
+const matchesTodayLabel = (count: number): string =>
+  `${count} ${count === 1 ? 'match' : 'matches'} today`
+
 /**
  * The rating chart's card: a heading, the signed change, the range tabs, a
  * sentence, and the line.
@@ -107,6 +112,14 @@ export const RatingChartDisplay = ({
               Try again
             </Button>
           </div>
+        ) : chart?.singleInstant ? (
+          // The whole history is one instant (#957): N matches recorded at the
+          // same moment, ≈ now. A calendar axis cannot fan them out — the line
+          // would be a sub-pixel spike against the right edge — so the card states
+          // the fact in words instead of drawing a spike.
+          <p className="rating-chart__single-instant" role="status">
+            {matchesTodayLabel(chart.singleInstant.matchCount)}
+          </p>
         ) : chart ? (
           <div
             className={cn(

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.test.ts
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.test.ts
@@ -377,8 +377,6 @@ describe('selectRatingChart', () => {
     // clustering against the right edge.
     expect(xCoords.at(-1)! - xCoords[0]).toBeGreaterThan(400)
     expect(new Set(xCoords).size).toBeGreaterThan(2)
-    // It is a real line, not the degenerate single-instant fallback.
-    expect(view.singleInstant).toBeNull()
   })
 
   it('draws a LINE for a freshly-rated player: seed rating + first match, seconds apart, no anchor (#957)', () => {
@@ -387,9 +385,10 @@ describe('selectRatingChart', () => {
     // rating and their first match — with no carry-in anchor, on the 90d range. The
     // old zoom floored the domain to a fixed [now − 3h, now] window, which clustered
     // these two *recent* points against the right edge; the drawn extent fell below
-    // a viewBox unit and the projection reported "2 matches today" INSTEAD of the
-    // line (5 e2e specs asserting the line went red). Distinct timestamps must fan
-    // into a real line: `singleInstant` is null and the session spans the plot.
+    // a viewBox unit and the card showed "2 matches today" INSTEAD of the line (5
+    // e2e specs asserting the line went red). The zoom-to-fit pins the earliest
+    // point to the left edge, so these distinct timestamps fan into a real line that
+    // spans the plot.
     const sec = 1 / (24 * 60 * 60)
     const view = selectRatingChart(
       buildRatingHistoryWindow({
@@ -405,8 +404,7 @@ describe('selectRatingChart', () => {
       NOW,
     )
 
-    // A real, drawn line — not the degenerate single-instant label.
-    expect(view.singleInstant).toBeNull()
+    // A real, drawn line.
     expect(view.line).not.toBe('')
     const xCoords = xs(view.line)
     // The earliest (seed) point is pinned to the left edge — the domain fit the
@@ -443,15 +441,16 @@ describe('selectRatingChart', () => {
     // The in-window matches sit hard against the right edge — the full-window
     // behaviour the anchor preserves, and the spike the no-anchor case above avoids.
     expect(xCoords[1]).toBeGreaterThan(580)
-    expect(view.singleInstant).toBeNull()
   })
 
-  it('degrades to an "N matches today" state when every match is at one instant (#957)', () => {
-    // The one case the zoom cannot rescue: genuinely identical timestamps. The
-    // minimum-span floor fans nothing when there is nothing to fan, so rather than
-    // draw a sub-pixel spike the projection reports the real count for the card to
-    // state in words.
-    const instant = at(0)
+  it('draws a LINE even when every match is at ONE instant — a flat run to today (#957)', () => {
+    // The case the zoom-to-fit handles without a label: genuinely identical
+    // timestamps. The coincident instant pins to the left edge and the line then
+    // runs flat to today — a drawable line, not a sub-pixel spike. There is no
+    // single-instant "N matches today" fallback any more — a fixed-floor domain
+    // misfired that label on close-but-distinct recent points, so it was removed and
+    // the zoom-to-fit always produces a drawable line.
+    const instant = at(1)
     const view = selectRatingChart(
       buildRatingHistoryWindow({
         anchor: null,
@@ -467,7 +466,13 @@ describe('selectRatingChart', () => {
       NOW,
     )
 
-    expect(view.singleInstant).toEqual({ matchCount: 3 })
+    // A real, drawn path — not an empty string, not a degenerate label.
+    expect(view.line).not.toBe('')
+    const xCoords = xs(view.line)
+    // The coincident instant is pinned to the left edge; the flat run reaches today.
+    expect(xCoords[0]).toBe(42) // PLOT.left
+    expect(xCoords.at(-1)).toBe(590) // CHART_WIDTH - PLOT.right — today's edge
+    expect(JSON.stringify(view)).not.toContain('singleInstant')
   })
 })
 

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.test.ts
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.test.ts
@@ -346,6 +346,93 @@ describe('selectRatingChart', () => {
     expect(xCoords.at(-1)! - xCoords[0]).toBeGreaterThan(400)
     expect(new Set(xCoords).size).toBeGreaterThan(2)
   })
+
+  it('zooms the x-domain to fit a history collapsed into one evening (#957)', () => {
+    // A brand-new player's whole history is one session. On the raw 90-day calendar
+    // axis every point shares almost the same x and the line collapses to a ~1px
+    // spike hard against the right edge (`M589.48 … L589.5`). With no anchor pinning
+    // it to the left, the domain zooms to the data so the session fans across the
+    // plot instead.
+    const view = selectRatingChart(
+      buildRatingHistoryWindow({
+        anchor: null,
+        points: [
+          buildRatingPoint({ at: at(0.8), rating: 1500 }),
+          buildRatingPoint({ at: at(0.4), rating: 1516 }),
+          buildRatingPoint({ at: at(0.05), rating: 1524 }),
+        ],
+        peak: buildRatingPoint({ at: at(0.05), rating: 1524 }),
+        change: 24,
+      }),
+      '90d',
+      NOW,
+    )
+
+    const xCoords = xs(view.line)
+    // The earliest match is pinned to the plot's left edge — the domain was zoomed
+    // to the data span, NOT left at window-start (where a 0.8-day-old point would
+    // sit at x ≈ 585, jammed against the others in a sub-pixel cluster).
+    expect(xCoords[0]).toBe(42) // PLOT.left
+    // …so the whole session fans across most of the 548-unit plot rather than
+    // clustering against the right edge.
+    expect(xCoords.at(-1)! - xCoords[0]).toBeGreaterThan(400)
+    expect(new Set(xCoords).size).toBeGreaterThan(2)
+    // It is a real line, not the degenerate single-instant fallback.
+    expect(view.singleInstant).toBeNull()
+  })
+
+  it('does NOT zoom when a carry-in anchor holds the line to the left edge (#957)', () => {
+    // The zoom is only for a line with nothing pinning it left. An anchored line
+    // already spans the plot — the anchor is drawn at window-start (ADR-0915), and
+    // re-homing it onto a zoomed domain would misdate a point whose whole meaning
+    // is "as of the window start". So the same one-evening points, given an anchor,
+    // stay on the full calendar domain: the anchor at the far left, the matches
+    // clustered at the right, exactly as ADR-0915 draws them.
+    const view = selectRatingChart(
+      buildRatingHistoryWindow({
+        anchor: buildRatingPoint({ at: at(120), rating: 1490 }),
+        points: [
+          buildRatingPoint({ at: at(0.8), rating: 1500 }),
+          buildRatingPoint({ at: at(0.05), rating: 1524 }),
+        ],
+        peak: buildRatingPoint({ at: at(0.05), rating: 1524 }),
+        change: 34,
+      }),
+      '90d',
+      NOW,
+    )
+
+    const xCoords = xs(view.line)
+    expect(xCoords[0]).toBe(42) // the anchor, drawn at window-start
+    // The in-window matches sit hard against the right edge — the full-window
+    // behaviour the anchor preserves, and the spike the no-anchor case above avoids.
+    expect(xCoords[1]).toBeGreaterThan(580)
+    expect(view.singleInstant).toBeNull()
+  })
+
+  it('degrades to an "N matches today" state when every match is at one instant (#957)', () => {
+    // The one case the zoom cannot rescue: genuinely identical timestamps. The
+    // minimum-span floor fans nothing when there is nothing to fan, so rather than
+    // draw a sub-pixel spike the projection reports the real count for the card to
+    // state in words.
+    const instant = at(0)
+    const view = selectRatingChart(
+      buildRatingHistoryWindow({
+        anchor: null,
+        points: [
+          buildRatingPoint({ at: instant, rating: 1500 }),
+          buildRatingPoint({ at: instant, rating: 1512 }),
+          buildRatingPoint({ at: instant, rating: 1525 }),
+        ],
+        peak: buildRatingPoint({ at: instant, rating: 1525 }),
+        change: 25,
+      }),
+      '90d',
+      NOW,
+    )
+
+    expect(view.singleInstant).toEqual({ matchCount: 3 })
+  })
 })
 
 describe('the chart’s own query', () => {

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.test.ts
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.test.ts
@@ -381,6 +381,42 @@ describe('selectRatingChart', () => {
     expect(view.singleInstant).toBeNull()
   })
 
+  it('draws a LINE for a freshly-rated player: seed rating + first match, seconds apart, no anchor (#957)', () => {
+    // The regression the composed root-e2e caught (`seedRatedPlayer`). A brand-new
+    // rated player's whole history is TWO points seconds apart — the `initial` seed
+    // rating and their first match — with no carry-in anchor, on the 90d range. The
+    // old zoom floored the domain to a fixed [now − 3h, now] window, which clustered
+    // these two *recent* points against the right edge; the drawn extent fell below
+    // a viewBox unit and the projection reported "2 matches today" INSTEAD of the
+    // line (5 e2e specs asserting the line went red). Distinct timestamps must fan
+    // into a real line: `singleInstant` is null and the session spans the plot.
+    const sec = 1 / (24 * 60 * 60)
+    const view = selectRatingChart(
+      buildRatingHistoryWindow({
+        anchor: null,
+        points: [
+          buildRatingPoint({ at: at(15 * sec), rating: 1500 }), // the seed rating
+          buildRatingPoint({ at: at(5 * sec), rating: 1516 }), // the first match, 10s later
+        ],
+        peak: buildRatingPoint({ at: at(5 * sec), rating: 1516 }),
+        change: 16,
+      }),
+      '90d',
+      NOW,
+    )
+
+    // A real, drawn line — not the degenerate single-instant label.
+    expect(view.singleInstant).toBeNull()
+    expect(view.line).not.toBe('')
+    const xCoords = xs(view.line)
+    // The earliest (seed) point is pinned to the left edge — the domain fit the
+    // data span rather than flooring recent points against the right edge…
+    expect(xCoords[0]).toBe(42) // PLOT.left
+    // …so the two-point session fans across most of the plot.
+    expect(xCoords.at(-1)! - xCoords[0]).toBeGreaterThan(400)
+    expect(new Set(xCoords).size).toBeGreaterThan(1)
+  })
+
   it('does NOT zoom when a carry-in anchor holds the line to the left edge (#957)', () => {
     // The zoom is only for a line with nothing pinning it left. An anchored line
     // already spans the plot — the anchor is drawn at window-start (ADR-0915), and

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.ts
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.ts
@@ -77,7 +77,7 @@ const FLAT_PADDING = 20
  * whole history is one evening, so on a 30d/90d/1y axis every point shares almost
  * the same `x` and the series collapses to a ~1px vertical spike hard against the
  * right edge — the honest rendering of one instant on a calendar, and unusable.
- * These three constants size the fix.
+ * These two constants size the fix.
  */
 
 /** When the drawn line reaches back **less than this fraction** of the selected
@@ -89,16 +89,15 @@ const FLAT_PADDING = 20
  * (ADR-0915), not something to zoom away. */
 const COLLAPSE_RANGE_FRACTION = 0.05
 
-/** The tightest the zoomed axis goes — its minimum-span floor. Matches closer
- * together than this fan into a near-vertical cluster rather than being spread
- * edge-to-edge, which would imply hours between matches that were minutes (or
- * seconds) apart. Three hours reads as "one session". */
-const MIN_SPAN_FLOOR_MS = 3 * 60 * 60 * 1000
-
-/** Below this drawn x-extent (in viewBox units) even the floored zoom has not
- * separated the points: every match shares one instant (≈ now), so there is no
- * line to draw. The card shows an "N matches today" label instead of a spike. */
-const SINGLE_INSTANT_MIN_SPAN = 1
+/** How coincident the in-window matches must be to count as **one instant** — the
+ * "N matches today" fallback. Measured on the RAW timestamps (`max − min`), not on
+ * the drawn x-extent: the zoom pins the earliest match to the left edge and fans
+ * distinct matches across the plot, so a *drawn* extent can never distinguish
+ * "seconds apart" (a real line) from "same moment" (no line). A whole second of
+ * slack absorbs clock jitter while still leaving a genuine two-matches-a-minute
+ * -apart session on the zoomed line — which is exactly a freshly-rated player's
+ * `initial` seed rating plus their first match (the regression this guards). */
+const SINGLE_INSTANT_MAX_SPAN_MS = 1000
 
 /* ------------------------------------------------------- the peak's label --
  * The peak carries a dot AND its rating, and the two must not sit on top of each
@@ -190,10 +189,13 @@ export type ChartView = {
    * case.
    *
    * When a whole history is one instant — N matches recorded at the same moment,
-   * ≈ now — the time axis cannot fan them out even after the minimum-span floor,
-   * and the line above collapses to a sub-pixel spike. The card then renders an
-   * "N matches today" label *in place of* the SVG. `matchCount` is the real number
-   * of in-window matches, for the "1 match" / "6 matches" copy.
+   * ≈ now — there is no span for the time axis to fan out, and a line would be a
+   * sub-pixel spike. The card then renders an "N matches today" label *in place of*
+   * the SVG. Fired on the RAW timestamps being coincident (`max − min` under a
+   * one-second slack), NOT on a collapsed drawn extent: distinct-but-close matches
+   * (a `initial` seed rating plus a first match, seconds apart) zoom to a real line
+   * and are never labelled. `matchCount` is the real number of in-window matches,
+   * for the "1 match" / "6 matches" copy.
    */
   singleInstant: { matchCount: number } | null
 }
@@ -388,8 +390,14 @@ type XDomain = { xMin: number; xMax: number; collapsed: boolean }
  * tonight" (reaches back hours → zoom) apart from "played early, quiet since"
  * (reaches back the whole window → keep it; that flat run is the honest story).
  * When the reach is under `COLLAPSE_RANGE_FRACTION` of the window, the domain
- * zooms to the data, floored to `MIN_SPAN_FLOOR_MS`, with the right edge pinned at
- * now so the flat-run-to-today and the current dot are always in frame.
+ * zooms to **fit the data**: the earliest match is pinned to the left edge and now
+ * to the right, so the session fans across the full plot. Fitting rather than
+ * flooring to a fixed `[now − 3h, now]` window is the fix for the over-firing
+ * label — a floor clusters *recent* matches (a freshly-rated player's seed rating
+ * plus a first match, minutes apart) against the right edge, where they read as one
+ * instant even though they aren't. The right edge stays pinned at now so the
+ * flat-run-to-today and the current dot are always in frame; `xSpan`'s own
+ * `Math.max(1, …)` floor keeps a truly-tiny span from dividing by zero.
  */
 function xDomain(
   window: RatingHistoryWindow,
@@ -413,8 +421,11 @@ function xDomain(
   const rangeSpan = RANGE_DAYS[range] * DAY_MS
   if (reach >= COLLAPSE_RANGE_FRACTION * rangeSpan) return full
 
-  const xMin = Math.min(minPoint, now - MIN_SPAN_FLOOR_MS)
-  return { xMin, xMax: now, collapsed: true }
+  // Zoom to fit: the earliest match at the left edge, now at the right. Distinct
+  // matches — however close — fan into a visible line; only truly coincident ones
+  // (caught by `SINGLE_INSTANT_MAX_SPAN_MS` in `selectRatingChart`) degrade to the
+  // "N matches today" label.
+  return { xMin: minPoint, xMax: now, collapsed: true }
 }
 
 /**
@@ -434,11 +445,11 @@ function xDomain(
  * **previous** range's data on screen (`keepPreviousData`), and re-projecting a
  * 90-day line into a 30-day domain would pile two thirds of it up on the left
  * edge, so widening to fit draws the old line as itself until the new one lands.
- * And it **zooms in** — starting *later* than the window start — when the data
- * has collapsed against the right edge (a brand-new player's one evening), so an
- * otherwise sub-pixel spike fans out to fill the plot (#957). Both live in
- * `xDomain`; a single-instant history degrades to an "N matches today" label
- * instead.
+ * And it **zooms in** — starting *later* than the window start, at the earliest
+ * match itself — when the data has collapsed against the right edge (a brand-new
+ * player's one evening), so an otherwise sub-pixel spike fans out to fill the plot
+ * (#957). Both live in `xDomain`; only a genuinely one-instant history (coincident
+ * raw timestamps) degrades to an "N matches today" label instead.
  */
 export function selectRatingChart(
   window: RatingHistoryWindow,
@@ -491,17 +502,18 @@ export function selectRatingChart(
       ? `${line} L${last.x} ${baseline} L${first.x} ${baseline} Z`
       : ''
 
-  // The genuinely-single-instant fallback (#957): the zoom branch was taken, yet
-  // even the floored domain has not separated the drawn vertices — every match is
-  // at one instant ≈ now, so the line is a sub-pixel spike. The card shows an
-  // "N matches today" label rather than draw it. Measured on the DRAWN x-extent,
-  // not the raw timestamps, so it is exactly "did the zoom fail to fan them".
-  const drawnXs = coords.map((point) => point.x)
-  const drawnXExtent = drawnXs.length
-    ? Math.max(...drawnXs) - Math.min(...drawnXs)
+  // The genuinely-single-instant fallback (#957): the zoom branch was taken AND the
+  // in-window matches are truly coincident — one instant, ≈ now — so there is no
+  // span to fan out and a line would be a sub-pixel spike. Gated on the RAW
+  // timestamps (`max − min`), NOT the drawn x-extent: the zoom pins the earliest
+  // match to the left edge, so distinct-but-close matches (a seed rating plus a
+  // first match, seconds apart) fan into a real line and must NOT be labelled —
+  // only genuinely one-instant histories degrade to "N matches today".
+  const rawSpan = pointTimes.length
+    ? Math.max(...pointTimes) - Math.min(...pointTimes)
     : 0
   const singleInstant =
-    collapsed && drawnXExtent < SINGLE_INSTANT_MIN_SPAN
+    collapsed && rawSpan < SINGLE_INSTANT_MAX_SPAN_MS
       ? { matchCount: window.points.length }
       : null
 

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.ts
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.ts
@@ -72,6 +72,34 @@ const PLOT_HEIGHT = CHART_HEIGHT - PLOT.top - PLOT.bottom
  * and paint every point at `NaN`). */
 const FLAT_PADDING = 20
 
+/* ------------------------------------------------- zoom-to-fit (#957) --
+ * The calendar axis has a sharp edge (ADR-0915 amendment). A brand-new player's
+ * whole history is one evening, so on a 30d/90d/1y axis every point shares almost
+ * the same `x` and the series collapses to a ~1px vertical spike hard against the
+ * right edge — the honest rendering of one instant on a calendar, and unusable.
+ * These three constants size the fix.
+ */
+
+/** When the drawn line reaches back **less than this fraction** of the selected
+ * window, the calendar axis is almost entirely empty and the series piles up on
+ * the right edge — so the x-domain zooms to the data instead of running
+ * window-start → now. 5%: an evening is *hours* against 30–365 days, far under
+ * this; a player whose activity genuinely reaches back a meaningful slice of the
+ * window stays on the full calendar domain, whose flat run is honest inactivity
+ * (ADR-0915), not something to zoom away. */
+const COLLAPSE_RANGE_FRACTION = 0.05
+
+/** The tightest the zoomed axis goes — its minimum-span floor. Matches closer
+ * together than this fan into a near-vertical cluster rather than being spread
+ * edge-to-edge, which would imply hours between matches that were minutes (or
+ * seconds) apart. Three hours reads as "one session". */
+const MIN_SPAN_FLOOR_MS = 3 * 60 * 60 * 1000
+
+/** Below this drawn x-extent (in viewBox units) even the floored zoom has not
+ * separated the points: every match shares one instant (≈ now), so there is no
+ * line to draw. The card shows an "N matches today" label instead of a spike. */
+const SINGLE_INSTANT_MIN_SPAN = 1
+
 /* ------------------------------------------------------- the peak's label --
  * The peak carries a dot AND its rating, and the two must not sit on top of each
  * other. The label normally rides ABOVE the dot — but the peak is very often the
@@ -157,6 +185,17 @@ export type ChartView = {
    * false and in the second is better said in words than in a chip.
    */
   change: ChartChangeView | null
+  /**
+   * The genuinely-single-instant fallback (#957), or **`null`** in every drawable
+   * case.
+   *
+   * When a whole history is one instant — N matches recorded at the same moment,
+   * ≈ now — the time axis cannot fan them out even after the minimum-span floor,
+   * and the line above collapses to a sub-pixel spike. The card then renders an
+   * "N matches today" label *in place of* the SVG. `matchCount` is the real number
+   * of in-window matches, for the "1 match" / "6 matches" copy.
+   */
+  singleInstant: { matchCount: number } | null
 }
 
 const round = (value: number): number => Math.round(value * 100) / 100
@@ -322,6 +361,57 @@ const formatDay = (at: number, now: number): string => {
   })
 }
 
+/** The x-domain the line is drawn into: normally window-start → now, but zoomed
+ * to fit when the data has collapsed against the right edge. `collapsed` says
+ * which branch was taken, so the caller knows a single-instant fallback is even
+ * possible. */
+type XDomain = { xMin: number; xMax: number; collapsed: boolean }
+
+/**
+ * Where the x-axis starts and ends (#957).
+ *
+ * The default is ADR-0915's calendar domain: `windowStart → now`, stretched back
+ * to take in any point OLDER than the window start (the previous range's line,
+ * held on screen while a flip loads — see `selectRatingChart`).
+ *
+ * The zoom-to-fit branch fires only when **there is no carry-in anchor**. An
+ * anchor is drawn at the domain's left edge — it *is* the rating the window opens
+ * at (ADR-0915) — so an anchored line already spans the plot edge-to-edge and can
+ * never collapse; and re-homing the anchor onto a zoomed domain would misdate a
+ * point whose whole meaning is "as of the window start". So an anchored window,
+ * and the empty/unrated windows with no points at all, keep the full domain
+ * unchanged.
+ *
+ * Without an anchor, the deciding measure is how far back the DRAWN line reaches:
+ * from its earliest match to today (the line runs flat to now). That — not the
+ * matches' own max−min span — is what tells "brand-new player, first session
+ * tonight" (reaches back hours → zoom) apart from "played early, quiet since"
+ * (reaches back the whole window → keep it; that flat run is the honest story).
+ * When the reach is under `COLLAPSE_RANGE_FRACTION` of the window, the domain
+ * zooms to the data, floored to `MIN_SPAN_FLOOR_MS`, with the right edge pinned at
+ * now so the flat-run-to-today and the current dot are always in frame.
+ */
+function xDomain(
+  window: RatingHistoryWindow,
+  range: RatingRange,
+  now: number,
+  windowStart: number,
+  pointTimes: number[],
+): XDomain {
+  const fullMin = Math.min(windowStart, ...pointTimes)
+  const full: XDomain = { xMin: fullMin, xMax: now, collapsed: false }
+
+  if (window.anchor || pointTimes.length === 0) return full
+
+  const minPoint = Math.min(...pointTimes)
+  const reach = now - minPoint
+  const rangeSpan = RANGE_DAYS[range] * DAY_MS
+  if (reach >= COLLAPSE_RANGE_FRACTION * rangeSpan) return full
+
+  const xMin = Math.min(minPoint, now - MIN_SPAN_FLOOR_MS)
+  return { xMin, xMax: now, collapsed: true }
+}
+
 /**
  * The chart, projected out of one window of rating history.
  *
@@ -347,14 +437,18 @@ export function selectRatingChart(
   now: number = Date.now(),
 ): ChartView {
   const windowStart = now - RANGE_DAYS[range] * DAY_MS
-  // The domain's left edge: the window's, stretched back to take in any point
-  // older than it (see above — that is the previous range's line, held on screen
-  // while this one loads).
-  const xMin = Math.min(
+  const pointTimes = window.points.map((point) => Date.parse(point.at))
+  // The domain: the calendar window, stretched back to take in any point older
+  // than it (the previous range's line, held on screen while this one loads) —
+  // OR, when the data has collapsed against the right edge, zoomed to fit it
+  // (#957). See `xDomain`.
+  const { xMin, xMax, collapsed } = xDomain(
+    window,
+    range,
+    now,
     windowStart,
-    ...window.points.map((point) => Date.parse(point.at)),
+    pointTimes,
   )
-  const xMax = now
   const xSpan = Math.max(1, xMax - xMin)
   const drawn = vertices(window, xMin, now)
 
@@ -387,6 +481,20 @@ export function selectRatingChart(
     first && last
       ? `${line} L${last.x} ${baseline} L${first.x} ${baseline} Z`
       : ''
+
+  // The genuinely-single-instant fallback (#957): the zoom branch was taken, yet
+  // even the floored domain has not separated the drawn vertices — every match is
+  // at one instant ≈ now, so the line is a sub-pixel spike. The card shows an
+  // "N matches today" label rather than draw it. Measured on the DRAWN x-extent,
+  // not the raw timestamps, so it is exactly "did the zoom fail to fan them".
+  const drawnXs = coords.map((point) => point.x)
+  const drawnXExtent = drawnXs.length
+    ? Math.max(...drawnXs) - Math.min(...drawnXs)
+    : 0
+  const singleInstant =
+    collapsed && drawnXExtent < SINGLE_INSTANT_MIN_SPAN
+      ? { matchCount: window.points.length }
+      : null
 
   const currentVertex = drawn.at(-1)
   // The peak of the DRAWN line, anchor included — not `window.peak` read straight
@@ -425,6 +533,7 @@ export function selectRatingChart(
     ],
     summary: summarize(window, range),
     change: changeChip(window.change),
+    singleInstant,
   }
 }
 

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.ts
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.ts
@@ -398,12 +398,17 @@ function xDomain(
   windowStart: number,
   pointTimes: number[],
 ): XDomain {
-  const fullMin = Math.min(windowStart, ...pointTimes)
-  const full: XDomain = { xMin: fullMin, xMax: now, collapsed: false }
+  // `Math.min(...[])` is `Infinity`, so on an empty series `fullMin` falls back
+  // to `windowStart` and the early return below fires before `minPoint` is used.
+  const minPoint = Math.min(...pointTimes)
+  const full: XDomain = {
+    xMin: Math.min(windowStart, minPoint),
+    xMax: now,
+    collapsed: false,
+  }
 
   if (window.anchor || pointTimes.length === 0) return full
 
-  const minPoint = Math.min(...pointTimes)
   const reach = now - minPoint
   const rangeSpan = RANGE_DAYS[range] * DAY_MS
   if (reach >= COLLAPSE_RANGE_FRACTION * rangeSpan) return full

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.ts
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.ts
@@ -428,13 +428,17 @@ function xDomain(
  * *numbers*, and they are asserted against numbers here rather than against
  * rendered pixels.
  *
- * The x-domain deserves a note. It runs from the window's start to now — except
- * that it stretches back to take in any point OLDER than the window start, which
- * happens for exactly one reason: while a range flip is in flight the card keeps
- * the **previous** range's data on screen (`keepPreviousData`), and re-projecting
- * a 90-day line into a 30-day domain would pile two thirds of it up on the left
- * edge. Widening the domain to fit the data draws the old line as itself until
- * the new one lands.
+ * The x-domain deserves a note. It usually runs from the window's start to now,
+ * but bends at both ends. It **stretches back** to take in any point OLDER than
+ * the window start: while a range flip is in flight the card keeps the
+ * **previous** range's data on screen (`keepPreviousData`), and re-projecting a
+ * 90-day line into a 30-day domain would pile two thirds of it up on the left
+ * edge, so widening to fit draws the old line as itself until the new one lands.
+ * And it **zooms in** — starting *later* than the window start — when the data
+ * has collapsed against the right edge (a brand-new player's one evening), so an
+ * otherwise sub-pixel spike fans out to fill the plot (#957). Both live in
+ * `xDomain`; a single-instant history degrades to an "N matches today" label
+ * instead.
  */
 export function selectRatingChart(
   window: RatingHistoryWindow,

--- a/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.ts
+++ b/web-client/src/components/players/player-profile/rating-chart/rating-chart-fetcher/rating-chart-query.ts
@@ -77,7 +77,10 @@ const FLAT_PADDING = 20
  * whole history is one evening, so on a 30d/90d/1y axis every point shares almost
  * the same `x` and the series collapses to a ~1px vertical spike hard against the
  * right edge — the honest rendering of one instant on a calendar, and unusable.
- * These two constants size the fix.
+ * The zoom-to-fit below sizes the fix, and it always produces a drawable line: a
+ * genuinely coincident-instant history simply fits its zero-width span to the
+ * left edge and runs flat to today (a horizontal line), which draws fine and needs
+ * no label.
  */
 
 /** When the drawn line reaches back **less than this fraction** of the selected
@@ -88,16 +91,6 @@ const FLAT_PADDING = 20
  * window stays on the full calendar domain, whose flat run is honest inactivity
  * (ADR-0915), not something to zoom away. */
 const COLLAPSE_RANGE_FRACTION = 0.05
-
-/** How coincident the in-window matches must be to count as **one instant** — the
- * "N matches today" fallback. Measured on the RAW timestamps (`max − min`), not on
- * the drawn x-extent: the zoom pins the earliest match to the left edge and fans
- * distinct matches across the plot, so a *drawn* extent can never distinguish
- * "seconds apart" (a real line) from "same moment" (no line). A whole second of
- * slack absorbs clock jitter while still leaving a genuine two-matches-a-minute
- * -apart session on the zoomed line — which is exactly a freshly-rated player's
- * `initial` seed rating plus their first match (the regression this guards). */
-const SINGLE_INSTANT_MAX_SPAN_MS = 1000
 
 /* ------------------------------------------------------- the peak's label --
  * The peak carries a dot AND its rating, and the two must not sit on top of each
@@ -184,20 +177,6 @@ export type ChartView = {
    * false and in the second is better said in words than in a chip.
    */
   change: ChartChangeView | null
-  /**
-   * The genuinely-single-instant fallback (#957), or **`null`** in every drawable
-   * case.
-   *
-   * When a whole history is one instant — N matches recorded at the same moment,
-   * ≈ now — there is no span for the time axis to fan out, and a line would be a
-   * sub-pixel spike. The card then renders an "N matches today" label *in place of*
-   * the SVG. Fired on the RAW timestamps being coincident (`max − min` under a
-   * one-second slack), NOT on a collapsed drawn extent: distinct-but-close matches
-   * (a `initial` seed rating plus a first match, seconds apart) zoom to a real line
-   * and are never labelled. `matchCount` is the real number of in-window matches,
-   * for the "1 match" / "6 matches" copy.
-   */
-  singleInstant: { matchCount: number } | null
 }
 
 const round = (value: number): number => Math.round(value * 100) / 100
@@ -364,10 +343,8 @@ const formatDay = (at: number, now: number): string => {
 }
 
 /** The x-domain the line is drawn into: normally window-start → now, but zoomed
- * to fit when the data has collapsed against the right edge. `collapsed` says
- * which branch was taken, so the caller knows a single-instant fallback is even
- * possible. */
-type XDomain = { xMin: number; xMax: number; collapsed: boolean }
+ * to fit when the data has collapsed against the right edge. */
+type XDomain = { xMin: number; xMax: number }
 
 /**
  * Where the x-axis starts and ends (#957).
@@ -392,12 +369,13 @@ type XDomain = { xMin: number; xMax: number; collapsed: boolean }
  * When the reach is under `COLLAPSE_RANGE_FRACTION` of the window, the domain
  * zooms to **fit the data**: the earliest match is pinned to the left edge and now
  * to the right, so the session fans across the full plot. Fitting rather than
- * flooring to a fixed `[now − 3h, now]` window is the fix for the over-firing
- * label — a floor clusters *recent* matches (a freshly-rated player's seed rating
- * plus a first match, minutes apart) against the right edge, where they read as one
- * instant even though they aren't. The right edge stays pinned at now so the
- * flat-run-to-today and the current dot are always in frame; `xSpan`'s own
- * `Math.max(1, …)` floor keeps a truly-tiny span from dividing by zero.
+ * flooring to a fixed `[now − 3h, now]` window is what keeps *recent* matches (a
+ * freshly-rated player's seed rating plus a first match, minutes apart) fanned into
+ * a real line instead of clustered against the right edge. The right edge stays
+ * pinned at now so the flat-run-to-today and the current dot are always in frame;
+ * `xSpan`'s own `Math.max(1, …)` floor keeps a truly-tiny span from dividing by
+ * zero — a genuinely coincident-instant history then pins to the left edge and
+ * runs flat to today, a horizontal line that draws fine and needs no label.
  */
 function xDomain(
   window: RatingHistoryWindow,
@@ -412,7 +390,6 @@ function xDomain(
   const full: XDomain = {
     xMin: Math.min(windowStart, minPoint),
     xMax: now,
-    collapsed: false,
   }
 
   if (window.anchor || pointTimes.length === 0) return full
@@ -421,11 +398,10 @@ function xDomain(
   const rangeSpan = RANGE_DAYS[range] * DAY_MS
   if (reach >= COLLAPSE_RANGE_FRACTION * rangeSpan) return full
 
-  // Zoom to fit: the earliest match at the left edge, now at the right. Distinct
-  // matches — however close — fan into a visible line; only truly coincident ones
-  // (caught by `SINGLE_INSTANT_MAX_SPAN_MS` in `selectRatingChart`) degrade to the
-  // "N matches today" label.
-  return { xMin: minPoint, xMax: now, collapsed: true }
+  // Zoom to fit: the earliest match at the left edge, now at the right. Every
+  // history — however close its points, down to a single coincident instant —
+  // fans (or, at zero span, runs flat) into a drawable line.
+  return { xMin: minPoint, xMax: now }
 }
 
 /**
@@ -448,8 +424,9 @@ function xDomain(
  * And it **zooms in** — starting *later* than the window start, at the earliest
  * match itself — when the data has collapsed against the right edge (a brand-new
  * player's one evening), so an otherwise sub-pixel spike fans out to fill the plot
- * (#957). Both live in `xDomain`; only a genuinely one-instant history (coincident
- * raw timestamps) degrades to an "N matches today" label instead.
+ * (#957). Both live in `xDomain`. The zoom always yields a drawable line, even for
+ * a genuinely one-instant history: its zero-width span fits to the left edge and
+ * runs flat to today — a horizontal line, no label.
  */
 export function selectRatingChart(
   window: RatingHistoryWindow,
@@ -462,13 +439,7 @@ export function selectRatingChart(
   // than it (the previous range's line, held on screen while this one loads) —
   // OR, when the data has collapsed against the right edge, zoomed to fit it
   // (#957). See `xDomain`.
-  const { xMin, xMax, collapsed } = xDomain(
-    window,
-    range,
-    now,
-    windowStart,
-    pointTimes,
-  )
+  const { xMin, xMax } = xDomain(window, range, now, windowStart, pointTimes)
   const xSpan = Math.max(1, xMax - xMin)
   const drawn = vertices(window, xMin, now)
 
@@ -501,21 +472,6 @@ export function selectRatingChart(
     first && last
       ? `${line} L${last.x} ${baseline} L${first.x} ${baseline} Z`
       : ''
-
-  // The genuinely-single-instant fallback (#957): the zoom branch was taken AND the
-  // in-window matches are truly coincident — one instant, ≈ now — so there is no
-  // span to fan out and a line would be a sub-pixel spike. Gated on the RAW
-  // timestamps (`max − min`), NOT the drawn x-extent: the zoom pins the earliest
-  // match to the left edge, so distinct-but-close matches (a seed rating plus a
-  // first match, seconds apart) fan into a real line and must NOT be labelled —
-  // only genuinely one-instant histories degrade to "N matches today".
-  const rawSpan = pointTimes.length
-    ? Math.max(...pointTimes) - Math.min(...pointTimes)
-    : 0
-  const singleInstant =
-    collapsed && rawSpan < SINGLE_INSTANT_MAX_SPAN_MS
-      ? { matchCount: window.points.length }
-      : null
 
   const currentVertex = drawn.at(-1)
   // The peak of the DRAWN line, anchor included — not `window.peak` read straight
@@ -554,7 +510,6 @@ export function selectRatingChart(
     ],
     summary: summarize(window, range),
     change: changeChip(window.change),
-    singleInstant,
   }
 }
 

--- a/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher.test.tsx
+++ b/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher.test.tsx
@@ -3,6 +3,7 @@ import { HttpResponse } from 'msw'
 import {
   buildJustRatedPlayerDetail,
   buildPlayerDetail,
+  buildRankedPlayerDetail,
   buildUnratedPlayerDetail,
 } from '@/mocks/factories/players/player-detail.factory'
 import { waitForElementToBeRemoved } from '@/test/utilities'
@@ -28,6 +29,43 @@ describe('RatingPanelFetcher', () => {
     )
     expect(ratingPanelFetcherPage.queryStat('Peak')).toHaveTextContent('1712')
     expect(ratingPanelFetcherPage.getChips()).toHaveLength(10)
+  })
+
+  it('renders RANK for a sub-threshold-league profile — the ladder is too small for a percentile', async () => {
+    // Below `PERCENTILE_MIN_RATED_PLAYERS` the API withholds the percentile and
+    // sends rank+rank_of; the hero shows "#N of M" in the standing slot, honest at
+    // the very bottom of a small ladder where "Top 100%" was a lie (#959, ADR
+    // 20260725). This is the default fixture's shape — a 42-strong ladder.
+    ratingPanelFetcherPage.mockEndpoint(() =>
+      HttpResponse.json(
+        buildPlayerDetail({ rank: 49, rank_of: 49, percentile: null }),
+      ),
+    )
+
+    ratingPanelFetcherPage.render()
+
+    await waitForElementToBeRemoved(ratingPanelFetcherPage.queryLoading())
+    expect(ratingPanelFetcherPage.queryStat('Rank')).toHaveTextContent(
+      '#49 of 49',
+    )
+    expect(ratingPanelFetcherPage.queryStat('Percentile')).toBeNull()
+  })
+
+  it('renders the PERCENTILE for an at-or-above-threshold profile, and drops the rank line so it reads like the dashboard', async () => {
+    // Past the threshold the percentile means something: the hero prints "Top 2%"
+    // and the rank line steps aside. The two surfaces now agree — rank below,
+    // percentile above (ADR 20260725).
+    ratingPanelFetcherPage.mockEndpoint(() =>
+      HttpResponse.json(buildRankedPlayerDetail()),
+    )
+
+    ratingPanelFetcherPage.render()
+
+    await waitForElementToBeRemoved(ratingPanelFetcherPage.queryLoading())
+    expect(ratingPanelFetcherPage.queryStat('Percentile')).toHaveTextContent(
+      'Top 2%',
+    )
+    expect(ratingPanelFetcherPage.queryStat('Rank')).toBeNull()
   })
 
   it('shows an unrated player as Unrated, with no rank', async () => {

--- a/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher/rating-panel-display.test.tsx
+++ b/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher/rating-panel-display.test.tsx
@@ -54,6 +54,18 @@ describe('RatingPanelDisplay', () => {
     )
   })
 
+  it('shows the percentile in the standing slot when the API sends one', () => {
+    ratingPanelDisplayPage.render({
+      standing: buildRatingPanelView({
+        stats: [buildStandingStatView({ label: 'Percentile', value: 'Top 2%' })],
+      }),
+    })
+
+    expect(ratingPanelDisplayPage.queryStat('Percentile')).toHaveTextContent(
+      'Top 2%',
+    )
+  })
+
   it('shows the peak rating', () => {
     ratingPanelDisplayPage.render({
       standing: buildRatingPanelView({

--- a/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher/rating-panel-query.test.ts
+++ b/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher/rating-panel-query.test.ts
@@ -62,6 +62,21 @@ describe('ratingPanelQuery', () => {
     })
   })
 
+  it('shows RANK below the percentile threshold and PERCENTILE at or above it — never both, so the profile reads like the dashboard (ADR 20260725)', async () => {
+    // Below the threshold the API withholds the percentile and sends rank+rank_of
+    // — the honest bottom of a small ladder, "#49 of 49" (#959). The rank takes
+    // the standing slot the percentile would have occupied.
+    const below = await selectFrom({ rank: 49, rank_of: 49, percentile: null })
+    expect(below.stats).toContainEqual({ label: 'Rank', value: '#49 of 49' })
+    expect(below.stats.map((s) => s.label)).not.toContain('Percentile')
+
+    // At or above it the percentile is present and takes that slot; the rank line
+    // steps aside, so the two surfaces agree (rank below, percentile above).
+    const above = await selectFrom({ rank: 3, rank_of: 220, percentile: 2 })
+    expect(above.stats).toContainEqual({ label: 'Percentile', value: 'Top 2%' })
+    expect(above.stats.map((s) => s.label)).not.toContain('Rank')
+  })
+
   it('signs the rating delta from the most recent rated match', async () => {
     const view = await selectFrom({
       rating_delta: buildRatingChange({ before: 1675, after: 1687 }),

--- a/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher/rating-panel-query.ts
+++ b/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher/rating-panel-query.ts
@@ -1,6 +1,7 @@
 import { playerByIdQueryOptions, type PlayerDetail, type RatingRange } from '@/api/players'
 import {
   formatRating,
+  formatRankOfPopulation,
   formatRatingDelta,
   formatRatingDeltaAria,
 } from '@/lib/rating'
@@ -114,7 +115,10 @@ const selectStats = (player: PlayerDetail): StandingStatView[] => {
   if (player.percentile != null) {
     stats.push({ label: 'Percentile', value: `Top ${player.percentile}%` })
   } else if (player.rank != null && player.rank_of != null) {
-    stats.push({ label: 'Rank', value: `#${player.rank} of ${player.rank_of}` })
+    stats.push({
+      label: 'Rank',
+      value: formatRankOfPopulation(player.rank, player.rank_of),
+    })
   }
   return stats
 }

--- a/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher/rating-panel-query.ts
+++ b/web-client/src/components/players/player-profile/rating-panel/rating-panel-fetcher/rating-panel-query.ts
@@ -43,9 +43,12 @@ export type RatingPanelView = {
    * fallen from the 1500 their league-join seeded — they simply have no delta
    * (#952). */
   delta: RatingDeltaView | null
-  /** Rank, peak and percentile, in that order — each present only when the
-   * player has it. An unrated player has none of them: no rating, no rank
-   * (CONTEXT.md § *Rank*). */
+  /** Peak, then one standing line — rank OR percentile, never both (ADR
+   * 20260725). At or above the percentile threshold the standing line is the
+   * percentile ("Top N%"); below it, where the API withholds the percentile, it
+   * is the rank ("#N of M") in the same slot, so the profile and the dashboard
+   * agree. Each present only when the player has it — an unrated player has none:
+   * no rating, no rank (CONTEXT.md § *Rank*). */
   stats: StandingStatView[]
   /** `null` for a player with no decided matches at all. Independent of the
    * rating: form counts decided matches, rated or not. */
@@ -93,19 +96,25 @@ const selectDelta = (
 
 const selectStats = (player: PlayerDetail): StandingStatView[] => {
   const stats: StandingStatView[] = []
-  // Rank is always reported *out of the rated population* — "#3 of 42", never a
-  // naked "#3", which in a twelve-player league flatters. Both halves or
-  // neither.
-  if (player.rank != null && player.rank_of != null) {
-    stats.push({ label: 'Rank', value: `#${player.rank} of ${player.rank_of}` })
-  }
   if (player.peak != null) {
     stats.push({ label: 'Peak', value: formatRating(player.peak) })
   }
-  // The API withholds the percentile while the league is too small for it to
-  // mean anything, so its presence — not a threshold here — is the signal.
+  // The standing line — rank OR percentile, never both, so the profile and the
+  // dashboard say the same thing (ADR 20260725). The API withholds `percentile`
+  // while the league is too small for "Top N%" to mean anything and populates
+  // `rank`/`rank_of` instead; its presence — not a threshold here — is the switch:
+  //
+  // - AT OR ABOVE the threshold the percentile is present and takes the slot;
+  // - BELOW it the percentile is null, so the hero reads RANK ("#3 of 42") in the
+  //   same slot — honest at any position and league size, where "Top 100%" for the
+  //   last-place player of a small ladder was a compliment-shaped lie (#959).
+  //
+  // Rank is always reported *out of the rated population* — "#3 of 42", never a
+  // naked "#3", which in a twelve-player league flatters: both halves or neither.
   if (player.percentile != null) {
     stats.push({ label: 'Percentile', value: `Top ${player.percentile}%` })
+  } else if (player.rank != null && player.rank_of != null) {
+    stats.push({ label: 'Rank', value: `#${player.rank} of ${player.rank_of}` })
   }
   return stats
 }

--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display.factory.tsx
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display.factory.tsx
@@ -39,6 +39,7 @@ export function buildRecentMatchesView(
         }),
         status: buildRecentMatchStatusView({ tone: 'lost', label: 'Lost' }),
         delta: {
+          kind: 'change',
           label: '-14',
           ariaLabel: 'Lost 14 rating',
           tone: 'loss',

--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display.test.tsx
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display.test.tsx
@@ -3,6 +3,7 @@ import {
   buildRecentMatchesView,
 } from './recent-matches-display.factory'
 import {
+  buildEmptyRecentMatchDeltaView,
   buildLiveRecentMatchRowView,
   buildRecentMatchOpponentView,
   buildRecentMatchRowView,
@@ -27,7 +28,7 @@ const sixMixedRows = () => [
       label: 'Awaiting acceptance',
     }),
     score: { kind: 'text', text: 'Awaiting' },
-    delta: null,
+    delta: buildEmptyRecentMatchDeltaView({ ariaLabel: 'Not yet decided' }),
   }),
   buildRecentMatchRowView({
     id: 'm-win',
@@ -38,13 +39,13 @@ const sixMixedRows = () => [
     opponent: buildRecentMatchOpponentView({ id: 'p-12', name: 'joe.bell' }),
     status: buildRecentMatchStatusView({ tone: 'voided', label: 'Voided' }),
     score: { kind: 'text', text: '—' },
-    delta: null,
+    delta: buildEmptyRecentMatchDeltaView(),
   }),
   buildSoloRecentMatchRowView({ id: 'm-solo' }),
   buildRecentMatchRowView({
     id: 'm-unrated',
     opponent: buildRecentMatchOpponentView({ id: 'p-13', name: 'nia.k' }),
-    delta: null,
+    delta: buildEmptyRecentMatchDeltaView(),
   }),
 ]
 

--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display/recent-match-row.factory.tsx
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display/recent-match-row.factory.tsx
@@ -46,16 +46,26 @@ export function buildRecentMatchStatusView(
   return { tone: 'won', label: 'Won', ...overrides }
 }
 
-/** A rating gain from a decided, rated match. */
+/** A rating gain from a decided, rated match — the `change` variant. */
 export function buildRecentMatchDeltaView(
-  overrides: Partial<RecentMatchDeltaView> = {},
+  overrides: Partial<Extract<RecentMatchDeltaView, { kind: 'change' }>> = {},
 ): RecentMatchDeltaView {
   return {
+    kind: 'change',
     label: '+12',
     ariaLabel: 'Gained 12 rating',
     tone: 'win',
     ...overrides,
   }
+}
+
+/** An em-dash Δ cell — the `empty` variant, no signed figure. `ariaLabel`
+ * defaults to "No rating change"; pass "Not yet decided" / "Rating established"
+ * for the other two no-move states. */
+export function buildEmptyRecentMatchDeltaView(
+  overrides: Partial<Extract<RecentMatchDeltaView, { kind: 'empty' }>> = {},
+): RecentMatchDeltaView {
+  return { kind: 'empty', ariaLabel: 'No rating change', ...overrides }
 }
 
 /** A decided, rated **win**: a green dot, three game chips and a +12. Every
@@ -108,7 +118,7 @@ export function buildLiveRecentMatchRowView(
     id: LIVE_MATCH_ID,
     status: buildRecentMatchStatusView({ tone: 'live', label: 'Live' }),
     score: { kind: 'text', text: 'Live' },
-    delta: null,
+    delta: buildEmptyRecentMatchDeltaView({ ariaLabel: 'Not yet decided' }),
     ...overrides,
   })
 }

--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display/recent-match-row.page.tsx
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display/recent-match-row.page.tsx
@@ -92,8 +92,10 @@ const scoped = (container: Container) => ({
   getScoreCell(opponent: string) {
     return cellsOf(container, opponent)[1]
   },
-  /** The Δ cell. Reads `—` for any row that moved no rating — undecided *or*
-   * unrated. Never "+0". */
+  /** The Δ cell. Reads `—` for any row that moved no rating — undecided,
+   * unrated, or a rating just established. Never "+0". The em-dash cell still
+   * carries a truthful accessible name naming which of those it is, so read the
+   * `role="img"` inside it for that. */
   getDeltaCell(opponent: string) {
     return cellsOf(container, opponent)[2]
   },

--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display/recent-match-row.test.tsx
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display/recent-match-row.test.tsx
@@ -2,6 +2,7 @@ import {
   LIVE_MATCH_ID,
   RECENT_MATCH_HREF,
   SOLO_MATCH_ID,
+  buildEmptyRecentMatchDeltaView,
   buildLiveRecentMatchRowView,
   buildRecentMatchDeltaView,
   buildRecentMatchGameView,
@@ -74,16 +75,38 @@ describe('RecentMatchRow', () => {
   })
 
   it('prints an em dash — never "+0" — when no rating moved', async () => {
-    recentMatchRowPage.render({ row: buildRecentMatchRowView({ delta: null }) })
+    recentMatchRowPage.render({
+      row: buildRecentMatchRowView({ delta: buildEmptyRecentMatchDeltaView() }),
+    })
 
     await recentMatchRowPage.findRow(OPPONENT)
 
     const delta = recentMatchRowPage.getDeltaCell(OPPONENT)
     expect(delta).toHaveTextContent('—')
     expect(delta).not.toHaveTextContent('0')
-    expect(delta.querySelector('[role="img"]')).toHaveAccessibleName(
-      'No rating change',
-    )
+  })
+
+  // The em dash stands for three different facts, and a screen reader must be
+  // told which — before this the cell announced "No rating change" for all three,
+  // which was a lie for two of them (#915). The state is resolved in the view
+  // model (`selectDelta` / `emptyRatingDeltaAria`); the row simply renders the
+  // name it is handed.
+  it.each([
+    ['No rating change'],
+    ['Not yet decided'],
+    ['Rating established'],
+  ])('gives the em-dash cell the accessible name %s', async (ariaLabel) => {
+    recentMatchRowPage.render({
+      row: buildRecentMatchRowView({
+        delta: buildEmptyRecentMatchDeltaView({ ariaLabel }),
+      }),
+    })
+
+    await recentMatchRowPage.findRow(OPPONENT)
+
+    const delta = recentMatchRowPage.getDeltaCell(OPPONENT)
+    expect(delta).toHaveTextContent('—')
+    expect(delta.querySelector('[role="img"]')).toHaveAccessibleName(ariaLabel)
   })
 
   it('marks the games the player lost apart from the ones they won', async () => {

--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display/recent-match-row.tsx
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-display/recent-match-row.tsx
@@ -127,7 +127,7 @@ export const RecentMatchRow = ({ row }: RecentMatchRowProps) => (
       )}
     </td>
     <td>
-      {row.delta ? (
+      {row.delta.kind === 'change' ? (
         <span
           role="img"
           aria-label={row.delta.ariaLabel}
@@ -141,9 +141,13 @@ export const RecentMatchRow = ({ row }: RecentMatchRowProps) => (
           {row.delta.label}
         </span>
       ) : (
+        // The em dash means different things for different rows — undecided,
+        // unrated, or a rating just established — so the accessible name comes
+        // off the view model (`emptyRatingDeltaAria`) rather than a hardcoded
+        // "No rating change" that lied for two of the three.
         <span
           role="img"
-          aria-label="No rating change"
+          aria-label={row.delta.ariaLabel}
           className="recent-matches__delta-none"
         >
           {NO_VALUE}

--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.test.ts
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.test.ts
@@ -69,6 +69,20 @@ describe('recentMatchesQuery', () => {
     ])
   })
 
+  it('caps the drawn rows at six, however long a bundle it is handed', () => {
+    // The six-row shape is the API's contract (`PROFILE_RECENT_MATCHES`), but the
+    // card owns its own drawing: hand the projection an over-long bundle — 25
+    // rows — and it must still yield exactly six, never a long table. Drop the
+    // `.slice` and this reds with 25.
+    const bundle = buildPlayerDetail({
+      matches: buildPlayerMatchList(
+        Array.from({ length: 25 }, () => buildPlayerMatchRow()),
+      ),
+    })
+
+    expect(selectRecentMatches(bundle).rows).toHaveLength(6)
+  })
+
   it('names the footer link with the all-inclusive total, not the decided count', async () => {
     // 24 wins + 11 losses = 35 decided, but 50 matches exist — the extra fifteen
     // are in play, voided or unrated. The link names *fifty* (ADR-0915: the two

--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.test.ts
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.test.ts
@@ -118,6 +118,7 @@ describe('recentMatchesQuery', () => {
       ],
     })
     expect(row.delta).toEqual({
+      kind: 'change',
       label: '+12',
       ariaLabel: 'Gained 12 rating',
       tone: 'win',
@@ -129,8 +130,12 @@ describe('recentMatchesQuery', () => {
     const row = await selectRow(buildLossMatchRow())
 
     expect(row.status.tone).toBe('lost')
-    expect(row.delta?.label).toBe('-14')
-    expect(row.delta?.tone).toBe('loss')
+    expect(row.delta).toEqual({
+      kind: 'change',
+      label: '-14',
+      ariaLabel: 'Lost 14 rating',
+      tone: 'loss',
+    })
   })
 
   it('shows an em dash for the match that ESTABLISHED the rating', async () => {
@@ -141,7 +146,9 @@ describe('recentMatchesQuery', () => {
     // result and its score: the match was decided, it just moved no rating.
     const row = await selectRow(buildFirstRatedMatchRow())
 
-    expect(row.delta).toBeNull()
+    // The em-dash cell, named for THIS state — "Rating established", not the
+    // "No rating change" it once announced for all three no-move rows (#915).
+    expect(row.delta).toEqual({ kind: 'empty', ariaLabel: 'Rating established' })
     expect(row.status).toEqual({ tone: 'lost', label: 'Lost' })
     expect(row.score.kind).toBe('games')
   })
@@ -160,8 +167,16 @@ describe('recentMatchesQuery', () => {
     expect(established.rating_change?.before).toBeNull()
     expect(established.rating_change?.after).toBe(1268)
 
-    expect((await selectRow(unrated)).delta).toBeNull()
-    expect((await selectRow(established)).delta).toBeNull()
+    // Both read `—`, but the em-dash cell now names WHICH: an unrated decided
+    // match moved no rating; the first rated one established one.
+    expect((await selectRow(unrated)).delta).toEqual({
+      kind: 'empty',
+      ariaLabel: 'No rating change',
+    })
+    expect((await selectRow(established)).delta).toEqual({
+      kind: 'empty',
+      ariaLabel: 'Rating established',
+    })
   })
 
   it('reports a live match as Live — no score, no delta', async () => {
@@ -171,7 +186,8 @@ describe('recentMatchesQuery', () => {
 
     expect(row.status).toEqual({ tone: 'live', label: 'Live' })
     expect(row.score).toEqual({ kind: 'text', text: 'Live' })
-    expect(row.delta).toBeNull()
+    // Undecided, so the em-dash cell says so — not "No rating change".
+    expect(row.delta).toEqual({ kind: 'empty', ariaLabel: 'Not yet decided' })
   })
 
   it('tells an awaiting-acceptance match apart from a live one', async () => {
@@ -184,7 +200,7 @@ describe('recentMatchesQuery', () => {
       label: 'Awaiting acceptance',
     })
     expect(row.score).toEqual({ kind: 'text', text: 'Awaiting' })
-    expect(row.delta).toBeNull()
+    expect(row.delta).toEqual({ kind: 'empty', ariaLabel: 'Not yet decided' })
   })
 
   it('reports an up-next match with an em dash where the score would go', async () => {
@@ -192,7 +208,7 @@ describe('recentMatchesQuery', () => {
 
     expect(row.status).toEqual({ tone: 'up_next', label: 'Up next' })
     expect(row.score).toEqual({ kind: 'text', text: '—' })
-    expect(row.delta).toBeNull()
+    expect(row.delta).toEqual({ kind: 'empty', ariaLabel: 'Not yet decided' })
   })
 
   it('keeps a voided match, and lets it decide nothing', async () => {
@@ -200,7 +216,9 @@ describe('recentMatchesQuery', () => {
 
     expect(row.status).toEqual({ tone: 'voided', label: 'Voided' })
     expect(row.score).toEqual({ kind: 'text', text: '—' })
-    expect(row.delta).toBeNull()
+    // A voided match is decided — it reached a terminal state — so its em dash
+    // reads "No rating change", not "Not yet decided".
+    expect(row.delta).toEqual({ kind: 'empty', ariaLabel: 'No rating change' })
   })
 
   it('has NO delta — not a "+0" — for a decided but UNRATED win', async () => {
@@ -211,7 +229,8 @@ describe('recentMatchesQuery', () => {
 
     expect(row.status.tone).toBe('won')
     expect(row.score.kind).toBe('games')
-    expect(row.delta).toBeNull()
+    // Decided, but unrated — nothing moved, so "No rating change".
+    expect(row.delta).toEqual({ kind: 'empty', ariaLabel: 'No rating change' })
   })
 
   it('carries the opponent’s id, so the row can link to their profile', async () => {

--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.ts
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.ts
@@ -14,6 +14,14 @@ import { formatRatingDelta, formatRatingDeltaAria } from '@/lib/rating'
  * Never a "+0" (ADR-0915). */
 export const NO_VALUE = '—'
 
+/**
+ * How many rows the overview card draws. The API already caps the bundle at six
+ * (`PROFILE_RECENT_MATCHES`), so this is normally a no-op — but the card owns its
+ * own shape: cap the projection here too, so a longer bundle from any code path
+ * can never silently turn the overview into a long table. The full history lives
+ * behind the "view all" link, on its own paginated surface. */
+export const RECENT_MATCHES_SHOWN = 6
+
 /** What the Opponent cell reads for a solo match — one with nobody on the other
  * side (ADR-0008). It is a name for an absence, not a player. */
 export const NO_OPPONENT = 'No opponent'
@@ -281,9 +289,13 @@ export const selectRecentMatches = (
   const total = player.match_total
   return {
     playerId: player.id,
-    // Straight through, unfiltered: the bundle already sent the six most recent,
-    // and every state in them belongs on the card.
-    rows: player.matches.items.map((row) => selectRow(row, timeZone)),
+    // Unfiltered — every state belongs on the card — but capped: the card draws
+    // the six most recent, no matter how long a bundle it is handed. The API
+    // already sends six; the slice makes that the card's own contract rather than
+    // a promise it merely trusts the server to keep.
+    rows: player.matches.items
+      .slice(0, RECENT_MATCHES_SHOWN)
+      .map((row) => selectRow(row, timeZone)),
     total,
     // "View all 1 match" reads wrong — "all" presupposes more than one — so the
     // lone-match case drops both the count and the "all".

--- a/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.ts
+++ b/web-client/src/components/players/player-profile/recent-matches/recent-matches-fetcher/recent-matches-query.ts
@@ -7,7 +7,11 @@ import {
 } from '@/api/players'
 import type { MatchDetailRoute } from '@/components/matches/match-row-link/match-row-link'
 import { matchRowAriaLabel } from '@/components/matches/match-row-link/match-row-naming'
-import { formatRatingDelta, formatRatingDeltaAria } from '@/lib/rating'
+import {
+  emptyRatingDeltaAria,
+  formatRatingDelta,
+  formatRatingDeltaAria,
+} from '@/lib/rating'
 
 /** The em dash the card prints wherever a number would lie: an unfinished
  * match has no score, and an undecided *or* unrated one has no rating change.
@@ -62,16 +66,31 @@ export type RecentMatchScoreView =
   | { kind: 'games'; games: RecentMatchGameView[] }
   | { kind: 'text'; text: string }
 
-/** The Δ cell's contents. `null` — rendered as `—` — for any row whose rating
- * did not *move*: undecided, unrated, or the player's first rated match (which
- * established the rating instead). */
-export type RecentMatchDeltaView = {
-  /** The terse signed figure, e.g. "+12" / "-14". */
-  label: string
-  /** Spelled out for a screen reader, e.g. "Gained 12 rating". */
-  ariaLabel: string
-  tone: 'win' | 'loss'
-}
+/**
+ * The Δ cell's contents — a discriminated union, not a nullable chip.
+ *
+ * A row whose rating *moved* is a `change`: the signed figure and its spoken
+ * label. A row whose rating did **not** move still renders the em dash, but it
+ * carries a truthful `ariaLabel` naming *which* of the three no-move states it
+ * is (`empty`) — "No rating change" / "Not yet decided" / "Rating established"
+ * (`emptyRatingDeltaAria`) — so a screen reader no longer hears the same nothing
+ * for a live match, an unrated one, and a first-rated one. */
+export type RecentMatchDeltaView =
+  | {
+      kind: 'change'
+      /** The terse signed figure, e.g. "+12" / "-14". */
+      label: string
+      /** Spelled out for a screen reader, e.g. "Gained 12 rating". */
+      ariaLabel: string
+      tone: 'win' | 'loss'
+    }
+  | {
+      kind: 'empty'
+      /** The visible cell is an em dash; this names which empty state it is for a
+       * screen reader — "No rating change" / "Not yet decided" / "Rating
+       * established". */
+      ariaLabel: string
+    }
 
 /**
  * Who the match was against — and, therefore, whether the cell is a **link**.
@@ -111,8 +130,9 @@ export type RecentMatchRowView = {
   opponent: RecentMatchOpponentView
   status: RecentMatchStatusView
   score: RecentMatchScoreView
-  /** `null` when no rating moved: the display prints `—`, never "+0". */
-  delta: RecentMatchDeltaView | null
+  /** The Δ cell. An `empty` variant (rendered as `—`, never "+0") still carries
+   * a spoken name for its no-move state; a `change` carries the signed figure. */
+  delta: RecentMatchDeltaView
   /** e.g. "Mar 14". `—` when the timestamp is unreadable. */
   when: string
   /** The `{to,params}` target of the row's link — the match's detail page. Built
@@ -208,19 +228,31 @@ const selectScore = (row: PlayerMatchRow): RecentMatchScoreView => {
   }
 }
 
-const selectDelta = (
-  ratingChange: PlayerMatchRow['rating_change'],
-): RecentMatchDeltaView | null => {
-  // Keyed on the field alone, never on the status: a *completed, decided* win in
-  // an unrated match moved no rating either, and it must read `—` too.
-  if (ratingChange == null) return null
-  // And a present change with a null `delta` is the player's FIRST rated match:
-  // it *established* their rating rather than moving it. The Δ column measures
-  // movement, and nothing moved — so `—`, not a signed number off the seeded
-  // 1500 they never held (#952). The row still shows its result and score; the
-  // match-detail page is where the new rating is spelled out (`Unrated → X`).
-  if (ratingChange.delta === null) return null
+const selectDelta = (row: PlayerMatchRow): RecentMatchDeltaView => {
+  const ratingChange = row.rating_change
+  // The em-dash path — no signed figure to show — but it stands for three
+  // different facts, so it carries a spoken name for the one this row is
+  // (`emptyRatingDeltaAria`):
+  //   - a *present* change with a null `delta` is the player's FIRST rated match:
+  //     it ESTABLISHED their rating rather than moving it, so `—`, never a signed
+  //     number off the seeded 1500 they never held (#952) → "Rating established";
+  //   - `rating_change == null` on a match still in play has not DECIDED a rating
+  //     yet → "Not yet decided";
+  //   - `rating_change == null` on a decided match (unrated / voided) moved no
+  //     rating → "No rating change".
+  // "Decided" is the match having reached a terminal state — completed or voided
+  // — which is exactly when a rating either moved or provably never will.
+  if (ratingChange == null || ratingChange.delta === null) {
+    return {
+      kind: 'empty',
+      ariaLabel: emptyRatingDeltaAria(
+        ratingChange,
+        row.status === 'completed' || row.status === 'voided',
+      ),
+    }
+  }
   return {
+    kind: 'change',
     label: formatRatingDelta(ratingChange.delta),
     ariaLabel: formatRatingDeltaAria(ratingChange.delta),
     tone: ratingChange.delta >= 0 ? 'win' : 'loss',
@@ -260,7 +292,7 @@ const selectRow = (
     opponent,
     status: selectStatus(row),
     score: selectScore(row),
-    delta: selectDelta(row.rating_change),
+    delta: selectDelta(row),
     when,
     // The row is a link to its match (#989). Both halves of that link are
     // *derived data*, so they belong here rather than in the row component: the

--- a/web-client/src/components/realtime-provider.test.tsx
+++ b/web-client/src/components/realtime-provider.test.tsx
@@ -6,6 +6,7 @@ import { useDashboard } from '@/api/dashboard'
 import { closeRealtimeConnections } from '@/api/realtime/connection'
 import { SSE_CONTENT_TYPE } from '@/mocks/realtime-stream'
 import { server } from '@/mocks/server'
+import { unratedDashboardRating } from '@/test/factories'
 import type { components } from '@/api/schema'
 import { RealtimeProvider } from './realtime-provider'
 
@@ -33,7 +34,9 @@ function dashboardWith(attentionTotal: number): DashboardResponse {
     attention: [],
     attention_total_count: attentionTotal,
     waiting_count: 0,
-    rating: null,
+    // Rating is irrelevant to the resync behaviour under test; the block is
+    // always present now, so stand in a valid non-RATED shape.
+    rating: unratedDashboardRating(),
     completed_match_count: 0,
     recent_results: [],
     tournaments: [],

--- a/web-client/src/lib/rating.ts
+++ b/web-client/src/lib/rating.ts
@@ -71,3 +71,11 @@ export function emptyRatingDeltaAria(
     ? RATING_DELTA_EMPTY_ARIA.noChange
     : RATING_DELTA_EMPTY_ARIA.undecided
 }
+
+/** The rank line — "#3 of 42": the player's 1-based position out of the rated
+ * population it's drawn from. Always both halves, never a naked "#3" (which in a
+ * twelve-player league flatters). Shared by the dashboard rating card and the
+ * profile standing so the format cannot drift (#959, ADR 20260725). */
+export function formatRankOfPopulation(rank: number, rankOf: number): string {
+  return `#${rank} of ${rankOf}`
+}

--- a/web-client/src/lib/rating.ts
+++ b/web-client/src/lib/rating.ts
@@ -31,3 +31,43 @@ export function formatRatingDeltaAria(delta: number): string {
   const verb = rounded > 0 ? 'Gained' : 'Lost'
   return `${verb} ${Math.abs(rounded)} rating`
 }
+
+/**
+ * The three truthful accessible names for a Δ (rating-change) cell that prints
+ * an **em dash** instead of a signed figure. The same glyph stands for three
+ * different facts, and a screen reader must be told which — otherwise every
+ * no-delta row announces identically (or, on the dashboard, not at all).
+ */
+export const RATING_DELTA_EMPTY_ARIA = {
+  /** A decided match that moved no rating — unrated, voided, or a rounded-0. */
+  noChange: 'No rating change',
+  /** A live / awaiting / up-next match — the rating is not decided yet. */
+  undecided: 'Not yet decided',
+  /** The player's FIRST rated match: a *present* change whose `delta` is null.
+   * It established the rating rather than moving it (#915). */
+  established: 'Rating established',
+} as const
+
+/**
+ * The accessible name for a Δ cell with no signed figure to show, resolved from
+ * the two facts that separate its three states:
+ *
+ * - a *present* rating change with a `null` delta established the rating rather
+ *   than moving it → "Rating established";
+ * - otherwise, an undecided (still-in-play) match → "Not yet decided";
+ * - otherwise, a decided match that moved no rating → "No rating change".
+ *
+ * A present change with a *numeric* delta never reaches here — that renders the
+ * signed figure via `formatRatingDeltaAria` (which itself says "No rating
+ * change" for a rounded-0). Shared by the profile recent-match row and the
+ * dashboard recent-results card so the two surfaces cannot drift.
+ */
+export function emptyRatingDeltaAria(
+  ratingChange: { delta: number | null } | null | undefined,
+  decided: boolean,
+): string {
+  if (ratingChange != null) return RATING_DELTA_EMPTY_ARIA.established
+  return decided
+    ? RATING_DELTA_EMPTY_ARIA.noChange
+    : RATING_DELTA_EMPTY_ARIA.undecided
+}

--- a/web-client/src/mocks/factories/players/player-detail.factory.ts
+++ b/web-client/src/mocks/factories/players/player-detail.factory.ts
@@ -177,6 +177,30 @@ export function buildPlayerDetail(
 }
 
 /**
+ * A rated player high on a LARGE ladder — one past `PERCENTILE_MIN_RATED_PLAYERS`,
+ * so a percentile means something and the API sends it: the hero prints "Top 2%"
+ * and drops the rank line (ADR 20260725). The sub-threshold default
+ * (`buildPlayerDetail`, `percentile: null` on a 42-strong ladder) is the other arm
+ * of the same switch — it keeps `rank`/`rank_of` and the hero shows "#N of M"
+ * instead. Between them the two fixtures pin both halves of the rank-vs-percentile
+ * decision the profile shares with the dashboard, so a regression that collapsed
+ * them back together reds here.
+ *
+ * `rank`/`rank_of` stay populated (the API sends them at any league size); the
+ * profile simply prefers the percentile once it exists.
+ */
+export function buildRankedPlayerDetail(
+  overrides: Partial<PlayerDetail> = {},
+): PlayerDetail {
+  return buildPlayerDetail({
+    rank: 3,
+    rank_of: 220,
+    percentile: 2,
+    ...overrides,
+  })
+}
+
+/**
  * A player who has never finished a rated match. No rating means no rank — and
  * so no ladder position, no peak, no percentile and no rating delta
  * (`CONTEXT.md` § *Rank*). They may still have *form*: form counts decided

--- a/web-client/src/mocks/match-store.ts
+++ b/web-client/src/mocks/match-store.ts
@@ -859,15 +859,16 @@ export function projectRecentResult(seed: SeedMatch): DashboardRecentResult | nu
  * `user_league_ratings`, so the wired RatingCard renders against the same
  * shape MSW and prod return.
  *
- * **`null` when no rated match has been finished** (#950). This mock used to
- * hand every caller a card starting at `MOCK_BASE_RATING` — current 1500, peak
- * 1500, a one-point sparkline — for a user who had played nothing, which is a
- * shape the API does not send and never did claim to: joining a league seeds
- * `rating_value` as the strategy's *prior*, and `DashboardResponse.rating` is
- * `null` for a player who has never finished a rated match (`CONTEXT.md` §
- * *Rating*). A mock that models a rating the server withholds is how a 1500 on a
- * brand-new dashboard survived the entire suite; it now models the withholding. */
-export function projectRating(seeds: SeedMatch[]): DashboardRating | null {
+ * **The `UNRATED` state when no rated match has been finished** (#950, #956).
+ * This mock used to hand every caller a card starting at `MOCK_BASE_RATING` —
+ * current 1500, peak 1500, a one-point sparkline — for a user who had played
+ * nothing, which is a shape the API does not send: joining a league seeds
+ * `rating_value` as the strategy's *prior*. It then returned a bare `null`,
+ * which conflated three distinct facts. Now the block is always present and
+ * carries a `state` discriminator: a glicko2 player who hasn't finished a rated
+ * match is `UNRATED` (in a rated league, no rating yet), not `null`
+ * (ADR 20260725). */
+export function projectRating(seeds: SeedMatch[]): DashboardRating {
   const completed = seeds
     .filter(
       (s): s is SeedMatch & { completed_at: string } =>
@@ -878,9 +879,26 @@ export function projectRating(seeds: SeedMatch[]): DashboardRating | null {
     )
     .sort((a, b) => a.completed_at.localeCompare(b.completed_at))
 
-  // Never finished a rated match ⇒ no rating, and so no rating card at all —
-  // not a card seeded at the strategy's prior.
-  if (completed.length === 0) return null
+  // Never finished a rated match ⇒ UNRATED, not a card seeded at the strategy's
+  // prior and not a bare `null`: the player IS in a glicko2 league, they just
+  // have no rating yet, and the card says exactly that (ADR 20260725).
+  if (completed.length === 0) {
+    return {
+      state: 'UNRATED',
+      league_id: MOCK_DEFAULT_LEAGUE.id,
+      league_name: MOCK_DEFAULT_LEAGUE.name,
+      strategy_key: 'glicko2',
+      current: null,
+      delta: null,
+      peak: null,
+      percentile: null,
+      rank: null,
+      population: null,
+      spark_data: [],
+      streak: null,
+      stats: [],
+    }
+  }
 
   // The same timeline every other surface reads, so the dashboard card, the
   // dashboard's Δ column and the match-detail card cannot disagree about what a
@@ -916,6 +934,7 @@ export function projectRating(seeds: SeedMatch[]): DashboardRating | null {
   const gamesPlayed = completed.length
   const rd = Math.max(80, 350 - gamesPlayed * 18)
   return {
+    state: 'RATED',
     league_id: MOCK_DEFAULT_LEAGUE.id,
     league_name: MOCK_DEFAULT_LEAGUE.name,
     strategy_key: 'glicko2',
@@ -925,8 +944,11 @@ export function projectRating(seeds: SeedMatch[]): DashboardRating | null {
     // Unconditional now: the zero-match case returned above, and a rated player
     // has a ladder position. (This ternary used to be the one place that noticed
     // an unplayed player had no business holding a percentile — #382 — while the
-    // other four figures printed the prior anyway.)
+    // other four figures printed the prior anyway.) The seeded roster clears the
+    // percentile threshold, so this shows a percentile rather than "#N of M".
     percentile: 72,
+    rank: null,
+    population: null,
     spark_data: sparkData,
     streak: projectStreak(seeds),
     stats: [

--- a/web-client/src/test/factories.ts
+++ b/web-client/src/test/factories.ts
@@ -340,13 +340,24 @@ export function dashboardRating(
   overrides: Partial<DashboardRating> = {},
 ): DashboardRating {
   return {
+    // The everyday case: a player with a rating. The `state` discriminator, not
+    // a `null` parent, is what tells the card which of four stories to tell
+    // (ADR 20260725) — the three non-rated arms have their own factories below.
+    state: 'RATED',
     league_id: nextId('lg'),
     league_name: 'FortyMM',
     strategy_key: 'glicko2',
     current: 1500,
     delta: 0,
     peak: 1500,
+    // `percentile` OR `rank`/`population`, never both: at/above the population
+    // threshold the server sends a percentile; below it, it sends rank so the
+    // card can show "#N of M" instead of a "Top 100%" that lies at the bottom of
+    // a small ladder (#959). Default carries neither, so the card shows just the
+    // league name — the same fallback the pre-`state` default had.
     percentile: null,
+    rank: null,
+    population: null,
     spark_data: [],
     streak: null,
     stats: [
@@ -355,6 +366,82 @@ export function dashboardRating(
     ],
     ...overrides,
   }
+}
+
+/**
+ * The rating block for a player who is **in a glicko2 (rated) league but has not
+ * finished a rated match yet** — the real state #915 introduced and #956 found
+ * `null` was lying about. Card copy: *"Unrated — finish a rated match to start
+ * your rating"*. The whole rating payload is null/empty; only the league context
+ * survives.
+ */
+export function unratedDashboardRating(
+  overrides: Partial<DashboardRating> = {},
+): DashboardRating {
+  return dashboardRating({
+    state: 'UNRATED',
+    strategy_key: 'glicko2',
+    current: null,
+    delta: null,
+    peak: null,
+    percentile: null,
+    rank: null,
+    population: null,
+    spark_data: [],
+    streak: null,
+    stats: [],
+    ...overrides,
+  })
+}
+
+/**
+ * The rating block for a player in a **manual-strategy league whose ratings
+ * haven't been imported yet**. Card copy: *"Ratings haven't been imported for
+ * this league yet"*. Names its league; carries no rating payload.
+ */
+export function awaitingImportDashboardRating(
+  overrides: Partial<DashboardRating> = {},
+): DashboardRating {
+  return dashboardRating({
+    state: 'AWAITING_IMPORT',
+    strategy_key: 'manual',
+    current: null,
+    delta: null,
+    peak: null,
+    percentile: null,
+    rank: null,
+    population: null,
+    spark_data: [],
+    streak: null,
+    stats: [],
+    ...overrides,
+  })
+}
+
+/**
+ * The rating block for a player **not in a rated league at all**. Card copy:
+ * *"Not in a rated league yet."* — the existing string, now shown only when it
+ * is actually true. No league, no strategy, no payload.
+ */
+export function notRatedLeagueDashboardRating(
+  overrides: Partial<DashboardRating> = {},
+): DashboardRating {
+  return dashboardRating({
+    state: 'NOT_RATED_LEAGUE',
+    league_id: null,
+    league_name: null,
+    strategy_key: null,
+    current: null,
+    delta: null,
+    peak: null,
+    percentile: null,
+    rank: null,
+    population: null,
+    spark_data: [],
+    streak: null,
+    stats: [],
+    ...overrides,
+  })
 }
 
 /**


### PR DESCRIPTION
Cluster of QA-filed fast-follows to the #915 rating rollout, driven through /epic (grill → chores → land). Eight tracer-bullet slices, one commit each; two ADRs written/amended during the grill.

Closes #959.
Closes #956.
Closes #946.
Closes #951.
Closes #947.
Closes #961.
Closes #957.
Closes #998.

## What changed (per slice)

- **Slice 1 (#956, #959) — the rating block tells the truth.** `DashboardRating` is always returned with a `state` discriminator (`RATED`/`UNRATED`/`AWAITING_IMPORT`/`NOT_RATED_LEAGUE`) + `rank`/`population`; below `PERCENTILE_MIN_RATED_PLAYERS` (50) both dashboard and profile show rank "#N of M" instead of a percentile — killing the "Top 100%" lie for the last-place player. Shared `league_percentile_if_ranked` helper so the two surfaces can't drift. New ADR `20260725-a-rating-block-names-its-state-and-shows-rank-below-threshold.md`.
- **Slice 2 (#951) — pre-match snapshot.** Anchors `pre_match_ratings`/`career_before`/`head_to_head` on the *as-played* instant (`completed_at`, else now) instead of `created_at`, so batch-created matches no longer read "Unrated · 0 career". Amends ADR-0012.
- **Slice 3 (#946) — confidence invariant.** Asserts `rating_value == state_rating_value(state)` at the `ratings/state.py` parse boundary (null carve-out), turning silent drift into a loud error.
- **Slice 4 (#947) — recent-matches cap.** Client-side `RECENT_MATCHES_SHOWN = 6` cap in the projection + test.
- **Slice 5 (#961) — Δ-cell a11y.** Three-way accessible names ("No rating change" / "Not yet decided" / "Rating established") shared across the profile row and the dashboard card (which had none).
- **Slice 6 (#957) — rating chart.** Zooms the x-domain to fit a history collapsed into one evening (min-span floor); single-instant → "N matches today". Amends ADR-0915.
- **Slice 7 (#998) — notifications.** The result *poster* is now notified when their result is accepted (was silent). The other half of #998 — the empty "Rating" pill — needs no change: #1178 already hid `rating_change` client-side the documented way; building the rating-change fan-out and un-hiding it stays tracked by **#1176**.
- **simplify pass:** deduped the "#N of M" formatter (`formatRankOfPopulation`) and the user-rating-row resolver; single-reduce in the chart x-domain.

## Reviewer notes / QA flags

- **Profile, large league (≥50 rated):** the standing line now shows the percentile *instead of* an exact "#N of M" rank (ADR-faithful: small league → rank, big league → percentile). Deliberate — flagging for a look.
- **`/notifications/settings`:** the Rating preference row is hidden only where #1178's client filter reaches — worth confirming in QA.

## Testing

Local, all green: **API** ruff+format+mypy+pytest (**1838 passed**); **web unit** (**3104 passed**) + eslint + tsc + vite build; **web e2e** Playwright (**302 passed**, MSW off); **iOS** clean simulator build (**BUILD SUCCEEDED**); **OpenAPI drift** none.

**Root full-stack e2e (`compose-e2e`) was inconclusive locally** — the host was saturated by 8 other worktree e2e/qa stacks, so the solver-backed `/v1/health` 502/504'd before specs ran (all containers came up Healthy; the failure is unrelated to this diff, which touches nothing near solver/health/nginx). Relying on CI's `compose-e2e` required check to run it on a clean runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)