### PR TITLE
"Near me" tournament discovery: geocode venues, filter by distance, venue map (#1169)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,13 @@ MCP_PUBLIC_RESOURCE_URL=https://uat.fortymm.com/api/mcp
 # real key for UAT/prod; redeploy-uat.sh loads it into the fortymm-uat-env
 # Secret, from which the api pod reads it.
 GOOGLE_GEOCODING_API_KEY=
+
+# --- Browser maps (baked into the web bundle at build time) ---
+# Browser Google Maps JS API key, exposed to the web client via
+# import.meta.env.VITE_GOOGLE_MAPS_API_KEY. OPTIONAL: leave blank and the map
+# degrades to a text fallback (the intended default for dev, CI, e2e, and QA).
+# Being VITE_-prefixed it is baked into the bundle at build time, so
+# redeploy-uat.sh passes it as a --build-arg to the web image (and the QA/dev
+# compose stacks accept it as a build arg / dev-server env). Distinct from the
+# server-side GOOGLE_GEOCODING_API_KEY above.
+VITE_GOOGLE_MAPS_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,13 @@ AUTH0_AUDIENCE=
 MCP_PUBLIC_BASE_URL=https://uat.fortymm.com/api
 # Public MCP resource URL used in the RFC 9728 protected-resource metadata.
 MCP_PUBLIC_RESOURCE_URL=https://uat.fortymm.com/api/mcp
+
+# --- Server-side geocoding (UAT/prod only) ---
+# Google Geocoding API key the API uses to geocode venue addresses at write
+# time; see
+# docs/adr/20260725-a-venues-coordinates-are-geocoded-server-side-and-not-null.md.
+# OPTIONAL: leave it blank/unset and the API uses a deterministic, network-free
+# FakeGeocoder (the intended default for local dev, CI, e2e, and QA). Only set a
+# real key for UAT/prod; redeploy-uat.sh loads it into the fortymm-uat-env
+# Secret, from which the api pod reads it.
+GOOGLE_GEOCODING_API_KEY=

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -78,6 +78,13 @@ class Settings(BaseSettings):
     #: stream's ``realtime_max_stream_seconds`` finally expired.
     realtime_max_connections_per_user: int = 4
 
+    #: Google Geocoding API key. When set, a venue's coordinates are resolved
+    #: server-side by ``GoogleGeocoder`` on write (ADR "a venue's coordinates are
+    #: geocoded server-side and not null"). Unset — the default in local dev, CI,
+    #: and tests — selects the deterministic, network-free ``FakeGeocoder`` in
+    #: ``app.geocoding.dependencies.get_geocoder``.
+    google_geocoding_api_key: str | None = None
+
     #: Base of the SSE ``retry:`` hint sent to the client, in milliseconds —
     #: how long it waits before reconnecting after the stream ends.
     realtime_retry_base_ms: int = 3000

--- a/api/app/geocoding/__init__.py
+++ b/api/app/geocoding/__init__.py
@@ -1,0 +1,23 @@
+"""Server-side geocoding: the ``Geocoder`` seam and its implementations."""
+
+from __future__ import annotations
+
+from app.geocoding.geocoder import (
+    AddressNotGeocodableError,
+    FakeGeocoder,
+    Geocoder,
+    GeocoderError,
+    GeocodeResult,
+    GoogleGeocoder,
+    compose_address,
+)
+
+__all__ = [
+    "AddressNotGeocodableError",
+    "FakeGeocoder",
+    "GeocodeResult",
+    "Geocoder",
+    "GeocoderError",
+    "GoogleGeocoder",
+    "compose_address",
+]

--- a/api/app/geocoding/dependencies.py
+++ b/api/app/geocoding/dependencies.py
@@ -1,0 +1,40 @@
+"""FastAPI wiring for the geocoding seam — the single place that decides which
+:class:`~app.geocoding.geocoder.Geocoder` a handler receives.
+
+The choice is key-driven: when ``GOOGLE_GEOCODING_API_KEY`` is configured the
+provider hands out a :class:`GoogleGeocoder`; otherwise (local dev, CI, tests) a
+network-free :class:`FakeGeocoder`. Handlers declare
+``geocoder: Geocoder = Depends(get_geocoder)`` and tests override it via
+``app.dependency_overrides`` — mirroring the service-layer rules in
+``api/CLAUDE.md``.
+
+The ``httpx.AsyncClient`` behind the real geocoder is a process-wide singleton
+(a connection pool with no request state, like the notifications ``PushSender``),
+not a request-scoped resource.
+"""
+
+from __future__ import annotations
+
+import httpx
+from fastapi import Depends
+
+from app.config import Settings, get_settings
+from app.geocoding.geocoder import FakeGeocoder, Geocoder, GoogleGeocoder
+
+#: Shared connection pool for the real geocoder. Constructed lazily-pooled by
+#: httpx (no socket work at import), so importing this module performs no I/O.
+_client = httpx.AsyncClient(timeout=5.0)
+
+
+def get_geocoder(settings: Settings = Depends(get_settings)) -> Geocoder:
+    """Return the geocoder implied by configuration.
+
+    ``GoogleGeocoder`` when ``GOOGLE_GEOCODING_API_KEY`` is set, otherwise the
+    deterministic ``FakeGeocoder``. Selection reads ``Settings`` so tests can
+    exercise both branches by constructing/overriding ``Settings`` rather than
+    mutating the process environment.
+    """
+    api_key = settings.google_geocoding_api_key
+    if api_key:
+        return GoogleGeocoder(api_key=api_key, client=_client)
+    return FakeGeocoder()

--- a/api/app/geocoding/geocoder.py
+++ b/api/app/geocoding/geocoder.py
@@ -1,0 +1,224 @@
+"""Server-side geocoding seam.
+
+A venue is geocoded server-side on write (ADR "a venue's coordinates are
+geocoded server-side and not null"): coordinates are never accepted from the
+client and never written null. The geocoder is an **injectable seam** — the
+interior of the app depends on the ``Geocoder`` protocol, not a concrete
+client — so handlers and tests substitute an implementation the same way the
+match layer substitutes a ``RatingCalculator`` / ``PushSender``.
+
+Three pieces live here:
+
+* ``Geocoder`` — the protocol every implementation satisfies: one async
+  ``geocode(address: str) -> GeocodeResult``.
+* ``GoogleGeocoder`` — the real implementation, calling the Google Geocoding
+  API over an injected ``httpx.AsyncClient``. It never touches the network at
+  construction time, only inside ``geocode``.
+* ``FakeGeocoder`` — a deterministic, network-free implementation for tests and
+  keyless environments (see its docstring for the stable mapping and the
+  unresolvable sentinel).
+
+A lookup that resolves to zero candidates is an **expected** failure the caller
+turns into a ``422`` — it is raised as ``AddressNotGeocodableError`` and is the
+only failure a caller is expected to catch. Anything else (a transport error, a
+Google status like ``REQUEST_DENIED``) is genuinely unexpected and propagates.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Protocol
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+#: Google's forward-geocoding endpoint (address -> coordinates).
+GOOGLE_GEOCODE_URL = "https://maps.googleapis.com/maps/api/geocode/json"
+
+#: The sentinel token the :class:`FakeGeocoder` treats as unresolvable. Any
+#: address whose *normalized* form contains this token — or normalizes to the
+#: empty string — raises :class:`AddressNotGeocodableError` instead of returning
+#: coordinates. Later chores (the create/edit 422 tests, the near-me e2e test)
+#: rely on this being stable and network-free.
+UNRESOLVABLE_SENTINEL = "__unresolvable__"
+
+
+class GeocodeResult(BaseModel):
+    """The typed result of a successful geocode — a single resolved location.
+
+    Frozen so a resolved location cannot be mutated after it crosses the seam,
+    and range-validated so an implementation cannot hand back a latitude or
+    longitude outside the real coordinate space (``make illegal states
+    unrepresentable``). Carries the provider's canonical ``formatted`` label so
+    a caller can echo back the normalized address it actually matched.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    latitude: float = Field(ge=-90.0, le=90.0)
+    longitude: float = Field(ge=-180.0, le=180.0)
+    formatted: str
+
+
+class AddressNotGeocodableError(Exception):
+    """The address resolved to zero candidates — it cannot be geocoded.
+
+    The **only** expected failure a caller handles: the write verbs map it to a
+    ``422`` rather than writing null coordinates. Every other failure mode
+    (transport errors, non-``OK``/non-``ZERO_RESULTS`` provider statuses) is
+    unexpected and is allowed to propagate.
+    """
+
+    def __init__(self, address: str) -> None:
+        self.address = address
+        super().__init__(f"Address could not be geocoded: {address!r}")
+
+
+class GeocoderError(Exception):
+    """An unexpected geocoding-provider failure (not a zero-result lookup).
+
+    Distinct from :class:`AddressNotGeocodableError` precisely so callers do not
+    accidentally turn a provider misconfiguration (``REQUEST_DENIED``) or quota
+    exhaustion (``OVER_QUERY_LIMIT``) into a client-facing ``422``. It carries a
+    server fault to the 500 handler instead.
+    """
+
+
+class Geocoder(Protocol):
+    """A service that resolves a free-form address string to coordinates.
+
+    Implementations take a single composed address string (build one from the
+    venue value-object fields with :func:`compose_address`) so the same seam
+    serves both the write verbs and a later address-preview endpoint.
+    """
+
+    async def geocode(self, address: str) -> GeocodeResult:
+        """Resolve ``address`` to its top-ranked location.
+
+        Raises :class:`AddressNotGeocodableError` when the address resolves to
+        zero candidates.
+        """
+        ...
+
+
+def compose_address(
+    *,
+    venue: str,
+    street: str,
+    city: str,
+    region: str,
+    postal: str,
+    country: str,
+) -> str:
+    """Compose the venue value-object fields into a single geocodable string.
+
+    Kept here (rather than importing the ``Address`` schema, which would couple
+    the seam to the tournament layer) so both the write verbs and a preview
+    endpoint share one composition. Empty/whitespace-only parts are dropped so a
+    partially filled address still composes cleanly.
+    """
+    parts = (venue, street, city, region, postal, country)
+    return ", ".join(part.strip() for part in parts if part.strip())
+
+
+def _normalize(address: str) -> str:
+    """Case-fold and collapse whitespace so trivially different spellings of the
+    same address map to the same deterministic result in :class:`FakeGeocoder`."""
+    return " ".join(address.lower().split())
+
+
+class _GoogleLocation(BaseModel):
+    lat: float
+    lng: float
+
+
+class _GoogleGeometry(BaseModel):
+    location: _GoogleLocation
+
+
+class _GoogleResult(BaseModel):
+    formatted_address: str
+    geometry: _GoogleGeometry
+
+
+class _GoogleResponse(BaseModel):
+    """The slice of Google's Geocoding response we consume, parsed at the
+    boundary (parse-at-boundaries) so the interior holds typed fields rather
+    than a ``dict[str, Any]`` indexed by string keys."""
+
+    status: str
+    results: list[_GoogleResult] = Field(default_factory=list)
+
+
+class GoogleGeocoder:
+    """The real geocoder, backed by the Google Geocoding API.
+
+    The ``httpx.AsyncClient`` is injected so the network is a substitutable seam
+    (a test can pass a client wired to a mock transport). Construction performs
+    no I/O; the network is only touched inside :meth:`geocode`.
+    """
+
+    def __init__(self, api_key: str, client: httpx.AsyncClient) -> None:
+        self._api_key = api_key
+        self._client = client
+
+    async def geocode(self, address: str) -> GeocodeResult:
+        response = await self._client.get(
+            GOOGLE_GEOCODE_URL,
+            params={"address": address, "key": self._api_key},
+        )
+        response.raise_for_status()
+        body = _GoogleResponse.model_validate(response.json())
+
+        if body.status == "ZERO_RESULTS":
+            raise AddressNotGeocodableError(address)
+        if body.status != "OK":
+            # REQUEST_DENIED / OVER_QUERY_LIMIT / INVALID_REQUEST etc. — a
+            # provider/configuration fault, not "no such place". Propagate.
+            raise GeocoderError(f"Google Geocoding API returned status {body.status!r}")
+        if not body.results:
+            raise AddressNotGeocodableError(address)
+
+        top = body.results[0]
+        return GeocodeResult(
+            latitude=top.geometry.location.lat,
+            longitude=top.geometry.location.lng,
+            formatted=top.formatted_address,
+        )
+
+
+class FakeGeocoder:
+    """A deterministic, network-free geocoder for tests and keyless environments.
+
+    Determinism is the whole point: a given address always maps to the same
+    coordinates, so later chores can assert exact values (the near-me e2e test
+    needs known coordinates) and the create/edit 422 tests need a reliable way
+    to force the no-result path.
+
+    * **Normal address** — the normalized address string (case-folded,
+      whitespace-collapsed) is SHA-256 hashed; the first four bytes seed a
+      latitude in ``[-90, 90)`` and the next four a longitude in ``[-180, 180)``.
+      Same input, same coordinates, every run, on every machine.
+    * **Unresolvable sentinel** — an address whose normalized form is empty, or
+      contains the literal token :data:`UNRESOLVABLE_SENTINEL`
+      (``"__unresolvable__"``), raises :class:`AddressNotGeocodableError`. This
+      is the designated input a test uses to exercise the zero-result → 422 path
+      without a network call.
+    """
+
+    async def geocode(self, address: str) -> GeocodeResult:
+        normalized = _normalize(address)
+        if not normalized or UNRESOLVABLE_SENTINEL in normalized:
+            raise AddressNotGeocodableError(address)
+
+        digest = hashlib.sha256(normalized.encode("utf-8")).digest()
+        lat_raw = int.from_bytes(digest[0:4], "big")
+        lng_raw = int.from_bytes(digest[4:8], "big")
+        latitude = (lat_raw / 2**32) * 180.0 - 90.0
+        longitude = (lng_raw / 2**32) * 360.0 - 180.0
+
+        return GeocodeResult(
+            latitude=latitude,
+            longitude=longitude,
+            formatted=address.strip(),
+        )

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -1003,11 +1003,11 @@ def _map_tournament_write_tool_error(
 def _map_address_not_geocodable_tool_error(
     exc: AddressNotGeocodableError,
 ) -> ToolError:
-    """Adapt an unresolvable venue address (ADR "an unresolvable address is a 422 at the
-    boundary") to a ``ToolError`` that NAMES the machine-readable code the HTTP surface
-    answers with, then hands the agent the address it could not resolve.
+    """Adapt an unresolvable venue address (ADR-0968's coded-refusal convention) to a
+    ``ToolError`` that NAMES the machine-readable code the HTTP surface answers with,
+    then hands the agent the address it could not resolve.
 
-    The HTTP create/edit adapters answer this with the coded 422
+    The HTTP create/edit adapters answer this with the coded 409
     ``{"detail": {"code": ADDRESS_NOT_GEOCODABLE_CODE, ...}}``; an agent reads prose, so
     the code rides in the prose (``[address_not_geocodable]``, exactly as the coded
     entry refusals do) and the verb's own message — which address failed — follows, so

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -66,6 +66,8 @@ from app.draws import (
     NonSinglesDraw,
     UnsupportedDrawType,
 )
+from app.geocoding import AddressNotGeocodableError
+from app.geocoding.dependencies import get_geocoder
 from app.mappers.match_extras_mapper import empty_extras
 from app.match_creation import create_match as create_match_core
 from app.match_errors import (
@@ -174,6 +176,7 @@ from app.tournament_errors import (
 from app.tournament_events import create_event as create_event_core
 from app.tournament_events import delete_event as delete_event_core
 from app.tournament_events import update_event as update_event_core
+from app.tournament_geocoding import ADDRESS_NOT_GEOCODABLE_CODE
 from app.tournament_lifecycle import create_tournament as create_tournament_core
 from app.tournament_lifecycle import delete_tournament as delete_tournament_core
 from app.tournament_lifecycle import (
@@ -997,6 +1000,21 @@ def _map_tournament_write_tool_error(
     return ToolError(str(exc))
 
 
+def _map_address_not_geocodable_tool_error(
+    exc: AddressNotGeocodableError,
+) -> ToolError:
+    """Adapt an unresolvable venue address (ADR "an unresolvable address is a 422 at the
+    boundary") to a ``ToolError`` that NAMES the machine-readable code the HTTP surface
+    answers with, then hands the agent the address it could not resolve.
+
+    The HTTP create/edit adapters answer this with the coded 422
+    ``{"detail": {"code": ADDRESS_NOT_GEOCODABLE_CODE, ...}}``; an agent reads prose, so
+    the code rides in the prose (``[address_not_geocodable]``, exactly as the coded
+    entry refusals do) and the verb's own message — which address failed — follows, so
+    the agent is told both *which* rule refused it and *why* in its own words."""
+    return ToolError(f"Address not geocodable [{ADDRESS_NOT_GEOCODABLE_CODE}]: {exc}")
+
+
 @mcp.tool
 async def edit_tournament(
     tournament_id: uuid.UUID,
@@ -1025,10 +1043,16 @@ async def edit_tournament(
 
     Raises a ``ToolError`` when no tournament with that id exists, when you are not
     the tournament's owner (only the creator may edit it), when you try to change
-    the league of a tournament that has left ``draft``, or when ``league_id`` names
-    no league.
+    the league of a tournament that has left ``draft``, when ``league_id`` names
+    no league, or when a changed venue ``address`` cannot be geocoded (the
+    ``[address_not_geocodable]`` refusal — coordinates are geocoded server-side on
+    write and are NOT NULL).
     """
     user_id = _authenticated_user_id()
+    # The geocoder is built from ``Settings`` (Google when keyed, else the keyless
+    # deterministic fake) — the MCP surface has no ``Depends``, so it constructs the
+    # same seam the HTTP route resolves with ``Depends(get_geocoder)``.
+    geocoder = get_geocoder(get_settings())
     async with mcp_session() as db:
         actor = await _load_user(db, user_id)
         if actor is None:
@@ -1039,6 +1063,7 @@ async def edit_tournament(
                 tournament_id=tournament_id,
                 actor=actor,
                 updates=updates,
+                geocoder=geocoder,
             )
         except _TOURNAMENT_WRITE_TOOL_ERRORS as exc:
             raise _map_tournament_write_tool_error(
@@ -1048,6 +1073,8 @@ async def edit_tournament(
             raise ToolError(str(exc)) from exc
         except LeagueNotFoundError as exc:
             raise ToolError("No league found with that id.") from exc
+        except AddressNotGeocodableError as exc:
+            raise _map_address_not_geocodable_tool_error(exc) from exc
         # The core raised ``NotTournamentOwnerError`` unless the caller is the owner,
         # so here the actor is the creator — the owner's perspective the HTTP PATCH
         # serializes from (``created_by_username`` known, ``can_edit`` true).
@@ -1080,10 +1107,16 @@ async def create_tournament(payload: TournamentCreate) -> TournamentRead:
     requires.
 
     Raises a ``ToolError`` when you lack ``tournament.create``, when ``league_id`` names
-    no league, or (a broken deployment) when no ``league_id`` is given and there is no
-    default league.
+    no league, when the venue ``address`` cannot be geocoded (the
+    ``[address_not_geocodable]`` refusal — coordinates are geocoded server-side on write
+    and are NOT NULL), or (a broken deployment) when no ``league_id`` is given and there
+    is no default league.
     """
     user_id = _authenticated_user_id()
+    # The geocoder is built from ``Settings`` (Google when keyed, else the keyless
+    # deterministic fake) — the MCP surface has no ``Depends``, so it constructs the
+    # same seam the HTTP route resolves with ``Depends(get_geocoder)``.
+    geocoder = get_geocoder(get_settings())
     async with mcp_session() as db:
         # Permission first, through the same shared gate the HTTP ``require_create``
         # dependency asks — before the caller is loaded or anything is written, the
@@ -1093,9 +1126,13 @@ async def create_tournament(payload: TournamentCreate) -> TournamentRead:
         if actor is None:
             raise ToolError("Not authenticated.")
         try:
-            tournament = await create_tournament_core(db, actor=actor, payload=payload)
+            tournament = await create_tournament_core(
+                db, actor=actor, payload=payload, geocoder=geocoder
+            )
         except LeagueNotFoundError as exc:
             raise ToolError("No league found with that id.") from exc
+        except AddressNotGeocodableError as exc:
+            raise _map_address_not_geocodable_tool_error(exc) from exc
         except NoDefaultLeagueError as exc:
             raise ToolError(
                 "This deployment has no default league configured, so a tournament "

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -204,9 +204,9 @@ class GeocodePreview(BaseModel):
     :class:`~app.geocoding.Geocoder` the create/edit write path geocodes with, so
     the pin the previewer sees matches the coordinates a subsequent write records.
 
-    An address that resolves to zero candidates is a coded ``422`` at the boundary
-    carrying the same ``address_not_geocodable`` code the write path answers with —
-    never a coordinate-less preview."""
+    An address that resolves to zero candidates is a coded ``409`` carrying the same
+    ``address_not_geocodable`` code the write path answers with — never a
+    coordinate-less preview."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -194,6 +194,27 @@ class Address(BaseModel):
     longitude: float
 
 
+class GeocodePreview(BaseModel):
+    """The result of the read-only address-preview lookup (``GET /v1/geocode``).
+
+    The coordinates a free-text address string resolves to, plus the provider's
+    canonical ``formatted`` label, so the web "Preview location" pin can drop a
+    marker (and echo the normalized address it matched) *before* the tournament
+    write. This is not stored — it is a live lookup through the same injected
+    :class:`~app.geocoding.Geocoder` the create/edit write path geocodes with, so
+    the pin the previewer sees matches the coordinates a subsequent write records.
+
+    An address that resolves to zero candidates is a coded ``422`` at the boundary
+    carrying the same ``address_not_geocodable`` code the write path answers with —
+    never a coordinate-less preview."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    latitude: float
+    longitude: float
+    formatted: str
+
+
 def _is_iana_timezone(value: str) -> str:
     """Refuse a timezone that names no real IANA zone (422 at the boundary).
 

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -144,8 +144,18 @@ too — which is a feature. A rule the client can express is a rule the organize
 under the field instead of in a 422."""
 
 
-class Address(BaseModel):
-    """A tournament venue address. Stored as a JSONB value-object."""
+class AddressInput(BaseModel):
+    """The venue address a client **sends** on a write (create/edit).
+
+    Six free-text components and **no coordinates**: coordinates are geocoded
+    server-side at write time and are never supplied by a client (ADR "a venue's
+    coordinates are geocoded server-side at write time and are NOT NULL"). A client
+    that tries to send ``latitude``/``longitude`` gets a 422 — ``extra="forbid"`` —
+    rather than an unverified number the server would have to trust or re-check.
+
+    The write verbs geocode this input and construct the stored :class:`Address`
+    (with coordinates) before persisting; this is the shape on the *request*
+    schemas, and :class:`Address` is the shape on the *read* schemas."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -155,6 +165,33 @@ class Address(BaseModel):
     region: str
     postal: str
     country: str
+
+
+class Address(BaseModel):
+    """A tournament venue address as **stored and read**. A JSONB value-object.
+
+    The six free-text components a client sends (:class:`AddressInput`) **plus**
+    the ``latitude``/``longitude`` the server geocoded at write time — both NOT
+    NULL (ADR "a venue's coordinates are geocoded server-side at write time and are
+    NOT NULL"). Coordinates live inside the JSONB value-object, so the stored
+    address always carries them; a read that validates the column into this model
+    can rely on non-null coordinates rather than threading ``Optional[float]``
+    through every downstream reader.
+
+    This is the shape on the *read* schemas (:class:`TournamentRead` and the
+    detail/dashboard reads); the write schemas take :class:`AddressInput`, which
+    has no coordinates."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    venue: str
+    street: str
+    city: str
+    region: str
+    postal: str
+    country: str
+    latitude: float
+    longitude: float
 
 
 def _is_iana_timezone(value: str) -> str:
@@ -933,6 +970,17 @@ class TournamentRead(BaseModel):
 
 class TournamentDetailRead(TournamentRead):
     events: list[TournamentEventRead]
+    # The tournament's distance from the caller's point, in **miles**, when the list
+    # was queried with a ``lat``/``lng``/``radius_miles`` triple (the "near me" filter,
+    # ADR "a venue's coordinates are geocoded server-side ... Distance is a haversine
+    # expression"). Computed server-side by the same haversine the radius filter uses,
+    # so a card can show "12.3 mi away" without the client doing any geo math.
+    #
+    # ``null`` means **no location was asked for** — the designed state of every read
+    # that is not near-me (the unfiltered list, the single-tournament detail read, the
+    # MCP owner-scoped list): there is no point to measure from, so there is no
+    # distance, and a client renders no "away" badge rather than a bogus zero.
+    distance_miles: float | None = None
     # The Schedule tab's solve strip (ADR "the schedule is solved, the call is
     # pinned"): the NEWEST row of the tournament's solve ledger, by ``requested_at``.
     # One row, not the ledger — the strip shows the current run's state (queued /
@@ -969,7 +1017,10 @@ class TournamentCreate(BaseModel):
     description: str | None = Field(default=None, max_length=1024)
     start_date: date | None = None
     end_date: date | None = None
-    address: Address
+    # The write shape: six free-text components, no coordinates. The verb geocodes
+    # it into a stored ``Address`` (with coordinates) before persisting (ADR "a
+    # venue's coordinates are geocoded server-side ... and are NOT NULL").
+    address: AddressInput
     table_catalogue: list[TournamentTable] = Field(default_factory=list)
     league_id: uuid.UUID | None = None
 
@@ -1002,7 +1053,10 @@ class TournamentUpdate(BaseModel):
     description: str | None = Field(default=None, max_length=1024)
     start_date: date | None = None
     end_date: date | None = None
-    address: Address | None = None
+    # The write shape: six free-text components, no coordinates (see
+    # ``TournamentCreate.address``). An explicit ``null`` is rejected below; an
+    # omitted key leaves the stored address (and its coordinates) unchanged.
+    address: AddressInput | None = None
     table_catalogue: list[TournamentTable] | None = None
     league_id: uuid.UUID | None = None
 

--- a/api/app/tournament_edit.py
+++ b/api/app/tournament_edit.py
@@ -19,6 +19,7 @@ resolver's strict 404.
 """
 
 import uuid
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -27,7 +28,12 @@ from app.geocoding import Geocoder
 from app.leagues import _load_league
 from app.models import ScheduleSolveTrigger, Tournament, TournamentStatus, User
 from app.schedule_solves import request_solve, tournament_has_drawn_event
-from app.schemas.tournament import TournamentTable, TournamentUpdate
+from app.schemas.tournament import (
+    Address,
+    AddressInput,
+    TournamentTable,
+    TournamentUpdate,
+)
 from app.tournament_errors import (
     LeagueNotEditableError,
     LeagueNotFoundError,
@@ -97,6 +103,53 @@ def _catalogue_ids(tournament: Tournament) -> list[str]:
     ]
 
 
+#: The six free-text components of a venue address — the fields a client sends
+#: (:class:`~app.schemas.tournament.AddressInput`) and the fields stored alongside the
+#: server-geocoded coordinates. The coordinates are deliberately NOT in this tuple: they
+#: are the server's to (re)compute, and are exactly what is kept when the text is
+#: unchanged.
+_ADDRESS_TEXT_FIELDS: tuple[str, ...] = (
+    "venue",
+    "street",
+    "city",
+    "region",
+    "postal",
+    "country",
+)
+
+
+async def _stored_address(
+    db: AsyncSession, tournament_id: uuid.UUID
+) -> dict[str, Any] | None:
+    """The tournament's currently-stored ``address`` JSONB (six text fields plus the
+    geocoded coordinates), read **without** the row lock — or ``None`` if no such
+    tournament exists.
+
+    Lock-free on purpose: it exists only to decide whether a submitted address is
+    actually changing, and that decision must not hold the ``FOR UPDATE`` lock across
+    the (up-to-5s) geocode network call it gates. It is an **optimization only** — the
+    authoritative write still happens under the lock in :func:`edit_tournament`, and a
+    stale read here can at worst cost one needless geocode or skip one, never a wrong or
+    coordinate-less write (see the address branch there for the race reasoning)."""
+    return (
+        await db.execute(
+            select(Tournament.address).where(Tournament.id == tournament_id)
+        )
+    ).scalar_one_or_none()
+
+
+def _address_text_unchanged(submitted: AddressInput, stored: dict[str, Any]) -> bool:
+    """True when ``submitted``'s six free-text components equal ``stored``'s six.
+
+    Compared field-by-field over :data:`_ADDRESS_TEXT_FIELDS` rather than by dict
+    equality, because ``stored`` also carries ``latitude``/``longitude`` that
+    ``AddressInput`` does not — and those coordinates are precisely what is preserved
+    when the text has not moved."""
+    return all(
+        getattr(submitted, field) == stored.get(field) for field in _ADDRESS_TEXT_FIELDS
+    )
+
+
 async def edit_tournament(
     db: AsyncSession,
     *,
@@ -126,16 +179,28 @@ async def edit_tournament(
       ``_load_league``): a director's typo must not silently swap to the default.
 
     An **address change re-geocodes** (:func:`geocode_address`, via the injected
-    ``geocoder``): a patch that carries ``address`` (the six free-text components,
-    :class:`~app.schemas.tournament.AddressInput`) resolves the new address to
-    coordinates and stores the coordinate-bearing
-    :class:`~app.schemas.tournament.Address`, so an edited venue keeps the NOT NULL
-    coordinates invariant (ADR "a venue's coordinates are geocoded server-side at write
-    time and are NOT NULL"). A patch that does **not** touch ``address`` geocodes
-    nothing — the stored address and its coordinates are left unchanged. An unresolvable
-    new address raises :class:`~app.geocoding.AddressNotGeocodableError` **before** any
-    field is written or committed, so the edit is atomic — nothing changes; the caller
-    maps it to a coded ``422``
+    ``geocoder``) — but the geocode runs **before the row lock is taken**, never under
+    it. The geocode is an external HTTP call (up to ~5s); the tournament ``FOR UPDATE``
+    lock serializes every writer of this tournament, so geocoding under it would block
+    them all for a network round-trip — the same reason the CP-SAT solve runs outside
+    any transaction (``app.schedule_solves``). So a patch that carries a *changed*
+    ``address`` (the six free-text components,
+    :class:`~app.schemas.tournament.AddressInput`) is resolved to coordinates first, and
+    the coordinate-bearing :class:`~app.schemas.tournament.Address` is written under the
+    lock, keeping the NOT NULL coordinates invariant (ADR "a venue's coordinates are
+    geocoded server-side at write time and are NOT NULL").
+
+    And it geocodes **only when the address text actually changes**. The web client
+    sends ``address`` on every edit, so re-geocoding on each PATCH would bill the
+    provider for a name-only edit. A **lock-free** read of the stored address
+    (:func:`_stored_address`) decides: submitted six text fields identical to the stored
+    six ⇒ no geocode, the stored coordinates stand. That read is only an optimization;
+    the authoritative write is under the lock (see the address branch in the body for
+    why it is correct whatever a concurrent writer does in between). A patch that does
+    **not** touch ``address`` geocodes nothing. An unresolvable new address raises
+    :class:`~app.geocoding.AddressNotGeocodableError` **before the lock and before any
+    field is written or committed**, so the edit is atomic — nothing changes; the caller
+    maps it to a coded ``409``
     (:data:`~app.tournament_geocoding.ADDRESS_NOT_GEOCODABLE_CODE`).
 
     Then it applies the remaining fields (``model_dump(exclude_unset=True)``
@@ -151,6 +216,21 @@ async def edit_tournament(
     Commits and refreshes before returning. Never raises ``HTTPException`` — the
     caller adapts each domain exception to its transport.
     """
+    # Geocode the changed address BEFORE taking the lock — never under it (see the
+    # docstring). ``updates.address`` is ``None`` unless the client sent an address (an
+    # explicit ``null`` is rejected by the schema), so this runs only when an address is
+    # on the payload; and even then only when its six text fields differ from what is
+    # stored, read lock-free. An unresolvable address raises here, before the lock is
+    # taken and before anything is written — the edit aborts atomically.
+    geocoded_address: Address | None = None
+    if updates.address is not None:
+        stored = await _stored_address(db, tournament_id)
+        if stored is None or not _address_text_unchanged(updates.address, stored):
+            # A new venue — or a tournament this unlocked read cannot see, in which case
+            # the locked owner-load below is the authority and will 404/403 it, and this
+            # result is simply discarded. Either way the geocode is off the lock.
+            geocoded_address = await geocode_address(geocoder, updates.address)
+
     tournament = await _load_owned_tournament_for_update(db, tournament_id, actor)
 
     fields = updates.model_dump(exclude_unset=True)
@@ -171,18 +251,28 @@ async def edit_tournament(
             raise LeagueNotFoundError()
         tournament.league_id = league.id
 
-    # An address patch RE-geocodes the new address; a patch that doesn't touch the
-    # address geocodes nothing (its coordinates are left as they stand). ``updates``
-    # rejects an explicit ``null`` for ``address``, so ``updates.address is not None``
-    # is exactly "the address is being changed" — and it holds the parsed
-    # ``AddressInput``. Replace the coordinate-less dict ``model_dump`` put in
-    # ``fields`` with the geocoded, coordinate-bearing ``Address`` before the generic
-    # apply loop writes it. Geocoded before any ``setattr``, so an unresolvable address
-    # aborts the whole edit (nothing is written or committed).
+    # Write the pre-geocoded address, or leave the stored one untouched. The geocode
+    # decision was made before the lock (above); ``geocoded_address`` is set exactly
+    # when the submitted address differs from what was stored:
+    #
+    #   * set ⇒ write it — the caller's requested venue, freshly geocoded. Correct even
+    #     if a concurrent edit changed the address between the lock-free read and this
+    #     locked write: this is the value the caller asked for, and it overwrites.
+    #   * unset (address submitted but unchanged, or not submitted) ⇒ do NOT write the
+    #     ``address`` column, so the stored value AND its coordinates stand. For a
+    #     resubmitted-but-identical address that is the whole point (no geocode,
+    #     coordinates preserved); and if a concurrent edit moved the venue in between, a
+    #     caller who submitted the value they had loaded is expressing no change, so
+    #     leaving the concurrent value is correct, not a lost update.
+    #
+    # ``updates`` rejects an explicit ``null`` for ``address``, so ``updates.address is
+    # not None`` is exactly "an address is on the payload"; ``model_dump`` put its
+    # coordinate-less dict in ``fields``, which we either replace or drop here.
     if updates.address is not None:
-        fields["address"] = (
-            await geocode_address(geocoder, updates.address)
-        ).model_dump()
+        if geocoded_address is not None:
+            fields["address"] = geocoded_address.model_dump()
+        else:
+            del fields["address"]
 
     catalogue_ids_before = _catalogue_ids(tournament)
     for key, value in fields.items():

--- a/api/app/tournament_edit.py
+++ b/api/app/tournament_edit.py
@@ -23,6 +23,7 @@ import uuid
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.geocoding import Geocoder
 from app.leagues import _load_league
 from app.models import ScheduleSolveTrigger, Tournament, TournamentStatus, User
 from app.schedule_solves import request_solve, tournament_has_drawn_event
@@ -33,6 +34,7 @@ from app.tournament_errors import (
     NotTournamentOwnerError,
     TournamentNotFoundError,
 )
+from app.tournament_geocoding import geocode_address
 
 
 async def _load_tournament_for_update(
@@ -101,6 +103,7 @@ async def edit_tournament(
     tournament_id: uuid.UUID,
     actor: User,
     updates: TournamentUpdate,
+    geocoder: Geocoder,
 ) -> Tournament:
     """Apply the partial ``updates`` to the tournament ``actor`` owns, and return
     the refreshed :class:`Tournament`.
@@ -121,6 +124,19 @@ async def edit_tournament(
     * **404** — a ``league_id`` that names no league raises
       :class:`LeagueNotFoundError` (the STRICT resolution, via the FastAPI-free
       ``_load_league``): a director's typo must not silently swap to the default.
+
+    An **address change re-geocodes** (:func:`geocode_address`, via the injected
+    ``geocoder``): a patch that carries ``address`` (the six free-text components,
+    :class:`~app.schemas.tournament.AddressInput`) resolves the new address to
+    coordinates and stores the coordinate-bearing
+    :class:`~app.schemas.tournament.Address`, so an edited venue keeps the NOT NULL
+    coordinates invariant (ADR "a venue's coordinates are geocoded server-side at write
+    time and are NOT NULL"). A patch that does **not** touch ``address`` geocodes
+    nothing — the stored address and its coordinates are left unchanged. An unresolvable
+    new address raises :class:`~app.geocoding.AddressNotGeocodableError` **before** any
+    field is written or committed, so the edit is atomic — nothing changes; the caller
+    maps it to a coded ``422``
+    (:data:`~app.tournament_geocoding.ADDRESS_NOT_GEOCODABLE_CODE`).
 
     Then it applies the remaining fields (``model_dump(exclude_unset=True)``
     already serialized the nested value-objects to plain dicts/lists, so one
@@ -154,6 +170,19 @@ async def edit_tournament(
         if league is None:
             raise LeagueNotFoundError()
         tournament.league_id = league.id
+
+    # An address patch RE-geocodes the new address; a patch that doesn't touch the
+    # address geocodes nothing (its coordinates are left as they stand). ``updates``
+    # rejects an explicit ``null`` for ``address``, so ``updates.address is not None``
+    # is exactly "the address is being changed" — and it holds the parsed
+    # ``AddressInput``. Replace the coordinate-less dict ``model_dump`` put in
+    # ``fields`` with the geocoded, coordinate-bearing ``Address`` before the generic
+    # apply loop writes it. Geocoded before any ``setattr``, so an unresolvable address
+    # aborts the whole edit (nothing is written or committed).
+    if updates.address is not None:
+        fields["address"] = (
+            await geocode_address(geocoder, updates.address)
+        ).model_dump()
 
     catalogue_ids_before = _catalogue_ids(tournament)
     for key, value in fields.items():

--- a/api/app/tournament_geocoding.py
+++ b/api/app/tournament_geocoding.py
@@ -1,0 +1,78 @@
+"""Geocode a venue ``AddressInput`` into a stored ``Address`` at write time.
+
+The one place the tournament write verbs turn the six free-text address components a
+client sends (:class:`~app.schemas.tournament.AddressInput`) into the stored
+value-object that also carries coordinates (:class:`~app.schemas.tournament.Address`),
+by asking the injected :class:`~app.geocoding.Geocoder` (ADR "a venue's coordinates are
+geocoded server-side at write time and are NOT NULL"). Shared by ``create_tournament``
+(``app.tournament_lifecycle``) and ``edit_tournament`` (``app.tournament_edit``) so both
+verbs geocode through one composition and one code path.
+
+FastAPI-free on purpose — the verbs that import it must stay constructible without
+FastAPI (``api/CLAUDE.md``, "service layer and dependency injection"). It builds the
+:class:`Address`, which lives in the tournament layer, rather than the geocoding seam
+building it: :func:`~app.geocoding.compose_address` is kept generic precisely so the
+seam does not import the tournament schema.
+
+A zero-result lookup raises :class:`~app.geocoding.AddressNotGeocodableError`, which
+these verbs let propagate to their transport adapter — the HTTP handler and the MCP
+tool each map it to a ``422`` carrying the machine-readable
+:data:`ADDRESS_NOT_GEOCODABLE_CODE` (ADR-0968's coded-refusal convention). Every other
+geocoder failure (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to
+the ``500`` handler — it is not caught here.
+"""
+
+from app.geocoding import Geocoder, compose_address
+from app.schemas.tournament import Address, AddressInput
+
+#: The stable machine-readable code a client (and the MCP agent) switches on when a
+#: venue address cannot be geocoded (ADR "an unresolvable address is a 422 at the
+#: boundary"). The HTTP adapter puts it in the coded ``{"detail": {"code", "message"}}``
+#: body and the MCP adapter names it in the ``ToolError`` prose, so both surfaces carry
+#: the same word for the same refusal. Defined here, FastAPI-free, so both adapters
+#: share one source and cannot drift.
+ADDRESS_NOT_GEOCODABLE_CODE = "address_not_geocodable"
+
+#: The human sentence paired with :data:`ADDRESS_NOT_GEOCODABLE_CODE` — the fallback a
+#: client without copy for the code, or a person, reads. The code is the contract; this
+#: is prose, so rewording it is safe.
+ADDRESS_NOT_GEOCODABLE_MESSAGE = (
+    "We couldn't locate that address. Check the venue, street, city, region, postal "
+    "code and country, then try again."
+)
+
+
+async def geocode_address(geocoder: Geocoder, address: AddressInput) -> Address:
+    """Geocode ``address`` and return the stored :class:`Address` (its six text fields
+    plus the resolved ``latitude`` / ``longitude``).
+
+    Composes the six components into one geocodable string
+    (:func:`~app.geocoding.compose_address`), asks ``geocoder`` for the top candidate,
+    and carries the client's typed text through unchanged — only the coordinates come
+    from the geocoder (the ADR stores coordinates only, leaving the free text as
+    entered).
+
+    Raises :class:`~app.geocoding.AddressNotGeocodableError` when the address resolves
+    to zero candidates; the caller maps it to a coded ``422``. Any other geocoder
+    failure propagates.
+    """
+    result = await geocoder.geocode(
+        compose_address(
+            venue=address.venue,
+            street=address.street,
+            city=address.city,
+            region=address.region,
+            postal=address.postal,
+            country=address.country,
+        )
+    )
+    return Address(
+        venue=address.venue,
+        street=address.street,
+        city=address.city,
+        region=address.region,
+        postal=address.postal,
+        country=address.country,
+        latitude=result.latitude,
+        longitude=result.longitude,
+    )

--- a/api/app/tournament_geocoding.py
+++ b/api/app/tournament_geocoding.py
@@ -56,23 +56,13 @@ async def geocode_address(geocoder: Geocoder, address: AddressInput) -> Address:
     to zero candidates; the caller maps it to a coded ``422``. Any other geocoder
     failure propagates.
     """
-    result = await geocoder.geocode(
-        compose_address(
-            venue=address.venue,
-            street=address.street,
-            city=address.city,
-            region=address.region,
-            postal=address.postal,
-            country=address.country,
-        )
-    )
+    # ``AddressInput`` holds exactly ``compose_address``'s six keyword params, and
+    # ``Address`` is those same six plus the coordinates, so one ``model_dump`` feeds
+    # both without re-listing the field names (``extra="forbid"`` keeps it honest).
+    components = address.model_dump()
+    result = await geocoder.geocode(compose_address(**components))
     return Address(
-        venue=address.venue,
-        street=address.street,
-        city=address.city,
-        region=address.region,
-        postal=address.postal,
-        country=address.country,
+        **components,
         latitude=result.latitude,
         longitude=result.longitude,
     )

--- a/api/app/tournament_geocoding.py
+++ b/api/app/tournament_geocoding.py
@@ -15,22 +15,27 @@ building it: :func:`~app.geocoding.compose_address` is kept generic precisely so
 seam does not import the tournament schema.
 
 A zero-result lookup raises :class:`~app.geocoding.AddressNotGeocodableError`, which
-these verbs let propagate to their transport adapter — the HTTP handler and the MCP
-tool each map it to a ``422`` carrying the machine-readable
-:data:`ADDRESS_NOT_GEOCODABLE_CODE` (ADR-0968's coded-refusal convention). Every other
-geocoder failure (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to
-the ``500`` handler — it is not caught here.
+these verbs let propagate to their transport adapter — the HTTP handler maps it to a
+coded ``409`` (:class:`AddressNotGeocodable`) and the MCP tool to a ``ToolError``, both
+carrying the machine-readable :data:`ADDRESS_NOT_GEOCODABLE_CODE` (ADR-0968's
+coded-refusal convention). It is a ``409``, not a ``422``: FastAPI reserves ``422`` for
+its own ``HTTPValidationError`` (a ``detail`` **array**), so a hand-rolled ``422``
+object body collides with the shape the generated clients expect there (ADR-0968). Every
+other geocoder failure (:class:`~app.geocoding.GeocoderError`) is unexpected and
+propagates to the ``500`` handler — it is not caught here.
 """
+
+from pydantic import BaseModel, ConfigDict
 
 from app.geocoding import Geocoder, compose_address
 from app.schemas.tournament import Address, AddressInput
 
 #: The stable machine-readable code a client (and the MCP agent) switches on when a
-#: venue address cannot be geocoded (ADR "an unresolvable address is a 422 at the
-#: boundary"). The HTTP adapter puts it in the coded ``{"detail": {"code", "message"}}``
-#: body and the MCP adapter names it in the ``ToolError`` prose, so both surfaces carry
-#: the same word for the same refusal. Defined here, FastAPI-free, so both adapters
-#: share one source and cannot drift.
+#: venue address cannot be geocoded (ADR-0968's coded-refusal convention). The HTTP
+#: adapter puts it in the coded ``409`` ``{"detail": {"code", "message"}}`` body and the
+#: MCP adapter names it in the ``ToolError`` prose, so both surfaces carry the same word
+#: for the same refusal. Defined here, FastAPI-free, so both adapters share one source
+#: and cannot drift.
 ADDRESS_NOT_GEOCODABLE_CODE = "address_not_geocodable"
 
 #: The human sentence paired with :data:`ADDRESS_NOT_GEOCODABLE_CODE` — the fallback a
@@ -40,6 +45,32 @@ ADDRESS_NOT_GEOCODABLE_MESSAGE = (
     "We couldn't locate that address. Check the venue, street, city, region, postal "
     "code and country, then try again."
 )
+
+
+class AddressNotGeocodable(BaseModel):
+    """The ``409`` response body for a venue address that resolved to zero geocoding
+    candidates — the coded-refusal convention of ADR-0968, mirroring the entry
+    endpoint's ``{"code", "message"}`` shape.
+
+    ``code`` is the stable contract a client switches on — always
+    :data:`ADDRESS_NOT_GEOCODABLE_CODE`, carried as the field's default so the one
+    constant is the single source of the string (no fork) and the concrete value
+    still surfaces in the generated OpenAPI. ``message`` is fallback prose for a
+    client without copy for the code, or a person.
+
+    Modeled (rather than a hand-rolled ``dict`` detail) so the create/edit/preview
+    routes' ``responses={409: {"model": AddressNotGeocodable}}`` describes the body
+    the generated web + iOS types actually receive — instead of the refusal riding on
+    FastAPI's reserved ``422``, whose auto-generated ``HTTPValidationError`` schema
+    says ``detail`` is an **array** and so cannot decode this object body (ADR-0968).
+    Pure Pydantic, kept beside the code/message it carries; the FastAPI
+    ``HTTPException`` that wraps it lives in the router adapter (``app.tournaments``),
+    so this module stays FastAPI-free."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str = ADDRESS_NOT_GEOCODABLE_CODE
+    message: str
 
 
 async def geocode_address(geocoder: Geocoder, address: AddressInput) -> Address:
@@ -53,7 +84,7 @@ async def geocode_address(geocoder: Geocoder, address: AddressInput) -> Address:
     entered).
 
     Raises :class:`~app.geocoding.AddressNotGeocodableError` when the address resolves
-    to zero candidates; the caller maps it to a coded ``422``. Any other geocoder
+    to zero candidates; the caller maps it to a coded ``409``. Any other geocoder
     failure propagates.
     """
     # ``AddressInput`` holds exactly ``compose_address``'s six keyword params, and

--- a/api/app/tournament_lifecycle.py
+++ b/api/app/tournament_lifecycle.py
@@ -29,6 +29,7 @@ from typing import assert_never
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.geocoding import Geocoder
 from app.leagues import _load_league, get_default_league
 from app.models import (
     League,
@@ -49,6 +50,7 @@ from app.tournament_errors import (
     TournamentAlreadyInStatusError,
     TournamentNotReadyToGoLiveError,
 )
+from app.tournament_geocoding import geocode_address
 from app.tournament_materialization import materialize_live_draw
 from app.tournament_realtime import stage_tournament_entrant_hints
 
@@ -99,12 +101,22 @@ async def create_tournament(
     *,
     actor: User,
     payload: TournamentCreate,
+    geocoder: Geocoder,
 ) -> Tournament:
     """Create a tournament owned by ``actor`` from ``payload``, and return the
     refreshed :class:`Tournament`.
 
     Runs the same orchestration the HTTP handler used to run inline:
 
+    * The venue ``address`` is **geocoded on write** (:func:`geocode_address`, via the
+      injected ``geocoder``): the client sends the six free-text components
+      (:class:`~app.schemas.tournament.AddressInput`, no coordinates) and this verb
+      persists the stored :class:`~app.schemas.tournament.Address` that carries the
+      resolved ``latitude`` / ``longitude`` (ADR "a venue's coordinates are geocoded
+      server-side at write time and are NOT NULL"). An unresolvable address raises
+      :class:`~app.geocoding.AddressNotGeocodableError` **before** anything is written,
+      so a write that cannot produce coordinates commits nothing; the caller maps it to
+      a coded ``422`` (:data:`~app.tournament_geocoding.ADDRESS_NOT_GEOCODABLE_CODE`).
     * The value-objects (``address``, ``table_catalogue``) persist as plain JSONB;
       the dicts ``model_dump`` produces don't propagate beyond this write boundary.
     * **No** ``status`` is set: it isn't on the create schema (ADR-0017), so a
@@ -117,15 +129,19 @@ async def create_tournament(
       default raises :class:`NoDefaultLeagueError`.
 
     Commits and refreshes before returning. Never raises ``HTTPException`` — the
-    caller adapts each domain exception to its transport.
+    caller adapts each domain exception (league misses, an unresolvable address) to its
+    transport.
     """
     league = await _resolve_league_strict(db, payload.league_id)
+    # Geocode before constructing the row, so an unresolvable address fails at the edge
+    # and never reaches ``db.add``/``commit`` — the write is atomic (writes nothing).
+    address = await geocode_address(geocoder, payload.address)
     tournament = Tournament(
         name=payload.name,
         description=payload.description,
         start_date=payload.start_date,
         end_date=payload.end_date,
-        address=payload.address.model_dump(),
+        address=address.model_dump(),
         table_catalogue=[t.model_dump() for t in payload.table_catalogue],
         league_id=league.id,
         created_by_user_id=actor.id,

--- a/api/app/tournament_lifecycle.py
+++ b/api/app/tournament_lifecycle.py
@@ -116,7 +116,7 @@ async def create_tournament(
       server-side at write time and are NOT NULL"). An unresolvable address raises
       :class:`~app.geocoding.AddressNotGeocodableError` **before** anything is written,
       so a write that cannot produce coordinates commits nothing; the caller maps it to
-      a coded ``422`` (:data:`~app.tournament_geocoding.ADDRESS_NOT_GEOCODABLE_CODE`).
+      a coded ``409`` (:data:`~app.tournament_geocoding.ADDRESS_NOT_GEOCODABLE_CODE`).
     * The value-objects (``address``, ``table_catalogue``) persist as plain JSONB;
       the dicts ``model_dump`` produces don't propagate beyond this write boundary.
     * **No** ``status`` is set: it isn't on the create schema (ADR-0017), so a

--- a/api/app/tournament_list.py
+++ b/api/app/tournament_list.py
@@ -19,9 +19,11 @@ compose the shared ``serialize_detail`` serializer; keeping them out of
 ``tournament_queries`` keeps that module import-free of the serializer.
 """
 
+import math
 import uuid
 
-from sqlalchemy import ColumnElement, select
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import ColumnElement, Float, and_, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Tournament, TournamentEvent, User
@@ -37,12 +39,105 @@ from app.tournament_queries import (
 )
 from app.tournament_serialization import serialize_detail
 
+# The Earth's mean radius in miles — the constant the haversine is scaled by, and the
+# unit the ADR fixes (``radius_miles`` in, ``distance_miles`` out): "Distance is a
+# haversine expression, not PostGIS ... it keeps the Postgres image unchanged".
+_EARTH_RADIUS_MILES = 3958.8
+
+# Miles per degree of latitude (``EARTH_RADIUS * pi / 180`` ≈ 69.09). Deliberately
+# rounded *down* to 69.0: the bounding-box prefilter must be a SUPERSET of the true
+# radius (the haversine ``WHERE`` below is what actually decides membership), and a
+# smaller miles-per-degree makes the degree window it computes slightly *wider* — so
+# the box can never exclude a venue the haversine would have kept.
+_MILES_PER_DEGREE_LAT = 69.0
+
+
+class NearMeFilter(BaseModel):
+    """A parsed, all-three-present "near me" location filter for the tournament list.
+
+    The HTTP list endpoint's ``lat``/``lng``/``radius_miles`` query triple, once it has
+    passed the all-or-nothing boundary check (a partial triple is a 422, ADR "Distance
+    is a haversine expression"). Its presence is what switches the list from "every
+    visible tournament, ``distance_miles`` null" to "only those within ``radius_miles``
+    of ``(lat, lng)``, each carrying its ``distance_miles``". The MCP list never
+    constructs one, so its read is unaffected.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    lat: float
+    lng: float
+    radius_miles: float
+
+
+def _venue_coordinate(key: str) -> ColumnElement[float]:
+    """The venue's ``latitude``/``longitude`` lifted out of the ``address`` JSONB as a
+    real ``float`` column, for the haversine and the bounding box to compute on.
+
+    Both keys are NOT NULL inside the value-object (they are geocoded server-side on
+    every write, ADR "a venue's coordinates are geocoded server-side ... and are NOT
+    NULL"), so the cast never meets a null — there is no "tournament with no
+    coordinates" row to defend against here."""
+    return cast(Tournament.address[key].astext, Float)
+
+
+def _distance_miles_column(near: NearMeFilter) -> ColumnElement[float]:
+    """The haversine great-circle distance, in miles, from ``near`` to each row's venue.
+
+    Computed in SQL with stdlib-equivalent trig (``postgres`` ``radians``/``sin``/
+    ``cos``/``asin``/``sqrt``) rather than PostGIS, which the stack does not ship
+    (ADR "Distance is a haversine expression, not PostGIS"). The query point is a
+    Python constant, so only the venue coordinates are columns."""
+    venue_lat = _venue_coordinate("latitude")
+    venue_lng = _venue_coordinate("longitude")
+    d_lat = func.radians(venue_lat - near.lat)
+    d_lng = func.radians(venue_lng - near.lng)
+    sin_half_lat = func.sin(d_lat / 2)
+    sin_half_lng = func.sin(d_lng / 2)
+    a = (
+        sin_half_lat * sin_half_lat
+        + func.cos(func.radians(near.lat))
+        * func.cos(func.radians(venue_lat))
+        * sin_half_lng
+        * sin_half_lng
+    )
+    return 2 * _EARTH_RADIUS_MILES * func.asin(func.sqrt(a))
+
+
+def _bounding_box(near: NearMeFilter) -> ColumnElement[bool]:
+    """A cheap lat/lng rectangle around ``near`` that contains its whole radius — the
+    prefilter that runs before (and alongside) the haversine so the query can discard
+    the far-away rows on plain range comparisons rather than trig on every row.
+
+    The window half-widths are Python constants (the query point and radius are known
+    off the wire), so the box is a pair of literal ``BETWEEN``s, not an expression over
+    the row. It is deliberately a SUPERSET of the true circle — see
+    ``_MILES_PER_DEGREE_LAT`` — so it never drops a venue the haversine would keep; the
+    haversine ``<= radius`` is the exact membership test. Longitude degrees shrink with
+    latitude (``cos``); near the poles ``cos`` collapses, so the longitude bound falls
+    back to the whole ``[-180, 180]`` span rather than dividing by ~0."""
+    lat_delta = near.radius_miles / _MILES_PER_DEGREE_LAT
+    cos_lat = math.cos(math.radians(near.lat))
+    if abs(cos_lat) < 1e-9:
+        lng_delta = 360.0
+    else:
+        lng_delta = near.radius_miles / (_MILES_PER_DEGREE_LAT * cos_lat)
+    venue_lat = _venue_coordinate("latitude")
+    venue_lng = _venue_coordinate("longitude")
+    return and_(
+        venue_lat >= near.lat - lat_delta,
+        venue_lat <= near.lat + lat_delta,
+        venue_lng >= near.lng - lng_delta,
+        venue_lng <= near.lng + lng_delta,
+    )
+
 
 async def list_tournament_details(
     db: AsyncSession,
     *,
     where: ColumnElement[bool],
     current_user_id: uuid.UUID,
+    near_me: NearMeFilter | None = None,
 ) -> list[TournamentDetailRead]:
     """Every tournament matching ``where``, newest first, as the full
     ``TournamentDetailRead`` aggregate the list cards render.
@@ -66,15 +161,44 @@ async def list_tournament_details(
 
     ``current_user_id`` is the perspective the aggregate is projected from — the
     ``can_edit`` flag, the per-event ``entry_state``, and the ladder ``rating``.
+
+    ``near_me`` is the HTTP list's optional "near me" filter (ADR "Distance is a
+    haversine expression, not PostGIS"). When present, the FIRST query gains a WHERE —
+    a cheap bounding-box prefilter plus the exact ``haversine <= radius_miles`` — so
+    only tournaments within ``radius_miles`` of ``(lat, lng)`` survive, and each
+    carries its computed ``distance_miles``. Both the predicate and the computed
+    column ride on that one existing query, so the statement count is unchanged and
+    the tripwire still reads five. When ``near_me`` is ``None`` (the unfiltered list,
+    and the MCP owner-scoped list, which never passes it) the query, the row set and
+    every ``distance_miles`` are exactly as before — the latter all null.
     """
-    rows = (
-        await db.execute(
-            select(Tournament, User.username)
-            .join(User, User.id == Tournament.created_by_user_id)
-            .where(where)
-            .order_by(Tournament.created_at.desc())
+    stmt = (
+        select(Tournament, User.username)
+        .join(User, User.id == Tournament.created_by_user_id)
+        .where(where)
+        .order_by(Tournament.created_at.desc())
+    )
+    distance_by_id: dict[uuid.UUID, float] = {}
+    rows: list[tuple[Tournament, str]]
+    if near_me is not None:
+        # The distance column and the radius filter both ride on this ONE query — a
+        # computed column and a WHERE predicate, not a per-row follow-up — so the
+        # five-statement batched read stays five (the tripwire in test_tournaments.py).
+        # The bounding box discards the far rows cheaply; the haversine is the exact
+        # membership test and the number a card shows.
+        distance = _distance_miles_column(near_me)
+        stmt = stmt.add_columns(distance.label("distance_miles")).where(
+            _bounding_box(near_me), distance <= near_me.radius_miles
         )
-    ).all()
+        rows = []
+        for row in (await db.execute(stmt)).all():
+            tournament, username, distance_miles = row[0], row[1], row[2]
+            rows.append((tournament, username))
+            # Round to one decimal — a card shows "12.3 mi away"; the raw float would
+            # print a spurious-precision tail. Still a float, per the response schema.
+            distance_by_id[tournament.id] = round(distance_miles, 1)
+    else:
+        rows = [(row[0], row[1]) for row in (await db.execute(stmt)).all()]
     tournament_ids = [tournament.id for tournament, _ in rows]
     events_by_tournament: dict[uuid.UUID, list[TournamentEvent]] = {
         tid: [] for tid in tournament_ids
@@ -129,6 +253,9 @@ async def list_tournament_details(
             # it skips the ledger read rather than paying a query for a field every
             # card throws away. The solve strip is a detail-BFF concern.
             latest_schedule_solve=None,
+            # The near-me distance, or ``None`` when the list was not location-filtered
+            # (``distance_by_id`` is empty then, so every card carries a null distance).
+            distance_miles=distance_by_id.get(tournament.id),
         )
         for tournament, username in rows
     ]

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -379,6 +379,7 @@ def serialize_detail(
     game_counts: dict[uuid.UUID, tuple[int, int]] | None,
     rating: float | None,
     latest_schedule_solve: ScheduleSolve | None,
+    distance_miles: float | None = None,
 ) -> TournamentDetailRead:
     # The full aggregate: tournament fields plus its events (each event's JSONB
     # value-objects validate into Pydantic models here, at this single boundary).
@@ -403,6 +404,9 @@ def serialize_detail(
                 if latest_schedule_solve is not None
                 else None
             ),
+            # The near-me distance in miles, or ``None`` on every read that was not
+            # location-filtered (the detail read, the unfiltered/owner-scoped lists).
+            "distance_miles": distance_miles,
             "events": [
                 serialize_event(
                     e,

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -36,6 +36,7 @@ from app.schemas.schedule_preview import (
     PreviewRequest,
 )
 from app.schemas.tournament import (
+    GeocodePreview,
     ScheduleSolveRead,
     TournamentCreate,
     TournamentDetailRead,
@@ -363,6 +364,46 @@ async def create_tournament(
         tournament,
         created_by_username=current_user.username,
         current_user_id=current_user.id,
+    )
+
+
+@router.get(
+    "/geocode",
+    response_model=GeocodePreview,
+    dependencies=[Depends(require_create)],
+)
+async def preview_geocode(
+    address: Annotated[str, Query(min_length=1)],
+    geocoder: Geocoder = Depends(get_geocoder),
+) -> GeocodePreview:
+    """Resolve a free-text ``address`` string to coordinates for the web
+    "Preview location" pin, without writing anything.
+
+    Its own BFF-style endpoint (root ``CLAUDE.md``, "BFF endpoints"): it fetches
+    on a user action — the previewer typing/blurring the venue fields — not on
+    page load, so it is not folded into a page endpoint. It resolves through the
+    same injected :class:`~app.geocoding.Geocoder` the create/edit write path
+    geocodes with, so the pin the previewer sees matches the coordinates a
+    subsequent write would record.
+
+    Gated on ``tournament.create``: previewing a venue is part of composing a
+    tournament, so the same grant that lets a user create one lets them preview
+    its location — this is deliberately not a wide-open geocoding proxy.
+
+    A zero-result / unresolvable address is the same coded ``422`` the write path
+    answers (:func:`_address_not_geocodable`, ``address_not_geocodable``), so the
+    preview and the write agree on the refusal. Any other geocoder failure
+    (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to the
+    ``500`` handler.
+    """
+    try:
+        result = await geocoder.geocode(address)
+    except AddressNotGeocodableError as exc:
+        raise _address_not_geocodable() from exc
+    return GeocodePreview(
+        latitude=result.latitude,
+        longitude=result.longitude,
+        formatted=result.formatted,
     )
 
 

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -257,8 +257,7 @@ def _near_me_or_422(
     returns ``None``; all three present returns the filter the haversine reads. Each
     value's own range is checked by the ``Query`` bounds on the handler, so this only
     decides the cross-field "present together or not at all" rule."""
-    provided = [lat, lng, radius_miles]
-    if all(v is None for v in provided):
+    if lat is None and lng is None and radius_miles is None:
         return None
     if lat is None or lng is None or radius_miles is None:
         raise HTTPException(

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -88,8 +88,8 @@ from app.tournament_events import create_event as create_event_core
 from app.tournament_events import delete_event as delete_event_core
 from app.tournament_events import update_event as update_event_core
 from app.tournament_geocoding import (
-    ADDRESS_NOT_GEOCODABLE_CODE,
     ADDRESS_NOT_GEOCODABLE_MESSAGE,
+    AddressNotGeocodable,
 )
 from app.tournament_lifecycle import create_tournament as create_tournament_core
 from app.tournament_lifecycle import delete_tournament as delete_tournament_core
@@ -171,26 +171,33 @@ router = APIRouter(prefix="/v1")
 
 
 def _address_not_geocodable() -> HTTPException:
-    """The 422 for a venue address that resolved to zero candidates (ADR "an
-    unresolvable address is a 422 at the boundary").
+    """The coded ``409`` for a venue address that resolved to zero candidates.
 
     A coded refusal, following the entry endpoint's ``entry_refused`` precedent
     (ADR-0968): the machine-readable ``code`` is the contract a client switches on, the
     ``message`` is fallback prose. The ``create``/``update`` verbs raise the
     transport-neutral ``AddressNotGeocodableError``; this adapter turns it into the
     ``{"detail": {"code": ..., "message": ...}}`` body — the same word
-    (:data:`ADDRESS_NOT_GEOCODABLE_CODE`) the MCP tool names in its ``ToolError``, so a
-    client holds one copy table whichever surface refused it. The address is
-    unresolvable in any state the tournament could be in, so it is a boundary 422, not a
-    state 409."""
+    (:data:`ADDRESS_NOT_GEOCODABLE_CODE`, carried on the :class:`AddressNotGeocodable`
+    model) the MCP tool names in its ``ToolError``, so a client holds one copy table
+    whichever surface refused it.
+
+    A ``409``, deliberately **not** a ``422``: FastAPI reserves ``422`` for its own
+    ``HTTPValidationError``, whose ``detail`` is an **array**, so a hand-rolled ``422``
+    object body drifts the generated ``schema.d.ts``/``Types.swift`` to a shape these
+    endpoints never return — and the strict-Codable iOS client cannot decode the real
+    object body (ADR-0968 rejects "one status, two body shapes" and uses coded ``409``).
+    The body is modeled (:class:`AddressNotGeocodable`) and declared on each route's
+    ``responses={409: ...}`` so the generated clients describe exactly what is sent."""
     return HTTPException(
-        # A bare ``422``, as the other tournament 422s here send (the
-        # ``status.HTTP_422_*`` alias is deprecated in the pinned Starlette).
-        status_code=422,
-        detail={
-            "code": ADDRESS_NOT_GEOCODABLE_CODE,
-            "message": ADDRESS_NOT_GEOCODABLE_MESSAGE,
-        },
+        status_code=409,
+        # ``AddressNotGeocodable`` carries the code (its default) + message;
+        # ``.model_dump`` gives the ``{"code", "message"}`` object FastAPI nests under
+        # ``detail`` — the same ``{"detail": {"code", "message"}}`` envelope the entry
+        # endpoint's coded refusals send (``entry_refused`` / ``_score_conflict``).
+        detail=AddressNotGeocodable(
+            message=ADDRESS_NOT_GEOCODABLE_MESSAGE
+        ).model_dump(),
     )
 
 
@@ -325,6 +332,7 @@ async def list_tournaments(
     response_model=TournamentRead,
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(require_create)],
+    responses={409: {"model": AddressNotGeocodable}},
 )
 async def create_tournament(
     payload: TournamentCreate,
@@ -335,11 +343,11 @@ async def create_tournament(
     # Thin adapter over the transport-neutral ``create_tournament`` verb: it owns
     # the STRICT (FastAPI-free) league resolution, the on-write geocode and the write,
     # and signals each refusal with a domain exception. This handler maps each back to
-    # the exact status + body it produced before, plus the new geocode-failure 422:
+    # the exact status + body it produced before, plus the geocode-failure 409:
     #
     #   LeagueNotFoundError         -> 404 "League not found."
     #   NoDefaultLeagueError        -> 500 "No default league configured."
-    #   AddressNotGeocodableError   -> 422 coded ``address_not_geocodable`` refusal
+    #   AddressNotGeocodableError   -> 409 coded ``address_not_geocodable`` refusal
     try:
         tournament = await create_tournament_core(
             db, actor=current_user, payload=payload, geocoder=geocoder
@@ -349,9 +357,9 @@ async def create_tournament(
         # never a silent fall back to the default (ADR-0783).
         raise HTTPException(status_code=404, detail="League not found.") from exc
     except AddressNotGeocodableError as exc:
-        # The venue address resolved to zero candidates: a coded 422 at the boundary,
-        # never a coordinate-less write (the columns are NOT NULL). The verb geocodes
-        # before ``db.add``, so nothing was written.
+        # The venue address resolved to zero candidates: a coded 409 refusal, never a
+        # coordinate-less write (the columns are NOT NULL). The verb geocodes before
+        # ``db.add``, so nothing was written.
         raise _address_not_geocodable() from exc
     except NoDefaultLeagueError as exc:
         # An omitted league binds the default, so a deployment with no default is a
@@ -370,6 +378,7 @@ async def create_tournament(
     "/geocode",
     response_model=GeocodePreview,
     dependencies=[Depends(require_create)],
+    responses={409: {"model": AddressNotGeocodable}},
 )
 async def preview_geocode(
     address: Annotated[str, Query(min_length=1)],
@@ -389,7 +398,7 @@ async def preview_geocode(
     tournament, so the same grant that lets a user create one lets them preview
     its location — this is deliberately not a wide-open geocoding proxy.
 
-    A zero-result / unresolvable address is the same coded ``422`` the write path
+    A zero-result / unresolvable address is the same coded ``409`` the write path
     answers (:func:`_address_not_geocodable`, ``address_not_geocodable``), so the
     preview and the write agree on the refusal. Any other geocoder failure
     (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to the
@@ -446,7 +455,11 @@ async def get_tournament(
     )
 
 
-@router.patch("/tournaments/{tournament_id}", response_model=TournamentRead)
+@router.patch(
+    "/tournaments/{tournament_id}",
+    response_model=TournamentRead,
+    responses={409: {"model": AddressNotGeocodable}},
+)
 async def update_tournament(
     tournament_id: uuid.UUID,
     payload: TournamentUpdate,
@@ -456,16 +469,16 @@ async def update_tournament(
 ) -> TournamentRead:
     # Thin adapter over the transport-neutral ``edit_tournament`` verb: it owns the
     # load-lock, the owner gate, the league state-rule, the STRICT league lookup, the
-    # on-write geocode of a changed address, the partial apply and the table-catalogue →
-    # re-solve trigger, and signals each refusal with a domain exception. This handler
-    # maps each back to the exact status + body it produced before, plus the new
-    # geocode-failure 422:
+    # before-lock geocode of a changed address, the partial apply and the
+    # table-catalogue → re-solve trigger, and signals each refusal with a domain
+    # exception. This handler maps each back to the exact status + body it produced
+    # before, plus the geocode-failure 409:
     #
     #   TournamentNotFoundError    -> 404 "Tournament not found."
     #   NotTournamentOwnerError    -> 403 "You can only modify tournaments you created."
     #   LeagueNotEditableError     -> 409 "This tournament is {status}; its league …"
     #   LeagueNotFoundError        -> 404 "League not found."
-    #   AddressNotGeocodableError  -> 422 coded ``address_not_geocodable`` refusal
+    #   AddressNotGeocodableError  -> 409 coded ``address_not_geocodable`` refusal
     try:
         tournament = await edit_tournament(
             db,
@@ -483,9 +496,9 @@ async def update_tournament(
         # for a ``league_id`` that names none is this adapter's alone.
         raise HTTPException(status_code=404, detail="League not found.") from exc
     except AddressNotGeocodableError as exc:
-        # A changed venue address resolved to zero candidates: the same coded 422 the
-        # create path answers. The verb geocodes before any ``setattr``/commit, so the
-        # edit wrote nothing.
+        # A changed venue address resolved to zero candidates: the same coded 409 the
+        # create path answers. The verb geocodes before the lock and before any
+        # ``setattr``/commit, so the edit wrote nothing.
         raise _address_not_geocodable() from exc
     # The owner is the current user, so the username and can_edit are known.
     return serialize(

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -1,7 +1,8 @@
 import hashlib
 import uuid
+from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from pyrate_limiter import Duration, Rate
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +14,8 @@ from app.draws import (
     NonSinglesDraw,
     UnsupportedDrawType,
 )
+from app.geocoding import AddressNotGeocodableError, Geocoder
+from app.geocoding.dependencies import get_geocoder
 from app.models import (
     Tournament,
     User,
@@ -83,10 +86,18 @@ from app.tournament_errors import (
 from app.tournament_events import create_event as create_event_core
 from app.tournament_events import delete_event as delete_event_core
 from app.tournament_events import update_event as update_event_core
+from app.tournament_geocoding import (
+    ADDRESS_NOT_GEOCODABLE_CODE,
+    ADDRESS_NOT_GEOCODABLE_MESSAGE,
+)
 from app.tournament_lifecycle import create_tournament as create_tournament_core
 from app.tournament_lifecycle import delete_tournament as delete_tournament_core
 from app.tournament_lifecycle import transition_tournament
-from app.tournament_list import list_tournament_details, tournament_detail
+from app.tournament_list import (
+    NearMeFilter,
+    list_tournament_details,
+    tournament_detail,
+)
 from app.tournament_placement import place_fixture as place_fixture_core
 from app.tournament_queries import visible_to as _visible_to
 from app.tournament_serialization import (
@@ -158,6 +169,30 @@ router = APIRouter(prefix="/v1")
 # the rule has one home the MCP tool shares too.
 
 
+def _address_not_geocodable() -> HTTPException:
+    """The 422 for a venue address that resolved to zero candidates (ADR "an
+    unresolvable address is a 422 at the boundary").
+
+    A coded refusal, following the entry endpoint's ``entry_refused`` precedent
+    (ADR-0968): the machine-readable ``code`` is the contract a client switches on, the
+    ``message`` is fallback prose. The ``create``/``update`` verbs raise the
+    transport-neutral ``AddressNotGeocodableError``; this adapter turns it into the
+    ``{"detail": {"code": ..., "message": ...}}`` body — the same word
+    (:data:`ADDRESS_NOT_GEOCODABLE_CODE`) the MCP tool names in its ``ToolError``, so a
+    client holds one copy table whichever surface refused it. The address is
+    unresolvable in any state the tournament could be in, so it is a boundary 422, not a
+    state 409."""
+    return HTTPException(
+        # A bare ``422``, as the other tournament 422s here send (the
+        # ``status.HTTP_422_*`` alias is deprecated in the pinned Starlette).
+        status_code=422,
+        detail={
+            "code": ADDRESS_NOT_GEOCODABLE_CODE,
+            "message": ADDRESS_NOT_GEOCODABLE_MESSAGE,
+        },
+    )
+
+
 # The transport-neutral tournament write verbs (``tournament_edit`` /
 # ``tournament_draw_service`` / ``tournament_solve_service``) each raise this closed
 # family of domain exceptions for the refusals that map identically across every
@@ -208,6 +243,33 @@ def _map_tournament_write_error(exc: _TournamentWriteError) -> HTTPException:
 # ----- tournament routes ---------------------------------------------------
 
 
+def _near_me_or_422(
+    *, lat: float | None, lng: float | None, radius_miles: float | None
+) -> NearMeFilter | None:
+    """Parse the list's ``lat``/``lng``/``radius_miles`` query triple into a
+    :class:`NearMeFilter`, enforcing **all-or-nothing** at the boundary.
+
+    The three are one filter, not three independent knobs: a point without a radius
+    (or a radius without a point) cannot describe "near me", so a *partial* triple is a
+    client bug worth a 422, not something to silently ignore (parse-at-boundaries). All
+    three absent is the unfiltered list — the request every caller already sends — and
+    returns ``None``; all three present returns the filter the haversine reads. Each
+    value's own range is checked by the ``Query`` bounds on the handler, so this only
+    decides the cross-field "present together or not at all" rule."""
+    provided = [lat, lng, radius_miles]
+    if all(v is None for v in provided):
+        return None
+    if lat is None or lng is None or radius_miles is None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "lat, lng and radius_miles must be supplied together (or all "
+                "omitted) to filter tournaments near a location."
+            ),
+        )
+    return NearMeFilter(lat=lat, lng=lng, radius_miles=radius_miles)
+
+
 @router.get(
     "/tournaments",
     response_model=list[TournamentDetailRead],
@@ -216,22 +278,45 @@ def _map_tournament_write_error(exc: _TournamentWriteError) -> HTTPException:
 async def list_tournaments(
     db: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
+    # ``Annotated`` (not ``= Query(...)``) so the runtime default is a real ``None``:
+    # the handler is called directly, without FastAPI, by the statement-count tripwire
+    # in tests/test_tournaments.py, and a ``Query(None)`` sentinel default would reach
+    # ``_near_me_or_422`` as a non-null value.
+    lat: Annotated[float | None, Query(ge=-90.0, le=90.0)] = None,
+    lng: Annotated[float | None, Query(ge=-180.0, le=180.0)] = None,
+    radius_miles: Annotated[float | None, Query(gt=0.0)] = None,
 ) -> list[TournamentDetailRead]:
+    """List the tournaments the caller may see, newest first, each as the full detail
+    aggregate the list cards render.
+
+    Pass an **all-or-nothing** `lat` / `lng` / `radius_miles` triple to filter to
+    tournaments **near a point**: only those whose venue is within `radius_miles` of
+    `(lat, lng)` come back, each carrying its `distance_miles` (a haversine
+    great-circle distance, in miles). Supplying some but not all three is a `422` — the
+    three describe one location filter, not three independent knobs. Omit all three
+    (the default) for every visible tournament, with `distance_miles` null.
+    """
     # The list page's cards render event-derived stats (event count, total
     # entries, table count), so the list returns the full aggregate — events, their
     # entrants and their draws included — rather than a thinner summary. The FIVE-query
     # batched read (no N+1, whatever the number of tournaments or events) lives in the
     # shared ``list_tournament_details`` so the MCP ``list_my_tournaments`` tool runs
-    # the exact same shape; this handler only supplies the WHERE.
+    # the exact same shape; this handler only supplies the WHERE and the optional
+    # near-me filter.
     #
     # Scoped by ``_visible_to``: somebody else's draft is not the caller's to see, so it
     # never enters the result set — and, because the filter is a WHERE clause on the
     # first of the five queries, the events and entrants queries are keyed off the
     # surviving ids and cannot leak a hidden tournament's contents either. A predicate
     # costs no extra statement, so the statement-count tripwire in
-    # tests/test_tournaments.py still reads the same count.
+    # tests/test_tournaments.py still reads the same count — the near-me distance column
+    # and radius WHERE ride on that same first query too.
+    near_me = _near_me_or_422(lat=lat, lng=lng, radius_miles=radius_miles)
     return await list_tournament_details(
-        db, where=_visible_to(current_user.id), current_user_id=current_user.id
+        db,
+        where=_visible_to(current_user.id),
+        current_user_id=current_user.id,
+        near_me=near_me,
     )
 
 
@@ -245,22 +330,29 @@ async def create_tournament(
     payload: TournamentCreate,
     db: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
+    geocoder: Geocoder = Depends(get_geocoder),
 ) -> TournamentRead:
     # Thin adapter over the transport-neutral ``create_tournament`` verb: it owns
-    # the STRICT (FastAPI-free) league resolution and the write, and signals each
-    # league refusal with a domain exception. This handler maps each back to the
-    # exact status + body it produced before, so the wire contract is unchanged:
+    # the STRICT (FastAPI-free) league resolution, the on-write geocode and the write,
+    # and signals each refusal with a domain exception. This handler maps each back to
+    # the exact status + body it produced before, plus the new geocode-failure 422:
     #
-    #   LeagueNotFoundError   -> 404 "League not found."
-    #   NoDefaultLeagueError  -> 500 "No default league configured."
+    #   LeagueNotFoundError         -> 404 "League not found."
+    #   NoDefaultLeagueError        -> 500 "No default league configured."
+    #   AddressNotGeocodableError   -> 422 coded ``address_not_geocodable`` refusal
     try:
         tournament = await create_tournament_core(
-            db, actor=current_user, payload=payload
+            db, actor=current_user, payload=payload, geocoder=geocoder
         )
     except LeagueNotFoundError as exc:
         # The STRICT resolution: a ``league_id`` that names no league is a 404,
         # never a silent fall back to the default (ADR-0783).
         raise HTTPException(status_code=404, detail="League not found.") from exc
+    except AddressNotGeocodableError as exc:
+        # The venue address resolved to zero candidates: a coded 422 at the boundary,
+        # never a coordinate-less write (the columns are NOT NULL). The verb geocodes
+        # before ``db.add``, so nothing was written.
+        raise _address_not_geocodable() from exc
     except NoDefaultLeagueError as exc:
         # An omitted league binds the default, so a deployment with no default is a
         # broken configuration — the 500 ``resolve_league`` raised inline before.
@@ -320,20 +412,27 @@ async def update_tournament(
     payload: TournamentUpdate,
     db: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
+    geocoder: Geocoder = Depends(get_geocoder),
 ) -> TournamentRead:
     # Thin adapter over the transport-neutral ``edit_tournament`` verb: it owns the
-    # load-lock, the owner gate, the league state-rule, the STRICT league lookup,
-    # the partial apply and the table-catalogue → re-solve trigger, and signals
-    # each refusal with a domain exception. This handler maps each back to the
-    # exact status + body it produced before, so the wire contract is unchanged:
+    # load-lock, the owner gate, the league state-rule, the STRICT league lookup, the
+    # on-write geocode of a changed address, the partial apply and the table-catalogue →
+    # re-solve trigger, and signals each refusal with a domain exception. This handler
+    # maps each back to the exact status + body it produced before, plus the new
+    # geocode-failure 422:
     #
-    #   TournamentNotFoundError  -> 404 "Tournament not found."
-    #   NotTournamentOwnerError  -> 403 "You can only modify tournaments you created."
-    #   LeagueNotEditableError   -> 409 "This tournament is {status}; its league …"
-    #   LeagueNotFoundError      -> 404 "League not found."
+    #   TournamentNotFoundError    -> 404 "Tournament not found."
+    #   NotTournamentOwnerError    -> 403 "You can only modify tournaments you created."
+    #   LeagueNotEditableError     -> 409 "This tournament is {status}; its league …"
+    #   LeagueNotFoundError        -> 404 "League not found."
+    #   AddressNotGeocodableError  -> 422 coded ``address_not_geocodable`` refusal
     try:
         tournament = await edit_tournament(
-            db, tournament_id=tournament_id, actor=current_user, updates=payload
+            db,
+            tournament_id=tournament_id,
+            actor=current_user,
+            updates=payload,
+            geocoder=geocoder,
         )
     except _TOURNAMENT_WRITE_ERRORS as exc:
         # Shared arms: the 404 (absent), the 403 (not the owner), and the 409
@@ -343,6 +442,11 @@ async def update_tournament(
         # Verb-specific: only the edit verb resolves a league, so the strict 404
         # for a ``league_id`` that names none is this adapter's alone.
         raise HTTPException(status_code=404, detail="League not found.") from exc
+    except AddressNotGeocodableError as exc:
+        # A changed venue address resolved to zero candidates: the same coded 422 the
+        # create path answers. The verb geocodes before any ``setattr``/commit, so the
+        # edit wrote nothing.
+        raise _address_not_geocodable() from exc
     # The owner is the current user, so the username and can_edit are known.
     return serialize(
         tournament,

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -408,6 +408,8 @@ async def test_merge_repoints_tournament_ownership(db_session: AsyncSession):
             "region": "CA",
             "postal": "94703",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[{"id": "t1", "label": "Table 1", "court": "A"}],
     )
@@ -467,6 +469,8 @@ async def _make_event(db: AsyncSession, owner: User) -> TournamentEvent:
             "region": "CA",
             "postal": "94703",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[{"id": "t1", "label": "Table 1", "court": "A"}],
     )
@@ -960,6 +964,8 @@ async def _make_rr_event(
                 "region": "CA",
                 "postal": "94703",
                 "country": "USA",
+                "latitude": 37.8703,
+                "longitude": -122.2731,
             },
             table_catalogue=[{"id": "t1", "label": "Table 1", "court": "A"}],
         )

--- a/api/tests/test_admin_schedule_solves.py
+++ b/api/tests/test_admin_schedule_solves.py
@@ -53,6 +53,8 @@ async def _make_tournament(db: AsyncSession, owner: User, name: str) -> uuid.UUI
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[],
         league_id=league.id,

--- a/api/tests/test_geocoder.py
+++ b/api/tests/test_geocoder.py
@@ -1,0 +1,155 @@
+"""Unit tests for the geocoding seam (chore 1a).
+
+None of these touch the network or a database: they exercise the deterministic
+``FakeGeocoder`` and the key-driven provider selection directly, and drive
+``GoogleGeocoder`` through an ``httpx`` mock transport.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.config import Settings
+from app.geocoding.dependencies import get_geocoder
+from app.geocoding.geocoder import (
+    UNRESOLVABLE_SENTINEL,
+    AddressNotGeocodableError,
+    FakeGeocoder,
+    GeocoderError,
+    GoogleGeocoder,
+    compose_address,
+)
+
+A_NORMAL_ADDRESS = "1600 Amphitheatre Parkway, Mountain View, CA 94043, USA"
+
+
+# --- provider selection -----------------------------------------------------
+
+
+def test_provider_returns_google_geocoder_when_key_is_set() -> None:
+    settings = Settings(google_geocoding_api_key="a-real-looking-key")
+    geocoder = get_geocoder(settings=settings)
+    assert isinstance(geocoder, GoogleGeocoder)
+
+
+def test_provider_returns_fake_geocoder_when_no_key() -> None:
+    settings = Settings(google_geocoding_api_key=None)
+    geocoder = get_geocoder(settings=settings)
+    assert isinstance(geocoder, FakeGeocoder)
+
+
+def test_provider_treats_empty_string_key_as_unconfigured() -> None:
+    settings = Settings(google_geocoding_api_key="")
+    geocoder = get_geocoder(settings=settings)
+    assert isinstance(geocoder, FakeGeocoder)
+
+
+# --- FakeGeocoder: determinism ----------------------------------------------
+
+
+async def test_fake_geocoder_is_deterministic() -> None:
+    fake = FakeGeocoder()
+    first = await fake.geocode(A_NORMAL_ADDRESS)
+    second = await fake.geocode(A_NORMAL_ADDRESS)
+    assert first == second
+
+
+async def test_fake_geocoder_coordinates_are_in_range() -> None:
+    fake = FakeGeocoder()
+    result = await fake.geocode(A_NORMAL_ADDRESS)
+    assert -90.0 <= result.latitude <= 90.0
+    assert -180.0 <= result.longitude <= 180.0
+    assert result.formatted == A_NORMAL_ADDRESS
+
+
+async def test_fake_geocoder_normalizes_before_hashing() -> None:
+    fake = FakeGeocoder()
+    spaced = await fake.geocode("  1600   Amphitheatre  Parkway  ")
+    tidy = await fake.geocode("1600 Amphitheatre Parkway")
+    assert (spaced.latitude, spaced.longitude) == (tidy.latitude, tidy.longitude)
+
+
+async def test_fake_geocoder_maps_distinct_addresses_apart() -> None:
+    fake = FakeGeocoder()
+    one = await fake.geocode("Somewhere, City A")
+    two = await fake.geocode("Elsewhere, City B")
+    assert (one.latitude, one.longitude) != (two.latitude, two.longitude)
+
+
+# --- FakeGeocoder: the unresolvable sentinel --------------------------------
+
+
+async def test_fake_geocoder_raises_for_the_sentinel_token() -> None:
+    fake = FakeGeocoder()
+    address = compose_address(
+        venue=UNRESOLVABLE_SENTINEL,
+        street="1 Nowhere Rd",
+        city="Nulltown",
+        region="NA",
+        postal="00000",
+        country="Nowhereland",
+    )
+    with pytest.raises(AddressNotGeocodableError):
+        await fake.geocode(address)
+
+
+async def test_fake_geocoder_raises_for_empty_address() -> None:
+    fake = FakeGeocoder()
+    with pytest.raises(AddressNotGeocodableError):
+        await fake.geocode("   ")
+
+
+# --- GoogleGeocoder: no real network, via a mock transport ------------------
+
+
+def _google_client(handler: httpx.MockTransport) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=handler)
+
+
+async def test_google_geocoder_takes_the_top_candidate() -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "status": "OK",
+                "results": [
+                    {
+                        "formatted_address": "Top Match, City",
+                        "geometry": {"location": {"lat": 37.42, "lng": -122.08}},
+                    },
+                    {
+                        "formatted_address": "Runner Up, City",
+                        "geometry": {"location": {"lat": 1.0, "lng": 2.0}},
+                    },
+                ],
+            },
+        )
+
+    async with _google_client(httpx.MockTransport(handle)) as client:
+        geocoder = GoogleGeocoder(api_key="k", client=client)
+        result = await geocoder.geocode(A_NORMAL_ADDRESS)
+
+    assert result.latitude == 37.42
+    assert result.longitude == -122.08
+    assert result.formatted == "Top Match, City"
+
+
+async def test_google_geocoder_raises_not_geocodable_on_zero_results() -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"status": "ZERO_RESULTS", "results": []})
+
+    async with _google_client(httpx.MockTransport(handle)) as client:
+        geocoder = GoogleGeocoder(api_key="k", client=client)
+        with pytest.raises(AddressNotGeocodableError):
+            await geocoder.geocode(A_NORMAL_ADDRESS)
+
+
+async def test_google_geocoder_propagates_provider_error_status() -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"status": "REQUEST_DENIED", "results": []})
+
+    async with _google_client(httpx.MockTransport(handle)) as client:
+        geocoder = GoogleGeocoder(api_key="k", client=client)
+        with pytest.raises(GeocoderError):
+            await geocoder.geocode(A_NORMAL_ADDRESS)

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -118,6 +118,8 @@ async def _make_tournament(
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": table, "label": table.upper(), "court": "Main"} for table in tables

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -1539,6 +1539,8 @@ async def _seed_owned_tournament(
             "region": "CA",
             "postal": "94607",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[],
         league_id=league.id,
@@ -2096,6 +2098,8 @@ async def _seed_drawable_tournament(
             "region": "CA",
             "postal": "94703",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": "t1", "label": "Table 1", "court": "A"},
@@ -2561,6 +2565,8 @@ async def _seed_previewable_tournament(
             "region": "CA",
             "postal": "94703",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": "t1", "label": "Table 1", "court": "A"},
@@ -2851,6 +2857,43 @@ async def test_create_tournament_without_permission_raises_tool_error(
             )
 
     # Nothing was created.
+    db_session.expire_all()
+    assert (
+        await db_session.execute(
+            select(Tournament).where(Tournament.created_by_user_id == me_id)
+        )
+    ).scalar_one_or_none() is None
+
+
+async def test_create_tournament_unresolvable_address_raises_tool_error(
+    db_session: AsyncSession,
+) -> None:
+    """A venue address the geocoder cannot resolve (the ``FakeGeocoder``
+    ``__unresolvable__`` sentinel) surfaces as a ``ToolError`` naming the same
+    machine-readable code the HTTP surface answers with (``address_not_geocodable``),
+    and nothing is created — the coordinate NOT NULL invariant holds on the MCP path
+    too (ADR "an unresolvable address is a 422 at the boundary")."""
+    me = await make_user(db_session, "mcp-create-bad-address")
+    me_id = me.id
+    await grant_permissions(db_session, me, [TOURNAMENT_CREATE])
+    raw = await _mint(db_session, me)
+    payload: dict[str, object] = {
+        **_tournament_payload(),
+        "address": {
+            "venue": "__unresolvable__",
+            "street": "2727 Milvia St",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94703",
+            "country": "USA",
+        },
+    }
+
+    async with _mcp_client(raw) as client, client:
+        with pytest.raises(ToolError, match="address_not_geocodable"):
+            await client.call_tool("create_tournament", {"payload": payload})
+
+    # Nothing was created — the geocode failed before the write.
     db_session.expire_all()
     assert (
         await db_session.execute(
@@ -3878,6 +3921,8 @@ async def _seed_placeable_fixture(
             "region": "CA",
             "postal": "94703",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": "t1", "label": "Table 1", "court": "A"},

--- a/api/tests/test_realtime_publishing_calls.py
+++ b/api/tests/test_realtime_publishing_calls.py
@@ -100,6 +100,8 @@ async def _stage(
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": "t1", "label": "T1", "court": "Main"},

--- a/api/tests/test_realtime_publishing_tournaments.py
+++ b/api/tests/test_realtime_publishing_tournaments.py
@@ -165,6 +165,8 @@ async def _seed_field(
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": table, "label": table.upper(), "court": "Main"} for table in tables

--- a/api/tests/test_schedule_preview_route.py
+++ b/api/tests/test_schedule_preview_route.py
@@ -110,6 +110,8 @@ async def _make_tournament(
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=TABLE_CATALOGUE,
         league_id=league.id,

--- a/api/tests/test_schedule_preview_snapshot.py
+++ b/api/tests/test_schedule_preview_snapshot.py
@@ -72,6 +72,8 @@ async def _make_tournament(
             "region": "CA",
             "postal": "94703",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=TABLE_CATALOGUE,
         league_id=league.id,

--- a/api/tests/test_schedule_preview_solve.py
+++ b/api/tests/test_schedule_preview_solve.py
@@ -129,6 +129,8 @@ async def _make_tournament(
             "region": "CA",
             "postal": "94703",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=TABLE_CATALOGUE,
         league_id=league.id,

--- a/api/tests/test_schedule_solve_models.py
+++ b/api/tests/test_schedule_solve_models.py
@@ -60,6 +60,8 @@ async def _make_tournament(db_session: AsyncSession) -> Tournament:
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         league_id=league.id,
         created_by_user_id=owner.id,

--- a/api/tests/test_schedule_solve_queries.py
+++ b/api/tests/test_schedule_solve_queries.py
@@ -37,6 +37,8 @@ async def _make_tournament(db: AsyncSession, owner: User, name: str) -> uuid.UUI
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[],
         league_id=league.id,

--- a/api/tests/test_schedule_solve_route.py
+++ b/api/tests/test_schedule_solve_route.py
@@ -132,6 +132,8 @@ async def _make_tournament(
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": table, "label": table.upper(), "court": "Main"} for table in tables

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -157,6 +157,8 @@ async def _make_tournament(
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": table, "label": table.upper(), "court": "Main"} for table in tables

--- a/api/tests/test_schedule_triggers.py
+++ b/api/tests/test_schedule_triggers.py
@@ -94,6 +94,8 @@ async def _make_tournament(
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": table, "label": table.upper(), "court": "Main"} for table in tables

--- a/api/tests/test_tournament_draw_service.py
+++ b/api/tests/test_tournament_draw_service.py
@@ -72,6 +72,8 @@ async def _make_tournament(
             "region": "CA",
             "postal": "94703",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": "t1", "label": "Table 1", "court": "A"},

--- a/api/tests/test_tournament_edit.py
+++ b/api/tests/test_tournament_edit.py
@@ -17,7 +17,12 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.geocoding import AddressNotGeocodableError, FakeGeocoder, compose_address
+from app.geocoding import (
+    AddressNotGeocodableError,
+    FakeGeocoder,
+    GeocodeResult,
+    compose_address,
+)
 from app.models import (
     League,
     LeagueVisibility,
@@ -46,6 +51,25 @@ from tests._helpers import make_user
 # (the same one ``get_geocoder`` hands out with no ``GOOGLE_GEOCODING_API_KEY``). A
 # service-layer test builds it directly, exactly as it constructs the raw session.
 _GEOCODER = FakeGeocoder()
+
+
+class _CountingGeocoder:
+    """A ``Geocoder`` that records how many times it was asked to geocode, delegating to
+    the deterministic ``FakeGeocoder`` so results stay stable.
+
+    Lets a test assert the edit verb geocodes **only** when the address text actually
+    changes — a name-only edit, or one that resubmits the identical address, must never
+    pay for a geocode (and, in production, must never hold the row lock across the
+    network call). Structurally satisfies the ``Geocoder`` protocol, so it is injected
+    exactly where the real geocoder would be."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self._inner = FakeGeocoder()
+
+    async def geocode(self, address: str) -> GeocodeResult:
+        self.calls += 1
+        return await self._inner.geocode(address)
 
 
 async def _geocoded(address: dict[str, str]) -> dict[str, object]:
@@ -247,6 +271,110 @@ async def test_unresolvable_new_address_raises_and_writes_nothing(
     ).scalar_one()
     assert row.name == "Bay Area Open 2026"
     assert row.address == _stored_address()
+
+
+# ----- geocode ONLY when the address text actually changes -------------------
+
+
+async def test_name_only_edit_does_not_geocode(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A patch that carries no address geocodes nothing — the stored address and its
+    coordinates are left untouched, and the geocoder is never called."""
+    owner = await make_user(db_session, "owner-name-only")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+
+    counting = _CountingGeocoder()
+    await edit_tournament(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        updates=TournamentUpdate(name="Renamed, Same Venue"),
+        geocoder=counting,
+    )
+
+    assert counting.calls == 0
+    db_session.expire_all()
+    row = (
+        await db_session.execute(
+            select(Tournament).where(Tournament.id == tournament_id)
+        )
+    ).scalar_one()
+    assert row.name == "Renamed, Same Venue"
+    # The stored address — coordinates included — did not move.
+    assert row.address == _stored_address()
+
+
+async def test_resubmitting_the_identical_address_does_not_geocode(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """Resubmitting the SAME six address text fields (as the web client does on every
+    edit) geocodes nothing — the six stored text fields are unchanged, so the stored
+    coordinates are preserved rather than recomputed. Only the other edited field moves.
+    """
+    owner = await make_user(db_session, "owner-same-address")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+
+    counting = _CountingGeocoder()
+    await edit_tournament(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        # The address is byte-for-byte the stored one; only the name changes.
+        updates=TournamentUpdate(
+            name="Bay Area Major",
+            address=AddressInput(**_address()),
+        ),
+        geocoder=counting,
+    )
+
+    assert counting.calls == 0
+    db_session.expire_all()
+    row = (
+        await db_session.execute(
+            select(Tournament).where(Tournament.id == tournament_id)
+        )
+    ).scalar_one()
+    assert row.name == "Bay Area Major"
+    # The stored coordinates were kept, not re-derived (the seed's coordinates are NOT
+    # the ``FakeGeocoder`` output for this address, so a stray re-geocode would show).
+    assert row.address == _stored_address()
+
+
+async def test_changed_address_geocodes_exactly_once(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A genuinely different address IS geocoded — exactly once — and the stored
+    coordinates are the ones the geocoder resolved, beside the new six text fields."""
+    owner = await make_user(db_session, "owner-new-address")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+
+    counting = _CountingGeocoder()
+    new_address = {**_address(), "venue": "Palo Alto Community Center"}
+    result = await edit_tournament(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        updates=TournamentUpdate(address=AddressInput(**new_address)),
+        geocoder=counting,
+    )
+
+    assert counting.calls == 1
+    # The new venue's six text fields plus the coordinates the geocoder resolved.
+    assert result.address == await _geocoded(new_address)
+    db_session.expire_all()
+    row = (
+        await db_session.execute(
+            select(Tournament).where(Tournament.id == tournament_id)
+        )
+    ).scalar_one()
+    assert row.address == await _geocoded(new_address)
 
 
 # ----- non-owner is refused with a domain exception -------------------------

--- a/api/tests/test_tournament_edit.py
+++ b/api/tests/test_tournament_edit.py
@@ -17,6 +17,7 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.geocoding import AddressNotGeocodableError, FakeGeocoder, compose_address
 from app.models import (
     League,
     LeagueVisibility,
@@ -31,7 +32,7 @@ from app.models import (
     User,
 )
 from app.models.tournament import DrawType, EventFormat
-from app.schemas.tournament import Address, TournamentTable, TournamentUpdate
+from app.schemas.tournament import AddressInput, TournamentTable, TournamentUpdate
 from app.tournament_edit import edit_tournament
 from app.tournament_errors import (
     LeagueNotEditableError,
@@ -40,6 +41,19 @@ from app.tournament_errors import (
     TournamentNotFoundError,
 )
 from tests._helpers import make_user
+
+# The keyless deterministic geocoder the edit verb re-geocodes a changed address with
+# (the same one ``get_geocoder`` hands out with no ``GOOGLE_GEOCODING_API_KEY``). A
+# service-layer test builds it directly, exactly as it constructs the raw session.
+_GEOCODER = FakeGeocoder()
+
+
+async def _geocoded(address: dict[str, str]) -> dict[str, object]:
+    """The stored address dict the verb writes for ``address``: its six text fields
+    plus the coordinates the deterministic ``FakeGeocoder`` resolves them to — computed
+    through the very geocoder the verb uses, so the expectation cannot drift from it."""
+    result = await _GEOCODER.geocode(compose_address(**address))
+    return {**address, "latitude": result.latitude, "longitude": result.longitude}
 
 
 @pytest_asyncio.fixture
@@ -62,6 +76,9 @@ async def other_league(
 
 
 def _address() -> dict[str, str]:
+    # The write shape (``AddressInput``): six text components, no coordinates. Used
+    # to build ``TournamentUpdate`` payloads. Stored seeds add coordinates via
+    # ``_stored_address``.
     return {
         "venue": "Berkeley TT Club",
         "street": "2727 Milvia St",
@@ -70,6 +87,12 @@ def _address() -> dict[str, str]:
         "postal": "94703",
         "country": "USA",
     }
+
+
+def _stored_address() -> dict[str, object]:
+    # The stored/read shape a ``Tournament`` row holds: the write fields plus the
+    # NOT NULL geocoded coordinates.
+    return {**_address(), "latitude": 37.8703, "longitude": -122.2731}
 
 
 async def _make_tournament(
@@ -83,7 +106,7 @@ async def _make_tournament(
     tournament = Tournament(
         name="Bay Area Open 2026",
         description="Two-day open.",
-        address=_address(),
+        address=_stored_address(),
         table_catalogue=table_catalogue
         or [
             {"id": "t1", "label": "Table 1", "court": "A"},
@@ -166,12 +189,16 @@ async def test_owner_edit_updates_and_persists(
         actor=owner,
         updates=TournamentUpdate(
             name="Bay Area Major",
-            address=Address(**new_address),
+            address=AddressInput(**new_address),
         ),
+        geocoder=_GEOCODER,
     )
 
+    # The changed address is re-geocoded on write: the stored value is the six text
+    # fields plus the coordinates the geocoder resolved (NOT NULL, ADR-geocoded venues).
+    expected_address = await _geocoded(new_address)
     assert result.name == "Bay Area Major"
-    assert result.address == new_address
+    assert result.address == expected_address
     # The edit does not touch the lifecycle.
     assert result.status is TournamentStatus.draft
 
@@ -183,7 +210,43 @@ async def test_owner_edit_updates_and_persists(
         )
     ).scalar_one()
     assert row.name == "Bay Area Major"
-    assert row.address == new_address
+    assert row.address == expected_address
+
+
+async def test_unresolvable_new_address_raises_and_writes_nothing(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A changed address the geocoder cannot resolve (the ``FakeGeocoder``
+    ``__unresolvable__`` sentinel) raises ``AddressNotGeocodableError`` before any
+    field is written — the edit is atomic, so the stored address (and its coordinates)
+    is left exactly as it was. The verb never writes a coordinate-less address."""
+    owner = await make_user(db_session, "owner-bad-address")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+
+    bad_address = {**_address(), "venue": "__unresolvable__"}
+    with pytest.raises(AddressNotGeocodableError):
+        await edit_tournament(
+            db_session,
+            tournament_id=tournament_id,
+            actor=owner,
+            updates=TournamentUpdate(
+                name="Should Not Persist",
+                address=AddressInput(**bad_address),
+            ),
+            geocoder=_GEOCODER,
+        )
+
+    # Nothing was written: neither the name nor the original stored address moved.
+    db_session.expire_all()
+    row = (
+        await db_session.execute(
+            select(Tournament).where(Tournament.id == tournament_id)
+        )
+    ).scalar_one()
+    assert row.name == "Bay Area Open 2026"
+    assert row.address == _stored_address()
 
 
 # ----- non-owner is refused with a domain exception -------------------------
@@ -204,6 +267,7 @@ async def test_non_owner_raises_not_owner(
             tournament_id=tournament_id,
             actor=stranger,
             updates=TournamentUpdate(name="Hijack"),
+            geocoder=_GEOCODER,
         )
 
     # Nothing was written.
@@ -228,6 +292,7 @@ async def test_missing_tournament_raises_not_found(
             tournament_id=uuid.uuid4(),
             actor=owner,
             updates=TournamentUpdate(name="Nowhere"),
+            geocoder=_GEOCODER,
         )
 
 
@@ -248,6 +313,7 @@ async def test_league_change_while_draft_moves_the_ladder(
         tournament_id=tournament_id,
         actor=owner,
         updates=TournamentUpdate(league_id=other_league.id),
+        geocoder=_GEOCODER,
     )
 
     assert result.league_id == other_league.id
@@ -277,6 +343,7 @@ async def test_league_change_after_publish_raises_not_editable(
             tournament_id=tournament_id,
             actor=owner,
             updates=TournamentUpdate(league_id=other_league.id),
+            geocoder=_GEOCODER,
         )
 
     # Carries the current status, so the HTTP adapter can rebuild the exact 409
@@ -301,6 +368,7 @@ async def test_league_that_names_no_league_raises_not_found(
             tournament_id=tournament_id,
             actor=owner,
             updates=TournamentUpdate(league_id=uuid.uuid4()),
+            geocoder=_GEOCODER,
         )
 
     # The STRICT lookup did not silently swap the ladder to the default.
@@ -338,6 +406,7 @@ async def test_table_catalogue_change_on_a_drawn_tournament_requests_a_solve(
                 TournamentTable(id="t3", label="Table 3", court="B"),
             ]
         ),
+        geocoder=_GEOCODER,
     )
 
     (solve,) = await _queued_solves(db_session, tournament_id)
@@ -364,6 +433,7 @@ async def test_table_catalogue_change_without_a_draw_requests_no_solve(
                 TournamentTable(id="t9", label="Table 9", court="C"),
             ]
         ),
+        geocoder=_GEOCODER,
     )
 
     assert await _queued_solves(db_session, tournament_id) == []

--- a/api/tests/test_tournament_entries.py
+++ b/api/tests/test_tournament_entries.py
@@ -146,6 +146,8 @@ async def _make_event(
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         league_id=league.id,
         created_by_user_id=owner.id,

--- a/api/tests/test_tournament_events.py
+++ b/api/tests/test_tournament_events.py
@@ -45,6 +45,8 @@ from tests._helpers import make_user
 
 
 def _address() -> Address:
+    # The stored/read shape: it seeds a ``Tournament`` row's JSONB address, which
+    # carries the NOT NULL geocoded coordinates.
     return Address(
         venue="Berkeley TT Club",
         street="2727 Milvia St",
@@ -52,6 +54,8 @@ def _address() -> Address:
         region="CA",
         postal="94703",
         country="USA",
+        latitude=37.8703,
+        longitude=-122.2731,
     )
 
 

--- a/api/tests/test_tournament_fixtures.py
+++ b/api/tests/test_tournament_fixtures.py
@@ -69,6 +69,8 @@ async def _make_event(db_session: AsyncSession) -> TournamentEvent:
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         league_id=league.id,
         created_by_user_id=owner.id,

--- a/api/tests/test_tournament_lifecycle.py
+++ b/api/tests/test_tournament_lifecycle.py
@@ -17,6 +17,7 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.geocoding import FakeGeocoder
 from app.models import (
     DrawType,
     EventFormat,
@@ -34,7 +35,7 @@ from app.models import (
     TournamentStatus,
     User,
 )
-from app.schemas.tournament import Address, TournamentCreate, TournamentTable
+from app.schemas.tournament import AddressInput, TournamentCreate, TournamentTable
 from app.tournament_draws import cut_draw
 from app.tournament_errors import (
     IllegalTournamentTransitionError,
@@ -51,6 +52,11 @@ from app.tournament_lifecycle import (
     transition_tournament,
 )
 from tests._helpers import make_user
+
+# The keyless deterministic geocoder the create verb resolves the venue address with
+# (the same one ``get_geocoder`` hands out with no ``GOOGLE_GEOCODING_API_KEY``). A
+# service-layer test builds it directly, exactly as it constructs the raw session.
+_GEOCODER = FakeGeocoder()
 
 
 @pytest_asyncio.fixture
@@ -72,8 +78,10 @@ async def other_league(
     return league
 
 
-def _address() -> Address:
-    return Address(
+def _address() -> AddressInput:
+    """The write-shape address a client sends on create — no coordinates (1c's
+    verb geocodes it). Stored seeds add coordinates via ``_stored_address``."""
+    return AddressInput(
         venue="Berkeley TT Club",
         street="2727 Milvia St",
         city="Berkeley",
@@ -81,6 +89,12 @@ def _address() -> Address:
         postal="94703",
         country="USA",
     )
+
+
+def _stored_address() -> dict[str, object]:
+    """The stored/read-shape address dict a ``Tournament`` row holds: the write
+    fields plus the NOT NULL geocoded coordinates."""
+    return {**_address().model_dump(), "latitude": 37.8703, "longitude": -122.2731}
 
 
 def _payload(*, league_id: uuid.UUID | None = None) -> TournamentCreate:
@@ -103,7 +117,9 @@ async def test_create_persists_a_draft_owned_by_the_actor(
     actor = await make_user(db_session, "lifecycle-create-owner")
     actor_id = actor.id
 
-    tournament = await create_tournament(db_session, actor=actor, payload=_payload())
+    tournament = await create_tournament(
+        db_session, actor=actor, payload=_payload(), geocoder=_GEOCODER
+    )
 
     assert tournament.created_by_user_id == actor.id
     # Born ``draft`` from the column default — never set on the create path.
@@ -134,7 +150,10 @@ async def test_create_naming_a_league_runs_on_that_league(
     actor = await make_user(db_session, "lifecycle-create-league")
 
     tournament = await create_tournament(
-        db_session, actor=actor, payload=_payload(league_id=other_league.id)
+        db_session,
+        actor=actor,
+        payload=_payload(league_id=other_league.id),
+        geocoder=_GEOCODER,
     )
 
     assert tournament.league_id == other_league.id
@@ -149,7 +168,10 @@ async def test_create_naming_a_missing_league_raises_not_found(
 
     with pytest.raises(LeagueNotFoundError):
         await create_tournament(
-            db_session, actor=actor, payload=_payload(league_id=uuid.uuid4())
+            db_session,
+            actor=actor,
+            payload=_payload(league_id=uuid.uuid4()),
+            geocoder=_GEOCODER,
         )
 
     # The STRICT resolution created nothing.
@@ -174,7 +196,9 @@ async def test_create_without_a_league_and_no_default_raises(
     await db_session.commit()
 
     with pytest.raises(NoDefaultLeagueError):
-        await create_tournament(db_session, actor=actor, payload=_payload())
+        await create_tournament(
+            db_session, actor=actor, payload=_payload(), geocoder=_GEOCODER
+        )
 
 
 # ----- delete --------------------------------------------------------------
@@ -185,7 +209,7 @@ async def _make_tournament(
 ) -> Tournament:
     tournament = Tournament(
         name="Deletable Cup",
-        address=_address().model_dump(),
+        address=_stored_address(),
         table_catalogue=[],
         league_id=league.id,
         created_by_user_id=owner.id,
@@ -272,7 +296,7 @@ async def _make_tournament_at(
     it)."""
     tournament = Tournament(
         name="Lifecycle Cup",
-        address=_address().model_dump(),
+        address=_stored_address(),
         table_catalogue=[
             {"id": "t1", "label": "Table 1", "court": "A"},
             {"id": "t2", "label": "Table 2", "court": "A"},

--- a/api/tests/test_tournament_placement.py
+++ b/api/tests/test_tournament_placement.py
@@ -71,6 +71,8 @@ async def _seed_placeable_fixture(
             "region": "CA",
             "postal": "94703",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": "t1", "label": "Table 1", "court": "A"},

--- a/api/tests/test_tournament_solve_service.py
+++ b/api/tests/test_tournament_solve_service.py
@@ -84,6 +84,8 @@ async def _make_tournament(
             "region": "CA",
             "postal": "94704",
             "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
         },
         table_catalogue=[
             {"id": table, "label": table.upper(), "court": "Main"} for table in tables

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -228,6 +228,66 @@ async def test_create_with_unresolvable_address_is_422_and_creates_nothing(
     assert count == 0
 
 
+# ----- GET /v1/geocode address preview -------------------------------------
+
+
+async def test_geocode_preview_resolves_an_address(
+    authed_client: tuple[AsyncClient, User],
+):
+    """The read-only preview endpoint resolves a free-text address string to the
+    coordinates + formatted label the injected ``FakeGeocoder`` deterministically
+    returns for it, so the web "Preview location" pin matches what a subsequent
+    write would record."""
+    client, _ = authed_client
+    query = "Berkeley TT Club, 2727 Milvia St, Berkeley, CA"
+
+    response = await client.get("/v1/geocode", params={"address": query})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # Assert against the very ``FakeGeocoder`` the keyless test env resolves with,
+    # so the preview's coordinates cannot drift from the seam's output.
+    expected = await FakeGeocoder().geocode(query)
+    assert body == {
+        "latitude": expected.latitude,
+        "longitude": expected.longitude,
+        "formatted": expected.formatted,
+    }
+
+
+async def test_geocode_preview_unresolvable_address_is_the_coded_422(
+    authed_client: tuple[AsyncClient, User],
+):
+    """An address the geocoder cannot resolve is the same coded 422 the write path
+    answers — the machine-readable ``address_not_geocodable`` code (ADR-0968), so
+    the preview and the write agree on the refusal. Uses the deterministic
+    ``FakeGeocoder`` sentinel so the zero-result path is exercised with no
+    network."""
+    client, _ = authed_client
+
+    response = await client.get("/v1/geocode", params={"address": "__unresolvable__"})
+
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"]["code"] == "address_not_geocodable"
+
+
+async def test_geocode_preview_requires_the_create_permission(
+    db_session: AsyncSession,
+):
+    """The preview is gated on ``tournament.create`` — the same grant that lets a
+    user compose a tournament lets them preview its venue. A bare guest session
+    with no tournament permissions is 403, exactly as the create route rejects
+    them; it is not a wide-open geocoding proxy."""
+    async with make_client() as client:
+        await start_session(client, db_session)
+
+        response = await client.get(
+            "/v1/geocode", params={"address": "Berkeley TT Club, Berkeley, CA"}
+        )
+
+        assert response.status_code == 403, response.text
+
+
 async def test_create_is_born_draft_from_the_column_default(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -12,6 +12,7 @@ carry the double-submit CSRF token via ``CSRF_EVENT_HOOKS`` (baked into both the
 
 import asyncio
 import json
+import math
 import uuid
 from collections.abc import AsyncIterator, Sequence
 from datetime import UTC, datetime, timedelta
@@ -32,6 +33,7 @@ from sqlalchemy.orm import selectinload
 from app import match_calls
 from app.account_merge import merge_user
 from app.draws import DrawError
+from app.geocoding import FakeGeocoder, compose_address
 from app.leagues import seed_user_league_rating
 from app.models import (
     League,
@@ -121,6 +123,18 @@ def _address() -> dict[str, str]:
     }
 
 
+async def _geocoded_address(address: dict[str, str]) -> dict[str, object]:
+    """The stored/read address a created or edited tournament carries: the six text
+    fields the client sent plus the coordinates the server geocoded on write (NOT NULL,
+    ADR "a venue's coordinates are geocoded server-side ... and are NOT NULL").
+
+    Computed through the very ``FakeGeocoder`` the keyless test env resolves with (
+    ``get_geocoder`` returns it with no ``GOOGLE_GEOCODING_API_KEY``), so the expected
+    coordinates cannot drift from what the write path actually produced."""
+    result = await FakeGeocoder().geocode(compose_address(**address))
+    return {**address, "latitude": result.latitude, "longitude": result.longitude}
+
+
 def _create_payload(**overrides: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "name": "Bay Area Open 2026",
@@ -177,7 +191,9 @@ async def test_create_tournament_returns_201(
     assert body["status"] == "draft"
     assert body["start_date"] == "2026-06-13"
     assert body["end_date"] == "2026-06-14"
-    assert body["address"] == _address()
+    # The venue address is geocoded on write: the read carries the six text fields the
+    # client sent PLUS the server-resolved coordinates (NOT NULL).
+    assert body["address"] == await _geocoded_address(_address())
     assert body["table_catalogue"] == [
         {"id": "t1", "label": "Table 1", "court": "A"},
         {"id": "t2", "label": "Table 2", "court": "A"},
@@ -185,6 +201,31 @@ async def test_create_tournament_returns_201(
     assert body["can_edit"] is True
     assert body["created_by_username"] == user.username
     assert body["created_by_user_id"] == str(user.id)
+
+
+async def test_create_with_unresolvable_address_is_422_and_creates_nothing(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+):
+    """A venue address the geocoder cannot resolve is a coded 422 at the boundary, and
+    the write is atomic — no coordinate-less row is created (ADR "an unresolvable
+    address is a 422 at the boundary").
+
+    Uses the deterministic ``FakeGeocoder`` sentinel (``__unresolvable__``) so the
+    zero-result path is exercised with no network. The body carries the machine-readable
+    ``address_not_geocodable`` code (ADR-0968) the MCP surface names too.
+    """
+    client, _ = authed_client
+    bad = {**_address(), "venue": "__unresolvable__"}
+    response = await client.post("/v1/tournaments", json=_create_payload(address=bad))
+
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"]["code"] == "address_not_geocodable"
+    # A 422 that had already written a row would be a 422 in name only.
+    count = (
+        await db_session.execute(select(func.count()).select_from(Tournament))
+    ).scalar_one()
+    assert count == 0
 
 
 async def test_create_is_born_draft_from_the_column_default(
@@ -299,9 +340,38 @@ async def test_patch_by_creator_updates_fields(
     assert body["name"] == "Bay Area Major"
     assert body["start_date"] == "2026-08-01"
     assert body["end_date"] == "2026-08-02"
-    assert body["address"] == new_address
+    # The changed address is re-geocoded on write, so the read carries the new venue's
+    # server-resolved coordinates alongside the six text fields.
+    assert body["address"] == await _geocoded_address(new_address)
     # Editing the tournament does not touch where it is in its lifecycle.
     assert body["status"] == "draft"
+
+
+async def test_patch_with_unresolvable_address_is_422_and_leaves_the_address(
+    authed_client: tuple[AsyncClient, User],
+):
+    """Editing the venue to an address the geocoder cannot resolve is the same coded
+    422 the create path answers, and the edit is atomic — the stored address (and its
+    coordinates) is left unchanged.
+
+    Re-reads the address afterwards rather than trusting the 422: a handler that wrote
+    the coordinate-less address and *then* failed would pass a status-code-only
+    assertion.
+    """
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    original_address = created["address"]
+
+    bad = {**_address(), "venue": "__unresolvable__"}
+    response = await client.patch(
+        f"/v1/tournaments/{created['id']}", json={"address": bad}
+    )
+
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"]["code"] == "address_not_geocodable"
+    # The stored address did not move — including its coordinates.
+    read_back = (await client.get(f"/v1/tournaments/{created['id']}")).json()
+    assert read_back["address"] == original_address
 
 
 async def test_patch_explicit_null_name_returns_422(
@@ -1641,6 +1711,202 @@ async def test_list_tournaments_statement_count_does_not_grow_with_events(
         == [("p-a", 1, 1), ("p-a", 1, 2)]
         for e in tournament.events
     )
+
+
+# ----- near-me radius filter (ADR "Distance is a haversine expression") ------
+
+
+def _haversine_miles(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    """The great-circle distance in miles between two points — the SAME haversine, with
+    the SAME Earth radius (3958.8 mi), the endpoint computes in SQL. Used to assert the
+    ``distance_miles`` a located list returns is the real distance, not a number pulled
+    from the implementation under test."""
+    r = 3958.8
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    d_phi = math.radians(lat2 - lat1)
+    d_lambda = math.radians(lng2 - lng1)
+    a = (
+        math.sin(d_phi / 2) ** 2
+        + math.cos(phi1) * math.cos(phi2) * math.sin(d_lambda / 2) ** 2
+    )
+    return 2 * r * math.asin(math.sqrt(a))
+
+
+async def _seed_located_tournament(
+    db_session: AsyncSession,
+    *,
+    owner: User,
+    league: League,
+    name: str,
+    latitude: float,
+    longitude: float,
+    status: TournamentStatus = TournamentStatus.published,
+) -> Tournament:
+    """A tournament seeded DIRECTLY with controlled venue coordinates, so distance
+    assertions are stable — rather than through the create route, whose ``FakeGeocoder``
+    coordinates are a hash of the address text (deterministic but not a place on a map
+    a reader can reason about)."""
+    tournament = Tournament(
+        name=name,
+        status=status,
+        address={**_address(), "latitude": latitude, "longitude": longitude},
+        table_catalogue=[],
+        league_id=league.id,
+        created_by_user_id=owner.id,
+    )
+    db_session.add(tournament)
+    await db_session.commit()
+    return tournament
+
+
+# A query point (downtown San Francisco) and two venues: one ~10 mi away (Berkeley,
+# inside a 50-mi radius) and one ~350 mi away (Los Angeles, well outside it).
+_SF_LAT, _SF_LNG = 37.7749, -122.4194
+_BERKELEY_LAT, _BERKELEY_LNG = 37.8716, -122.2727
+_LA_LAT, _LA_LNG = 34.0522, -118.2437
+
+
+async def test_list_near_me_returns_only_tournaments_within_radius(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    default_league: League,
+):
+    """The ``lat``/``lng``/``radius_miles`` triple filters the list to venues within
+    the radius and stamps each survivor with its haversine ``distance_miles``: the
+    ~10-mi Berkeley venue comes back carrying its real distance, the ~350-mi LA venue is
+    gone."""
+    client, user = authed_client
+    near = await _seed_located_tournament(
+        db_session,
+        owner=user,
+        league=default_league,
+        name="Berkeley Open",
+        latitude=_BERKELEY_LAT,
+        longitude=_BERKELEY_LNG,
+    )
+    far = await _seed_located_tournament(
+        db_session,
+        owner=user,
+        league=default_league,
+        name="LA Open",
+        latitude=_LA_LAT,
+        longitude=_LA_LNG,
+    )
+
+    response = await client.get(
+        "/v1/tournaments",
+        params={"lat": _SF_LAT, "lng": _SF_LNG, "radius_miles": 50},
+    )
+    assert response.status_code == 200
+    rows = {r["id"]: r for r in response.json()}
+
+    assert str(far.id) not in rows
+    assert str(near.id) in rows
+    expected = _haversine_miles(_SF_LAT, _SF_LNG, _BERKELEY_LAT, _BERKELEY_LNG)
+    assert rows[str(near.id)]["distance_miles"] == pytest.approx(expected, abs=0.1)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"lat": _SF_LAT},
+        {"lng": _SF_LNG},
+        {"radius_miles": 50},
+        {"lat": _SF_LAT, "lng": _SF_LNG},
+        {"lat": _SF_LAT, "radius_miles": 50},
+    ],
+)
+async def test_list_near_me_partial_triple_is_422(
+    authed_client: tuple[AsyncClient, User],
+    params: dict[str, float],
+):
+    """The three are one location filter, not three independent knobs: any partial
+    subset — a point with no radius, a radius with no point — is a 422 at the boundary,
+    never a silently-ignored parameter."""
+    client, _ = authed_client
+    response = await client.get("/v1/tournaments", params=params)
+    assert response.status_code == 422
+
+
+async def test_list_without_location_is_unchanged_with_null_distance(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    default_league: League,
+):
+    """With no location triple the list behaves exactly as before: every visible
+    tournament is returned (the far-away one included), each with ``distance_miles``
+    null — there is no point to measure from."""
+    client, user = authed_client
+    near = await _seed_located_tournament(
+        db_session,
+        owner=user,
+        league=default_league,
+        name="Berkeley Open",
+        latitude=_BERKELEY_LAT,
+        longitude=_BERKELEY_LNG,
+    )
+    far = await _seed_located_tournament(
+        db_session,
+        owner=user,
+        league=default_league,
+        name="LA Open",
+        latitude=_LA_LAT,
+        longitude=_LA_LNG,
+    )
+
+    response = await client.get("/v1/tournaments")
+    assert response.status_code == 200
+    rows = {r["id"]: r for r in response.json()}
+
+    assert {str(near.id), str(far.id)} <= set(rows)
+    assert rows[str(near.id)]["distance_miles"] is None
+    assert rows[str(far.id)]["distance_miles"] is None
+
+
+async def test_list_near_me_statement_count_stays_five(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+):
+    """The near-me distance column and radius WHERE ride on the FIRST of the five
+    batched queries — a computed column and a predicate, not a per-row follow-up — so a
+    located list is still exactly ``EXPECTED_TOURNAMENT_LIST_STATEMENTS`` statements (no
+    N+1 reintroduced by the filter).
+
+    The list is queried at the tournament's OWN geocoded coordinates so it is squarely
+    inside the radius and the events / entrants / fixtures / rating batches all run —
+    the shape the pin is about. See ``counted_statements``.
+    """
+    client, user = authed_client
+    user_id = user.id  # read outside the counted block, as the sibling pin does
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    event = (
+        await client.post(
+            f"/v1/tournaments/{created['id']}/events", json=_event_payload()
+        )
+    ).json()
+    await _enter(db_session, event["id"], await make_user(db_session, "near-player"))
+    await _cut(db_session, event["id"], pool_id="p-a", round=1, position=1)
+    await _cut(db_session, event["id"], pool_id="p-a", round=1, position=2)
+    # The coordinates the write path actually geocoded this address to (the FakeGeocoder
+    # the keyless test env resolves with), so the query point sits on the venue.
+    coords = await _geocoded_address(_address())
+
+    async with counted_statements(engine) as (session, statements):
+        listed = await list_tournaments(
+            db=session,
+            current_user=User(id=user_id),
+            lat=float(coords["latitude"]),
+            lng=float(coords["longitude"]),
+            radius_miles=25.0,
+        )
+
+    for n, statement in enumerate(statements, start=1):
+        print(f"[{n}] {' '.join(statement.split())}")
+
+    assert len(statements) == EXPECTED_TOURNAMENT_LIST_STATEMENTS, statements
+    (tournament,) = [t for t in listed if str(t.id) == created["id"]]
+    assert tournament.distance_miles is not None
 
 
 # ----- permission gate -----------------------------------------------------

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -203,13 +203,14 @@ async def test_create_tournament_returns_201(
     assert body["created_by_user_id"] == str(user.id)
 
 
-async def test_create_with_unresolvable_address_is_422_and_creates_nothing(
+async def test_create_with_unresolvable_address_is_409_and_creates_nothing(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
 ):
-    """A venue address the geocoder cannot resolve is a coded 422 at the boundary, and
-    the write is atomic — no coordinate-less row is created (ADR "an unresolvable
-    address is a 422 at the boundary").
+    """A venue address the geocoder cannot resolve is a coded 409 refusal, and the write
+    is atomic — no coordinate-less row is created. It is a 409, not a 422: FastAPI
+    reserves 422 for its own ``HTTPValidationError`` (a ``detail`` array), so this coded
+    object body rides on 409 instead (ADR-0968).
 
     Uses the deterministic ``FakeGeocoder`` sentinel (``__unresolvable__``) so the
     zero-result path is exercised with no network. The body carries the machine-readable
@@ -219,7 +220,7 @@ async def test_create_with_unresolvable_address_is_422_and_creates_nothing(
     bad = {**_address(), "venue": "__unresolvable__"}
     response = await client.post("/v1/tournaments", json=_create_payload(address=bad))
 
-    assert response.status_code == 422, response.text
+    assert response.status_code == 409, response.text
     assert response.json()["detail"]["code"] == "address_not_geocodable"
     # A 422 that had already written a row would be a 422 in name only.
     count = (
@@ -255,10 +256,10 @@ async def test_geocode_preview_resolves_an_address(
     }
 
 
-async def test_geocode_preview_unresolvable_address_is_the_coded_422(
+async def test_geocode_preview_unresolvable_address_is_the_coded_409(
     authed_client: tuple[AsyncClient, User],
 ):
-    """An address the geocoder cannot resolve is the same coded 422 the write path
+    """An address the geocoder cannot resolve is the same coded 409 the write path
     answers — the machine-readable ``address_not_geocodable`` code (ADR-0968), so
     the preview and the write agree on the refusal. Uses the deterministic
     ``FakeGeocoder`` sentinel so the zero-result path is exercised with no
@@ -267,7 +268,7 @@ async def test_geocode_preview_unresolvable_address_is_the_coded_422(
 
     response = await client.get("/v1/geocode", params={"address": "__unresolvable__"})
 
-    assert response.status_code == 422, response.text
+    assert response.status_code == 409, response.text
     assert response.json()["detail"]["code"] == "address_not_geocodable"
 
 
@@ -407,14 +408,14 @@ async def test_patch_by_creator_updates_fields(
     assert body["status"] == "draft"
 
 
-async def test_patch_with_unresolvable_address_is_422_and_leaves_the_address(
+async def test_patch_with_unresolvable_address_is_409_and_leaves_the_address(
     authed_client: tuple[AsyncClient, User],
 ):
     """Editing the venue to an address the geocoder cannot resolve is the same coded
-    422 the create path answers, and the edit is atomic — the stored address (and its
+    409 the create path answers, and the edit is atomic — the stored address (and its
     coordinates) is left unchanged.
 
-    Re-reads the address afterwards rather than trusting the 422: a handler that wrote
+    Re-reads the address afterwards rather than trusting the 409: a handler that wrote
     the coordinate-less address and *then* failed would pass a status-code-only
     assertion.
     """
@@ -427,7 +428,7 @@ async def test_patch_with_unresolvable_address_is_422_and_leaves_the_address(
         f"/v1/tournaments/{created['id']}", json={"address": bad}
     )
 
-    assert response.status_code == 422, response.text
+    assert response.status_code == 409, response.text
     assert response.json()["detail"]["code"] == "address_not_geocodable"
     # The stored address did not move — including its coordinates.
     read_back = (await client.get(f"/v1/tournaments/{created['id']}")).json()

--- a/deploy/uat/templates/api.yaml
+++ b/deploy/uat/templates/api.yaml
@@ -55,6 +55,23 @@ spec:
               memory: 512Mi
           envFrom:
             {{- include "fortymm-uat.appEnvFrom" . | nindent 12 }}
+          env:
+            # Server-side geocoding key for venue addresses — see
+            # docs/adr/20260725-a-venues-coordinates-are-geocoded-server-side-and-not-null.md.
+            # Sourced from the .env-backed Secret (secrets.env), the same place
+            # every other sensitive var comes from; only UAT/prod set it.
+            # optional:true is the whole point of "keyless everywhere else":
+            # when the key is absent from the Secret the var stays unset and the
+            # API selects its deterministic, network-free FakeGeocoder, so local
+            # dev / CI / e2e / QA never touch the network. Declared explicitly
+            # (not just via the bulk envFrom Secret) so the wiring is visible and
+            # greppable in the rendered Deployment.
+            - name: GOOGLE_GEOCODING_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.env }}
+                  key: GOOGLE_GEOCODING_API_KEY
+                  optional: true
           ports:
             - containerPort: 8000
           volumeMounts:

--- a/deploy/uat/values.yaml
+++ b/deploy/uat/values.yaml
@@ -68,6 +68,10 @@ postgres:
   storageSize: 5Gi
 
 # Pre-created out-of-band by scripts/redeploy-uat.sh from .env and secrets/.
+# The api Deployment pulls GOOGLE_GEOCODING_API_KEY from `env` (below) as an
+# optional key — supply it via .env for UAT/prod (real Google geocoding), or
+# leave it out and the API falls back to the keyless FakeGeocoder. No real key
+# is ever committed here; the operator provides it out of band in .env.
 secrets:
   env: fortymm-uat-env
   apns: fortymm-uat-apns

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -108,6 +108,12 @@ services:
     environment:
       CHOKIDAR_USEPOLLING: "true"
       VITE_ENABLE_MSW: "false"
+      # Browser Google Maps key. Dev runs the Vite dev server (not a bundle
+      # build), so this is a runtime passthrough, not a build arg — the dev
+      # server reads import.meta.env.VITE_* from its process env. OPTIONAL:
+      # empty default => the map degrades to a text fallback. Export
+      # VITE_GOOGLE_MAPS_API_KEY in your shell to supply a real key locally.
+      VITE_GOOGLE_MAPS_API_KEY: ${VITE_GOOGLE_MAPS_API_KEY:-}
     volumes:
       - ./web-client:/app
       - web-client-node-modules:/app/node_modules

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -161,6 +161,11 @@ services:
     build:
       context: ./web-client
       dockerfile: Dockerfile.uat
+      args:
+        # Browser Google Maps key, baked into the built bundle. OPTIONAL: empty
+        # default => a keyless QA build succeeds and the map degrades to a text
+        # fallback. Export VITE_GOOGLE_MAPS_API_KEY in the shell to supply one.
+        VITE_GOOGLE_MAPS_API_KEY: ${VITE_GOOGLE_MAPS_API_KEY:-}
     depends_on:
       - api
 

--- a/docs/adr/20260725-a-venues-coordinates-are-geocoded-server-side-and-not-null.md
+++ b/docs/adr/20260725-a-venues-coordinates-are-geocoded-server-side-and-not-null.md
@@ -1,0 +1,118 @@
+# A venue's coordinates are geocoded server-side at write time and are NOT NULL; the browser only displays them
+
+Date: 2026-07-25 (date-prefixed; sequential ADR numbers collide across concurrent
+worktrees, so recent ADRs are dated, not numbered)
+
+## Status
+
+Accepted. This ADR is the design output of the `/grill` on issue #1169 ("Near me"
+tournament discovery). It **deliberately diverges from the approach the issue
+proposed** — see Context — so the divergence is recorded here rather than left as a
+surprise to the next reader who opens #1169 and finds the code doing the opposite.
+
+## Context
+
+Issue #1169 adds a real geographic radius filter to the tournament list
+("tournaments within 50 miles of me"). Two gaps block it: a tournament's
+`Address` value-object (`api/app/schemas/tournament.py`) is free text with **no
+coordinates**, and there is nothing to compute a distance *from* or *to*.
+
+The issue's proposed approach was **capture coordinates in the browser** via a
+Google Places autocomplete on the venue field — `place.geometry.location` gives
+the client lat/lng for free, and the API never needs a geocoding provider. Its own
+"open design decisions" flagged the weak point: **non-web creators have no Place.**
+The MCP `create_tournament`/`edit_tournament` tools (and a future iOS create flow)
+submit an address without a browser, so a client-capture design either leaves those
+callers unable to produce coordinates or forces a server-side geocode fallback
+"just for them" — at which point a geocoding provider is in scope anyway, only on a
+second code path.
+
+Grilling that decision collapsed it: once a geocoder exists on the server for the
+non-web callers, a client-supplied lat/lng is just an unverified number the server
+must either trust (a parse-at-boundary smell) or re-check (wasted work). The clean
+resolution is to make the **server the single authority** for coordinates and drop
+client capture entirely.
+
+The stack runs `postgres:16-alpine` (no PostGIS), so distance has to be computed
+without a geography type.
+
+## Decision
+
+### A venue is geocoded server-side on every write; coordinates are NOT NULL
+
+`Address` grows `latitude` / `longitude`, both **NOT NULL**. The shared
+transport-neutral `create_tournament` / `edit_tournament` verbs geocode the address
+before the write, so **every** caller — web, MCP, future iOS — gets correct
+coordinates through **one** path. There is no client-supplied coordinate anywhere on
+the wire, so there is no "do we trust the browser's number" boundary question.
+
+Because the app is **pre-deploy**, the new NOT NULL columns need no backfill: per
+`api/CLAUDE.md` we edit the migration in place and wipe existing tournaments rather
+than chaining a data migration. NOT NULL is the whole point — no `Optional[float]`
+leaking through every downstream read, and no "tournament that mysteriously never
+appears in near-me" state.
+
+### An unresolvable address is a 422 at the boundary
+
+Geocoding returns ranked candidates. We take the top-ranked candidate; **zero
+results is a 422** ("We couldn't locate that address," a machine-readable code so
+the MCP adapter can surface it too), never a silent write of null/0,0. This is what
+lets the columns stay NOT NULL: a write that cannot produce coordinates fails loudly
+at the edge (parse-at-boundaries) instead of leaking a bad row inward.
+
+We store coordinates **only** — the organizer's typed address text is left exactly
+as entered. Normalizing the free-text components to the geocoder's canonical form is
+a real improvement but a separate concern with its own UX surprises; it needs no
+schema change and is deliberately deferred.
+
+### The geocoder is an injectable seam
+
+Geocoding lives behind a `Geocoder` **Protocol** (a `GoogleGeocoder` real
+implementation, a `FakeGeocoder` for tests), wired through `dependencies.py` into
+the verbs — so the test suite never touches Google's network and the provider is
+swappable. Google is the provider we picked (an API key already exists); it is not
+load-bearing on the design.
+
+### Distance is a haversine expression, not PostGIS
+
+`GET /v1/tournaments` gains an all-or-nothing `lat` / `lng` / `radius_miles` query
+triple and filters by a **haversine distance in SQL with a cheap bounding-box
+prefilter**, returning a `distance_miles` per tournament. At this data volume the
+haversine is right and it keeps the Postgres image (and the UAT Helm chart)
+unchanged. Radius filtering goes in the **endpoint**, not client-side like the name
+search and status tabs, because it is the first filter with a genuine server-side
+reason: eventually you do not want to ship every tournament on the platform to a
+phone.
+
+### The browser gets a map, but only to *display* coordinates
+
+The web loads Google Maps JS (a browser-referrer-restricted key,
+`VITE_GOOGLE_MAPS_API_KEY`, distinct from the server's IP-restricted geocoding key)
+purely to **render pins it never authors**: a venue pin on the detail page, and a
+confirmation pin on the create/edit form fed by a small read-only
+`GET /v1/geocode?address=…` preview endpoint (triggered by an explicit "Preview
+location" button, not as-you-type, to keep geocoding cost trivial). The map is a
+confirmation/display affordance; the coordinates that get stored always come from
+the server geocode on write.
+
+## Consequences
+
+- **Changing `Address` is an OpenAPI change**, so both generated clients regenerate
+  in the same change: `mise run regen-api-types`
+  (`web-client/src/api/schema.d.ts`) and `mise run regen-ios-api-types`
+  (`ios/Fortymm/Generated/Types.swift`), plus every fixture that builds an address
+  (`web-client/src/mocks/factories/tournaments/tournament.factory.ts`,
+  `web-client/src/mocks/tournaments-store.ts`,
+  `web-client/src/components/tournaments/data/seed.factory.ts`,
+  `e2e/support/tournament-api.ts`).
+- **"Me" is never persisted.** The list page reads `navigator.geolocation` at query
+  time and passes it through; `User` gains no location fields. Denial/unavailable is
+  a graceful fallback to the unfiltered list, and near-me is opt-in.
+- **A geocoding provider is now a runtime dependency of tournament creation** — the
+  thing the issue's client-capture approach was designed to avoid. We accepted it
+  because it makes MCP/iOS first-class rather than a fallback, and behind the
+  `Geocoder` Protocol it stays swappable and test-fakeable.
+- **Anonymous access is unchanged.** The list stays behind `require_view`; near-me
+  does not open it to anonymous callers (#1169's open decision 5 stays closed).
+</content>
+</invoke>

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -1,3 +1,4 @@
+import type { APIResponse } from '@playwright/test'
 import type { Guest } from './match-api'
 
 // Composed-stack API helpers for provisioning the **inert scaffolding** of a
@@ -45,6 +46,29 @@ export interface TableSpec {
   readonly court: string
 }
 
+/** A venue's six free-text address components (`AddressInput` on the wire). The
+ * server geocodes these to coordinates at write time via the injected
+ * `Geocoder` — the compose stack sets no `GOOGLE_GEOCODING_API_KEY`, so that is
+ * the deterministic, network-free `FakeGeocoder`, which maps the composed
+ * address string to stable coords by SHA-256. Two *different* addresses
+ * therefore geocode to two different, stable points — which is exactly what the
+ * near-me filter spec needs to place a venue at a known distance from another. */
+export interface AddressInput {
+  readonly venue: string
+  readonly street: string
+  readonly city: string
+  readonly region: string
+  readonly postal: string
+  readonly country: string
+}
+
+/** A venue's stored coordinates as geocoded server-side and read back off the
+ * tournament's `address` value-object — both NOT NULL by the ADR. */
+export interface Coords {
+  readonly latitude: number
+  readonly longitude: number
+}
+
 /** Optional knobs on `seedTournament`. Defaults reproduce the original minimal
  * shape (one table, one pool, a far-future window), so existing specs are
  * untouched; the solver-schedule spec overrides both — its pool window must
@@ -61,6 +85,11 @@ export interface SeedTournamentOptions {
    * the real solver returns a fast, clean "fits" verdict rather than an
    * over-the-cap `unknown`. */
   readonly maxPlayers?: number
+  /** The venue address the server geocodes to the tournament's coordinates.
+   * Defaults to a single fixed address (so existing specs are untouched); the
+   * near-me spec passes two *distinct* addresses so the two tournaments land at
+   * two different, stable `FakeGeocoder` points. */
+  readonly address?: AddressInput
 }
 
 /** A seeded tournament and the ids a spec needs to address it and its event. */
@@ -93,19 +122,20 @@ export async function seedTournament(
 ): Promise<SeededTournament> {
   const slot = options.slot ?? { date: '2026-08-01', start: '09:00', end: '17:00' }
   const tables = options.tables ?? [{ id: TABLE_ID, label: 'Table 1', court: 'A' }]
+  const address = options.address ?? {
+    venue: 'Test Arena',
+    street: '1 Test Way',
+    city: 'Testville',
+    region: 'TS',
+    postal: '00000',
+    country: 'Testland',
+  }
 
   const tournamentRes = await director.ctx.post(`${API}/tournaments`, {
     headers: { [CSRF_HEADER]: director.csrf },
     data: {
       name,
-      address: {
-        venue: 'Test Arena',
-        street: '1 Test Way',
-        city: 'Testville',
-        region: 'TS',
-        postal: '00000',
-        country: 'Testland',
-      },
+      address,
       // The pool references these tables by id, so the catalogue must carry them.
       table_catalogue: tables,
     },
@@ -393,4 +423,75 @@ export async function callFixture(
   if (res.status() !== 200) {
     throw new Error(`call fixture failed: ${res.status()} ${await res.text()}`)
   }
+}
+
+/**
+ * Read back the coordinates the server geocoded a tournament's venue to, off the
+ * detail read's `address` value-object (`GET /v1/tournaments/{id}`).
+ *
+ * The near-me spec's whole method rests on this: the `FakeGeocoder` is
+ * deterministic but its SHA-256 mapping from address to lat/lng is not something
+ * a spec should reproduce or hardcode — so a spec seeds an address, then *reads
+ * the coordinates back* here and computes its query point/radius from the real,
+ * stored numbers. That keeps the assertion robust to the actual coords rather
+ * than a guessed literal.
+ */
+export async function getVenueCoords(
+  viewer: Guest,
+  tournamentId: string,
+): Promise<Coords> {
+  const res = await viewer.ctx.get(`${API}/tournaments/${tournamentId}`)
+  if (!res.ok()) {
+    throw new Error(`load tournament failed: ${res.status()} ${await res.text()}`)
+  }
+  const { address } = (await res.json()) as { address: Coords }
+  return { latitude: address.latitude, longitude: address.longitude }
+}
+
+/** One row of the tournament list, scoped to the near-me facts a spec reads:
+ * which tournament (`id`) and its server-computed `distance_miles` from the
+ * query point (a haversine great-circle distance, in miles; `null` on any read
+ * that was not location-filtered). */
+export interface NearMeListing {
+  readonly id: string
+  readonly distance_miles: number | null
+}
+
+/** The all-or-nothing near-me query triple the list endpoint accepts: a point
+ * plus a radius, in miles. Supplying a partial triple is a 422 by design. */
+export interface NearMeQuery {
+  readonly lat: number
+  readonly lng: number
+  readonly radiusMiles: number
+}
+
+/** Raw `GET /v1/tournaments` with an arbitrary (possibly partial) near-me query,
+ * returning the `APIResponse` so a spec can assert on its status — e.g. that a
+ * partial `lat`/`lng`/`radius_miles` triple is a 422. */
+export async function listTournamentsRaw(
+  viewer: Guest,
+  params: Record<string, string | number>,
+): Promise<APIResponse> {
+  return viewer.ctx.get(`${API}/tournaments`, { params })
+}
+
+/**
+ * List the tournaments within `radiusMiles` of `(lat, lng)` — the near-me filter
+ * through the real API — returning each surviving row's id and its
+ * server-computed `distance_miles`. Only the near-me slice is parsed; the cards'
+ * other fields are the browser's concern, not this seam's.
+ */
+export async function listTournamentsNearMe(
+  viewer: Guest,
+  query: NearMeQuery,
+): Promise<ReadonlyArray<NearMeListing>> {
+  const res = await listTournamentsRaw(viewer, {
+    lat: query.lat,
+    lng: query.lng,
+    radius_miles: query.radiusMiles,
+  })
+  if (!res.ok()) {
+    throw new Error(`near-me list failed: ${res.status()} ${await res.text()}`)
+  }
+  return (await res.json()) as ReadonlyArray<NearMeListing>
 }

--- a/e2e/tests/tournaments-near-me.spec.ts
+++ b/e2e/tests/tournaments-near-me.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+
+import { mintGuest } from '../support/match-api'
+import { grantBetaTester } from '../support/rbac-grant'
+import {
+  getVenueCoords,
+  listTournamentsNearMe,
+  listTournamentsRaw,
+  seedTournament,
+  type AddressInput,
+  type Coords,
+} from '../support/tournament-api'
+
+// End-to-end proof of the tournament list's **near-me distance filter** against
+// the REAL composed stack (browser-less, but every hop is real: nginx → api →
+// postgres). `GET /v1/tournaments?lat&lng&radius_miles` filters to the venues
+// within `radius_miles` of the point and stamps each survivor with its
+// server-computed `distance_miles` (a haversine great-circle distance). This
+// spec seeds two venues at a KNOWN separation, queries a radius that brackets
+// one but not the other, and asserts the near one comes back with a distance and
+// the far one is excluded — by real computed distance, not by guessed literals.
+//
+// ## Where the coordinates come from — why nothing is hardcoded
+//
+// The compose stack sets no `GOOGLE_GEOCODING_API_KEY`, so venue coordinates are
+// produced by the deterministic, network-free `FakeGeocoder`, which maps the
+// composed address string to stable lat/lng by SHA-256. That mapping is stable
+// but not something a spec should reproduce — so the spec seeds two *distinct*
+// addresses, reads back each venue's stored coordinates (`getVenueCoords`), and
+// derives its query point and radii from those real numbers using the SAME
+// haversine (Earth radius 3958.8 mi) the API computes with. The query point is
+// placed AT the near venue (distance 0, unconditionally inside); the radius is
+// half the near→far separation, so the far venue (a full separation away) is
+// necessarily outside. Robust to whatever coordinates the two addresses hash to.
+
+/** The Earth's mean radius in miles — the exact constant the API's haversine is
+ * scaled by (`app/tournament_list.py`), so this spec's distance math mirrors the
+ * server's rather than approximating it. */
+const EARTH_RADIUS_MILES = 3958.8
+
+const toRadians = (degrees: number): number => (degrees * Math.PI) / 180
+
+/** The haversine great-circle distance between two points, in miles — a term-for
+ * -term mirror of `_distance_miles_column` in `app/tournament_list.py`, so the
+ * distance this spec expects is the distance the API computes. */
+function haversineMiles(from: Coords, to: Coords): number {
+  const dLat = toRadians(to.latitude - from.latitude)
+  const dLng = toRadians(to.longitude - from.longitude)
+  const sinHalfLat = Math.sin(dLat / 2)
+  const sinHalfLng = Math.sin(dLng / 2)
+  const a =
+    sinHalfLat * sinHalfLat +
+    Math.cos(toRadians(from.latitude)) *
+      Math.cos(toRadians(to.latitude)) *
+      sinHalfLng *
+      sinHalfLng
+  return 2 * EARTH_RADIUS_MILES * Math.asin(Math.sqrt(a))
+}
+
+/** A fresh, unique venue address — a distinct string each call so the
+ * `FakeGeocoder` hashes it to its own stable point, letting the spec seed two
+ * venues that are genuinely apart. */
+function uniqueAddress(): AddressInput {
+  return {
+    venue: `${faker.company.name()} Arena ${faker.string.uuid()}`,
+    street: faker.location.streetAddress(),
+    city: faker.location.city(),
+    region: faker.location.state({ abbreviated: true }),
+    postal: faker.location.zipCode(),
+    country: 'Testland',
+  }
+}
+
+test.describe('tournament list — near-me distance filter', () => {
+  test('a radius query includes the near venue with its distance and excludes the far one', async ({
+    baseURL,
+  }) => {
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+    const director = await mintGuest(baseURL!)
+    // An ephemeral guest holds no tournament permissions; the "Beta tester" role
+    // is what grants `tournament.view`/`create`, so without it every seed and
+    // list 403s (see `rbac-grant.ts`).
+    grantBetaTester(director.username)
+
+    // Two tournaments at two distinct addresses → two distinct, stable
+    // FakeGeocoder points. Names are unique so the ids are the only join key the
+    // assertions rely on (the shared stack holds other tournaments too).
+    const nearName = `Near ${faker.string.uuid()}`
+    const farName = `Far ${faker.string.uuid()}`
+    const near = await seedTournament(director, nearName, { address: uniqueAddress() })
+    const far = await seedTournament(director, farName, { address: uniqueAddress() })
+
+    // Discover the real coordinates the server geocoded each venue to — the
+    // spec measures from these, never from a hardcoded literal.
+    const nearCoords = await getVenueCoords(director, near.tournamentId)
+    const farCoords = await getVenueCoords(director, far.tournamentId)
+
+    const separation = haversineMiles(nearCoords, farCoords)
+    // Distinct SHA-256 outputs → distinct points → a real separation. A zero
+    // separation would mean the two addresses hashed to the same coordinates
+    // (astronomically unlikely) and would make the radius choice below
+    // meaningless — fail loudly with the reason rather than on a later assertion.
+    expect(
+      separation,
+      'the two seeded venues must geocode to different points',
+    ).toBeGreaterThan(0)
+
+    // Query AT the near venue. The near venue's distance from the point is 0
+    // (unconditionally inside); a radius of half the separation is strictly less
+    // than the full separation to the far venue, so the far venue is outside.
+    const tightRadius = separation / 2
+    const listing = await listTournamentsNearMe(director, {
+      lat: nearCoords.latitude,
+      lng: nearCoords.longitude,
+      radiusMiles: tightRadius,
+    })
+
+    const nearRow = listing.find((t) => t.id === near.tournamentId)
+    const farRow = listing.find((t) => t.id === far.tournamentId)
+
+    // The near venue is returned, carrying a real (here, ~zero) distance.
+    expect(nearRow, 'the near tournament must be within the radius').toBeDefined()
+    expect(nearRow!.distance_miles).not.toBeNull()
+    expect(nearRow!.distance_miles!).toBeCloseTo(0, 5)
+
+    // The far venue is excluded — by distance, since it is a full separation away
+    // and the radius only reaches half that far.
+    expect(farRow, 'the far tournament must be outside the radius').toBeUndefined()
+
+    // Widening the radius past the full separation lets the far venue back in —
+    // and it comes back stamped with the exact distance this spec computed
+    // independently, proving `distance_miles` is the real haversine, not a flag.
+    const wideList = await listTournamentsNearMe(director, {
+      lat: nearCoords.latitude,
+      lng: nearCoords.longitude,
+      radiusMiles: separation * 2,
+    })
+    const farInWide = wideList.find((t) => t.id === far.tournamentId)
+    expect(farInWide, 'a wide radius must now include the far tournament').toBeDefined()
+    expect(farInWide!.distance_miles).not.toBeNull()
+    // The API rounds `distance_miles` to one decimal; allow for that plus any
+    // JS↔Postgres float drift (far below 0.1 mi over any Earth-scale distance).
+    expect(Math.abs(farInWide!.distance_miles! - separation)).toBeLessThan(0.2)
+  })
+
+  test('a partial lat/lng/radius_miles triple is rejected (422)', async ({ baseURL }) => {
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+    const guest = await mintGuest(baseURL!)
+    // `tournament.view` is required to reach the handler's all-or-nothing check;
+    // without the grant the list 403s before it can 422 the partial triple.
+    grantBetaTester(guest.username)
+
+    // The three params describe ONE location filter, not three independent knobs
+    // — supplying some but not all is a boundary rejection, not a silently
+    // ignored param.
+    const res = await listTournamentsRaw(guest, { lat: 40, lng: -74 })
+    expect(res.status()).toBe(422)
+  })
+})

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -550,6 +550,31 @@ internal protocol APIProtocol: Sendable {
     /// - Remark: HTTP `POST /v1/tournaments`.
     /// - Remark: Generated from `#/paths//v1/tournaments/post(create_tournament_v1_tournaments_post)`.
     func createTournamentV1TournamentsPost(_ input: Operations.CreateTournamentV1TournamentsPost.Input) async throws -> Operations.CreateTournamentV1TournamentsPost.Output
+    /// Preview Geocode
+    ///
+    /// Resolve a free-text ``address`` string to coordinates for the web
+    /// "Preview location" pin, without writing anything.
+    ///
+    /// Its own BFF-style endpoint (root ``CLAUDE.md``, "BFF endpoints"): it fetches
+    /// on a user action — the previewer typing/blurring the venue fields — not on
+    /// page load, so it is not folded into a page endpoint. It resolves through the
+    /// same injected :class:`~app.geocoding.Geocoder` the create/edit write path
+    /// geocodes with, so the pin the previewer sees matches the coordinates a
+    /// subsequent write would record.
+    ///
+    /// Gated on ``tournament.create``: previewing a venue is part of composing a
+    /// tournament, so the same grant that lets a user create one lets them preview
+    /// its location — this is deliberately not a wide-open geocoding proxy.
+    ///
+    /// A zero-result / unresolvable address is the same coded ``422`` the write path
+    /// answers (:func:`_address_not_geocodable`, ``address_not_geocodable``), so the
+    /// preview and the write agree on the refusal. Any other geocoder failure
+    /// (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to the
+    /// ``500`` handler.
+    ///
+    /// - Remark: HTTP `GET /v1/geocode`.
+    /// - Remark: Generated from `#/paths//v1/geocode/get(preview_geocode_v1_geocode_get)`.
+    func previewGeocodeV1GeocodeGet(_ input: Operations.PreviewGeocodeV1GeocodeGet.Input) async throws -> Operations.PreviewGeocodeV1GeocodeGet.Output
     /// Get Tournament
     ///
     /// - Remark: HTTP `GET /v1/tournaments/{tournament_id}`.
@@ -1875,6 +1900,39 @@ extension APIProtocol {
         try await createTournamentV1TournamentsPost(Operations.CreateTournamentV1TournamentsPost.Input(
             headers: headers,
             body: body
+        ))
+    }
+    /// Preview Geocode
+    ///
+    /// Resolve a free-text ``address`` string to coordinates for the web
+    /// "Preview location" pin, without writing anything.
+    ///
+    /// Its own BFF-style endpoint (root ``CLAUDE.md``, "BFF endpoints"): it fetches
+    /// on a user action — the previewer typing/blurring the venue fields — not on
+    /// page load, so it is not folded into a page endpoint. It resolves through the
+    /// same injected :class:`~app.geocoding.Geocoder` the create/edit write path
+    /// geocodes with, so the pin the previewer sees matches the coordinates a
+    /// subsequent write would record.
+    ///
+    /// Gated on ``tournament.create``: previewing a venue is part of composing a
+    /// tournament, so the same grant that lets a user create one lets them preview
+    /// its location — this is deliberately not a wide-open geocoding proxy.
+    ///
+    /// A zero-result / unresolvable address is the same coded ``422`` the write path
+    /// answers (:func:`_address_not_geocodable`, ``address_not_geocodable``), so the
+    /// preview and the write agree on the refusal. Any other geocoder failure
+    /// (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to the
+    /// ``500`` handler.
+    ///
+    /// - Remark: HTTP `GET /v1/geocode`.
+    /// - Remark: Generated from `#/paths//v1/geocode/get(preview_geocode_v1_geocode_get)`.
+    internal func previewGeocodeV1GeocodeGet(
+        query: Operations.PreviewGeocodeV1GeocodeGet.Input.Query,
+        headers: Operations.PreviewGeocodeV1GeocodeGet.Input.Headers = .init()
+    ) async throws -> Operations.PreviewGeocodeV1GeocodeGet.Output {
+        try await previewGeocodeV1GeocodeGet(Operations.PreviewGeocodeV1GeocodeGet.Input(
+            query: query,
+            headers: headers
         ))
     }
     /// Get Tournament
@@ -4321,6 +4379,68 @@ internal enum Components {
                 case instant
                 case localLabel = "local_label"
                 case tzAbbrev = "tz_abbrev"
+            }
+        }
+        /// The result of the read-only address-preview lookup (``GET /v1/geocode``).
+        ///
+        /// The coordinates a free-text address string resolves to, plus the provider's
+        /// canonical ``formatted`` label, so the web "Preview location" pin can drop a
+        /// marker (and echo the normalized address it matched) *before* the tournament
+        /// write. This is not stored — it is a live lookup through the same injected
+        /// :class:`~app.geocoding.Geocoder` the create/edit write path geocodes with, so
+        /// the pin the previewer sees matches the coordinates a subsequent write records.
+        ///
+        /// An address that resolves to zero candidates is a coded ``422`` at the boundary
+        /// carrying the same ``address_not_geocodable`` code the write path answers with —
+        /// never a coordinate-less preview.
+        ///
+        /// - Remark: Generated from `#/components/schemas/GeocodePreview`.
+        internal struct GeocodePreview: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/GeocodePreview/latitude`.
+            internal var latitude: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/GeocodePreview/longitude`.
+            internal var longitude: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/GeocodePreview/formatted`.
+            internal var formatted: Swift.String
+            /// Creates a new `GeocodePreview`.
+            ///
+            /// - Parameters:
+            ///   - latitude:
+            ///   - longitude:
+            ///   - formatted:
+            internal init(
+                latitude: Swift.Double,
+                longitude: Swift.Double,
+                formatted: Swift.String
+            ) {
+                self.latitude = latitude
+                self.longitude = longitude
+                self.formatted = formatted
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case latitude
+                case longitude
+                case formatted
+            }
+            internal init(from decoder: any Swift.Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.latitude = try container.decode(
+                    Swift.Double.self,
+                    forKey: .latitude
+                )
+                self.longitude = try container.decode(
+                    Swift.Double.self,
+                    forKey: .longitude
+                )
+                self.formatted = try container.decode(
+                    Swift.String.self,
+                    forKey: .formatted
+                )
+                try decoder.ensureNoAdditionalProperties(knownKeys: [
+                    "latitude",
+                    "longitude",
+                    "formatted"
+                ])
             }
         }
         /// - Remark: Generated from `#/components/schemas/HTTPValidationError`.
@@ -21018,6 +21138,205 @@ internal enum Operations {
             /// - Throws: An error if `self` is not `.unprocessableContent`.
             /// - SeeAlso: `.unprocessableContent`.
             internal var unprocessableContent: Operations.CreateTournamentV1TournamentsPost.Output.UnprocessableContent {
+                get throws {
+                    switch self {
+                    case let .unprocessableContent(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "unprocessableContent",
+                            response: self
+                        )
+                    }
+                }
+            }
+            /// Undocumented response.
+            ///
+            /// A response with a code that is not documented in the OpenAPI document.
+            case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+        }
+        internal enum AcceptableContentType: AcceptableProtocol {
+            case json
+            case other(Swift.String)
+            internal init?(rawValue: Swift.String) {
+                switch rawValue.lowercased() {
+                case "application/json":
+                    self = .json
+                default:
+                    self = .other(rawValue)
+                }
+            }
+            internal var rawValue: Swift.String {
+                switch self {
+                case let .other(string):
+                    return string
+                case .json:
+                    return "application/json"
+                }
+            }
+            internal static var allCases: [Self] {
+                [
+                    .json
+                ]
+            }
+        }
+    }
+    /// Preview Geocode
+    ///
+    /// Resolve a free-text ``address`` string to coordinates for the web
+    /// "Preview location" pin, without writing anything.
+    ///
+    /// Its own BFF-style endpoint (root ``CLAUDE.md``, "BFF endpoints"): it fetches
+    /// on a user action — the previewer typing/blurring the venue fields — not on
+    /// page load, so it is not folded into a page endpoint. It resolves through the
+    /// same injected :class:`~app.geocoding.Geocoder` the create/edit write path
+    /// geocodes with, so the pin the previewer sees matches the coordinates a
+    /// subsequent write would record.
+    ///
+    /// Gated on ``tournament.create``: previewing a venue is part of composing a
+    /// tournament, so the same grant that lets a user create one lets them preview
+    /// its location — this is deliberately not a wide-open geocoding proxy.
+    ///
+    /// A zero-result / unresolvable address is the same coded ``422`` the write path
+    /// answers (:func:`_address_not_geocodable`, ``address_not_geocodable``), so the
+    /// preview and the write agree on the refusal. Any other geocoder failure
+    /// (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to the
+    /// ``500`` handler.
+    ///
+    /// - Remark: HTTP `GET /v1/geocode`.
+    /// - Remark: Generated from `#/paths//v1/geocode/get(preview_geocode_v1_geocode_get)`.
+    internal enum PreviewGeocodeV1GeocodeGet {
+        internal static let id: Swift.String = "preview_geocode_v1_geocode_get"
+        internal struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/v1/geocode/GET/query`.
+            internal struct Query: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/geocode/GET/query/address`.
+                internal var address: Swift.String
+                /// Creates a new `Query`.
+                ///
+                /// - Parameters:
+                ///   - address:
+                internal init(address: Swift.String) {
+                    self.address = address
+                }
+            }
+            internal var query: Operations.PreviewGeocodeV1GeocodeGet.Input.Query
+            /// - Remark: Generated from `#/paths/v1/geocode/GET/header`.
+            internal struct Headers: Sendable, Hashable {
+                internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.PreviewGeocodeV1GeocodeGet.AcceptableContentType>]
+                /// Creates a new `Headers`.
+                ///
+                /// - Parameters:
+                ///   - accept:
+                internal init(accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.PreviewGeocodeV1GeocodeGet.AcceptableContentType>] = .defaultValues()) {
+                    self.accept = accept
+                }
+            }
+            internal var headers: Operations.PreviewGeocodeV1GeocodeGet.Input.Headers
+            /// Creates a new `Input`.
+            ///
+            /// - Parameters:
+            ///   - query:
+            ///   - headers:
+            internal init(
+                query: Operations.PreviewGeocodeV1GeocodeGet.Input.Query,
+                headers: Operations.PreviewGeocodeV1GeocodeGet.Input.Headers = .init()
+            ) {
+                self.query = query
+                self.headers = headers
+            }
+        }
+        internal enum Output: Sendable, Hashable {
+            internal struct Ok: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/geocode/GET/responses/200/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/geocode/GET/responses/200/content/application\/json`.
+                    case json(Components.Schemas.GeocodePreview)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.GeocodePreview {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.PreviewGeocodeV1GeocodeGet.Output.Ok.Body
+                /// Creates a new `Ok`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.PreviewGeocodeV1GeocodeGet.Output.Ok.Body) {
+                    self.body = body
+                }
+            }
+            /// Successful Response
+            ///
+            /// - Remark: Generated from `#/paths//v1/geocode/get(preview_geocode_v1_geocode_get)/responses/200`.
+            ///
+            /// HTTP response code: `200 ok`.
+            case ok(Operations.PreviewGeocodeV1GeocodeGet.Output.Ok)
+            /// The associated value of the enum case if `self` is `.ok`.
+            ///
+            /// - Throws: An error if `self` is not `.ok`.
+            /// - SeeAlso: `.ok`.
+            internal var ok: Operations.PreviewGeocodeV1GeocodeGet.Output.Ok {
+                get throws {
+                    switch self {
+                    case let .ok(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct UnprocessableContent: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/geocode/GET/responses/422/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/geocode/GET/responses/422/content/application\/json`.
+                    case json(Components.Schemas.HTTPValidationError)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.HTTPValidationError {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.PreviewGeocodeV1GeocodeGet.Output.UnprocessableContent.Body
+                /// Creates a new `UnprocessableContent`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.PreviewGeocodeV1GeocodeGet.Output.UnprocessableContent.Body) {
+                    self.body = body
+                }
+            }
+            /// Validation Error
+            ///
+            /// - Remark: Generated from `#/paths//v1/geocode/get(preview_geocode_v1_geocode_get)/responses/422`.
+            ///
+            /// HTTP response code: `422 unprocessableContent`.
+            case unprocessableContent(Operations.PreviewGeocodeV1GeocodeGet.Output.UnprocessableContent)
+            /// The associated value of the enum case if `self` is `.unprocessableContent`.
+            ///
+            /// - Throws: An error if `self` is not `.unprocessableContent`.
+            /// - SeeAlso: `.unprocessableContent`.
+            internal var unprocessableContent: Operations.PreviewGeocodeV1GeocodeGet.Output.UnprocessableContent {
                 get throws {
                     switch self {
                     case let .unprocessableContent(response):

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -532,6 +532,16 @@ internal protocol APIProtocol: Sendable {
     func broadcastNotificationV1NotificationsBroadcastPost(_ input: Operations.BroadcastNotificationV1NotificationsBroadcastPost.Input) async throws -> Operations.BroadcastNotificationV1NotificationsBroadcastPost.Output
     /// List Tournaments
     ///
+    /// List the tournaments the caller may see, newest first, each as the full detail
+    /// aggregate the list cards render.
+    ///
+    /// Pass an **all-or-nothing** `lat` / `lng` / `radius_miles` triple to filter to
+    /// tournaments **near a point**: only those whose venue is within `radius_miles` of
+    /// `(lat, lng)` come back, each carrying its `distance_miles` (a haversine
+    /// great-circle distance, in miles). Supplying some but not all three is a `422` — the
+    /// three describe one location filter, not three independent knobs. Omit all three
+    /// (the default) for every visible tournament, with `distance_miles` null.
+    ///
     /// - Remark: HTTP `GET /v1/tournaments`.
     /// - Remark: Generated from `#/paths//v1/tournaments/get(list_tournaments_v1_tournaments_get)`.
     func listTournamentsV1TournamentsGet(_ input: Operations.ListTournamentsV1TournamentsGet.Input) async throws -> Operations.ListTournamentsV1TournamentsGet.Output
@@ -1833,10 +1843,26 @@ extension APIProtocol {
     }
     /// List Tournaments
     ///
+    /// List the tournaments the caller may see, newest first, each as the full detail
+    /// aggregate the list cards render.
+    ///
+    /// Pass an **all-or-nothing** `lat` / `lng` / `radius_miles` triple to filter to
+    /// tournaments **near a point**: only those whose venue is within `radius_miles` of
+    /// `(lat, lng)` come back, each carrying its `distance_miles` (a haversine
+    /// great-circle distance, in miles). Supplying some but not all three is a `422` — the
+    /// three describe one location filter, not three independent knobs. Omit all three
+    /// (the default) for every visible tournament, with `distance_miles` null.
+    ///
     /// - Remark: HTTP `GET /v1/tournaments`.
     /// - Remark: Generated from `#/paths//v1/tournaments/get(list_tournaments_v1_tournaments_get)`.
-    internal func listTournamentsV1TournamentsGet(headers: Operations.ListTournamentsV1TournamentsGet.Input.Headers = .init()) async throws -> Operations.ListTournamentsV1TournamentsGet.Output {
-        try await listTournamentsV1TournamentsGet(Operations.ListTournamentsV1TournamentsGet.Input(headers: headers))
+    internal func listTournamentsV1TournamentsGet(
+        query: Operations.ListTournamentsV1TournamentsGet.Input.Query = .init(),
+        headers: Operations.ListTournamentsV1TournamentsGet.Input.Headers = .init()
+    ) async throws -> Operations.ListTournamentsV1TournamentsGet.Output {
+        try await listTournamentsV1TournamentsGet(Operations.ListTournamentsV1TournamentsGet.Input(
+            query: query,
+            headers: headers
+        ))
     }
     /// Create Tournament
     ///
@@ -2420,7 +2446,19 @@ internal enum Servers {}
 internal enum Components {
     /// Types generated from the `#/components/schemas` section of the OpenAPI document.
     internal enum Schemas {
-        /// A tournament venue address. Stored as a JSONB value-object.
+        /// A tournament venue address as **stored and read**. A JSONB value-object.
+        ///
+        /// The six free-text components a client sends (:class:`AddressInput`) **plus**
+        /// the ``latitude``/``longitude`` the server geocoded at write time — both NOT
+        /// NULL (ADR "a venue's coordinates are geocoded server-side at write time and are
+        /// NOT NULL"). Coordinates live inside the JSONB value-object, so the stored
+        /// address always carries them; a read that validates the column into this model
+        /// can rely on non-null coordinates rather than threading ``Optional[float]``
+        /// through every downstream reader.
+        ///
+        /// This is the shape on the *read* schemas (:class:`TournamentRead` and the
+        /// detail/dashboard reads); the write schemas take :class:`AddressInput`, which
+        /// has no coordinates.
         ///
         /// - Remark: Generated from `#/components/schemas/Address`.
         internal struct Address: Codable, Hashable, Sendable {
@@ -2436,7 +2474,123 @@ internal enum Components {
             internal var postal: Swift.String
             /// - Remark: Generated from `#/components/schemas/Address/country`.
             internal var country: Swift.String
+            /// - Remark: Generated from `#/components/schemas/Address/latitude`.
+            internal var latitude: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/Address/longitude`.
+            internal var longitude: Swift.Double
             /// Creates a new `Address`.
+            ///
+            /// - Parameters:
+            ///   - venue:
+            ///   - street:
+            ///   - city:
+            ///   - region:
+            ///   - postal:
+            ///   - country:
+            ///   - latitude:
+            ///   - longitude:
+            internal init(
+                venue: Swift.String,
+                street: Swift.String,
+                city: Swift.String,
+                region: Swift.String,
+                postal: Swift.String,
+                country: Swift.String,
+                latitude: Swift.Double,
+                longitude: Swift.Double
+            ) {
+                self.venue = venue
+                self.street = street
+                self.city = city
+                self.region = region
+                self.postal = postal
+                self.country = country
+                self.latitude = latitude
+                self.longitude = longitude
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case venue
+                case street
+                case city
+                case region
+                case postal
+                case country
+                case latitude
+                case longitude
+            }
+            internal init(from decoder: any Swift.Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.venue = try container.decode(
+                    Swift.String.self,
+                    forKey: .venue
+                )
+                self.street = try container.decode(
+                    Swift.String.self,
+                    forKey: .street
+                )
+                self.city = try container.decode(
+                    Swift.String.self,
+                    forKey: .city
+                )
+                self.region = try container.decode(
+                    Swift.String.self,
+                    forKey: .region
+                )
+                self.postal = try container.decode(
+                    Swift.String.self,
+                    forKey: .postal
+                )
+                self.country = try container.decode(
+                    Swift.String.self,
+                    forKey: .country
+                )
+                self.latitude = try container.decode(
+                    Swift.Double.self,
+                    forKey: .latitude
+                )
+                self.longitude = try container.decode(
+                    Swift.Double.self,
+                    forKey: .longitude
+                )
+                try decoder.ensureNoAdditionalProperties(knownKeys: [
+                    "venue",
+                    "street",
+                    "city",
+                    "region",
+                    "postal",
+                    "country",
+                    "latitude",
+                    "longitude"
+                ])
+            }
+        }
+        /// The venue address a client **sends** on a write (create/edit).
+        ///
+        /// Six free-text components and **no coordinates**: coordinates are geocoded
+        /// server-side at write time and are never supplied by a client (ADR "a venue's
+        /// coordinates are geocoded server-side at write time and are NOT NULL"). A client
+        /// that tries to send ``latitude``/``longitude`` gets a 422 — ``extra="forbid"`` —
+        /// rather than an unverified number the server would have to trust or re-check.
+        ///
+        /// The write verbs geocode this input and construct the stored :class:`Address`
+        /// (with coordinates) before persisting; this is the shape on the *request*
+        /// schemas, and :class:`Address` is the shape on the *read* schemas.
+        ///
+        /// - Remark: Generated from `#/components/schemas/AddressInput`.
+        internal struct AddressInput: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/AddressInput/venue`.
+            internal var venue: Swift.String
+            /// - Remark: Generated from `#/components/schemas/AddressInput/street`.
+            internal var street: Swift.String
+            /// - Remark: Generated from `#/components/schemas/AddressInput/city`.
+            internal var city: Swift.String
+            /// - Remark: Generated from `#/components/schemas/AddressInput/region`.
+            internal var region: Swift.String
+            /// - Remark: Generated from `#/components/schemas/AddressInput/postal`.
+            internal var postal: Swift.String
+            /// - Remark: Generated from `#/components/schemas/AddressInput/country`.
+            internal var country: Swift.String
+            /// Creates a new `AddressInput`.
             ///
             /// - Parameters:
             ///   - venue:
@@ -9091,7 +9245,7 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/TournamentCreate/end_date`.
             internal var endDate: Swift.String?
             /// - Remark: Generated from `#/components/schemas/TournamentCreate/address`.
-            internal var address: Components.Schemas.Address
+            internal var address: Components.Schemas.AddressInput
             /// - Remark: Generated from `#/components/schemas/TournamentCreate/table_catalogue`.
             internal var tableCatalogue: [Components.Schemas.TournamentTable]?
             /// - Remark: Generated from `#/components/schemas/TournamentCreate/league_id`.
@@ -9111,7 +9265,7 @@ internal enum Components {
                 description: Swift.String? = nil,
                 startDate: Swift.String? = nil,
                 endDate: Swift.String? = nil,
-                address: Components.Schemas.Address,
+                address: Components.Schemas.AddressInput,
                 tableCatalogue: [Components.Schemas.TournamentTable]? = nil,
                 leagueId: Swift.String? = nil
             ) {
@@ -9151,7 +9305,7 @@ internal enum Components {
                     forKey: .endDate
                 )
                 self.address = try container.decode(
-                    Components.Schemas.Address.self,
+                    Components.Schemas.AddressInput.self,
                     forKey: .address
                 )
                 self.tableCatalogue = try container.decodeIfPresent(
@@ -9205,6 +9359,8 @@ internal enum Components {
             internal var updatedAt: Foundation.Date
             /// - Remark: Generated from `#/components/schemas/TournamentDetailRead/events`.
             internal var events: [Components.Schemas.TournamentEventRead]
+            /// - Remark: Generated from `#/components/schemas/TournamentDetailRead/distance_miles`.
+            internal var distanceMiles: Swift.Double?
             /// - Remark: Generated from `#/components/schemas/TournamentDetailRead/latest_schedule_solve`.
             internal struct LatestScheduleSolvePayload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/TournamentDetailRead/latest_schedule_solve/value1`.
@@ -9243,6 +9399,7 @@ internal enum Components {
             ///   - createdAt:
             ///   - updatedAt:
             ///   - events:
+            ///   - distanceMiles:
             ///   - latestScheduleSolve:
             internal init(
                 id: Swift.String,
@@ -9260,6 +9417,7 @@ internal enum Components {
                 createdAt: Foundation.Date,
                 updatedAt: Foundation.Date,
                 events: [Components.Schemas.TournamentEventRead],
+                distanceMiles: Swift.Double? = nil,
                 latestScheduleSolve: Components.Schemas.TournamentDetailRead.LatestScheduleSolvePayload? = nil
             ) {
                 self.id = id
@@ -9277,6 +9435,7 @@ internal enum Components {
                 self.createdAt = createdAt
                 self.updatedAt = updatedAt
                 self.events = events
+                self.distanceMiles = distanceMiles
                 self.latestScheduleSolve = latestScheduleSolve
             }
             internal enum CodingKeys: String, CodingKey {
@@ -9295,6 +9454,7 @@ internal enum Components {
                 case createdAt = "created_at"
                 case updatedAt = "updated_at"
                 case events
+                case distanceMiles = "distance_miles"
                 case latestScheduleSolve = "latest_schedule_solve"
             }
         }
@@ -10463,12 +10623,12 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/TournamentUpdate/address`.
             internal struct AddressPayload: Codable, Hashable, Sendable {
                 /// - Remark: Generated from `#/components/schemas/TournamentUpdate/address/value1`.
-                internal var value1: Components.Schemas.Address
+                internal var value1: Components.Schemas.AddressInput
                 /// Creates a new `AddressPayload`.
                 ///
                 /// - Parameters:
                 ///   - value1:
-                internal init(value1: Components.Schemas.Address) {
+                internal init(value1: Components.Schemas.AddressInput) {
                     self.value1 = value1
                 }
                 internal init(from decoder: any Swift.Decoder) throws {
@@ -20530,11 +20690,46 @@ internal enum Operations {
     }
     /// List Tournaments
     ///
+    /// List the tournaments the caller may see, newest first, each as the full detail
+    /// aggregate the list cards render.
+    ///
+    /// Pass an **all-or-nothing** `lat` / `lng` / `radius_miles` triple to filter to
+    /// tournaments **near a point**: only those whose venue is within `radius_miles` of
+    /// `(lat, lng)` come back, each carrying its `distance_miles` (a haversine
+    /// great-circle distance, in miles). Supplying some but not all three is a `422` — the
+    /// three describe one location filter, not three independent knobs. Omit all three
+    /// (the default) for every visible tournament, with `distance_miles` null.
+    ///
     /// - Remark: HTTP `GET /v1/tournaments`.
     /// - Remark: Generated from `#/paths//v1/tournaments/get(list_tournaments_v1_tournaments_get)`.
     internal enum ListTournamentsV1TournamentsGet {
         internal static let id: Swift.String = "list_tournaments_v1_tournaments_get"
         internal struct Input: Sendable, Hashable {
+            /// - Remark: Generated from `#/paths/v1/tournaments/GET/query`.
+            internal struct Query: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/GET/query/lat`.
+                internal var lat: Swift.Double?
+                /// - Remark: Generated from `#/paths/v1/tournaments/GET/query/lng`.
+                internal var lng: Swift.Double?
+                /// - Remark: Generated from `#/paths/v1/tournaments/GET/query/radius_miles`.
+                internal var radiusMiles: Swift.Double?
+                /// Creates a new `Query`.
+                ///
+                /// - Parameters:
+                ///   - lat:
+                ///   - lng:
+                ///   - radiusMiles:
+                internal init(
+                    lat: Swift.Double? = nil,
+                    lng: Swift.Double? = nil,
+                    radiusMiles: Swift.Double? = nil
+                ) {
+                    self.lat = lat
+                    self.lng = lng
+                    self.radiusMiles = radiusMiles
+                }
+            }
+            internal var query: Operations.ListTournamentsV1TournamentsGet.Input.Query
             /// - Remark: Generated from `#/paths/v1/tournaments/GET/header`.
             internal struct Headers: Sendable, Hashable {
                 internal var accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.ListTournamentsV1TournamentsGet.AcceptableContentType>]
@@ -20550,8 +20745,13 @@ internal enum Operations {
             /// Creates a new `Input`.
             ///
             /// - Parameters:
+            ///   - query:
             ///   - headers:
-            internal init(headers: Operations.ListTournamentsV1TournamentsGet.Input.Headers = .init()) {
+            internal init(
+                query: Operations.ListTournamentsV1TournamentsGet.Input.Query = .init(),
+                headers: Operations.ListTournamentsV1TournamentsGet.Input.Headers = .init()
+            ) {
+                self.query = query
                 self.headers = headers
             }
         }

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -566,7 +566,7 @@ internal protocol APIProtocol: Sendable {
     /// tournament, so the same grant that lets a user create one lets them preview
     /// its location — this is deliberately not a wide-open geocoding proxy.
     ///
-    /// A zero-result / unresolvable address is the same coded ``422`` the write path
+    /// A zero-result / unresolvable address is the same coded ``409`` the write path
     /// answers (:func:`_address_not_geocodable`, ``address_not_geocodable``), so the
     /// preview and the write agree on the refusal. Any other geocoder failure
     /// (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to the
@@ -1918,7 +1918,7 @@ extension APIProtocol {
     /// tournament, so the same grant that lets a user create one lets them preview
     /// its location — this is deliberately not a wide-open geocoding proxy.
     ///
-    /// A zero-result / unresolvable address is the same coded ``422`` the write path
+    /// A zero-result / unresolvable address is the same coded ``409`` the write path
     /// answers (:func:`_address_not_geocodable`, ``address_not_geocodable``), so the
     /// preview and the write agree on the refusal. Any other geocoder failure
     /// (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to the
@@ -2713,6 +2713,63 @@ internal enum Components {
                     "region",
                     "postal",
                     "country"
+                ])
+            }
+        }
+        /// The ``409`` response body for a venue address that resolved to zero geocoding
+        /// candidates — the coded-refusal convention of ADR-0968, mirroring the entry
+        /// endpoint's ``{"code", "message"}`` shape.
+        ///
+        /// ``code`` is the stable contract a client switches on — always
+        /// :data:`ADDRESS_NOT_GEOCODABLE_CODE`, carried as the field's default so the one
+        /// constant is the single source of the string (no fork) and the concrete value
+        /// still surfaces in the generated OpenAPI. ``message`` is fallback prose for a
+        /// client without copy for the code, or a person.
+        ///
+        /// Modeled (rather than a hand-rolled ``dict`` detail) so the create/edit/preview
+        /// routes' ``responses={409: {"model": AddressNotGeocodable}}`` describes the body
+        /// the generated web + iOS types actually receive — instead of the refusal riding on
+        /// FastAPI's reserved ``422``, whose auto-generated ``HTTPValidationError`` schema
+        /// says ``detail`` is an **array** and so cannot decode this object body (ADR-0968).
+        /// Pure Pydantic, kept beside the code/message it carries; the FastAPI
+        /// ``HTTPException`` that wraps it lives in the router adapter (``app.tournaments``),
+        /// so this module stays FastAPI-free.
+        ///
+        /// - Remark: Generated from `#/components/schemas/AddressNotGeocodable`.
+        internal struct AddressNotGeocodable: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/AddressNotGeocodable/code`.
+            internal var code: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/AddressNotGeocodable/message`.
+            internal var message: Swift.String
+            /// Creates a new `AddressNotGeocodable`.
+            ///
+            /// - Parameters:
+            ///   - code:
+            ///   - message:
+            internal init(
+                code: Swift.String? = nil,
+                message: Swift.String
+            ) {
+                self.code = code
+                self.message = message
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case code
+                case message
+            }
+            internal init(from decoder: any Swift.Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.code = try container.decodeIfPresent(
+                    Swift.String.self,
+                    forKey: .code
+                )
+                self.message = try container.decode(
+                    Swift.String.self,
+                    forKey: .message
+                )
+                try decoder.ensureNoAdditionalProperties(knownKeys: [
+                    "code",
+                    "message"
                 ])
             }
         }
@@ -4390,9 +4447,9 @@ internal enum Components {
         /// :class:`~app.geocoding.Geocoder` the create/edit write path geocodes with, so
         /// the pin the previewer sees matches the coordinates a subsequent write records.
         ///
-        /// An address that resolves to zero candidates is a coded ``422`` at the boundary
-        /// carrying the same ``address_not_geocodable`` code the write path answers with —
-        /// never a coordinate-less preview.
+        /// An address that resolves to zero candidates is a coded ``409`` carrying the same
+        /// ``address_not_geocodable`` code the write path answers with — never a
+        /// coordinate-less preview.
         ///
         /// - Remark: Generated from `#/components/schemas/GeocodePreview`.
         internal struct GeocodePreview: Codable, Hashable, Sendable {
@@ -21099,6 +21156,57 @@ internal enum Operations {
                     }
                 }
             }
+            internal struct Conflict: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/POST/responses/409/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/tournaments/POST/responses/409/content/application\/json`.
+                    case json(Components.Schemas.AddressNotGeocodable)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.AddressNotGeocodable {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.CreateTournamentV1TournamentsPost.Output.Conflict.Body
+                /// Creates a new `Conflict`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.CreateTournamentV1TournamentsPost.Output.Conflict.Body) {
+                    self.body = body
+                }
+            }
+            /// Conflict
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/post(create_tournament_v1_tournaments_post)/responses/409`.
+            ///
+            /// HTTP response code: `409 conflict`.
+            case conflict(Operations.CreateTournamentV1TournamentsPost.Output.Conflict)
+            /// The associated value of the enum case if `self` is `.conflict`.
+            ///
+            /// - Throws: An error if `self` is not `.conflict`.
+            /// - SeeAlso: `.conflict`.
+            internal var conflict: Operations.CreateTournamentV1TournamentsPost.Output.Conflict {
+                get throws {
+                    switch self {
+                    case let .conflict(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "conflict",
+                            response: self
+                        )
+                    }
+                }
+            }
             internal struct UnprocessableContent: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/v1/tournaments/POST/responses/422/content`.
                 internal enum Body: Sendable, Hashable {
@@ -21197,7 +21305,7 @@ internal enum Operations {
     /// tournament, so the same grant that lets a user create one lets them preview
     /// its location — this is deliberately not a wide-open geocoding proxy.
     ///
-    /// A zero-result / unresolvable address is the same coded ``422`` the write path
+    /// A zero-result / unresolvable address is the same coded ``409`` the write path
     /// answers (:func:`_address_not_geocodable`, ``address_not_geocodable``), so the
     /// preview and the write agree on the refusal. Any other geocoder failure
     /// (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to the
@@ -21293,6 +21401,57 @@ internal enum Operations {
                     default:
                         try throwUnexpectedResponseStatus(
                             expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct Conflict: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/geocode/GET/responses/409/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/geocode/GET/responses/409/content/application\/json`.
+                    case json(Components.Schemas.AddressNotGeocodable)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.AddressNotGeocodable {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.PreviewGeocodeV1GeocodeGet.Output.Conflict.Body
+                /// Creates a new `Conflict`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.PreviewGeocodeV1GeocodeGet.Output.Conflict.Body) {
+                    self.body = body
+                }
+            }
+            /// Conflict
+            ///
+            /// - Remark: Generated from `#/paths//v1/geocode/get(preview_geocode_v1_geocode_get)/responses/409`.
+            ///
+            /// HTTP response code: `409 conflict`.
+            case conflict(Operations.PreviewGeocodeV1GeocodeGet.Output.Conflict)
+            /// The associated value of the enum case if `self` is `.conflict`.
+            ///
+            /// - Throws: An error if `self` is not `.conflict`.
+            /// - SeeAlso: `.conflict`.
+            internal var conflict: Operations.PreviewGeocodeV1GeocodeGet.Output.Conflict {
+                get throws {
+                    switch self {
+                    case let .conflict(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "conflict",
                             response: self
                         )
                     }
@@ -21660,6 +21819,57 @@ internal enum Operations {
                     default:
                         try throwUnexpectedResponseStatus(
                             expectedStatus: "ok",
+                            response: self
+                        )
+                    }
+                }
+            }
+            internal struct Conflict: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/PATCH/responses/409/content`.
+                internal enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/v1/tournaments/{tournament_id}/PATCH/responses/409/content/application\/json`.
+                    case json(Components.Schemas.AddressNotGeocodable)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    internal var json: Components.Schemas.AddressNotGeocodable {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                internal var body: Operations.UpdateTournamentV1TournamentsTournamentIdPatch.Output.Conflict.Body
+                /// Creates a new `Conflict`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                internal init(body: Operations.UpdateTournamentV1TournamentsTournamentIdPatch.Output.Conflict.Body) {
+                    self.body = body
+                }
+            }
+            /// Conflict
+            ///
+            /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/patch(update_tournament_v1_tournaments__tournament_id__patch)/responses/409`.
+            ///
+            /// HTTP response code: `409 conflict`.
+            case conflict(Operations.UpdateTournamentV1TournamentsTournamentIdPatch.Output.Conflict)
+            /// The associated value of the enum case if `self` is `.conflict`.
+            ///
+            /// - Throws: An error if `self` is not `.conflict`.
+            /// - SeeAlso: `.conflict`.
+            internal var conflict: Operations.UpdateTournamentV1TournamentsTournamentIdPatch.Output.Conflict {
+                get throws {
+                    switch self {
+                    case let .conflict(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "conflict",
                             response: self
                         )
                     }

--- a/scripts/redeploy-uat.sh
+++ b/scripts/redeploy-uat.sh
@@ -115,6 +115,17 @@ WEB_BUILD_ARGS=()
 if [ "$DEPLOY_OBSERVABILITY" = "true" ]; then
   WEB_BUILD_ARGS+=(--build-arg "VITE_FARO_COLLECTOR_URL=/faro/collect")
 fi
+# Bake the browser Google Maps key into the UAT bundle when the operator has set
+# it in .env. OPTIONAL: unset/blank => no build arg, the bundle ships without a
+# Maps key and the map component falls back to a text render (keyless build stays
+# valid). This is the *browser* key; the server-side GOOGLE_GEOCODING_API_KEY is
+# synced into the fortymm-uat-env Secret below, not passed as a build arg.
+# `|| true`: read_env greps .env under `set -e -o pipefail`, so an absent
+# (optional) line would otherwise abort the deploy — swallow that miss.
+VITE_GOOGLE_MAPS_API_KEY="$(read_env VITE_GOOGLE_MAPS_API_KEY || true)"
+if [ -n "$VITE_GOOGLE_MAPS_API_KEY" ]; then
+  WEB_BUILD_ARGS+=(--build-arg "VITE_GOOGLE_MAPS_API_KEY=$VITE_GOOGLE_MAPS_API_KEY")
+fi
 docker build -t "$WEB_IMAGE" "${WEB_BUILD_ARGS[@]+"${WEB_BUILD_ARGS[@]}"}" -f web-client/Dockerfile.uat web-client
 
 echo

--- a/web-client/Dockerfile.uat
+++ b/web-client/Dockerfile.uat
@@ -19,6 +19,14 @@ COPY . .
 ARG VITE_FARO_COLLECTOR_URL=""
 ENV VITE_FARO_COLLECTOR_URL=$VITE_FARO_COLLECTOR_URL
 
+# Browser Google Maps JS API key, baked into the bundle at build time. OPTIONAL:
+# empty by default, so a keyless build still succeeds and produces a working
+# bundle — the map component reads import.meta.env.VITE_GOOGLE_MAPS_API_KEY and
+# degrades to a text fallback when it's unset. This is the *browser* key; the
+# server-side GOOGLE_GEOCODING_API_KEY is a separate runtime secret, not this.
+ARG VITE_GOOGLE_MAPS_API_KEY=""
+ENV VITE_GOOGLE_MAPS_API_KEY=$VITE_GOOGLE_MAPS_API_KEY
+
 RUN npm run build
 
 FROM nginx:1.31-alpine

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-router": "^1.170.18",
         "@tanstack/zod-adapter": "^1.167.0",
+        "@vis.gl/react-google-maps": "^1.9.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -2260,6 +2261,15 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-2.1.1.tgz",
+      "integrity": "sha512-yUpAwksbHrlZIWD49JmveNSfBG4oAK0AwMknfSaPMnP5N7UT8oFRVCqwjGb1XQovi//7KLbPQKZpbofiLGzpDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/google.maps": "^3.53.1"
       }
     },
     "node_modules/@grafana/faro-core": {
@@ -6610,6 +6620,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/google.maps": {
+      "version": "3.65.3",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.65.3.tgz",
+      "integrity": "sha512-tqbbx7MUtoDk+RwpZMymPDj6Skez0FhqDZNhLhS5UDmCx4D1dgP+BJOHTebiO/rhjJLa1f8te2p6mJJeFKVFOQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
@@ -6915,6 +6931,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vis.gl/react-google-maps": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.9.0.tgz",
+      "integrity": "sha512-ELL/zo8mRMPGDQZwHRClf2tE1/PMYYKjg+C/dUn8rmlQ0e+s7rkcNmCgaeBAV48GJzEcrBsr+vjDv4AvzJrlUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "^2.0.2",
+        "@types/google.maps": "^3.64.0",
+        "fast-equals": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": ">=16.8.0 || ^19.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -8806,6 +8837,15 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.2.tgz",
+      "integrity": "sha512-sAjhj9ZhOxYCGiNMnZLaucOqf5ZeFnHNoKoAZiD9thhJ0N8RP85qJK759/97C/3L7NzzmGVB5uiX9AUpySZmUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -26,6 +26,7 @@
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.18",
     "@tanstack/zod-adapter": "^1.167.0",
+    "@vis.gl/react-google-maps": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/web-client/src/api/geocode.test.ts
+++ b/web-client/src/api/geocode.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { ApiError } from './client'
+import { ADDRESS_NOT_GEOCODABLE, isAddressNotGeocodable } from './geocode'
+
+/** The coded refusal `previewGeocode` (and the create/edit write path) answers a
+ * zero-result address with. It is a `409` — the same status the OTHER tournament
+ * refusals use — so the classifier must discriminate on the coded `detail`, never
+ * the bare status. */
+const geocodeRefusal = (code = ADDRESS_NOT_GEOCODABLE) =>
+  new ApiError(409, "We couldn't locate that address.", 'preview the location', {
+    detail: { code, message: "We couldn't locate that address." },
+  })
+
+describe('isAddressNotGeocodable', () => {
+  it('recognizes the coded 409 the preview/write path answers an unresolvable address with', () => {
+    expect(isAddressNotGeocodable(geocodeRefusal())).toBe(true)
+  })
+
+  it('does NOT confuse another 409 refusal (plain-string detail) for an unlocatable address', () => {
+    // league-not-editable / draw-under-way carry a bare `detail` STRING under the
+    // same 409 — a status-only check would misclassify them.
+    const drawUnderWay = new ApiError(
+      409,
+      'The draw is already under way.',
+      'save the tournament',
+      { detail: 'The draw is already under way.' },
+    )
+    expect(isAddressNotGeocodable(drawUnderWay)).toBe(false)
+  })
+
+  it('does NOT match a 409 whose code is something else', () => {
+    expect(isAddressNotGeocodable(geocodeRefusal('registration_closed'))).toBe(
+      false,
+    )
+  })
+
+  it('does NOT match the same coded body under a different status (a stale 422)', () => {
+    const asFourTwentyTwo = new ApiError(
+      422,
+      "We couldn't locate that address.",
+      'preview the location',
+      { detail: { code: ADDRESS_NOT_GEOCODABLE, message: 'x' } },
+    )
+    expect(isAddressNotGeocodable(asFourTwentyTwo)).toBe(false)
+  })
+
+  it('is false for a non-ApiError and for a null body', () => {
+    expect(isAddressNotGeocodable(new Error('boom'))).toBe(false)
+    expect(
+      isAddressNotGeocodable(
+        new ApiError(409, null, 'preview the location', null),
+      ),
+    ).toBe(false)
+  })
+})

--- a/web-client/src/api/geocode.ts
+++ b/web-client/src/api/geocode.ts
@@ -1,0 +1,57 @@
+// The read-only "Preview location" lookup (`GET /v1/geocode`). Geocodes a
+// free-text venue address to coordinates for a confirmation pin, WITHOUT writing
+// anything — the tournament create/edit surfaces call it on a user action (the
+// "Preview location" button), so it is its own endpoint rather than folded into a
+// page's BFF payload (root CLAUDE.md, "BFF endpoints").
+
+import { z } from 'zod'
+
+import { ApiError, api, unwrap } from './client'
+
+/** The wire's `GeocodePreview` — parsed at the fetch boundary (web-client
+ * CLAUDE.md "Boundaries"). The generated `schema.d.ts` gives the compile-time
+ * shape; this gives the runtime guarantee. */
+export const geocodePreviewSchema = z.object({
+  latitude: z.number(),
+  longitude: z.number(),
+  formatted: z.string(),
+})
+
+export type GeocodePreview = z.infer<typeof geocodePreviewSchema>
+
+/** The coded reason a `422` carries when an address resolves to zero candidates.
+ * The preview endpoint answers with the SAME code the create/edit write path
+ * uses, so "we couldn't locate that address" is one refusal, told once. */
+export const ADDRESS_NOT_GEOCODABLE = 'address_not_geocodable'
+
+/**
+ * True when `error` is the coded "unresolvable address" `422` — the one failure
+ * the preview surfaces INLINE ("we couldn't locate that address"). Every other
+ * failure (a 5xx, an outage, a 403) is not this, and the caller toasts it instead
+ * of implying the organizer typed a bad address. Reads the structured code off
+ * the stored `ApiError.body`, never the bare status.
+ */
+export function isAddressNotGeocodable(error: unknown): boolean {
+  if (!(error instanceof ApiError) || error.status !== 422) return false
+  const detail = (error.body as { detail?: unknown } | null | undefined)?.detail
+  return (
+    !!detail &&
+    typeof detail === 'object' &&
+    !Array.isArray(detail) &&
+    (detail as { code?: unknown }).code === ADDRESS_NOT_GEOCODABLE
+  )
+}
+
+/**
+ * Resolve a free-text `address` to coordinates for the preview pin. Throws an
+ * `ApiError` on failure — the caller distinguishes the coded "unresolvable"
+ * `422` (`isAddressNotGeocodable`) from everything else. The 2xx body is
+ * Zod-parsed before it flows inward.
+ */
+export async function previewGeocode(address: string): Promise<GeocodePreview> {
+  const data = unwrap(
+    'preview the location',
+    await api.GET('/v1/geocode', { params: { query: { address } } }),
+  )
+  return geocodePreviewSchema.parse(data)
+}

--- a/web-client/src/api/geocode.ts
+++ b/web-client/src/api/geocode.ts
@@ -19,20 +19,25 @@ export const geocodePreviewSchema = z.object({
 
 export type GeocodePreview = z.infer<typeof geocodePreviewSchema>
 
-/** The coded reason a `422` carries when an address resolves to zero candidates.
+/** The coded reason a `409` carries when an address resolves to zero candidates.
  * The preview endpoint answers with the SAME code the create/edit write path
  * uses, so "we couldn't locate that address" is one refusal, told once. */
 export const ADDRESS_NOT_GEOCODABLE = 'address_not_geocodable'
 
 /**
- * True when `error` is the coded "unresolvable address" `422` — the one failure
+ * True when `error` is the coded "unresolvable address" `409` — the one failure
  * the preview surfaces INLINE ("we couldn't locate that address"). Every other
  * failure (a 5xx, an outage, a 403) is not this, and the caller toasts it instead
- * of implying the organizer typed a bad address. Reads the structured code off
- * the stored `ApiError.body`, never the bare status.
+ * of implying the organizer typed a bad address.
+ *
+ * The `code` check is load-bearing, not belt-and-braces: `409` is ALSO the status
+ * of the other tournament refusals (league-not-editable, draw-under-way), which
+ * carry a plain-string `detail`. A bare `status === 409` would misclassify those
+ * as "unlocatable address", so we discriminate on the structured code read off the
+ * stored `ApiError.body` — never the bare status.
  */
 export function isAddressNotGeocodable(error: unknown): boolean {
-  if (!(error instanceof ApiError) || error.status !== 422) return false
+  if (!(error instanceof ApiError) || error.status !== 409) return false
   const detail = (error.body as { detail?: unknown } | null | undefined)?.detail
   return (
     !!detail &&
@@ -45,7 +50,7 @@ export function isAddressNotGeocodable(error: unknown): boolean {
 /**
  * Resolve a free-text `address` to coordinates for the preview pin. Throws an
  * `ApiError` on failure — the caller distinguishes the coded "unresolvable"
- * `422` (`isAddressNotGeocodable`) from everything else. The 2xx body is
+ * `409` (`isAddressNotGeocodable`) from everything else. The 2xx body is
  * Zod-parsed before it flows inward.
  */
 export async function previewGeocode(address: string): Promise<GeocodePreview> {

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1031,7 +1031,7 @@ export interface paths {
          *     tournament, so the same grant that lets a user create one lets them preview
          *     its location — this is deliberately not a wide-open geocoding proxy.
          *
-         *     A zero-result / unresolvable address is the same coded ``422`` the write path
+         *     A zero-result / unresolvable address is the same coded ``409`` the write path
          *     answers (:func:`_address_not_geocodable`, ``address_not_geocodable``), so the
          *     preview and the write agree on the refusal. Any other geocoder failure
          *     (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to the
@@ -1680,6 +1680,36 @@ export interface components {
             country: string;
         };
         /**
+         * AddressNotGeocodable
+         * @description The ``409`` response body for a venue address that resolved to zero geocoding
+         *     candidates — the coded-refusal convention of ADR-0968, mirroring the entry
+         *     endpoint's ``{"code", "message"}`` shape.
+         *
+         *     ``code`` is the stable contract a client switches on — always
+         *     :data:`ADDRESS_NOT_GEOCODABLE_CODE`, carried as the field's default so the one
+         *     constant is the single source of the string (no fork) and the concrete value
+         *     still surfaces in the generated OpenAPI. ``message`` is fallback prose for a
+         *     client without copy for the code, or a person.
+         *
+         *     Modeled (rather than a hand-rolled ``dict`` detail) so the create/edit/preview
+         *     routes' ``responses={409: {"model": AddressNotGeocodable}}`` describes the body
+         *     the generated web + iOS types actually receive — instead of the refusal riding on
+         *     FastAPI's reserved ``422``, whose auto-generated ``HTTPValidationError`` schema
+         *     says ``detail`` is an **array** and so cannot decode this object body (ADR-0968).
+         *     Pure Pydantic, kept beside the code/message it carries; the FastAPI
+         *     ``HTTPException`` that wraps it lives in the router adapter (``app.tournaments``),
+         *     so this module stays FastAPI-free.
+         */
+        AddressNotGeocodable: {
+            /**
+             * Code
+             * @default address_not_geocodable
+             */
+            code: string;
+            /** Message */
+            message: string;
+        };
+        /**
          * AdminScheduleSolveListResponse
          * @description Paginated `/v1/admin/schedule-solves` response backing the Administration
          *     area's solve-ledger page.
@@ -2323,9 +2353,9 @@ export interface components {
          *     :class:`~app.geocoding.Geocoder` the create/edit write path geocodes with, so
          *     the pin the previewer sees matches the coordinates a subsequent write records.
          *
-         *     An address that resolves to zero candidates is a coded ``422`` at the boundary
-         *     carrying the same ``address_not_geocodable`` code the write path answers with —
-         *     never a coordinate-less preview.
+         *     An address that resolves to zero candidates is a coded ``409`` carrying the same
+         *     ``address_not_geocodable`` code the write path answers with — never a
+         *     coordinate-less preview.
          */
         GeocodePreview: {
             /** Latitude */
@@ -6772,6 +6802,15 @@ export interface operations {
                     "application/json": components["schemas"]["TournamentRead"];
                 };
             };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AddressNotGeocodable"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 headers: {
@@ -6803,6 +6842,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GeocodePreview"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AddressNotGeocodable"];
                 };
             };
             /** @description Validation Error */
@@ -6904,6 +6952,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TournamentRead"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AddressNotGeocodable"];
                 };
             };
             /** @description Validation Error */

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1008,6 +1008,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/geocode": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Preview Geocode
+         * @description Resolve a free-text ``address`` string to coordinates for the web
+         *     "Preview location" pin, without writing anything.
+         *
+         *     Its own BFF-style endpoint (root ``CLAUDE.md``, "BFF endpoints"): it fetches
+         *     on a user action — the previewer typing/blurring the venue fields — not on
+         *     page load, so it is not folded into a page endpoint. It resolves through the
+         *     same injected :class:`~app.geocoding.Geocoder` the create/edit write path
+         *     geocodes with, so the pin the previewer sees matches the coordinates a
+         *     subsequent write would record.
+         *
+         *     Gated on ``tournament.create``: previewing a venue is part of composing a
+         *     tournament, so the same grant that lets a user create one lets them preview
+         *     its location — this is deliberately not a wide-open geocoding proxy.
+         *
+         *     A zero-result / unresolvable address is the same coded ``422`` the write path
+         *     answers (:func:`_address_not_geocodable`, ``address_not_geocodable``), so the
+         *     preview and the write agree on the refusal. Any other geocoder failure
+         *     (:class:`~app.geocoding.GeocoderError`) is unexpected and propagates to the
+         *     ``500`` handler.
+         */
+        get: operations["preview_geocode_v1_geocode_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/tournaments/{tournament_id}": {
         parameters: {
             query?: never;
@@ -2273,6 +2311,29 @@ export interface components {
             local_label: string;
             /** Tz Abbrev */
             tz_abbrev: string;
+        };
+        /**
+         * GeocodePreview
+         * @description The result of the read-only address-preview lookup (``GET /v1/geocode``).
+         *
+         *     The coordinates a free-text address string resolves to, plus the provider's
+         *     canonical ``formatted`` label, so the web "Preview location" pin can drop a
+         *     marker (and echo the normalized address it matched) *before* the tournament
+         *     write. This is not stored — it is a live lookup through the same injected
+         *     :class:`~app.geocoding.Geocoder` the create/edit write path geocodes with, so
+         *     the pin the previewer sees matches the coordinates a subsequent write records.
+         *
+         *     An address that resolves to zero candidates is a coded ``422`` at the boundary
+         *     carrying the same ``address_not_geocodable`` code the write path answers with —
+         *     never a coordinate-less preview.
+         */
+        GeocodePreview: {
+            /** Latitude */
+            latitude: number;
+            /** Longitude */
+            longitude: number;
+            /** Formatted */
+            formatted: string;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -6709,6 +6770,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TournamentRead"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_geocode_v1_geocode_get: {
+        parameters: {
+            query: {
+                address: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: {
+                session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GeocodePreview"];
                 };
             };
             /** @description Validation Error */

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -986,7 +986,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List Tournaments */
+        /**
+         * List Tournaments
+         * @description List the tournaments the caller may see, newest first, each as the full detail
+         *     aggregate the list cards render.
+         *
+         *     Pass an **all-or-nothing** `lat` / `lng` / `radius_miles` triple to filter to
+         *     tournaments **near a point**: only those whose venue is within `radius_miles` of
+         *     `(lat, lng)` come back, each carrying its `distance_miles` (a haversine
+         *     great-circle distance, in miles). Supplying some but not all three is a `422` — the
+         *     three describe one location filter, not three independent knobs. Omit all three
+         *     (the default) for every visible tournament, with `distance_miles` null.
+         */
         get: operations["list_tournaments_v1_tournaments_get"];
         put?: never;
         /** Create Tournament */
@@ -1570,9 +1581,53 @@ export interface components {
     schemas: {
         /**
          * Address
-         * @description A tournament venue address. Stored as a JSONB value-object.
+         * @description A tournament venue address as **stored and read**. A JSONB value-object.
+         *
+         *     The six free-text components a client sends (:class:`AddressInput`) **plus**
+         *     the ``latitude``/``longitude`` the server geocoded at write time — both NOT
+         *     NULL (ADR "a venue's coordinates are geocoded server-side at write time and are
+         *     NOT NULL"). Coordinates live inside the JSONB value-object, so the stored
+         *     address always carries them; a read that validates the column into this model
+         *     can rely on non-null coordinates rather than threading ``Optional[float]``
+         *     through every downstream reader.
+         *
+         *     This is the shape on the *read* schemas (:class:`TournamentRead` and the
+         *     detail/dashboard reads); the write schemas take :class:`AddressInput`, which
+         *     has no coordinates.
          */
         Address: {
+            /** Venue */
+            venue: string;
+            /** Street */
+            street: string;
+            /** City */
+            city: string;
+            /** Region */
+            region: string;
+            /** Postal */
+            postal: string;
+            /** Country */
+            country: string;
+            /** Latitude */
+            latitude: number;
+            /** Longitude */
+            longitude: number;
+        };
+        /**
+         * AddressInput
+         * @description The venue address a client **sends** on a write (create/edit).
+         *
+         *     Six free-text components and **no coordinates**: coordinates are geocoded
+         *     server-side at write time and are never supplied by a client (ADR "a venue's
+         *     coordinates are geocoded server-side at write time and are NOT NULL"). A client
+         *     that tries to send ``latitude``/``longitude`` gets a 422 — ``extra="forbid"`` —
+         *     rather than an unverified number the server would have to trust or re-check.
+         *
+         *     The write verbs geocode this input and construct the stored :class:`Address`
+         *     (with coordinates) before persisting; this is the shape on the *request*
+         *     schemas, and :class:`Address` is the shape on the *read* schemas.
+         */
+        AddressInput: {
             /** Venue */
             venue: string;
             /** Street */
@@ -4187,7 +4242,7 @@ export interface components {
             start_date?: string | null;
             /** End Date */
             end_date?: string | null;
-            address: components["schemas"]["Address"];
+            address: components["schemas"]["AddressInput"];
             /** Table Catalogue */
             table_catalogue?: components["schemas"]["TournamentTable"][];
             /** League Id */
@@ -4238,6 +4293,8 @@ export interface components {
             updated_at: string;
             /** Events */
             events: components["schemas"]["TournamentEventRead"][];
+            /** Distance Miles */
+            distance_miles?: number | null;
             latest_schedule_solve: components["schemas"]["ScheduleSolveRead"] | null;
         };
         /**
@@ -4667,7 +4724,7 @@ export interface components {
             start_date?: string | null;
             /** End Date */
             end_date?: string | null;
-            address?: components["schemas"]["Address"] | null;
+            address?: components["schemas"]["AddressInput"] | null;
             /** Table Catalogue */
             table_catalogue?: components["schemas"]["TournamentTable"][] | null;
             /** League Id */
@@ -6597,7 +6654,11 @@ export interface operations {
     };
     list_tournaments_v1_tournaments_get: {
         parameters: {
-            query?: never;
+            query?: {
+                lat?: number | null;
+                lng?: number | null;
+                radius_miles?: number | null;
+            };
             header?: never;
             path?: never;
             cookie?: {

--- a/web-client/src/components/maps/location-map.factory.tsx
+++ b/web-client/src/components/maps/location-map.factory.tsx
@@ -1,0 +1,16 @@
+import type { LocationMapProps } from './location-map'
+
+/**
+ * Props for `LocationMap` — a pin on the Oakland Convention Center, the kind of
+ * venue a tournament detail page shows.
+ */
+export function buildLocationMapProps(
+  overrides: Partial<LocationMapProps> = {},
+): LocationMapProps {
+  return {
+    latitude: 37.8014,
+    longitude: -122.2711,
+    label: '1001 Broadway, Oakland, CA 94607',
+    ...overrides,
+  }
+}

--- a/web-client/src/components/maps/location-map.page.tsx
+++ b/web-client/src/components/maps/location-map.page.tsx
@@ -1,0 +1,37 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { LocationMap, type LocationMapProps } from './location-map'
+import { buildLocationMapProps } from './location-map.factory'
+
+const scoped = (container: Container) => ({
+  /** The map container — present only when a Maps key is configured. */
+  queryMap() {
+    return container.queryByTestId('location-map')
+  },
+  /** The text fallback shown when no Maps key is configured; else null. */
+  queryFallback() {
+    return container.queryByTestId('location-map-fallback')
+  },
+  /** The text fallback; throws if it is absent (a key was configured). */
+  getFallback() {
+    return container.getByTestId('location-map-fallback')
+  },
+})
+
+/**
+ * Test page-object for `LocationMap`. The Google Maps library is inert in
+ * jsdom, so tests that exercise the key-present branch must mock
+ * `@vis.gl/react-google-maps`; this page object only touches the component's own
+ * `location-map` / `location-map-fallback` containers.
+ */
+export const locationMapPage = {
+  render(overrides: Partial<LocationMapProps> = {}) {
+    render(<LocationMap {...buildLocationMapProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/maps/location-map.test.tsx
+++ b/web-client/src/components/maps/location-map.test.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from 'react'
+
+// jsdom has no Google Maps runtime, so replace the library with inert doubles.
+// `mapProps` / `markerProps` capture what the component passes so we can assert
+// the pin is centered on the given coordinates without loading Google.
+const { mapProps, markerProps } = vi.hoisted(() => ({
+  mapProps: vi.fn(),
+  markerProps: vi.fn(),
+}))
+
+vi.mock('@vis.gl/react-google-maps', () => ({
+  APIProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Map: (props: { children: ReactNode; [k: string]: unknown }) => {
+    mapProps(props)
+    return <div data-testid="mock-map">{props.children}</div>
+  },
+  AdvancedMarker: (props: Record<string, unknown>) => {
+    markerProps(props)
+    return <div data-testid="mock-marker" />
+  },
+}))
+
+// Imported after the mock is declared (vi.mock is hoisted above all imports).
+import { locationMapPage } from './location-map.page'
+
+const KEY = 'VITE_GOOGLE_MAPS_API_KEY'
+
+describe('LocationMap', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    mapProps.mockClear()
+    markerProps.mockClear()
+  })
+
+  describe('with no Maps key configured', () => {
+    beforeEach(() => {
+      vi.stubEnv(KEY, '')
+    })
+
+    it('renders the label as a text fallback instead of a map', () => {
+      locationMapPage.render({ label: '1001 Broadway, Oakland, CA 94607' })
+
+      expect(locationMapPage.getFallback()).toHaveTextContent(
+        '1001 Broadway, Oakland, CA 94607',
+      )
+      expect(locationMapPage.queryMap()).toBeNull()
+    })
+
+    it('does not load the Google Maps library', () => {
+      locationMapPage.render()
+
+      expect(mapProps).not.toHaveBeenCalled()
+      expect(markerProps).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('with a Maps key configured', () => {
+    beforeEach(() => {
+      vi.stubEnv(KEY, 'test-browser-key')
+    })
+
+    it('renders the map instead of the text fallback', () => {
+      locationMapPage.render()
+
+      expect(locationMapPage.queryMap()).not.toBeNull()
+      expect(locationMapPage.queryFallback()).toBeNull()
+    })
+
+    it('centers the map and the pin on the given coordinates', () => {
+      locationMapPage.render({ latitude: 40.7128, longitude: -74.006 })
+
+      expect(mapProps).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defaultCenter: { lat: 40.7128, lng: -74.006 },
+        }),
+      )
+      expect(markerProps).toHaveBeenCalledWith(
+        expect.objectContaining({
+          position: { lat: 40.7128, lng: -74.006 },
+        }),
+      )
+    })
+
+    it('titles the pin with the label', () => {
+      locationMapPage.render({ label: 'Center Court' })
+
+      expect(markerProps).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Center Court' }),
+      )
+    })
+  })
+})

--- a/web-client/src/components/maps/location-map.tsx
+++ b/web-client/src/components/maps/location-map.tsx
@@ -1,0 +1,81 @@
+import { APIProvider, AdvancedMarker, Map } from '@vis.gl/react-google-maps'
+
+import { cn } from '@/lib/utils'
+
+export interface LocationMapProps {
+  /** Latitude of the pin, in decimal degrees. */
+  latitude: number
+  /** Longitude of the pin, in decimal degrees. */
+  longitude: number
+  /**
+   * Human-readable location. Titles the pin, and is shown verbatim as the text
+   * fallback when no Google Maps key is configured.
+   */
+  label: string
+  /** Map zoom level. Ignored by the text fallback. */
+  zoom?: number
+  /** Extra classes for the outer container — e.g. to override the height. */
+  className?: string
+}
+
+const DEFAULT_ZOOM = 14
+
+// Google's public demo vector style. `AdvancedMarker` needs a map ID to render,
+// and this one works without a Cloud-configured map. Override with
+// VITE_GOOGLE_MAPS_MAP_ID in a real deploy.
+const DEMO_MAP_ID = 'DEMO_MAP_ID'
+
+/**
+ * Display-only venue map: renders a single pin at (`latitude`, `longitude`) with
+ * Google Maps via `@vis.gl/react-google-maps`, reading the browser key from
+ * `VITE_GOOGLE_MAPS_API_KEY`.
+ *
+ * When no key is configured (dev/CI/e2e all run keyless) it degrades gracefully
+ * to a text fallback of `label` — it never loads Google and never throws. This
+ * component only *renders* coordinates; it does not author them.
+ */
+export const LocationMap = ({
+  latitude,
+  longitude,
+  label,
+  zoom = DEFAULT_ZOOM,
+  className,
+}: LocationMapProps) => {
+  const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY
+  const position = { lat: latitude, lng: longitude }
+
+  if (!apiKey) {
+    return (
+      <div
+        data-testid="location-map-fallback"
+        className={cn(
+          'flex min-h-32 items-center justify-center rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-2)] p-4 text-center',
+          className,
+        )}
+      >
+        <span className="text-sm text-[color:var(--fg-3)]">{label}</span>
+      </div>
+    )
+  }
+
+  const mapId = import.meta.env.VITE_GOOGLE_MAPS_MAP_ID || DEMO_MAP_ID
+
+  return (
+    <div
+      data-testid="location-map"
+      className={cn('h-48 overflow-hidden rounded-lg', className)}
+    >
+      <APIProvider apiKey={apiKey}>
+        <Map
+          defaultCenter={position}
+          defaultZoom={zoom}
+          mapId={mapId}
+          gestureHandling="cooperative"
+          disableDefaultUI
+        >
+          <AdvancedMarker position={position} title={label} />
+        </Map>
+      </APIProvider>
+    </div>
+  )
+}

--- a/web-client/src/components/maps/preview-location.factory.tsx
+++ b/web-client/src/components/maps/preview-location.factory.tsx
@@ -1,0 +1,20 @@
+import type { PreviewLocationProps } from './preview-location'
+
+/** Props for `PreviewLocation` — a fully-typed Berkeley venue address, the kind
+ * a real preview geocodes. Override any field to exercise the blank/partial
+ * composition paths. */
+export function buildPreviewLocationProps(
+  overrides: Partial<PreviewLocationProps> = {},
+): PreviewLocationProps {
+  return {
+    address: {
+      venue: 'Berkeley TT Club',
+      street: '2727 Milvia St',
+      city: 'Berkeley',
+      region: 'CA',
+      postal: '94703',
+      country: 'USA',
+    },
+    ...overrides,
+  }
+}

--- a/web-client/src/components/maps/preview-location.page.tsx
+++ b/web-client/src/components/maps/preview-location.page.tsx
@@ -1,0 +1,43 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { PreviewLocation, type PreviewLocationProps } from './preview-location'
+import { buildPreviewLocationProps } from './preview-location.factory'
+
+const scoped = (container: Container) => ({
+  /** The "Preview location" button — its label flips to "Locating…" in flight. */
+  getPreviewButton() {
+    return container.getByRole('button', { name: /Preview location|Locating/ })
+  },
+  /** The confirmation pin's text fallback (dev/CI/e2e run keyless), present only
+   * after a resolvable address geocodes; else null. */
+  queryPin() {
+    return container.queryByTestId('location-map-fallback')
+  },
+  /** The inline "we couldn't locate that address" note — present only on the
+   * coded 422 path; else null. */
+  queryError() {
+    return container.queryByTestId('preview-location-error')
+  },
+  findError() {
+    return container.findByTestId('preview-location-error')
+  },
+})
+
+/**
+ * Test page-object for `PreviewLocation`. The geocode call goes through the
+ * `openapi-fetch` client, so tests must have an MSW handler for `GET /v1/geocode`
+ * (the default handler resolves normal addresses and 422s the `__unresolvable__`
+ * sentinel). The Google Maps library is inert in jsdom, so the pin asserts via
+ * the `location-map-fallback` text.
+ */
+export const previewLocationPage = {
+  render(overrides: Partial<PreviewLocationProps> = {}) {
+    render(<PreviewLocation {...buildPreviewLocationProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/maps/preview-location.test.tsx
+++ b/web-client/src/components/maps/preview-location.test.tsx
@@ -33,7 +33,7 @@ describe('PreviewLocation', () => {
   })
 
   it('surfaces the inline error and NO pin for an unresolvable address', async () => {
-    // The `__unresolvable__` sentinel drives the mock's coded 422
+    // The `__unresolvable__` sentinel drives the mock's coded 409
     // (`address_not_geocodable`) — the same refusal the write path answers with.
     previewLocationPage.render({
       address: {

--- a/web-client/src/components/maps/preview-location.test.tsx
+++ b/web-client/src/components/maps/preview-location.test.tsx
@@ -1,0 +1,85 @@
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { toast } from 'sonner'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { server } from '@/mocks/server'
+import { waitFor } from '@/test/utilities'
+
+import { previewLocationPage } from './preview-location.page'
+
+vi.mock('sonner', async () => {
+  const actual = await vi.importActual<typeof import('sonner')>('sonner')
+  return { ...actual, toast: { ...actual.toast, error: vi.fn() } }
+})
+
+beforeEach(() => vi.mocked(toast.error).mockClear())
+
+describe('PreviewLocation', () => {
+  it('geocodes the typed address and drops a confirmation pin', async () => {
+    previewLocationPage.render()
+
+    expect(previewLocationPage.queryPin()).toBeNull()
+    await userEvent.click(previewLocationPage.getPreviewButton())
+
+    // Keyless (dev/CI), `LocationMap` renders its text fallback of the returned
+    // `formatted` label — the pin is present, at the geocoded location.
+    await waitFor(() => expect(previewLocationPage.queryPin()).not.toBeNull())
+    // The pin's fallback echoes the geocoder's `formatted` (the composed address
+    // in the mock), and there is no inline error.
+    expect(previewLocationPage.queryPin()).toHaveTextContent('Berkeley TT Club')
+    expect(previewLocationPage.queryError()).toBeNull()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the inline error and NO pin for an unresolvable address', async () => {
+    // The `__unresolvable__` sentinel drives the mock's coded 422
+    // (`address_not_geocodable`) — the same refusal the write path answers with.
+    previewLocationPage.render({
+      address: {
+        venue: '__unresolvable__',
+        street: '',
+        city: '',
+        region: '',
+        postal: '',
+      },
+    })
+
+    await userEvent.click(previewLocationPage.getPreviewButton())
+
+    expect(await previewLocationPage.findError()).toBeVisible()
+    expect(previewLocationPage.queryPin()).toBeNull()
+    // An unresolvable address is a fact about the address, not an error to toast.
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('resolves its pending state — never a permanent spinner', async () => {
+    previewLocationPage.render()
+
+    await userEvent.click(previewLocationPage.getPreviewButton())
+
+    // Once the lookup settles the button is enabled again and back to its resting
+    // label — the "Locating…" state does not latch.
+    await waitFor(() =>
+      expect(previewLocationPage.getPreviewButton()).toBeEnabled(),
+    )
+    expect(previewLocationPage.getPreviewButton()).toHaveTextContent(
+      'Preview location',
+    )
+  })
+
+  it('toasts a non-geocode failure instead of the inline "couldn’t locate" note', async () => {
+    // A 500 is not "your address is unlocatable" — it must not accuse a good
+    // address. It toasts, and the inline note stays absent.
+    server.use(
+      http.get('*/v1/geocode', () => new HttpResponse(null, { status: 500 })),
+    )
+    previewLocationPage.render()
+
+    await userEvent.click(previewLocationPage.getPreviewButton())
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(previewLocationPage.queryError()).toBeNull()
+    expect(previewLocationPage.queryPin()).toBeNull()
+  })
+})

--- a/web-client/src/components/maps/preview-location.tsx
+++ b/web-client/src/components/maps/preview-location.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react'
+import { MapPin, MapPinOff } from 'lucide-react'
+
+import {
+  type GeocodePreview,
+  isAddressNotGeocodable,
+  previewGeocode,
+} from '@/api/geocode'
+import { notifyError } from '@/lib/notify-error'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+
+import { LocationMap } from './location-map'
+
+/** The six free-text venue components as currently typed on the write surface.
+ * `country` is optional — the create modal has no country field, only the edit
+ * form does — but the rest are always present (empty strings when unfilled). */
+export interface PreviewAddress {
+  venue: string
+  street: string
+  city: string
+  region: string
+  postal: string
+  country?: string
+}
+
+export interface PreviewLocationProps {
+  /** The address to geocode, read live from the surrounding form. */
+  address: PreviewAddress
+}
+
+/** Compose the typed parts into one address line for the geocoder, dropping the
+ * blanks so an empty region/venue doesn't wedge stray commas into the query. */
+function composeAddress(address: PreviewAddress): string {
+  return [
+    address.venue,
+    address.street,
+    address.city,
+    address.region,
+    address.postal,
+    address.country,
+  ]
+    .map((part) => part?.trim() ?? '')
+    .filter(Boolean)
+    .join(', ')
+}
+
+/** `idle` → the button, no pin. `pending` → the in-flight state that always
+ * resolves (never a permanent spinner). `located` → a `LocationMap` pin at the
+ * geocoded coords. `not_found` → the inline "we couldn't locate that address"
+ * note, and no pin. */
+type PreviewState =
+  | { status: 'idle' }
+  | { status: 'pending' }
+  | { status: 'located'; preview: GeocodePreview }
+  | { status: 'not_found' }
+
+/**
+ * The shared "Preview location" affordance on both tournament write surfaces (the
+ * create modal and the edit form). It geocodes the currently-typed venue address
+ * via `GET /v1/geocode` on a user action — fetch-on-click, its own request, never
+ * on load — and drops a confirmation pin so the organizer can confirm the venue
+ * *before* saving.
+ *
+ * It is display-only confirmation: it adds NO coordinates to the create/edit
+ * submit payload (the server geocodes on save; the write shape stays
+ * coordinate-free). An unresolvable address surfaces inline ("we couldn't locate
+ * that address") with no pin — the coded `422` both this endpoint and the write
+ * path answer with. Any other failure is a toast, so a real address is never
+ * blamed for a server outage.
+ */
+export const PreviewLocation = ({ address }: PreviewLocationProps) => {
+  const [state, setState] = useState<PreviewState>({ status: 'idle' })
+
+  const preview = async () => {
+    setState({ status: 'pending' })
+    try {
+      const result = await previewGeocode(composeAddress(address))
+      setState({ status: 'located', preview: result })
+    } catch (error) {
+      // The coded "zero candidates" 422 is the one failure told inline — the
+      // organizer's address didn't resolve. Everything else (a 5xx, an outage, a
+      // 403) is not about their address, so it toasts and the button returns to
+      // idle rather than accusing a good address of being unlocatable.
+      if (isAddressNotGeocodable(error)) {
+        setState({ status: 'not_found' })
+        return
+      }
+      notifyError('preview the location')(error)
+      setState({ status: 'idle' })
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2" data-testid="preview-location">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={preview}
+        disabled={state.status === 'pending'}
+        className="self-start"
+      >
+        <MapPin size={16} />
+        {state.status === 'pending' ? 'Locating…' : 'Preview location'}
+      </Button>
+
+      {state.status === 'located' && (
+        <LocationMap
+          latitude={state.preview.latitude}
+          longitude={state.preview.longitude}
+          // The provider's canonical label when it gave one, else the venue name
+          // the organizer typed — never an empty pin title.
+          label={state.preview.formatted || address.venue}
+          className="h-44 max-w-md"
+        />
+      )}
+
+      {state.status === 'not_found' && (
+        <Alert
+          variant="destructive"
+          data-testid="preview-location-error"
+          className="max-w-md"
+        >
+          <MapPinOff />
+          <AlertTitle>We couldn&rsquo;t locate that address</AlertTitle>
+          <AlertDescription>
+            Check the venue details and try again. Nothing was saved.
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/maps/preview-location.tsx
+++ b/web-client/src/components/maps/preview-location.tsx
@@ -65,7 +65,7 @@ type PreviewState =
  * It is display-only confirmation: it adds NO coordinates to the create/edit
  * submit payload (the server geocodes on save; the write shape stays
  * coordinate-free). An unresolvable address surfaces inline ("we couldn't locate
- * that address") with no pin — the coded `422` both this endpoint and the write
+ * that address") with no pin — the coded `409` both this endpoint and the write
  * path answer with. Any other failure is a toast, so a real address is never
  * blamed for a server outage.
  */
@@ -78,10 +78,11 @@ export const PreviewLocation = ({ address }: PreviewLocationProps) => {
       const result = await previewGeocode(composeAddress(address))
       setState({ status: 'located', preview: result })
     } catch (error) {
-      // The coded "zero candidates" 422 is the one failure told inline — the
+      // The coded "zero candidates" 409 is the one failure told inline — the
       // organizer's address didn't resolve. Everything else (a 5xx, an outage, a
-      // 403) is not about their address, so it toasts and the button returns to
-      // idle rather than accusing a good address of being unlocatable.
+      // 403, or another 409 whose code is not `address_not_geocodable`) is not
+      // about their address, so it toasts and the button returns to idle rather
+      // than accusing a good address of being unlocatable.
       if (isAddressNotGeocodable(error)) {
         setState({ status: 'not_found' })
         return

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -107,6 +107,54 @@ describe('useTournaments', () => {
       tableIds: ['t1', 't2', 't3', 't4'],
     })
   })
+
+  // The near-me filter (chore 3a): a location + radius goes on the wire as the API's
+  // all-or-nothing `lat`/`lng`/`radius_miles` triple, and each row's server-computed
+  // `distance_miles` is parsed onto `distanceMiles`.
+  it('sends lat/lng/radius_miles and surfaces the parsed distanceMiles when given a location', async () => {
+    let seenUrl = ''
+    mockTournamentsListEndpoint(server, ({ request }) => {
+      seenUrl = request.url
+      return HttpResponse.json([
+        buildTournamentDetailRead({
+          id: 't-1',
+          name: 'Bay Area Open 2026',
+          distance_miles: 4.2,
+        }),
+      ])
+    })
+
+    const { result } = renderHook(() =>
+      useTournaments({ lat: 37.7749, lng: -122.4194, radiusMiles: 25 }),
+    )
+
+    await waitFor(() => expect(result.current).toHaveLength(1))
+
+    const params = new URL(seenUrl).searchParams
+    expect(params.get('lat')).toBe('37.7749')
+    expect(params.get('lng')).toBe('-122.4194')
+    expect(params.get('radius_miles')).toBe('25')
+    // The server-computed haversine distance, parsed at the boundary (`./api`).
+    expect(result.current[0].distanceMiles).toBe(4.2)
+  })
+
+  // Absent a location the request is EXACTLY the default list — no query params at all —
+  // and every row's `distanceMiles` is the designed `null` (the server sent none).
+  it('sends no query params for the default list, and surfaces distanceMiles null', async () => {
+    let seenUrl = ''
+    mockTournamentsListEndpoint(server, ({ request }) => {
+      seenUrl = request.url
+      return HttpResponse.json([buildTournamentDetailRead({ id: 't-1' })])
+    })
+
+    const { result } = renderHook(() => useTournaments())
+
+    await waitFor(() => expect(result.current).toHaveLength(1))
+
+    // No `?lat=…&lng=…&radius_miles=…` — the default list is unchanged.
+    expect(new URL(seenUrl).search).toBe('')
+    expect(result.current[0].distanceMiles).toBeNull()
+  })
 })
 
 describe('useTournament', () => {

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -487,6 +487,9 @@ const draft: Omit<Tournament, 'id'> = {
   startDate: '2026-09-01',
   endDate: '2026-09-02',
   description: 'A new draft.',
+  // A read `Address` carries the server-geocoded coordinates (NOT NULL). The
+  // write builders below must STRIP them — the create/edit wire shape is the
+  // coord-free `AddressInput` — so the fixture is coord-carrying on purpose.
   address: {
     venue: 'Oakland Arena',
     street: '7000 Coliseum Way',
@@ -494,6 +497,8 @@ const draft: Omit<Tournament, 'id'> = {
     region: 'CA',
     postal: '94621',
     country: 'USA',
+    latitude: 37.7503,
+    longitude: -122.2032,
   },
   tableIds: [],
   events: [],
@@ -509,7 +514,18 @@ describe('draftToCreateBody', () => {
       description: 'A new draft.',
       start_date: '2026-09-01',
       end_date: '2026-09-02',
-      address: draft.address,
+      // The write shape is the coord-free `AddressInput`: the six text fields
+      // and NOTHING else. The draft's `address` carries `latitude`/`longitude`
+      // (it is a read `Address`), so this asserts the projector STRIPPED them —
+      // a client never sends coordinates, and the server 422s the extra keys.
+      address: {
+        venue: 'Oakland Arena',
+        street: '7000 Coliseum Way',
+        city: 'Oakland',
+        region: 'CA',
+        postal: '94621',
+        country: 'USA',
+      },
       table_catalogue: [],
     })
   })
@@ -532,6 +548,17 @@ describe('tournamentToUpdateBody', () => {
     expect(body.name).toBe('Renamed')
     expect(body.start_date).toBe('2026-09-01')
     expect(body.end_date).toBe('2026-09-02')
+    // The edit wire shape is the coord-free `AddressInput` too: the tournament
+    // is a read model carrying `latitude`/`longitude`, and the builder strips
+    // them — the server geocodes on its own and 422s a client-sent coordinate.
+    expect(body.address).toEqual({
+      venue: 'Oakland Arena',
+      street: '7000 Coliseum Way',
+      city: 'Oakland',
+      region: 'CA',
+      postal: '94621',
+      country: 'USA',
+    })
     expect('events' in body).toBe(false)
   })
 

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -382,7 +382,13 @@ export function tournamentsListQuery(nearMe?: TournamentsNearMe) {
       )
       return rows.map(apiToTournament)
     },
-    throwOnError: true,
+    // Throw to the error boundary only on a cold load (nothing on screen), not on a
+    // background-refetch failure — matching `tournamentDetailQuery` below. `throwOnError:
+    // true` fires on background refetches too (see web-client/CLAUDE.md), so a transient
+    // blip re-fetching the list — now more likely, since near-me round-trips through
+    // browser geolocation + the network and each radius/location is its own cache entry —
+    // would tear down an already-rendered list rather than keep the last-good view.
+    throwOnError: (_error, query) => query.state.data === undefined,
     retry: false,
   })
 }

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -14,6 +14,7 @@ import {
 } from '@tanstack/react-query'
 import { notFound } from '@tanstack/react-router'
 import { toast } from 'sonner'
+import { z } from 'zod'
 
 import { ApiError, api, unwrap } from '@/api/client'
 import { notifyError } from '@/lib/notify-error'
@@ -169,6 +170,19 @@ function apiToPool(p: ApiPool): Pool {
   return { id: p.id, name: p.name, slot: p.slot, tableIds: p.table_ids }
 }
 
+/** The server returns `distance_miles` on each tournament — a non-negative haversine
+ * distance in **miles** when the list query was given a location (the all-or-nothing
+ * `lat`/`lng`/`radius_miles` triple), or `null`/absent when it was not. PARSED at the
+ * boundary (`.claude/rules/parse-at-boundaries.md`): the wire is untrusted, so a
+ * negative or non-numeric value fails HERE — inside the queryFn — rather than surfacing
+ * as a nonsense badge three components away. Absent and `null` both collapse to `null`,
+ * the designed "no location sent" state, so a reader models one thing, not three. */
+const distanceMilesSchema = z
+  .number()
+  .nonnegative()
+  .nullish()
+  .transform((v) => v ?? null)
+
 /** Map an API tournament (list or detail; both return `TournamentDetailRead`)
  * to the prototype's `Tournament`. The tournament's `table_catalogue` IS the
  * catalogue, so `tableIds` is just its ids. */
@@ -184,6 +198,10 @@ export function apiToTournament(t: TournamentDetailRead): Tournament {
     address: t.address,
     tableIds: t.table_catalogue.map((tbl) => tbl.id),
     events: t.events.map(apiToEvent),
+    // PARSED, not cast — a non-negative miles distance or `null` (`distanceMilesSchema`
+    // above). Present only when the list query sent a location; `null` on every other
+    // list card and on the detail payload.
+    distanceMiles: distanceMilesSchema.parse(t.distance_miles),
     // PARSED, not cast — the same boundary the fixtures and results cross
     // (`./solve`, `.claude/rules/parse-at-boundaries.md`): the solve strip switches
     // on this row's `status`/`trigger`/`verdict` by value, so an enum member this
@@ -300,6 +318,30 @@ export function eventToUpdateBody(ev: TournamentEvent): TournamentEventUpdate {
 const TOURNAMENTS_KEY = ['tournaments'] as const
 const tournamentKey = (id: string) => ['tournaments', id] as const
 
+/** A location + radius to filter the list to tournaments **near a point**. All three
+ * are sent together or not at all — the API's `lat`/`lng`/`radius_miles` triple is
+ * all-or-nothing — so this client carries them as one value (present or `undefined`),
+ * never three loose optionals that could send a partial triple the server would 422. */
+export type TournamentsNearMe = {
+  lat: number
+  lng: number
+  radiusMiles: number
+}
+
+/** The list query's key. The near-me triple is PART of the key, so a change of
+ * location or radius is a different cache entry and refetches (rather than showing the
+ * previous radius's stale results). The default (no location) list keeps the bare
+ * `['tournaments']` key it has always had — which is also the prefix every mutation
+ * invalidates, so both the default and every near-me list refresh after a write. The
+ * near-me second element is an object, never colliding with a detail key's string id. */
+const tournamentsListKey = (nearMe?: TournamentsNearMe) =>
+  nearMe
+    ? ([
+        ...TOURNAMENTS_KEY,
+        { lat: nearMe.lat, lng: nearMe.lng, radiusMiles: nearMe.radiusMiles },
+      ] as const)
+    : TOURNAMENTS_KEY
+
 /** Invalidate both the list and one tournament's detail after a mutation. */
 function invalidateTournament(qc: QueryClient, id: string) {
   qc.invalidateQueries({ queryKey: TOURNAMENTS_KEY })
@@ -309,17 +351,46 @@ function invalidateTournament(qc: QueryClient, id: string) {
 // ----- queries -------------------------------------------------------------
 
 /** The tournament list, mapped to prototype `Tournament[]`. A 403 (a permitted
- * non-creator the server still gates) bubbles to the `RbacBoundary`. */
-export function useTournaments(): Tournament[] {
-  const { data } = useQuery({
-    queryKey: TOURNAMENTS_KEY,
+ * non-creator the server still gates) bubbles to the `RbacBoundary`.
+ *
+ * Pass `nearMe` to filter to tournaments **near a point**: its `lat`/`lng`/
+ * `radiusMiles` go on the wire as the API's all-or-nothing `lat`/`lng`/`radius_miles`
+ * query triple, and each row comes back carrying its `distance_miles` (parsed onto
+ * `Tournament.distanceMiles`). Omit it and the request is exactly the default list —
+ * no params — with every row's `distanceMiles` `null`. The triple is part of the query
+ * KEY (see `tournamentsListKey`), so changing location or radius refetches. */
+export function tournamentsListQuery(nearMe?: TournamentsNearMe) {
+  return queryOptions({
+    queryKey: tournamentsListKey(nearMe),
     queryFn: async (): Promise<Tournament[]> => {
-      const rows = unwrap('load tournaments', await api.GET('/v1/tournaments'))
+      const rows = unwrap(
+        'load tournaments',
+        await api.GET(
+          '/v1/tournaments',
+          nearMe
+            ? {
+                params: {
+                  query: {
+                    lat: nearMe.lat,
+                    lng: nearMe.lng,
+                    radius_miles: nearMe.radiusMiles,
+                  },
+                },
+              }
+            : undefined,
+        ),
+      )
       return rows.map(apiToTournament)
     },
     throwOnError: true,
     retry: false,
   })
+}
+
+/** Thin hook over `tournamentsListQuery` — returns the mapped list (or `[]` before
+ * it loads). Takes the same optional `nearMe` filter. */
+export function useTournaments(nearMe?: TournamentsNearMe): Tournament[] {
+  const { data } = useQuery(tournamentsListQuery(nearMe))
   return data ?? []
 }
 

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -29,6 +29,7 @@ import {
 } from './solve'
 import type { LifecycleEdge } from './lifecycle'
 import type {
+  Address,
   Entrant,
   EventEntryState,
   Fixture,
@@ -46,6 +47,7 @@ type TournamentEventRead = components['schemas']['TournamentEventRead']
 type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
 type TournamentCreate = components['schemas']['TournamentCreate']
 type TournamentUpdate = components['schemas']['TournamentUpdate']
+type AddressInput = components['schemas']['AddressInput']
 type TournamentEventCreate = components['schemas']['TournamentEventCreate']
 type TournamentEventUpdate = components['schemas']['TournamentEventUpdate']
 type ApiPool = components['schemas']['Pool']
@@ -192,6 +194,23 @@ export function apiToTournament(t: TournamentDetailRead): Tournament {
   }
 }
 
+/** Project the read `Address` (which carries the server-geocoded
+ * `latitude`/`longitude`) down to the coordinate-free `AddressInput` a write
+ * verb sends. Coordinates are geocoded server-side at write time and a client
+ * NEVER supplies them — the write schema is `extra="forbid"`, so sending them
+ * would 422. Picking the six text fields keeps the write path coord-free no
+ * matter what the read side accreted. */
+function toAddressInput(a: Address): AddressInput {
+  return {
+    venue: a.venue,
+    street: a.street,
+    city: a.city,
+    region: a.region,
+    postal: a.postal,
+    country: a.country,
+  }
+}
+
 /** Build the `TournamentCreate` body from a prototype draft (the "New
  * tournament" modal). The modal collects no tables, so `table_catalogue` is the
  * empty array the bare-create endpoint expects.
@@ -209,7 +228,7 @@ export function draftToCreateBody(
     description: draft.description,
     start_date: draft.startDate,
     end_date: draft.endDate,
-    address: draft.address,
+    address: toAddressInput(draft.address),
     table_catalogue: [],
   }
 }
@@ -232,7 +251,7 @@ export function tournamentToUpdateBody(
     description: t.description,
     start_date: t.startDate,
     end_date: t.endDate,
-    address: t.address,
+    address: toAddressInput(t.address),
     table_catalogue: catalogue,
   }
 }

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -137,6 +137,19 @@ export function fmtVenueLine(address: Address): string {
   return joinPresent([address.venue, locality], ' · ')
 }
 
+/** A venue's distance from the searched-from point, as a card badge's label:
+ * `12 mi`, `0.4 mi` — never `12.0 mi`. The server already rounds to one decimal
+ * (`distance_miles`), so this only cleans the display: it re-rounds to one
+ * decimal (idempotent, guarding float artifacts like `0.30000000000000004`) and
+ * lets `String` drop a trailing `.0`, without flattening a real `0.4` to `0`.
+ *
+ * Called only with a number — the card decides whether the badge exists at all,
+ * since `distanceMiles` is `null`/absent when the list query sent no location. */
+export function fmtDistance(miles: number): string {
+  const rounded = Math.round(miles * 10) / 10
+  return `${rounded} mi`
+}
+
 /** A compact, human range: collapses same-day, same-month, and full spans. */
 export function fmtDateRange(
   a: string | null | undefined,

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -302,6 +302,10 @@ export function emptyTournament(): Omit<Tournament, 'id'> {
     startDate: null,
     endDate: null,
     description: '',
+    // `Tournament` is the READ model, so its `Address` carries the geocoded
+    // coordinates; a blank draft has none yet, so they seed at 0. The write path
+    // (`draftToCreateBody`) drops them — a client never sends coordinates — so
+    // these placeholders never reach the wire.
     address: {
       venue: '',
       street: '',
@@ -309,6 +313,8 @@ export function emptyTournament(): Omit<Tournament, 'id'> {
       region: '',
       postal: '',
       country: 'USA',
+      latitude: 0,
+      longitude: 0,
     },
     tableIds: ['t1', 't2', 't3', 't4', 't5', 't6', 't7', 't8'],
     events: [],

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -32,6 +32,9 @@ export function buildAddress(overrides: Partial<Address> = {}): Address {
     region: 'CA',
     postal: '94703',
     country: 'USA',
+    // Server-geocoded on the read model (NOT NULL) — Berkeley, CA.
+    latitude: 37.8715,
+    longitude: -122.273,
     ...overrides,
   }
 }

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -407,4 +407,11 @@ export interface Tournament {
    * the boundary by `./solve`; read it, never write it — a new row appears only
    * through `POST …/schedule/solves` (or the server's own triggers). */
   latestScheduleSolve: ScheduleSolve | null
+  /** How far this tournament's venue is from the point the list query was given a
+   * location for — a non-negative haversine distance in **miles** — or `null` when the
+   * query sent no location (the default list, and the detail payload). The server
+   * computes it (`distance_miles`) and this client only reads it, parsed at the boundary
+   * by `./api`. Optional because the tournaments the app builds from seeds/drafts carry
+   * no distance; a mapped API row always sets it (to `null` when no location was sent). */
+  distanceMiles?: number | null
 }

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -36,6 +36,14 @@ export interface Address {
   region: string
   postal: string
   country: string
+  /** Server-geocoded at write time and **NOT NULL** on the read schema — mirrors
+   * `Address` in `schema.d.ts` (the ADR "a venue's coordinates are geocoded
+   * server-side at write time and are NOT NULL"). The *write* shape a client
+   * sends (`AddressInput`) has no coordinates; a client never supplies these.
+   * The read model always carries them, so downstream readers (distance badge,
+   * map) can rely on non-null coordinates rather than threading `number | null`. */
+  latitude: number
+  longitude: number
 }
 
 /** Eligibility-rule field keys understood by the predicate builder.

--- a/web-client/src/components/tournaments/near-me-control.factory.tsx
+++ b/web-client/src/components/tournaments/near-me-control.factory.tsx
@@ -1,0 +1,12 @@
+import type { NearMeControlProps } from './near-me-control'
+
+/** Props for `NearMeControl` — a no-op `onNearMeChange` by default, so a bare
+ * `page.render()` mounts the toggle + radius picker with nothing wired. */
+export function buildNearMeControlProps(
+  overrides: Partial<NearMeControlProps> = {},
+): NearMeControlProps {
+  return {
+    onNearMeChange: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/near-me-control.page.tsx
+++ b/web-client/src/components/tournaments/near-me-control.page.tsx
@@ -1,0 +1,52 @@
+import userEvent from '@testing-library/user-event'
+
+import { render, screen, type Container } from '@/test/utilities'
+
+import { NearMeControl, type NearMeControlProps } from './near-me-control'
+import { buildNearMeControlProps } from './near-me-control.factory'
+
+const scoped = (container: Container) => ({
+  /** The "Near me" toggle (a Radix Switch → role `switch`). */
+  getToggle() {
+    return container.getByRole('switch', { name: /near me/i })
+  },
+  /** The radius picker's trigger (a Radix Select → role `combobox`). */
+  getRadiusTrigger() {
+    return container.getByRole('combobox', { name: /search radius/i })
+  },
+  /** The transient "Locating…" indicator — absent unless a request is in flight. */
+  queryLocating() {
+    return container.queryByText(/locating/i)
+  },
+  /** The inline "location unavailable" note — absent unless we fell back. */
+  queryUnavailableNote() {
+    return container.queryByRole('alert')
+  },
+  /** Toggle the switch (on or off — Radix flips the current state). */
+  async clickToggle() {
+    await userEvent.click(this.getToggle())
+  },
+  /** Open the radius picker and choose `${miles} mi` — options portal to the
+   * body, so they resolve against `screen`, not the scoped container. */
+  async selectRadius(miles: number) {
+    await userEvent.click(this.getRadiusTrigger())
+    await userEvent.click(
+      await screen.findByRole('option', { name: `${miles} mi` }),
+    )
+  },
+})
+
+/** Test page-object for `NearMeControl`. Geolocation is the boundary under
+ * test, so tests install their own `navigator.geolocation` mock before
+ * rendering (granted / denied / undefined) and assert on `onNearMeChange`. */
+export const nearMeControlPage = {
+  render(overrides: Partial<NearMeControlProps> = {}) {
+    render(<NearMeControl {...buildNearMeControlProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/near-me-control.test.tsx
+++ b/web-client/src/components/tournaments/near-me-control.test.tsx
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { nearMeControlPage } from './near-me-control.page'
+
+/** Install a `navigator.geolocation` whose `getCurrentPosition` resolves
+ * synchronously to `(lat, lng)` — a granted permission. */
+function grantAt(lat: number, lng: number) {
+  Object.defineProperty(navigator, 'geolocation', {
+    configurable: true,
+    value: {
+      getCurrentPosition: (
+        success: PositionCallback,
+      ) => success({ coords: { latitude: lat, longitude: lng } } as GeolocationPosition),
+    },
+  })
+}
+
+/** A geolocation whose `getCurrentPosition` invokes the error callback — a
+ * denied permission (or any position error). */
+function denyGeolocation() {
+  Object.defineProperty(navigator, 'geolocation', {
+    configurable: true,
+    value: {
+      getCurrentPosition: (
+        _success: PositionCallback,
+        error?: PositionErrorCallback,
+      ) => error?.({ code: 1, message: 'User denied Geolocation' } as GeolocationPositionError),
+    },
+  })
+}
+
+/** Remove `navigator.geolocation` entirely — an insecure origin or an old
+ * browser where the API does not exist. */
+function removeGeolocation() {
+  Object.defineProperty(navigator, 'geolocation', {
+    configurable: true,
+    value: undefined,
+  })
+}
+
+afterEach(() => {
+  Object.defineProperty(navigator, 'geolocation', {
+    configurable: true,
+    value: undefined,
+  })
+})
+
+describe('NearMeControl', () => {
+  it('emits the resolved lat/lng/radius triple when enabled and permission is granted', async () => {
+    grantAt(37.7749, -122.4194)
+    const onNearMeChange = vi.fn()
+    nearMeControlPage.render({ onNearMeChange })
+
+    await nearMeControlPage.clickToggle()
+
+    // The triple the list query needs — the default 25 mi radius plus the
+    // granted coordinates, parsed at the boundary.
+    expect(onNearMeChange).toHaveBeenLastCalledWith({
+      lat: 37.7749,
+      lng: -122.4194,
+      radiusMiles: 25,
+    })
+    // The toggle stays ON, and there is no lingering spinner or error note.
+    expect(nearMeControlPage.getToggle()).toBeChecked()
+    expect(nearMeControlPage.queryLocating()).toBeNull()
+    expect(nearMeControlPage.queryUnavailableNote()).toBeNull()
+  })
+
+  it('re-queries with the new radius when it changes while located', async () => {
+    grantAt(40.7128, -74.006)
+    const onNearMeChange = vi.fn()
+    nearMeControlPage.render({ onNearMeChange })
+
+    await nearMeControlPage.clickToggle()
+    onNearMeChange.mockClear()
+
+    await nearMeControlPage.selectRadius(100)
+
+    // Same coordinates, new radius — a fresh triple, so the list re-fetches.
+    expect(onNearMeChange).toHaveBeenLastCalledWith({
+      lat: 40.7128,
+      lng: -74.006,
+      radiusMiles: 100,
+    })
+  })
+
+  it('falls back gracefully when permission is denied: unfiltered list, toggle off, inline note', async () => {
+    denyGeolocation()
+    const onNearMeChange = vi.fn()
+    nearMeControlPage.render({ onNearMeChange })
+
+    await nearMeControlPage.clickToggle()
+
+    // No filter is sent — the full list stays.
+    expect(onNearMeChange).toHaveBeenLastCalledWith(undefined)
+    // The toggle snaps back off, and NO spinner is left spinning.
+    expect(nearMeControlPage.getToggle()).not.toBeChecked()
+    expect(nearMeControlPage.queryLocating()).toBeNull()
+    // The inline note explains why location is unavailable.
+    expect(nearMeControlPage.queryUnavailableNote()).toHaveTextContent(
+      /location unavailable/i,
+    )
+  })
+
+  it('falls back the same way when the geolocation API is unavailable', async () => {
+    removeGeolocation()
+    const onNearMeChange = vi.fn()
+    nearMeControlPage.render({ onNearMeChange })
+
+    await nearMeControlPage.clickToggle()
+
+    expect(onNearMeChange).toHaveBeenLastCalledWith(undefined)
+    expect(nearMeControlPage.getToggle()).not.toBeChecked()
+    expect(nearMeControlPage.queryUnavailableNote()).toHaveTextContent(
+      /location unavailable/i,
+    )
+  })
+
+  it('clears the note and filters on a successful retry after a denial', async () => {
+    denyGeolocation()
+    const onNearMeChange = vi.fn()
+    nearMeControlPage.render({ onNearMeChange })
+
+    await nearMeControlPage.clickToggle()
+    expect(nearMeControlPage.queryUnavailableNote()).not.toBeNull()
+
+    // The user grants it and tries again — the note clears and the filter lands.
+    grantAt(51.5074, -0.1278)
+    await nearMeControlPage.clickToggle()
+
+    expect(nearMeControlPage.queryUnavailableNote()).toBeNull()
+    expect(onNearMeChange).toHaveBeenLastCalledWith({
+      lat: 51.5074,
+      lng: -0.1278,
+      radiusMiles: 25,
+    })
+  })
+
+  it('clears the filter when toggled back off', async () => {
+    grantAt(37.7749, -122.4194)
+    const onNearMeChange = vi.fn()
+    nearMeControlPage.render({ onNearMeChange })
+
+    await nearMeControlPage.clickToggle()
+    onNearMeChange.mockClear()
+
+    await nearMeControlPage.clickToggle()
+
+    expect(onNearMeChange).toHaveBeenLastCalledWith(undefined)
+    expect(nearMeControlPage.getToggle()).not.toBeChecked()
+  })
+})

--- a/web-client/src/components/tournaments/near-me-control.tsx
+++ b/web-client/src/components/tournaments/near-me-control.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react'
+import { MapPin, MapPinOff } from 'lucide-react'
+import { z } from 'zod'
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+
+import type { TournamentsNearMe } from './data/api'
+
+/** The radii (in miles) the picker offers — the API accepts an arbitrary
+ * `radius_miles`, but the UI settles the user on a coarse choice. */
+const RADIUS_OPTIONS = [25, 50, 100] as const
+
+/** The Geolocation result is UNTRUSTED input like any other boundary
+ * (`.claude/rules/parse-at-boundaries.md`): the browser hands back a
+ * `GeolocationPosition`, but we only ever carry a `(lat, lng)` inward, and only
+ * once it has parsed to two finite numbers. A `NaN`/`Infinity` coordinate — or a
+ * shape that is not a position at all — is treated as a failure, not sent to the
+ * server as a nonsense query. */
+const positionSchema = z.object({
+  coords: z.object({
+    latitude: z.number().finite(),
+    longitude: z.number().finite(),
+  }),
+})
+
+type Status = 'idle' | 'locating' | 'error'
+
+export interface NearMeControlProps {
+  /** Called with the effective near-me filter whenever it changes: the resolved
+   * `{ lat, lng, radiusMiles }` triple once the toggle is on AND a location has
+   * been granted, or `undefined` whenever it is off, denied, or unavailable. The
+   * caller (the tournaments route) feeds this straight to the list query, which
+   * re-runs — this control never fetches, it only produces the filter. */
+  onNearMeChange: (nearMe: TournamentsNearMe | undefined) => void
+}
+
+/** The list's "Near me" filter: a toggle that asks the browser for the user's
+ * location, plus a radius picker (25 / 50 / 100 mi).
+ *
+ * **Graceful failure is load-bearing.** If the user denies permission, the
+ * browser errors, or `navigator.geolocation` is unavailable, we do NOT filter —
+ * the toggle snaps back off, the parent is handed `undefined` (so the full list
+ * stays), and an inline `Alert` explains that location is unavailable. No crash,
+ * no permanent spinner. */
+export const NearMeControl = ({ onNearMeChange }: NearMeControlProps) => {
+  const [enabled, setEnabled] = useState(false)
+  const [radiusMiles, setRadiusMiles] = useState<number>(RADIUS_OPTIONS[0])
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null)
+  const [status, setStatus] = useState<Status>('idle')
+
+  /** The one graceful-failure path: fall back to the unfiltered list, snap the
+   * toggle off, and surface the inline note. Never leaves a spinner up. */
+  const fail = () => {
+    setEnabled(false)
+    setCoords(null)
+    setStatus('error')
+    onNearMeChange(undefined)
+  }
+
+  const locate = (radius: number) => {
+    const geo =
+      typeof navigator !== 'undefined' ? navigator.geolocation : undefined
+    // Unavailable API (an insecure origin, an old browser) fails exactly like a
+    // denial does — the same fallback, no special-casing.
+    if (!geo || typeof geo.getCurrentPosition !== 'function') {
+      fail()
+      return
+    }
+    setStatus('locating')
+    geo.getCurrentPosition(
+      (position) => {
+        const parsed = positionSchema.safeParse(position)
+        if (!parsed.success) {
+          fail()
+          return
+        }
+        const { latitude, longitude } = parsed.data.coords
+        setCoords({ lat: latitude, lng: longitude })
+        setStatus('idle')
+        onNearMeChange({ lat: latitude, lng: longitude, radiusMiles: radius })
+      },
+      // Permission denied, position unavailable, or a timeout — all one fallback.
+      () => fail(),
+    )
+  }
+
+  const handleToggle = (next: boolean) => {
+    if (!next) {
+      setEnabled(false)
+      setCoords(null)
+      setStatus('idle')
+      onNearMeChange(undefined)
+      return
+    }
+    setEnabled(true)
+    // Clear any prior error note on a fresh attempt.
+    setStatus('idle')
+    locate(radiusMiles)
+  }
+
+  const handleRadiusChange = (value: string) => {
+    const next = Number(value)
+    setRadiusMiles(next)
+    // Re-query only if we are actually filtering: the radius is part of the
+    // triple, so a change while located re-runs the list. Changing it while off
+    // just pre-sets the choice for the next enable.
+    if (enabled && coords) {
+      onNearMeChange({ ...coords, radiusMiles: next })
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2.5">
+        <label className="flex items-center gap-2 text-sm text-[color:var(--fg-2)]">
+          <Switch
+            checked={enabled}
+            onCheckedChange={handleToggle}
+            aria-label="Filter by tournaments near me"
+          />
+          <span className="inline-flex items-center gap-1.5">
+            <MapPin size={14} className="text-[color:var(--fg-3)]" />
+            Near me
+          </span>
+        </label>
+        <Select value={String(radiusMiles)} onValueChange={handleRadiusChange}>
+          <SelectTrigger size="sm" aria-label="Search radius">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {RADIUS_OPTIONS.map((r) => (
+              <SelectItem key={r} value={String(r)}>
+                {r} mi
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {status === 'locating' && (
+          <span
+            role="status"
+            className="font-mono text-[11px] text-[color:var(--fg-3)]"
+          >
+            Locating…
+          </span>
+        )}
+      </div>
+
+      {status === 'error' && (
+        <Alert className="max-w-sm">
+          <MapPinOff />
+          <AlertTitle>Location unavailable</AlertTitle>
+          <AlertDescription>
+            We couldn&rsquo;t get your location, so we&rsquo;re showing every
+            tournament. Check your browser&rsquo;s location permission and try
+            again.
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/new-tournament-modal.page.tsx
+++ b/web-client/src/components/tournaments/new-tournament-modal.page.tsx
@@ -33,6 +33,23 @@ const scoped = (container: Container) => ({
   findErrorBanner() {
     return container.findByTestId('new-tournament-error')
   },
+  /** The "Preview location" button (chore 4e) — label flips to "Locating…" while
+   * the geocode is in flight. */
+  getPreviewButton() {
+    return container.getByRole('button', { name: /Preview location|Locating/ })
+  },
+  /** The preview pin's text fallback (keyless in tests), once a resolvable
+   * address geocodes; else null. */
+  queryPreviewPin() {
+    return container.queryByTestId('location-map-fallback')
+  },
+  /** The preview's inline "we couldn't locate that address" note; else null. */
+  queryPreviewError() {
+    return container.queryByTestId('preview-location-error')
+  },
+  findPreviewError() {
+    return container.findByTestId('preview-location-error')
+  },
 })
 
 /**

--- a/web-client/src/components/tournaments/new-tournament-modal.test.tsx
+++ b/web-client/src/components/tournaments/new-tournament-modal.test.tsx
@@ -310,7 +310,7 @@ describe('NewTournamentModal', () => {
   it('surfaces an inline error and no pin for an unresolvable address', async () => {
     newTournamentModalPage.render()
 
-    // The `__unresolvable__` sentinel drives the mock's coded 422 — the same
+    // The `__unresolvable__` sentinel drives the mock's coded 409 — the same
     // refusal the write path answers a zero-result address with.
     await userEvent.type(
       screen.getByLabelText('Venue name'),

--- a/web-client/src/components/tournaments/new-tournament-modal.test.tsx
+++ b/web-client/src/components/tournaments/new-tournament-modal.test.tsx
@@ -3,7 +3,7 @@ import { toast } from 'sonner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ApiError } from '@/api/client'
-import { screen } from '@/test/utilities'
+import { screen, waitFor } from '@/test/utilities'
 
 import { newTournamentModalPage } from './new-tournament-modal.page'
 
@@ -284,5 +284,73 @@ describe('NewTournamentModal', () => {
 
     await userEvent.click(newTournamentModalPage.getCancelButton())
     expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  // ----- Preview location (chore 4e) -------------------------------------
+
+  it('previews the typed venue address and drops a pin — without saving', async () => {
+    const onCreate = vi.fn()
+    newTournamentModalPage.render({ onCreate })
+
+    await userEvent.type(
+      screen.getByLabelText('Venue name'),
+      'Berkeley TT Club',
+    )
+    await userEvent.click(newTournamentModalPage.getPreviewButton())
+
+    // The geocode resolves and the pin renders (keyless text fallback), and the
+    // preview did NOT fire a save.
+    await waitFor(() =>
+      expect(newTournamentModalPage.queryPreviewPin()).not.toBeNull(),
+    )
+    expect(newTournamentModalPage.queryPreviewError()).toBeNull()
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an inline error and no pin for an unresolvable address', async () => {
+    newTournamentModalPage.render()
+
+    // The `__unresolvable__` sentinel drives the mock's coded 422 — the same
+    // refusal the write path answers a zero-result address with.
+    await userEvent.type(
+      screen.getByLabelText('Venue name'),
+      '__unresolvable__',
+    )
+    await userEvent.click(newTournamentModalPage.getPreviewButton())
+
+    expect(await newTournamentModalPage.findPreviewError()).toBeVisible()
+    expect(newTournamentModalPage.queryPreviewPin()).toBeNull()
+  })
+
+  it('a preview then a submit sends only the address fields — no geocoded coords leak in', async () => {
+    const onCreate = vi.fn()
+    newTournamentModalPage.render({ onCreate })
+
+    await userEvent.type(newTournamentModalPage.getNameInput(), 'Spring Open')
+    await userEvent.type(
+      screen.getByLabelText('Venue name'),
+      'Berkeley TT Club',
+    )
+    // Preview first (the geocode returns lat/lng), then save.
+    await userEvent.click(newTournamentModalPage.getPreviewButton())
+    await waitFor(() =>
+      expect(newTournamentModalPage.queryPreviewPin()).not.toBeNull(),
+    )
+    await userEvent.click(newTournamentModalPage.getCreateButton())
+
+    // The submitted address is exactly what was typed; the geocoded coordinates
+    // never leaked into it — the placeholder 0/0 the read-model draft carries is
+    // untouched, and `draftToCreateBody` drops even those on the wire.
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(onCreate.mock.calls[0][0].address).toEqual({
+      venue: 'Berkeley TT Club',
+      street: '',
+      city: '',
+      region: '',
+      postal: '',
+      country: 'USA',
+      latitude: 0,
+      longitude: 0,
+    })
   })
 })

--- a/web-client/src/components/tournaments/new-tournament-modal.tsx
+++ b/web-client/src/components/tournaments/new-tournament-modal.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import { z } from 'zod'
 import { Check, TriangleAlert } from 'lucide-react'
 
@@ -15,6 +15,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { PreviewLocation } from '@/components/maps/preview-location'
 
 import { emptyTournament } from './data/helpers'
 import {
@@ -117,8 +118,17 @@ export const NewTournamentModal = ({
   })
   const {
     register,
+    control,
     formState: { errors },
   } = form
+
+  // Live address values, so the "Preview location" pin geocodes exactly what the
+  // organizer has typed at click time. This form has no country field (the edit
+  // form does), so the previewer composes the five it holds.
+  const [venue, street, city, region, postal] = useWatch({
+    control,
+    name: ['venue', 'street', 'city', 'region', 'postal'],
+  })
 
   // Reset to a blank draft each time the dialog (re)opens — the modal stays
   // mounted, so without this a second open would show the prior attempt.
@@ -244,6 +254,11 @@ export const NewTournamentModal = ({
                 )}
               </Field>
             </div>
+
+            {/* Confirm the venue before saving: geocodes the typed address and
+                drops a pin. Display-only — it adds no coordinates to the create
+                payload (the server geocodes on save). */}
+            <PreviewLocation address={{ venue, street, city, region, postal }} />
           </div>
 
           {/* The refusal the form cannot pin to one box. An `Alert`, not a toast:

--- a/web-client/src/components/tournaments/tournament-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-card.page.tsx
@@ -23,6 +23,11 @@ const scoped = (container: Container) => ({
   queryVenueLine() {
     return container.queryByTestId('tournament-venue-line')
   },
+  /** The distance badge (e.g. `12 mi`), or null when the tournament carries no
+   * `distanceMiles` — its absence is the assertion, so this is a `query`. */
+  queryDistanceBadge() {
+    return container.queryByTestId('tournament-distance-badge')
+  },
   /** The card's status pill, reusing the badge's own query. */
   ...statusBadgePage.within(container),
 })

--- a/web-client/src/components/tournaments/tournament-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-card.test.tsx
@@ -63,6 +63,42 @@ describe('TournamentCard', () => {
     })
   })
 
+  // The distance is `null`/absent unless the list query carried a location, so
+  // the card shows a badge only when it's a number — and never a "— mi" hole.
+  describe('the distance badge', () => {
+    it('shows the formatted distance when the tournament carries one', () => {
+      tournamentCardPage.render({
+        tournament: buildTournament({ distanceMiles: 12 }),
+      })
+
+      expect(tournamentCardPage.queryDistanceBadge()).toHaveTextContent('12 mi')
+    })
+
+    it('renders a sub-mile distance cleanly, without re-rounding to zero', () => {
+      tournamentCardPage.render({
+        tournament: buildTournament({ distanceMiles: 0.4 }),
+      })
+
+      expect(tournamentCardPage.queryDistanceBadge()).toHaveTextContent('0.4 mi')
+    })
+
+    it('renders no badge when the tournament carries no distance', () => {
+      tournamentCardPage.render({
+        tournament: buildTournament({ distanceMiles: null }),
+      })
+
+      expect(tournamentCardPage.queryDistanceBadge()).toBeNull()
+    })
+
+    it('renders no badge when distance is absent from the payload', () => {
+      // The default seed sets no `distanceMiles` at all (a seed/draft tournament,
+      // or the default un-located list) — the badge element must not exist.
+      tournamentCardPage.render({ tournament: buildTournament() })
+
+      expect(tournamentCardPage.queryDistanceBadge()).toBeNull()
+    })
+  })
+
   it('opens the tournament when the card is clicked', async () => {
     const onOpen = vi.fn()
     tournamentCardPage.render({

--- a/web-client/src/components/tournaments/tournament-card.tsx
+++ b/web-client/src/components/tournaments/tournament-card.tsx
@@ -1,9 +1,15 @@
 import { MapPin, Trash2 } from 'lucide-react'
 
+import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 
-import { effectiveDateRange, fmtDateRange, fmtVenueLine } from './data/helpers'
+import {
+  effectiveDateRange,
+  fmtDateRange,
+  fmtDistance,
+  fmtVenueLine,
+} from './data/helpers'
 import type { Tournament } from './data/types'
 import { StatusBadge } from './status-badge'
 
@@ -70,6 +76,18 @@ export const TournamentCard = ({
               <MapPin size={12} />
               {venue}
             </div>
+          )}
+          {/* Rendered independently of the venue line: a distance is a fact
+              about the row whether or not the venue string is present, and it
+              only exists when the list query carried a location. */}
+          {t.distanceMiles != null && (
+            <Badge
+              variant="secondary"
+              data-testid="tournament-distance-badge"
+              className="mt-1.5"
+            >
+              {fmtDistance(t.distanceMiles)}
+            </Badge>
           )}
         </div>
 

--- a/web-client/src/components/tournaments/tournament-detail-page.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.page.tsx
@@ -67,6 +67,12 @@ const scoped = (container: Container) => ({
   queryVenueLine() {
     return container.queryByTestId('tournament-venue-line')
   },
+  /** The venue `LocationMap`'s text fallback — the branch rendered when no Google
+   * Maps key is configured (dev/CI/vitest all run keyless). Its text is the venue
+   * line. Absent when the tournament has no address. */
+  queryVenueMapFallback() {
+    return container.queryByTestId('location-map-fallback')
+  },
   ...eventsTabPage.within(container),
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.test.tsx
@@ -1,5 +1,22 @@
+import type { ReactNode } from 'react'
 import userEvent from '@testing-library/user-event'
 import { HttpResponse } from 'msw'
+
+// jsdom has no Google Maps runtime. Replace `@vis.gl/react-google-maps` with inert
+// doubles that capture the marker's props, so the key-present branch of the venue
+// `LocationMap` can be asserted (the pin lands on the tournament's stored
+// coordinates) without loading Google. Keyless — the default vitest env — the
+// component never touches these and renders its text fallback.
+const { markerProps } = vi.hoisted(() => ({ markerProps: vi.fn() }))
+
+vi.mock('@vis.gl/react-google-maps', () => ({
+  APIProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Map: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  AdvancedMarker: (props: Record<string, unknown>) => {
+    markerProps(props)
+    return <div data-testid="mock-marker" />
+  },
+}))
 
 import { ApiError } from '@/api/client'
 import { mockSessionEndpoint } from '@/mocks/endpoints/session/session.endpoint'
@@ -55,6 +72,53 @@ describe('TournamentDetailPage', () => {
       // interpunct legitimately appears elsewhere on the page — the event card's
       // own meta — so this asserts the item, not the character.)
       expect(tournamentDetailPagePage.queryVenueLine()).toBeNull()
+    })
+  })
+
+  // The display-only venue map (chore 4d): opening a tournament shows its venue on
+  // a map at the server-geocoded coordinates the read `Address` carries.
+  describe('the venue map', () => {
+    afterEach(() => markerProps.mockClear())
+
+    it('mounts a venue map — labelled with the venue line — at the stored coordinates', () => {
+      // The default vitest env is keyless, so `LocationMap` renders its text
+      // fallback (labelled with the venue line) rather than loading Google.
+      tournamentDetailPagePage.render({
+        tournament: buildTournament({
+          address: buildAddress({ latitude: 40.7128, longitude: -74.006 }),
+        }),
+      })
+
+      expect(tournamentDetailPagePage.queryVenueMapFallback()).toHaveTextContent(
+        'Berkeley TT Club · Berkeley, CA',
+      )
+    })
+
+    it('centers the pin on the tournament coordinates when a Maps key is present', () => {
+      vi.stubEnv('VITE_GOOGLE_MAPS_API_KEY', 'test-browser-key')
+      tournamentDetailPagePage.render({
+        tournament: buildTournament({
+          address: buildAddress({ latitude: 40.7128, longitude: -74.006 }),
+        }),
+      })
+
+      // The coords are threaded through, not the factory defaults: an
+      // `objectContaining({ lat: 37.8715 })` would pass a wiring that ignored the
+      // tournament and re-geocoded from nothing.
+      expect(markerProps).toHaveBeenCalledWith(
+        expect.objectContaining({ position: { lat: 40.7128, lng: -74.006 } }),
+      )
+      vi.unstubAllEnvs()
+    })
+
+    it('shows no venue map when the tournament has no address', () => {
+      tournamentDetailPagePage.render({
+        tournament: buildTournament({
+          address: buildAddress({ venue: '', city: '', region: '' }),
+        }),
+      })
+
+      expect(tournamentDetailPagePage.queryVenueMapFallback()).toBeNull()
     })
   })
 

--- a/web-client/src/components/tournaments/tournament-detail-page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Calendar, Layers, MapPin, Table2, Trophy, Users } from 'lucide-react'
 
+import { LocationMap } from '@/components/maps/location-map'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 import { ConfirmDeleteDialog } from './confirm-delete-dialog'
@@ -163,6 +164,19 @@ export const TournamentDetailPage = ({
             </MetaItem>
           )}
         </div>
+
+        {/* Display-only venue map at the tournament's server-geocoded coordinates
+            (read `Address` carries non-null lat/lng). Gated on the same `venue`
+            presence as the meta line so an address-less tournament shows nothing;
+            keyless (dev/CI/e2e) it degrades to a text fallback of the venue line. */}
+        {venue && (
+          <LocationMap
+            latitude={tournament.address.latitude}
+            longitude={tournament.address.longitude}
+            label={venue}
+            className="mb-5 h-44 max-w-md"
+          />
+        )}
 
         <div className="grid grid-cols-5 gap-3">
           <HeroStat label="Events" value={tournament.events.length} icon={<Trophy size={16} />} />

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
@@ -10,6 +10,11 @@ import type { Address, Tournament } from '../data/types'
 import { Field } from '../field'
 import { SectionHeader } from './section-header'
 
+/** The address's six free-text components — everything the edit form touches.
+ * `latitude`/`longitude` are geocoded server-side and never edited here, so they
+ * are excluded from the keys the form can address. */
+type AddressTextField = Exclude<keyof Address, 'latitude' | 'longitude'>
+
 export interface DetailsTabProps {
   tournament: Tournament
   /** When false (a non-creator), the tab renders the tournament's details as
@@ -60,10 +65,15 @@ export const DetailsTab = ({
   const save = () => onUpdate(draft)
 
   /** The address rows are the same shape six times over: an `Input` over the
-   * same value, which `Field` renders as text for a reader. */
+   * same value, which `Field` renders as text for a reader.
+   *
+   * Keyed by the six **text** components only — never `latitude`/`longitude`.
+   * Coordinates are geocoded server-side at write time and are read-only on the
+   * client (the read `Address` carries them; the write shape does not), so the
+   * edit form neither shows nor submits them. */
   const addressField = (
     label: string,
-    key: keyof Address,
+    key: AddressTextField,
     className?: string,
   ) => (
     <Field

--- a/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/details-tab.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
+import { PreviewLocation } from '@/components/maps/preview-location'
 
 import type { Address, Tournament } from '../data/types'
 import { Field } from '../field'
@@ -169,6 +170,11 @@ export const DetailsTab = ({
               {addressField('Postal', 'postal', 'font-mono')}
             </div>
             {addressField('Country', 'country')}
+            {/* Confirm the venue before saving: geocodes the typed address and
+                drops a pin. An editor-only affordance (ADR 0015 — hide mutating
+                affordances, never disable them) and display-only: it adds no
+                coordinates to the update payload (the server geocodes on save). */}
+            {canEdit && <PreviewLocation address={draft.address} />}
           </div>
         </Card>
       </div>

--- a/web-client/src/components/tournaments/tournaments-list-page.factory.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.factory.tsx
@@ -16,6 +16,7 @@ export function buildTournamentsListPageProps(
     onCreate: () => {},
     onDelete: () => {},
     canCreate: true,
+    onNearMeChange: () => {},
     ...overrides,
   }
 }

--- a/web-client/src/components/tournaments/tournaments-list-page.page.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.page.tsx
@@ -5,6 +5,7 @@ import {
   type TournamentsListPageProps,
 } from './tournaments-list-page'
 import { buildTournamentsListPageProps } from './tournaments-list-page.factory'
+import { nearMeControlPage } from './near-me-control.page'
 import { tournamentCardPage } from './tournament-card.page'
 
 const scoped = (container: Container) => ({
@@ -37,6 +38,8 @@ const scoped = (container: Container) => ({
   },
   /** Reuse the card delete control query. */
   ...tournamentCardPage.within(container),
+  /** The "Near me" toggle + radius picker live in the filter row. */
+  nearMe: nearMeControlPage.within(container),
 })
 
 /** Test page-object for `TournamentsListPage`. */

--- a/web-client/src/components/tournaments/tournaments-list-page.tsx
+++ b/web-client/src/components/tournaments/tournaments-list-page.tsx
@@ -7,8 +7,10 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 import { ConfirmDeleteDialog } from './confirm-delete-dialog'
 import { EmptyState } from './empty-state'
+import { NearMeControl } from './near-me-control'
 import { NewTournamentModal } from './new-tournament-modal'
 import { STATUS_FILTER_OPTIONS } from './data/options'
+import type { TournamentsNearMe } from './data/api'
 import type { Tournament } from './data/types'
 import { PageHeading } from './page-heading'
 import { TournamentCard } from './tournament-card'
@@ -21,6 +23,11 @@ export interface TournamentsListPageProps {
   /** Whether to surface the "New tournament" action — gated on the caller's
    * `tournament.create` permission. Creating 403s without it, so hide it. */
   canCreate: boolean
+  /** The "Near me" filter changed: the resolved `{ lat, lng, radiusMiles }`
+   * triple, or `undefined` when off/denied/unavailable. The route lifts this to
+   * where the list query is called so the query re-runs — the filtering is
+   * server-side, layered on top of the client-side name/status filters below. */
+  onNearMeChange: (nearMe: TournamentsNearMe | undefined) => void
 }
 
 type StatusFilter = (typeof STATUS_FILTER_OPTIONS)[number]['value']
@@ -33,6 +40,7 @@ export const TournamentsListPage = ({
   onCreate,
   onDelete,
   canCreate,
+  onNearMeChange,
 }: TournamentsListPageProps) => {
   const [query, setQuery] = useState('')
   const [filter, setFilter] = useState<StatusFilter>('all')
@@ -93,6 +101,7 @@ export const TournamentsListPage = ({
             ))}
           </TabsList>
         </Tabs>
+        <NearMeControl onNearMeChange={onNearMeChange} />
         <span className="flex-1" />
         <span className="font-mono text-[11px] text-[color:var(--fg-3)]">
           {filtered.length} {filtered.length === 1 ? 'result' : 'results'}

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -612,6 +612,8 @@ export function buildTournamentDetailRead(
       region: 'CA',
       postal: '94703',
       country: 'USA',
+      latitude: 37.8715,
+      longitude: -122.273,
     },
     table_catalogue: [
       buildTournamentTable({ id: 't1', label: 'T1', court: '1' }),

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -1690,6 +1690,37 @@ export const handlers = [
     )
   }),
 
+  // ----- geocode (preview pin) -------------------------------------------
+  // The "Preview location" lookup (`GET /v1/geocode`). Mirrors the server: a
+  // normal address resolves to deterministic coords + a `formatted` label, while
+  // the `__unresolvable__` sentinel (or an empty address) is the coded 422 both
+  // the preview and the create/edit write path answer a zero-result address with
+  // (`address_not_geocodable`). Deterministic per address, so the pin is stable
+  // across reloads and testable in vitest.
+  http.get('*/v1/geocode', async ({ request }) => {
+    await delay(200)
+    const address =
+      new URL(request.url).searchParams.get('address')?.trim() ?? ''
+    if (!address || address.includes('__unresolvable__')) {
+      return HttpResponse.json(
+        {
+          detail: {
+            code: 'address_not_geocodable',
+            message: 'We couldn’t locate that address.',
+          },
+        },
+        { status: 422 },
+      )
+    }
+    const seed = djb2(address)
+    // A small deterministic jitter around Berkeley, so `npm run dev` drops a pin
+    // near a plausible place rather than at (0, 0).
+    return HttpResponse.json({
+      latitude: 37.87 + (seed % 1000) / 100000,
+      longitude: -122.27 + ((seed >> 3) % 1000) / 100000,
+      formatted: address,
+    })
+  }),
   // ----- tournaments (admin) ---------------------------------------------
   // Dev-only handlers backed by `tournaments-store`. The seed includes rows
   // owned by the dev user (editable, with events + pools) and one owned by

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -1693,10 +1693,12 @@ export const handlers = [
   // ----- geocode (preview pin) -------------------------------------------
   // The "Preview location" lookup (`GET /v1/geocode`). Mirrors the server: a
   // normal address resolves to deterministic coords + a `formatted` label, while
-  // the `__unresolvable__` sentinel (or an empty address) is the coded 422 both
+  // the `__unresolvable__` sentinel (or an empty address) is the coded 409 both
   // the preview and the create/edit write path answer a zero-result address with
-  // (`address_not_geocodable`). Deterministic per address, so the pin is stable
-  // across reloads and testable in vitest.
+  // (`address_not_geocodable`). It shares the 409 status with the other tournament
+  // refusals (league-not-editable, draw-under-way) but is told apart by its coded
+  // `detail`. Deterministic per address, so the pin is stable across reloads and
+  // testable in vitest.
   http.get('*/v1/geocode', async ({ request }) => {
     await delay(200)
     const address =
@@ -1709,7 +1711,7 @@ export const handlers = [
             message: 'We couldn’t locate that address.',
           },
         },
-        { status: 422 },
+        { status: 409 },
       )
     }
     const seed = djb2(address)

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -53,6 +53,7 @@ import {
   enterEvent as enterTournamentEvent,
   findTournament,
   listTournaments,
+  type NearMeFilter,
   placeFixture as placeTournamentFixture,
   requestScheduleSolve as requestTournamentScheduleSolve,
   transitionTournament,
@@ -1039,6 +1040,33 @@ function notNull<T>(value: T | null): value is T {
   return value !== null
 }
 
+/** Parse the list's near-me triple off the query string. The API's `lat`/`lng`/
+ * `radius_miles` are ALL-OR-NOTHING (they describe one location filter, not three
+ * independent knobs), so a partial triple is a 422 there and here. Returns `{}` when none
+ * are present (the default list), a `filter` when all three are, or an `error` string when
+ * some — but not all — are. A non-numeric value is treated as present-but-invalid, so it
+ * cannot silently drop out and turn a partial triple into a valid pair. */
+function parseNearMe(params: URLSearchParams):
+  | { filter?: NearMeFilter; error?: undefined }
+  | { error: string; filter?: undefined } {
+  const raw = [
+    params.get('lat'),
+    params.get('lng'),
+    params.get('radius_miles'),
+  ]
+  const present = raw.filter(notNull)
+  if (present.length === 0) return {}
+  if (present.length < 3 || present.some((v) => !Number.isFinite(Number(v)))) {
+    return {
+      error:
+        'lat, lng and radius_miles must be sent together as valid numbers — a location ' +
+        'filter is all-or-nothing.',
+    }
+  }
+  const [lat, lng, radiusMiles] = raw.map(Number)
+  return { filter: { lat, lng, radiusMiles } }
+}
+
 export const handlers = [
   http.get('*/v1/health', async () => {
     await delay(400)
@@ -1675,9 +1703,14 @@ export const handlers = [
   // announced tournaments plus the dev user's own, so the seeded foreign draft is
   // missing from the list and 404s (not 403s) on detail — no branch here, because
   // `findTournament` simply does not find it.
-  http.get('*/v1/tournaments', async () => {
+  http.get('*/v1/tournaments', async ({ request }) => {
     await delay(250)
-    return HttpResponse.json(listTournaments())
+    const near = parseNearMe(new URL(request.url).searchParams)
+    // The near-me triple is ALL-OR-NOTHING on the server: a partial one is a 422, not a
+    // silent default. The mock mirrors that so a UI that sent, say, a lat with no radius
+    // meets the same wall in `npm run dev` and vitest that it would in production.
+    if (near.error) return detail(near.error, 422)
+    return HttpResponse.json(listTournaments(near.filter))
   }),
   http.post('*/v1/tournaments', async ({ request }) => {
     await delay(250)

--- a/web-client/src/mocks/tournaments-handlers.test.ts
+++ b/web-client/src/mocks/tournaments-handlers.test.ts
@@ -1,0 +1,105 @@
+// The mock `GET /v1/tournaments` handler's contract with the API it stands in for —
+// specifically the **near-me** filter (the all-or-nothing `lat`/`lng`/`radius_miles`
+// triple). These exercise the handler itself, over the same MSW server the whole suite and
+// `npm run dev` share, so the Near-me control can be built and tested without a backend:
+// with a location + radius the endpoint returns only nearby mock tournaments, each carrying
+// a real haversine `distance_miles`; without, it returns them all with `distance_miles`
+// null; and a partial triple 422s exactly as the server's does.
+//
+// The seed venues are at known, real coordinates, so the radii below are deterministic:
+//   • Bay Area Open  — Berkeley   (37.8715, -122.273)   published, owned  → visible
+//   • Summer Slam    — Palo Alto  (37.4419, -122.143)   draft,     owned  → visible
+//   • Club Champs    — San Jose   (37.3382, -121.8863)  published, foreign→ visible
+//   • League Office  — San Jose   draft, foreign                          → HIDDEN
+// From Berkeley: Palo Alto ≈ 30.5 mi, San Jose ≈ 42.5 mi. So a 10-mile radius isolates
+// Berkeley, a 35-mile one adds Palo Alto, and a wide one returns all three visible rows.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { components } from '@/api/schema'
+import { resetTournamentsStore } from './tournaments-store'
+
+type TournamentDetailRead = components['schemas']['TournamentDetailRead']
+
+// The dev user's own venue — a point ON the Bay Area Open's coordinates, so its distance
+// rounds to 0 and the radii read like a map.
+const BERKELEY = { lat: 37.8715, lng: -122.273 }
+
+const BAY_AREA = 'bay-area-open-2026' // Berkeley
+const SUMMER_SLAM = 'summer-slam-2026' // Palo Alto, ~30.5 mi
+const CLUB_CHAMPS = 'club-champs-2026' // San Jose, ~42.5 mi
+
+async function listTournaments(query = ''): Promise<{
+  status: number
+  body: TournamentDetailRead[]
+}> {
+  const res = await fetch(`http://localhost/v1/tournaments${query}`)
+  return { status: res.status, body: (await res.json()) as TournamentDetailRead[] }
+}
+
+const idsOf = (rows: TournamentDetailRead[]) => rows.map((t) => t.id)
+const byId = (rows: TournamentDetailRead[], id: string) =>
+  rows.find((t) => t.id === id)
+
+beforeEach(() => {
+  resetTournamentsStore()
+})
+afterEach(() => {
+  resetTournamentsStore()
+})
+
+describe('GET /v1/tournaments — the near-me filter', () => {
+  it('with a location + radius, returns ONLY nearby tournaments, each with a distance_miles', async () => {
+    const { status, body } = await listTournaments(
+      `?lat=${BERKELEY.lat}&lng=${BERKELEY.lng}&radius_miles=10`,
+    )
+
+    expect(status).toBe(200)
+    // A 10-mile radius around Berkeley keeps only the Berkeley venue; Palo Alto (~30.5)
+    // and San Jose (~42.5) fall outside it.
+    expect(idsOf(body)).toEqual([BAY_AREA])
+    expect(byId(body, BAY_AREA)?.distance_miles).toBe(0)
+    // Every returned row carries a real numeric distance — never null when a location was
+    // asked about.
+    for (const t of body) {
+      expect(typeof t.distance_miles).toBe('number')
+    }
+  })
+
+  it('widens the result set as the radius grows, and each distance is the haversine to that venue', async () => {
+    const { body } = await listTournaments(
+      `?lat=${BERKELEY.lat}&lng=${BERKELEY.lng}&radius_miles=35`,
+    )
+
+    // 35 miles now admits Palo Alto but still excludes San Jose.
+    expect(idsOf(body).sort()).toEqual([BAY_AREA, SUMMER_SLAM].sort())
+    expect(byId(body, BAY_AREA)?.distance_miles).toBe(0)
+    expect(byId(body, SUMMER_SLAM)?.distance_miles).toBeCloseTo(30.5, 1)
+    expect(idsOf(body)).not.toContain(CLUB_CHAMPS)
+  })
+
+  it('returns every visible tournament with distance_miles null when no location is sent', async () => {
+    const { status, body } = await listTournaments()
+
+    expect(status).toBe(200)
+    // All three VISIBLE rows (the foreign draft stays hidden regardless), each with the
+    // designed "no location asked about" distance.
+    expect(idsOf(body).sort()).toEqual([BAY_AREA, CLUB_CHAMPS, SUMMER_SLAM].sort())
+    for (const t of body) {
+      expect(t.distance_miles).toBeNull()
+    }
+  })
+
+  it('422s a PARTIAL triple — the location filter is all-or-nothing, as on the server', async () => {
+    // A lat with no lng and no radius: the server 422s this rather than silently ignoring
+    // it, so the mock must too.
+    const { status } = await listTournaments(`?lat=${BERKELEY.lat}`)
+    expect(status).toBe(422)
+
+    // Two of three is still partial.
+    const { status: twoOfThree } = await listTournaments(
+      `?lat=${BERKELEY.lat}&lng=${BERKELEY.lng}`,
+    )
+    expect(twoOfThree).toBe(422)
+  })
+})

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -42,6 +42,8 @@ type TournamentStatus = components['schemas']['TournamentStatus']
 type TournamentEventRead = components['schemas']['TournamentEventRead']
 type TournamentCreate = components['schemas']['TournamentCreate']
 type TournamentUpdate = components['schemas']['TournamentUpdate']
+type Address = components['schemas']['Address']
+type AddressInput = components['schemas']['AddressInput']
 type TournamentEventCreate = components['schemas']['TournamentEventCreate']
 type TournamentEventUpdate = components['schemas']['TournamentEventUpdate']
 type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
@@ -180,6 +182,8 @@ function seed(): StoredTournament[] {
         region: 'CA',
         postal: '94703',
         country: 'USA',
+        latitude: 37.8715,
+        longitude: -122.273,
       },
       table_catalogue: tables(12),
       created_by_user_id: DEV_USER_ID,
@@ -383,6 +387,8 @@ function seed(): StoredTournament[] {
         region: 'CA',
         postal: '94303',
         country: 'USA',
+        latitude: 37.4419,
+        longitude: -122.143,
       },
       table_catalogue: tables(8),
       created_by_user_id: DEV_USER_ID,
@@ -450,6 +456,8 @@ function seed(): StoredTournament[] {
         region: 'CA',
         postal: '95112',
         country: 'USA',
+        latitude: 37.3382,
+        longitude: -121.8863,
       },
       table_catalogue: tables(10),
       created_by_user_id: 'u-office',
@@ -549,6 +557,8 @@ function seed(): StoredTournament[] {
         region: 'CA',
         postal: '95112',
         country: 'USA',
+        latitude: 37.3382,
+        longitude: -121.8863,
       },
       table_catalogue: tables(6),
       created_by_user_id: 'u-office',
@@ -697,6 +707,15 @@ function slugId(name: string): string {
  *
  * It is born `draft`, unconditionally: `TournamentCreate` has no `status` to ask
  * for one (ADR-0017), so this mirrors the server's column default. */
+/** Stand in for the server's write-time geocoding: a client sends the six-field
+ * coordinate-free `AddressInput`, and the server derives and stores the read
+ * `Address` (with `latitude`/`longitude`, NOT NULL). The store can't geocode, so
+ * it stamps a fixed Bay-Area coordinate — enough to satisfy the read contract
+ * every reader now depends on. */
+function geocodeAddress(input: AddressInput): Address {
+  return { ...input, latitude: 37.8715, longitude: -122.273 }
+}
+
 export function createTournament(body: TournamentCreate): TournamentRead {
   const now = new Date().toISOString()
   const id = slugId(body.name)
@@ -712,7 +731,7 @@ export function createTournament(body: TournamentCreate): TournamentRead {
     // names the ladder it will be judged on — the caller only says which when it
     // is not the default. No client surface sends one yet.
     league_id: body.league_id ?? DEFAULT_LEAGUE_ID,
-    address: body.address,
+    address: geocodeAddress(body.address),
     table_catalogue: body.table_catalogue ?? [],
     created_by_user_id: DEV_USER_ID,
     created_by_username: DEV_USERNAME,
@@ -843,7 +862,8 @@ export function updateTournament(
     start_date:
       patch.start_date === undefined ? existing.start_date : patch.start_date,
     end_date: patch.end_date === undefined ? existing.end_date : patch.end_date,
-    address: patch.address ?? existing.address,
+    address:
+      patch.address == null ? existing.address : geocodeAddress(patch.address),
     table_catalogue:
       patch.table_catalogue === undefined || patch.table_catalogue === null
         ? existing.table_catalogue

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -604,7 +604,54 @@ function readEvent(event: StoredEvent): TournamentEventRead {
 }
 
 function readDetail(t: StoredTournament): TournamentDetailRead {
-  return { ...t, events: t.events.map(readEvent) }
+  // `distance_miles` is a property of a *near-me* read, not of the tournament: the
+  // default list and every detail read carry `null` (no location was asked about),
+  // exactly as the server sends it. `listTournaments` overwrites it for the rows a
+  // near-me query keeps.
+  return { ...t, events: t.events.map(readEvent), distance_miles: null }
+}
+
+// ----- near-me filtering (mirrors the API's haversine) ---------------------
+//
+// The list can be scoped to tournaments **near a point** (the all-or-nothing
+// `lat`/`lng`/`radius_miles` triple): only venues within `radius_miles` come back, each
+// carrying its `distance_miles`. The store computes that distance the way the server does
+// — a haversine over the coords each address already stores (`geocodeAddress`) — so
+// `npm run dev` and vitest exercise real filtering with no backend behind them.
+
+/** A location + radius the list is scoped to. All three fields or none: the handler
+ * enforces the all-or-nothing contract at the boundary, so by the time a filter reaches
+ * here it is complete. */
+export type NearMeFilter = {
+  lat: number
+  lng: number
+  radiusMiles: number
+}
+
+/** Earth's mean radius in miles — the SAME constant the API's haversine uses, so a mock
+ * `distance_miles` rounds to the value the real server would send. */
+const EARTH_RADIUS_MILES = 3958.8
+
+const toRadians = (deg: number): number => (deg * Math.PI) / 180
+
+/** Great-circle distance in miles between two `(lat, lng)` points, rounded to one decimal
+ * — the API's `distance_miles` precision. Mirrors the server's haversine so a mock card
+ * shows the distance the real card would. */
+function haversineMiles(
+  aLat: number,
+  aLng: number,
+  bLat: number,
+  bLng: number,
+): number {
+  const dLat = toRadians(bLat - aLat)
+  const dLng = toRadians(bLng - aLng)
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRadians(aLat)) *
+      Math.cos(toRadians(bLat)) *
+      Math.sin(dLng / 2) ** 2
+  const miles = 2 * EARTH_RADIUS_MILES * Math.asin(Math.sqrt(h))
+  return Math.round(miles * 10) / 10
 }
 
 /** Reset the store to its seed — used by the dev worker bootstrap if needed, and
@@ -662,12 +709,29 @@ function isVisible(t: StoredTournament): boolean {
 }
 
 /** The list, newest-created first (mirrors the API's ordering) — and scoped to what
- * the dev user may see: another organiser's draft never appears. */
-export function listTournaments(): TournamentDetailRead[] {
-  return tournaments
+ * the dev user may see: another organiser's draft never appears.
+ *
+ * Pass `nearMe` to scope it to venues **within the radius of a point**: each surviving
+ * row carries its `distance_miles` (a haversine from that point to its venue), and the
+ * ones outside the radius are dropped — the server's near-me contract. Omit it and every
+ * visible tournament comes back with `distance_miles` null (via `readDetail`). */
+export function listTournaments(nearMe?: NearMeFilter): TournamentDetailRead[] {
+  const visible = tournaments
     .filter(isVisible)
     .sort((a, b) => b.created_at.localeCompare(a.created_at))
     .map(readDetail)
+  if (!nearMe) return visible
+  return visible
+    .map((t) => ({
+      ...t,
+      distance_miles: haversineMiles(
+        nearMe.lat,
+        nearMe.lng,
+        t.address.latitude,
+        t.address.longitude,
+      ),
+    }))
+    .filter((t) => t.distance_miles <= nearMe.radiusMiles)
 }
 
 /** A single tournament's detail, or `undefined` if it is missing **or hidden**.

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -35,6 +35,7 @@ import {
 } from '@/mocks/factories/tournaments/solver-sim'
 import { mockUuid } from '@/mocks/mock-uuid'
 import { conjoinWithAnd } from '@/components/tournaments/data/helpers'
+import type { TournamentsNearMe } from '@/components/tournaments/data/api'
 
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
 type TournamentRead = components['schemas']['TournamentRead']
@@ -619,14 +620,11 @@ function readDetail(t: StoredTournament): TournamentDetailRead {
 // — a haversine over the coords each address already stores (`geocodeAddress`) — so
 // `npm run dev` and vitest exercise real filtering with no backend behind them.
 
-/** A location + radius the list is scoped to. All three fields or none: the handler
- * enforces the all-or-nothing contract at the boundary, so by the time a filter reaches
- * here it is complete. */
-export type NearMeFilter = {
-  lat: number
-  lng: number
-  radiusMiles: number
-}
+/** A location + radius the list is scoped to — the same shape the app-side list query
+ * carries (`TournamentsNearMe`), aliased here under the mock's name so the store and the
+ * app share one definition. All three fields or none: the handler enforces the
+ * all-or-nothing contract at the boundary, so a filter that reaches here is complete. */
+export type NearMeFilter = TournamentsNearMe
 
 /** Earth's mean radius in miles — the SAME constant the API's haversine uses, so a mock
  * `distance_miles` rounds to the value the real server would send. */

--- a/web-client/src/routes/_app/tournaments/index.test.tsx
+++ b/web-client/src/routes/_app/tournaments/index.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { server } from '@/mocks/server'
+import { sessionResponse } from '@/test/factories'
+import { buildTournamentDetailRead } from '@/mocks/factories/tournaments/tournament.factory'
+import { Route } from './index'
+
+const TournamentsRoute = Route.options.component!
+
+const NEAR = 'Near Club Open'
+const FAR = 'Far Away Classic'
+
+/** Install a granted geolocation whose position resolves synchronously. */
+function grantGeolocation(lat = 37.7749, lng = -122.4194) {
+  Object.defineProperty(navigator, 'geolocation', {
+    configurable: true,
+    value: {
+      getCurrentPosition: (success: PositionCallback) =>
+        success({ coords: { latitude: lat, longitude: lng } } as GeolocationPosition),
+    },
+  })
+}
+
+/** A denied geolocation — the error callback fires. */
+function denyGeolocation() {
+  Object.defineProperty(navigator, 'geolocation', {
+    configurable: true,
+    value: {
+      getCurrentPosition: (
+        _success: PositionCallback,
+        error?: PositionErrorCallback,
+      ) =>
+        error?.({
+          code: 1,
+          message: 'User denied Geolocation',
+        } as GeolocationPositionError),
+    },
+  })
+}
+
+/** The list endpoint, near-me-aware: with no location it returns BOTH rows
+ * (the full list); with a location it filters to what falls inside the radius —
+ * only `NEAR` at 25/50 mi, and both once the radius opens to 100 mi. This
+ * mirrors the real server + the MSW store contract (chore 3b), so the whole
+ * wire round-trip (lat/lng/radius_miles → filtered rows + `distance_miles`) is
+ * exercised. Returns the last-seen URL for the param assertion. */
+function installList(): { lastUrl: () => string } {
+  let url = ''
+  const near = buildTournamentDetailRead({ id: 'near', name: NEAR })
+  const far = buildTournamentDetailRead({ id: 'far', name: FAR })
+  server.use(
+    http.get('*/v1/session', () => HttpResponse.json(sessionResponse())),
+    http.get('*/v1/tournaments', ({ request }) => {
+      url = request.url
+      const params = new URL(request.url).searchParams
+      const lat = params.get('lat')
+      if (!lat) return HttpResponse.json([near, far])
+      const radius = Number(params.get('radius_miles'))
+      const rows =
+        radius >= 100
+          ? [
+              { ...near, distance_miles: 4.2 },
+              { ...far, distance_miles: 88.6 },
+            ]
+          : [{ ...near, distance_miles: 4.2 }]
+      return HttpResponse.json(rows)
+    }),
+  )
+  return { lastUrl: () => url }
+}
+
+function renderRoute() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute()
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/tournaments/',
+    component: TournamentsRoute,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([indexRoute]),
+    history: createMemoryHistory({ initialEntries: ['/tournaments'] }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+const toggle = () => screen.getByRole('switch', { name: /near me/i })
+const card = (name: string) => screen.queryByRole('button', { name })
+
+afterEach(() => {
+  Object.defineProperty(navigator, 'geolocation', {
+    configurable: true,
+    value: undefined,
+  })
+})
+
+describe('tournaments list — Near me filter', () => {
+  it('enabling with a granted location fires the list query with lat/lng/radius_miles and narrows the list', async () => {
+    grantGeolocation()
+    const list = installList()
+    renderRoute()
+
+    // The full list loads first — both venues visible.
+    await screen.findByRole('button', { name: NEAR })
+    expect(card(FAR)).toBeInTheDocument()
+
+    await userEvent.click(toggle())
+
+    // The far venue drops out once the near-me query resolves; the near one stays.
+    await waitFor(() => expect(card(NEAR)).toBeInTheDocument())
+    expect(card(FAR)).toBeNull()
+
+    // The wire carried the all-or-nothing triple.
+    const params = new URL(list.lastUrl()).searchParams
+    expect(params.get('lat')).toBe('37.7749')
+    expect(params.get('lng')).toBe('-122.4194')
+    expect(params.get('radius_miles')).toBe('25')
+  })
+
+  it('changing the radius re-queries — widening to 100 mi brings the far venue back', async () => {
+    grantGeolocation()
+    const list = installList()
+    renderRoute()
+
+    await screen.findByRole('button', { name: NEAR })
+    await userEvent.click(toggle())
+    await waitFor(() => expect(card(NEAR)).toBeInTheDocument())
+    expect(card(FAR)).toBeNull()
+
+    // Open the radius picker and widen to 100 mi.
+    await userEvent.click(screen.getByRole('combobox', { name: /search radius/i }))
+    await userEvent.click(await screen.findByRole('option', { name: '100 mi' }))
+
+    // The list re-fetches at the new radius and the far venue reappears.
+    await waitFor(() => expect(card(FAR)).toBeInTheDocument())
+    expect(new URL(list.lastUrl()).searchParams.get('radius_miles')).toBe('100')
+  })
+
+  it('a denied location falls back: the full list stays and an inline note shows', async () => {
+    denyGeolocation()
+    installList()
+    renderRoute()
+
+    await screen.findByRole('button', { name: NEAR })
+    await userEvent.click(toggle())
+
+    // No filtering — both venues remain — and the note explains why.
+    expect(card(NEAR)).toBeInTheDocument()
+    expect(card(FAR)).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent(/location unavailable/i)
+    // The toggle snapped back off — no permanent spinner, no crash.
+    expect(toggle()).not.toBeChecked()
+  })
+})

--- a/web-client/src/routes/_app/tournaments/index.tsx
+++ b/web-client/src/routes/_app/tournaments/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
 import { TournamentsListPage } from '@/components/tournaments/tournaments-list-page'
@@ -6,6 +7,7 @@ import {
   useCreateTournament,
   useDeleteTournament,
   useTournaments,
+  type TournamentsNearMe,
 } from '@/components/tournaments/data/api'
 import { useHasPermission } from '@/api/session'
 import { PERM } from '@/lib/permissions'
@@ -20,7 +22,11 @@ export const Route = createFileRoute('/_app/tournaments/')({
 
 function TournamentsRoute() {
   const navigate = useNavigate()
-  const tournaments = useTournaments()
+  // The near-me filter is lifted here, where the list query is called, so a
+  // resolved location + radius re-runs it server-side. `undefined` = off (the
+  // default, and where a denied/unavailable location snaps back to).
+  const [nearMe, setNearMe] = useState<TournamentsNearMe | undefined>(undefined)
+  const tournaments = useTournaments(nearMe)
   const createTournament = useCreateTournament()
   const deleteTournament = useDeleteTournament()
   const canCreate = useHasPermission(PERM.TOURNAMENT_CREATE)
@@ -45,6 +51,7 @@ function TournamentsRoute() {
         })
       }}
       onDelete={(id) => deleteTournament.mutate(id)}
+      onNearMeChange={setNearMe}
     />
   )
 }

--- a/web-client/src/test/setup.ts
+++ b/web-client/src/test/setup.ts
@@ -64,6 +64,19 @@ if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {}
 }
 
+// jsdom doesn't implement the Pointer Capture API; Radix's Select trigger (the
+// "Near me" radius picker) calls hasPointerCapture/releasePointerCapture on
+// pointer-down, so userEvent.click throws without these inert stubs.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {}
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {}
+}
+
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
 afterEach(() => {
   server.resetHandlers()


### PR DESCRIPTION
Implements the **"near me" tournament discovery** epic (#1169) — a real geographic radius filter on the tournament list, plus the venue coordinates and map surfaces it needs.

## Design (see ADR)
`docs/adr/20260725-a-venues-coordinates-are-geocoded-server-side-and-not-null.md`. Key bet, **diverging from the issue's browser-capture proposal**: the **server** is the single authority for coordinates — it geocodes the venue address on write (Google Geocoding behind an injectable `Geocoder` seam; a deterministic, network-free `FakeGeocoder` everywhere without a key). Coordinates are **NOT NULL**; an unresolvable address is a coded **422**. The browser only ever *displays* coordinates.

## What's here (4 tracer-bullet slices, committed separately)
1. **Geocode on write + distance filter** — `AddressInput` (write, no coords) vs `Address` (read, lat/lng NOT NULL); `create`/`edit` verbs geocode via the seam; `GET /v1/tournaments` gains an all-or-nothing `lat`/`lng`/`radius_miles` triple and filters by **haversine in SQL** (bounding-box prefilter, no PostGIS), returning `distance_miles`. Batched-read stays 5 statements; MCP unaffected.
2. **"Near me" control** — geolocation toggle + radius (25/50/100 mi) with a graceful denial/unavailable fallback; distance badge on each card; MSW mirrors the server (incl. the 422); composed-stack e2e proves the filter end-to-end.
3. **Venue map + preview** — `GET /v1/geocode` preview endpoint; a reusable `@vis.gl/react-google-maps` `LocationMap` that **degrades to a text fallback with no key**; venue pin on the detail page; "Preview location" on create/edit (writes stay coordinate-free).

Both Google keys are optional and empty-defaulted (`GOOGLE_GEOCODING_API_KEY` server-side via the UAT secret; `VITE_GOOGLE_MAPS_API_KEY` baked into the web build). Every environment without a key stays fully functional (keyless FakeGeocoder + map text fallback).

## Testing
- **API**: ruff + mypy + `pytest` — **1851 passed**.
- **Web**: vitest **3121 passed**, eslint clean, `tsc -b && vite build` clean.
- **iOS**: clean simulator build — **BUILD SUCCEEDED**.
- **OpenAPI**: regenerated `schema.d.ts` + `Types.swift`, **no drift**.
- **Root e2e**: the near-me spec and all tournament detail/schedule/solver specs (which exercise the new venue map) pass. A few unrelated specs (player-profile chart, score-conflict) flaked locally under a heavily-loaded multi-stack box + a recurring stale-nginx-502 — **not near-me** and not reproducible cleanly here; **relying on CI's isolated root-e2e as the gate.** (A local-only gotcha was fixed en route: the dev compose's named `node_modules` volume masks a newly-added dep until wiped — CI/prod unaffected, they build the dep in.)

Closes #1169.
Closes #1170.
Closes #1171.
Closes #1172.
Closes #1173.
Closes #1174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)