### PR TITLE
Stop a wedged Loki from permanently blocking the observability deploy

### DIFF
--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -113,6 +113,46 @@ unprompted.**
   **[destructive/shared]** — `DROP SCHEMA` wipes all UAT data. **Always flag for
   the user; never run unprompted.**
 
+### Observability deploy hangs — release stuck in `pending-upgrade` behind a Terminating `loki-0`
+
+- **Symptom:** `mise run redeploy-uat` hangs on the monitoring chart. `helm list
+  -n monitoring` shows `pending-upgrade` with **no helm process running**, so it
+  never resolves; every later upgrade then fails with *"another operation
+  (install/upgrade/rollback) is in progress"*. `kubectl get pods -n monitoring`
+  shows `loki-0` in `Terminating` — often for over an hour. Each retry strands
+  another revision.
+- **Cause:** two things compounding. The k3d node flaps `NotReady` (Docker
+  Desktop strain / host sleep) and the node controller evicts `loki-0`
+  (`DisruptionTarget: True`). Loki is typically already sick — 503 on its
+  readiness probe, many restarts — and **doesn't exit on SIGTERM**. The loki
+  subchart ships `terminationGracePeriodSeconds: 4800` (**80 minutes**), which
+  the kubelet honours in full before SIGKILL. A StatefulSet can't recreate
+  ordinal 0 until the old pod is gone, so `helm upgrade --wait` blocks on it.
+  We now pin this to 60s in `deploy/observability/values.yaml` — but the guard
+  only helps once a *successful* upgrade has applied it.
+- **Reading the clock:** `metadata.deletionTimestamp` is the moment the grace
+  period **expires**, not when deletion was requested. Subtract the grace period
+  to get the eviction time:
+  ```bash
+  kubectl get pod loki-0 -n monitoring \
+    -o jsonpath='{.metadata.deletionTimestamp} {.metadata.deletionGracePeriodSeconds}'
+  ```
+- **Fix (force-delete + clear the stranded release):** Loki here has **no PVC**
+  and its storage renders as `emptyDir: {}`, so force-deleting loses nothing that
+  wasn't already ephemeral:
+  ```bash
+  kubectl delete pod loki-0 -n monitoring --grace-period=0 --force
+  helm rollback observability <last-deployed-rev> -n monitoring --wait
+  helm list -n monitoring        # expect: deployed
+  ```
+  Use `helm history observability -n monitoring` to find the last `deployed`
+  revision. `helm rollback` is the way out of `pending-upgrade`; a plain
+  `helm upgrade` will just refuse. **[destructive/shared]** — flag for the user;
+  do not run unprompted.
+- **Sidestep it:** `DEPLOY_OBSERVABILITY=false mise run redeploy-uat` deploys the
+  app without touching the monitoring chart, so a wedged Loki doesn't block
+  shipping UAT.
+
 ### Compose nginx 502 with stale upstream IPs
 
 - **Symptom:** After recreating `api`/`web-client` in a compose stack, nginx

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -137,18 +137,32 @@ unprompted.**
   kubectl get pod loki-0 -n monitoring \
     -o jsonpath='{.metadata.deletionTimestamp} {.metadata.deletionGracePeriodSeconds}'
   ```
-- **Fix (force-delete + clear the stranded release):** Loki here has **no PVC**
+- **Waiting does NOT fix it.** When the grace period expires the kubelet SIGKILLs
+  the pod and the StatefulSet recreates it, so the *pods* go healthy on their
+  own — but the release stays `pending-upgrade` forever, because no helm process
+  is alive to finish or fail it. The rollback below is mandatory; the
+  force-delete only buys back the remaining grace-period minutes.
+- **Fix (clear the stranded release, then the pod):** Loki here has **no PVC**
   and its storage renders as `emptyDir: {}`, so force-deleting loses nothing that
   wasn't already ephemeral:
   ```bash
-  kubectl delete pod loki-0 -n monitoring --grace-period=0 --force
-  helm rollback observability <last-deployed-rev> -n monitoring --wait
-  helm list -n monitoring        # expect: deployed
+  # Required — nothing else clears `pending-upgrade`:
+  helm --kube-context k3d-fortymm-uat rollback observability <last-deployed-rev> -n monitoring
+  # Optional — skips the wait for SIGKILL:
+  kubectl --context k3d-fortymm-uat delete pod loki-0 -n monitoring --grace-period=0 --force
+  helm --kube-context k3d-fortymm-uat list -n monitoring   # expect: deployed
   ```
   Use `helm history observability -n monitoring` to find the last `deployed`
   revision. `helm rollback` is the way out of `pending-upgrade`; a plain
   `helm upgrade` will just refuse. **[destructive/shared]** — flag for the user;
   do not run unprompted.
+- **Mind the kube context.** The default context is usually `docker-desktop`,
+  **not** the k3d cluster, and both tools fail *quietly* against the wrong one:
+  `helm list -n monitoring` returns an empty table and
+  `helm rollback ...` says `Error: release: not found` — neither of which reads
+  like "you're pointed at the wrong cluster". Pass
+  `--kube-context k3d-fortymm-uat` / `--context k3d-fortymm-uat` as above, or
+  `export KUBECONFIG="$(k3d kubeconfig write fortymm-uat)"` once per shell.
 - **Sidestep it:** `DEPLOY_OBSERVABILITY=false mise run redeploy-uat` deploys the
   app without touching the monitoring chart, so a wedged Loki doesn't block
   shipping UAT.

--- a/deploy/observability/values.yaml
+++ b/deploy/observability/values.yaml
@@ -43,6 +43,18 @@ loki-stack:
     # 2.8). Bump to 2.9.x and enable it so Explore shows volume.
     image:
       tag: 2.9.10
+    # The loki subchart defaults this to 4800 (80 minutes) — a sane figure for a
+    # production Loki flushing chunks to object storage on shutdown, and a trap
+    # here. We run with `persistence.enabled: false`, so Loki's storage is an
+    # EmptyDir: there is nothing durable to flush, and anything it does write
+    # dies with the pod regardless. But when Loki wedges (it 503s its readiness
+    # probe under memory pressure and then stops answering SIGTERM), the kubelet
+    # still honours the full 80 minutes before SIGKILL. The StatefulSet cannot
+    # recreate ordinal 0 until the old pod is gone, so a `helm upgrade --wait`
+    # that lands in that window blocks until it times out and leaves the release
+    # stranded in `pending-upgrade` — which then fails every subsequent upgrade
+    # with "another operation is in progress". 60s is plenty to exit cleanly.
+    terminationGracePeriodSeconds: 60
     config:
       limits_config:
         volume_enabled: true

--- a/scripts/redeploy-uat.sh
+++ b/scripts/redeploy-uat.sh
@@ -233,9 +233,14 @@ if [ "$DEPLOY_OBSERVABILITY" = "true" ]; then
 
   echo
   echo "==> helm upgrade --install $OBS_RELEASE"
+  # --atomic so a timeout self-heals. Without it, `--wait` timing out leaves the
+  # release in `pending-upgrade` forever, and because nothing clears that state,
+  # EVERY later upgrade aborts with "another operation is in progress" until
+  # someone manually runs `helm rollback`. --atomic rolls back on failure and
+  # leaves the release `deployed`, so the next redeploy can still proceed.
   helm upgrade --install "$OBS_RELEASE" "$OBS_CHART" \
     --namespace "$OBS_NAMESPACE" \
-    --wait --timeout 10m
+    --wait --timeout 10m --atomic
 
   echo
   echo "==> Observability pods"


### PR DESCRIPTION
## The symptom

The observability stack deployment gets stuck. `helm list -n monitoring` shows the release parked in `pending-upgrade` with **no helm process running** — so it never resolves, and it blocks every subsequent `helm upgrade` with *"another operation (install/upgrade/rollback) is in progress"*.

## What actually happens

1. The k3d node flaps `NotReady` (Docker Desktop strain / host sleep). The node controller evicts `loki-0` — the pod carries `DisruptionTarget: True`.
2. Loki is already sick: 503s on its readiness probe, 18 restarts. It gets SIGTERM and **doesn't exit**.
3. The loki subchart ships `terminationGracePeriodSeconds: 4800` — **80 minutes**. The kubelet honours it in full before SIGKILL, so the pod sits in `Terminating`.
4. A StatefulSet can't recreate ordinal 0 until the old pod is gone, so `helm upgrade --wait` blocks and eventually times out.
5. Because the upgrade ran **without `--atomic`**, that timeout leaves the release stranded in `pending-upgrade` — and nothing ever clears it. So one wedged pod became a *permanently* blocked deploy instead of one failed run. Each retry stranded another revision.

Observed live on UAT: eviction at 18:16Z, redeploy at 18:55Z blocked behind it (revision 27 stranded), and a retry at 19:08Z stranded revision 28 the same way — while `loki-0` still had until 19:36Z before SIGKILL.

## The two fixes

**1. Cap the grace period at 60s** (`deploy/observability/values.yaml`). The 4800 default is sized for a production Loki flushing chunks to object storage on shutdown. We run `persistence.enabled: false`, so Loki's storage renders as `emptyDir: {}` — there is nothing durable to flush, and whatever it writes dies with the pod anyway.

**2. Add `--atomic`** to the observability `helm upgrade` (`scripts/redeploy-uat.sh`). On failure Helm now rolls back and leaves the release `deployed`, so a future hiccup costs one failed run instead of a manual `helm rollback` before anything can deploy again.

These are independent: (1) makes the hang far less likely, (2) makes it recoverable without hand-holding when it does happen.

## Verification

Rendered the subchart StatefulSet both ways (`helm template ... -s charts/loki-stack/charts/loki/templates/statefulset.yaml`):

- before: `terminationGracePeriodSeconds: 4800`
- after: `terminationGracePeriodSeconds: 60`

The same render confirms the storage volume is `emptyDir: {}`, so the no-durable-flush reasoning is checked rather than assumed. `bash -n scripts/redeploy-uat.sh` passes.

Not verified by an actual UAT deploy — the cluster is still holding the stuck release, which needs the operator recovery below first.

## Docs

Adds the failure mode to `deploy/CLAUDE.md`, including the bit that cost the most time to work out: **`deletionTimestamp` is when the grace period *expires*, not when deletion was requested** — subtract `deletionGracePeriodSeconds` to get the real eviction time.

## Operator recovery (not done by this PR)

This prevents recurrence; it does not clear the release already stuck on UAT:

```bash
kubectl delete pod loki-0 -n monitoring --grace-period=0 --force
helm rollback observability 26 -n monitoring --wait
```

Safe — no PVCs in the namespace, Loki's storage is an EmptyDir. Left to the human as a shared-cluster mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVPEeZxm4sNyQH1SPUnqDv