### PR TITLE
rr-then-ko: round-robin pools, then a knockout seeded from the pool finishers (#1227)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -390,7 +390,8 @@ rating rank, never the player's index on the current page).
 
 **Draw**:
 The complete set of **fixtures** an event's draw type prescribes for its
-entrants — a bracket, a set of pools, or (later) rounds of pairings. A draw is
+entrants — a bracket, a set of pools, pools feeding a bracket, or (later)
+rounds of pairings. A draw is
 **cut** (the deliberate, reviewable act of generating it; re-cutting replaces
 it wholesale and is refused once there is any evidence of play), and it is
 **current** when its fixtures cover exactly the event's active entrants —
@@ -441,6 +442,30 @@ running tournament (a table breaks, a table frees up).
 _Avoid_: group (a pool is not a grouping abstraction separate from the venue
 slice), division.
 
+**Stage**:
+One phase of a **draw** that must finish before the next can be played. Most
+draw types have exactly one; a round-robin-then-knockout draw has two — a
+**pool stage**, whose **fixtures** each name a **pool**, and a **knockout
+stage**, whose fixtures name none. Whether a fixture has a pool *is* the
+discriminator; there is no stage of its own recorded anywhere. Both stages are
+**cut together** in one stroke, so the knockout bracket exists — with its sides
+still unknown — from the moment the draw does.
+_Avoid_: round (a **round** is one layer *within* a stage), phase, leg, group
+stage (a **pool** is not a group).
+
+**Qualifier**:
+An entrant who advances out of a **pool** into the **knockout stage**: the top
+*K* of that pool's **standings**, where *K* is the event's qualifiers-per-pool
+setting. Qualifiers are seated into the bracket **as each pool finishes**, not
+when the whole **pool stage** does. Within a finishing place, pools are **not
+ranked against each other** — every pool winner is an equal — and that freedom
+is what lets the seating guarantee no first-round knockout **fixture** pairs two
+entrants from the same pool. The guarantee holds for two or more pools; with a
+single pool every knockout match is necessarily a rematch, which is the format
+working as intended, not a failure of the rule.
+_Avoid_: seed (a **seed** is an *input* to the draw; a qualifier is what playing
+it produces), advancer, survivor, winner (that is one side of one **match**).
+
 **Materialize**:
 Turning a **ready** **fixture** into a real **match**: the fixture's two known
 sides become the match's two sides, the event's `match_settings` (rated flag,
@@ -458,7 +483,9 @@ is the schedule's concern).
 How an event turned out, computed for display — a concept **universal across draw
 types but shaped differently by each**: a round-robin's results are its
 **standings**; a single-elimination's are its **finishes** (and its
-**champion**). Computed **live from the fixtures' completed matches**, so a
+**champion**); a round-robin-then-knockout's are **both** — its pools'
+standings *and* its bracket's finishes, one per **stage**. Computed **live from
+the fixtures' completed matches**, so a
 **correction** or **voided match** is reflected at once — never stored, never a
 snapshot. An event is **complete** when every fixture is **decided**; only then
 are its results final. Each draw type computes its own results shape; the display
@@ -485,7 +512,8 @@ Same-round losers **tie**: single-elimination genuinely does not rank them
 against each other, so a shared position is honest, not a missing tiebreak.
 Computed **live from completed fixtures**, like all **results**. On the wire the
 results block is a discriminated union tagged by shape — `standings` for a
-round-robin, `finishes` for a single-elimination.
+round-robin, `finishes` for a single-elimination, `standings_then_finishes` for
+a round-robin-then-knockout, which carries one of each.
 _Avoid_: **placement** (that is a **match**'s spot in the **schedule** — table
 and time — an unrelated concept; a finish is an *entrant*'s standing in the
 bracket), standings (the round-robin shape), rank (a league rating position),
@@ -494,8 +522,12 @@ seed (a seed is an *input* to the draw; a finish is its *outcome*).
 **Champion**:
 The entrant atop a **complete** event's **results** — for a round-robin, first in
 the **standings**; for a single-elimination, the undefeated entrant, first in the
-**finishes**. **Derived, never stored**: a **correction** can re-crown, so
-the champion is always read from the current results.
+**finishes**; for a round-robin-then-knockout, the winner of the **knockout
+stage**, never the leader of a **pool**. **Derived, never stored**: a
+**correction** can re-crown, so the champion is always read from the current
+results. A **multi-pool** round-robin has **no champion even when complete** —
+there is nothing to join its pool winners, which is exactly the gap a knockout
+stage fills.
 _Avoid_: winner (a **winner** is one side of one match; the champion is the whole
 event's), first place.
 

--- a/api/app/dashboard_tournaments.py
+++ b/api/app/dashboard_tournaments.py
@@ -64,6 +64,7 @@ from app.schemas.tournament import (
     MatchSettings,
     Pool,
     StandingsResultsRead,
+    StandingsThenFinishesResultsRead,
     TournamentEntrantRead,
     TournamentFixtureRead,
     TournamentTable,
@@ -300,11 +301,12 @@ def _build_event(
     my_standing = None
     field_size = 0
     pool_complete = False
-    # Only the round-robin **standings** shape has a per-pool table with the caller's
-    # row in it; a single-elim **finishes** block does not, so it falls through to the
-    # fixture-counted record below (``StandingsResultsRead`` narrows the results union —
-    # a new results shape is a type error here until it says whether it has a pool row).
-    if isinstance(results, StandingsResultsRead):
+    # The two shapes that carry a per-pool table with the caller's row in it: the
+    # round-robin **standings**, and the pool stage of an rr-then-ko event's
+    # **standings_then_finishes** (ADR 20260727 — the same ``PoolStandingsRead`` model,
+    # which is why one branch reads both). A single-elim **finishes** block has no such
+    # table, so it falls through to the fixture-counted record below.
+    if isinstance(results, StandingsResultsRead | StandingsThenFinishesResultsRead):
         for pool_standings in results.pools:
             if my_pool_id is not None and pool_standings.pool_id != my_pool_id:
                 continue
@@ -316,6 +318,19 @@ def _build_event(
                     break
             if my_standing is not None:
                 break
+    # What ``stage_label`` is judged on, and it is NOT always the pool's completeness.
+    # For a round-robin the two coincide — the pool finishing IS the event finishing,
+    # and "Group complete" is the right thing to say. For a two-stage event they come
+    # apart badly: the caller's pool finishes early and the bracket it seeds them into
+    # runs for hours afterwards, so reading the pool's flag would announce "Complete"
+    # over an event still being played. The two-stage shape's own ``complete`` is both
+    # stages decided (ADR 20260727) — the only honest answer this minimal label can
+    # give.
+    stage_complete = (
+        results.complete
+        if isinstance(results, StandingsThenFinishesResultsRead)
+        else pool_complete
+    )
 
     # The caller's own decided fixtures, counted directly — draw-type-agnostic, so it
     # stands in wherever there is no standings row to read (see the record below).
@@ -369,7 +384,7 @@ def _build_event(
         losses=my_standing.losses if my_standing is not None else record_losses,
         position=my_standing.rank if my_standing is not None else None,
         field_size=field_size,
-        stage_label=_stage_label(draw_type, complete=pool_complete),
+        stage_label=_stage_label(draw_type, complete=stage_complete),
         pool_label=(
             pools[my_pool_id].name
             if my_pool_id is not None and my_pool_id in pools
@@ -433,7 +448,7 @@ def _build_match(
         opponent_games=opponent_games,
         best_of=best_of,
         games=_games(match, side=side),
-        round_label=_round_label(draw_type, fixture.round),
+        round_label=_round_label(draw_type, fixture.pool_id, fixture.round),
         table_label=_table_label(fixture.table_id, tables),
         start_label=_time_label(fixture),
         next_game_number=(current_game_number(match) if match is not None else None),
@@ -573,9 +588,15 @@ def _fixture_state(status: MatchStatus | None) -> TournamentFixtureState:
             assert_never(status)
 
 
-def _round_label(draw_type: DrawType, round_number: int) -> str:
+def _round_label(draw_type: DrawType, pool_id: str | None, round_number: int) -> str:
     """A round number in its draw type's own vocabulary, composed here so no client
     maps an integer to a word.
+
+    It takes the fixture's ``pool_id`` because for a two-stage draw the vocabulary is a
+    property of the **stage**, not of the event: ``pool_id IS NULL`` is already how the
+    knockout stage is spelled everywhere else (ADR-0786), so there is nothing new to
+    carry — the discriminator is on the row. The one-stage draw types ignore it; their
+    fixtures are all pooled or all un-pooled anyway.
 
     An exhaustive ``match`` with no catch-all: a new ``DrawType`` is a type error until
     it says what it calls a round (api/CLAUDE.md)."""
@@ -587,6 +608,16 @@ def _round_label(draw_type: DrawType, round_number: int) -> str:
             # cannot be composed from the round number alone — it needs the bracket's
             # depth, which this helper is not given.
             return f"Round {round_number}"
+        case DrawType.rr_then_ko:
+            # Both existing vocabularies, verbatim, chosen by the stage the fixture is
+            # in (ADR 20260727). Inventing a third — "Group match 3" becoming "Pool
+            # match 3" because the event also has a bracket — would make the same match
+            # read differently in two events for no reason a player could name.
+            return (
+                f"Group match {round_number}"
+                if pool_id is not None
+                else f"Round {round_number}"
+            )
         case _:
             assert_never(draw_type)
 
@@ -596,6 +627,13 @@ def _stage_label(draw_type: DrawType, *, complete: bool) -> str:
         case DrawType.round_robin:
             return "Group complete" if complete else "Group play"
         case DrawType.single_elim:
+            return "Complete" if complete else "In play"
+        case DrawType.rr_then_ko:
+            # Deliberately minimal, and deliberately not the round-robin wording:
+            # "Group complete" on a two-stage event would announce the event over while
+            # its knockout stage is still being played. Naming *which* stage is live
+            # needs more plumbing than this ticket buys (ADR 20260727), so the label
+            # says only whether the event has finished.
             return "Complete" if complete else "In play"
         case _:
             assert_never(draw_type)

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -37,12 +37,13 @@ from __future__ import annotations
 
 import enum
 import uuid
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import NewType, Protocol
 
 from app.models.tournament import DrawType, EventFormat
+from app.pool_finishing_order import EntryTally, MatchOutcome, finishing_order
 
 # Distinct id types, so the checker rejects handing a fixture id to something that
 # wants an entry id. They are plain ``uuid.UUID`` at runtime.
@@ -118,6 +119,35 @@ class NonSinglesDraw(DrawError):
         )
 
 
+class MissingFixtureGames(RuntimeError):
+    """A draw was advanced with decided pool fixtures but **no game counts anywhere** —
+    the caller never loaded them.
+
+    Deliberately **not** a :class:`DrawError`. A ``DrawError`` is a director-facing
+    refusal the HTTP layer turns into a 422 ("the draw you asked for isn't a
+    competition"); this is a *wiring* bug in the projection seam, and the only useful
+    response to it is a loud 500 in the logs. Nothing a director can type causes it and
+    there is no input they could correct.
+
+    It exists because the alternative failure is silent and wrong. A pools-then-knockout
+    draw picks its qualifiers with
+    :func:`~app.pool_finishing_order.finishing_order`, whose chain runs wins →
+    head-to-head → game difference → games won; handed
+    :attr:`FixtureState.games` of ``None`` it would still *produce an order* — one
+    computed on wins alone, which silently disagrees with the standings table on screen
+    at exactly the moment a director is looking hardest (a multi-way tie for the last
+    qualifying spot). Every test in the suite would stay green, because nothing else
+    reads the field. So the strategy refuses to order a pool it cannot see the games of.
+
+    The condition is scoped to "**no** fixture in this input carries games", which is
+    precisely "the caller did not load them" and nothing else. A *single* fixture
+    without games while its neighbours have them is an ordinary live state — a result
+    under correction leaves the match un-``completed`` while the fixture's written-back
+    ``winner_entry_id`` stays put — and that one is handled honestly by the strategy
+    (its pool is simply not finished yet), not raised at.
+    """
+
+
 class Side(enum.Enum):
     """Which of a fixture's two sides — ``entry_a_id`` or ``entry_b_id``."""
 
@@ -156,6 +186,27 @@ class OrderedEntrant:
 
     entry_id: EntryId
     position: int
+
+
+@dataclass(frozen=True, slots=True)
+class QualifierSeat:
+    """*Which* qualifier a knockout seed belongs to — a pool and a finishing place
+    within it, never an entry.
+
+    The whole point of this shape is what it **cannot** name. A pools-then-knockout
+    bracket is cut before a single pool game is played, so the seed → qualifier map
+    has to be expressible without knowing who won anything; keeping it as
+    ``(pool_index, place)`` is what makes it computable at cut time and what lets one
+    pool's qualifiers take their predetermined slots the moment *that* pool is
+    decided, with the other pools still playing.
+
+    ``pool_index`` is 0-based into :attr:`DrawConfig.pool_ids` — the event's own pool
+    order, the same order the snake dealt against. ``place`` is 1-based within that
+    pool, so ``place=1`` is the pool winner.
+    """
+
+    pool_index: int
+    place: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -210,6 +261,27 @@ class PlannedFixture:
 
 
 @dataclass(frozen=True, slots=True)
+class FixtureGames:
+    """How many games **each side of a fixture won**, read off its completed match.
+
+    One object carrying both counts, rather than two ``int | None`` fields on
+    :class:`FixtureState`, so "we know this fixture's games" is a single fact: there is
+    no way to hold a half-known score in which one side's count is present and the
+    other's is missing (api/CLAUDE.md — make illegal states unrepresentable).
+
+    ``entry_a`` ↔ side 1 and ``entry_b`` ↔ side 2, the fixed materialization convention
+    (#788) every other read of a fixture's match already uses.
+
+    A tie is representable here and is not this type's job to refuse: a match is played
+    to an odd best-of, so a *completed* one cannot tie, but a count is a count and this
+    object never sees the best-of that would make the claim checkable.
+    """
+
+    entry_a_games: int
+    entry_b_games: int
+
+
+@dataclass(frozen=True, slots=True)
 class FixtureState:
     """A persisted fixture as it currently stands — the whole input to
     :meth:`DrawStrategy.advance`.
@@ -229,6 +301,24 @@ class FixtureState:
     winner_entry_id: EntryId | None = None
     #: Set once the fixture **materialized** into a real match. ``None`` before that.
     match_id: MatchId | None = None
+    #: The games each side won, when this fixture's match is **currently completed** —
+    #: and ``None`` when it is not (no match yet, or one that has not completed).
+    #:
+    #: ``None``, never ``FixtureGames(0, 0)``: a real completed match *can* read 0
+    #: games for a side (a walkover, a retirement in game one), so a zero pair is a
+    #: score and cannot double as "there is no score". The two must stay tellable
+    #: apart, because they mean opposite things to a standings tiebreaker — one is a
+    #: result to fold in, the other a fixture to leave out.
+    #:
+    #: Derived from the match's games rather than from ``winner_entry_id``, so a
+    #: correction re-shapes it the instant it lands — the same live-outcome view the
+    #: standings are projected from (ADR-0788, ADR 20260727). Which is why a strategy
+    #: computing a pool's finishing order from these agrees with the table on screen
+    #: **structurally**, down to the game-difference and games-won tiebreakers, rather
+    #: than by two implementations happening to concur.
+    #:
+    #: No strategy reads this yet; round-robin and single-elim ignore it.
+    games: FixtureGames | None = None
 
     @property
     def is_pending(self) -> bool:
@@ -328,6 +418,92 @@ def order_entrants(entrants: Iterable[Entrant]) -> list[OrderedEntrant]:
     ]
 
 
+def qualifier_seed_assignment(
+    pool_count: int, qualifiers_per_pool: int
+) -> dict[int, QualifierSeat]:
+    """Which qualifier takes which knockout **seed number**, so that no round-one
+    fixture pairs two entrants out of the same pool (ADR "rr-then-ko cuts both stages
+    upfront and seeds qualifiers rematch-free").
+
+    Returns a map ``seed → QualifierSeat`` covering every seed ``1 .. P·K``. It is a
+    pure function of the pool count ``P`` and the qualifiers-per-pool ``K`` — it never
+    sees an entry, a result or a standing, which is exactly what lets the bracket be
+    cut upfront and each pool's qualifiers be seated as that pool finishes. Bracket
+    size is *derived* here (``B`` = smallest power of two ≥ ``P·K``), never passed in,
+    so it cannot contradict the qualifier count.
+
+    Qualifiers are ordered **place-major**: every pool winner outranks every runner-up,
+    so place block ``k`` (0-based) owns seeds ``kP+1 .. kP+P``. Within a block the pool
+    order is *chosen*, not fixed, and that is the whole mechanism. Three facts make the
+    guarantee provable rather than best-effort:
+
+    - a block holds each pool exactly once, so a round-one pair falling **inside** one
+      block is conflict-free for free;
+    - round one is a perfect matching on seeds (:func:`_seed_slots` pairs ``s`` with
+      ``B+1−s``), so a seed has **at most one** partner and therefore at most one
+      forbidden pool;
+    - assigning blocks in ascending order, every position in the block still admits at
+      least ``P−1`` pools, so Hall's condition holds for ``P ≥ 2`` and a conflict-free
+      system of distinct representatives always exists. The search below finds one
+      deterministically — pools tried in ascending index order, augmenting when stuck
+      — so a re-cut reproduces the same bracket, the same promise
+      :func:`order_entrants` makes.
+
+    The two fixed orderings this replaces cannot work: place-then-pool pairs ``C1``
+    against ``C2`` at three pools, and reversing the runners-up fixes three pools while
+    breaking two, because *which* pairs are cross-block depends on ``B − P·K``, which
+    jumps around with ``P``.
+
+    **One pool is an explicit waiver, not a failure.** With ``P = 1`` every qualifier
+    shares the one pool, so every knockout match is necessarily a rematch — that is
+    "league, then a playoff" working as intended. The assignment is then simply
+    ``seed k+1 → place k+1``, and this function says so rather than raising.
+
+    Raises :class:`ValueError` on inputs outside the format's legal space (``P ≥ 1``,
+    ``K ≥ 1``, ``P·K ≥ 2``). Those are *programmer* errors here: the director-facing
+    refusals are the caller's, raised as :class:`DegenerateDraw` at the cut, where the
+    entrant count is in hand.
+    """
+    if pool_count < 1:
+        raise ValueError(f"pool_count must be at least 1, got {pool_count}.")
+    if qualifiers_per_pool < 1:
+        raise ValueError(
+            f"qualifiers_per_pool must be at least 1, got {qualifiers_per_pool}."
+        )
+    qualifier_count = pool_count * qualifiers_per_pool
+    if qualifier_count < 2:
+        raise ValueError(
+            "A knockout stage needs at least 2 qualifiers, got "
+            f"{qualifier_count} ({pool_count} × {qualifiers_per_pool})."
+        )
+
+    def seat(seed: int, pool_index: int) -> QualifierSeat:
+        # Place-major: the block a seed sits in *is* its finishing place.
+        return QualifierSeat(pool_index=pool_index, place=(seed - 1) // pool_count + 1)
+
+    if pool_count == 1:
+        # The waiver. Every qualifier is out of the same pool, so there is nothing to
+        # avoid and no permutation to choose.
+        return {seed: seat(seed, 0) for seed in range(1, qualifier_count + 1)}
+
+    partners = _round_one_partners(qualifier_count)
+    pool_by_seed: dict[int, int] = {}
+    for block in range(qualifiers_per_pool):
+        seeds = [block * pool_count + offset + 1 for offset in range(pool_count)]
+        # A seed's only constraint is its round-one partner, and only once that partner
+        # has a pool — i.e. when it sits in an *earlier* block. A partner inside this
+        # block needs no constraint (the block holds each pool once, so they differ
+        # anyway); a partner in a later block will see *this* seed as its constraint.
+        forbidden = {
+            seed: pool_by_seed[partners[seed]]
+            for seed in seeds
+            if seed in partners and partners[seed] in pool_by_seed
+        }
+        pool_by_seed.update(_assign_block_pools(seeds, pool_count, forbidden))
+
+    return {seed: seat(seed, pool) for seed, pool in sorted(pool_by_seed.items())}
+
+
 @dataclass(frozen=True, slots=True)
 class RoundRobinStrategy:
     """All-play-all within each pool: every pair in a pool meets exactly once, and
@@ -402,66 +578,7 @@ class SingleElimStrategy:
                 "one has nobody to play."
             )
         seed_entry = {entrant.position: entrant.entry_id for entrant in entrants}
-
-        # ``bracket`` = smallest power of two ≥ N; ``rounds`` = its depth (log2).
-        bracket = 1
-        while bracket < size:
-            bracket <<= 1
-        rounds = bracket.bit_length() - 1
-        slots = _seed_slots(bracket)
-
-        fixtures: list[PlannedFixture] = []
-        # A byed seed is seated straight onto its round-2 side here, keyed
-        # ``(round-2 position, side)`` — the round-2 fixtures are emitted below with
-        # exactly these sides pre-filled and the rest left TBD.
-        seated_by_bye: dict[tuple[int, Side], EntryId] = {}
-
-        for pair_index in range(bracket // 2):
-            # ``position`` is the **full-bracket** slot index, 1-based, *not* a
-            # contiguous 1..k renumbering of the surviving matches: it is what makes the
-            # successor arithmetic (:func:`_successor`, ``ceil(position / 2)``) feed the
-            # right round-2 fixture, and a byed seed is placed by the *same* arithmetic,
-            # so the two agree. A round-1 slot that is a bye simply leaves a gap here.
-            position = pair_index + 1
-            first, second = slots[2 * pair_index], slots[2 * pair_index + 1]
-            top, bottom = min(first, second), max(first, second)
-            if bottom <= size:
-                # Two real seeds: a genuine round-1 match. Top seat = ``entry_a`` for
-                # readability only — the successor side is decided by ``position``, not
-                # by which seed is ``a``.
-                fixtures.append(
-                    PlannedFixture(
-                        pool_id=None,
-                        round=1,
-                        position=position,
-                        entry_a_id=seed_entry[top],
-                        entry_b_id=seed_entry[bottom],
-                    )
-                )
-            else:
-                # One phantom (``bottom`` > N; two phantoms cannot happen when
-                # ``bracket`` is the smallest power of two ≥ N). The real ``top`` seed
-                # byes straight into round 2.
-                _, successor_position, side = _successor(1, position)
-                seated_by_bye[(successor_position, side)] = seed_entry[top]
-
-        if rounds >= 2:
-            for position in range(1, bracket // 4 + 1):
-                fixtures.append(
-                    PlannedFixture(
-                        pool_id=None,
-                        round=2,
-                        position=position,
-                        entry_a_id=seated_by_bye.get((position, Side.a)),
-                        entry_b_id=seated_by_bye.get((position, Side.b)),
-                    )
-                )
-        for round_number in range(3, rounds + 1):
-            for position in range(1, (bracket >> round_number) + 1):
-                fixtures.append(
-                    PlannedFixture(pool_id=None, round=round_number, position=position)
-                )
-        return fixtures
+        return _knockout_fixtures(size, seed_entry)
 
     def advance(self, fixtures: Sequence[FixtureState]) -> AdvancePlan:
         """Seat every decided fixture's winner into its successor slot, plus report the
@@ -498,6 +615,236 @@ class SingleElimStrategy:
             side_fills=tuple(side_fills),
             ready_fixture_ids=ready_fixtures(fixtures),
         )
+
+
+@dataclass(frozen=True, slots=True)
+class RrThenKoStrategy:
+    """Round-robin pools, then a knockout bracket seeded from the pool finishers — the
+    top :attr:`qualifiers_per_pool` out of each pool advance (ADR "rr-then-ko cuts both
+    stages upfront and seeds qualifiers rematch-free").
+
+    **Both stages are cut in one stroke.** ``plan_initial`` emits every pool's
+    round-robin *and* the full bracket, all of the latter's sides TBD. That is not a
+    convenience: :class:`AdvancePlan` can express only :class:`SideFill` — there is
+    deliberately no way for an ``advance()`` to *create* a fixture — so a bracket that
+    did not exist at the cut could never come into being. It costs nothing, because the
+    qualifier count ``P × K`` is known before anybody plays, so the bracket size (the
+    smallest power of two ≥ ``P × K``) and *which seeds bye* are determined at cut time.
+    Bracket size is **derived, never configured**, so it cannot contradict the qualifier
+    count.
+
+    **The pool stage is round-robin's, not a copy of it**: ``plan_initial`` calls
+    :class:`RoundRobinStrategy` for the pool fixtures, so "the pools of an rr-then-ko
+    draw are laid out exactly as a round-robin draw's" is true structurally rather than
+    by two implementations agreeing. The knockout stage is likewise
+    :func:`_knockout_fixtures` — the same bracket shape :class:`SingleElimStrategy`
+    cuts — and its ``advance`` reuses :meth:`SingleElimStrategy.advance` verbatim for
+    the forward seating once the knockout is under way.
+
+    **Qualifiers are seated per-pool, as each pool finishes.** The seed → (pool, place)
+    map (:func:`qualifier_seed_assignment`) depends only on ``P`` and ``K`` — never on a
+    result — so pool A's qualifiers take their predetermined slots the moment *A* is
+    decided, with B and C still playing. A knockout fixture simply is not ``ready``
+    until both its sides are seated, which :func:`ready_fixtures` already handles.
+
+    **A pool is finished when every one of its fixtures has a score** — the live-outcome
+    view (:attr:`FixtureState.games`), the same one the standings are projected from,
+    not the written-back ``winner_entry_id`` that no read reads. So a result under
+    correction un-finishes its pool rather than freezing a stale qualifier list, and a
+    pool whose match was **voided** never finishes: that pairing genuinely produced no
+    result, and this shape cannot tell a voided pairing from an unplayed one.
+
+    **A correction that changes who qualified does not re-seat the bracket**,
+    knowingly (ADR): a :class:`SideFill` only ever fills an *empty* side, so a pool
+    match corrected after its qualifiers were seated leaves them in the bracket while
+    the standings
+    re-order beneath them — the same way single-elim never un-seats a winner. That
+    property is also what makes ``advance`` idempotent.
+    """
+
+    #: How many entrants qualify out of **each** pool. ``K ≥ 1`` is static — a Pydantic
+    #: constraint at the request boundary — so a smaller value is a *programmer* error
+    #: and is refused in the constructor; the refusals that depend on the entrant count
+    #: (which moves) are :class:`DegenerateDraw`\\ s at the cut.
+    qualifiers_per_pool: int
+
+    def __post_init__(self) -> None:
+        if self.qualifiers_per_pool < 1:
+            raise ValueError(
+                "qualifiers_per_pool must be at least 1, got "
+                f"{self.qualifiers_per_pool}."
+            )
+
+    def plan_initial(
+        self, config: DrawConfig, ordered_entrants: Sequence[OrderedEntrant]
+    ) -> list[PlannedFixture]:
+        # The snake is run here for the refusals below — it is a pure function of the
+        # same inputs, so running it again inside round-robin's own cut deals the
+        # identical pools, and the pool stage stays *literally* round-robin's rather
+        # than a second implementation that has to be kept in step.
+        pools = _snake(ordered_entrants, config.pool_ids)
+        # The snake has already refused a pool of fewer than two, so ``smallest`` is at
+        # least 2 and the noun below never needs inflecting.
+        smallest = min(len(members) for _, members in pools)
+        if self.qualifiers_per_pool > smallest:
+            raise DegenerateDraw(
+                f"Taking {self.qualifiers_per_pool} qualifiers from each pool is more "
+                f"than the {smallest} entrants in the smallest pool — take fewer "
+                "qualifiers from each pool, or add entrants."
+            )
+        if len(pools) * self.qualifiers_per_pool < 2:
+            # ``K ≥ 1`` is static and the snake guarantees ``P ≥ 1``, so the *only* way
+            # to arrive here is one pool taking one qualifier: the sentence is fully
+            # determined, and interpolating the counts would only add branches no input
+            # can reach.
+            raise DegenerateDraw(
+                "Taking 1 qualifier from a single pool leaves one player in the "
+                "knockout stage, who would have nobody to play — take more qualifiers "
+                "from each pool, or configure more pools."
+            )
+        qualifier_count = len(pools) * self.qualifiers_per_pool
+        fixtures = RoundRobinStrategy().plan_initial(config, ordered_entrants)
+        # Cut in the same stroke: every side TBD (nobody has qualified), ``pool_id``
+        # ``None`` (the knockout stage *is* ``pool_id IS NULL``), rounds from 1.
+        fixtures.extend(_knockout_fixtures(qualifier_count, {}))
+        return fixtures
+
+    def advance(self, fixtures: Sequence[FixtureState]) -> AdvancePlan:
+        """Seat the qualifiers of every **finished** pool into their predetermined
+        bracket slots, then seat the knockout's own decided winners forward.
+
+        Idempotent, twice over: a qualifier is seated only into a still-empty side,
+        and the knockout half is :meth:`SingleElimStrategy.advance`, which already is.
+        Run it against a state its own last plan was applied to and it plans nothing.
+        """
+        knockout = [fixture for fixture in fixtures if fixture.pool_id is None]
+        return AdvancePlan(
+            side_fills=(
+                *self._qualifier_fills(fixtures, knockout),
+                # The knockout stage, once it is under way, advances exactly as a
+                # single-elim bracket does — so it is advanced *by* single-elim, over
+                # the un-pooled fixtures alone. Passing the pool fixtures too would let
+                # a pool's ``(round, position)`` collide with the bracket's and seat a
+                # pool winner into a knockout slot.
+                *SingleElimStrategy().advance(knockout).side_fills,
+            ),
+            ready_fixture_ids=ready_fixtures(fixtures),
+        )
+
+    def _qualifier_fills(
+        self, fixtures: Sequence[FixtureState], knockout: Sequence[FixtureState]
+    ) -> list[SideFill]:
+        """The qualifiers of every finished pool, seated into their bracket slots."""
+        pooled = [fixture for fixture in fixtures if fixture.pool_id is not None]
+        _refuse_gameless_pool_results(pooled, fixtures)
+        # The event's pool order is not recoverable from the fixtures (a fixture holds a
+        # pool *ref*, not an index), so the pools are indexed by their sorted ids — a
+        # deterministic labelling, stable across every re-run, which is all the seed
+        # assignment needs. Which pool is index 0 is genuinely arbitrary: within a
+        # finishing place pools are not ranked against each other, and relabelling them
+        # is a bijection, so the rematch-free guarantee holds under any labelling.
+        pool_ids = sorted(
+            {fixture.pool_id for fixture in pooled if fixture.pool_id is not None}
+        )
+        if not pool_ids:
+            return []
+        seed_by_seat = {
+            seat: seed
+            for seed, seat in qualifier_seed_assignment(
+                len(pool_ids), self.qualifiers_per_pool
+            ).items()
+        }
+        seats = _knockout_seats(len(pool_ids) * self.qualifiers_per_pool)
+        by_slot = {(fixture.round, fixture.position): fixture for fixture in knockout}
+
+        fills: list[SideFill] = []
+        for pool_index, pool_id in enumerate(pool_ids):
+            order = _finished_pool_order(
+                [fixture for fixture in pooled if fixture.pool_id == pool_id]
+            )
+            if order is None:
+                continue  # still playing (or a result in flux) — nothing to seat yet
+            for place, tally in enumerate(order[: self.qualifiers_per_pool], start=1):
+                seed = seed_by_seat[QualifierSeat(pool_index=pool_index, place=place)]
+                round_number, position, side = seats[seed]
+                slot = by_slot.get((round_number, position))
+                if slot is None:
+                    continue  # no such fixture — a bracket cut for a different K
+                already = slot.entry_a_id if side is Side.a else slot.entry_b_id
+                if already is not None:
+                    continue  # already seated — the source of idempotence
+                fills.append(
+                    SideFill(
+                        fixture_id=slot.fixture_id, side=side, entry_id=tally.entry_id
+                    )
+                )
+        return fills
+
+
+#: Static proof that :class:`RrThenKoStrategy` satisfies :class:`DrawStrategy`. For the
+#: other two that check falls out of :func:`strategy_for`'s return type; rr-then-ko does
+#: not reach it until the enum member lands, so the conformance is asserted here instead
+#: of going unchecked in the meantime.
+_RR_THEN_KO_IS_A_STRATEGY: DrawStrategy = RrThenKoStrategy(qualifiers_per_pool=1)
+
+
+def _finished_pool_order(
+    pool_fixtures: Sequence[FixtureState],
+) -> list[EntryTally] | None:
+    """This pool's finishing order, or ``None`` if the pool is **not finished**.
+
+    Finished = every fixture in it carries a score. The order itself is
+    :func:`~app.pool_finishing_order.finishing_order` — *the* definition of how a pool
+    finished, the same call :class:`~app.results.RoundRobinResults` makes for the
+    standings table — so the qualifiers are exactly the top of the table a director is
+    reading, structurally and not by coincidence.
+    """
+    entrants: dict[EntryId, None] = {}
+    outcomes: list[MatchOutcome] = []
+    for fixture in pool_fixtures:
+        if (
+            fixture.entry_a_id is None
+            or fixture.entry_b_id is None
+            or fixture.games is None
+        ):
+            return None
+        entrants[fixture.entry_a_id] = None
+        entrants[fixture.entry_b_id] = None
+        outcomes.append(
+            MatchOutcome(
+                entry_a_id=fixture.entry_a_id,
+                entry_b_id=fixture.entry_b_id,
+                entry_a_games=fixture.games.entry_a_games,
+                entry_b_games=fixture.games.entry_b_games,
+            )
+        )
+    if not outcomes:
+        return None
+    return finishing_order(entrants, outcomes)
+
+
+def _refuse_gameless_pool_results(
+    pooled: Sequence[FixtureState], fixtures: Sequence[FixtureState]
+) -> None:
+    """Raise :class:`MissingFixtureGames` when pool fixtures are decided and the whole
+    input carries no game counts — see that class for why this is loud rather than
+    tolerated."""
+    gameless = [
+        fixture
+        for fixture in pooled
+        if fixture.winner_entry_id is not None and fixture.games is None
+    ]
+    if not gameless or any(fixture.games is not None for fixture in fixtures):
+        return
+    fixture_noun = "fixture" if len(gameless) == 1 else "fixtures"
+    raise MissingFixtureGames(
+        f"{len(gameless)} decided pool {fixture_noun} reached advance() with no game "
+        "counts, and no fixture in this draw carries any — the caller projected the "
+        "fixtures without loading their completed matches' games. Qualifiers are the "
+        "top of the same standings the tiebreak chain produces (wins, head-to-head, "
+        "game difference, games won), so ordering a pool without games would pick "
+        "different qualifiers from the table on screen."
+    )
 
 
 def ready_fixtures(fixtures: Sequence[FixtureState]) -> tuple[FixtureId, ...]:
@@ -656,6 +1003,204 @@ def _seed_slots(bracket_size: int) -> list[int]:
             expanded.extend(pair)
         slots = expanded
     return slots
+
+
+def _knockout_seats(field_size: int) -> dict[int, tuple[int, int, Side]]:
+    """Where every seed **enters** the bracket that holds ``field_size`` of them:
+    ``seed → (round, position, side)``.
+
+    One description of a bracket's shape, for the two questions that need it: *which
+    fixtures exist* (:func:`_knockout_fixtures`) and *where does a given seed sit*
+    (:meth:`RrThenKoStrategy.advance`, seating a qualifier the moment its pool
+    finishes). Keeping them one function is what stops a qualifier being seated into a
+    slot the cut never emitted.
+
+    Byes are the top ``B − field_size`` seeds, and a byed seed's entry point is its
+    **round-2** side — computed with :func:`_successor` from the round-1 position it
+    would have played, so a bye and a played feeder land on the two sides of the same
+    successor. ``position`` is always the **full-bracket** slot index, never a
+    renumbering of the surviving matches, which is what keeps that arithmetic true.
+    """
+    bracket = 1
+    while bracket < field_size:
+        bracket <<= 1
+    slots = _seed_slots(bracket)
+    seats: dict[int, tuple[int, int, Side]] = {}
+    for pair_index in range(bracket // 2):
+        position = pair_index + 1
+        first, second = slots[2 * pair_index], slots[2 * pair_index + 1]
+        top, bottom = min(first, second), max(first, second)
+        if bottom <= field_size:
+            # Two real seeds: a genuine round-1 match. Top seat = ``entry_a`` for
+            # readability only — the successor side is decided by ``position``, not by
+            # which seed is ``a``.
+            seats[top] = (1, position, Side.a)
+            seats[bottom] = (1, position, Side.b)
+        else:
+            # One phantom (``bottom`` > N; two phantoms cannot happen when
+            # ``bracket`` is the smallest power of two ≥ N). The real ``top`` seed byes
+            # straight into round 2.
+            successor_round, successor_position, side = _successor(1, position)
+            seats[top] = (successor_round, successor_position, side)
+    return seats
+
+
+def _knockout_fixtures(
+    field_size: int, entry_for_seed: Mapping[int, EntryId]
+) -> list[PlannedFixture]:
+    """The whole un-pooled bracket for ``field_size`` seeds, with each seed's entry
+    taken from ``entry_for_seed`` — **or left TBD for every seed the map does not
+    name**.
+
+    Two callers, one bracket. :class:`SingleElimStrategy` passes the full seed → entry
+    map, because a single-elim cut knows its field. :class:`RrThenKoStrategy` passes an
+    **empty** map, because its qualifiers have not played yet — and gets the identical
+    shape with every side ``None``. That the shape is a pure function of ``field_size``
+    is exactly why a pools-then-knockout bracket can be cut in the same stroke as the
+    pools (ADR "rr-then-ko cuts both stages upfront"): the qualifier count ``P × K`` is
+    known at cut time, so *which* slots exist and *which* seeds bye is settled before
+    anybody has played.
+
+    A **bye is absence** (ADR-0786): a byed seed has no round-1 fixture at all, and the
+    round-1 positions it would have occupied are simply skipped, leaving gaps in the
+    position sequence. Every later round is emitted whole, its sides ``None`` except a
+    side a bye already makes known.
+
+    Rounds are numbered from **1** for both callers. For the knockout stage of an
+    rr-then-ko draw that is a *restart*, not a continuation of the pool rounds: the
+    fixture uniqueness constraint is ``(event_id, pool_id, round, position)`` with
+    ``NULLS NOT DISTINCT``, so ``pool_id IS NULL`` is its own numbering namespace, and
+    "the round after the pools" is ill-defined anyway when pools may differ in size.
+    """
+    bracket = 1
+    while bracket < field_size:
+        bracket <<= 1
+    rounds = bracket.bit_length() - 1
+    seats = _knockout_seats(field_size)
+
+    # The sides a seed is known to occupy at cut time, keyed by its slot. A seed the
+    # caller cannot name yet contributes nothing, so its side stays TBD.
+    seated: dict[tuple[int, int, Side], EntryId | None] = {
+        seat: entry_for_seed.get(seed) for seed, seat in seats.items()
+    }
+    round_one_positions = sorted(
+        {position for round_number, position, _ in seats.values() if round_number == 1}
+    )
+
+    fixtures = [
+        PlannedFixture(
+            pool_id=None,
+            round=1,
+            position=position,
+            entry_a_id=seated.get((1, position, Side.a)),
+            entry_b_id=seated.get((1, position, Side.b)),
+        )
+        for position in round_one_positions
+    ]
+    if rounds >= 2:
+        fixtures.extend(
+            PlannedFixture(
+                pool_id=None,
+                round=2,
+                position=position,
+                entry_a_id=seated.get((2, position, Side.a)),
+                entry_b_id=seated.get((2, position, Side.b)),
+            )
+            for position in range(1, bracket // 4 + 1)
+        )
+    fixtures.extend(
+        PlannedFixture(pool_id=None, round=round_number, position=position)
+        for round_number in range(3, rounds + 1)
+        for position in range(1, (bracket >> round_number) + 1)
+    )
+    return fixtures
+
+
+def _round_one_partners(qualifier_count: int) -> dict[int, int]:
+    """Who meets whom in round one of the bracket that holds ``qualifier_count``
+    qualifiers — ``{seed: opposing seed}``, symmetric, and **only** for the pairs that
+    are real matches.
+
+    Read straight off :func:`_seed_slots` rather than restated as ``B+1−s``, so there is
+    one description of the bracket's shape and not two that can drift. A seed whose
+    opposite number lands past ``qualifier_count`` has a **bye** and simply does not
+    appear here: a bye plays nobody, so it can never be a same-pool rematch.
+    """
+    bracket = 1
+    while bracket < qualifier_count:
+        bracket <<= 1
+    slots = _seed_slots(bracket)
+    partners: dict[int, int] = {}
+    for index in range(0, bracket, 2):
+        first, second = slots[index], slots[index + 1]
+        if max(first, second) > qualifier_count:
+            continue  # one side is a phantom seat — that seed byes
+        partners[first] = second
+        partners[second] = first
+    return partners
+
+
+def _assign_block_pools(
+    seeds: Sequence[int], pool_count: int, forbidden: dict[int, int]
+) -> dict[int, int]:
+    """Hand each seed in one place block a distinct pool, avoiding each seed's one
+    forbidden pool — the bipartite matching at the heart of
+    :func:`qualifier_seed_assignment`.
+
+    Kuhn's augmenting-path algorithm, walked in ascending seed then ascending pool
+    order, which makes the matching it lands on a *function of the inputs* rather than
+    of dict iteration luck. Hall's condition guarantees a matching exists whenever
+    ``pool_count ≥ 2`` (each seed forbids at most one pool, so each admits at least
+    ``pool_count − 1``), so the failure arm is unreachable and says so.
+
+    A seed takes the **lowest free pool** it is allowed, and only displaces an incumbent
+    when every pool it admits is taken — the standard greedy initialization for Kuhn's.
+    Skipping it costs nothing in correctness (an augmenting path repairs any greedy
+    mistake) but a great deal in legibility: without it an *unconstrained* block still
+    shuffles, so a two-pool bracket seats pool B's winner at seed 1, which reads as a
+    bug to anyone printing the draw.
+    """
+    seed_by_pool: dict[int, int] = {}
+    for seed in seeds:
+        free = next(
+            (
+                pool
+                for pool in range(pool_count)
+                if pool not in seed_by_pool and pool != forbidden.get(seed)
+            ),
+            None,
+        )
+        if free is not None:
+            seed_by_pool[free] = seed
+            continue
+        if not _augment_pool(seed, pool_count, forbidden, seed_by_pool, set()):
+            raise RuntimeError(  # pragma: no cover - Hall's condition forbids it
+                f"No conflict-free pool assignment for seed {seed} across "
+                f"{pool_count} pools, which Hall's condition says cannot happen."
+            )
+    return {seed: pool for pool, seed in seed_by_pool.items()}
+
+
+def _augment_pool(
+    seed: int,
+    pool_count: int,
+    forbidden: dict[int, int],
+    seed_by_pool: dict[int, int],
+    visited: set[int],
+) -> bool:
+    """Try to seat ``seed`` in some pool, displacing an incumbent that can move
+    elsewhere. ``True`` when ``seed_by_pool`` has been extended to cover it."""
+    for pool in range(pool_count):
+        if pool == forbidden.get(seed) or pool in visited:
+            continue
+        visited.add(pool)
+        incumbent = seed_by_pool.get(pool)
+        if incumbent is None or _augment_pool(
+            incumbent, pool_count, forbidden, seed_by_pool, visited
+        ):
+            seed_by_pool[pool] = seed
+            return True
+    return False
 
 
 def _successor(round_number: int, position: int) -> tuple[int, int, Side]:

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -781,10 +781,10 @@ class RrThenKoStrategy:
         return fills
 
 
-#: Static proof that :class:`RrThenKoStrategy` satisfies :class:`DrawStrategy`. For the
-#: other two that check falls out of :func:`strategy_for`'s return type; rr-then-ko does
-#: not reach it until the enum member lands, so the conformance is asserted here instead
-#: of going unchecked in the meantime.
+#: Static proof that :class:`RrThenKoStrategy` satisfies :class:`DrawStrategy`. It is
+#: now redundant — the enum member landed (#1227) and :func:`strategy_for`'s return type
+#: checks all three arms — and it is kept because it is *free*, and because it names the
+#: conformance at the class rather than leaving it a side effect of a dispatch table.
 _RR_THEN_KO_IS_A_STRATEGY: DrawStrategy = RrThenKoStrategy(qualifiers_per_pool=1)
 
 
@@ -878,8 +878,11 @@ def ready_fixtures(fixtures: Sequence[FixtureState]) -> tuple[FixtureId, ...]:
     return tuple(f.fixture_id for f in ready)
 
 
-def strategy_for(draw_type: DrawType) -> DrawStrategy:
-    """The strategy that cuts and advances this draw type.
+def strategy_for(
+    draw_type: DrawType, *, qualifiers_per_pool: int | None
+) -> DrawStrategy:
+    """The strategy that cuts and advances this draw type, configured as the event's
+    draw-settings row configures it.
 
     **Total** — every :class:`DrawType` returns a strategy, and there is no refusal arm
     left to reach. That is the whole point of holding only what runs in the enum (ADR
@@ -890,12 +893,36 @@ def strategy_for(draw_type: DrawType) -> DrawStrategy:
     Still an exhaustive ``match`` with **no catch-all**, and now with nowhere to park a
     new member lazily: adding one to :class:`DrawType` fails to type-check here until
     its strategy exists.
+
+    ``qualifiers_per_pool`` is the settings row's **K** column, passed straight through:
+    ``rr-then-ko`` is the first draw type whose strategy takes a *parameter*, and the
+    parameter lives on the event, not in this module. It is keyword-only and has **no
+    default**, so every call site has to answer "where does K come from" rather than
+    silently taking a strategy configured by omission — and the two draw types that take
+    no configuration say ``None`` out loud. Production callers do not spell the pair
+    themselves; :func:`app.tournament_draws.strategy_for_event` reads both facts off the
+    one row that holds them.
+
+    A ``None`` on the ``rr-then-ko`` arm is a **programmer** error, not a director's,
+    and raises :class:`ValueError` — the same status
+    :meth:`RrThenKoStrategy.__post_init__` gives ``K < 1``. Nothing a director can type
+    reaches it: the request boundary refuses an ``rr-then-ko`` payload with no qualifier
+    count (422) and the settings table's ``CHECK`` refuses such a row outright, so the
+    only way here is a caller that dropped the column on the floor — which is exactly
+    the silent-wrong-answer this refuses to give.
     """
     match draw_type:
         case DrawType.round_robin:
             return RoundRobinStrategy()
         case DrawType.single_elim:
             return SingleElimStrategy()
+        case DrawType.rr_then_ko:
+            if qualifiers_per_pool is None:
+                raise ValueError(
+                    f"A {DrawType.rr_then_ko.value!r} draw needs a qualifiers_per_pool "
+                    "— the event's draw settings carry it, and the caller passed None."
+                )
+            return RrThenKoStrategy(qualifiers_per_pool=qualifiers_per_pool)
 
 
 def _snake(

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import enum
 import uuid
+from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -145,6 +146,27 @@ class MissingFixtureGames(RuntimeError):
     under correction leaves the match un-``completed`` while the fixture's written-back
     ``winner_entry_id`` stays put — and that one is handled honestly by the strategy
     (its pool is simply not finished yet), not raised at.
+    """
+
+
+class MissingBracketSlot(RuntimeError):
+    """A qualifier's predetermined knockout slot **does not exist in this draw** — the
+    bracket standing here was cut for a different qualifier count than the one being
+    advanced.
+
+    :class:`MissingFixtureGames`' sibling, and deliberately not a :class:`DrawError` for
+    the same reason: nothing a director can type reaches it. The qualifier count is
+    frozen the moment a draw is cut (a 409 from the event editor), and the bracket is
+    cut upfront from ``P × K``, so a seed with no slot means a caller advanced these
+    fixtures with a strategy configured differently from the one that dealt them. That
+    is a wiring bug, and the only useful response is a loud 500.
+
+    It exists because the alternative failure is silent and wrong in exactly the way the
+    freeze's own 409 refuses to allow: skipping the seed seats *some* of the qualifiers
+    and leaves the rest out, producing a bracket that looks cut, looks seeded, and is
+    playable — while the entrants who earned those places are simply missing from it.
+    The 409 is the first line of defence, not a licence for the domain to be quiet when
+    it has been breached.
     """
 
 
@@ -317,7 +339,9 @@ class FixtureState:
     #: **structurally**, down to the game-difference and games-won tiebreakers, rather
     #: than by two implementations happening to concur.
     #:
-    #: No strategy reads this yet; round-robin and single-elim ignore it.
+    #: Only ``rr-then-ko`` reads it; round-robin and single-elim ignore it, and
+    #: :func:`reads_fixture_games` is where that is said once so a caller knows whether
+    #: it has to load the counts at all.
     games: FixtureGames | None = None
 
     @property
@@ -442,12 +466,16 @@ def qualifier_seed_assignment(
     - round one is a perfect matching on seeds (:func:`_seed_slots` pairs ``s`` with
       ``B+1−s``), so a seed has **at most one** partner and therefore at most one
       forbidden pool;
-    - assigning blocks in ascending order, every position in the block still admits at
-      least ``P−1`` pools, so Hall's condition holds for ``P ≥ 2`` and a conflict-free
-      system of distinct representatives always exists. The search below finds one
-      deterministically — pools tried in ascending index order, augmenting when stuck
-      — so a re-cut reproduces the same bracket, the same promise
-      :func:`order_entrants` makes.
+    - assigning blocks in ascending order, one forbidden pool per seed leaves Hall's
+      condition exactly **one** way to fail — all ``P`` of a block's seeds forbidding
+      the *same* pool — and the block's own geometry closes it, so a conflict-free
+      system of distinct representatives always exists. That last step is the one worth
+      reading in full, and it is stated where it is relied on
+      (:func:`_assign_block_pools`), because "each admits at least ``P−1`` pools" is not
+      by itself the reason. The search below finds a representative system
+      deterministically — pools tried in ascending index order, augmenting when stuck —
+      so a re-cut reproduces the same bracket, the same promise :func:`order_entrants`
+      makes.
 
     The two fixed orderings this replaces cannot work: place-then-pool pairs ``C1``
     against ``C2`` at three pools, and reversing the runners-up fixes three pools while
@@ -769,7 +797,16 @@ class RrThenKoStrategy:
                 round_number, position, side = seats[seed]
                 slot = by_slot.get((round_number, position))
                 if slot is None:
-                    continue  # no such fixture — a bracket cut for a different K
+                    raise MissingBracketSlot(
+                        f"Seed {seed} (place {place} in pool {pool_id!r}) qualifies "
+                        f"into knockout slot (round {round_number}, position "
+                        f"{position}), which this draw has no fixture for: the bracket "
+                        f"standing here holds {len(by_slot)} fixtures and was cut for "
+                        "a different number of qualifiers than the "
+                        f"{len(pool_ids) * self.qualifiers_per_pool} "
+                        f"({len(pool_ids)} pools × {self.qualifiers_per_pool}) this "
+                        "advance is seating."
+                    )
                 already = slot.entry_a_id if side is Side.a else slot.entry_b_id
                 if already is not None:
                     continue  # already seated — the source of idempotence
@@ -779,13 +816,6 @@ class RrThenKoStrategy:
                     )
                 )
         return fills
-
-
-#: Static proof that :class:`RrThenKoStrategy` satisfies :class:`DrawStrategy`. It is
-#: now redundant — the enum member landed (#1227) and :func:`strategy_for`'s return type
-#: checks all three arms — and it is kept because it is *free*, and because it names the
-#: conformance at the class rather than leaving it a side effect of a dispatch table.
-_RR_THEN_KO_IS_A_STRATEGY: DrawStrategy = RrThenKoStrategy(qualifiers_per_pool=1)
 
 
 def _finished_pool_order(
@@ -925,6 +955,32 @@ def strategy_for(
             return RrThenKoStrategy(qualifiers_per_pool=qualifiers_per_pool)
 
 
+def reads_fixture_games(draw_type: DrawType) -> bool:
+    """Whether this draw type's ``advance()`` reads :attr:`FixtureState.games` — i.e.
+    whether a caller projecting fixtures for it has to load the game counts first.
+
+    A fact about the strategies, kept beside them rather than inferred at the seam.
+    ``rr-then-ko`` picks its qualifiers by the standings' own tiebreak chain and so
+    reads the games (refusing loudly — :class:`MissingFixtureGames` — when they were not
+    loaded); round-robin and single-elim never touch the field, and for them the load is
+    a SQL statement and a few hundred score rows discarded, on the completion seam,
+    inside the score-accept transaction, once per result.
+
+    An exhaustive ``match`` with **no catch-all**, exactly like :func:`strategy_for`: a
+    new :class:`DrawType` member has to *declare* whether it needs the games, and until
+    it does this fails to type-check. The alternative — a default of ``False`` — is a
+    new strategy silently advancing on ``games=None``, which is the one failure
+    :class:`MissingFixtureGames` exists to make impossible.
+    """
+    match draw_type:
+        case DrawType.round_robin:
+            return False
+        case DrawType.single_elim:
+            return False
+        case DrawType.rr_then_ko:
+            return True
+
+
 def _snake(
     ordered_entrants: Sequence[OrderedEntrant], pool_ids: Sequence[PoolId]
 ) -> list[tuple[PoolId, tuple[EntryId, ...]]]:
@@ -1003,6 +1059,27 @@ def _circle_method(pool_id: PoolId, members: Sequence[EntryId]) -> list[PlannedF
     return fixtures
 
 
+def _bracket_size(field_size: int) -> int:
+    """The bracket a field of ``field_size`` is played in: the **smallest power of two ≥
+    field_size**.
+
+    Stated once, because the questions that turn on it — which slots exist
+    (:func:`_knockout_fixtures`) and where a seed enters (:func:`_knockout_seats`) —
+    must not size the bracket one way here and another way there, which is a draw that
+    disagrees with itself. The ``B − field_size`` spare seats are the byes, which is why
+    the padding rule and the bye rule are the same fact.
+
+    A field of one pads to one (there is no zero-th power below it) and a field of zero
+    to one as well; neither is a competition, and the refusals that say so
+    (:class:`DegenerateDraw`) are the strategies', raised at the cut where the field is
+    in hand.
+    """
+    bracket = 1
+    while bracket < field_size:
+        bracket <<= 1
+    return bracket
+
+
 def _seed_slots(bracket_size: int) -> list[int]:
     """The **standard single-elimination seeding order** for a bracket of
     ``bracket_size`` slots (a power of two): the 1-based seed positions laid out
@@ -1036,11 +1113,13 @@ def _knockout_seats(field_size: int) -> dict[int, tuple[int, int, Side]]:
     """Where every seed **enters** the bracket that holds ``field_size`` of them:
     ``seed → (round, position, side)``.
 
-    One description of a bracket's shape, for the two questions that need it: *which
-    fixtures exist* (:func:`_knockout_fixtures`) and *where does a given seed sit*
+    One description of a bracket's shape, for the three questions that need it: *which
+    fixtures exist* (:func:`_knockout_fixtures`), *where does a given seed sit*
     (:meth:`RrThenKoStrategy.advance`, seating a qualifier the moment its pool
-    finishes). Keeping them one function is what stops a qualifier being seated into a
-    slot the cut never emitted.
+    finishes) and *who does a seed meet in round one* (:func:`_round_one_partners`, the
+    constraint the rematch-free seeding is solved against). Keeping them one function is
+    what stops a qualifier being seated into a slot the cut never emitted — and what
+    stops the seeding believing in a bye the bracket does not give.
 
     Byes are the top ``B − field_size`` seeds, and a byed seed's entry point is its
     **round-2** side — computed with :func:`_successor` from the round-1 position it
@@ -1048,9 +1127,7 @@ def _knockout_seats(field_size: int) -> dict[int, tuple[int, int, Side]]:
     successor. ``position`` is always the **full-bracket** slot index, never a
     renumbering of the surviving matches, which is what keeps that arithmetic true.
     """
-    bracket = 1
-    while bracket < field_size:
-        bracket <<= 1
+    bracket = _bracket_size(field_size)
     slots = _seed_slots(bracket)
     seats: dict[int, tuple[int, int, Side]] = {}
     for pair_index in range(bracket // 2):
@@ -1099,9 +1176,7 @@ def _knockout_fixtures(
     ``NULLS NOT DISTINCT``, so ``pool_id IS NULL`` is its own numbering namespace, and
     "the round after the pools" is ill-defined anyway when pools may differ in size.
     """
-    bracket = 1
-    while bracket < field_size:
-        bracket <<= 1
+    bracket = _bracket_size(field_size)
     rounds = bracket.bit_length() - 1
     seats = _knockout_seats(field_size)
 
@@ -1124,20 +1199,20 @@ def _knockout_fixtures(
         )
         for position in round_one_positions
     ]
-    if rounds >= 2:
-        fixtures.extend(
-            PlannedFixture(
-                pool_id=None,
-                round=2,
-                position=position,
-                entry_a_id=seated.get((2, position, Side.a)),
-                entry_b_id=seated.get((2, position, Side.b)),
-            )
-            for position in range(1, bracket // 4 + 1)
-        )
+    # Every later round, in one loop. Round 2 is the only one a *bye* can pre-fill —
+    # :func:`_knockout_seats` seats a byed seed via ``_successor(1, …)``, which lands in
+    # round 2 and nowhere further — so from round 3 on the lookup is ``None`` for every
+    # slot and asking it costs nothing. Splitting the two would be two statements of one
+    # rule ("a side is known only where a seat says so"), which is how they drift.
     fixtures.extend(
-        PlannedFixture(pool_id=None, round=round_number, position=position)
-        for round_number in range(3, rounds + 1)
+        PlannedFixture(
+            pool_id=None,
+            round=round_number,
+            position=position,
+            entry_a_id=seated.get((round_number, position, Side.a)),
+            entry_b_id=seated.get((round_number, position, Side.b)),
+        )
+        for round_number in range(2, rounds + 1)
         for position in range(1, (bracket >> round_number) + 1)
     )
     return fixtures
@@ -1148,20 +1223,30 @@ def _round_one_partners(qualifier_count: int) -> dict[int, int]:
     qualifiers — ``{seed: opposing seed}``, symmetric, and **only** for the pairs that
     are real matches.
 
-    Read straight off :func:`_seed_slots` rather than restated as ``B+1−s``, so there is
-    one description of the bracket's shape and not two that can drift. A seed whose
-    opposite number lands past ``qualifier_count`` has a **bye** and simply does not
-    appear here: a bye plays nobody, so it can never be a same-pool rematch.
+    Read off :func:`_knockout_seats` — the *one* description of a bracket's shape —
+    rather than re-walking :func:`_seed_slots` and re-stating the bye rule beside it.
+    Two seats at the same round-1 position are two seeds in the same fixture, which is
+    exactly what "meets in round one" means. A **byed** seed enters at round 2 by
+    construction, so it never appears here at all, and the rematch-free guarantee
+    (:func:`qualifier_seed_assignment`) is therefore built on the same bracket the cut
+    emits rather than on a second opinion about it — the drift that would otherwise be
+    silent, because a partner map that thinks a seed byes admits the same-pool pairing
+    that seed actually plays.
     """
-    bracket = 1
-    while bracket < qualifier_count:
-        bracket <<= 1
-    slots = _seed_slots(bracket)
+    by_position: dict[int, dict[Side, int]] = defaultdict(dict)
+    for seed, (round_number, position, side) in _knockout_seats(
+        qualifier_count
+    ).items():
+        if round_number == 1:
+            by_position[position][side] = seed
     partners: dict[int, int] = {}
-    for index in range(0, bracket, 2):
-        first, second = slots[index], slots[index + 1]
-        if max(first, second) > qualifier_count:
-            continue  # one side is a phantom seat — that seed byes
+    for sides in by_position.values():
+        first, second = sides.get(Side.a), sides.get(Side.b)
+        # A round-1 position always carries both sides (``_knockout_seats`` seats them
+        # together or byes the survivor into round 2); the guard only narrows the
+        # Optionals for the type checker.
+        if first is None or second is None:
+            continue
         partners[first] = second
         partners[second] = first
     return partners
@@ -1176,9 +1261,28 @@ def _assign_block_pools(
 
     Kuhn's augmenting-path algorithm, walked in ascending seed then ascending pool
     order, which makes the matching it lands on a *function of the inputs* rather than
-    of dict iteration luck. Hall's condition guarantees a matching exists whenever
-    ``pool_count ≥ 2`` (each seed forbids at most one pool, so each admits at least
-    ``pool_count − 1``), so the failure arm is unreachable and says so.
+    of dict iteration luck.
+
+    **Why the failure arm below is unreachable**, stated the way it is actually true.
+    "Each seed forbids at most one pool, so each admits at least ``P−1``" is the fact,
+    but it is *not* the reason: a subset ``S`` of the block's seeds sees all ``P`` pools
+    the moment two of its members forbid different pools (or one forbids none), so the
+    only subset that can fail Hall's condition is the whole block — all ``P`` seeds
+    forbidding the **same** pool, leaving ``P−1`` pools for ``P`` seeds. Admitting
+    ``P−1`` each is exactly what does not rule that out.
+
+    What rules it out is the geometry of a block. A block is ``P`` **consecutive**
+    seeds; round one pairs ``s`` with ``B+1−s`` (:func:`_seed_slots`, ``B`` the bracket
+    size), an order-reversing pairing, so a block's partners are themselves ``P``
+    consecutive seeds — a run spanning at most **two** blocks. Each block hands each
+    pool to exactly one seed, so at most two of a block's seeds can forbid one pool,
+    which is fewer than ``P`` for every ``P ≥ 3``. ``P = 2`` is the one size where two
+    would be enough, and there the partner run is ``{B−2b−1, B−2b}`` (block ``b``),
+    whose lower member is odd because ``B`` is a power of two — so both partners sit in
+    the *same* block and necessarily hold different pools. Either way a block never
+    forbids one pool ``P`` times, Hall's condition holds, and a matching exists.
+    (Measured over ``P`` 2..64 × ``K`` 1..40 the margin is wider still: no two seeds of
+    a block were ever seen to forbid the same pool at all.)
 
     A seed takes the **lowest free pool** it is allowed, and only displaces an incumbent
     when every pool it admits is taken — the standard greedy initialization for Kuhn's.

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -343,6 +343,23 @@ class FixtureState:
     #: :func:`reads_fixture_games` is where that is said once so a caller knows whether
     #: it has to load the counts at all.
     games: FixtureGames | None = None
+    #: Whether this fixture's match is **voided** — terminal, and contributing nothing
+    #: (ADR-0013). A voided pairing genuinely produced no result and never will: the
+    #: match is closed to proposals, and ``ready_fixtures`` will not re-materialize a
+    #: fixture that already has a ``match_id``.
+    #:
+    #: A plain ``bool``, not the ``MatchStatus`` it is read off, because this module is
+    #: constructible from literals and imports nothing from the ORM. Voided-ness is the
+    #: only thing about a match's status any strategy asks, so the bridge
+    #: (:func:`app.tournament_draws.fixture_state`) answers that one question and the
+    #: enum stays on its own side of the seam.
+    #:
+    #: It is what stops a voided pairing wedging its pool: without it the pool would sit
+    #: one score short of "every fixture carries a score" forever — never finished, its
+    #: qualifiers never seated — while the standings, which already exclude voided
+    #: pairings from a pool's ``fixture_count`` (:class:`app.results.PoolInput`), showed
+    #: that same pool ``complete``. Two layers disagreeing about whether a pool is over.
+    match_voided: bool = False
 
     @property
     def is_pending(self) -> bool:
@@ -675,12 +692,18 @@ class RrThenKoStrategy:
     decided, with B and C still playing. A knockout fixture simply is not ``ready``
     until both its sides are seated, which :func:`ready_fixtures` already handles.
 
-    **A pool is finished when every one of its fixtures has a score** — the live-outcome
-    view (:attr:`FixtureState.games`), the same one the standings are projected from,
-    not the written-back ``winner_entry_id`` that no read reads. So a result under
-    correction un-finishes its pool rather than freezing a stale qualifier list, and a
-    pool whose match was **voided** never finishes: that pairing genuinely produced no
-    result, and this shape cannot tell a voided pairing from an unplayed one.
+    **A pool is finished when every one of its fixtures that can still produce a
+    result has a score** — the live-outcome view (:attr:`FixtureState.games`), the
+    same one the standings are projected from, not the written-back
+    ``winner_entry_id`` that no read reads. So a result under correction un-finishes
+    its pool rather than freezing a stale qualifier list. A **voided** pairing is the
+    one exception: it never will produce a result, so it is left out of the
+    requirement rather than counted-but-missing, exactly as the standings leave it out
+    of a pool's ``fixture_count`` (:class:`app.results.PoolInput`). Counting it would
+    hold the pool one score short forever — never finished, its qualifiers never
+    seated, the knockout never ready, and no remedy a director could reach — while the
+    table on screen called that same pool ``complete``. See
+    :func:`_finished_pool_order`.
 
     **A correction that changes who qualified does not re-seat the bracket**,
     knowingly (ADR): a :class:`SideFill` only ever fills an *empty* side, so a pool
@@ -823,23 +846,44 @@ def _finished_pool_order(
 ) -> list[EntryTally] | None:
     """This pool's finishing order, or ``None`` if the pool is **not finished**.
 
-    Finished = every fixture in it carries a score. The order itself is
-    :func:`~app.pool_finishing_order.finishing_order` — *the* definition of how a pool
-    finished, the same call :class:`~app.results.RoundRobinResults` makes for the
-    standings table — so the qualifiers are exactly the top of the table a director is
-    reading, structurally and not by coincidence.
+    Finished = every fixture in it that can still produce a result carries a score. The
+    order itself is :func:`~app.pool_finishing_order.finishing_order` — *the* definition
+    of how a pool finished, the same call :class:`~app.results.RoundRobinResults` makes
+    for the standings table — so the qualifiers are exactly the top of the table a
+    director is reading, structurally and not by coincidence.
+
+    Which is why a **voided** fixture is skipped rather than treated as a missing score:
+    it can never produce one (the match is terminal, and ``ready_fixtures`` will not
+    re-materialize a fixture that has a ``match_id``), and the standings already exclude
+    it from the ``fixture_count`` they call a pool ``complete`` against
+    (:class:`app.results.PoolInput`). Requiring its score here would leave the pool
+    permanently un-finished and its qualifiers permanently unseated while the table on
+    screen said the pool was over — the two layers disagreeing about the one fact this
+    function exists to share. Its **entrants** still count: they are seated in the pool
+    and appear in the standings, so a player whose only pairing was voided is in the
+    order with a row of zeros, exactly as the table shows them.
+
+    A pool with **no** usable outcome at all — every fixture voided — is ``None``, not
+    an order. The only thing left to rank on would be the entry-id fallback at the end
+    of the tiebreak chain, so "the qualifiers" would be arbitrary. This is the one
+    place the two layers part company on purpose: the standings call such a pool
+    ``complete`` (0 outcomes of 0 countable fixtures) and show a table of zeros, which
+    is honest to look at, and seating qualifiers off it would not be. It takes every
+    pairing in a pool being voided to reach, and voiding has exactly one producer today
+    (an account merge's self-play collision, ADR-0013), so it is a shape to refuse
+    rather than to serve.
     """
     entrants: dict[EntryId, None] = {}
     outcomes: list[MatchOutcome] = []
     for fixture in pool_fixtures:
-        if (
-            fixture.entry_a_id is None
-            or fixture.entry_b_id is None
-            or fixture.games is None
-        ):
+        if fixture.entry_a_id is None or fixture.entry_b_id is None:
             return None
         entrants[fixture.entry_a_id] = None
         entrants[fixture.entry_b_id] = None
+        if fixture.match_voided:
+            continue
+        if fixture.games is None:
+            return None
         outcomes.append(
             MatchOutcome(
                 entry_a_id=fixture.entry_a_id,
@@ -858,11 +902,23 @@ def _refuse_gameless_pool_results(
 ) -> None:
     """Raise :class:`MissingFixtureGames` when pool fixtures are decided and the whole
     input carries no game counts — see that class for why this is loud rather than
-    tolerated."""
+    tolerated.
+
+    A **voided** fixture is not evidence of the wiring bug and is excluded. Voiding
+    does not clear the ``winner_entry_id`` a completion wrote back, but it does take
+    the match out of ``completed``, so its games go away: "decided, and no games" is
+    that fixture's ordinary settled state, not a projection that forgot to load them.
+    Counting it would turn a single voided pairing in a draw nobody has scored yet into
+    a 500. What the guard still catches is unchanged, because it needs a decided fixture
+    that *should* carry games: project a played-out pool without its counts and every
+    one of its scored fixtures lands in this list.
+    """
     gameless = [
         fixture
         for fixture in pooled
-        if fixture.winner_entry_id is not None and fixture.games is None
+        if fixture.winner_entry_id is not None
+        and fixture.games is None
+        and not fixture.match_voided
     ]
     if not gameless or any(fixture.games is not None for fixture in fixtures):
         return

--- a/api/app/models/tournament.py
+++ b/api/app/models/tournament.py
@@ -62,6 +62,7 @@ class DrawType(enum.Enum):
     # agree) as well as the JSON the clients send.
     single_elim = "single-elim"
     round_robin = "round-robin"
+    rr_then_ko = "rr-then-ko"
 
 
 class Tournament(Base):

--- a/api/app/models/tournament.py
+++ b/api/app/models/tournament.py
@@ -316,8 +316,8 @@ class TournamentEvent(Base):
     #
     # NULLs last, explicitly, rather than relying on Postgres' ASC default: a NULL
     # ``pool_id`` is a real value here ("this fixture belongs to no pool" —
-    # single-elim today, and the knockout stage of a pools-then-knockout draw type
-    # once #787 adds one), and it belongs after the pools that feed it.
+    # single-elim, or this is the KO stage of an rr-then-ko event), and it belongs
+    # after the pools that feed it.
     fixtures: Mapped[list["TournamentFixture"]] = relationship(
         back_populates="event",
         cascade="all, delete-orphan",

--- a/api/app/models/tournament_event_draw_settings.py
+++ b/api/app/models/tournament_event_draw_settings.py
@@ -2,7 +2,15 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, String, func, text
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    func,
+    text,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -31,11 +39,33 @@ class TournamentEventDrawSettings(Base):
     has a seeded row — i.e. one ``app.draws.strategy_for`` can actually dispatch —
     and a seeded row cannot be deleted out from under an event that uses it.
 
-    Thin for now: it holds exactly the draw type. The follow-on pools ticket moves
-    ``TournamentEvent.pools`` in here, and #787 adds ``qualifiers_per_pool``.
+    Two columns of configuration today: the draw type, and ``qualifiers_per_pool``
+    — the **K** of "the top K from each pool advance", which only ``rr-then-ko``
+    has (#1227). The follow-on pools ticket moves ``TournamentEvent.pools`` in
+    here.
     """
 
     __tablename__ = "tournament_event_draw_settings"
+    __table_args__ = (
+        # ``qualifiers_per_pool`` belongs to exactly one draw type, and this is
+        # what says so at the storage layer: it is NOT NULL and at least 1 when
+        # the row names ``rr-then-ko``, and NULL for every other draw type. A
+        # round-robin row carrying a qualifier count is not a row Postgres will
+        # accept, so the pairing cannot drift no matter which writer produced it.
+        #
+        # The slug is spelled out in the DDL on purpose. It is the same
+        # hand-copied seed data migration 0010 already carries (``DRAW_TYPE_SEED``)
+        # — a constraint cannot import ``DrawType``, and a lookup-driven
+        # "does this draw type take qualifiers?" column on ``draw_types`` would be
+        # a second, mutable home for a fact the code already dispatches on.
+        CheckConstraint(
+            "CASE WHEN draw_type_key = 'rr-then-ko'"
+            " THEN qualifiers_per_pool IS NOT NULL AND qualifiers_per_pool >= 1"
+            " ELSE qualifiers_per_pool IS NULL"
+            " END",
+            name="ck_tournament_event_draw_settings_qualifiers_per_pool",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
@@ -51,6 +81,23 @@ class TournamentEventDrawSettings(Base):
         ForeignKey("draw_types.key", ondelete="RESTRICT"),
         nullable=False,
     )
+    # **K** — how many of each pool's finishers advance into the knockout stage of
+    # an ``rr-then-ko`` draw (ADR "rr-then-ko cuts both stages upfront and seeds
+    # qualifiers rematch-free"). The knockout bracket's size is
+    # ``next_power_of_two(P × K)`` and is DERIVED at the cut, never stored beside
+    # this — carrying both lets them contradict.
+    #
+    # Nullable because it is meaningless for every other draw type: a round-robin
+    # event has no cut to size and a single-elim event has no pools to cut from,
+    # so ``NULL`` here is "this draw type takes no qualifier count", not "unknown".
+    # The ``CASE`` constraint above is what keeps NULL and the draw type in step.
+    #
+    # ``K >= 1`` is the STATIC half of the ADR's legal configuration space and so
+    # is enforced here (and at the request boundary). The two bounds that move with
+    # the entrant count — ``P × K >= 2`` and ``K <= ⌊N/P⌋`` — are refused at the cut
+    # as ``DegenerateDraw``, because a row that was legal when it was written must
+    # not become unwritable when a player withdraws.
+    qualifiers_per_pool: Mapped[int | None] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -75,17 +122,49 @@ class TournamentEventDrawSettings(Base):
     )
 
     @classmethod
-    def for_draw_type(cls, draw_type: DrawType) -> "TournamentEventDrawSettings":
-        """Build the settings row for ``draw_type``.
+    def for_draw_type(
+        cls, draw_type: DrawType, *, qualifiers_per_pool: int | None = None
+    ) -> "TournamentEventDrawSettings":
+        """Build the settings row for ``draw_type``, configured as ``draw_type``
+        configures.
 
-        The create path's door onto the ``draw_type`` setter below, which is the
-        ONE place a :class:`DrawType` member becomes the persisted slug — so every
-        construction site names the draw type once and no site can invent a key the
-        reference table has never heard of.
+        The create path's door onto :meth:`configure` below, which is the ONE place a
+        :class:`DrawType` member becomes the persisted slug and the qualifier count
+        beside it.
+
+        It takes the draw type and the count as two values rather than the request
+        boundary's parsed union arm (``app.schemas.tournament.DrawSettingsWrite``), and
+        that is a **layering** choice, not an oversight: the schemas import the models,
+        so a model naming a request schema inverts the direction the rest of the package
+        points in. The union arm is consumed one layer up, in
+        ``app.tournament_events``, which already holds both — so the pair reaching here
+        has been parsed, and "a round-robin row with a qualifier count" was refused at
+        the boundary before it could be spelled. The ``CHECK`` on this table is the
+        second, unconditional lock: a caller that assembles an illegal pair by hand gets
+        an ``IntegrityError``, not a stored contradiction.
+
+        ``qualifiers_per_pool`` defaults to ``None`` because that is what all but one
+        draw type carry, and it keeps every construction site that names a
+        configuration-free draw type reading as it always did.
         """
         settings = cls()
-        settings.draw_type = draw_type
+        settings.configure(draw_type, qualifiers_per_pool=qualifiers_per_pool)
         return settings
+
+    def configure(
+        self, draw_type: DrawType, *, qualifiers_per_pool: int | None = None
+    ) -> None:
+        """Write this row's whole draw configuration — the ONE place the pair is set.
+
+        Both writers go through here: :meth:`for_draw_type` at create, and
+        ``app.tournament_events.update_event`` at edit. The two columns are written
+        **together**, because they are one fact: setting the draw type without clearing
+        the qualifier count beside it is how a round-robin row ends up carrying a ``K``
+        the ``CHECK`` refuses — and it is the edit path (draw type patched from
+        ``rr-then-ko`` back to ``round-robin``) where that would happen.
+        """
+        self.draw_type = draw_type
+        self.qualifiers_per_pool = qualifiers_per_pool
 
     @property
     def draw_type(self) -> DrawType:
@@ -103,9 +182,8 @@ class TournamentEventDrawSettings(Base):
     def draw_type(self, draw_type: DrawType) -> None:
         """The ONE place a :class:`DrawType` member becomes the persisted slug.
 
-        Both writers go through here — ``for_draw_type`` above at create, and
-        ``app.tournament_events.update_event`` at edit. Without a setter the edit
-        path had to reach past the property and write
+        Every writer goes through here, via :meth:`configure` above. Without a
+        setter the edit path had to reach past the property and write
         ``draw_settings.draw_type_key = draw_type.value`` itself, which gave
         enum→slug conversion a second home to drift in and made the "ONE place"
         claim above false.

--- a/api/app/pool_finishing_order.py
+++ b/api/app/pool_finishing_order.py
@@ -146,14 +146,22 @@ def finishing_order(
         entry_id: EntryTally(entry_id=entry_id) for entry_id in entrants
     }
     for outcome in outcomes:
-        record_outcome(
+        _record_outcome(
             tallies[outcome.entry_a_id], tallies[outcome.entry_b_id], outcome
         )
     return _order(list(tallies.values()), outcomes)
 
 
-def record_outcome(a: EntryTally, b: EntryTally, outcome: MatchOutcome) -> None:
-    """Fold one decided fixture into both sides' tallies."""
+def _record_outcome(a: EntryTally, b: EntryTally, outcome: MatchOutcome) -> None:
+    """Fold one decided fixture into both sides' tallies.
+
+    Private, like every other step of the order: :func:`finishing_order` is the module's
+    verb and the accumulator is its internals. Nothing outside builds a tally, so a
+    public one would advertise a protocol no caller wants — and invite a second, partial
+    tallying path beside the one definition this module exists to be.
+    (:func:`entry_id_order` is the exception, and is public because the *results* layer
+    genuinely shares that final tiebreak.)
+    """
     a.played += 1
     b.played += 1
     a.games_won += outcome.entry_a_games

--- a/api/app/pool_finishing_order.py
+++ b/api/app/pool_finishing_order.py
@@ -1,0 +1,227 @@
+"""How a **pool finished** — the one definition of the tiebreak chain that orders a
+round-robin pool's entrants, shared by the draw layer and the results layer.
+
+Two layers need this answer and they must never disagree about it. ``app.results``
+reads it out as a pool's **standings** table, the thing a director is looking at on
+screen; ``app.draws`` needs the same order to decide which entrants *qualify* out of a
+pool into a knockout stage. If each computed its own, "the qualifiers" and "the top of
+the table" could differ at precisely the moment somebody is looking hardest — a
+three-way tie for the last qualifying spot. One function, imported by both, makes them
+the same order **structurally**, not by two implementations happening to agree (ADR
+20260727, "the pool finishing order moves to a shared pure module").
+
+It lives in its own module rather than in either caller because ``app.results`` already
+imports ``app.draws``: putting the order in ``app.results`` would make the draw layer's
+use of it an import cycle. For the same reason this module imports **nothing** from
+``app.draws`` at runtime — :class:`~app.draws.EntryId` is a ``NewType`` over
+``uuid.UUID``, needed only as a *type*, so it is imported under ``TYPE_CHECKING`` and
+the draw layer can import this module freely.
+
+Like ``app.draws`` and ``app.results``, this module is **pure**: no session, no query,
+no SQLAlchemy or FastAPI construct. Its whole input is the pool's seated entrants plus
+the :class:`MatchOutcome`\\ s of its **currently-completed** matches, so nothing here is
+a snapshot — a corrected or voided match re-derives the order the instant it leaves
+``completed``.
+
+The chain, in order:
+
+1. **wins** — most match wins first;
+2. **head-to-head**, *only when exactly two entries are tied* on wins — the one that
+   beat the other ranks above it. A three-or-more-way tie can cycle (A beat B beat C
+   beat A), so it is **not** broken head-to-head; it falls straight through to the game
+   tiebreakers rather than a recursive mini-league;
+3. **game difference** — games won minus games lost;
+4. **games won**;
+5. the **entry id** — a total, deterministic fallback, so a pool in which two entries
+   are genuinely level on every count still orders the same way on every read.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Type-only: importing ``app.draws`` at runtime would be the very cycle this
+    # module exists to avoid, and ``EntryId`` is a plain ``uuid.UUID`` at runtime.
+    #
+    # The consequence, deliberately accepted: the annotations below are **not
+    # runtime-resolvable**. ``typing.get_type_hints(MatchOutcome)`` raises
+    # ``NameError: name 'EntryId' is not defined``, because ``from __future__ import
+    # annotations`` leaves them as strings and ``EntryId`` never exists at runtime.
+    # Nothing does that today (these are plain dataclasses, and the wire schemas in
+    # ``app.schemas.tournament`` are separate Pydantic models). But **do not hand
+    # ``MatchOutcome`` — or anything else here — to a Pydantic model, a FastAPI
+    # signature, or ``TypeAdapter``**: they all resolve hints at runtime and would
+    # fail with that baffling ``NameError`` far from this line. If you need one of
+    # these on a wire surface, mirror it as a Pydantic model there; the fix is *not*
+    # to un-guard this import, which re-creates the cycle
+    # ``tests/test_pool_finishing_order.py`` pins.
+    from app.draws import EntryId
+
+
+@dataclass(frozen=True, slots=True)
+class MatchOutcome:
+    """One decided fixture, as the standings need to see it: who was in it, who won,
+    and the games each side took.
+
+    Projected by the caller from a fixture whose match is **currently completed** — so
+    it is a fact about live state, never a snapshot. The games are the count each entry
+    *won*, which is all the game-difference and games-won tiebreakers need — and the
+    winner falls out of them.
+    """
+
+    entry_a_id: EntryId
+    entry_b_id: EntryId
+    entry_a_games: int
+    entry_b_games: int
+
+    @property
+    def winner_entry_id(self) -> EntryId:
+        """Whichever entry took more games. A decided match has no tie (odd best-of),
+        so the higher count is always the winner — derived here rather than stored, so
+        it cannot be handed in disagreeing with the counts beside it."""
+        return (
+            self.entry_a_id
+            if self.entry_a_games > self.entry_b_games
+            else self.entry_b_id
+        )
+
+    @property
+    def loser_entry_id(self) -> EntryId:
+        """The other side of :attr:`winner_entry_id` — whichever entry took fewer
+        games. A decided match has no tie (odd best-of), so the lower count is always
+        the loser; single-elim's finishes read a fixture's loser straight off this,
+        since losing is exactly what places you (ADR-0785)."""
+        return (
+            self.entry_b_id
+            if self.entry_a_games > self.entry_b_games
+            else self.entry_a_id
+        )
+
+
+@dataclass(slots=True)
+class EntryTally:
+    """A mutable per-entry accumulator — what one entry has done in its pool so far.
+
+    Built and mutated inside :func:`finishing_order`; callers only ever see the
+    finished list. Every entrant seated in the pool gets one, including a player who
+    has not played yet (a row of zeros), so the order is a *live, partial* one.
+    """
+
+    entry_id: EntryId
+    played: int = 0
+    wins: int = 0
+    losses: int = 0
+    games_won: int = 0
+    games_lost: int = 0
+
+    @property
+    def game_difference(self) -> int:
+        return self.games_won - self.games_lost
+
+
+# The tiebreak chain, after wins (which groups) and the two-way head-to-head (which
+# refines a pair): each entry maps to a value where HIGHER is better, tried in order.
+# A new comparator is **appended** here, not surgically inserted between the existing
+# ones — the chain is data, so extending it touches nothing already in it (ADR-0788).
+_TIEBREAKERS: tuple[Callable[[EntryTally], int], ...] = (
+    lambda tally: tally.game_difference,
+    lambda tally: tally.games_won,
+)
+
+
+def finishing_order(
+    entrants: Iterable[EntryId], outcomes: Sequence[MatchOutcome]
+) -> list[EntryTally]:
+    """The pool's finishing order: its ``entrants`` tallied from ``outcomes``, then
+    ordered by the chain in this module's docstring.
+
+    ``entrants`` is the full seated field — not just the entries that have played — so
+    the returned list always covers the whole pool. First place is index ``0``.
+    """
+    tallies: dict[EntryId, EntryTally] = {
+        entry_id: EntryTally(entry_id=entry_id) for entry_id in entrants
+    }
+    for outcome in outcomes:
+        record_outcome(
+            tallies[outcome.entry_a_id], tallies[outcome.entry_b_id], outcome
+        )
+    return _order(list(tallies.values()), outcomes)
+
+
+def record_outcome(a: EntryTally, b: EntryTally, outcome: MatchOutcome) -> None:
+    """Fold one decided fixture into both sides' tallies."""
+    a.played += 1
+    b.played += 1
+    a.games_won += outcome.entry_a_games
+    a.games_lost += outcome.entry_b_games
+    b.games_won += outcome.entry_b_games
+    b.games_lost += outcome.entry_a_games
+    if outcome.winner_entry_id == outcome.entry_a_id:
+        a.wins += 1
+        b.losses += 1
+    else:
+        b.wins += 1
+        a.losses += 1
+
+
+def entry_id_order(entry_id: EntryId) -> int:
+    """A total, deterministic order over entry ids — the final list-order tiebreak both
+    shapes fall back to so equal rows never come out in a nondeterministic order."""
+    return int.from_bytes(entry_id.bytes, "big")
+
+
+def _order(
+    tallies: list[EntryTally], outcomes: Sequence[MatchOutcome]
+) -> list[EntryTally]:
+    """Group by wins (descending), then break each tie."""
+    by_wins: dict[int, list[EntryTally]] = defaultdict(list)
+    for tally in tallies:
+        by_wins[tally.wins].append(tally)
+    ordered: list[EntryTally] = []
+    for wins in sorted(by_wins, reverse=True):
+        ordered.extend(_break_tie(by_wins[wins], outcomes))
+    return ordered
+
+
+def _break_tie(
+    group: list[EntryTally], outcomes: Sequence[MatchOutcome]
+) -> list[EntryTally]:
+    """Order a group of entries level on wins.
+
+    A **two-way** tie is broken head-to-head when the pair has actually met — the
+    winner of that match ranks above the loser. A larger tie (which can cycle) and a
+    two-way tie whose pair has not met yet (mid-pool) fall through to the game
+    tiebreakers.
+    """
+    if len(group) == 2:
+        decided = _head_to_head(group[0], group[1], outcomes)
+        if decided is not None:
+            return decided
+    return sorted(group, key=_scalar_key)
+
+
+def _head_to_head(
+    first: EntryTally, second: EntryTally, outcomes: Sequence[MatchOutcome]
+) -> list[EntryTally] | None:
+    """``[winner, loser]`` if these two have met, else ``None`` (not yet played)."""
+    pair = {first.entry_id, second.entry_id}
+    for outcome in outcomes:
+        if {outcome.entry_a_id, outcome.entry_b_id} == pair:
+            if outcome.winner_entry_id == first.entry_id:
+                return [first, second]
+            return [second, first]
+    return None
+
+
+def _scalar_key(tally: EntryTally) -> tuple[int, ...]:
+    """The tiebreak-chain sort key: each comparator negated (higher is better ⇒
+    earlier), then the entry id as the final deterministic tiebreak so the order is
+    total."""
+    return (
+        *(-tiebreaker(tally) for tiebreaker in _TIEBREAKERS),
+        entry_id_order(tally.entry_id),
+    )

--- a/api/app/results.py
+++ b/api/app/results.py
@@ -14,67 +14,55 @@ it reads out.
 
 Like ``app.draws`` this module is **pure**: it holds no session, issues no query, and
 imports no SQLAlchemy construct. Its whole input is small frozen value objects
-(:class:`MatchOutcome`, grouped into :class:`PoolInput` for a round-robin or
-:class:`BracketFixture` for a single-elim bracket) that the persistence layer projects
-from the fixtures' **currently-completed** matches — so nothing here is a snapshot, and
-a corrected or voided match re-derives the results the instant it leaves ``completed``,
-with no bookkeeping to keep in step (ADR-0788, "everything derives from the matches").
+(:class:`~app.pool_finishing_order.MatchOutcome`, grouped into :class:`PoolInput` for a
+round-robin or :class:`BracketFixture` for a single-elim bracket) that the persistence
+layer projects from the fixtures' **currently-completed** matches — so nothing here is a
+snapshot, and a corrected or voided match re-derives the results the instant it leaves
+``completed``, with no bookkeeping to keep in step (ADR-0788, "everything derives from
+the matches").
 
-Two arms are implemented: :class:`RoundRobinResults`, whose shape is a **standings**
-table per pool, and :class:`SingleElimResults` (ADR-0785), whose shape is the bracket's
-**finishes** — each entrant's finishing position by the round it was eliminated in. The
-two shapes cross the wire as a discriminated union tagged by ``kind`` (ADR-0785); here
-they are simply two different value objects returned by two ``tabulate`` methods.
+The round-robin **tiebreak chain itself** lives in ``app.pool_finishing_order``, not
+here: the draw layer needs the same order to pick a pool's qualifiers, and this module
+already imports ``app.draws``, so a shared third module is the only place both can
+reach (ADR 20260727). ``MatchOutcome`` is re-exported from here for the callers that
+already know it by this name.
+
+Three arms are implemented: :class:`RoundRobinResults`, whose shape is a **standings**
+table per pool; :class:`SingleElimResults` (ADR-0785), whose shape is the bracket's
+**finishes** — each entrant's finishing position by the round it was eliminated in; and
+:class:`RrThenKoResults` (ADR 20260727), a two-**stage** event whose shape is **both**,
+one block per stage. The shapes cross the wire as a discriminated union tagged by
+``kind`` (ADR-0785); here they are simply different value objects returned by different
+``tabulate`` methods.
 """
 
 from __future__ import annotations
 
-from collections import defaultdict
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from app.draws import EntryId, PoolId
 from app.models.tournament import DrawType
+from app.pool_finishing_order import MatchOutcome, entry_id_order, finishing_order
 
-
-@dataclass(frozen=True, slots=True)
-class MatchOutcome:
-    """One decided fixture, as the standings need to see it: who was in it, who won,
-    and the games each side took.
-
-    Projected by the caller from a fixture whose match is **currently completed** — so
-    it is a fact about live state, never a snapshot. The games are the count each entry
-    *won*, which is all the game-difference and games-won tiebreakers need — and the
-    winner falls out of them.
-    """
-
-    entry_a_id: EntryId
-    entry_b_id: EntryId
-    entry_a_games: int
-    entry_b_games: int
-
-    @property
-    def winner_entry_id(self) -> EntryId:
-        """Whichever entry took more games. A decided match has no tie (odd best-of),
-        so the higher count is always the winner — derived here rather than stored, so
-        it cannot be handed in disagreeing with the counts beside it."""
-        return (
-            self.entry_a_id
-            if self.entry_a_games > self.entry_b_games
-            else self.entry_b_id
-        )
-
-    @property
-    def loser_entry_id(self) -> EntryId:
-        """The other side of :attr:`winner_entry_id` — whichever entry took fewer
-        games. A decided match has no tie (odd best-of), so the lower count is always
-        the loser; single-elim's finishes read a fixture's loser straight off this,
-        since losing is exactly what places you (ADR-0785)."""
-        return (
-            self.entry_b_id
-            if self.entry_a_games > self.entry_b_games
-            else self.entry_a_id
-        )
+__all__ = [
+    "BracketFinishes",
+    "BracketFixture",
+    "EventResults",
+    "FinishRow",
+    # Re-exported: the value object the tabulation consumes lives in
+    # ``app.pool_finishing_order`` so the draw layer can reach it too, but every
+    # existing caller imports it from here.
+    "MatchOutcome",
+    "PoolInput",
+    "PoolStandings",
+    "RoundRobinResults",
+    "RrThenKoResults",
+    "SingleElimResults",
+    "StandingRow",
+    "StandingsThenFinishes",
+    "results_for",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -199,30 +187,31 @@ class BracketFinishes:
     champion: EntryId | None
 
 
-@dataclass(slots=True)
-class _Stat:
-    """A mutable per-entry accumulator — private to the tabulation, never returned."""
+@dataclass(frozen=True, slots=True)
+class StandingsThenFinishes:
+    """A round-robin-then-knockout event's results: **one block per stage** — the pool
+    stage's standings *and* the knockout stage's finishes — read out together (ADR
+    20260727, "results are a third arm of the wire union").
 
-    entry_id: EntryId
-    played: int = 0
-    wins: int = 0
-    losses: int = 0
-    games_won: int = 0
-    games_lost: int = 0
+    Both blocks are exactly what the one-stage shapes carry: ``pools`` is
+    :class:`EventResults`' standings, ``finishes`` is :class:`BracketFinishes`' ranked
+    rows, each still live and partial — pool rows appear before a pool has finished, and
+    only *placed* knockout entrants have a finish. Neither is a new reading of a stage;
+    see :class:`RrThenKoResults`.
 
-    @property
-    def game_difference(self) -> int:
-        return self.games_won - self.games_lost
+    ``champion`` is the **knockout final's winner, never a pool leader** (CONTEXT.md,
+    "Champion"): the pool stage only seeds the bracket, so topping a pool wins nothing.
+    It is ``None`` until that final is decided — which, since the final cannot be
+    decided before the pools that seat it, is also the only way it can be non-``None``.
 
+    ``complete`` is **both stages decided**, and the two are asserted separately rather
+    than one inferred from the other. See :meth:`RrThenKoResults.tabulate`.
+    """
 
-# The tiebreak chain, after wins (which groups) and the two-way head-to-head (which
-# refines a pair): each entry maps to a value where HIGHER is better, tried in order.
-# A new comparator is **appended** here, not surgically inserted between the existing
-# ones — the chain is data, so extending it touches nothing already in it (ADR-0788).
-_TIEBREAKERS: tuple[Callable[[_Stat], int], ...] = (
-    lambda stat: stat.game_difference,
-    lambda stat: stat.games_won,
-)
+    pools: tuple[PoolStandings, ...]
+    finishes: tuple[FinishRow, ...]
+    complete: bool
+    champion: EntryId | None
 
 
 def results_for(draw_type: DrawType) -> RoundRobinResults | SingleElimResults:
@@ -252,18 +241,12 @@ def results_for(draw_type: DrawType) -> RoundRobinResults | SingleElimResults:
 class RoundRobinResults:
     """A round-robin event's results: a standings table per pool.
 
-    Each pool is ordered by an extensible chain of tiebreakers (ADR-0788):
-
-    1. **wins** — most match wins first;
-    2. **head-to-head**, *only when exactly two entries are tied* on wins — the one
-       that beat the other ranks above it. A three-or-more-way tie can cycle (A beat B
-       beat C beat A), so it is **not** broken head-to-head; it falls straight through
-       to the game tiebreakers rather than a recursive mini-league;
-    3. **game difference** — games won minus games lost;
-    4. **games won**.
-
-    The entry id is the final, deterministic tiebreak, so a pool in which two entries
-    are genuinely level on every count still orders the same way on every read.
+    Each pool is ordered by :func:`~app.pool_finishing_order.finishing_order` — the
+    extensible tiebreak chain of ADR-0788 (wins, then head-to-head when exactly two are
+    tied, then game difference, then games won, then the entry id as a deterministic
+    final fallback). That chain lives in its own module because the draw layer reads the
+    same order to pick a pool's qualifiers; this strategy is the *standings* reading of
+    it, and the two cannot drift because there is only one of them (ADR 20260727).
     """
 
     def tabulate(self, pools: Sequence[PoolInput]) -> EventResults:
@@ -325,7 +308,7 @@ class SingleElimResults:
         # Ranked by position; the entry id is the final *list*-order tiebreak so tied
         # rows come out deterministically — without conferring an order on the tie
         # itself (the shared ``position`` is what the reader sees).
-        rows.sort(key=lambda row: (row.position, _entry_id_order(row.entry_id)))
+        rows.sort(key=lambda row: (row.position, entry_id_order(row.entry_id)))
         # Complete once every fixture is decided — which is exactly when the final is,
         # so ``champion`` is non-None precisely then. A voided (never-completed) fixture
         # holds the bracket incomplete, honestly: its winner was never seated forward,
@@ -337,98 +320,68 @@ class SingleElimResults:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class RrThenKoResults:
+    """A round-robin-then-knockout event's results: **both stages, read out together**
+    (ADR 20260727).
+
+    It computes neither stage itself. The pool stage *is*
+    :meth:`RoundRobinResults.tabulate` and the knockout stage *is*
+    :meth:`SingleElimResults.tabulate` — the same two readings a pure round-robin and a
+    pure single-elim get — so "an rr-then-ko event's pools stand exactly as a
+    round-robin's do, and its bracket places exactly as a single-elim's do" is true
+    structurally rather than by three implementations agreeing. This strategy's whole
+    job is to run both and say what the *event* (as opposed to either stage) makes of
+    them: who is champion, and whether it is over. It is the results-side mirror of
+    :class:`~app.draws.RrThenKoStrategy`, which composes the same two draw strategies.
+
+    Live and partial like every other shape, in either stage independently: pools
+    part-played read as a live table with an empty bracket behind them, and pools
+    decided with the bracket mid-flight read as a settled table plus the finishes of
+    whoever has been knocked out so far.
+    """
+
+    def tabulate(
+        self, pools: Sequence[PoolInput], bracket: Sequence[BracketFixture]
+    ) -> StandingsThenFinishes:
+        pool_stage = RoundRobinResults().tabulate(pools)
+        knockout_stage = SingleElimResults().tabulate(bracket)
+        return StandingsThenFinishes(
+            pools=pool_stage.pools,
+            finishes=knockout_stage.finishes,
+            # Both stages, asserted separately. The conjunction's left half is not
+            # redundant even though it is implied: nothing is seated into the bracket
+            # until a pool finishes, so a decided final entails decided pools. Deriving
+            # ``complete`` from the bracket alone would make this shape's headline claim
+            # depend on an invariant enforced two modules away (``RrThenKoStrategy``'s
+            # seating) rather than on the standings it is handed — and it would read as
+            # complete for any caller that projects the two stages inconsistently.
+            complete=pool_stage.complete and knockout_stage.complete,
+            # The champion is the **bracket's**. ``pool_stage.champion`` is deliberately
+            # dropped, and it is not always ``None``: a legal one-pool rr-then-ko (a
+            # league, then a playoff) makes ``RoundRobinResults`` crown its complete
+            # pool's leader, who is merely the top *seed* of the knockout here. Taking
+            # it would crown somebody the playoff went on to eliminate.
+            champion=knockout_stage.champion,
+        )
+
+
 def _pool_standings(pool: PoolInput) -> PoolStandings:
-    stats: dict[EntryId, _Stat] = {
-        entry_id: _Stat(entry_id=entry_id) for entry_id in pool.entrants
-    }
-    for outcome in pool.outcomes:
-        _record(stats[outcome.entry_a_id], stats[outcome.entry_b_id], outcome)
-    ordered = _order(list(stats.values()), pool.outcomes)
+    ordered = finishing_order(pool.entrants, pool.outcomes)
     rows = tuple(
         StandingRow(
-            entry_id=stat.entry_id,
+            entry_id=tally.entry_id,
             rank=rank,
-            played=stat.played,
-            wins=stat.wins,
-            losses=stat.losses,
-            games_won=stat.games_won,
-            games_lost=stat.games_lost,
+            played=tally.played,
+            wins=tally.wins,
+            losses=tally.losses,
+            games_won=tally.games_won,
+            games_lost=tally.games_lost,
         )
-        for rank, stat in enumerate(ordered, start=1)
+        for rank, tally in enumerate(ordered, start=1)
     )
     return PoolStandings(
         pool_id=pool.pool_id,
         rows=rows,
         complete=len(pool.outcomes) == pool.fixture_count,
     )
-
-
-def _record(a: _Stat, b: _Stat, outcome: MatchOutcome) -> None:
-    a.played += 1
-    b.played += 1
-    a.games_won += outcome.entry_a_games
-    a.games_lost += outcome.entry_b_games
-    b.games_won += outcome.entry_b_games
-    b.games_lost += outcome.entry_a_games
-    if outcome.winner_entry_id == outcome.entry_a_id:
-        a.wins += 1
-        b.losses += 1
-    else:
-        b.wins += 1
-        a.losses += 1
-
-
-def _order(stats: list[_Stat], outcomes: Sequence[MatchOutcome]) -> list[_Stat]:
-    """The pool's finishing order: group by wins (descending), then break each tie."""
-    by_wins: dict[int, list[_Stat]] = defaultdict(list)
-    for stat in stats:
-        by_wins[stat.wins].append(stat)
-    ordered: list[_Stat] = []
-    for wins in sorted(by_wins, reverse=True):
-        ordered.extend(_break_tie(by_wins[wins], outcomes))
-    return ordered
-
-
-def _break_tie(group: list[_Stat], outcomes: Sequence[MatchOutcome]) -> list[_Stat]:
-    """Order a group of entries level on wins.
-
-    A **two-way** tie is broken head-to-head when the pair has actually met — the
-    winner of that match ranks above the loser. A larger tie (which can cycle) and a
-    two-way tie whose pair has not met yet (mid-pool) fall through to the game
-    tiebreakers.
-    """
-    if len(group) == 2:
-        decided = _head_to_head(group[0], group[1], outcomes)
-        if decided is not None:
-            return decided
-    return sorted(group, key=_scalar_key)
-
-
-def _head_to_head(
-    first: _Stat, second: _Stat, outcomes: Sequence[MatchOutcome]
-) -> list[_Stat] | None:
-    """``[winner, loser]`` if these two have met, else ``None`` (not yet played)."""
-    pair = {first.entry_id, second.entry_id}
-    for outcome in outcomes:
-        if {outcome.entry_a_id, outcome.entry_b_id} == pair:
-            if outcome.winner_entry_id == first.entry_id:
-                return [first, second]
-            return [second, first]
-    return None
-
-
-def _scalar_key(stat: _Stat) -> tuple[int, ...]:
-    """The tiebreak-chain sort key: each comparator negated (higher is better ⇒
-    earlier), then the entry id as the final deterministic tiebreak so the order is
-    total."""
-    return (*(-tiebreaker(stat) for tiebreaker in _TIEBREAKERS), _entry_order(stat))
-
-
-def _entry_order(stat: _Stat) -> int:
-    return _entry_id_order(stat.entry_id)
-
-
-def _entry_id_order(entry_id: EntryId) -> int:
-    """A total, deterministic order over entry ids — the final list-order tiebreak both
-    shapes fall back to so equal rows never come out in a nondeterministic order."""
-    return int.from_bytes(entry_id.bytes, "big")

--- a/api/app/results.py
+++ b/api/app/results.py
@@ -124,10 +124,14 @@ class EventResults:
 
     ``champion`` is the leader of a **complete, single-pool** event — a pure
     round-robin's winner. A multi-pool round-robin has no single champion without a
-    knockout stage to join its pool winners (that is a round-robin-then-knockout draw
-    type, which does not exist yet — not this slice), so
-    ``champion`` is ``None`` there even when the event is complete. ``None`` also while
-    any fixture is still to be played.
+    knockout stage to join its pool winners, so ``champion`` is ``None`` there even when
+    the event is complete. ``None`` also while any fixture is still to be played.
+
+    That carve-out is unchanged by the arrival of the ``rr-then-ko`` draw type (ADR
+    20260727): a pools-then-knockout event *does* have a knockout stage to join its pool
+    winners, and it reads out as :class:`StandingsThenFinishes` — a **different shape**,
+    crowned from its bracket. This one still describes a draw with pools and nothing
+    after them, and for such a draw the claim is as true as it ever was.
     """
 
     pools: tuple[PoolStandings, ...]
@@ -214,7 +218,9 @@ class StandingsThenFinishes:
     champion: EntryId | None
 
 
-def results_for(draw_type: DrawType) -> RoundRobinResults | SingleElimResults:
+def results_for(
+    draw_type: DrawType,
+) -> RoundRobinResults | SingleElimResults | RrThenKoResults:
     """The results strategy for this draw type.
 
     **Total**, exactly as ``app.draws.strategy_for``: an exhaustive ``match`` with
@@ -225,16 +231,24 @@ def results_for(draw_type: DrawType) -> RoundRobinResults | SingleElimResults:
 
     The return type is a **union tagged by shape** (ADR-0785): round-robin's
     :class:`RoundRobinResults` reads out a **standings** table, single-elim's
-    :class:`SingleElimResults` reads out the bracket's **finishes**. A caller narrows
-    the union (an exhaustive ``match`` over the two concrete strategies) to call the
-    right ``tabulate`` — so a third strategy is a type error at every call site until
-    handled. A further draw type lands its own strategy and widens this union.
+    :class:`SingleElimResults` reads out the bracket's **finishes**, and rr-then-ko's
+    :class:`RrThenKoResults` reads out **both**. A caller narrows the union (an
+    exhaustive ``match`` over the concrete strategies) to call the right ``tabulate`` —
+    so a further strategy is a type error at every call site until handled.
+
+    The narrowing is not uniform, and cannot be: :meth:`RrThenKoResults.tabulate` takes
+    **two** stage inputs where its siblings take one, because a two-stage event has two
+    stages to project (the pooled fixtures and the ``pool_id IS NULL`` ones). That is
+    what the ``match`` at the call site is for — each arm builds the input its own shape
+    needs, rather than a single call signature pretending every draw type has one stage.
     """
     match draw_type:
         case DrawType.round_robin:
             return RoundRobinResults()
         case DrawType.single_elim:
             return SingleElimResults()
+        case DrawType.rr_then_ko:
+            return RrThenKoResults()
 
 
 @dataclass(frozen=True, slots=True)

--- a/api/app/schedule_preview.py
+++ b/api/app/schedule_preview.py
@@ -27,22 +27,33 @@ events, which is what makes the preview *optimistic on duration* (it ignores the
 cross-event contention a multi-event human would cause — a deliberate,
 honestly-noted simplification, ADR).
 
-**Draw coverage is round-robin only; every other type is refused loud (ADR).**
-Every event's draw is planned by :func:`app.draws.strategy_for` — the single
-source of truth production's own ``cut_draw`` uses:
+**Draw coverage is the POOL stage; a pool-less stage is skipped, and a pool-less
+draw type is refused loud (ADR).** Every event's draw is planned by
+:func:`app.tournament_draws.strategy_for_event` — the single source of truth
+production's own ``cut_draw`` uses:
 
 * **round-robin** — the whole draw is planned;
-* **every other draw type** — refused loud with
-  :class:`~app.draws.UnsupportedDrawType`, so the whole preview fails rather than
-  producing a partial, misleading snapshot. Today that means **single-elim**, which
+* **rr-then-ko** — the whole draw is planned, and only its **pool stage** is
+  previewed: the knockout fixtures (``pool_id IS NULL``) are dropped in the
+  conversion pass below. Scheduling a bracket is #1228 and deliberately out of
+  scope — a freshly cut one is entirely TBD-sided, so it is placeable only
+  incrementally, as pools resolve. The *live* solver already behaves this way for
+  free (``schedule_solves.py`` skips un-pooled and TBD-sided fixtures
+  independently), so this is the preview catching up with it rather than a new
+  rule;
+* **single-elim** — refused loud with :class:`~app.draws.UnsupportedDrawType`. It
   *has* a draw strategy (#785) — its bracket can be cut — but the table scheduler is
-  pool-based and cannot place a pool-less bracket yet, so this builder gates it
-  explicitly (an exhaustive ``match`` on ``DrawType`` that plans only round-robin).
-  A preview must run the *same* engine as production and cannot invent a schedule
-  for a format the solver cannot place. (When single-elim scheduling lands, that gate
-  is where it opens up.) This is the only surviving raiser of
-  ``UnsupportedDrawType``: :func:`app.draws.strategy_for` is total, because the enum
-  holds only draw types that run (ADR).
+  pool-based and a pool-less bracket has no windows to solve over, and unlike
+  rr-then-ko there is no other stage left to preview: the refusal is about the whole
+  event, so a partial snapshot would be a fiction rather than a subset. This is the
+  only surviving raiser of ``UnsupportedDrawType``:
+  :func:`app.draws.strategy_for` is total, because the enum holds only draw types
+  that run (ADR).
+
+The refusal is per **event** but aborts the whole **tournament**'s preview — this
+builder sits inside a per-event loop of a whole-tournament build. That is why
+rr-then-ko is skipped rather than refused: refusing it would take every unrelated
+round-robin event beside it down too (ADR 20260727).
 
 The per-event :class:`EventFieldSummary` (the count used) is returned alongside
 the snapshot so :mod:`app.schedule_preview_solve` composes the preview's
@@ -62,7 +73,6 @@ from app.draws import (
     OrderedEntrant,
     PlannedFixture,
     UnsupportedDrawType,
-    strategy_for,
 )
 from app.models.tournament import DrawType, Tournament, TournamentEvent
 from app.scheduling import (
@@ -78,7 +88,7 @@ from app.scheduling import (
     Window,
 )
 from app.schemas.tournament import MatchSettings, Pool, TournamentTable
-from app.tournament_draws import draw_config, event_pools
+from app.tournament_draws import draw_config, event_pools, strategy_for_event
 from app.venue_time import anchor_wallclock
 
 #: The synthetic field size for an *uncapped* event (``max_players IS NULL``,
@@ -192,7 +202,7 @@ def build_preview_snapshot(
     :data:`DEFAULT_UNCAPPED_FIELD` for an uncapped event), mints **globally
     disjoint** ``Placeholder`` entrants for it (event A gets ``1..N``, event B
     ``N+1..``, so no synthetic player is ever in two events), runs the real draw
-    over them (:func:`app.draws.strategy_for`), and assembles the pure
+    over them (:func:`app.tournament_draws.strategy_for_event`), and assembles the pure
     :class:`~app.scheduling.ScheduleSnapshot` — pools become minute windows over
     the tournament's table catalogue, exactly as
     ``schedule_solves._load_solver_inputs`` builds it from DB rows, but from
@@ -210,8 +220,12 @@ def build_preview_snapshot(
     Persists nothing: no ``TournamentEntry`` / ``TournamentFixture`` row is
     created. Raises :class:`~app.draws.UnsupportedDrawType` — itself, not from
     :func:`app.draws.strategy_for`, which is total — for any event this SCHEDULER
-    cannot place, today meaning single-elim: a bracket has no pools, and pools are
-    where the solver's windows come from. Also raises
+    cannot place *at all*, today meaning single-elim: a bracket has no pools, and pools
+    are where the solver's windows come from. An **rr-then-ko** event is not such an
+    event: its pool stage places exactly as a round-robin's does and is previewed, and
+    only its knockout fixtures are dropped (ADR 20260727) — which matters because this
+    builder is per-tournament, so refusing one event takes every event beside it with
+    it. Also raises
     :class:`~app.draws.DegenerateDraw` if a synthesized field is too small for
     the event's pools — a clear domain error either way, never a partial
     snapshot. An event with no pools configured is one such case: the
@@ -245,21 +259,29 @@ def build_preview_snapshot(
         ]
         next_entrant += field_size
         # The real draw, dispatched exactly as production's ``cut_draw`` does. The table
-        # scheduler is round-robin-only (ADR): single-elim *has* a draw strategy (#785)
-        # — its bracket can be cut — but a pool-less bracket has no windows to solve
-        # over yet, so the preview refuses it loud with ``UnsupportedDrawType`` rather
-        # than invent a grid the solver cannot place. This is now the only place that
-        # exception is raised: ``strategy_for`` is total (ADR "the enum holds only what
-        # runs"), so the refusal is this builder's, about scheduling, not the domain's
-        # about planning.
+        # scheduler is POOL-based (ADR): single-elim *has* a draw strategy (#785) — its
+        # bracket can be cut — but a pool-less bracket has no windows to solve over yet,
+        # so the preview refuses it loud with ``UnsupportedDrawType`` rather than invent
+        # a grid the solver cannot place. This is now the only place that exception is
+        # raised: ``strategy_for`` is total (ADR "the enum holds only what runs"), so
+        # the refusal is this builder's, about scheduling, not the domain's about
+        # planning.
+        #
+        # ``rr-then-ko`` is planned in FULL and previewed in part: its pools schedule
+        # exactly as a round-robin's do, and its knockout fixtures are dropped in the
+        # conversion pass below (ADR 20260727). Planning the whole draw rather than
+        # cutting a round-robin in its place is what keeps the previewed pools the ones
+        # production would deal — the same snake, and the same cut-time refusals
+        # (``DegenerateDraw`` when K exceeds the smallest pool) a director would meet
+        # for real.
         # Off the event's ``draw_settings`` row — the one home of the draw type
         # (ADR "an event's draw configuration is a row, not a column") — bound once
         # so the exhaustive ``match`` below narrows a name rather than re-deriving it
         # per branch.
         draw_type = event.draw_settings.draw_type
         match draw_type:
-            case DrawType.round_robin:
-                fixtures = strategy_for(draw_type).plan_initial(
+            case DrawType.round_robin | DrawType.rr_then_ko:
+                fixtures = strategy_for_event(event).plan_initial(
                     draw_config(event), ordered_entrants
                 )
             case DrawType.single_elim:
@@ -335,6 +357,14 @@ def build_preview_snapshot(
                 )
             )
         for fixture in plan.fixtures:
+            if fixture.pool_id is None:
+                # The knockout stage of an rr-then-ko draw (``pool_id IS NULL`` *is* the
+                # stage, ADR-0786). It is skipped rather than refused: the solver places
+                # fixtures into their pool's window on their pool's tables, and a
+                # bracket has neither — so there is nothing to place it against, and
+                # inventing one would preview a schedule production will never run.
+                # #1228 schedules it, incrementally, as the pools that feed it resolve.
+                continue
             schedule_fixtures.append(
                 _schedule_fixture(plan.event.id, event_id, fixture)
             )
@@ -360,10 +390,12 @@ def _schedule_fixture(
     """Map one synthetic :class:`~app.draws.PlannedFixture` onto the solver's
     :class:`~app.scheduling.ScheduleFixture`.
 
-    A previewable fixture is always pooled and both-sides-known (the pool stage
-    of a round-robin draw), so ``pool_id`` and both entrant ids are non-``None``
-    — an un-pooled or TBD fixture would be a bug in :func:`_plan_previewable`, so
-    we let the ``None`` surface loudly rather than inventing a placeholder. The
+    A previewable fixture is always pooled and both-sides-known — a **pool-stage**
+    fixture, of a round-robin draw or of the pool stage of an rr-then-ko one, the
+    caller having already dropped the un-pooled knockout fixtures — so ``pool_id``
+    and both entrant ids are non-``None``. An un-pooled or TBD fixture reaching
+    here would be a bug in the caller's filter, so we let the ``None`` surface
+    loudly rather than inventing a placeholder. The
     pool ref is namespaced by the event id, matching the ``SchedulePool`` keys;
     the fixture id is a deterministic, event-namespaced composite (unique because
     ``(pool, round, position)`` is unique within an event). Each synthetic

--- a/api/app/schedule_preview.py
+++ b/api/app/schedule_preview.py
@@ -55,9 +55,12 @@ builder sits inside a per-event loop of a whole-tournament build. That is why
 rr-then-ko is skipped rather than refused: refusing it would take every unrelated
 round-robin event beside it down too (ADR 20260727).
 
-The per-event :class:`EventFieldSummary` (the count used) is returned alongside
-the snapshot so :mod:`app.schedule_preview_solve` composes the preview's
-honest-notes strip and per-event breakdown from it without re-deriving it.
+The per-event :class:`EventFieldSummary` (the count used, and how many knockout
+fixtures were left out) is returned alongside the snapshot so
+:mod:`app.schedule_preview_solve` composes the preview's honest-notes strip and
+per-event breakdown from it without re-deriving it — including the note that tells
+a director an rr-then-ko event's knockout stage is not in the schedule they are
+looking at.
 """
 
 from __future__ import annotations
@@ -114,10 +117,18 @@ class EventFieldSummary:
     ``field_size`` is the entrant count actually synthesized for the event (the
     override if the caller gave one, else the event's cap, else
     :data:`DEFAULT_UNCAPPED_FIELD`).
+
+    ``knockout_fixtures`` is how many of the event's drawn fixtures this preview
+    **left out** — the un-pooled knockout stage of an rr-then-ko draw (``0`` for a
+    plain round-robin, which has none). It is *measured* on the way past rather than
+    re-derived from the draw type downstream, so the honest note the caller writes
+    from it says something is missing exactly when something is (api/CLAUDE.md —
+    don't carry a field and its own derivation).
     """
 
     event_id: EventId
     field_size: int
+    knockout_fixtures: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -356,6 +367,9 @@ def build_preview_snapshot(
                     window=Window(start_min=to_min(start), end_min=to_min(end)),
                 )
             )
+        # Counted, not just dropped: the caller turns a non-zero count into the honest
+        # note that this event's knockout stage is missing from the schedule shown.
+        knockout_fixtures = 0
         for fixture in plan.fixtures:
             if fixture.pool_id is None:
                 # The knockout stage of an rr-then-ko draw (``pool_id IS NULL`` *is* the
@@ -364,12 +378,17 @@ def build_preview_snapshot(
                 # bracket has neither — so there is nothing to place it against, and
                 # inventing one would preview a schedule production will never run.
                 # #1228 schedules it, incrementally, as the pools that feed it resolve.
+                knockout_fixtures += 1
                 continue
             schedule_fixtures.append(
                 _schedule_fixture(plan.event.id, event_id, fixture)
             )
         summaries.append(
-            EventFieldSummary(event_id=event_id, field_size=plan.field_size)
+            EventFieldSummary(
+                event_id=event_id,
+                field_size=plan.field_size,
+                knockout_fixtures=knockout_fixtures,
+            )
         )
 
     snapshot = ScheduleSnapshot(

--- a/api/app/schedule_preview_solve.py
+++ b/api/app/schedule_preview_solve.py
@@ -147,14 +147,17 @@ class _PreviewPoolResolution:
 
 @dataclass(frozen=True, slots=True)
 class _PreviewEventMeta:
-    """One event's honest-notes + breakdown ingredients: its id, display ``name``
-    and the synthetic ``field_size`` the preview drew a field to. Carried from the
-    enqueue verb (which has the loaded events) to the job (which has only the pure
-    snapshot)."""
+    """One event's honest-notes + breakdown ingredients: its id, display ``name``,
+    the synthetic ``field_size`` the preview drew a field to, and how many of its
+    drawn fixtures the preview **left out** — ``knockout_fixtures``, the un-pooled
+    knockout stage of an rr-then-ko draw, ``0`` for a plain round-robin. Carried from
+    the enqueue verb (which has the loaded events) to the job (which has only the pure
+    snapshot, from which "a bracket was dropped" is no longer visible)."""
 
     event_id: str
     name: str
     field_size: int
+    knockout_fixtures: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -325,6 +328,7 @@ async def request_schedule_preview(
                 event_id=summary.event_id,
                 name=event_names.get(summary.event_id, summary.event_id),
                 field_size=summary.field_size,
+                knockout_fixtures=summary.knockout_fixtures,
             )
             for summary in preview.field_summaries
         ),
@@ -613,13 +617,30 @@ def _resolve_reason(
 def _honest_notes(inputs: PreviewJobInputs) -> list[str]:
     """The always-present honest-notes strip (ADR): first the disjoint-field
     caveat that makes a preview *optimistic* (its synthetic fields are disjoint
-    across events, so it ignores multi-event contention), then one line per event
-    naming the synthetic count it assumed — so the estimate reads as the floor it
-    is, never a hidden simplification."""
+    across events, so it ignores multi-event contention), then a line for each event
+    whose knockout stage this preview left out, then one line per event naming the
+    synthetic count it assumed — so the estimate reads as the floor it is, never a
+    hidden simplification.
+
+    The knockout line is what stops the strip lying by omission about an
+    **rr-then-ko** event: the preview plans that event's whole draw but schedules only
+    its pool stage (ADR 20260727 — a bracket is placeable only incrementally, as the
+    pools that feed it resolve, which is #1228), so without a note the director reads a
+    schedule that silently covers part of their event. It is emitted off the count of
+    fixtures actually dropped, so a tournament of plain round-robins — which drops none
+    — gets the strip it always had, unchanged."""
     notes = [
         "This estimate assumes no player is entered in more than one event; a "
         "real multi-event field would take longer."
     ]
+    notes.extend(
+        f"Only the pool stage of {meta.name} is scheduled here: its knockout "
+        f"bracket ({meta.knockout_fixtures} further "
+        f"{'match' if meta.knockout_fixtures == 1 else 'matches'}) is played "
+        "after the pools finish and is not in this estimate."
+        for meta in inputs.events
+        if meta.knockout_fixtures > 0
+    )
     notes.extend(
         f"Assumed {meta.field_size} entrants for {meta.name}." for meta in inputs.events
     )

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -10,6 +10,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    PrivateAttr,
     TypeAdapter,
     ValidationError,
     computed_field,
@@ -192,12 +193,21 @@ class RrThenKoDrawSettingsWrite(BaseModel):
     qualifiers_per_pool: QualifiersPerPool
 
 
-DrawSettingsWrite = Annotated[
+DrawSettingsWriteArm = (
     RoundRobinDrawSettingsWrite
     | SingleElimDrawSettingsWrite
-    | RrThenKoDrawSettingsWrite,
-    Field(discriminator="draw_type"),
-]
+    | RrThenKoDrawSettingsWrite
+)
+"""The **arms** of the draw-settings union, listed once.
+
+A parsed draw configuration is one of these — the type a caller holds after
+:data:`DrawSettingsWrite` has done its work, and the type the parse itself returns. It
+is named because the list of arms was being spelled three times (the discriminated
+alias, its ``TypeAdapter``, and the parse's return type), which made "add a draw type"
+three edits with nothing to catch a fourth spelling that fell behind. Now it is one, and
+the three are the same list by construction rather than by review."""
+
+DrawSettingsWrite = Annotated[DrawSettingsWriteArm, Field(discriminator="draw_type")]
 """An event's draw configuration as it arrives: a **discriminated union tagged by the
 draw-type slug** (ADR 20260727, promised by ADR 20260726's companion and first built
 here).
@@ -209,25 +219,19 @@ half-honoured, and the settings table's ``CHECK`` and this union say the same th
 two different boundaries rather than one of them silently absorbing what the other
 refuses.
 
-Adding a draw type is an arm here, and it is *not* a type error until it has one — the
+Adding a draw type is an arm in :data:`DrawSettingsWriteArm` above (one list, read by
+this alias, its ``TypeAdapter`` and the parse alike), and it is *not* a type error until
+it has one — the
 enum's exhaustiveness is enforced at the four dispatch sites, and a missing arm surfaces
 as ``_draw_settings_write`` refusing a payload the enum accepts. Which is loud, at the
 boundary, and in the director's request."""
 
-_DRAW_SETTINGS_WRITE: TypeAdapter[
-    RoundRobinDrawSettingsWrite
-    | SingleElimDrawSettingsWrite
-    | RrThenKoDrawSettingsWrite
-] = TypeAdapter(DrawSettingsWrite)
+_DRAW_SETTINGS_WRITE: TypeAdapter[DrawSettingsWriteArm] = TypeAdapter(DrawSettingsWrite)
 
 
 def _draw_settings_write(
     draw_type: DrawType, qualifiers_per_pool: int | None
-) -> (
-    RoundRobinDrawSettingsWrite
-    | SingleElimDrawSettingsWrite
-    | RrThenKoDrawSettingsWrite
-):
+) -> DrawSettingsWriteArm:
     """Parse a ``(draw_type, qualifiers_per_pool)`` pair into the union arm it names, or
     raise :class:`ValueError` — a 422 — when it names none.
 
@@ -1594,22 +1598,39 @@ class TournamentEventCreate(BaseModel):
     # same alias the patch schema carries, so the rule holds on both verbs.
     pools: EventPools = Field(default_factory=list)
 
+    #: The arm :meth:`_parse_draw_settings` parsed, kept rather than re-derived. Set by
+    #: that validator and by nothing else; it cannot fall out of step with the two
+    #: fields it was parsed from because a request model is **read-only after
+    #: validation** — nothing assigns to ``draw_type``/``qualifiers_per_pool`` and
+    #: nothing ``model_copy(update=…)``s one, which are the two gestures that would
+    #: move a field without re-running the validator. It has no default because a model
+    #: that exists has run the validator, and reading it on one that has not is a
+    #: programmer error worth an ``AttributeError`` rather than a plausible-looking
+    #: second parse.
+    _draw_settings: DrawSettingsWriteArm = PrivateAttr()
+
     @property
-    def draw_settings(self) -> DrawSettingsWrite:
+    def draw_settings(self) -> DrawSettingsWriteArm:
         """The parsed draw configuration — the union arm this payload names.
 
-        Total by the time anybody can call it: :meth:`_parse_draw_settings` has already
-        run the same parse during validation, so a model that exists is a model whose
-        pair is legal. Callers take the *arm*, never the two loose fields, which is what
-        keeps "which draw types carry a qualifier count" a fact stated in one place."""
-        return _draw_settings_write(self.draw_type, self.qualifiers_per_pool)
+        Total by the time anybody can call it **because the validator ran**:
+        :meth:`_parse_draw_settings` parsed this pair during validation and kept the
+        arm, so a model that exists is a model whose pair is legal and already parsed.
+        The totality is the validator's, not this property's — which is why reading it
+        twice (``create_event`` reads two attributes off it) costs one parse, not three.
+        Callers take the *arm*, never the two loose fields, which is what keeps "which
+        draw types carry a qualifier count" a fact stated in one place."""
+        return self._draw_settings
 
     @model_validator(mode="after")
     def _parse_draw_settings(self) -> "TournamentEventCreate":
         """Parse at the boundary: an illegal ``(draw_type, qualifiers_per_pool)`` pair
         is a 422 on the create, not a row the settings table's ``CHECK`` rejects later
-        with a 500."""
-        _draw_settings_write(self.draw_type, self.qualifiers_per_pool)
+        with a 500. The arm it parses is **kept** (:attr:`_draw_settings`) rather than
+        discarded — parse once, at the boundary, and carry the parsed value inward."""
+        self._draw_settings = _draw_settings_write(
+            self.draw_type, self.qualifiers_per_pool
+        )
         return self
 
 
@@ -1682,16 +1703,22 @@ class TournamentEventUpdate(BaseModel):
             raise ValueError("must not be null")
         return value
 
+    #: The arm :meth:`_parse_draw_settings` parsed, or ``None`` when this patch does not
+    #: touch the draw configuration. Kept rather than re-derived, exactly as the create
+    #: schema's is — and here it is worth more, because the update path reads it twice
+    #: (the freeze guard, then the write). ``None`` is a real answer on this verb, so
+    #: unlike create's it carries that default.
+    _draw_settings: DrawSettingsWriteArm | None = PrivateAttr(default=None)
+
     @property
-    def draw_settings(self) -> DrawSettingsWrite | None:
+    def draw_settings(self) -> DrawSettingsWriteArm | None:
         """The parsed draw configuration this patch asks for, or ``None`` when it is not
         patching the draw configuration at all.
 
-        Total by the time anybody can call it, exactly as the create schema's is:
-        :meth:`_parse_draw_settings` ran the same parse during validation."""
-        if self.draw_type is None:
-            return None
-        return _draw_settings_write(self.draw_type, self.qualifiers_per_pool)
+        Total by the time anybody can call it, exactly as the create schema's is and
+        for the same reason: :meth:`_parse_draw_settings` ran the parse during
+        validation and kept the arm."""
+        return self._draw_settings
 
     @model_validator(mode="after")
     def _parse_draw_settings(self) -> "TournamentEventUpdate":
@@ -1703,14 +1730,19 @@ class TournamentEventUpdate(BaseModel):
         patch carrying only ``K`` does not hold that pair: judging it would mean reading
         the event's stored draw type, which happens two layers in, after the request has
         been accepted. Sending both is what the event editor does anyway — it PATCHes
-        the form it rendered."""
+        the form it rendered.
+
+        The arm it parses is **kept** (:attr:`_draw_settings`) rather than discarded, so
+        the freeze guard and the write that follows it read one parse between them."""
         if self.draw_type is None and self.qualifiers_per_pool is not None:
             raise ValueError(
                 "qualifiers_per_pool is part of an event's draw configuration and is "
                 "patched with it: send draw_type alongside it."
             )
         if self.draw_type is not None:
-            _draw_settings_write(self.draw_type, self.qualifiers_per_pool)
+            self._draw_settings = _draw_settings_write(
+                self.draw_type, self.qualifiers_per_pool
+            )
         return self
 
 

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -1215,6 +1215,24 @@ class TournamentEventRead(BaseModel):
     name: str
     format: EventFormat
     draw_type: DrawType
+    # **K** — how many of each pool's finishers advance into the knockout stage — read
+    # back flat beside the ``draw_type`` it belongs to, exactly as the write schemas
+    # send the pair (ADR 20260727). Both halves come off the same ``draw_settings`` row,
+    # so this is the stored configuration and not a second copy of it.
+    #
+    # ``null`` for a round-robin or single-elim event, and that is a *fact* rather than
+    # missing data: neither draw type has a qualifier count, which is what the settings
+    # table's ``CHECK`` says in DDL and what the write union says at the boundary. This
+    # read is the third statement of the same pairing and it cannot disagree with
+    # either, because it does not decide anything — it reports the column.
+    #
+    # It is on the read at all because the client edits the pair as a unit. The event
+    # editor always sends ``draw_type``, and the server parses ``(draw_type, K)``
+    # together with K required and no default — so every PATCH of an rr-then-ko event,
+    # even a rename, has to carry a K. Without this field the client would have to guess
+    # one, which pre-draw silently overwrites the director's number and post-draw trips
+    # the freeze with a 409 for an edit nobody made.
+    qualifiers_per_pool: int | None
     # ``null`` means the event is uncapped — there is no entrant limit (ADR-0935).
     max_players: int | None
     # Typed ``float`` so JSON emits a number, not a Decimal string. The

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -10,6 +10,8 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    TypeAdapter,
+    ValidationError,
     computed_field,
     field_validator,
     model_validator,
@@ -114,6 +116,150 @@ EventEntryFee = Annotated[
 ]
 """An event's entry fee: a non-negative amount in whole cents that the
 ``Numeric(8, 2)`` column can hold. ``0`` is a real answer — a free event."""
+
+# ----- the draw configuration, as a union tagged by the draw type -----------
+
+QualifiersPerPool = Annotated[int, Field(ge=1)]
+"""**K** — how many of each pool's finishers advance into an ``rr-then-ko`` draw's
+knockout stage.
+
+``K >= 1`` is the **static** half of the ADR's legal configuration space ("rr-then-ko
+cuts both stages upfront and seeds qualifiers rematch-free"): zero advances nobody, and
+a negative count is not a count, whatever the field looks like. It is stated once, here,
+and shared by the create schema, the patch schema and the union arm below, so the three
+cannot drift.
+
+The two bounds that **move with the entrant count** — ``P × K >= 2`` and
+``K <= ⌊N/P⌋`` — are deliberately *not* here. They are refused at the cut as
+``DegenerateDraw``, because a configuration that was legal when it was written must not
+become unwritable when a player withdraws (the same split ``_snake`` already uses for
+its own pool floor)."""
+
+
+class RoundRobinDrawSettingsWrite(BaseModel):
+    """A round-robin event's draw configuration: the draw type, and nothing else.
+
+    ``extra="forbid"`` is doing real work on this arm — it is what makes
+    ``qualifiers_per_pool`` on a round-robin event a **422 at the boundary** rather than
+    a value silently dropped on the way to a column that cannot hold it (the settings
+    table's ``CHECK`` says ``NULL`` for every draw type but ``rr-then-ko``). A director
+    who names a qualifier count for a format that has no knockout stage has
+    misunderstood something, and the useful answer is to say so, not to run the event
+    they did not ask for.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    draw_type: Literal[DrawType.round_robin] = DrawType.round_robin
+
+    @property
+    def qualifiers_per_pool(self) -> int | None:
+        """``None`` — this draw type has no knockout stage to qualify for.
+
+        A read-side **property**, not a field: the field's absence is what refuses the
+        key on the wire, and this is what lets a caller holding the parsed union ask
+        every arm the same question without an ``isinstance`` ladder."""
+        return None
+
+
+class SingleElimDrawSettingsWrite(BaseModel):
+    """A single-elimination event's draw configuration: the draw type, and nothing else.
+    See :class:`RoundRobinDrawSettingsWrite` for why ``extra="forbid"`` is the rule and
+    not decoration."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    draw_type: Literal[DrawType.single_elim] = DrawType.single_elim
+
+    @property
+    def qualifiers_per_pool(self) -> int | None:
+        """``None`` — a bracket has no pools to qualify out of."""
+        return None
+
+
+class RrThenKoDrawSettingsWrite(BaseModel):
+    """A round-robin-then-knockout event's draw configuration: the draw type **and** its
+    qualifier count (ADR 20260727).
+
+    ``qualifiers_per_pool`` is **required** here, with no default. There is no
+    defensible number to assume — "2" is a convention, not a fact about the event — and
+    a draw silently cut for a K the director never chose is the worst of the available
+    failures: it looks like it worked."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    draw_type: Literal[DrawType.rr_then_ko] = DrawType.rr_then_ko
+    qualifiers_per_pool: QualifiersPerPool
+
+
+DrawSettingsWrite = Annotated[
+    RoundRobinDrawSettingsWrite
+    | SingleElimDrawSettingsWrite
+    | RrThenKoDrawSettingsWrite,
+    Field(discriminator="draw_type"),
+]
+"""An event's draw configuration as it arrives: a **discriminated union tagged by the
+draw-type slug** (ADR 20260727, promised by ADR 20260726's companion and first built
+here).
+
+One arm per :class:`DrawType`, carrying exactly the configuration that draw type has —
+which for two of the three is nothing at all. That is the whole point: "a round-robin
+event with 2 qualifiers per pool" is not a payload this type can hold, so it cannot be
+half-honoured, and the settings table's ``CHECK`` and this union say the same thing at
+two different boundaries rather than one of them silently absorbing what the other
+refuses.
+
+Adding a draw type is an arm here, and it is *not* a type error until it has one — the
+enum's exhaustiveness is enforced at the four dispatch sites, and a missing arm surfaces
+as ``_draw_settings_write`` refusing a payload the enum accepts. Which is loud, at the
+boundary, and in the director's request."""
+
+_DRAW_SETTINGS_WRITE: TypeAdapter[
+    RoundRobinDrawSettingsWrite
+    | SingleElimDrawSettingsWrite
+    | RrThenKoDrawSettingsWrite
+] = TypeAdapter(DrawSettingsWrite)
+
+
+def _draw_settings_write(
+    draw_type: DrawType, qualifiers_per_pool: int | None
+) -> (
+    RoundRobinDrawSettingsWrite
+    | SingleElimDrawSettingsWrite
+    | RrThenKoDrawSettingsWrite
+):
+    """Parse a ``(draw_type, qualifiers_per_pool)`` pair into the union arm it names, or
+    raise :class:`ValueError` — a 422 — when it names none.
+
+    The pair is **flat on the wire** and a union in the interior. Nesting it
+    (``draw: {…}``) would express the union in the generated clients too, at the cost of
+    changing the shape of every event create and patch that has ever been written; the
+    same rule is enforced either way, and this is the shape that lets the draw type stay
+    where every existing caller already sends it.
+
+    ``None`` means "no qualifier count was sent" and is therefore *omitted* rather than
+    passed as ``null``: an absent key and an explicit ``null`` mean the same thing for
+    this field — the draw type takes no count — and ``extra="forbid"`` would reject the
+    explicit one on the two arms that have no such field.
+
+    The refusal text is the **union's own**, re-raised as a ``ValueError`` so FastAPI
+    renders it as an ordinary 422 body. Composing a friendlier sentence here would be a
+    second statement of a rule the arms already make, and the two would drift.
+    """
+    payload: dict[str, object] = {"draw_type": draw_type}
+    if qualifiers_per_pool is not None:
+        payload["qualifiers_per_pool"] = qualifiers_per_pool
+    try:
+        return _DRAW_SETTINGS_WRITE.validate_python(payload)
+    except ValidationError as exc:
+        raise ValueError(
+            f"“{draw_type.value}” draw settings: "
+            + "; ".join(
+                f"{'.'.join(str(part) for part in error['loc'])}: {error['msg']}"
+                for error in exc.errors()
+            )
+        ) from exc
+
 
 # ----- value-objects (typed JSONB) -----------------------------------------
 
@@ -962,10 +1108,11 @@ class StandingsResultsRead(BaseModel):
 
     ``champion`` is the leader of a **complete, single-pool** event — a pure
     round-robin's winner. A multi-pool round-robin has no single champion without a
-    knockout stage to join its pool winners (a pools-then-knockout draw type, a later
-    slice), so it is
-    ``null`` there even when ``complete``; and ``null`` while any fixture is still to be
-    played."""
+    knockout stage to join its pool winners, so it is ``null`` there even when
+    ``complete``; and ``null`` while any fixture is still to be played. An event that
+    *does* have a knockout stage to join them is a ``rr-then-ko`` draw, which reads out
+    as the ``standings_then_finishes`` arm below and is crowned from its bracket — a
+    different shape, not an exception to this one."""
 
     # The tag that discriminates the ``results`` union on the wire (ADR-0785): a client
     # switches on ``kind`` — a ``standings`` table here vs. a ``finishes`` list —
@@ -1017,14 +1164,46 @@ class FinishesResultsRead(BaseModel):
     champion: uuid.UUID | None
 
 
+class StandingsThenFinishesResultsRead(BaseModel):
+    """The **two-stage** shape of an event's results (ADR 20260727) — the
+    round-robin-then-knockout arm of the ``results`` discriminated union, tagged
+    ``kind: "standings_then_finishes"``.
+
+    One block per stage: ``pools`` is the pool stage's standings, exactly the
+    :class:`PoolStandingsRead` a round-robin event reads out, and ``finishes`` is the
+    knockout stage's ranked :class:`FinishRowRead`\\ s, exactly the ones a
+    single-elimination event reads out. They are the *same* models rather than
+    two-stage-flavoured near-copies, so a client renders each stage with the panel it
+    already has and the two shapes cannot drift apart.
+
+    A third arm rather than a restructuring of the union into a composite: making
+    ``standings`` and ``finishes`` sub-objects of one wrapper would change how the
+    existing two arms are read, forcing round-robin and single-elim client changes that
+    buy nothing.
+
+    ``champion`` is the **knockout final's winner, never a pool leader** — the pool
+    stage only seeds the bracket, so topping a pool wins nothing — and ``null`` until
+    that final is decided. ``complete`` is **both stages decided**. Live and partial
+    like every other results shape: the pool tables fill in as pool matches land, and
+    the finishes list grows as the bracket is played out."""
+
+    kind: Literal["standings_then_finishes"] = "standings_then_finishes"
+    pools: list[PoolStandingsRead]
+    finishes: list[FinishRowRead]
+    complete: bool
+    champion: uuid.UUID | None
+
+
 # An event's results cross the wire as a **discriminated union tagged by shape**
 # (ADR-0785): a round-robin reads out ``standings``, a single-elim reads out
-# ``finishes``. Coercing finishes into the standings row shape was rejected — a bracket
-# has no wins/game-difference columns, so every such row would carry meaningless
-# nullable fields, the tri-state smell ``api/CLAUDE.md`` warns against. Each shape is
-# its own model; the client switches on ``kind``.
+# ``finishes``, and a round-robin-then-knockout reads out ``standings_then_finishes`` —
+# both blocks at once (ADR 20260727). Coercing finishes into the standings row shape was
+# rejected — a bracket has no wins/game-difference columns, so every such row would
+# carry meaningless nullable fields, the tri-state smell ``api/CLAUDE.md`` warns
+# against. Each shape is its own model; the client switches on ``kind``.
 EventResultsRead = Annotated[
-    StandingsResultsRead | FinishesResultsRead, Field(discriminator="kind")
+    StandingsResultsRead | FinishesResultsRead | StandingsThenFinishesResultsRead,
+    Field(discriminator="kind"),
 ]
 
 
@@ -1089,11 +1268,12 @@ class TournamentEventRead(BaseModel):
     # The event's RESULTS: a discriminated union tagged by shape (ADR-0785), derived
     # live from the fixtures' completed matches — ``kind: "standings"`` (a per-pool
     # table, ADR-0788) for a round-robin, ``kind: "finishes"`` (a ranked placement list)
-    # for a single-elimination bracket. Either fills in as results land and crowns a
-    # champion when the last one does. ``null`` for an event with no draw cut (nothing
-    # to stand) or one whose draw type has no results strategy yet — round-robin and
-    # single-elim have one today. It rides on this same payload for the same
-    # one-endpoint-per-page reason ``fixtures`` does: results are part of the
+    # for a single-elimination bracket, ``kind: "standings_then_finishes"`` (both, one
+    # block per stage, ADR 20260727) for a round-robin-then-knockout event. Each fills
+    # in as results land and crowns a champion when the last one does. ``null`` only for
+    # an event with no draw cut — nothing to stand; every draw type has a results
+    # strategy, because the enum holds only what runs. It rides on this same payload for
+    # the same one-endpoint-per-page reason ``fixtures`` does: results are part of the
     # tournament-detail page, not a second round-trip.
     results: EventResultsRead | None
 
@@ -1364,6 +1544,13 @@ class TournamentEventCreate(BaseModel):
     name: str = Field(min_length=1, max_length=255)
     format: EventFormat
     draw_type: DrawType
+    # **K**, and only for the one draw type that has one. It is flat beside
+    # ``draw_type`` on the wire and a *union* in the interior: the pair is parsed into
+    # ``DrawSettingsWrite`` by the validator below, so a qualifier count on a
+    # round-robin or single-elim event is a 422 here and never a value quietly dropped
+    # (ADR 20260727). ``QualifiersPerPool`` is the same ``K >= 1`` alias the union arm
+    # carries, restated on the field so the bound reaches the generated clients too.
+    qualifiers_per_pool: QualifiersPerPool | None = None
     # ``None`` (or omitted) is the uncapped event — the "no cap" sentinel of ADR-0935,
     # not a cap of zero. When a cap IS supplied it is an ``EventMaxPlayers``: ``gt=0``
     # (a cap of zero admits nobody, which is not an event) and ``le=512`` (the column
@@ -1388,6 +1575,24 @@ class TournamentEventCreate(BaseModel):
     # (a fixture names its pool by that string, and a duplicate id 500'd the cut). The
     # same alias the patch schema carries, so the rule holds on both verbs.
     pools: EventPools = Field(default_factory=list)
+
+    @property
+    def draw_settings(self) -> DrawSettingsWrite:
+        """The parsed draw configuration — the union arm this payload names.
+
+        Total by the time anybody can call it: :meth:`_parse_draw_settings` has already
+        run the same parse during validation, so a model that exists is a model whose
+        pair is legal. Callers take the *arm*, never the two loose fields, which is what
+        keeps "which draw types carry a qualifier count" a fact stated in one place."""
+        return _draw_settings_write(self.draw_type, self.qualifiers_per_pool)
+
+    @model_validator(mode="after")
+    def _parse_draw_settings(self) -> "TournamentEventCreate":
+        """Parse at the boundary: an illegal ``(draw_type, qualifiers_per_pool)`` pair
+        is a 422 on the create, not a row the settings table's ``CHECK`` rejects later
+        with a 500."""
+        _draw_settings_write(self.draw_type, self.qualifiers_per_pool)
+        return self
 
 
 class TournamentEventUpdate(BaseModel):
@@ -1416,6 +1621,11 @@ class TournamentEventUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=255)
     format: EventFormat | None = None
     draw_type: DrawType | None = None
+    # **K**, patched *with* its draw type and never alone — see ``_parse_draw_settings``
+    # below. An explicit ``null`` is meaningful here and means the same as absent from
+    # the pair's point of view ("this draw type takes no qualifier count"), which is why
+    # it is not in the ``_reject_explicit_null`` list.
+    qualifiers_per_pool: QualifiersPerPool | None = None
     max_players: EventMaxPlayers | None = None
     entry_fee: EventEntryFee | None = None
     # The same validated IANA zone create requires — correcting the venue timezone is a
@@ -1446,10 +1656,44 @@ class TournamentEventUpdate(BaseModel):
     @classmethod
     def _reject_explicit_null(cls, value: Any) -> Any:
         # ``max_players`` is deliberately absent here: it is a nullable column and
-        # an explicit ``null`` is meaningful — it clears the cap (ADR-0935).
+        # an explicit ``null`` is meaningful — it clears the cap (ADR-0935). So is
+        # ``qualifiers_per_pool``, for the same reason in a different key: ``null``
+        # there says "this draw type takes no qualifier count", which is exactly what
+        # patching an ``rr-then-ko`` event back to a round-robin means.
         if value is None:
             raise ValueError("must not be null")
         return value
+
+    @property
+    def draw_settings(self) -> DrawSettingsWrite | None:
+        """The parsed draw configuration this patch asks for, or ``None`` when it is not
+        patching the draw configuration at all.
+
+        Total by the time anybody can call it, exactly as the create schema's is:
+        :meth:`_parse_draw_settings` ran the same parse during validation."""
+        if self.draw_type is None:
+            return None
+        return _draw_settings_write(self.draw_type, self.qualifiers_per_pool)
+
+    @model_validator(mode="after")
+    def _parse_draw_settings(self) -> "TournamentEventUpdate":
+        """The draw configuration is patched **as a unit**: a ``qualifiers_per_pool``
+        without a ``draw_type`` beside it is a 422.
+
+        Not pedantry — it is what keeps the pairing rule *at the boundary*. Which draw
+        types carry a qualifier count is a fact about the ``(draw_type, K)`` pair, and a
+        patch carrying only ``K`` does not hold that pair: judging it would mean reading
+        the event's stored draw type, which happens two layers in, after the request has
+        been accepted. Sending both is what the event editor does anyway — it PATCHes
+        the form it rendered."""
+        if self.draw_type is None and self.qualifiers_per_pool is not None:
+            raise ValueError(
+                "qualifiers_per_pool is part of an event's draw configuration and is "
+                "patched with it: send draw_type alongside it."
+            )
+        if self.draw_type is not None:
+            _draw_settings_write(self.draw_type, self.qualifiers_per_pool)
+        return self
 
 
 def _naive_wall_clock(value: datetime) -> datetime:

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -120,15 +120,32 @@ EventEntryFee = Annotated[
 
 # ----- the draw configuration, as a union tagged by the draw type -----------
 
-QualifiersPerPool = Annotated[int, Field(ge=1)]
+MAX_QUALIFIERS_PER_POOL = 1000
+"""The ceiling on **K** — the same 1000 the web client's event form enforces.
+
+It is not the domain rule. K can never exceed the smallest pool's size in a real event,
+and the cut already refuses that with a message naming both numbers
+(``DegenerateDraw``). This is the *boundary* refusing counts that are nonsense on their
+face and would otherwise reach the column: 1000 is far above any pool a table-tennis
+event will ever have, and far below the ``Integer`` column's 2,147,483,647.
+
+The number that matters is the one past the column, not the one past 1000. A K of
+2,147,483,648 was a **500** — the driver refused it, deep behind the boundary, and the
+client's generic error copy then told the organizer that nothing they did caused it,
+which was false. A K of 999,999,999 was worse in the quieter way: ``201 Created``, and
+an event whose draw can never be cut. Both are a 422 now, under the field, where the
+organizer can see which number they meant."""
+
+QualifiersPerPool = Annotated[int, Field(ge=1, le=MAX_QUALIFIERS_PER_POOL)]
 """**K** — how many of each pool's finishers advance into an ``rr-then-ko`` draw's
 knockout stage.
 
-``K >= 1`` is the **static** half of the ADR's legal configuration space ("rr-then-ko
-cuts both stages upfront and seeds qualifiers rematch-free"): zero advances nobody, and
-a negative count is not a count, whatever the field looks like. It is stated once, here,
-and shared by the create schema, the patch schema and the union arm below, so the three
-cannot drift.
+``1 <= K <= MAX_QUALIFIERS_PER_POOL`` is the **static** half of the ADR's legal
+configuration space ("rr-then-ko cuts both stages upfront and seeds qualifiers
+rematch-free"): zero advances nobody, a negative count is not a count, and a count in
+the billions is not a qualifier count at all, whatever the field looks like. It is
+stated once, here, and shared by the create schema, the patch schema and the union arm
+below, so the three cannot drift.
 
 The two bounds that **move with the entrant count** — ``P × K >= 2`` and
 ``K <= ⌊N/P⌋`` — are deliberately *not* here. They are refused at the cut as
@@ -1570,8 +1587,9 @@ class TournamentEventCreate(BaseModel):
     # ``draw_type`` on the wire and a *union* in the interior: the pair is parsed into
     # ``DrawSettingsWrite`` by the validator below, so a qualifier count on a
     # round-robin or single-elim event is a 422 here and never a value quietly dropped
-    # (ADR 20260727). ``QualifiersPerPool`` is the same ``K >= 1`` alias the union arm
-    # carries, restated on the field so the bound reaches the generated clients too.
+    # (ADR 20260727). ``QualifiersPerPool`` is the same ``1 <= K <= 1000`` alias the
+    # union arm carries, restated on the field so both bounds reach the generated
+    # clients too.
     qualifiers_per_pool: QualifiersPerPool | None = None
     # ``None`` (or omitted) is the uncapped event — the "no cap" sentinel of ADR-0935,
     # not a cap of zero. When a cap IS supplied it is an ``EventMaxPlayers``: ``gt=0``

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -914,8 +914,7 @@ class TournamentFixtureRead(BaseModel):
       state without a per-slot round-trip; it is the match's *current* status, read
       live, not a copy frozen at go-live.
     * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
-      un-pooled (single-elim), or this is the knockout stage of a future
-      pools-then-knockout draw type. When
+      un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
       set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
       JSONB, not a foreign key, because pools are value-objects with no table.
     * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -26,7 +26,7 @@ that field must not be separated by another writer's entry (see the route).
 
 import enum
 import uuid
-from collections.abc import Collection, Sequence
+from collections.abc import Collection, Mapping, Sequence
 
 from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -35,6 +35,7 @@ from app.draws import (
     DrawConfig,
     Entrant,
     EntryId,
+    FixtureGames,
     FixtureId,
     FixtureState,
     MatchId,
@@ -87,7 +88,10 @@ async def active_draw_entrants(db: AsyncSession, event_id: uuid.UUID) -> list[En
     ]
 
 
-def fixture_state(fixture: TournamentFixture) -> FixtureState:
+def fixture_state(
+    fixture: TournamentFixture,
+    game_counts: Mapping[uuid.UUID, tuple[int, int]] | None = None,
+) -> FixtureState:
     """Project a persisted :class:`~app.models.tournament_fixture.TournamentFixture` row
     into the pure :class:`~app.draws.FixtureState` a strategy's ``advance()`` reads.
 
@@ -96,7 +100,34 @@ def fixture_state(fixture: TournamentFixture) -> FixtureState:
     lets every rule about the *shape* of a draw be tested without a database. Shared by
     every path that advances a draw (materialization at go-live #788, completion #789),
     so the projection is written once.
+
+    ``game_counts`` is the games each **side** won, keyed by match id, exactly as
+    :func:`app.tournament_queries.game_counts_by_match` returns it — and it holds
+    **only completed matches**, because that is what its caller batches over
+    (``completed_match_ids``, which filters on ``MatchStatus.completed``). An
+    in-progress match's part-scored board is not a result, so a fixture whose match has
+    not completed is simply not a key here and projects
+    :attr:`~app.draws.FixtureState.games` as ``None`` — the same absence a fixture with
+    no match at all gets. Passing nothing (the default) is "no games are known for any
+    fixture", which is what every caller that does not tabulate wants.
+
+    **side 1 ← ``entry_a``, side 2 ← ``entry_b``** (#788), the same fixed convention the
+    completion seam maps a winning side back to an entry with, so the ``(side_1,
+    side_2)`` pair is ``(entry_a, entry_b)``'s. Getting this backwards would hand a
+    strategy a mirrored scoreline that still looks like a plausible result, which is
+    what ``tests/test_tournament_draws.py`` asserts with an asymmetric one.
+
+    It is the caller — not this function — that loads the counts, because
+    ``advance()``'s current caller
+    (:func:`app.tournament_materialization.materialize_event`) loads fixtures and
+    nothing else. Reading the games here would mean a query per fixture inside the
+    projection; the batched load belongs at the seam, alongside the fixture load.
     """
+    games = (
+        game_counts.get(fixture.match_id)
+        if game_counts is not None and fixture.match_id is not None
+        else None
+    )
     return FixtureState(
         fixture_id=FixtureId(fixture.id),
         pool_id=PoolId(fixture.pool_id) if fixture.pool_id is not None else None,
@@ -114,6 +145,11 @@ def fixture_state(fixture: TournamentFixture) -> FixtureState:
             else None
         ),
         match_id=MatchId(fixture.match_id) if fixture.match_id is not None else None,
+        games=(
+            FixtureGames(entry_a_games=games[0], entry_b_games=games[1])
+            if games is not None
+            else None
+        ),
     )
 
 

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -7,6 +7,9 @@ reads the event's field, hands it to the strategy, and writes what comes back. T
 split is what lets every rule about *what a draw looks like* be tested with literals,
 and leaves this module with only the three things a database is actually needed for:
 
+- **the strategy** (``strategy_for_event``) — the one door onto ``app.draws``'
+  dispatch, because picking a strategy now takes the event's whole draw configuration
+  (its type *and*, for ``rr-then-ko``, its qualifier count) rather than a bare enum.
 - **the field** (``active_draw_entrants``) — the *active* entries, in the shape
   ``order_entrants`` wants. Withdrawal is a soft-delete, so a withdrawn entry is not an
   entrant (ADR-0016) and has no place in a draw.
@@ -33,6 +36,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.draws import (
     DrawConfig,
+    DrawStrategy,
     Entrant,
     EntryId,
     FixtureGames,
@@ -159,9 +163,8 @@ def draw_config(event: TournamentEvent) -> DrawConfig:
     against.
 
     It does **not** carry the event's ``draw_type``, though it once did. The draw type
-    is what ``cut_draw`` picks the *strategy* with
-    (``strategy_for(event.draw_settings.draw_type)``), and it does so before this config
-    exists; copying it in here as well gave the domain
+    is what ``cut_draw`` picks the *strategy* with (``strategy_for_event(event)``), and
+    it does so before this config exists; copying it in here as well gave the domain
     a second place to learn a fact it had already acted on — one that no strategy read,
     and that a future one could read and be lied to by. See :class:`DrawConfig`.
 
@@ -178,6 +181,27 @@ def draw_config(event: TournamentEvent) -> DrawConfig:
     """
     return DrawConfig(
         pool_ids=tuple(PoolId(Pool.model_validate(pool).id) for pool in event.pools),
+    )
+
+
+def strategy_for_event(event: TournamentEvent) -> DrawStrategy:
+    """The strategy that cuts and advances **this event's** draw — the one production
+    door onto :func:`app.draws.strategy_for`.
+
+    ``strategy_for`` is keyword-strict about the qualifier count and has no default, so
+    somebody has to read it off the event; this is that somebody, and it is one function
+    rather than three call sites each reaching into ``event.draw_settings`` for a pair
+    of columns. Which matters because forgetting the second column does not fail — it
+    produces a differently-configured strategy — and because the two facts live on one
+    row precisely so they are read together (ADR "an event's draw configuration is a
+    row, not a column").
+
+    The settings row rides along with the event (``lazy="joined"``), so this is
+    attribute access, not a lazy load in async context.
+    """
+    return strategy_for(
+        event.draw_settings.draw_type,
+        qualifiers_per_pool=event.draw_settings.qualifiers_per_pool,
     )
 
 
@@ -441,7 +465,7 @@ async def cut_draw(db: AsyncSession, event: TournamentEvent) -> None:
     """
     if event.format is not EventFormat.singles:
         raise NonSinglesDraw(event.format)
-    strategy = strategy_for(event.draw_settings.draw_type)
+    strategy = strategy_for_event(event)
     planned = strategy.plan_initial(
         draw_config(event), order_entrants(await active_draw_entrants(db, event.id))
     )

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -95,6 +95,7 @@ async def active_draw_entrants(db: AsyncSession, event_id: uuid.UUID) -> list[En
 def fixture_state(
     fixture: TournamentFixture,
     game_counts: Mapping[uuid.UUID, tuple[int, int]] | None = None,
+    voided_match_ids: frozenset[uuid.UUID] = frozenset(),
 ) -> FixtureState:
     """Project a persisted :class:`~app.models.tournament_fixture.TournamentFixture` row
     into the pure :class:`~app.draws.FixtureState` a strategy's ``advance()`` reads.
@@ -114,6 +115,16 @@ def fixture_state(
     :attr:`~app.draws.FixtureState.games` as ``None`` — the same absence a fixture with
     no match at all gets. Passing nothing (the default) is "no games are known for any
     fixture", which is what every caller that does not tabulate wants.
+
+    ``voided_match_ids`` rides in the same way, and is the whole of what the domain
+    knows about a match's status: a fixture whose match id is in it projects
+    :attr:`~app.draws.FixtureState.match_voided` ``True``. The ``MatchStatus`` enum
+    stops here — ``app.draws`` asks one question of a match's status ("can this pairing
+    still produce a result?"), so it is answered once, here, as a ``bool``, and that
+    module stays free of the ORM. The ids come off the same outer join the completed
+    ones do (``_fixtures_with_match_statuses``), so this costs no extra query and both
+    facts are read at one instant. The default — nothing is voided — is the truth for
+    every caller whose fixtures have no matches at all.
 
     **side 1 ← ``entry_a``, side 2 ← ``entry_b``** (#788), the same fixed convention the
     completion seam maps a winning side back to an entry with, so the ``(side_1,
@@ -153,6 +164,9 @@ def fixture_state(
             FixtureGames(entry_a_games=games[0], entry_b_games=games[1])
             if games is not None
             else None
+        ),
+        match_voided=(
+            fixture.match_id is not None and fixture.match_id in voided_match_ids
         ),
     )
 

--- a/api/app/tournament_events.py
+++ b/api/app/tournament_events.py
@@ -243,9 +243,15 @@ def _qualifiers_per_pool_frozen_detail(
     It is not hypothetical and it is not cosmetic. The knockout bracket is cut
     **upfront** from ``P × K``, and the qualifiers are seated into predetermined slots
     as each pool finishes: a bracket cut at ``K = 2`` and then advanced at ``K = 3`` has
-    three pools' worth of thirds with nowhere to sit — ``advance()`` seats the five it
-    finds slots for, raises nothing, and the draw is quietly wrong. So the count is
-    frozen exactly as the type is, and the way out is the same one.
+    three pools' worth of thirds with nowhere to sit. So the count is frozen exactly as
+    the type is, and the way out is the same one.
+
+    This is the **first** line of defence, not the only one: past it,
+    :meth:`app.draws.RrThenKoStrategy.advance` raises
+    :class:`~app.draws.MissingBracketSlot` rather than seating the qualifiers it finds
+    slots for and dropping the rest. Which is why the 409 is worth having — it is the
+    refusal a director can act on, in their own language, before the domain has to shout
+    about a state nothing they typed could have produced.
     """
     return (
         "This event's draw is already cut, so the number of qualifiers per pool is "

--- a/api/app/tournament_events.py
+++ b/api/app/tournament_events.py
@@ -115,9 +115,17 @@ async def create_event(
         # The event's draw configuration as a row, created here with the event and
         # flushed ahead of it by the relationship — the FK is NOT NULL, so an event
         # without one is not a row Postgres will accept. This is the ONLY place the
-        # requested draw type is persisted; there is no column beside it to keep in
-        # step.
-        draw_settings=TournamentEventDrawSettings.for_draw_type(payload.draw_type),
+        # requested draw configuration is persisted; there is no column beside it to
+        # keep in step.
+        #
+        # Written from the parsed union arm, never from the two loose payload fields:
+        # the boundary has already refused a qualifier count that does not belong to
+        # the draw type beside it (ADR 20260727), so what is written here is a pair
+        # the settings table's ``CHECK`` will accept.
+        draw_settings=TournamentEventDrawSettings.for_draw_type(
+            payload.draw_settings.draw_type,
+            qualifiers_per_pool=payload.draw_settings.qualifiers_per_pool,
+        ),
         max_players=payload.max_players,
         entry_fee=payload.entry_fee,
         timezone=payload.timezone,
@@ -225,6 +233,29 @@ def _draw_type_frozen_detail(current: DrawType) -> str:
     )
 
 
+def _qualifiers_per_pool_frozen_detail(
+    current: DrawType, qualifiers: int | None
+) -> str:
+    """The 409 sentence for a ``qualifiers_per_pool`` change on an event whose draw is
+    already cut — the same freeze as the draw type's, about the other half of the same
+    configuration (ADR 20260727).
+
+    It is not hypothetical and it is not cosmetic. The knockout bracket is cut
+    **upfront** from ``P × K``, and the qualifiers are seated into predetermined slots
+    as each pool finishes: a bracket cut at ``K = 2`` and then advanced at ``K = 3`` has
+    three pools' worth of thirds with nowhere to sit — ``advance()`` seats the five it
+    finds slots for, raises nothing, and the draw is quietly wrong. So the count is
+    frozen exactly as the type is, and the way out is the same one.
+    """
+    return (
+        "This event's draw is already cut, so the number of qualifiers per pool is "
+        f"frozen: its knockout bracket was cut for the top {qualifiers} out of each "
+        f"pool of a “{current.value}” draw, and changing that count would leave "
+        "qualifiers with no slot to be seated into. To change it, remove the draw "
+        "first, then cut it again."
+    )
+
+
 async def _enforce_pool_set_frozen(
     db: AsyncSession, event: TournamentEvent, updates: TournamentEventUpdate
 ) -> None:
@@ -276,11 +307,12 @@ async def _enforce_pool_set_frozen(
     )
 
 
-async def _enforce_draw_type_frozen(
+async def _enforce_draw_settings_frozen(
     db: AsyncSession, event: TournamentEvent, updates: TournamentEventUpdate
 ) -> None:
-    """Raise :class:`DrawTypeFrozenError` once a ``draw_type`` payload would change the
-    draw type of an event that **has a draw** (ADR-0786).
+    """Raise :class:`DrawTypeFrozenError` once a draw-configuration payload would change
+    the **draw type or its qualifier count** on an event that **has a draw** (ADR-0786,
+    ADR 20260727).
 
     A draw type is not a label on an event — it is the strategy that dealt the event's
     fixtures, and the fixtures are the shape that strategy prescribes. Patch it under a
@@ -288,29 +320,54 @@ async def _enforce_draw_type_frozen(
     cannot catch it (currency compares the seated entrant set against the active
     entrants, and re-labelling moves neither), which is why this guard has to exist.
 
-    **Presence is not enough — the change is what is refused.** A ``draw_type`` equal to
-    the one the event already has changes nothing, so a page PATCHing the whole event
-    form back (draw type included) to move a pool's tables is the very edit the freeze
-    exists to permit. Asked **before** anything is written, under the tournament's row
-    lock the verb holds.
+    ``qualifiers_per_pool`` is frozen by the **same** guard rather than a parallel one,
+    because it is the same fact wearing a second column: an ``rr-then-ko`` draw's
+    bracket is cut upfront for ``P × K``, so a K the fixtures were not cut for is
+    exactly as contradictory as a type they were not dealt by — and quieter (see
+    :func:`_qualifiers_per_pool_frozen_detail`). One comparison over the whole
+    configuration is also what keeps a payload that moves *both* from being judged
+    twice.
 
-    The type the event *currently* has is read off its ``draw_settings`` row — the one
-    home of that fact (ADR "an event's draw configuration is a row, not a column") —
-    and read once, before the caller's ``setattr`` loop, so what is compared is the
-    stored draw type and not the one the payload is asking for.
+    **Presence is not enough — the change is what is refused.** A configuration equal to
+    the one the event already has changes nothing, so a page PATCHing the whole event
+    form back (draw type and count included) to move a pool's tables is the very edit
+    the freeze exists to permit. Asked **before** anything is written, under the
+    tournament's row lock the verb holds.
+
+    What the event *currently* has is read off its ``draw_settings`` row — the one home
+    of that fact (ADR "an event's draw configuration is a row, not a column") — and read
+    once, before the caller's ``setattr`` loop, so what is compared is the stored
+    configuration and not the one the payload is asking for.
     """
-    current = event.draw_settings.draw_type
-    if updates.draw_type is None or updates.draw_type is current:
+    # ``None`` is "this patch does not touch the draw configuration": the schema refuses
+    # an explicit ``null`` on ``draw_type`` (422) and refuses a ``qualifiers_per_pool``
+    # with no ``draw_type`` beside it, so an absent draw type means an absent pair.
+    incoming = updates.draw_settings
+    if incoming is None:
         return
-    # Only now the query — and only for a payload that really moves the draw type. It is
-    # the same ``event_has_draw`` the pool freeze asks; a payload that changes both asks
-    # it twice — two COUNTs on an indexed column under a lock we hold, in exchange for
-    # two guards that each read as one rule.
+    current = event.draw_settings.draw_type
+    current_qualifiers = event.draw_settings.qualifiers_per_pool
+    if (
+        incoming.draw_type is current
+        and incoming.qualifiers_per_pool == current_qualifiers
+    ):
+        return
+    # Only now the query — and only for a payload that really moves the configuration.
+    # It is the same ``event_has_draw`` the pool freeze asks; a payload that changes
+    # both
+    # asks it twice — two COUNTs on an indexed column under a lock we hold, in exchange
+    # for two guards that each read as one rule.
     if not await event_has_draw(db, event.id):
         return
-    raise DrawTypeFrozenError(
-        _draw_type_frozen_detail(current), draw_type=current.value
+    # The draw type is named first when both moved: it is the bigger claim, and the
+    # qualifier-count sentence would be describing a bracket the event is no longer
+    # asking to have.
+    detail = (
+        _draw_type_frozen_detail(current)
+        if incoming.draw_type is not current
+        else _qualifiers_per_pool_frozen_detail(current, current_qualifiers)
     )
+    raise DrawTypeFrozenError(detail, draw_type=current.value)
 
 
 def _event_scheduling_facts(
@@ -426,8 +483,9 @@ async def update_event(
       :class:`EventNotFoundError`.
     * **409** — once the event's draw is cut, two things freeze (ADR-0786): a ``pools``
       payload that changes *which pools* the event has raises
-      :class:`PoolSetFrozenError`, and a ``draw_type`` payload that changes the type
-      raises :class:`DrawTypeFrozenError`. Both are judged **before** anything is
+      :class:`PoolSetFrozenError`, and a draw-configuration payload that changes the
+      draw type **or its qualifier count** (ADR 20260727) raises
+      :class:`DrawTypeFrozenError`. Both are judged **before** anything is
       written, so a refusal persists nothing.
 
     Then the partial apply (``model_dump(exclude_unset=True)`` serializes the nested
@@ -435,8 +493,9 @@ async def update_event(
     scalar columns alike), with three side effects — the first new, the other two
     preserved exactly from the router:
 
-    * a **draw_type** edit is applied to the event's ``draw_settings`` row, the only
-      place an event's draw type is stored. It is deliberately taken out of the
+    * a **draw-configuration** edit (the draw type and, for ``rr-then-ko``, its
+      qualifier count) is applied to the event's ``draw_settings`` row, the only place
+      an event's draw configuration is stored. Both are deliberately taken out of the
       ``setattr`` loop: there is no ``draw_type`` attribute on the mapped event, so
       the loop would bind an unmapped Python attribute and drop the edit;
     * a **timezone** edit re-anchors every placed fixture's ``scheduled_start`` so its
@@ -466,37 +525,43 @@ async def update_event(
     # 404 → 403 → 409: the freezes are asked before the setattr loop below, so a
     # refusal writes nothing at all.
     await _enforce_pool_set_frozen(db, event, updates)
-    await _enforce_draw_type_frozen(db, event, updates)
+    await _enforce_draw_settings_frozen(db, event, updates)
     facts_before = _event_scheduling_facts(event)
     # Captured BEFORE the setattr loop overwrites it: a timezone edit preserves the
     # wall-clock of already-placed fixtures, which needs the zone they were placed IN to
     # recover it.
     old_timezone = event.timezone
     changes = updates.model_dump(exclude_unset=True)
-    # ``draw_type`` is NOT a column on the event — it is the ``draw_type_key`` slug
-    # on the settings row the event points at — so it is routed OUT of the generic
-    # setattr loop rather than through it. This is not decoration: SQLAlchemy's
-    # declarative instances accept any attribute, so ``setattr(event, "draw_type",
-    # ...)`` would bind a plain Python attribute the mapper never persists — the
-    # edit would be silently accepted and silently dropped. Popping it leaves the
-    # loop below touching mapped columns only.
-    #
-    # ``None`` here means "absent", never "clear it": ``TournamentEventUpdate``
-    # rejects an explicit ``null`` on ``draw_type`` at the boundary (422), so a key
-    # that is present carries a real :class:`DrawType`.
-    draw_type: DrawType | None = changes.pop("draw_type", None)
+    # Neither half of the draw configuration is a column on the event — the draw type is
+    # the ``draw_type_key`` slug on the settings row the event points at, and the
+    # qualifier count is that row's ``qualifiers_per_pool`` — so both are routed OUT of
+    # the generic setattr loop rather than through it. This is not decoration:
+    # SQLAlchemy's declarative instances accept any attribute, so
+    # ``setattr(event, "draw_type", ...)`` would bind a plain Python attribute the
+    # mapper
+    # never persists — the edit would be silently accepted and silently dropped. Popping
+    # them leaves the loop below touching mapped columns only.
+    changes.pop("draw_type", None)
+    changes.pop("qualifiers_per_pool", None)
+    # The parsed union arm, not the loose keys: it is ``None`` exactly when the patch
+    # does not touch the draw configuration, and when it is not, the pair it carries is
+    # one the settings table's ``CHECK`` accepts (ADR 20260727).
+    draw_settings = updates.draw_settings
     for key, value in changes.items():
         setattr(event, key, value)
-    if draw_type is not None:
-        # The one place an event's draw type moves after create (the freeze above
-        # has already refused this on a cut draw). Assigned through the settings
-        # row's ``draw_type`` property, not its ``draw_type_key`` column, so the
-        # enum→slug conversion stays in the single place that owns it
-        # (``TournamentEventDrawSettings.draw_type``'s setter, which
-        # ``for_draw_type`` also goes through at create). The settings row is
-        # loaded with the event (``lazy="joined"``), so this is a plain attribute
+    if draw_settings is not None:
+        # The one place an event's draw configuration moves after create (the freeze
+        # above has already refused this on a cut draw). Assigned through the settings
+        # row's ``configure``, not its columns, so the enum→slug conversion and the
+        # "these two columns are one fact" pairing stay in the single place that owns
+        # them — the same door ``for_draw_type`` goes through at create. The settings
+        # row
+        # is loaded with the event (``lazy="joined"``), so this is a plain attribute
         # write, not a lazy load in async context.
-        event.draw_settings.draw_type = draw_type
+        event.draw_settings.configure(
+            draw_settings.draw_type,
+            qualifiers_per_pool=draw_settings.qualifiers_per_pool,
+        )
     if event.timezone != old_timezone:
         # The zone truly moved (a PATCH re-sending the same zone falls through as a
         # no-op): recompose every placement so its local reading is unchanged and only

--- a/api/app/tournament_materialization.py
+++ b/api/app/tournament_materialization.py
@@ -22,7 +22,7 @@ from collections.abc import Sequence
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.draws import Side, SideFill, ready_fixtures, strategy_for
+from app.draws import Side, SideFill, ready_fixtures
 from app.models import (
     Match,
     MatchSettings,
@@ -35,7 +35,8 @@ from app.models import (
     TournamentFixture,
 )
 from app.schemas.tournament import MatchSettings as EventMatchSettings
-from app.tournament_draws import fixture_state
+from app.tournament_draws import fixture_state, strategy_for_event
+from app.tournament_queries import game_counts_by_match
 
 
 async def materialize_live_draw(db: AsyncSession, tournament: Tournament) -> None:
@@ -87,9 +88,22 @@ async def materialize_event(
     ``advance()`` reports in ``ready_fixture_ids``) over the now-filled state so a
     fixture the fills just made whole (single-elim seating a decided fixture's winner
     onto its successor, #785) is materialized into a match in the **same** transaction.
-    For round-robin — the only other strategy today — the plan carries no side-fills at
-    all (every pairing is known at the cut), so that step is a no-op and its behaviour
-    is byte-identical.
+    For round-robin the plan carries no side-fills at all (every pairing is known at the
+    cut), so that step is a no-op and its behaviour is byte-identical.
+
+    **The projection loads the fixtures' game counts**, and that is load-bearing rather
+    than defensive. ``FixtureState.games`` is what a pools-then-knockout draw picks its
+    qualifiers by — the same tiebreak chain (wins → head-to-head → game difference →
+    games won) the standings on screen are ordered by (ADR 20260727) — and this seam is
+    the *only* place its ``advance()`` is ever run. Projected without them, every
+    fixture reaching ``advance()`` carries ``games=None``: the strategy refuses loudly
+    (``MissingFixtureGames``) rather than seating qualifiers computed on wins alone, so
+    the failure is not silent — but the correct outcome is that a pool finishes and its
+    qualifiers are seated, and that needs the counts. One batched load for the event,
+    beside the fixture load, exactly as the read path batches it per page
+    (``app.tournament_queries.game_counts_by_match``); reading them inside
+    ``fixture_state`` would be a query per fixture. The two strategies that do not read
+    ``games`` are unaffected.
     """
     fixtures = (
         (
@@ -105,8 +119,9 @@ async def materialize_event(
         # this is unreachable on that path (every event has a current draw). Guarding it
         # keeps the function honest for a future caller that has no such precondition.
         return
-    strategy = strategy_for(event.draw_settings.draw_type)
-    plan = strategy.advance([fixture_state(f) for f in fixtures])
+    game_counts = await _completed_game_counts(db, fixtures)
+    strategy = strategy_for_event(event)
+    plan = strategy.advance([fixture_state(f, game_counts) for f in fixtures])
     # Apply the side-fills a decided fixture implies BEFORE the readiness pass, so a
     # fixture made whole by them seats its match in this same transaction. A fill only
     # ever seats a still-empty side (``advance()`` never plans one over a filled side,
@@ -122,7 +137,7 @@ async def materialize_event(
     # a fixture the fills completed is seen ready here. Fills only add sides (never a
     # match or a winner), so this recomputed ready set is a superset of the first
     # plan's and needs no second side-fill pass beyond the loop above.
-    ready = set(ready_fixtures([fixture_state(f) for f in fixtures]))
+    ready = set(ready_fixtures([fixture_state(f, game_counts) for f in fixtures]))
     ready_fixture_rows = [f for f in fixtures if f.id in ready]
     if not ready_fixture_rows:
         return
@@ -153,6 +168,43 @@ async def materialize_event(
     await db.flush()
     for fixture, match in built:
         fixture.match_id = match.id
+
+
+async def _completed_game_counts(
+    db: AsyncSession, fixtures: Sequence[TournamentFixture]
+) -> dict[uuid.UUID, tuple[int, int]]:
+    """The games each side won, for every one of these fixtures' **completed** matches —
+    keyed by match id, the shape :func:`app.tournament_draws.fixture_state` consumes.
+
+    Two statements for the whole event, not per fixture: one to find which of the linked
+    matches are currently ``completed``, one to count their games
+    (:func:`app.tournament_queries.game_counts_by_match`, the same loader the read path
+    projects standings through — so the qualifiers a draw seats and the table a director
+    is reading are counted by one implementation).
+
+    The ``completed`` filter is the contract, not an optimization. An in-progress
+    match's
+    part-scored board is not a result; a fixture whose match has not completed projects
+    ``games=None`` and its pool is simply not finished yet, which is exactly how a
+    result
+    under correction un-finishes the pool it was in rather than freezing a stale
+    qualifier list (ADR 20260727).
+    """
+    match_ids = [f.match_id for f in fixtures if f.match_id is not None]
+    if not match_ids:
+        return {}
+    completed = (
+        (
+            await db.execute(
+                select(Match.id).where(
+                    Match.id.in_(match_ids), Match.status == MatchStatus.completed
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return await game_counts_by_match(db, list(completed))
 
 
 async def _entry_user_ids(

--- a/api/app/tournament_materialization.py
+++ b/api/app/tournament_materialization.py
@@ -22,7 +22,7 @@ from collections.abc import Sequence
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.draws import Side, SideFill, ready_fixtures
+from app.draws import Side, SideFill, reads_fixture_games, ready_fixtures
 from app.models import (
     Match,
     MatchSettings,
@@ -91,8 +91,9 @@ async def materialize_event(
     For round-robin the plan carries no side-fills at all (every pairing is known at the
     cut), so that step is a no-op and its behaviour is byte-identical.
 
-    **The projection loads the fixtures' game counts**, and that is load-bearing rather
-    than defensive. ``FixtureState.games`` is what a pools-then-knockout draw picks its
+    **The projection loads the fixtures' game counts — but only for the draw types that
+    read them**, and that is load-bearing rather than defensive.
+    ``FixtureState.games`` is what a pools-then-knockout draw picks its
     qualifiers by — the same tiebreak chain (wins → head-to-head → game difference →
     games won) the standings on screen are ordered by (ADR 20260727) — and this seam is
     the *only* place its ``advance()`` is ever run. Projected without them, every
@@ -102,25 +103,28 @@ async def materialize_event(
     qualifiers are seated, and that needs the counts. One batched load for the event,
     beside the fixture load, exactly as the read path batches it per page
     (``app.tournament_queries.game_counts_by_match``); reading them inside
-    ``fixture_state`` would be a query per fixture. The two strategies that do not read
-    ``games`` are unaffected.
+    ``fixture_state`` would be a query per fixture.
+
+    The strategy is therefore chosen **before** the counts are loaded, and the load is
+    gated on ``app.draws.reads_fixture_games``. Round-robin and single-elim never look
+    at the field, so for them the load was a few hundred score rows fetched and
+    discarded — on the completion seam, once per result submission, inside the
+    score-accept transaction under the match row lock. The gate is an exhaustive
+    ``match`` over the draw type with no catch-all, so a new one cannot arrive here
+    having quietly opted out of a load its strategy needs.
     """
-    fixtures = (
-        (
-            await db.execute(
-                select(TournamentFixture).where(TournamentFixture.event_id == event.id)
-            )
-        )
-        .scalars()
-        .all()
-    )
+    fixtures, completed_match_ids = await _fixtures_with_completed_matches(db, event.id)
     if not fixtures:
         # An event with no draw materializes nothing — but go-live's precondition means
         # this is unreachable on that path (every event has a current draw). Guarding it
         # keeps the function honest for a future caller that has no such precondition.
         return
-    game_counts = await _completed_game_counts(db, fixtures)
     strategy = strategy_for_event(event)
+    game_counts = (
+        await game_counts_by_match(db, completed_match_ids)
+        if reads_fixture_games(event.draw_settings.draw_type)
+        else {}
+    )
     plan = strategy.advance([fixture_state(f, game_counts) for f in fixtures])
     # Apply the side-fills a decided fixture implies BEFORE the readiness pass, so a
     # fixture made whole by them seats its match in this same transaction. A fill only
@@ -170,41 +174,46 @@ async def materialize_event(
         fixture.match_id = match.id
 
 
-async def _completed_game_counts(
-    db: AsyncSession, fixtures: Sequence[TournamentFixture]
-) -> dict[uuid.UUID, tuple[int, int]]:
-    """The games each side won, for every one of these fixtures' **completed** matches —
-    keyed by match id, the shape :func:`app.tournament_draws.fixture_state` consumes.
+async def _fixtures_with_completed_matches(
+    db: AsyncSession, event_id: uuid.UUID
+) -> tuple[list[TournamentFixture], list[uuid.UUID]]:
+    """This event's fixtures, and the ids of the matches among them that are **currently
+    completed** — in ONE statement.
 
-    Two statements for the whole event, not per fixture: one to find which of the linked
-    matches are currently ``completed``, one to count their games
-    (:func:`app.tournament_queries.game_counts_by_match`, the same loader the read path
-    projects standings through — so the qualifiers a draw seats and the table a director
-    is reading are counted by one implementation).
+    The status rides along on the fixture load rather than being asked for separately:
+    a fixture's match is reached by an outer join (outer, because most fixtures have no
+    match yet, and a fixture that lost its link — ``match_id`` is ``ON DELETE SET NULL``
+    — must still be returned), and the ``completed`` filter is applied in Python over
+    rows already in hand. Exactly what the read path does with the same two facts
+    (:func:`app.tournament_queries.completed_match_ids` filters an already-loaded
+    ``match_status``); the write seam has no reason to pay a round trip the read seam
+    does not.
 
     The ``completed`` filter is the contract, not an optimization. An in-progress
-    match's
-    part-scored board is not a result; a fixture whose match has not completed projects
-    ``games=None`` and its pool is simply not finished yet, which is exactly how a
-    result
-    under correction un-finishes the pool it was in rather than freezing a stale
-    qualifier list (ADR 20260727).
+    match's part-scored board is not a result; a fixture whose match has not completed
+    projects ``games=None`` and its pool is simply not finished yet, which is exactly
+    how a result under correction un-finishes the pool it was in rather than freezing a
+    stale qualifier list (ADR 20260727).
+
+    The ids are handed to :func:`app.tournament_queries.game_counts_by_match` — the same
+    loader the read path projects standings through, so the qualifiers a draw seats and
+    the table a director is reading are counted by one implementation — and only when
+    the draw type reads them at all.
     """
-    match_ids = [f.match_id for f in fixtures if f.match_id is not None]
-    if not match_ids:
-        return {}
-    completed = (
-        (
-            await db.execute(
-                select(Match.id).where(
-                    Match.id.in_(match_ids), Match.status == MatchStatus.completed
-                )
-            )
+    rows = (
+        await db.execute(
+            select(TournamentFixture, Match.status)
+            .outerjoin(Match, Match.id == TournamentFixture.match_id)
+            .where(TournamentFixture.event_id == event_id)
         )
-        .scalars()
-        .all()
-    )
-    return await game_counts_by_match(db, list(completed))
+    ).all()
+    fixtures: list[TournamentFixture] = []
+    completed_match_ids: list[uuid.UUID] = []
+    for fixture, status in rows:
+        fixtures.append(fixture)
+        if fixture.match_id is not None and status is MatchStatus.completed:
+            completed_match_ids.append(fixture.match_id)
+    return fixtures, completed_match_ids
 
 
 async def _entry_user_ids(

--- a/api/app/tournament_materialization.py
+++ b/api/app/tournament_materialization.py
@@ -113,7 +113,11 @@ async def materialize_event(
     ``match`` over the draw type with no catch-all, so a new one cannot arrive here
     having quietly opted out of a load its strategy needs.
     """
-    fixtures, completed_match_ids = await _fixtures_with_completed_matches(db, event.id)
+    (
+        fixtures,
+        completed_match_ids,
+        voided_match_ids,
+    ) = await _fixtures_with_match_statuses(db, event.id)
     if not fixtures:
         # An event with no draw materializes nothing — but go-live's precondition means
         # this is unreachable on that path (every event has a current draw). Guarding it
@@ -125,7 +129,9 @@ async def materialize_event(
         if reads_fixture_games(event.draw_settings.draw_type)
         else {}
     )
-    plan = strategy.advance([fixture_state(f, game_counts) for f in fixtures])
+    plan = strategy.advance(
+        [fixture_state(f, game_counts, voided_match_ids) for f in fixtures]
+    )
     # Apply the side-fills a decided fixture implies BEFORE the readiness pass, so a
     # fixture made whole by them seats its match in this same transaction. A fill only
     # ever seats a still-empty side (``advance()`` never plans one over a filled side,
@@ -141,7 +147,11 @@ async def materialize_event(
     # a fixture the fills completed is seen ready here. Fills only add sides (never a
     # match or a winner), so this recomputed ready set is a superset of the first
     # plan's and needs no second side-fill pass beyond the loop above.
-    ready = set(ready_fixtures([fixture_state(f, game_counts) for f in fixtures]))
+    ready = set(
+        ready_fixtures(
+            [fixture_state(f, game_counts, voided_match_ids) for f in fixtures]
+        )
+    )
     ready_fixture_rows = [f for f in fixtures if f.id in ready]
     if not ready_fixture_rows:
         return
@@ -174,11 +184,11 @@ async def materialize_event(
         fixture.match_id = match.id
 
 
-async def _fixtures_with_completed_matches(
+async def _fixtures_with_match_statuses(
     db: AsyncSession, event_id: uuid.UUID
-) -> tuple[list[TournamentFixture], list[uuid.UUID]]:
-    """This event's fixtures, and the ids of the matches among them that are **currently
-    completed** — in ONE statement.
+) -> tuple[list[TournamentFixture], list[uuid.UUID], frozenset[uuid.UUID]]:
+    """This event's fixtures, the ids of the matches among them that are **currently
+    completed**, and the ids of the ones that are **voided** — in ONE statement.
 
     The status rides along on the fixture load rather than being asked for separately:
     a fixture's match is reached by an outer join (outer, because most fixtures have no
@@ -195,10 +205,19 @@ async def _fixtures_with_completed_matches(
     how a result under correction un-finishes the pool it was in rather than freezing a
     stale qualifier list (ADR 20260727).
 
-    The ids are handed to :func:`app.tournament_queries.game_counts_by_match` — the same
-    loader the read path projects standings through, so the qualifiers a draw seats and
-    the table a director is reading are counted by one implementation — and only when
-    the draw type reads them at all.
+    The completed ids are handed to
+    :func:`app.tournament_queries.game_counts_by_match` — the same loader the read path
+    projects standings through, so the qualifiers a draw seats and the table a director
+    is reading are counted by one implementation — and only when the draw type reads
+    them at all.
+
+    The **voided** ids are the other half of the same fact, and they are collected
+    unconditionally: they cost nothing (the status is already in hand), and no draw type
+    can afford to be blind to them. A voided pairing can never produce a result, so a
+    strategy that treated it as a missing score would hold its pool permanently
+    unfinished — one score short forever — while the standings, which exclude voided
+    pairings from a pool's ``fixture_count``, showed that same pool ``complete``
+    (:attr:`app.draws.FixtureState.match_voided`).
     """
     rows = (
         await db.execute(
@@ -209,11 +228,16 @@ async def _fixtures_with_completed_matches(
     ).all()
     fixtures: list[TournamentFixture] = []
     completed_match_ids: list[uuid.UUID] = []
+    voided_match_ids: set[uuid.UUID] = set()
     for fixture, status in rows:
         fixtures.append(fixture)
-        if fixture.match_id is not None and status is MatchStatus.completed:
+        if fixture.match_id is None:
+            continue
+        if status is MatchStatus.completed:
             completed_match_ids.append(fixture.match_id)
-    return fixtures, completed_match_ids
+        elif status is MatchStatus.voided:
+            voided_match_ids.add(fixture.match_id)
+    return fixtures, completed_match_ids, frozenset(voided_match_ids)
 
 
 async def _entry_user_ids(

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -13,6 +13,7 @@ it stays cycle-free, mirroring ``app/match_serialization.py``.
 
 import uuid
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import Any, assert_never
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,10 +29,14 @@ from app.results import (
     BracketFinishes,
     BracketFixture,
     EventResults,
+    FinishRow,
     MatchOutcome,
     PoolInput,
+    PoolStandings,
     RoundRobinResults,
+    RrThenKoResults,
     SingleElimResults,
+    StandingsThenFinishes,
     results_for,
 )
 from app.schemas.tournament import (
@@ -47,6 +52,7 @@ from app.schemas.tournament import (
     ScheduleSolveRead,
     StandingRowRead,
     StandingsResultsRead,
+    StandingsThenFinishesResultsRead,
     TournamentDetailRead,
     TournamentEntrantRead,
     TournamentEventRead,
@@ -204,7 +210,8 @@ def event_results(
     """The event's results, projected from its fixtures' completed matches, or ``None``
     when there are none to compute — a **discriminated union tagged by shape**
     (ADR-0785): ``kind: "standings"`` for a round-robin (ADR-0788), ``kind: "finishes"``
-    for a single-elimination bracket.
+    for a single-elimination bracket, ``kind: "standings_then_finishes"`` for a
+    round-robin-then-knockout event, which carries one block per stage (ADR 20260727).
 
     ``None`` in exactly one case, meaning "no results here" rather than an empty table:
     an event whose draw has not been cut (no fixtures to stand). There used to be a
@@ -233,6 +240,20 @@ def event_results(
         case SingleElimResults():
             return _serialize_finishes(
                 strategy.tabulate(_bracket_fixtures(fixtures, game_counts))
+            )
+        case RrThenKoResults():
+            # The one arm whose ``tabulate`` takes TWO stage inputs, because a two-stage
+            # event has two stages to project. ``pool_id IS NULL`` is the stage
+            # discriminator (ADR-0786), and it is applied to the bracket half only:
+            # ``_pool_inputs`` already drops the un-pooled fixtures itself, so the pool
+            # half needs no filter and asking twice would let the two disagree.
+            return _serialize_standings_then_finishes(
+                strategy.tabulate(
+                    _pool_inputs(fixtures, game_counts),
+                    _bracket_fixtures(
+                        [f for f in fixtures if f.pool_id is None], game_counts
+                    ),
+                )
             )
         case _:
             assert_never(strategy)
@@ -322,27 +343,47 @@ def _fixture_outcome(
     )
 
 
+def _pool_standings_read(pools: Sequence[PoolStandings]) -> list[PoolStandingsRead]:
+    """The per-pool standings block, shared by the two shapes that carry one — the
+    round-robin arm and the pool stage of the rr-then-ko arm — so a table means the same
+    thing whichever event it is read off."""
+    return [
+        PoolStandingsRead(
+            pool_id=pool.pool_id,
+            rows=[
+                StandingRowRead(
+                    entry_id=row.entry_id,
+                    rank=row.rank,
+                    played=row.played,
+                    wins=row.wins,
+                    losses=row.losses,
+                    games_won=row.games_won,
+                    games_lost=row.games_lost,
+                )
+                for row in pool.rows
+            ],
+            complete=pool.complete,
+        )
+        for pool in pools
+    ]
+
+
+def _finish_rows_read(finishes: Sequence[FinishRow]) -> list[FinishRowRead]:
+    """The ranked finishes block, shared by the two shapes that carry one — the
+    single-elim arm and the knockout stage of the rr-then-ko arm."""
+    return [
+        FinishRowRead(
+            entry_id=row.entry_id,
+            position=row.position,
+            eliminated_in_round=row.eliminated_in_round,
+        )
+        for row in finishes
+    ]
+
+
 def _serialize_standings(results: EventResults) -> StandingsResultsRead:
     return StandingsResultsRead(
-        pools=[
-            PoolStandingsRead(
-                pool_id=pool.pool_id,
-                rows=[
-                    StandingRowRead(
-                        entry_id=row.entry_id,
-                        rank=row.rank,
-                        played=row.played,
-                        wins=row.wins,
-                        losses=row.losses,
-                        games_won=row.games_won,
-                        games_lost=row.games_lost,
-                    )
-                    for row in pool.rows
-                ],
-                complete=pool.complete,
-            )
-            for pool in results.pools
-        ],
+        pools=_pool_standings_read(results.pools),
         complete=results.complete,
         champion=results.champion,
     )
@@ -350,14 +391,22 @@ def _serialize_standings(results: EventResults) -> StandingsResultsRead:
 
 def _serialize_finishes(results: BracketFinishes) -> FinishesResultsRead:
     return FinishesResultsRead(
-        finishes=[
-            FinishRowRead(
-                entry_id=row.entry_id,
-                position=row.position,
-                eliminated_in_round=row.eliminated_in_round,
-            )
-            for row in results.finishes
-        ],
+        finishes=_finish_rows_read(results.finishes),
+        complete=results.complete,
+        champion=results.champion,
+    )
+
+
+def _serialize_standings_then_finishes(
+    results: StandingsThenFinishes,
+) -> StandingsThenFinishesResultsRead:
+    """Both stages, each serialized by the same helper its one-stage sibling uses — so
+    "an rr-then-ko event's pools cross the wire exactly as a round-robin's do, and its
+    bracket exactly as a single-elim's" is true structurally and not by three
+    serializers happening to agree (ADR 20260727)."""
+    return StandingsThenFinishesResultsRead(
+        pools=_pool_standings_read(results.pools),
+        finishes=_finish_rows_read(results.finishes),
         complete=results.complete,
         champion=results.champion,
     )

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -451,6 +451,15 @@ def serialize_event(
             # that loads an event (``lazy="joined"``), so the list endpoint's
             # per-event serialization still issues no query of its own.
             "draw_type": e.draw_settings.draw_type,
+            # The other half of the same fact, off the same already-joined row: the
+            # slug through the ``draw_type`` property (which owns the slug→enum parse,
+            # so this serializer never spells one), and **K** through the column beside
+            # it. Read as a pair because they are stored as a pair — taking the type
+            # from the settings row and the count from anywhere else is how the two
+            # start disagreeing. ``None`` for the two draw types that have no knockout
+            # stage to qualify for, which the table's ``CHECK`` guarantees rather than
+            # this line assuming.
+            "qualifiers_per_pool": e.draw_settings.qualifiers_per_pool,
             "max_players": e.max_players,
             "entry_fee": e.entry_fee,
             # The event's venue timezone anchors its wall-clock ``Slot`` windows to

--- a/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
+++ b/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
@@ -81,6 +81,16 @@ DRAW_TYPE_SEED = [
         "match, and a field that is not a power of two gives the top seeds byes.",
         2,
     ),
+    (
+        "rr-then-ko",
+        # The director-facing copy is pinned by the ADR "rr-then-ko cuts both
+        # stages upfront and seeds qualifiers rematch-free" — it is seed data, so
+        # changing either string is a migration.
+        "Round-robin then knockout",
+        "Pools play all-play-all, then the top finishers from each pool meet in a "
+        "knockout bracket.",
+        3,
+    ),
 ]
 
 
@@ -150,6 +160,13 @@ def upgrade() -> None:
             sa.ForeignKey("draw_types.key", ondelete="RESTRICT"),
             nullable=False,
         ),
+        # **K** — how many of each pool's finishers advance into the knockout
+        # stage. Only ``rr-then-ko`` has one, so the column is NULLABLE and the
+        # CHECK below is what pairs it with the draw type: NOT NULL and >= 1 for
+        # ``rr-then-ko``, NULL for every other slug. Added in place per the
+        # pre-deploy convention (api/CLAUDE.md), not as a chained ALTER —
+        # revision ids and the down_revision chain stay frozen.
+        sa.Column("qualifiers_per_pool", sa.Integer(), nullable=True),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -161,6 +178,13 @@ def upgrade() -> None:
             sa.DateTime(timezone=True),
             server_default=sa.func.now(),
             nullable=False,
+        ),
+        sa.CheckConstraint(
+            "CASE WHEN draw_type_key = 'rr-then-ko'"
+            " THEN qualifiers_per_pool IS NOT NULL AND qualifiers_per_pool >= 1"
+            " ELSE qualifiers_per_pool IS NULL"
+            " END",
+            name="ck_tournament_event_draw_settings_qualifiers_per_pool",
         ),
     )
 

--- a/api/tests/test_dashboard_tournaments.py
+++ b/api/tests/test_dashboard_tournaments.py
@@ -31,6 +31,7 @@ from app.models import (
 from tests._helpers import counted_statements, opponent_session
 from tests.test_tournaments import (
     POOL_A,
+    POOL_B,
     _call_fixtures,
     _cut_the_draw,
     _enter,
@@ -819,3 +820,99 @@ async def test_panel_statement_count_does_not_grow_with_events(
         assert event.match.round_label == (
             "Group match 1" if n % 2 == 0 else "Round 1"
         ), (event.name, event.match.round_label)
+
+
+async def test_an_rr_then_ko_panel_names_the_stage_each_fixture_is_in(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A two-stage event's round wording is a property of the **fixture's stage**, not
+    of the event (ADR 20260727).
+
+    ``pool_id IS NULL`` is already how the knockout stage is spelled everywhere else, so
+    ``_round_label`` reads the discriminator off the row: a pooled fixture is a "Group
+    match N", an un-pooled one a "Round N" — both vocabularies verbatim from the
+    one-stage draw types, because the same match must not read differently depending on
+    which event it happens to be in.
+
+    Driven end to end: four players, two pools of two, top one out of each, so the pool
+    winners meet in a single final. The caller's card is asserted **twice** — once while
+    their pool match is the focus, once after the final has materialized — which is what
+    makes this about the stage rather than about the event's draw type. ``stage_label``
+    stays minimal ("In play"), deliberately: naming which stage is live needs plumbing
+    this ticket does not buy, and "Group complete" on an event whose bracket is still
+    being played would announce it over.
+    """
+    client, owner = authed_client
+    async with (
+        opponent_session(db_session, "rrko-panel-2") as (client_2, user_2),
+        opponent_session(db_session, "rrko-panel-3") as (client_3, user_3),
+        opponent_session(db_session, "rrko-panel-4") as (client_4, user_4),
+    ):
+        tournament_id, (event,) = await _tournament_with_events(
+            client,
+            _rr_payload(
+                POOL_A,
+                POOL_B,
+                draw_type="rr-then-ko",
+                qualifiers_per_pool=1,
+                match_settings={"rated": False, "length_games": 3},
+                predicates=[],
+            ),
+        )
+        base = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+        entries = [
+            await _enter(
+                db_session,
+                event["id"],
+                user,
+                seed=seed,
+                created_at=base + timedelta(minutes=seed),
+            )
+            for seed, user in ((1, owner), (2, user_2), (3, user_3), (4, user_4))
+        ]
+        await _cut_the_draw(client, tournament_id, event["id"])
+        await _set_status(db_session, tournament_id, TournamentStatus.published)
+        assert (await _go_live(client, tournament_id)).status_code == 201
+        clients = dict(
+            zip(
+                [entry.id for entry in entries],
+                [client, client_2, client_3, client_4],
+                strict=True,
+            )
+        )
+
+        # -- the pool stage: the caller's own pool match is the focus, and it is a
+        #    "Group match".
+        pools = [f for f in await _fixture_rows(db_session, event["id"]) if f.pool_id]
+        await _call_fixtures(db_session, tournament_id, pools)
+        pools = [f for f in await _fixture_rows(db_session, event["id"]) if f.pool_id]
+        (panel,) = await _panels(client)
+        (pool_event,) = panel["events"]
+        assert pool_event["match"]["round_label"] == "Group match 1"
+        assert pool_event["stage_label"] == "In play"
+
+        # -- both pools decided: each winner is seated into the final, which becomes a
+        #    real match in the same transaction.
+        for fixture in pools:
+            assert fixture.entry_a_id is not None
+            await _win_fixture_match(
+                fixture,
+                clients_by_entry=clients,
+                # ``entry_a`` is the higher seed in both pools (1 over 4, 2 over 3).
+                winner_entry_id=fixture.entry_a_id,
+                rated=False,
+            )
+
+        (panel,) = await _panels(client)
+
+    (ko_event,) = panel["events"]
+    assert ko_event["draw_type"] == "rr-then-ko"
+    assert ko_event["match"]["round_label"] == "Round 1", (
+        "the knockout fixture is un-pooled, so it is a Round, not a Group match"
+    )
+    assert ko_event["match"]["opponent_username"] == "rrko-panel-2", (
+        "the caller's final is against the other pool's winner"
+    )
+    assert ko_event["stage_label"] == "In play"
+    assert [row["label"] for row in ko_event["fixtures"]] == ["M1", "M2"]

--- a/api/tests/test_draw_type_seed_migration.py
+++ b/api/tests/test_draw_type_seed_migration.py
@@ -46,6 +46,7 @@ from pathlib import Path
 import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.engine import make_url
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from app.models import DrawType
@@ -213,6 +214,160 @@ async def test_every_seeded_draw_type_carries_picker_copy(
     assert not blank, (
         f"seeded draw_types rows with a blank name or description: {blank}. "
         "Both are rendered in the director's draw-type picker."
+    )
+
+
+async def test_migration_creates_the_qualifiers_per_pool_column(
+    migrated_database_url: str,
+) -> None:
+    """The qualifier count exists, as a NULLABLE integer, on a database built by
+    Alembic — not by ``create_all``.
+
+    Worth its own test precisely because ``create_all`` is what the rest of the
+    suite runs on: a column added to the model and forgotten in the migration is
+    invisible to every other test in this repo and fails on the first real
+    deployment (api/CLAUDE.md, "pytest never runs the migrations"). Nullability is
+    asserted, not just presence, because ``NULL`` is the whole representation of
+    "this draw type takes no qualifier count" — a NOT NULL column would make every
+    round-robin row carry a number.
+    """
+    engine = create_async_engine(migrated_database_url)
+    try:
+        async with engine.connect() as conn:
+            column = (
+                await conn.execute(
+                    sa.text(
+                        "SELECT data_type, is_nullable, column_default"
+                        " FROM information_schema.columns"
+                        " WHERE table_name = 'tournament_event_draw_settings'"
+                        "   AND column_name = 'qualifiers_per_pool'"
+                    )
+                )
+            ).one_or_none()
+    finally:
+        await engine.dispose()
+
+    assert column is not None, (
+        "migrated database has no tournament_event_draw_settings.qualifiers_per_pool"
+        " column — the model has it and create_all builds it, so the whole suite is"
+        " green without the migration"
+    )
+    assert column.data_type == "integer", column
+    assert column.is_nullable == "YES", column
+    assert column.column_default is None, column
+
+
+# Every ``(draw_type_key, qualifiers_per_pool)`` pair the CHECK has an opinion
+# about, and the opinion. Written as data so the test below reports the WHOLE
+# outcome table on a failure rather than dying at the first disagreement — a
+# constraint that has lost one arm and a constraint that was never created look
+# very different here, and that difference is the finding.
+#
+# ``count`` is SQL text, not a bound parameter, because ``NULL`` is one of the
+# values under test and a bound ``None`` would be indistinguishable from the
+# literal in the failure message. The values are this module's own constants and
+# never touch user input.
+QUALIFIER_COUNT_CASES: list[tuple[str, str, bool]] = [
+    # No other draw type may carry a count at all: there is no cut to size for a
+    # round-robin, and no pools to cut from for a single-elim. Both are asked,
+    # because a constraint that had lost one of them looks identical on a
+    # one-slug test.
+    ("round-robin", "2", False),
+    ("single-elim", "2", False),
+    # ...and NULL is how they say so. This is the arm the verifier's `ELSE TRUE`
+    # corruption destroys while leaving everything else intact.
+    ("round-robin", "NULL", True),
+    ("single-elim", "NULL", True),
+    # ``K >= 1`` is the ADR's static bound: zero advances nobody, negative is not
+    # a count, and absent leaves the cut with no answer to "how many advance".
+    ("rr-then-ko", "0", False),
+    ("rr-then-ko", "-1", False),
+    ("rr-then-ko", "NULL", False),
+    # One qualifier per pool IS legal — two pools at K=1 is a single final
+    # between the pool winners, which the ADR names as a supported shape. Without
+    # an accepted case the refusals above would also be satisfied by a constraint
+    # that rejects everything.
+    ("rr-then-ko", "1", True),
+    ("rr-then-ko", "2", True),
+]
+
+
+async def test_migration_pairs_the_qualifier_count_with_its_draw_type(
+    migrated_database_url: str,
+) -> None:
+    """What the CHECK **does** on a migrated database, not what its text says.
+
+    An earlier version of this test asserted only that ``rr-then-ko`` and
+    ``qualifiers_per_pool`` appeared in ``pg_get_constraintdef``. That caught a
+    *missing* constraint but not a *wrong* one: corrupting the migration's ``ELSE
+    qualifiers_per_pool IS NULL`` to ``ELSE TRUE`` — keeping the ``THEN`` arm,
+    keeping the model correct — left this file green while shipping a database
+    that happily stores ``round-robin`` with two qualifiers. A wrong constraint is
+    the *likelier* mistake the next time someone edits migration 0010, since the
+    edit-in-place convention means that expression gets rewritten rather than
+    replaced.
+
+    So every case in :data:`QUALIFIER_COUNT_CASES` is actually attempted, and it
+    is the accept/reject outcome that is asserted. That also makes the test
+    immune to Postgres re-rendering the expression (it already normalises
+    ``'rr-then-ko'`` to ``'rr-then-ko'::text`` and adds its own parentheses).
+
+    The model's copy of this rule is exercised by
+    ``test_tournament_event_draw_settings.py`` against a ``create_all`` schema.
+    This is the same questions asked of the schema **Alembic** built — which is
+    the only way the two descriptions can be shown to agree.
+
+    Every slug the cases name — ``rr-then-ko`` included, since #1227 seeded it —
+    is a row the migration itself inserted, so the settings rows below FK against
+    the real seed rather than a test-local stand-in. Everything runs inside one
+    transaction that is **rolled back**, so the session-scoped migrated database
+    is left exactly as Alembic made it and the seed assertions in this file
+    cannot be affected by test ordering.
+    """
+    engine = create_async_engine(migrated_database_url)
+    outcomes: dict[tuple[str, str], bool] = {}
+    try:
+        conn = await engine.connect()
+        try:
+            transaction = await conn.begin()
+            try:
+                for slug, count, _ in QUALIFIER_COUNT_CASES:
+                    statement = sa.text(
+                        "INSERT INTO tournament_event_draw_settings"
+                        " (draw_type_key, qualifiers_per_pool)"
+                        f" VALUES (:slug, {count})"
+                    )
+                    try:
+                        # A SAVEPOINT per case: a refused INSERT poisons the
+                        # enclosing transaction, so without one the first
+                        # rejection would abort every case after it and the
+                        # outcome table would be a lie.
+                        async with conn.begin_nested():
+                            await conn.execute(statement, {"slug": slug})
+                    except IntegrityError:
+                        outcomes[(slug, count)] = False
+                    else:
+                        outcomes[(slug, count)] = True
+            finally:
+                await transaction.rollback()
+        finally:
+            await conn.close()
+    finally:
+        await engine.dispose()
+
+    expected = {
+        (slug, count): accepted for slug, count, accepted in QUALIFIER_COUNT_CASES
+    }
+    disagreed = {
+        case: f"expected {'accepted' if want else 'REFUSED'}, "
+        f"got {'accepted' if outcomes[case] else 'REFUSED'}"
+        for case, want in expected.items()
+        if outcomes[case] != want
+    }
+    assert not disagreed, (
+        "migration 0010's ck_tournament_event_draw_settings_qualifiers_per_pool "
+        "does not behave like the model's copy on a migrated database: "
+        f"{disagreed}"
     )
 
 

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -24,6 +24,7 @@ from app.draws import (
     FixtureId,
     FixtureState,
     MatchId,
+    MissingBracketSlot,
     MissingFixtureGames,
     OrderedEntrant,
     PlannedFixture,
@@ -36,6 +37,7 @@ from app.draws import (
     SingleElimStrategy,
     order_entrants,
     qualifier_seed_assignment,
+    reads_fixture_games,
     ready_fixtures,
     strategy_for,
 )
@@ -246,6 +248,62 @@ class TestStrategyRegistry:
         while the one that needs it must not be left guessing."""
         for draw_type in DrawType:
             assert strategy_for(draw_type, qualifiers_per_pool=2) is not None
+
+    def test_the_games_gate_names_every_draw_type_and_only_the_one_that_reads_them(
+        self,
+    ) -> None:
+        """``reads_fixture_games`` is what lets the materialization seam — which runs
+        inside the score-accept transaction on **every** result — skip loading game
+        counts nothing will read.
+
+        A whole-enum equality, so a new ``DrawType`` reds here as well as failing to
+        type-check in the catch-all-free ``match``: the gate is a claim about which
+        strategies read ``FixtureState.games``, and a wrong answer is either a discarded
+        query per result (harmless, slow) or a ``MissingFixtureGames`` on the seam
+        (loud), never a silently mis-seated qualifier.
+        """
+        assert {
+            draw_type: reads_fixture_games(draw_type) for draw_type in DrawType
+        } == {
+            DrawType.round_robin: False,
+            DrawType.single_elim: False,
+            DrawType.rr_then_ko: True,
+        }
+
+    def test_a_draw_type_the_gate_clears_advances_the_same_without_its_games(
+        self,
+    ) -> None:
+        """And the gate's answer is *true of the strategies*, not just asserted about
+        them: for every draw type it clears, a fully-played draw advances
+        byte-identically with the game counts stripped out.
+
+        This is the falsifiable half. A strategy that started reading the field would
+        plan something different from the two states and red here, rather than silently
+        advancing on ``games=None`` at the one seam that would have skipped the load.
+        """
+        for draw_type in DrawType:
+            if reads_fixture_games(draw_type):
+                continue
+            strategy = strategy_for(draw_type, qualifiers_per_pool=None)
+            cut = _persisted(strategy.plan_initial(_config(2), _ordered(8)))
+            with_games = _played(
+                cut,
+                {
+                    frozenset({f.entry_a_id.int, f.entry_b_id.int}): (
+                        min(f.entry_a_id.int, f.entry_b_id.int),
+                        3,
+                        1,
+                    )
+                    for f in cut
+                    if f.entry_a_id is not None and f.entry_b_id is not None
+                },
+            )
+            without_games = [dataclasses.replace(f, games=None) for f in with_games]
+            assert any(f.games is not None for f in with_games), (
+                f"{draw_type.value}: the two states must actually differ"
+            )
+
+            assert strategy.advance(with_games) == strategy.advance(without_games)
 
     def test_the_draw_type_lives_in_exactly_one_place_and_it_is_not_the_config(
         self,
@@ -1674,6 +1732,24 @@ class TestRrThenKoAdvance:
         assert "18 decided pool fixtures" in str(excinfo.value)
         # Not a DrawError: this is a wiring bug, not something a director can fix by
         # re-cutting, so it must not be dressed up as a 422.
+        assert not isinstance(excinfo.value, DrawError)
+
+    def test_rr_then_ko_refuses_a_bracket_that_was_cut_for_a_different_k(self) -> None:
+        # The sibling of the gameless refusal above, and the same reasoning: a bracket
+        # cut for K=1 advanced at K=2 has qualifiers whose predetermined slot does not
+        # exist. Skipping them seats *some* of the qualifiers and leaves the draw
+        # quietly wrong — the outcome the event editor's 409 freeze calls unacceptable —
+        # the domain says so instead of the freeze being the only thing standing between
+        # a director and a half-seated bracket.
+        cut = _persisted(_rr_then_ko(1).plan_initial(_config(2), _ordered(4)))
+        fixtures = _played(cut, _lower_seed_wins(cut))
+
+        with pytest.raises(MissingBracketSlot) as excinfo:
+            _rr_then_ko(2).advance(fixtures)
+
+        assert "cut for a different number of qualifiers" in str(excinfo.value)
+        # Not a DrawError: a frozen K means nothing a director can type reaches this, so
+        # it is a wiring bug and a 500, not a 422 they could act on.
         assert not isinstance(excinfo.value, DrawError)
 
     def test_rr_then_ko_tolerates_one_result_in_flux_among_scored_neighbours(

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -7,6 +7,7 @@ point of keeping the strategies pure.
 import dataclasses
 import uuid
 from collections import Counter
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from itertools import combinations
 
@@ -19,17 +20,22 @@ from app.draws import (
     DrawError,
     Entrant,
     EntryId,
+    FixtureGames,
     FixtureId,
     FixtureState,
     MatchId,
+    MissingFixtureGames,
     OrderedEntrant,
     PlannedFixture,
     PoolId,
+    QualifierSeat,
     RoundRobinStrategy,
+    RrThenKoStrategy,
     Side,
     SideFill,
     SingleElimStrategy,
     order_entrants,
+    qualifier_seed_assignment,
     ready_fixtures,
     strategy_for,
 )
@@ -981,3 +987,683 @@ class TestSingleElimAdvance:
         assert by_rp[(2, 2)].fixture_id in ready  # both-byes semifinal, fully known
         assert by_rp[(2, 1)].fixture_id not in ready  # one side still TBD
         assert by_rp[(3, 1)].fixture_id not in ready  # final, both sides TBD
+
+
+#: The legal configuration space the ADR defines: ``K ≥ 1`` (Pydantic, at the request
+#: boundary) and ``P × K ≥ 2`` (at the cut). Swept whole rather than sampled — the
+#: guarantee is universal, so a handful of hand-picked cases would not be evidence for
+#: it. ``P`` runs past any club-night pool count and ``K`` past any plausible cut.
+LEGAL_QUALIFIER_CONFIGURATIONS = [
+    (pool_count, per_pool)
+    for pool_count in range(1, 9)
+    for per_pool in range(1, 5)
+    if pool_count * per_pool >= 2
+]
+
+
+def _pool_letter(pool_index: int) -> str:
+    """``0 → 'A'`` — the same labelling :func:`_pool_ids` gives the pools themselves."""
+    return chr(ord("A") + pool_index)
+
+
+def _seat_label(seat: QualifierSeat) -> str:
+    """``A1`` — pool A's winner; ``C2`` — pool C's runner-up."""
+    return f"{_pool_letter(seat.pool_index)}{seat.place}"
+
+
+def _round_one_seed_pairs(qualifier_count: int) -> list[tuple[int, int]]:
+    """Which **seed numbers** meet in round one of a bracket holding this many
+    qualifiers.
+
+    Reconstructed by cutting a real single-elimination bracket over that many entrants,
+    rather than by restating ``B+1−s``: the knockout stage of an rr-then-ko draw is the
+    same bracket shape (the ADR reuses ``_seed_slots`` unchanged), and reading it off
+    the public cutter keeps the property test independent of the assignment's own idea
+    of who plays whom. Byed seeds have no round-1 fixture, so they simply do not appear
+    — which is correct, a bye can never be a rematch.
+    """
+    fixtures = SingleElimStrategy().plan_initial(
+        DrawConfig(), _ordered(qualifier_count)
+    )
+    return [
+        (_seed_of(f.entry_a_id), _seed_of(f.entry_b_id))
+        for f in fixtures
+        if f.round == 1
+    ]
+
+
+class TestQualifierSeedAssignment:
+    """Seeding pool qualifiers into the knockout bracket (ADR "rr-then-ko cuts both
+    stages upfront and seeds qualifiers rematch-free").
+
+    The claim these defend is absolute, not statistical: across the *whole* legal
+    configuration space, no round-one knockout fixture holds two qualifiers out of the
+    same pool — and the one-pool case is exempt on purpose, which is asserted as its own
+    positive property rather than skipped.
+    """
+
+    def test_no_round_one_pairing_holds_two_qualifiers_from_the_same_pool(
+        self,
+    ) -> None:
+        offenders = [
+            f"P={pool_count} K={per_pool}: seeds {left} v {right} are both out of "
+            f"pool {_pool_letter(assignment[left].pool_index)} "
+            f"({_seat_label(assignment[left])} vs {_seat_label(assignment[right])})"
+            for pool_count, per_pool in LEGAL_QUALIFIER_CONFIGURATIONS
+            # One pool is a waiver, asserted positively in its own test below.
+            if pool_count >= 2
+            for assignment in [qualifier_seed_assignment(pool_count, per_pool)]
+            for left, right in _round_one_seed_pairs(pool_count * per_pool)
+            if assignment[left].pool_index == assignment[right].pool_index
+        ]
+
+        assert offenders == []
+
+    def test_one_pool_seeds_qualifiers_by_place_and_is_all_rematches_by_design(
+        self,
+    ) -> None:
+        # The waiver, stated as a property rather than an exclusion: with a single pool
+        # every knockout match *is* a rematch, because every qualifier came out of the
+        # same pool. That is "league, then a playoff" working, not the guarantee
+        # failing — so assert it holds rather than skipping the case.
+        for per_pool in (2, 3, 4):
+            assignment = qualifier_seed_assignment(1, per_pool)
+
+            assert assignment == {
+                seed: QualifierSeat(pool_index=0, place=seed)
+                for seed in range(1, per_pool + 1)
+            }
+            pairs = _round_one_seed_pairs(per_pool)
+            assert pairs, f"K={per_pool} should have a round-1 match to be a rematch"
+            assert all(
+                assignment[left].pool_index == assignment[right].pool_index
+                for left, right in pairs
+            )
+
+    def test_seeds_are_place_major_and_each_qualifier_is_seeded_exactly_once(
+        self,
+    ) -> None:
+        # The shape the guarantee is built on: place block k owns seeds kP+1..kP+P, and
+        # holds every pool exactly once — which is what makes an intra-block round-one
+        # pair safe for free, and what leaves the pool order free to be chosen.
+        for pool_count, per_pool in LEGAL_QUALIFIER_CONFIGURATIONS:
+            assignment = qualifier_seed_assignment(pool_count, per_pool)
+            qualifier_count = pool_count * per_pool
+
+            assert sorted(assignment) == list(range(1, qualifier_count + 1))
+            assert len(set(assignment.values())) == qualifier_count
+            for block in range(per_pool):
+                seeds = range(block * pool_count + 1, (block + 1) * pool_count + 1)
+                assert {assignment[seed].place for seed in seeds} == {block + 1}
+                assert {assignment[seed].pool_index for seed in seeds} == set(
+                    range(pool_count)
+                )
+
+    def test_the_same_qualifier_configuration_always_gets_the_same_seeds(self) -> None:
+        # A re-cut must reproduce the bracket, exactly as `order_entrants` promises for
+        # the draw order — the augmenting search walks pools in ascending index order
+        # precisely so its answer is a function of the inputs and not of iteration luck.
+        # Collected rather than asserted in the loop so a red names *which* (P, K)
+        # wobbled, and how, instead of dying on the first one.
+        offenders = [
+            f"P={pool_count} K={per_pool}: "
+            f"{ {seed: _seat_label(s) for seed, s in first.items()} } "
+            f"then { {seed: _seat_label(s) for seed, s in second.items()} }"
+            for pool_count, per_pool in LEGAL_QUALIFIER_CONFIGURATIONS
+            for first in [qualifier_seed_assignment(pool_count, per_pool)]
+            for second in [qualifier_seed_assignment(pool_count, per_pool)]
+            if first != second
+        ]
+
+        assert offenders == []
+
+    def test_a_configuration_outside_the_legal_space_is_refused(self) -> None:
+        # Programmer errors, not director errors: the director-facing refusals are the
+        # strategy's `DegenerateDraw`s at the cut, where the entrant count is in hand.
+        with pytest.raises(ValueError):
+            qualifier_seed_assignment(0, 2)
+        with pytest.raises(ValueError):
+            qualifier_seed_assignment(2, 0)
+        with pytest.raises(ValueError):
+            # A "bracket" of one qualifier has nobody to play.
+            qualifier_seed_assignment(1, 1)
+
+
+# ── round-robin then knockout ────────────────────────────────────────────────────
+#
+# The cut matrix, spelled out by hand rather than recomputed: (pools, entrants,
+# qualifiers per pool) → the qualifier count, the derived bracket size, the round-1
+# positions that exist (the byed ones are *absent*), and the per-round knockout fixture
+# counts. Bracket size is the smallest power of two ≥ P × K and is never configured.
+RR_THEN_KO_MATRIX: list[tuple[int, int, int, int, int, set[int], dict[int, int]]] = [
+    # P, N, K, qualifiers, bracket, round-1 positions, per-round counts
+    (1, 4, 2, 2, 2, {1}, {1: 1}),  # one pool: league, then a playoff
+    (2, 8, 2, 4, 4, {1, 2}, {1: 2, 2: 1}),  # exact power of two: no byes
+    (3, 12, 1, 3, 4, {2}, {1: 1, 2: 1}),  # 1 bye — seed 1 walks into the final
+    (3, 12, 2, 6, 8, {2, 3}, {1: 2, 2: 2, 3: 1}),  # 2 byes into the semifinals
+    (4, 16, 1, 4, 4, {1, 2}, {1: 2, 2: 1}),
+    (5, 20, 3, 15, 16, {2, 3, 4, 5, 6, 7, 8}, {1: 7, 2: 4, 3: 2, 4: 1}),
+]
+RR_THEN_KO_IDS = [f"P={p},N={n},K={k}" for p, n, k, _, _, _, _ in RR_THEN_KO_MATRIX]
+
+#: Pool A of the 3-pool, 12-entrant cut — seeds 1, 6, 7 and 12 — played out so that
+#: the finishing order is 6, 12, 7, 1: the top seed loses everything and the pool's
+#: second seed wins it. Keyed by the *pair* and valued ``(winner, winner's games,
+#: loser's games)``, so a result reads the same whichever way round the fixture seated
+#: the two.
+POOL_A_RESULTS: dict[frozenset[int], tuple[int, int, int]] = {
+    frozenset({1, 12}): (12, 3, 0),
+    frozenset({6, 7}): (6, 3, 1),
+    frozenset({1, 7}): (7, 3, 2),
+    frozenset({12, 6}): (6, 3, 2),
+    frozenset({1, 6}): (6, 3, 0),
+    frozenset({7, 12}): (12, 3, 1),
+}
+POOL_A_FINISHING_ORDER = [6, 12, 7, 1]
+
+#: A four-entrant pool with a **three-way tie on wins** — 1 beat 2 beat 3 beat 1, and
+#: all three beat 4. A cycle cannot be broken head-to-head, so the order falls through
+#: to the game tiebreakers, which is the whole point: it settles 2 above 1 *even though
+#: 1 beat 2*, so an order computed on wins (+ head-to-head, + entry id) cannot make it.
+CYCLIC_POOL_RESULTS: dict[frozenset[int], tuple[int, int, int]] = {
+    frozenset({1, 2}): (1, 3, 2),
+    frozenset({2, 3}): (2, 3, 0),
+    frozenset({1, 3}): (3, 3, 1),
+    frozenset({1, 4}): (1, 3, 0),
+    frozenset({2, 4}): (2, 3, 1),
+    frozenset({3, 4}): (3, 3, 2),
+}
+#: Game difference: 2 → +4, 1 → +2, 3 → 0, 4 → −6.
+CYCLIC_POOL_FINISHING_ORDER = [2, 1, 3, 4]
+
+
+def _rr_then_ko(qualifiers_per_pool: int) -> RrThenKoStrategy:
+    return RrThenKoStrategy(qualifiers_per_pool=qualifiers_per_pool)
+
+
+def _knockout(fixtures: Sequence[PlannedFixture]) -> list[PlannedFixture]:
+    """The knockout stage — which *is* ``pool_id IS NULL`` (ADR-0786), no new column."""
+    return [f for f in fixtures if f.pool_id is None]
+
+
+def _pooled(fixtures: Sequence[PlannedFixture]) -> list[PlannedFixture]:
+    return [f for f in fixtures if f.pool_id is not None]
+
+
+def _played(
+    fixtures: Sequence[FixtureState],
+    results: Mapping[frozenset[int], tuple[int, int, int]],
+) -> list[FixtureState]:
+    """Play out every fixture whose seed pair appears in ``results`` — what the
+    completion seam leaves behind: a written-back ``winner_entry_id``, the match's game
+    counts oriented ``entry_a`` ↔ side 1, and a materialized match."""
+    played: list[FixtureState] = []
+    for index, fixture in enumerate(fixtures):
+        if fixture.entry_a_id is None or fixture.entry_b_id is None:
+            played.append(fixture)
+            continue
+        result = results.get(
+            frozenset({fixture.entry_a_id.int, fixture.entry_b_id.int})
+        )
+        if result is None:
+            played.append(fixture)
+            continue
+        winner_seed, winner_games, loser_games = result
+        winner = _entry_id(winner_seed)
+        a_won = fixture.entry_a_id == winner
+        played.append(
+            dataclasses.replace(
+                fixture,
+                winner_entry_id=winner,
+                games=FixtureGames(
+                    entry_a_games=winner_games if a_won else loser_games,
+                    entry_b_games=loser_games if a_won else winner_games,
+                ),
+                match_id=MatchId(uuid.UUID(int=3000 + index)),
+            )
+        )
+    return played
+
+
+def _lower_seed_wins(
+    fixtures: Sequence[FixtureState],
+) -> dict[frozenset[int], tuple[int, int, int]]:
+    """A whole-draw sweep in which the better seed always wins 3-1, so every pool
+    finishes in seed order and the qualifiers are its two best seeds."""
+    return {
+        pair: (min(pair), 3, 1)
+        for fixture in fixtures
+        if fixture.pool_id is not None
+        and fixture.entry_a_id is not None
+        and fixture.entry_b_id is not None
+        for pair in [frozenset({fixture.entry_a_id.int, fixture.entry_b_id.int})]
+    }
+
+
+def _knockout_sides(
+    fixtures: Sequence[FixtureState],
+) -> dict[tuple[int, int, str], int | None]:
+    """Every knockout side as ``(round, position, "a"/"b") → seed`` (``None`` = still
+    unknown), which is how a director reads a half-seeded bracket."""
+    sides: dict[tuple[int, int, str], int | None] = {}
+    for fixture in fixtures:
+        if fixture.pool_id is not None:
+            continue
+        for side, entry_id in (("a", fixture.entry_a_id), ("b", fixture.entry_b_id)):
+            sides[(fixture.round, fixture.position, side)] = (
+                None if entry_id is None else entry_id.int
+            )
+    return sides
+
+
+def _apply(fixtures: Sequence[FixtureState], plan: AdvancePlan) -> list[FixtureState]:
+    """Apply a plan's side-fills, exactly as ``materialize_event`` does before it
+    decides readiness — the state a *second* ``advance()`` sees, and so the input every
+    idempotence claim is made against."""
+    filled = {f.fixture_id: f for f in fixtures}
+    for fill in plan.side_fills:
+        target = filled[fill.fixture_id]
+        filled[fill.fixture_id] = dataclasses.replace(
+            target,
+            **(
+                {"entry_a_id": fill.entry_id}
+                if fill.side is Side.a
+                else {"entry_b_id": fill.entry_id}
+            ),
+        )
+    return [filled[f.fixture_id] for f in fixtures]
+
+
+class TestRrThenKoCut:
+    """One stroke cuts both stages: every pool's round-robin *and* the whole bracket,
+    the latter entirely TBD-sided (ADR "rr-then-ko cuts both stages upfront")."""
+
+    def test_rr_then_ko_cuts_the_pool_stage_a_round_robin_draw_would_have_cut(
+        self,
+    ) -> None:
+        # Structural, not "equivalent": the pool fixtures are round-robin's own cut,
+        # so the two cannot drift.
+        cut = _rr_then_ko(2).plan_initial(_config(3), _ordered(12))
+
+        assert _pooled(cut) == RoundRobinStrategy().plan_initial(
+            _config(3), _ordered(12)
+        )
+
+    @pytest.mark.parametrize(
+        ("pool_count", "entrants", "per_pool", "qualifiers", "bracket", "r1", "counts"),
+        RR_THEN_KO_MATRIX,
+        ids=RR_THEN_KO_IDS,
+    )
+    def test_rr_then_ko_cuts_the_whole_bracket_with_every_side_unknown(
+        self,
+        pool_count: int,
+        entrants: int,
+        per_pool: int,
+        qualifiers: int,
+        bracket: int,
+        r1: set[int],
+        counts: dict[int, int],
+    ) -> None:
+        cut = _rr_then_ko(per_pool).plan_initial(
+            _config(pool_count), _ordered(entrants)
+        )
+        knockout = _knockout(cut)
+
+        assert pool_count * per_pool == qualifiers
+        # Bracket size is *derived* (smallest power of two ≥ P × K), never configured.
+        assert 2 ** len(counts) == bracket
+        assert Counter(f.round for f in knockout) == counts
+        # Nobody has qualified, so every knockout side is TBD — and a TBD side is a
+        # ``None``, never a placeholder entry.
+        assert all(f.entry_a_id is None and f.entry_b_id is None for f in knockout)
+
+    @pytest.mark.parametrize(
+        ("pool_count", "entrants", "per_pool", "qualifiers", "bracket", "r1", "counts"),
+        RR_THEN_KO_MATRIX,
+        ids=RR_THEN_KO_IDS,
+    )
+    def test_rr_then_ko_byes_are_absent_round_one_fixtures_never_null_sided_rows(
+        self,
+        pool_count: int,
+        entrants: int,
+        per_pool: int,
+        qualifiers: int,
+        bracket: int,
+        r1: set[int],
+        counts: dict[int, int],
+    ) -> None:
+        # Which seeds bye is settled at cut time — the top B − Q of them — even though
+        # nobody has played, which is exactly what lets the bracket be cut upfront.
+        cut = _rr_then_ko(per_pool).plan_initial(
+            _config(pool_count), _ordered(entrants)
+        )
+
+        positions = {f.position for f in _knockout(cut) if f.round == 1}
+        assert positions == r1
+        byed_seeds = set(range(1, qualifiers + 1)) - {
+            seed
+            for pair in _single_elim_round_one(
+                SingleElimStrategy().plan_initial(DrawConfig(), _ordered(qualifiers))
+            ).values()
+            for seed in pair
+        }
+        assert byed_seeds == set(range(1, bracket - qualifiers + 1))
+
+    def test_rr_then_ko_cuts_the_bracket_a_single_elim_over_the_qualifiers_would(
+        self,
+    ) -> None:
+        # The knockout stage *is* a single-elimination bracket — the same shape, byes
+        # and all — with its seats not yet known. Asserted against the real cutter
+        # rather than a restatement, so the two cannot drift.
+        cut = _rr_then_ko(2).plan_initial(_config(3), _ordered(12))
+
+        assert _knockout(cut) == [
+            dataclasses.replace(f, entry_a_id=None, entry_b_id=None)
+            for f in SingleElimStrategy().plan_initial(DrawConfig(), _ordered(6))
+        ]
+
+    def test_rr_then_ko_knockout_rounds_restart_at_one_in_their_own_namespace(
+        self,
+    ) -> None:
+        # The unique constraint is ``(event_id, pool_id, round, position)`` with NULLS
+        # NOT DISTINCT, so ``pool_id IS NULL`` is its own numbering namespace and the
+        # knockout starts again at round 1 — a pool round 1 and a knockout round 1 are
+        # different keys, and nothing in the cut collides.
+        cut = _rr_then_ko(2).plan_initial(_config(3), _ordered(12))
+
+        assert min(f.round for f in _knockout(cut)) == 1
+        assert min(f.round for f in _pooled(cut)) == 1
+        keys = [(f.pool_id, f.round, f.position) for f in cut]
+        assert len(set(keys)) == len(keys)
+
+    def test_rr_then_ko_cuts_the_same_draw_twice(self) -> None:
+        first = _rr_then_ko(2).plan_initial(_config(3), _ordered(12))
+        second = _rr_then_ko(2).plan_initial(_config(3), _ordered(12))
+
+        assert first == second
+
+    def test_rr_then_ko_takes_the_whole_pool_when_everyone_qualifies(self) -> None:
+        # K = ⌊N/P⌋ is legal: the pool stage then exists purely to *seed* the knockout.
+        cut = _rr_then_ko(4).plan_initial(_config(4), _ordered(16))
+
+        assert len(_knockout(cut)) == 8 + 4 + 2 + 1  # a full 16-slot bracket, no byes
+        assert {f.position for f in _knockout(cut) if f.round == 1} == set(range(1, 9))
+
+    def test_rr_then_ko_a_single_pool_is_legal_and_is_league_then_a_playoff(
+        self,
+    ) -> None:
+        # The one-pool waiver: every knockout match is necessarily a rematch, which is
+        # the format working as intended, not a refusal.
+        cut = _rr_then_ko(2).plan_initial(_config(1), _ordered(5))
+
+        assert {f.pool_id for f in _pooled(cut)} == {PoolId("A")}
+        assert len(_knockout(cut)) == 1  # a two-qualifier final
+
+    def test_rr_then_ko_refuses_to_take_more_qualifiers_than_the_smallest_pool_holds(
+        self,
+    ) -> None:
+        with pytest.raises(DegenerateDraw) as excinfo:
+            # 7 entrants over 2 pools deals 3 and 4, so 4 qualifiers per pool is more
+            # than the smaller pool has players.
+            _rr_then_ko(4).plan_initial(_config(2), _ordered(7))
+
+        assert str(excinfo.value) == (
+            "Taking 4 qualifiers from each pool is more than the 3 entrants in the "
+            "smallest pool — take fewer qualifiers from each pool, or add entrants."
+        )
+        assert isinstance(excinfo.value, DrawError)
+
+    def test_rr_then_ko_refuses_a_knockout_stage_of_fewer_than_two_qualifiers(
+        self,
+    ) -> None:
+        with pytest.raises(DegenerateDraw) as excinfo:
+            _rr_then_ko(1).plan_initial(_config(1), _ordered(5))
+
+        assert str(excinfo.value) == (
+            "Taking 1 qualifier from a single pool leaves one player in the knockout "
+            "stage, who would have nobody to play — take more qualifiers from each "
+            "pool, or configure more pools."
+        )
+
+    def test_rr_then_ko_refuses_a_pool_of_fewer_than_two(self) -> None:
+        # Inherited from the snake, unchanged: the pool floor comes free with the pool
+        # stage, so rr-then-ko does not restate it.
+        with pytest.raises(DegenerateDraw) as excinfo:
+            _rr_then_ko(1).plan_initial(_config(3), _ordered(5))
+
+        assert "fewer than 2 entrants" in str(excinfo.value)
+
+    def test_rr_then_ko_refuses_fewer_than_one_qualifier_per_pool_at_construction(
+        self,
+    ) -> None:
+        # A *programmer* error, not a director one — K ≥ 1 is a static constraint at the
+        # request boundary — so it is a ValueError, and the illegal strategy cannot even
+        # be built.
+        with pytest.raises(ValueError, match="qualifiers_per_pool must be at least 1"):
+            RrThenKoStrategy(qualifiers_per_pool=0)
+
+
+class TestRrThenKoAdvance:
+    """Each pool seats its qualifiers the moment *it* is decided, into slots settled at
+    the cut — with the other pools still playing."""
+
+    def _cut(self) -> list[FixtureState]:
+        """The 3-pool, 12-entrant, top-2 draw as it reads back after the cut. The snake
+        deals pool A seeds 1, 6, 7, 12; B 2, 5, 8, 11; C 3, 4, 9, 10."""
+        return _persisted(_rr_then_ko(2).plan_initial(_config(3), _ordered(12)))
+
+    def test_rr_then_ko_seats_a_finished_pools_qualifiers_and_nobody_elses(
+        self,
+    ) -> None:
+        # THE claim: pool A is decided while B and C are still playing, and A's two
+        # qualifiers take their predetermined slots at once. The slots are fixed by
+        # ``qualifier_seed_assignment(3, 2)``, which never sees a result: pool A's
+        # winner is seed 1 (which byes into semifinal 1) and its runner-up is seed 6
+        # (round 1, position 3, side b).
+        fixtures = _played(self._cut(), POOL_A_RESULTS)
+        by_slot = {(f.round, f.position): f for f in fixtures if f.pool_id is None}
+
+        plan = _rr_then_ko(2).advance(fixtures)
+
+        assert plan.side_fills == (
+            SideFill(
+                fixture_id=by_slot[(2, 1)].fixture_id,
+                side=Side.a,
+                entry_id=_entry_id(6),
+            ),
+            SideFill(
+                fixture_id=by_slot[(1, 3)].fixture_id,
+                side=Side.b,
+                entry_id=_entry_id(12),
+            ),
+        )
+        # Every other knockout side is still unknown: B and C have not finished.
+        assert _knockout_sides(_apply(fixtures, plan)) == {
+            (1, 2, "a"): None,
+            (1, 2, "b"): None,
+            (1, 3, "a"): None,
+            (1, 3, "b"): 12,
+            (2, 1, "a"): 6,
+            (2, 1, "b"): None,
+            (2, 2, "a"): None,
+            (2, 2, "b"): None,
+            (3, 1, "a"): None,
+            (3, 1, "b"): None,
+        }
+
+    def test_rr_then_ko_qualifiers_are_the_top_of_the_pools_finishing_order(
+        self,
+    ) -> None:
+        # The qualifiers are the top K of *the* finishing order — the same function the
+        # standings table is built from — and this pool proves the whole tiebreak chain
+        # is live: a three-way cycle on wins is settled on game difference, which seats
+        # entry 2 above entry 1 even though 1 beat 2 head-to-head. An order computed on
+        # wins alone (or wins + head-to-head + entry id) puts 1 first.
+        cut = _persisted(_rr_then_ko(2).plan_initial(_config(1), _ordered(4)))
+        fixtures = _played(cut, CYCLIC_POOL_RESULTS)
+
+        plan = _rr_then_ko(2).advance(fixtures)
+
+        assert _knockout_sides(_apply(fixtures, plan)) == {
+            (1, 1, "a"): CYCLIC_POOL_FINISHING_ORDER[0],
+            (1, 1, "b"): CYCLIC_POOL_FINISHING_ORDER[1],
+        }
+
+    def test_rr_then_ko_seats_nothing_for_a_pool_that_is_still_playing(self) -> None:
+        # Per-pool, not all-or-nothing — and the converse: a pool with results in it but
+        # a fixture still to play seats nobody, because its order is not settled.
+        cut = self._cut()
+        partial = dict(list(POOL_A_RESULTS.items())[:-1])
+
+        assert _rr_then_ko(2).advance(_played(cut, partial)).side_fills == ()
+
+    def test_rr_then_ko_is_idempotent_once_the_qualifiers_are_seated(self) -> None:
+        # THE idempotence claim: apply the plan, feed the result back, and the second
+        # advance seats nobody — a SideFill only ever fills an *empty* side.
+        fixtures = _played(self._cut(), POOL_A_RESULTS)
+        first = _rr_then_ko(2).advance(fixtures)
+
+        assert _rr_then_ko(2).advance(_apply(fixtures, first)).side_fills == ()
+
+    def test_rr_then_ko_plans_nothing_at_all_over_its_own_fully_applied_plan(
+        self,
+    ) -> None:
+        # The stronger form: with the fills applied *and* the newly-ready fixtures
+        # materialized (what ``materialize_event`` does in the same transaction), the
+        # whole plan is empty — which is what makes re-running after every result safe.
+        fixtures = _played(self._cut(), POOL_A_RESULTS)
+        applied = _apply(fixtures, _rr_then_ko(2).advance(fixtures))
+        materialized = [
+            dataclasses.replace(f, match_id=MatchId(uuid.UUID(int=4000 + i)))
+            if f.match_id is None
+            else f
+            for i, f in enumerate(applied)
+        ]
+
+        assert _rr_then_ko(2).advance(materialized) == AdvancePlan()
+
+    def test_rr_then_ko_advances_the_knockout_as_a_single_elim_bracket_does(
+        self,
+    ) -> None:
+        # Once the bracket is under way it is single-elim's own forward seating: a
+        # decided knockout fixture seats its winner into its successor slot.
+        cut = self._cut()
+        seeded = [
+            dataclasses.replace(
+                f,
+                entry_a_id=_entry_id(3),
+                entry_b_id=_entry_id(6),
+                winner_entry_id=_entry_id(3),
+            )
+            if (f.pool_id, f.round, f.position) == (None, 1, 3)
+            else f
+            for f in cut
+        ]
+        by_slot = {(f.round, f.position): f for f in seeded if f.pool_id is None}
+
+        plan = _rr_then_ko(2).advance(seeded)
+
+        # Round 1 position 3 is odd → side a of round 2, position 2.
+        assert (
+            SideFill(
+                fixture_id=by_slot[(2, 2)].fixture_id,
+                side=Side.a,
+                entry_id=_entry_id(3),
+            )
+            in plan.side_fills
+        )
+
+    def test_rr_then_ko_never_seats_a_pool_winner_forward_into_a_knockout_slot(
+        self,
+    ) -> None:
+        # A pool fixture has no successor — its ``(round, position)`` lives in the
+        # pool's own namespace, and reading it as a bracket coordinate would seat a pool
+        # winner into a knockout slot belonging to somebody else. Only the *finished*
+        # pool's qualifier seating touches the bracket, so a half-played pool fills
+        # nothing.
+        cut = self._cut()
+        partial = dict(list(POOL_A_RESULTS.items())[:2])
+
+        assert _rr_then_ko(2).advance(_played(cut, partial)).side_fills == ()
+
+    def test_rr_then_ko_round_one_never_pairs_two_qualifiers_out_of_one_pool(
+        self,
+    ) -> None:
+        # The rematch-free guarantee, end to end through a real cut and advance rather
+        # than on the seed map alone.
+        planned = _rr_then_ko(2).plan_initial(_config(3), _ordered(12))
+        pool_of = {
+            seed: pool_id
+            for pool_id, seeds in _members_by_pool(_pooled(planned)).items()
+            for seed in seeds
+        }
+        cut = _persisted(planned)
+        fixtures = _played(cut, _lower_seed_wins(cut))
+
+        seeded = _apply(fixtures, _rr_then_ko(2).advance(fixtures))
+
+        round_one = [
+            (f.entry_a_id, f.entry_b_id)
+            for f in seeded
+            if f.pool_id is None and f.round == 1
+        ]
+        assert round_one
+        for entry_a, entry_b in round_one:
+            assert entry_a is not None and entry_b is not None
+            assert pool_of[entry_a.int] != pool_of[entry_b.int]
+
+    def test_rr_then_ko_a_freshly_cut_draw_is_ready_only_in_its_pools(self) -> None:
+        # At the cut every pool pairing is known and every knockout side is TBD, so the
+        # pool stage materializes at go-live and the bracket waits.
+        cut = self._cut()
+
+        plan = _rr_then_ko(2).advance(cut)
+
+        assert plan.side_fills == ()
+        assert set(plan.ready_fixture_ids) == {
+            f.fixture_id for f in cut if f.pool_id is not None
+        }
+
+    def test_rr_then_ko_refuses_to_order_a_pool_it_cannot_see_the_games_of(
+        self,
+    ) -> None:
+        # THE trap this raise exists for: ``FixtureState.games`` is populated by the ORM
+        # projection, but the materialization seam does not pass game counts yet, so
+        # every fixture reaching advance() carries ``games=None``. Ordering a pool
+        # without them would silently fall back to wins alone and choose different
+        # qualifiers from the standings on screen — with the whole suite still green,
+        # because nothing else reads the field. So it fails loudly instead.
+        gameless = [
+            dataclasses.replace(f, winner_entry_id=f.entry_a_id)
+            if f.pool_id is not None
+            else f
+            for f in self._cut()
+        ]
+
+        with pytest.raises(MissingFixtureGames) as excinfo:
+            _rr_then_ko(2).advance(gameless)
+
+        assert "no game counts" in str(excinfo.value)
+        assert "18 decided pool fixtures" in str(excinfo.value)
+        # Not a DrawError: this is a wiring bug, not something a director can fix by
+        # re-cutting, so it must not be dressed up as a 422.
+        assert not isinstance(excinfo.value, DrawError)
+
+    def test_rr_then_ko_tolerates_one_result_in_flux_among_scored_neighbours(
+        self,
+    ) -> None:
+        # The other side of that raise, and why it is scoped the way it is: a *single*
+        # fixture whose match left ``completed`` (a correction under review) keeps its
+        # written-back winner while its games go away. That is an ordinary live state —
+        # its pool is simply not finished — and must not blow up the whole advance.
+        fixtures = _played(self._cut(), POOL_A_RESULTS)
+        in_flux = [
+            dataclasses.replace(f, games=None)
+            if f.games is not None and f.round == 1 and f.position == 1
+            else f
+            for f in fixtures
+        ]
+
+        plan = _rr_then_ko(2).advance(in_flux)
+
+        assert plan.side_fills == ()

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -201,11 +201,34 @@ class TestOrderEntrants:
 
 class TestStrategyRegistry:
     def test_round_robin_resolves_to_the_round_robin_strategy(self) -> None:
-        assert isinstance(strategy_for(DrawType.round_robin), RoundRobinStrategy)
+        assert isinstance(
+            strategy_for(DrawType.round_robin, qualifiers_per_pool=None),
+            RoundRobinStrategy,
+        )
 
     def test_single_elim_resolves_to_the_single_elim_strategy(self) -> None:
         # The second implemented arm (ADR-0785).
-        assert isinstance(strategy_for(DrawType.single_elim), SingleElimStrategy)
+        assert isinstance(
+            strategy_for(DrawType.single_elim, qualifiers_per_pool=None),
+            SingleElimStrategy,
+        )
+
+    def test_rr_then_ko_resolves_to_the_configured_rr_then_ko_strategy(self) -> None:
+        """The third arm (ADR 20260727) — and the first whose strategy is *configured*:
+        the qualifier count is not a detail of the dispatch, it is what the strategy
+        cuts with, so it is asserted to have arrived rather than merely to have been
+        accepted."""
+        strategy = strategy_for(DrawType.rr_then_ko, qualifiers_per_pool=3)
+
+        assert strategy == RrThenKoStrategy(qualifiers_per_pool=3)
+
+    def test_rr_then_ko_without_a_qualifier_count_refuses_loudly(self) -> None:
+        """A wiring bug, not a director's mistake: the request boundary and the settings
+        table's CHECK both refuse an ``rr-then-ko`` configuration with no count, so the
+        only way here is a caller that dropped the column. Silently defaulting it would
+        cut a bracket for a K nobody chose."""
+        with pytest.raises(ValueError, match="qualifiers_per_pool"):
+            strategy_for(DrawType.rr_then_ko, qualifiers_per_pool=None)
 
     def test_every_draw_type_resolves_to_a_strategy_and_none_refuses(self) -> None:
         """``strategy_for`` is **total** — the enum holds only draw types that run (ADR
@@ -216,9 +239,13 @@ class TestStrategyRegistry:
         without a strategy — alongside the type error the catch-all-free ``match``
         already is. It replaces the old "unimplemented types raise": that refusal has
         no input any more, because Pydantic rejects an un-backed slug at the request
-        boundary instead."""
+        boundary instead.
+
+        Every member is handed a qualifier count, because handing one to a draw type
+        that takes none must be *harmless* — a configuration-free strategy ignores it —
+        while the one that needs it must not be left guessing."""
         for draw_type in DrawType:
-            assert strategy_for(draw_type) is not None
+            assert strategy_for(draw_type, qualifiers_per_pool=2) is not None
 
     def test_the_draw_type_lives_in_exactly_one_place_and_it_is_not_the_config(
         self,

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -7,7 +7,7 @@ point of keeping the strategies pure.
 import dataclasses
 import uuid
 from collections import Counter
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from itertools import combinations
 
@@ -1310,6 +1310,49 @@ def _played(
     return played
 
 
+def _voided(
+    fixtures: Sequence[FixtureState],
+    pairs: Collection[frozenset[int]],
+    *,
+    keep_winner: bool = True,
+) -> list[FixtureState]:
+    """Void the fixtures whose seed pair appears in ``pairs`` — what an account merge's
+    self-play collision leaves behind (ADR-0013): a terminal match that can never
+    produce a result, and therefore no games.
+
+    ``keep_winner`` is the nastier of the two real shapes and the default: the match was
+    **completed first**, so the completion wrote ``winner_entry_id`` back onto the
+    fixture, and voiding does not clear it (``app.match_voiding.void_match`` touches the
+    match and its sides, not the draw). The fixture is left reading *decided, with no
+    games* — which is exactly the shape ``MissingFixtureGames`` fires on for an
+    unvoided fixture, so this is also what pins that guard's exclusion. ``False`` is the
+    other shape: voided before anybody played, no winner ever written.
+    """
+    voided: list[FixtureState] = []
+    for index, fixture in enumerate(fixtures):
+        pair = (
+            frozenset({fixture.entry_a_id.int, fixture.entry_b_id.int})
+            if fixture.entry_a_id is not None and fixture.entry_b_id is not None
+            else None
+        )
+        if pair is None or pair not in pairs:
+            voided.append(fixture)
+            continue
+        voided.append(
+            dataclasses.replace(
+                fixture,
+                match_voided=True,
+                games=None,
+                winner_entry_id=(fixture.entry_a_id if keep_winner else None),
+                # A voided fixture always has a match — voiding is something done TO
+                # one — so it keeps the id ``_played`` gave it, or gets one here if it
+                # was voided without ever being scored.
+                match_id=fixture.match_id or MatchId(uuid.UUID(int=4000 + index)),
+            )
+        )
+    return voided
+
+
 def _lower_seed_wins(
     fixtures: Sequence[FixtureState],
 ) -> dict[frozenset[int], tuple[int, int, int]]:
@@ -1770,3 +1813,87 @@ class TestRrThenKoAdvance:
         plan = _rr_then_ko(2).advance(in_flux)
 
         assert plan.side_fills == ()
+
+    def test_rr_then_ko_finishes_a_pool_holding_a_voided_pairing(self) -> None:
+        # THE claim of the voided-fixture fix: a **voided** pairing can never produce a
+        # result, so it is left OUT of "every fixture carries a score" instead of
+        # counting as a score that never arrives. Requiring it would hold the pool one
+        # outcome short forever — never finished, its qualifiers never seated, the
+        # knockout never ready, nothing a director could do about it — while the
+        # standings, which already exclude voided pairings from a pool's
+        # ``fixture_count``, called that same pool ``complete``.
+        #
+        # And the order is genuinely the one the REMAINING results produce, not a
+        # leftover: played in full, this pool finishes 2, 1, 3, 4 and qualifies {2, 1}
+        # (``CYCLIC_POOL_FINISHING_ORDER``). With 1-v-4 voided, 1 drops to a single win
+        # and 3 rises past it, so the pool finishes 2, 3, 1, 4 and qualifies **{2, 3}**:
+        # a different runner-up, which is what makes this evidence about the ordering
+        # and not just about the seating.
+        cut = _persisted(_rr_then_ko(2).plan_initial(_config(1), _ordered(4)))
+        voided_pair = frozenset({1, 4})
+        played = _played(
+            cut,
+            {
+                pair: result
+                for pair, result in CYCLIC_POOL_RESULTS.items()
+                if pair != voided_pair
+            },
+        )
+        fixtures = _voided(played, {voided_pair})
+
+        plan = _rr_then_ko(2).advance(fixtures)
+
+        assert _knockout_sides(_apply(fixtures, plan)) == {
+            (1, 1, "a"): 2,
+            (1, 1, "b"): 3,
+        }
+
+    def test_rr_then_ko_seats_nobody_out_of_a_pool_whose_every_pairing_was_voided(
+        self,
+    ) -> None:
+        # The floor under the rule above. Skipping voided fixtures cannot become
+        # "finish a pool on no results at all": with nothing to rank on, the tiebreak
+        # chain falls through to its entry-id fallback and would hand back an order that
+        # is arbitrary rather than earned. So the pool is not finished, and nobody is
+        # seated — the one place this deliberately parts company with the standings,
+        # which call such a pool ``complete`` and show a table of zeros.
+        cut = _persisted(_rr_then_ko(2).plan_initial(_config(1), _ordered(4)))
+        fixtures = _voided(cut, set(CYCLIC_POOL_RESULTS))
+
+        plan = _rr_then_ko(2).advance(fixtures)
+
+        assert plan.side_fills == ()
+
+    def test_rr_then_ko_does_not_read_a_voided_pairing_as_a_lost_projection(
+        self,
+    ) -> None:
+        # ``MissingFixtureGames`` fires on "decided, and no games anywhere", and a
+        # completed-then-voided fixture reads exactly like that: voiding takes the match
+        # out of ``completed`` (so the games go away) without clearing the
+        # ``winner_entry_id`` the completion wrote back. Left in the guard's sights, a
+        # single voided pairing in a draw nobody else has scored yet would be a 500.
+        cut = self._cut()
+        fixtures = _voided(cut, {frozenset({1, 6})})
+
+        plan = _rr_then_ko(2).advance(fixtures)
+
+        assert plan.side_fills == (), "pool A has five pairings still to play"
+
+    def test_rr_then_ko_still_refuses_a_lost_projection_beside_a_voided_pairing(
+        self,
+    ) -> None:
+        # The other half: excluding voided fixtures must not blunt the guard. A pool
+        # played out and then projected WITHOUT its game counts still raises, and the
+        # count it reports is the fixtures that should have had games — five of pool A's
+        # six, because the sixth is voided and genuinely has none.
+        played = _played(self._cut(), POOL_A_RESULTS)
+        gameless = [
+            dataclasses.replace(f, games=None) if f.pool_id is not None else f
+            for f in played
+        ]
+        fixtures = _voided(gameless, {frozenset({1, 6})})
+
+        with pytest.raises(MissingFixtureGames) as excinfo:
+            _rr_then_ko(2).advance(fixtures)
+
+        assert "5 decided pool fixtures" in str(excinfo.value)

--- a/api/tests/test_pool_finishing_order.py
+++ b/api/tests/test_pool_finishing_order.py
@@ -1,0 +1,187 @@
+"""Pure tests for the shared pool finishing order (ADR 20260727).
+
+Two properties are pinned here, because both are load-bearing for
+round-robin-then-knockout and neither is observable from ``tests/test_results.py``:
+
+**The module stays importable on its own** — no runtime reach into ``app.results``,
+``app.draws``, SQLAlchemy or FastAPI. That is what lets the *draw* layer call it
+without an import cycle (``app.results`` already imports ``app.draws``).
+
+**The tiebreak chain's order is exactly wins → head-to-head → game difference →
+games won → entry id.** rr-then-ko's whole correctness claim is that the qualifiers
+are the top *K* of the standings table on screen, so a silently reordered chain
+changes who advances. Each test below isolates **one** link: the case is built so
+that link alone separates the pair, and so the *later* links — including the entry-id
+fallback — would give the opposite answer if the link under test were removed.
+"""
+
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import app.pool_finishing_order
+from app.draws import EntryId, PoolId
+from app.pool_finishing_order import MatchOutcome, finishing_order
+from app.results import PoolInput, RoundRobinResults
+
+_API_ROOT = Path(__file__).resolve().parent.parent
+
+# Imported in a *clean* interpreter, then asked what else came along for the ride.
+# The module name is echoed first so a subprocess that silently did nothing cannot
+# masquerade as a pass.
+_PURITY_PROBE = """
+import sys
+
+import app.pool_finishing_order as module
+
+forbidden = ("app.draws", "app.results", "sqlalchemy", "fastapi")
+print(module.__name__)
+print(module.__file__)
+print(",".join(sorted(name for name in forbidden if name in sys.modules)))
+"""
+
+
+def _eid(n: int) -> EntryId:
+    """A stable entry id — ``uuid.UUID(int=n)`` — so the final id tiebreak is a fact
+    of the test, not of ``uuid4``'s luck. Bigger ``n`` sorts later."""
+    return EntryId(uuid.UUID(int=n))
+
+
+def _outcome(
+    first: EntryId, second: EntryId, first_games: int, second_games: int
+) -> MatchOutcome:
+    """One decided fixture: ``first`` took ``first_games`` games, ``second`` took
+    ``second_games``; the winner is whoever took more."""
+    return MatchOutcome(
+        entry_a_id=first,
+        entry_b_id=second,
+        entry_a_games=first_games,
+        entry_b_games=second_games,
+    )
+
+
+def _order(entrants: list[EntryId], outcomes: list[MatchOutcome]) -> list[EntryId]:
+    return [tally.entry_id for tally in finishing_order(entrants, outcomes)]
+
+
+def test_the_shared_module_imports_no_layer_that_imports_it() -> None:
+    """The no-cycle property, guarded.
+
+    ``app.pool_finishing_order`` exists so that **both** ``app.results`` and
+    ``app.draws`` can reach one definition of how a pool finished. ``app.results``
+    already imports ``app.draws``, so the moment this module imports either of them
+    at runtime the draw layer's use of it becomes an import cycle — and the
+    ``TYPE_CHECKING`` guard on ``EntryId`` is the only thing preventing that today.
+    SQLAlchemy and FastAPI are checked too: this module must stay pure enough to run
+    in a REPL or a script with no app wiring.
+
+    **The subprocess is load-bearing.** Asserting inside the test process is
+    worthless — pytest has already imported ``app.results``, SQLAlchemy and FastAPI
+    via ``conftest`` before this line runs, so ``sys.modules`` would show them no
+    matter what this module does. Only a fresh interpreter can answer the question.
+    """
+    probe = subprocess.run(
+        [sys.executable, "-c", _PURITY_PROBE],
+        capture_output=True,
+        text=True,
+        cwd=_API_ROOT,
+    )
+    assert probe.returncode == 0, probe.stderr
+    imported_name, imported_file, leaked = probe.stdout.splitlines()
+    # Provenance: the subprocess imported *this* worktree's module, not some other
+    # copy on the path — otherwise a green result is about the wrong artifact.
+    assert imported_name == "app.pool_finishing_order"
+    assert imported_file == app.pool_finishing_order.__file__
+    assert leaked == "", f"pool_finishing_order pulled in {leaked} at import time"
+
+
+def test_game_difference_outranks_games_won() -> None:
+    """Game difference is the **third** link and games won the fourth, in that order.
+
+    X and Y are level on wins (1 each) in a three-way group, so head-to-head is not
+    consulted. X has the better game difference (+3 vs +1) and Y the better games-won
+    (5 vs 3), so the two comparators disagree and only their *order* decides. The ids
+    disagree as well — ascending id would be Z, Y, W, X — so the deterministic
+    fallback cannot be producing this answer by luck.
+
+        X beat W 3-0   → X: 1-0, GW 3, GL 0, GD +3
+        Y beat Z 3-1   ┐
+        W beat Y 3-2   ┴ Y: 1-1, GW 5, GL 4, GD +1;  W: 1-1, GW 3, GL 5, GD -2
+                         Z: 0-1, GW 1, GL 3, GD -2
+    """
+    x, y, w, z = _eid(9), _eid(2), _eid(5), _eid(1)
+    outcomes = [_outcome(x, w, 3, 0), _outcome(y, z, 3, 1), _outcome(w, y, 3, 2)]
+
+    # Game difference first: X (+3), Y (+1), W (-2). Were games won tried first it
+    # would be Y (5), X (3), W (3).
+    assert _order([w, x, y, z], outcomes) == [x, y, w, z]
+
+
+def test_head_to_head_outranks_the_game_tiebreakers_for_a_tied_pair() -> None:
+    """Head-to-head is the **second** link, ahead of both game tiebreakers.
+
+    P and Q are the only entries on 1 win, so the group is exactly two and they have
+    met. Q is ahead of P on game difference (+2 vs +1), on games won (5 vs 3) *and*
+    on entry id (3 vs 8) — every later link says Q. P is above Q solely because P
+    beat Q, so dropping the head-to-head flips the pair.
+
+        P beat Q 3-2   → P: 1-0, GW 3, GL 2, GD +1
+        Q beat R 3-0   → Q: 1-1, GW 5, GL 3, GD +2;  R: 0-1, GW 0, GL 3
+    """
+    p, q, r = _eid(8), _eid(3), _eid(1)
+    outcomes = [_outcome(p, q, 3, 2), _outcome(q, r, 3, 0)]
+
+    assert _order([p, q, r], outcomes) == [p, q, r]
+
+
+def test_a_three_way_tie_is_not_broken_head_to_head() -> None:
+    """The head-to-head link applies to a pair and **only** a pair.
+
+    A beat B, B beat C, C beat A — a cycle, so there is no head-to-head answer to
+    have. All three are identical on wins, game difference and games won, so the
+    order falls all the way through to the entry id.
+    """
+    a, b, c = _eid(2), _eid(5), _eid(7)
+    outcomes = [_outcome(a, b, 3, 1), _outcome(b, c, 3, 1), _outcome(c, a, 3, 1)]
+
+    assert _order([c, b, a], outcomes) == [a, b, c]
+
+
+def test_the_entry_id_is_the_final_deterministic_tiebreak() -> None:
+    """Entries level on every count still order the same way on every read.
+
+    The same cyclic pool as above, all three on 1-1 with GD 0 and 4 games won, fed in
+    **descending** id order. Python's sort is stable, so without the id fallback the
+    result would simply be the input order — the assertion is that it is the reverse.
+    """
+    a, b, c = _eid(2), _eid(5), _eid(7)
+    outcomes = [_outcome(a, b, 3, 1), _outcome(b, c, 3, 1), _outcome(c, a, 3, 1)]
+
+    fed_in = [c, b, a]
+    assert _order(fed_in, outcomes) == list(reversed(fed_in))
+
+
+def test_the_standings_table_is_this_order() -> None:
+    """The standings a director reads *are* the shared finishing order.
+
+    This is the claim rr-then-ko's qualifiers rest on: the top *K* of a pool is the
+    top *K* of the table on screen, because ``RoundRobinResults`` ranks by nothing
+    else. Asserting the two agree keeps the standings from acquiring a private
+    tiebreak of their own.
+    """
+    x, y, w, z = _eid(9), _eid(2), _eid(5), _eid(1)
+    entrants = [w, x, y, z]
+    outcomes = [_outcome(x, w, 3, 0), _outcome(y, z, 3, 1), _outcome(w, y, 3, 2)]
+    pool = PoolInput(
+        pool_id=PoolId("pool-a"),
+        entrants=tuple(entrants),
+        fixture_count=6,
+        outcomes=tuple(outcomes),
+    )
+
+    results = RoundRobinResults().tabulate([pool])
+
+    rows = results.pools[0].rows
+    assert [row.entry_id for row in rows] == _order(entrants, outcomes)
+    assert [row.rank for row in rows] == [1, 2, 3, 4]

--- a/api/tests/test_results.py
+++ b/api/tests/test_results.py
@@ -73,6 +73,11 @@ def test_results_for_returns_the_single_elim_strategy() -> None:
     assert isinstance(results_for(DrawType.single_elim), SingleElimResults)
 
 
+def test_results_for_returns_the_rr_then_ko_strategy() -> None:
+    """The third arm (ADR 20260727) — a two-stage event reads out as both blocks."""
+    assert isinstance(results_for(DrawType.rr_then_ko), RrThenKoResults)
+
+
 def test_every_draw_type_reads_out_and_none_refuses() -> None:
     """``results_for`` is **total** — the enum holds only draw types that run (ADR "a
     draw type is a seeded row, and the enum holds only what runs"), so every member has

--- a/api/tests/test_results.py
+++ b/api/tests/test_results.py
@@ -1,4 +1,5 @@
-"""Pure tests for the results strategies (ADR-0788 round-robin, ADR-0785 single-elim).
+"""Pure tests for the results strategies (ADR-0788 round-robin, ADR-0785 single-elim,
+ADR 20260727 round-robin-then-knockout).
 
 No database: ``app.results`` is pure, so every rule about how a pool stands or a bracket
 finishes is exercised against literal :class:`~app.results.MatchOutcome` /
@@ -17,6 +18,7 @@ from app.results import (
     MatchOutcome,
     PoolInput,
     RoundRobinResults,
+    RrThenKoResults,
     SingleElimResults,
     results_for,
 )
@@ -28,7 +30,7 @@ def _eid(n: int) -> EntryId:
     return EntryId(uuid.UUID(int=n))
 
 
-A, B, C, D = _eid(1), _eid(2), _eid(3), _eid(4)
+A, B, C, D, E, F = (_eid(n) for n in range(1, 7))
 
 
 def _outcome(
@@ -401,3 +403,187 @@ def test_a_corrected_final_re_crowns_the_champion() -> None:
     after = SingleElimResults().tabulate([_bracket_match(1, B, A)])
     assert after.champion == B
     assert {row.entry_id: row.position for row in after.finishes} == {B: 1, A: 2}
+
+
+# ----- round-robin then knockout: both stages at once (ADR 20260727) ----------
+#
+# The two-stage event every test below reads (except the single-pool one) is the same
+# one, at different moments:
+#
+#   pool P (A, B, C) and pool Q (D, E, F), K = 2 qualifiers each → a 4-slot bracket.
+#   Both pools are won on a clean sweep: A beats B and C, B beats C  → A, B, C;
+#                                        D beats E and F, E beats F  → D, E, F.
+#   So the qualifiers are A and B out of P, D and E out of Q.
+#   Semifinals (round 1): A beats E, B beats D.   Final (round 2): **B beats A**.
+#
+# B is deliberately pool P's *runner-up*: the champion of this event is neither pool's
+# leader, which is the whole point — a champion read off the standings would name A
+# (or nobody, since a multi-pool round-robin crowns none), never B.
+
+_POOL_P = PoolInput(
+    pool_id=PoolId("p-p"),
+    entrants=(A, B, C),
+    fixture_count=3,
+    outcomes=(
+        MatchOutcome(entry_a_id=A, entry_b_id=B, entry_a_games=2, entry_b_games=0),
+        MatchOutcome(entry_a_id=A, entry_b_id=C, entry_a_games=2, entry_b_games=0),
+        MatchOutcome(entry_a_id=B, entry_b_id=C, entry_a_games=2, entry_b_games=0),
+    ),
+)
+_POOL_Q = PoolInput(
+    pool_id=PoolId("p-q"),
+    entrants=(D, E, F),
+    fixture_count=3,
+    outcomes=(
+        MatchOutcome(entry_a_id=D, entry_b_id=E, entry_a_games=2, entry_b_games=0),
+        MatchOutcome(entry_a_id=D, entry_b_id=F, entry_a_games=2, entry_b_games=0),
+        MatchOutcome(entry_a_id=E, entry_b_id=F, entry_a_games=2, entry_b_games=0),
+    ),
+)
+
+
+def _part_played(pool: PoolInput) -> PoolInput:
+    """The same pool with only its first fixture decided — a live, mid-pool table."""
+    return PoolInput(
+        pool_id=pool.pool_id,
+        entrants=pool.entrants,
+        fixture_count=pool.fixture_count,
+        outcomes=pool.outcomes[:1],
+    )
+
+
+#: The bracket as cut: two semifinals and a final, every side TBD, nobody qualified yet.
+_UNPLAYED_BRACKET = [_bracket_tbd(1), _bracket_tbd(1), _bracket_tbd(2)]
+#: Both semifinals decided (A beat E, B beat D), the final still to play.
+_SEMIS_ONLY = [_bracket_match(1, A, E), _bracket_match(1, B, D), _bracket_tbd(2)]
+#: The whole knockout stage: B beats A in the final.
+_FULL_BRACKET = [*_SEMIS_ONLY[:2], _bracket_match(2, B, A)]
+
+
+def test_rr_then_ko_reads_out_both_stages_in_one_tabulation() -> None:
+    """The headline claim: **one** tabulation returns the pool stage's standings *and*
+    the knockout stage's finishes.
+
+    Both pools stand exactly as a round-robin's do (A, B, C and D, E, F), and the
+    bracket places exactly as a single-elim's do — champion B (1), runner-up A (2), the
+    two semifinal losers D and E tied 3rd. C and F never qualified, so they hold a
+    standings row and **no finish**: a knockout finish is a fact about the bracket, not
+    about the event's field."""
+    results = RrThenKoResults().tabulate([_POOL_P, _POOL_Q], _FULL_BRACKET)
+
+    assert [pool.pool_id for pool in results.pools] == [PoolId("p-p"), PoolId("p-q")]
+    assert [[row.entry_id for row in pool.rows] for pool in results.pools] == [
+        [A, B, C],
+        [D, E, F],
+    ]
+    assert {row.entry_id: row.position for row in results.finishes} == {
+        B: 1,
+        A: 2,
+        D: 3,
+        E: 3,
+    }
+
+
+def test_rr_then_ko_champion_is_the_bracket_winner_not_the_pool_leader() -> None:
+    """The champion comes from the **bracket**, never from a pool (CONTEXT.md,
+    "Champion").
+
+    Every pool is won by somebody else: P by A, Q by D. B — P's *runner-up* — wins the
+    knockout, so B is the event's champion. A champion read off the standings would
+    name A or D (or ``None``, which is what a multi-pool round-robin crowns); only
+    reading the final's winner names B."""
+    results = RrThenKoResults().tabulate([_POOL_P, _POOL_Q], _FULL_BRACKET)
+
+    assert results.champion == B
+    pool_leaders = [pool.rows[0].entry_id for pool in results.pools]
+    assert pool_leaders == [A, D]
+    assert results.champion not in pool_leaders
+
+
+def test_rr_then_ko_with_pools_part_played_stands_live_with_no_finishes() -> None:
+    """Pools mid-play, nobody qualified: the standings are live and partial, the bracket
+    is cut but empty.
+
+    Only A–B has been played in each pool, so every seated entrant still has a row (C
+    and F on zeros) and neither pool is complete. No knockout fixture is decided, so
+    there are no finishes, no champion, and the event is not complete."""
+    results = RrThenKoResults().tabulate(
+        [_part_played(_POOL_P), _part_played(_POOL_Q)], _UNPLAYED_BRACKET
+    )
+
+    assert [len(pool.rows) for pool in results.pools] == [3, 3]
+    assert [pool.complete for pool in results.pools] == [False, False]
+    assert results.finishes == ()
+    assert results.champion is None
+    assert results.complete is False
+
+
+def test_rr_then_ko_with_the_bracket_part_played_has_finishes_but_no_champion() -> None:
+    """Pools decided, knockout mid-flight: standings complete, finishes partial, still
+    no champion.
+
+    Both semifinals are in (A beat E, B beat D) but the final is not, so D and E are
+    placed — tied 3rd, measured from the final round the TBD final fixes — while A and B
+    are still alive and have no finish at all. The champion is the final's winner, so it
+    is ``None`` until that final is decided, and the event is not complete."""
+    results = RrThenKoResults().tabulate([_POOL_P, _POOL_Q], _SEMIS_ONLY)
+
+    assert [pool.complete for pool in results.pools] == [True, True]
+    assert {row.entry_id: row.position for row in results.finishes} == {D: 3, E: 3}
+    assert results.champion is None
+    assert results.complete is False
+
+
+def test_rr_then_ko_is_complete_only_when_both_stages_are() -> None:
+    """``complete`` is **both stages decided**, asserted separately.
+
+    Three states of the same event: pools decided and the bracket mid-flight → not
+    complete; the bracket decided while a pool is not → **not complete either**, even
+    though the champion is already known, because the pool stage this shape was handed
+    has not finished; both decided → complete. (The middle state is unreachable
+    through ``RrThenKoStrategy``, which seats nobody out of an unfinished pool — which
+    is exactly why ``complete`` must not lean on that invariant to hold.)"""
+    pools_only = RrThenKoResults().tabulate([_POOL_P, _POOL_Q], _SEMIS_ONLY)
+    assert pools_only.complete is False
+
+    bracket_only = RrThenKoResults().tabulate(
+        [_part_played(_POOL_P), _POOL_Q], _FULL_BRACKET
+    )
+    assert bracket_only.champion == B, "the knockout stage did finish"
+    assert bracket_only.complete is False, "but a pool has not, so the event has not"
+
+    both = RrThenKoResults().tabulate([_POOL_P, _POOL_Q], _FULL_BRACKET)
+    assert both.complete is True
+
+
+def test_rr_then_ko_with_a_single_pool_is_a_league_then_a_playoff() -> None:
+    """One pool is legal (ADR 20260727) — a league, then a playoff — and it reads out
+    like any other two-stage event.
+
+    A four-player pool, all six fixtures played on clean sweeps → A, B, C, D. The top
+    two qualify and meet in a one-fixture bracket, where **B beats A**. So the league
+    leader is A and the champion is B: the pool stage seeds the playoff, it does not win
+    it. (This is the case a pool-derived champion gets *wrong* rather than empty — a
+    complete single-pool round-robin does crown its leader, and that leader is A.)"""
+    pool = _single_pool(
+        (A, B, C, D),
+        fixture_count=6,
+        outcomes=[
+            _outcome(A, B, 2, 0),
+            _outcome(A, C, 2, 0),
+            _outcome(A, D, 2, 0),
+            _outcome(B, C, 2, 0),
+            _outcome(B, D, 2, 0),
+            _outcome(C, D, 2, 0),
+        ],
+    )
+    results = RrThenKoResults().tabulate([pool], [_bracket_match(1, B, A)])
+
+    (standings,) = results.pools
+    assert [row.entry_id for row in standings.rows] == [A, B, C, D]
+    assert RoundRobinResults().tabulate([pool]).champion == A, (
+        "the pool stage on its own would crown its leader"
+    )
+    assert results.champion == B, "but the event's champion is the playoff's winner"
+    assert {row.entry_id: row.position for row in results.finishes} == {B: 1, A: 2}
+    assert results.complete is True

--- a/api/tests/test_rr_then_ko.py
+++ b/api/tests/test_rr_then_ko.py
@@ -617,8 +617,9 @@ async def test_the_qualifier_count_is_frozen_once_the_draw_is_cut(
 
     The bracket is cut upfront for ``P × K`` and qualifiers are seated into
     predetermined slots. A bracket cut at K=2 and then advanced at K=3 would leave
-    three pools' worth of thirds with nowhere to sit: ``advance()`` seats the five it
-    finds slots for and raises nothing. Re-sending the SAME configuration is not a
+    three pools' worth of thirds with nowhere to sit — which past this refusal is a
+    ``MissingBracketSlot`` (a 500 nobody can act on), so the 409 is what makes it a
+    sentence a director can. Re-sending the SAME configuration is not a
     change and is allowed, which is what makes this a freeze on the edit rather than on
     the key being present.
     """

--- a/api/tests/test_rr_then_ko.py
+++ b/api/tests/test_rr_then_ko.py
@@ -42,6 +42,7 @@ from app.models import (
     TournamentStatus,
     User,
 )
+from app.schemas.tournament import MAX_QUALIFIERS_PER_POOL
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import (
     grant_permissions,
@@ -338,6 +339,112 @@ async def test_a_qualifier_count_below_one_is_422(
 
     assert response.status_code == 422, response.text
     assert "qualifiers_per_pool" in response.text
+
+
+# The other end of the same static bound. ``INT32_OVERFLOW`` is the number that made
+# this a defect rather than a nicety: it is one past what the ``Integer`` column holds,
+# so before the ceiling it reached the driver and came back a **500** — and the client's
+# generic error copy then told the organizer "nothing you did caused it", which was
+# false. ``MAX_QUALIFIERS_PER_POOL + 1`` is the quieter half: storable, so it answered
+# ``201 Created`` and left an event whose draw could never be cut.
+INT32_OVERFLOW = 2_147_483_648
+
+
+@pytest.mark.parametrize("count", [MAX_QUALIFIERS_PER_POOL + 1, INT32_OVERFLOW])
+async def test_a_qualifier_count_above_the_ceiling_is_422(
+    authed_client: tuple[AsyncClient, User], count: int, db_session: AsyncSession
+) -> None:
+    """**422, and specifically not 500.** The status is the whole assertion: an
+    unbounded K let a form value walk past the boundary into the column.
+
+    The ceiling is not the domain rule — K can never exceed the smallest pool's size in
+    a real event, and the cut already refuses that by name (``DegenerateDraw``). This is
+    the boundary refusing counts that are nonsense on their face, and it belongs here
+    because the alternative was a crash the organizer was told they had not caused.
+    """
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    response = await _create_event(client, tournament_id, qualifiers_per_pool=count)
+
+    assert response.status_code == 422, response.text
+    assert "qualifiers_per_pool" in response.text
+    # Refused at the boundary means refused before persistence.
+    events = (
+        await db_session.execute(
+            select(TournamentEvent).where(
+                TournamentEvent.tournament_id == uuid.UUID(tournament_id)
+            )
+        )
+    ).scalars()
+    assert list(events) == []
+
+
+async def test_a_qualifier_count_at_the_ceiling_is_accepted(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The bound is **inclusive**, and it is pinned so the refusal above cannot be
+    satisfied by an off-by-one that also refuses the last legal number.
+
+    A K of 1000 is absurd for a real pool and the cut will say so when the field is
+    known. That is deliberately not this layer's call: a configuration legal when it was
+    written must not depend on who has entered yet."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    created = await _create_event(
+        client, tournament_id, qualifiers_per_pool=MAX_QUALIFIERS_PER_POOL
+    )
+
+    assert created.status_code == 201, created.text
+    event = await _settings_of(db_session, created.json()["id"])
+    assert event.draw_settings.qualifiers_per_pool == MAX_QUALIFIERS_PER_POOL
+
+
+@pytest.mark.parametrize("count", [MAX_QUALIFIERS_PER_POOL + 1, INT32_OVERFLOW])
+async def test_patching_a_qualifier_count_above_the_ceiling_is_422(
+    authed_client: tuple[AsyncClient, User], count: int, db_session: AsyncSession
+) -> None:
+    """The patch schema shares the create schema's alias, so both verbs hold the same
+    ceiling. Asserted rather than assumed: a value create refuses but PATCH accepts
+    defeats create's boundary entirely — the event is born small and then edited into
+    the 500."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id)).json()["id"]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={"draw_type": RR_THEN_KO, "qualifiers_per_pool": count},
+    )
+
+    assert response.status_code == 422, response.text
+    assert "qualifiers_per_pool" in response.text
+    event = await _settings_of(db_session, event_id)
+    assert event.draw_settings.qualifiers_per_pool == 2, "a refusal wrote nothing"
+
+
+async def test_patching_a_qualifier_count_at_the_ceiling_is_accepted(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The inclusive half of the bound on the patch verb, for the same reason as on
+    create: a ceiling that also refused the last legal number would satisfy every
+    refusal test above."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id)).json()["id"]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={
+            "draw_type": RR_THEN_KO,
+            "qualifiers_per_pool": MAX_QUALIFIERS_PER_POOL,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    event = await _settings_of(db_session, event_id)
+    assert event.draw_settings.qualifiers_per_pool == MAX_QUALIFIERS_PER_POOL
 
 
 async def test_patching_a_qualifier_count_without_its_draw_type_is_422(

--- a/api/tests/test_rr_then_ko.py
+++ b/api/tests/test_rr_then_ko.py
@@ -30,8 +30,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import match_calls
+from app.match_voiding import void_match
 from app.models import (
     DrawType,
+    Match,
     Tournament,
     TournamentEntry,
     TournamentEntryStatus,
@@ -773,6 +775,129 @@ async def test_a_finished_pool_seats_its_qualifiers_into_the_bracket(
         # Nothing is ready to play: every knockout fixture still has a TBD side, so none
         # of them materialized into a match.
         assert all(f.match_id is None for f in bracket)
+
+
+async def test_a_pool_holding_a_voided_pairing_still_seats_its_qualifiers(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """**A voided pairing must not wedge the event.**
+
+    The same twelve entrants, the same pool A, and the same five scorelines as the
+    test above — except that pool A's sixth pairing (6 v 12) is played and then
+    **voided**, which is what an account merge's self-play collision does to a match
+    that has already been scored (ADR-0013). Voiding takes it out of ``completed`` (so
+    its games go away) but leaves the ``winner_entry_id`` the completion wrote back on
+    the fixture, so the fixture reads *decided, with no games* forever.
+
+    Before the fix, "a pool is finished when every fixture carries a score" counted
+    that pairing, so pool A sat one score short of finishing **permanently**: its
+    qualifiers were never seated, the knockout never became ready, no champion was ever
+    crowned, and there was nothing a director could do about it. Meanwhile the
+    standings — which already exclude voided pairings from a pool's ``fixture_count`` —
+    showed that very pool ``complete``. Two layers disagreeing about whether the pool
+    was over.
+
+    **The runner-up flips, which is what makes this evidence about the ordering.** With
+    6 v 12 counted, 6, 7 and 12 form a beat-cycle on one win apiece and game difference
+    seats **7**. With it voided, 6 and 7 are a plain two-way tie that head-to-head
+    settles for **6**: a different qualifier, reachable only by ordering the pool on
+    the results that survive. And it is asserted against the standings table read back
+    off the tournament payload rather than against a hardcoded pair, so "the qualifiers
+    are the top of the table a director is reading" is checked, not assumed.
+    """
+    client, owner = authed_client
+    async with (
+        opponent_session(db_session, "void-b") as (client_b, user_b),
+        opponent_session(db_session, "void-c") as (client_c, user_c),
+        opponent_session(db_session, "void-d") as (client_d, user_d),
+    ):
+        tournament_id = await _tournament(client)
+        event_id = (await _create_event(client, tournament_id)).json()["id"]
+        players = {1: owner, 6: user_b, 7: user_c, 12: user_d}
+        entries: dict[int, TournamentEntry] = {}
+        for seed in range(1, 13):
+            user = players.get(seed) or await make_user(db_session, f"voidextra{seed}")
+            entries[seed] = await _enter(
+                db_session, event_id, user, seed=seed, minutes=seed
+            )
+        assert (await _cut(client, tournament_id, event_id)).status_code == 201
+        await _set_status(db_session, tournament_id, TournamentStatus.published)
+        assert (
+            await client.post(
+                f"/v1/tournaments/{tournament_id}/transitions", json={"to": "live"}
+            )
+        ).status_code == 201
+
+        pool_a = [
+            f for f in await _fixtures(db_session, event_id) if f.pool_id == "p-a"
+        ]
+        await _call(db_session, tournament_id, pool_a)
+        pool_a = [
+            f for f in await _fixtures(db_session, event_id) if f.pool_id == "p-a"
+        ]
+        clients = {
+            entries[1].id: client,
+            entries[6].id: client_b,
+            entries[7].id: client_c,
+            entries[12].id: client_d,
+        }
+        by_pair = {frozenset({f.entry_a_id, f.entry_b_id}): f for f in pool_a}
+
+        def fixture_between(a: int, b: int) -> TournamentFixture:
+            return by_pair[frozenset({entries[a].id, entries[b].id})]
+
+        # Played first, so the completion writes a winner back onto the fixture — then
+        # voided, which strands that winner with no games. The nastiest of the two real
+        # shapes, and the one a naive "decided but gameless" check mistakes for a
+        # projection that forgot to load its game counts.
+        collision = fixture_between(6, 12)
+        await _win(
+            collision,
+            clients_by_entry=clients,
+            winner_entry_id=entries[12].id,
+            games=(2, 0),
+        )
+        match = await db_session.get(Match, collision.match_id)
+        assert match is not None
+        await void_match(db_session, match)
+        await db_session.commit()
+
+        for winner, loser, games in (
+            (1, 6, (2, 1)),
+            (1, 7, (2, 0)),
+            (1, 12, (2, 0)),
+            (6, 7, (2, 1)),
+            (7, 12, (2, 0)),
+        ):
+            await _win(
+                fixture_between(winner, loser),
+                clients_by_entry=clients,
+                winner_entry_id=entries[winner].id,
+                games=games,
+            )
+
+        results = (await _event_read(client, tournament_id))["results"]
+
+    bracket = [f for f in await _fixtures(db_session, event_id) if f.pool_id is None]
+    seated = {
+        entry_id
+        for f in bracket
+        for entry_id in (f.entry_a_id, f.entry_b_id)
+        if entry_id is not None
+    }
+    assert seated == {entries[1].id, entries[6].id}, (
+        "the pool finished on the five results that survived the void, and seated the "
+        "two the surviving results put on top — 6, not the 7 the beat-cycle would have"
+    )
+    # And the two layers agree, which is the whole point: the pool the bracket treated
+    # as over is the pool the director's table calls ``complete``, and the qualifiers
+    # are its top two rows.
+    (pool_a_read,) = [pool for pool in results["pools"] if pool["pool_id"] == "p-a"]
+    assert pool_a_read["complete"] is True
+    assert [row["entry_id"] for row in pool_a_read["rows"][:2]] == [
+        str(entries[1].id),
+        str(entries[6].id),
+    ]
 
 
 async def test_the_results_read_out_as_both_stages(

--- a/api/tests/test_rr_then_ko.py
+++ b/api/tests/test_rr_then_ko.py
@@ -403,6 +403,116 @@ async def test_patching_away_from_rr_then_ko_clears_the_qualifier_count(
     assert event.draw_settings.qualifiers_per_pool is None
 
 
+# ----- the read: the stored qualifier count comes back ------------------------------
+#
+# The event read carries ``qualifiers_per_pool`` beside ``draw_type`` because the
+# configuration is edited as a PAIR: the editor always sends the draw type, and the
+# server parses ``(draw_type, K)`` together with K required and no default. A client
+# that cannot read K back has to supply one on every PATCH — which pre-draw silently
+# overwrites the director's number and post-draw trips the freeze with a 409 for an edit
+# nobody made. So "the number the director chose survives a round trip" is the claim,
+# and it is asserted on all three shaping paths (create, detail GET, patch), which are
+# three call sites of one serializer and would otherwise be free to drift.
+
+
+async def test_an_rr_then_ko_events_qualifier_count_reads_back(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """Created with K=3, read back as 3 — and 3 is what the settings row holds.
+
+    The stored column is asserted alongside the two response bodies on purpose: a read
+    that echoed the *request* would satisfy the wire assertions while the cut used some
+    other number, which is the failure the wire alone cannot see.
+    """
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    created = await _create_event(client, tournament_id, qualifiers_per_pool=3)
+
+    assert created.status_code == 201, created.text
+    assert created.json()["qualifiers_per_pool"] == 3
+    assert (await _event_read(client, tournament_id))["qualifiers_per_pool"] == 3
+    event = await _settings_of(db_session, created.json()["id"])
+    assert event.draw_settings.qualifiers_per_pool == 3
+
+
+@pytest.mark.parametrize("draw_type", ["round-robin", "single-elim"])
+async def test_a_draw_type_with_no_knockout_stage_reads_back_no_qualifier_count(
+    authed_client: tuple[AsyncClient, User], draw_type: str
+) -> None:
+    """``null``, and the key is **present**.
+
+    The other side of the pairing, and it has to be asserted or the read is one-sided:
+    a field hard-wired to the requested K, or defaulted to some convention, would pass
+    the rr-then-ko test above and quietly tell a director that their round-robin
+    advances two per pool — a configuration the settings table's ``CHECK`` says cannot
+    exist. Both of the count-less draw types are asked, because a read keyed off a
+    single slug would look right on a one-slug test.
+
+    ``in`` before the value, so "the field vanished from the response" reds as itself
+    rather than as ``KeyError`` — the client distinguishes *absent* (an older server)
+    from *null* (this draw type takes no count).
+    """
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    payload = _event_payload(draw_type=draw_type, pools=[])
+    del payload["qualifiers_per_pool"]
+
+    created = await client.post(f"/v1/tournaments/{tournament_id}/events", json=payload)
+
+    assert created.status_code == 201, created.text
+    assert "qualifiers_per_pool" in created.json()
+    assert created.json()["qualifiers_per_pool"] is None
+    read = await _event_read(client, tournament_id)
+    assert "qualifiers_per_pool" in read
+    assert read["qualifiers_per_pool"] is None
+
+
+async def test_editing_the_qualifier_count_reads_the_edited_value_back(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """The round trip the editor actually runs: PATCH the pair, and the response the
+    form re-seeds itself from carries the K just written — not the one it replaced.
+
+    The edited event is reloaded and reprojected by a *different* shaping path than the
+    create, so it gets its own assertion; a read wired only into the create path would
+    hand the editor a stale number the moment the director changed it.
+    """
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id)).json()["id"]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={"draw_type": RR_THEN_KO, "qualifiers_per_pool": 4},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["qualifiers_per_pool"] == 4
+    assert (await _event_read(client, tournament_id))["qualifiers_per_pool"] == 4
+
+
+async def test_patching_away_from_rr_then_ko_reads_back_no_qualifier_count(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """The clear is visible on the wire too. ``configure`` writes both columns together,
+    so the count goes NULL when the draw type moves — and the editor has to *see* that,
+    or it re-sends the count it still believes in and gets a 422 for a round-robin event
+    carrying a K."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id)).json()["id"]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={"draw_type": "round-robin"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["qualifiers_per_pool"] is None
+    assert (await _event_read(client, tournament_id))["qualifiers_per_pool"] is None
+
+
 # ----- the cut: both stages in one stroke -------------------------------------------
 
 

--- a/api/tests/test_rr_then_ko.py
+++ b/api/tests/test_rr_then_ko.py
@@ -1,0 +1,734 @@
+"""Round-robin then knockout, end to end (#1227, ADR "rr-then-ko cuts both stages
+upfront and seeds qualifiers rematch-free").
+
+The draw strategy, the results strategy and the qualifier-seed assignment are pure and
+are tested from literals in ``test_draws.py`` / ``test_results.py``. What this file
+tests is everything *between* them and a director: the request boundary that admits a
+qualifier count for exactly one draw type, the settings row it lands on, the freeze that
+holds it still once a draw exists, the cut that emits both stages, the seam that seats a
+finished pool's qualifiers into the bracket, and the results block the tournament-detail
+page reads back.
+
+The load-bearing one is
+``test_a_finished_pool_seats_its_qualifiers_into_the_bracket``. Qualification is
+decided by the same tiebreak chain the standings are ordered by, which means the seam
+has to hand ``advance()`` the fixtures' **game counts**; the projection
+did not load them, so every fixture arrived with ``games=None`` and the strategy refused
+(``MissingFixtureGames``). Nothing else in the suite reads that field, so nothing else
+would have noticed. That test is green only when real game counts flow through the seam.
+"""
+
+import uuid
+from collections.abc import AsyncIterator, Sequence
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import match_calls
+from app.models import (
+    DrawType,
+    Tournament,
+    TournamentEntry,
+    TournamentEntryStatus,
+    TournamentEvent,
+    TournamentFixture,
+    TournamentStatus,
+    User,
+)
+from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
+from tests._helpers import (
+    grant_permissions,
+    make_user,
+    opponent_session,
+    start_session,
+)
+
+RR_THEN_KO = DrawType.rr_then_ko.value
+
+POOLS: list[dict[str, Any]] = [
+    {
+        "id": f"p-{letter}",
+        "name": f"Pool {letter.upper()}",
+        "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+        "table_ids": ["t1"],
+    }
+    for letter in ("a", "b", "c")
+]
+
+
+@pytest_asyncio.fixture
+async def authed_client(
+    api_client: AsyncClient, db_session: AsyncSession
+) -> AsyncIterator[tuple[AsyncClient, User]]:
+    user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, (TOURNAMENT_VIEW, TOURNAMENT_CREATE))
+    yield api_client, user
+
+
+def _tournament_payload() -> dict[str, Any]:
+    return {
+        "name": "Pools then Bracket Open",
+        "address": {
+            "venue": "Berkeley TT Club",
+            "street": "2727 Milvia St",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94703",
+            "country": "USA",
+        },
+        "table_catalogue": [{"id": "t1", "label": "Table 1", "court": "A"}],
+    }
+
+
+def _event_payload(**overrides: Any) -> dict[str, Any]:
+    """An ``rr-then-ko`` event over three pools, taking the top 2 out of each.
+
+    Best-of-3 and **unrated** by default: an unrated match self-accepts on the
+    proposal, so playing a pool out needs one request per match instead of two, and
+    nothing here is about the rating pipeline.
+    """
+    payload: dict[str, Any] = {
+        "name": "Open Singles",
+        "format": "singles",
+        "draw_type": RR_THEN_KO,
+        "qualifiers_per_pool": 2,
+        "max_players": 64,
+        "entry_fee": 0,
+        "timezone": "America/Chicago",
+        "slot": {"date": "2026-06-13", "start": "09:00", "end": "18:00"},
+        "match_settings": {"rated": False, "length_games": 3},
+        "predicates": [],
+        "pools": list(POOLS),
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def _tournament(client: AsyncClient) -> str:
+    created = await client.post("/v1/tournaments", json=_tournament_payload())
+    assert created.status_code == 201, created.text
+    tournament_id: str = created.json()["id"]
+    return tournament_id
+
+
+async def _create_event(
+    client: AsyncClient, tournament_id: str, **overrides: Any
+) -> Any:
+    return await client.post(
+        f"/v1/tournaments/{tournament_id}/events", json=_event_payload(**overrides)
+    )
+
+
+async def _enter(
+    db: AsyncSession, event_id: str, user: User, *, seed: int, minutes: int
+) -> TournamentEntry:
+    entry = TournamentEntry(
+        event_id=uuid.UUID(event_id),
+        user_id=user.id,
+        status=TournamentEntryStatus.entered,
+        seed=seed,
+        created_at=datetime(2026, 6, 1, 9, 0, tzinfo=UTC) + timedelta(minutes=minutes),
+    )
+    db.add(entry)
+    await db.commit()
+    return entry
+
+
+async def _cut(client: AsyncClient, tournament_id: str, event_id: str) -> Any:
+    return await client.post(f"/v1/tournaments/{tournament_id}/events/{event_id}/draw")
+
+
+async def _fixtures(db: AsyncSession, event_id: str) -> list[TournamentFixture]:
+    return list(
+        (
+            await db.execute(
+                select(TournamentFixture)
+                .where(TournamentFixture.event_id == uuid.UUID(event_id))
+                .order_by(
+                    TournamentFixture.pool_id.asc().nulls_last(),
+                    TournamentFixture.round,
+                    TournamentFixture.position,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def _settings_of(db: AsyncSession, event_id: str) -> TournamentEvent:
+    db.expire_all()
+    return (
+        await db.execute(
+            select(TournamentEvent).where(TournamentEvent.id == uuid.UUID(event_id))
+        )
+    ).scalar_one()
+
+
+async def _set_status(
+    db: AsyncSession, tournament_id: str, status: TournamentStatus
+) -> None:
+    tournament = (
+        await db.execute(
+            select(Tournament).where(Tournament.id == uuid.UUID(tournament_id))
+        )
+    ).scalar_one()
+    tournament.status = status
+    await db.commit()
+
+
+async def _call(
+    db: AsyncSession, tournament_id: str, fixtures: Sequence[TournamentFixture]
+) -> None:
+    """Route each materialized fixture through the real call, so its ``pending`` match
+    flips to ``in_progress`` and becomes scorable (#1073)."""
+    tournament = await db.get(Tournament, uuid.UUID(tournament_id))
+    assert tournament is not None
+    for fixture in fixtures:
+        await match_calls.apply_manual_placement(
+            db,
+            tournament,
+            fixture,
+            table_id="t1",
+            scheduled_start=datetime(2026, 6, 1, 10, 0),
+            event_timezone="America/Chicago",
+        )
+    await db.commit()
+
+
+async def _win(
+    fixture: TournamentFixture,
+    *,
+    clients_by_entry: dict[uuid.UUID, AsyncClient],
+    winner_entry_id: uuid.UUID,
+    games: tuple[int, int] = (2, 0),
+) -> None:
+    """Play a materialized fixture's match out through the real score endpoints, the
+    named entry taking it by ``games``.
+
+    ``games`` is ``(winner_games, loser_games)`` — settable because the qualifier order
+    is decided by a chain that runs through **game difference and games won**, so a
+    test that only ever played 2–0 could not tell a strategy reading games from one
+    reading wins alone. Side 1 is ``entry_a`` and side 2 is ``entry_b`` (#788).
+    """
+    assert fixture.match_id is not None
+    side_1_wins = winner_entry_id == fixture.entry_a_id
+    winner_games, loser_games = games
+    # The loser's games first, so the board's LAST game is the decider — a result
+    # carrying games past the decider is refused at the score boundary.
+    board = [(5, 11)] * loser_games + [(11, 5)] * winner_games
+    response = await clients_by_entry[winner_entry_id].post(
+        f"/v1/matches/{fixture.match_id}/results",
+        json={
+            "games": [
+                {
+                    "game_number": n,
+                    "side_1_points": (a if side_1_wins else b),
+                    "side_2_points": (b if side_1_wins else a),
+                }
+                for n, (a, b) in enumerate(board, start=1)
+            ]
+        },
+    )
+    assert response.status_code == 201, response.text
+
+
+async def _event_read(client: AsyncClient, tournament_id: str) -> dict[str, Any]:
+    response = await client.get(f"/v1/tournaments/{tournament_id}")
+    assert response.status_code == 200, response.text
+    (event,) = response.json()["events"]
+    read: dict[str, Any] = event
+    return read
+
+
+# ----- the request boundary: a qualifier count belongs to exactly one draw type ------
+
+
+async def test_creating_an_rr_then_ko_event_persists_its_qualifier_count(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The whole configuration lands on the settings row: the slug *and* the K.
+
+    Asserted from the database rather than the response, because the row is the thing
+    the cut reads — a response echoing a number nothing stored would satisfy a wire
+    assertion and cut a different draw.
+    """
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    created = await _create_event(client, tournament_id, qualifiers_per_pool=3)
+
+    assert created.status_code == 201, created.text
+    event = await _settings_of(db_session, created.json()["id"])
+    assert event.draw_settings.draw_type is DrawType.rr_then_ko
+    assert event.draw_settings.qualifiers_per_pool == 3
+
+
+@pytest.mark.parametrize("draw_type", ["round-robin", "single-elim"])
+async def test_a_qualifier_count_on_another_draw_type_is_422(
+    authed_client: tuple[AsyncClient, User], draw_type: str, db_session: AsyncSession
+) -> None:
+    """**Refused at the boundary, never silently dropped.**
+
+    "The top 2 from each pool advance" is meaningless for a round-robin (there is no
+    cut to size) and for a single-elim (there are no pools to cut from). Accepting the
+    number and dropping it would run an event the director did not ask for and show
+    them nothing; the settings table's CHECK would refuse the row anyway, which is a
+    500, not an answer. Both other draw types are asked, because a union that had lost
+    one arm's ``extra="forbid"`` would look identical on a one-slug test.
+    """
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    response = await _create_event(
+        client, tournament_id, draw_type=draw_type, qualifiers_per_pool=2, pools=[]
+    )
+
+    assert response.status_code == 422, response.text
+    assert "qualifiers_per_pool" in response.text
+    # Refused at the boundary means refused before persistence.
+    events = (
+        await db_session.execute(
+            select(TournamentEvent).where(
+                TournamentEvent.tournament_id == uuid.UUID(tournament_id)
+            )
+        )
+    ).scalars()
+    assert list(events) == []
+
+
+async def test_an_rr_then_ko_event_without_a_qualifier_count_is_422(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """There is no defensible default. "2" is a convention, not a fact about the event,
+    and a bracket cut for a K nobody chose is the worst kind of failure: it looks like
+    it worked."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    payload = _event_payload()
+    del payload["qualifiers_per_pool"]
+
+    response = await client.post(
+        f"/v1/tournaments/{tournament_id}/events", json=payload
+    )
+
+    assert response.status_code == 422, response.text
+    assert "qualifiers_per_pool" in response.text
+
+
+@pytest.mark.parametrize("count", [0, -1])
+async def test_a_qualifier_count_below_one_is_422(
+    authed_client: tuple[AsyncClient, User], count: int
+) -> None:
+    """``K >= 1`` is the STATIC half of the legal configuration space, so it is a
+    boundary rule: zero advances nobody and a negative is not a count. The two bounds
+    that move with the entrant count (``P × K >= 2``, ``K <= ⌊N/P⌋``) are deliberately
+    not here — they are refused at the cut, where the field is known."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    response = await _create_event(client, tournament_id, qualifiers_per_pool=count)
+
+    assert response.status_code == 422, response.text
+    assert "qualifiers_per_pool" in response.text
+
+
+async def test_patching_a_qualifier_count_without_its_draw_type_is_422(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """The draw configuration is patched **as a unit**.
+
+    Which draw types carry a qualifier count is a fact about the ``(draw_type, K)``
+    pair; a patch carrying only ``K`` does not hold that pair, so judging it would mean
+    reading the event's stored draw type two layers in, after the request had already
+    been accepted. The refusal says what to send instead.
+    """
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id)).json()["id"]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={"qualifiers_per_pool": 3},
+    )
+
+    assert response.status_code == 422, response.text
+    assert "draw_type" in response.text
+
+
+async def test_the_qualifier_count_is_editable_while_no_draw_exists(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The freeze below is about a **cut** draw. Before one, the configuration is
+    ordinary editable event configuration — this is the edit the freeze exists to
+    permit, and without it the 409 test could pass against a rule that refused every
+    change."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id)).json()["id"]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={"draw_type": RR_THEN_KO, "qualifiers_per_pool": 3},
+    )
+
+    assert response.status_code == 200, response.text
+    event = await _settings_of(db_session, event_id)
+    assert event.draw_settings.qualifiers_per_pool == 3
+
+
+async def test_patching_away_from_rr_then_ko_clears_the_qualifier_count(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The two columns are one fact, written together: a draw type moved back to
+    round-robin leaves NULL behind, not the K the event used to take. Writing the slug
+    alone would leave a pairing the settings table's CHECK refuses outright."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id)).json()["id"]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={"draw_type": "round-robin"},
+    )
+
+    assert response.status_code == 200, response.text
+    event = await _settings_of(db_session, event_id)
+    assert event.draw_settings.draw_type is DrawType.round_robin
+    assert event.draw_settings.qualifiers_per_pool is None
+
+
+# ----- the cut: both stages in one stroke -------------------------------------------
+
+
+async def _twelve_entrant_event(
+    client: AsyncClient, db: AsyncSession, **overrides: Any
+) -> tuple[str, str, list[TournamentEntry]]:
+    """An rr-then-ko event with a stated field of twelve seeded entrants.
+
+    Seeds and registration times are both pinned, so which pool each entrant snakes
+    into is a fact of the fixture rather than of how fast the rows were written.
+    """
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id, **overrides)).json()["id"]
+    entries = [
+        await _enter(db, event_id, await make_user(db, f"rrko{n}"), seed=n, minutes=n)
+        for n in range(1, 13)
+    ]
+    return tournament_id, event_id, entries
+
+
+async def test_the_cut_emits_the_pools_and_the_whole_bracket(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """One stroke, two stages: three pools of four (18 pool fixtures) plus the bracket
+    for the 6 qualifiers, cut before anybody has played.
+
+    The bracket is cut upfront because ``AdvancePlan`` can express only a side-fill —
+    there is deliberately no way for ``advance()`` to create a fixture — and it costs
+    nothing, since ``P × K`` is known at cut time. Its fixtures are ``pool_id IS NULL``
+    (that *is* the knockout stage) with every side TBD, and its rounds restart at 1.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, _ = await _twelve_entrant_event(client, db_session)
+
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+
+    fixtures = await _fixtures(db_session, event_id)
+    pooled = [f for f in fixtures if f.pool_id is not None]
+    bracket = [f for f in fixtures if f.pool_id is None]
+    # Three pools of four: every pairing within a pool, six per pool.
+    assert sorted(p.pool_id for p in pooled) == sorted(
+        [pool["id"] for pool in POOLS] * 6
+    )
+    assert all(f.entry_a_id is not None and f.entry_b_id is not None for f in pooled), (
+        "every pool pairing is known at the cut"
+    )
+    # 6 qualifiers → a bracket of 8: 4 quarterfinals (two of them byes, so absent),
+    # 2 semifinals, 1 final. A bye is the ABSENCE of a fixture (ADR-0786).
+    assert sorted((f.round, f.position) for f in bracket) == [
+        (1, 2),
+        (1, 3),
+        (2, 1),
+        (2, 2),
+        (3, 1),
+    ]
+    assert all(f.entry_a_id is None and f.entry_b_id is None for f in bracket), (
+        "nobody has qualified, so every knockout side is TBD"
+    )
+
+
+async def test_cutting_for_more_qualifiers_than_the_smallest_pool_holds_is_refused(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """A moving bound, refused at the cut in the director's own language — and it names
+    the two ways out.
+
+    It cannot live at the request boundary: it depends on the entrant count, which
+    moves. A configuration that was legal when it was written must not become
+    unwritable because a player withdrew.
+    """
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    event_id = (
+        await _create_event(client, tournament_id, qualifiers_per_pool=5)
+    ).json()["id"]
+    for n in range(1, 13):
+        await _enter(
+            db_session,
+            event_id,
+            await make_user(db_session, f"few{n}"),
+            seed=n,
+            minutes=n,
+        )
+
+    response = await _cut(client, tournament_id, event_id)
+
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail == (
+        "Taking 5 qualifiers from each pool is more than the 4 entrants in the "
+        "smallest pool — take fewer qualifiers from each pool, or add entrants."
+    )
+    assert await _fixtures(db_session, event_id) == [], (
+        "a refused cut writes nothing at all"
+    )
+
+
+async def test_the_qualifier_count_is_frozen_once_the_draw_is_cut(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """409, exactly as the draw type freezes — and it is not hypothetical.
+
+    The bracket is cut upfront for ``P × K`` and qualifiers are seated into
+    predetermined slots. A bracket cut at K=2 and then advanced at K=3 would leave
+    three pools' worth of thirds with nowhere to sit: ``advance()`` seats the five it
+    finds slots for and raises nothing. Re-sending the SAME configuration is not a
+    change and is allowed, which is what makes this a freeze on the edit rather than on
+    the key being present.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, _ = await _twelve_entrant_event(client, db_session)
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+    url = f"/v1/tournaments/{tournament_id}/events/{event_id}"
+
+    unchanged = await client.patch(
+        url, json={"draw_type": RR_THEN_KO, "qualifiers_per_pool": 2}
+    )
+    refused = await client.patch(
+        url, json={"draw_type": RR_THEN_KO, "qualifiers_per_pool": 3}
+    )
+
+    assert unchanged.status_code == 200, unchanged.text
+    assert refused.status_code == 409, refused.text
+    assert refused.json()["detail"] == (
+        "This event's draw is already cut, so the number of qualifiers per pool is "
+        "frozen: its knockout bracket was cut for the top 2 out of each pool of a "
+        "“rr-then-ko” draw, and changing that count would leave qualifiers with no "
+        "slot to be seated into. To change it, remove the draw first, then cut it "
+        "again."
+    )
+    event = await _settings_of(db_session, event_id)
+    assert event.draw_settings.qualifiers_per_pool == 2, "a refusal wrote nothing"
+
+
+# ----- the seam: a finished pool seats its qualifiers -------------------------------
+
+
+async def test_a_finished_pool_seats_its_qualifiers_into_the_bracket(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """**The one that proves the game counts reach ``advance()``.**
+
+    Twelve entrants, three pools of four, top two out of each. One pool is played out
+    in full through the real score routes while the other two are untouched; the moment
+    its last match completes, that pool's top two are seated into their predetermined
+    bracket slots — and the other pools' slots stay TBD, because a seat is filled per
+    pool, as that pool finishes, not per event.
+
+    **Who qualifies is decided by the games, not by the wins.** Seed 1 takes all three
+    of their matches; the other three form a beat-cycle (6 beats 7, 7 beats 12, 12 beats
+    6) and finish level on **one win apiece**. Wins alone cannot separate them, and
+    head-to-head does not apply to a three-way tie, so the second qualifying place is
+    settled by **game difference** — 7 at −1, 6 at −2, 12 at −4 — which exists only if
+    the seam loaded the fixtures' game counts. A pool played 2–0 throughout would be
+    ordered identically by a games-blind strategy, and this test would then be evidence
+    about nothing.
+
+    Pool A holds seeds 1, 6, 7, 12 (the snake deals 1..P then back), whose users are
+    the four with clients here.
+    """
+    client, owner = authed_client
+    async with (
+        opponent_session(db_session, "rrko-b") as (client_b, user_b),
+        opponent_session(db_session, "rrko-c") as (client_c, user_c),
+        opponent_session(db_session, "rrko-d") as (client_d, user_d),
+    ):
+        tournament_id = await _tournament(client)
+        event_id = (await _create_event(client, tournament_id)).json()["id"]
+        # Seeds 1, 6, 7, 12 snake into pool A; the eight extras fill B and C.
+        players = {1: owner, 6: user_b, 7: user_c, 12: user_d}
+        entries: dict[int, TournamentEntry] = {}
+        for seed in range(1, 13):
+            user = players.get(seed) or await make_user(db_session, f"extra{seed}")
+            entries[seed] = await _enter(
+                db_session, event_id, user, seed=seed, minutes=seed
+            )
+        assert (await _cut(client, tournament_id, event_id)).status_code == 201
+        await _set_status(db_session, tournament_id, TournamentStatus.published)
+        live = await client.post(
+            f"/v1/tournaments/{tournament_id}/transitions", json={"to": "live"}
+        )
+        assert live.status_code == 201, live.text
+
+        pool_a = [
+            f for f in await _fixtures(db_session, event_id) if f.pool_id == "p-a"
+        ]
+        assert len(pool_a) == 6, "a pool of four is six pairings"
+        await _call(db_session, tournament_id, pool_a)
+        pool_a = [
+            f for f in await _fixtures(db_session, event_id) if f.pool_id == "p-a"
+        ]
+
+        clients = {
+            entries[1].id: client,
+            entries[6].id: client_b,
+            entries[7].id: client_c,
+            entries[12].id: client_d,
+        }
+        by_pair = {frozenset({f.entry_a_id, f.entry_b_id}): f for f in pool_a}
+
+        def fixture_between(a: int, b: int) -> TournamentFixture:
+            return by_pair[frozenset({entries[a].id, entries[b].id})]
+
+        # Seed 1 takes all three, dropping one game on the way.
+        await _win(
+            fixture_between(1, 6),
+            clients_by_entry=clients,
+            winner_entry_id=entries[1].id,
+            games=(2, 1),
+        )
+        await _win(
+            fixture_between(1, 7),
+            clients_by_entry=clients,
+            winner_entry_id=entries[1].id,
+            games=(2, 0),
+        )
+        await _win(
+            fixture_between(1, 12),
+            clients_by_entry=clients,
+            winner_entry_id=entries[1].id,
+            games=(2, 0),
+        )
+        # The beat-cycle: 6 → 7 → 12 → 6, one win each, so nothing but the games can
+        # place them. Game difference comes out 7 (−1), 6 (−2), 12 (−4).
+        await _win(
+            fixture_between(6, 7),
+            clients_by_entry=clients,
+            winner_entry_id=entries[6].id,
+            games=(2, 1),
+        )
+        await _win(
+            fixture_between(7, 12),
+            clients_by_entry=clients,
+            winner_entry_id=entries[7].id,
+            games=(2, 0),
+        )
+        await _win(
+            fixture_between(6, 12),
+            clients_by_entry=clients,
+            winner_entry_id=entries[12].id,
+            games=(2, 0),
+        )
+
+        bracket = [
+            f for f in await _fixtures(db_session, event_id) if f.pool_id is None
+        ]
+        seated = {
+            entry_id
+            for f in bracket
+            for entry_id in (f.entry_a_id, f.entry_b_id)
+            if entry_id is not None
+        }
+        assert seated == {entries[1].id, entries[7].id}, (
+            "exactly pool A's top two are seated — and the runner-up is the one the "
+            "standings' game-difference tiebreak names, which wins alone cannot pick"
+        )
+        # Nothing is ready to play: every knockout fixture still has a TBD side, so none
+        # of them materialized into a match.
+        assert all(f.match_id is None for f in bracket)
+
+
+async def test_the_results_read_out_as_both_stages(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The tournament-detail payload carries the third arm of the results union.
+
+    ``kind: "standings_then_finishes"``, with one block per stage: the pool tables read
+    exactly as a round-robin's do (the same models), and the finishes list exactly as a
+    single-elim's does. It is live and partial, like every other results shape — the
+    played pool is ``complete`` while its neighbours are not, the bracket has produced
+    no finishes yet, and there is **no champion**, because a champion comes from the
+    bracket's final and never from topping a pool.
+    """
+    client, owner = authed_client
+    async with opponent_session(db_session, "rrko-solo") as (client_b, user_b):
+        tournament_id = await _tournament(client)
+        event_id = (await _create_event(client, tournament_id)).json()["id"]
+        players = {1: owner, 6: user_b}
+        entries: dict[int, TournamentEntry] = {}
+        for seed in range(1, 13):
+            user = players.get(seed) or await make_user(db_session, f"read{seed}")
+            entries[seed] = await _enter(
+                db_session, event_id, user, seed=seed, minutes=seed
+            )
+        assert (await _cut(client, tournament_id, event_id)).status_code == 201
+        await _set_status(db_session, tournament_id, TournamentStatus.published)
+        assert (
+            await client.post(
+                f"/v1/tournaments/{tournament_id}/transitions", json={"to": "live"}
+            )
+        ).status_code == 201
+        one = next(
+            f
+            for f in await _fixtures(db_session, event_id)
+            if {f.entry_a_id, f.entry_b_id} == {entries[1].id, entries[6].id}
+        )
+        await _call(db_session, tournament_id, [one])
+        (one,) = [f for f in await _fixtures(db_session, event_id) if f.id == one.id]
+        await _win(
+            one,
+            clients_by_entry={entries[1].id: client, entries[6].id: client_b},
+            winner_entry_id=entries[1].id,
+            games=(2, 1),
+        )
+
+    results = (await _event_read(client, tournament_id))["results"]
+
+    assert results["kind"] == "standings_then_finishes"
+    assert results["complete"] is False
+    assert results["champion"] is None
+    assert [pool["pool_id"] for pool in results["pools"]] == ["p-a", "p-b", "p-c"]
+    assert all(pool["complete"] is False for pool in results["pools"])
+    (pool_a,) = [pool for pool in results["pools"] if pool["pool_id"] == "p-a"]
+    leader = pool_a["rows"][0]
+    assert leader["entry_id"] == str(entries[1].id)
+    assert (leader["wins"], leader["games_won"], leader["games_lost"]) == (1, 2, 1)
+    assert results["finishes"] == [], "nobody has been knocked out yet"
+
+
+async def test_an_uncut_rr_then_ko_event_has_no_results(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """``null``, not an empty two-stage block: an event with no draw has nothing to
+    stand, and that is the one case the results are absent for."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    await _create_event(client, tournament_id)
+
+    assert (await _event_read(client, tournament_id))["results"] is None

--- a/api/tests/test_schedule_preview_snapshot.py
+++ b/api/tests/test_schedule_preview_snapshot.py
@@ -92,6 +92,7 @@ async def _add_event(
     tournament: Tournament,
     *,
     draw_type: DrawType = DrawType.round_robin,
+    qualifiers_per_pool: int | None = None,
     max_players: int | None = 6,
     pools: list[dict[str, object]] | None = None,
     length_games: int = 5,
@@ -102,7 +103,9 @@ async def _add_event(
         tournament_id=tournament.id,
         name=name,
         format=EventFormat.singles,
-        draw_settings=TournamentEventDrawSettings.for_draw_type(draw_type),
+        draw_settings=TournamentEventDrawSettings.for_draw_type(
+            draw_type, qualifiers_per_pool=qualifiers_per_pool
+        ),
         max_players=max_players,
         entry_fee=Decimal("0"),
         slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
@@ -403,7 +406,9 @@ async def test_preview_snapshot_count_override_resizes_field(
     # run (ADR "a draw type is a seeded row, …"): it *can* be cut (#785), but the
     # CP-SAT table scheduler is pool-based and a pool-less bracket has no windows to
     # solve over, so the preview must refuse it rather than invent a grid. The old
-    # double-elim / swiss / rr-then-ko subjects are no longer enum members.
+    # double-elim / swiss subjects are no longer enum members, and ``rr-then-ko`` is
+    # deliberately NOT here: it has a pool stage that schedules perfectly well, so it
+    # is previewed in part rather than refused (see the two tests below).
     [DrawType.single_elim],
 )
 async def test_preview_snapshot_unsupported_draw_raises(
@@ -416,6 +421,77 @@ async def test_preview_snapshot_unsupported_draw_raises(
 
     with pytest.raises(UnsupportedDrawType):
         build_preview_snapshot(loaded)
+
+
+async def test_preview_snapshot_previews_an_rr_then_ko_events_pool_stage_only(
+    db_session: AsyncSession, default_league: League
+) -> None:
+    """An ``rr-then-ko`` event is previewed, and what is previewed is its **pools**.
+
+    The knockout fixtures the cut emits alongside them (``pool_id IS NULL``) are
+    dropped: the solver places a fixture into its pool's window on its pool's tables,
+    and a bracket has neither. Scheduling it is #1228 — a freshly cut bracket is
+    entirely TBD-sided, so it is placeable only incrementally, as the pools resolve.
+
+    Six synthetic entrants in one pool, so the pool stage is C(6, 2) = 15 pairings and
+    the bracket for the top 2 would add 1 more fixture on top. The count is what
+    discriminates: a builder that passed the un-pooled fixtures through would answer 16
+    here and then trip ``_schedule_fixture``'s pool assertion.
+    """
+    owner = await make_user(db_session, "prev-rrko")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    await _add_event(
+        db_session,
+        tournament,
+        draw_type=DrawType.rr_then_ko,
+        qualifiers_per_pool=2,
+        max_players=6,
+    )
+    loaded = await _load(db_session, tournament.id)
+
+    preview = build_preview_snapshot(loaded)
+
+    assert len(preview.snapshot.fixtures) == 15
+    assert {f.pool_id for f in preview.snapshot.fixtures} == {
+        scheduling.PoolId(f"{loaded.events[0].id}:p-a")
+    }
+    assert preview.field_summaries[0].field_size == 6
+
+
+async def test_an_rr_then_ko_event_does_not_abort_the_tournaments_whole_preview(
+    db_session: AsyncSession, default_league: League
+) -> None:
+    """The reason it is skipped rather than refused.
+
+    This builder runs a **per-event loop inside a whole-tournament build**, so a
+    refusal is not scoped to the event that raised it — it takes the preview of every
+    event beside it. A director previewing a day that happens to contain one
+    pools-then-knockout event would get no schedule at all, including for their plain
+    round-robin events. The round-robin event's own 15 fixtures are asserted present,
+    which is the claim a bare "it did not raise" would miss.
+    """
+    owner = await make_user(db_session, "prev-rrko-beside")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    await _add_event(db_session, tournament, name="Open Singles", max_players=6)
+    await _add_event(
+        db_session,
+        tournament,
+        name="Second Singles",
+        draw_type=DrawType.rr_then_ko,
+        qualifiers_per_pool=2,
+        max_players=6,
+        pools=[_one_pool(["t2"])],
+    )
+    loaded = await _load(db_session, tournament.id)
+
+    preview = build_preview_snapshot(loaded)
+
+    by_event: dict[str, int] = {}
+    for fixture in preview.snapshot.fixtures:
+        by_event[fixture.event_id] = by_event.get(fixture.event_id, 0) + 1
+    assert by_event == {
+        scheduling.EventId(str(event.id)): 15 for event in loaded.events
+    }
 
 
 async def test_preview_snapshot_event_without_pools_refuses(

--- a/api/tests/test_schedule_preview_snapshot.py
+++ b/api/tests/test_schedule_preview_snapshot.py
@@ -176,6 +176,9 @@ async def test_preview_snapshot_round_robin_synthesizes_full_draw(
     summary = preview.field_summaries[0]
     assert summary.field_size == 6
     assert summary.event_id == scheduling.EventId(str(loaded.events[0].id))
+    # Nothing was left out: a round-robin has no knockout stage, so the honest-notes
+    # strip downstream has no missing-stage caveat to write.
+    assert summary.knockout_fixtures == 0
 
 
 async def test_preview_snapshot_base_is_the_earliest_window_start(
@@ -456,6 +459,12 @@ async def test_preview_snapshot_previews_an_rr_then_ko_events_pool_stage_only(
         scheduling.PoolId(f"{loaded.events[0].id}:p-a")
     }
     assert preview.field_summaries[0].field_size == 6
+    # What was dropped is *counted*, not silently discarded: the top 2 of the single
+    # pool make a 2-slot bracket, so one knockout fixture was left out. This is the
+    # fact the honest-notes strip turns into "the knockout stage is not scheduled" —
+    # a builder that dropped the bracket without counting it would report 0 here and
+    # leave the director reading a partial schedule with nothing to say so.
+    assert preview.field_summaries[0].knockout_fixtures == 1
 
 
 async def test_an_rr_then_ko_event_does_not_abort_the_tournaments_whole_preview(

--- a/api/tests/test_schedule_preview_solve.py
+++ b/api/tests/test_schedule_preview_solve.py
@@ -153,12 +153,16 @@ async def _add_event(
     length_games: int = 5,
     name: str = "Open Singles",
     timezone: str = "America/Los_Angeles",
+    draw_type: DrawType = DrawType.round_robin,
+    qualifiers_per_pool: int | None = None,
 ) -> TournamentEvent:
     event = TournamentEvent(
         tournament_id=tournament.id,
         name=name,
         format=EventFormat.singles,
-        draw_settings=TournamentEventDrawSettings.for_draw_type(DrawType.round_robin),
+        draw_settings=TournamentEventDrawSettings.for_draw_type(
+            draw_type, qualifiers_per_pool=qualifiers_per_pool
+        ),
         max_players=max_players,
         entry_fee=Decimal("0"),
         slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
@@ -334,6 +338,118 @@ async def test_preview_solve_reports_byes_for_an_odd_field(
     assert result.total_matches == 10  # C(5, 2)
     assert result.total_byes == 5
     assert result.events[0].byes == 5
+
+
+#: The two pools an rr-then-ko subject is drawn over, with distinct ids (the shared
+#: ``_pool`` helper's id is fixed, and two pools of one event may not collide).
+_TWO_POOLS: list[dict[str, object]] = [
+    {
+        "id": "p-a",
+        "name": "Pool A",
+        "slot": {"date": "2026-06-13", "start": "09:00", "end": "18:00"},
+        "table_ids": ["t1"],
+    },
+    {
+        "id": "p-b",
+        "name": "Pool B",
+        "slot": {"date": "2026-06-13", "start": "09:00", "end": "18:00"},
+        "table_ids": ["t2"],
+    },
+]
+
+#: The exact honest note an rr-then-ko event earns, pinned so the wording a director
+#: reads cannot drift silently. Six entrants over two pools taking the top 2 each
+#: gives 4 qualifiers → a 4-slot bracket → 3 knockout fixtures, none of them
+#: scheduled.
+_KNOCKOUT_NOTE = (
+    "Only the pool stage of Championship is scheduled here: its knockout "
+    "bracket (3 further matches) is played after the pools finish and is not "
+    "in this estimate."
+)
+
+
+async def test_preview_notes_say_an_rr_then_ko_events_knockout_stage_is_not_scheduled(
+    db_session: AsyncSession, default_league: League, preview_queue: Queue
+) -> None:
+    """The preview plans an rr-then-ko event's whole draw but schedules only its pool
+    stage (ADR 20260727 — a freshly cut bracket is entirely TBD-sided, so it is
+    placeable only incrementally as the pools resolve; that is #1228). Silently showing
+    the director a schedule that covers part of their event is the failure this note
+    prevents, so the strip says so in as many words.
+
+    The tournament also holds a plain round-robin event, which is the discriminating
+    part: its pools are scheduled beside the rr-then-ko event's (both events' match
+    counts are asserted), and **it** earns no such note — the strip names the event
+    that is actually missing a stage, not every event on the day.
+    """
+    owner = await make_user(db_session, "prev-rrko-note")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    await _add_event(
+        db_session,
+        tournament,
+        name="Open Singles",
+        max_players=4,
+        pools=[_pool(["t1"])],
+    )
+    await _add_event(
+        db_session,
+        tournament,
+        name="Championship",
+        max_players=6,
+        pools=_TWO_POOLS,
+        draw_type=DrawType.rr_then_ko,
+        qualifiers_per_pool=2,
+    )
+
+    await request_schedule_preview(db_session, tournament_id=tournament.id, actor=owner)
+    (job,) = preview_queue.jobs
+    (inputs,) = job.args
+    assert isinstance(inputs, PreviewJobInputs)
+
+    result = PreviewResult.model_validate(run_schedule_preview(inputs))
+
+    # Both events' POOL fixtures are previewed: C(4, 2) = 6 for the round-robin, and
+    # 2 × C(3, 2) = 6 for the rr-then-ko event's two pools of three. Its 3 knockout
+    # fixtures are not counted — they are what the note is about.
+    assert {e.name: e.matches for e in result.events} == {
+        "Open Singles": 6,
+        "Championship": 6,
+    }
+    assert result.total_matches == 12
+
+    assert _KNOCKOUT_NOTE in result.notes
+    # Exactly one event is called out, and it is not the round-robin one.
+    knockout_notes = [n for n in result.notes if "knockout" in n]
+    assert knockout_notes == [_KNOCKOUT_NOTE]
+    assert not any("Open Singles" in n for n in knockout_notes)
+    # The rest of the strip is untouched — the note is an addition, not a swap.
+    assert any("more than one event" in n for n in result.notes)
+    assert "Assumed 6 entrants for Championship." in result.notes
+
+
+async def test_a_round_robin_only_previews_notes_carry_no_knockout_caveat(
+    db_session: AsyncSession, default_league: League, preview_queue: Queue
+) -> None:
+    """The other direction: a tournament with no rr-then-ko event has no stage left
+    out, so its strip is exactly the two notes it always carried. Asserted as full
+    equality rather than a ``"knockout" not in`` scan, because an always-on note is
+    the failure mode a one-sided test would wave through."""
+    owner = await make_user(db_session, "prev-rr-only-note")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    await _add_event(db_session, tournament, name="Open Singles", max_players=4)
+
+    await request_schedule_preview(db_session, tournament_id=tournament.id, actor=owner)
+    (job,) = preview_queue.jobs
+    (inputs,) = job.args
+    assert isinstance(inputs, PreviewJobInputs)
+
+    result = PreviewResult.model_validate(run_schedule_preview(inputs))
+
+    assert result.notes == [
+        "This estimate assumes no player is entered in more than one event; a "
+        "real multi-event field would take longer.",
+        "Assumed 4 entrants for Open Singles.",
+    ]
 
 
 async def test_preview_solve_refuses_a_non_owner(

--- a/api/tests/test_tournament_draws.py
+++ b/api/tests/test_tournament_draws.py
@@ -1,0 +1,290 @@
+"""Direct tests for the ORM→domain projection ``app.tournament_draws.fixture_state``.
+
+The one bridge from a persisted ``TournamentFixture`` row to the pure
+:class:`~app.draws.FixtureState` every strategy's ``advance()`` reads. Everything else
+in the draw domain is exercised through it (go-live materialization, the completion
+seam), which is exactly why it is worth pinning on its own: those callers would still
+pass with the two sides of a scoreline transposed, because a mirrored 1–3 is as
+plausible-looking a result as a 3–1.
+
+The game counts are fed in the way a caller gets them — ``fixtures_by_event`` →
+``completed_match_ids`` → ``game_counts_by_match``, the shipped chain — rather than
+hand-built, so "an in-progress match's games do not reach a strategy" is a fact about
+the real filter and not about a literal this file wrote.
+"""
+
+import uuid
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.draws import FixtureGames
+from app.models import (
+    League,
+    Match,
+    MatchGame,
+    MatchGameScore,
+    MatchSettings,
+    MatchStatus,
+    Tournament,
+    TournamentEntry,
+    TournamentEntryStatus,
+    TournamentEvent,
+    TournamentEventDrawSettings,
+    TournamentFixture,
+    TournamentStatus,
+    User,
+)
+from app.models.tournament import DrawType, EventFormat
+from app.tournament_draws import fixture_state
+from app.tournament_queries import (
+    completed_match_ids,
+    fixtures_by_event,
+    game_counts_by_match,
+)
+from tests._helpers import make_user
+
+POOL_A: dict[str, object] = {
+    "id": "p-a",
+    "name": "Pool A",
+    "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+    "table_ids": ["t1"],
+}
+
+
+async def _make_event(
+    db: AsyncSession, *, owner: User, league: League
+) -> TournamentEvent:
+    tournament = Tournament(
+        name="Bay Area Open 2026",
+        description="Two-day open.",
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "2727 Milvia St",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94703",
+            "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
+        },
+        table_catalogue=[{"id": "t1", "label": "Table 1", "court": "A"}],
+        league_id=league.id,
+        created_by_user_id=owner.id,
+        status=TournamentStatus.live,
+    )
+    db.add(tournament)
+    await db.flush()
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Open Singles",
+        format=EventFormat.singles,
+        draw_settings=TournamentEventDrawSettings.for_draw_type(DrawType.round_robin),
+        max_players=64,
+        entry_fee=Decimal("45"),
+        timezone="America/Chicago",
+        slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
+        match_settings={"rated": True, "length_games": 5},
+        predicates=[],
+        pools=[POOL_A],
+    )
+    db.add(event)
+    await db.flush()
+    return event
+
+
+async def _entry(db: AsyncSession, event: TournamentEvent, username: str) -> uuid.UUID:
+    entry = TournamentEntry(
+        event_id=event.id,
+        user_id=(await make_user(db, username)).id,
+        status=TournamentEntryStatus.entered,
+    )
+    db.add(entry)
+    await db.flush()
+    return entry.id
+
+
+async def _match(
+    db: AsyncSession,
+    *,
+    owner: User,
+    league: League,
+    status: MatchStatus,
+    games: list[tuple[int, int]],
+) -> uuid.UUID:
+    """A match with ``games`` scored on its board — ``(side_1_points, side_2_points)``
+    per game — in ``status``.
+
+    The board is populated whatever the status, because a live match genuinely has one:
+    that is what makes the in-progress case below a real exclusion rather than an empty
+    query.
+    """
+    match = Match(
+        match_settings=MatchSettings(team_size=1, best_of=5, affects_rating=True),
+        league_id=league.id,
+        created_by_user_id=owner.id,
+        status=status,
+    )
+    db.add(match)
+    await db.flush()
+    for number, (side_1_points, side_2_points) in enumerate(games, start=1):
+        game = MatchGame(match_id=match.id, game_number=number)
+        db.add(game)
+        await db.flush()
+        db.add(
+            MatchGameScore(
+                match_game_id=game.id,
+                side_1_points=side_1_points,
+                side_2_points=side_2_points,
+            )
+        )
+    await db.flush()
+    return match.id
+
+
+async def _fixture(
+    db: AsyncSession,
+    event: TournamentEvent,
+    *,
+    position: int,
+    entry_a_id: uuid.UUID,
+    entry_b_id: uuid.UUID,
+    match_id: uuid.UUID | None,
+) -> TournamentFixture:
+    fixture = TournamentFixture(
+        event_id=event.id,
+        pool_id="p-a",
+        round=1,
+        position=position,
+        entry_a_id=entry_a_id,
+        entry_b_id=entry_b_id,
+        match_id=match_id,
+    )
+    db.add(fixture)
+    await db.flush()
+    return fixture
+
+
+async def _game_counts(
+    db: AsyncSession, event_id: uuid.UUID
+) -> dict[uuid.UUID, tuple[int, int]]:
+    """The games each side won, for this event's **completed** matches only — built
+    through the shipped loader chain a caller of ``fixture_state`` uses."""
+    return await game_counts_by_match(
+        db, completed_match_ids(await fixtures_by_event(db, [event_id]))
+    )
+
+
+async def test_a_completed_match_projects_the_games_each_side_won(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A decided fixture carries its per-side game counts, and they are **not**
+    symmetric: side 1 (``entry_a``) took 3, side 2 (``entry_b``) took 1.
+
+    Both orientations are asserted — one fixture won 3–1 by ``entry_a``, its mirror won
+    3–1 by ``entry_b`` — so neither transposing the two sides nor normalizing the
+    winner's count into the first slot can survive.
+    """
+    owner = await make_user(db_session, "proj-owner")
+    event = await _make_event(db_session, owner=owner, league=default_league)
+    a = await _entry(db_session, event, "proj-a")
+    b = await _entry(db_session, event, "proj-b")
+    c = await _entry(db_session, event, "proj-c")
+    d = await _entry(db_session, event, "proj-d")
+    a_won = await _fixture(
+        db_session,
+        event,
+        position=1,
+        entry_a_id=a,
+        entry_b_id=b,
+        match_id=await _match(
+            db_session,
+            owner=owner,
+            league=default_league,
+            status=MatchStatus.completed,
+            games=[(11, 5), (11, 7), (6, 11), (11, 9)],
+        ),
+    )
+    b_won = await _fixture(
+        db_session,
+        event,
+        position=2,
+        entry_a_id=c,
+        entry_b_id=d,
+        match_id=await _match(
+            db_session,
+            owner=owner,
+            league=default_league,
+            status=MatchStatus.completed,
+            games=[(5, 11), (7, 11), (11, 6), (9, 11)],
+        ),
+    )
+    await db_session.commit()
+
+    game_counts = await _game_counts(db_session, event.id)
+
+    assert fixture_state(a_won, game_counts).games == FixtureGames(
+        entry_a_games=3, entry_b_games=1
+    ), "side 1's games are entry A's — 3 of them — and side 2's are entry B's"
+    assert fixture_state(b_won, game_counts).games == FixtureGames(
+        entry_a_games=1, entry_b_games=3
+    ), "the mirror image: the winner's count does not move to the front"
+
+
+async def test_a_fixture_with_no_match_projects_no_games(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """An unplayed fixture's games are **absent**, not ``0–0``. A 0 is a real count (a
+    walkover reads 0 for the loser), so the two must stay tellable apart."""
+    owner = await make_user(db_session, "proj-nomatch-owner")
+    event = await _make_event(db_session, owner=owner, league=default_league)
+    a = await _entry(db_session, event, "proj-nomatch-a")
+    b = await _entry(db_session, event, "proj-nomatch-b")
+    unplayed = await _fixture(
+        db_session, event, position=1, entry_a_id=a, entry_b_id=b, match_id=None
+    )
+    await db_session.commit()
+
+    assert (
+        fixture_state(unplayed, await _game_counts(db_session, event.id)).games is None
+    )
+    # And with no counts loaded at all — the default every caller that does not tabulate
+    # takes — it is the same absence.
+    assert fixture_state(unplayed).games is None
+
+
+async def test_a_match_that_has_not_completed_projects_no_games(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A live fixture's part-scored board is not a result: its match has two scored
+    games in the database, and none of them reach the projection.
+
+    This is the case a hand-built count map cannot exercise — the games exist, and it is
+    ``completed_match_ids``' status filter that keeps them out."""
+    owner = await make_user(db_session, "proj-live-owner")
+    event = await _make_event(db_session, owner=owner, league=default_league)
+    a = await _entry(db_session, event, "proj-live-a")
+    b = await _entry(db_session, event, "proj-live-b")
+    in_play = await _fixture(
+        db_session,
+        event,
+        position=1,
+        entry_a_id=a,
+        entry_b_id=b,
+        match_id=await _match(
+            db_session,
+            owner=owner,
+            league=default_league,
+            status=MatchStatus.in_progress,
+            games=[(11, 5), (11, 7)],
+        ),
+    )
+    await db_session.commit()
+
+    state = fixture_state(in_play, await _game_counts(db_session, event.id))
+
+    assert state.match_id is not None, "the fixture HAS materialized into a match"
+    assert state.games is None, "an in-progress board is not a result"

--- a/api/tests/test_tournament_event_draw_settings.py
+++ b/api/tests/test_tournament_event_draw_settings.py
@@ -380,6 +380,158 @@ async def test_a_settings_row_naming_an_unseeded_draw_type_is_refused(
     await db_session.rollback()
 
 
+# The slug the qualifier count belongs to, taken **from the enum** — since #1227
+# ``rr-then-ko`` is a real ``DrawType`` member with a seeded lookup row (the autouse
+# ``draw_types`` fixture stands one up per enum member), so these tests no longer
+# have to insert a test-local parent row to reach the constraint's active half.
+RR_THEN_KO = DrawType.rr_then_ko.value
+
+
+async def test_a_new_events_settings_row_carries_no_qualifier_count(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A round-robin event's settings row has ``qualifiers_per_pool`` NULL — not 0,
+    and not "unset but present".
+
+    ``NULL`` is the whole representation of "this draw type takes no qualifier
+    count" (ADR "rr-then-ko cuts both stages upfront"). A default of ``0`` would
+    make every round-robin event carry a number that reads as a real configuration
+    and that the ``K >= 1`` floor would then contradict.
+    """
+    client, _ = authed_client
+    _, event_id = await _create_event(client, draw_type="round-robin")
+
+    (event,) = await _load_events(db_session, event_id)
+    assert event.draw_settings.draw_type is DrawType.round_robin
+    assert event.draw_settings.qualifiers_per_pool is None
+
+
+async def test_a_settings_row_that_is_not_rr_then_ko_may_not_carry_a_qualifier_count(
+    db_session: AsyncSession,
+) -> None:
+    """The qualifier count is unrepresentable on any other draw type — refused by
+    the database, not dropped on the way in.
+
+    This is the storage-layer half of the claim the request boundary makes: "top K
+    from each pool advance" is meaningless for a round-robin (there is no cut to
+    size) and for a single-elim (there are no pools to cut from), so a row pairing
+    either slug with a number is not a row Postgres will accept. Both other slugs
+    are asked, because a constraint that only covered one of them would look
+    identical on a one-slug test.
+
+    A NULL-carrying row of each slug is inserted first, so a green result cannot be
+    explained by the table or the statements being wrong.
+    """
+    for slug in ("round-robin", "single-elim"):
+        accepted = await db_session.execute(
+            sa.text(
+                "INSERT INTO tournament_event_draw_settings"
+                " (draw_type_key, qualifiers_per_pool)"
+                " VALUES (:slug, NULL) RETURNING qualifiers_per_pool"
+            ),
+            {"slug": slug},
+        )
+        assert accepted.scalar_one() is None
+
+        with pytest.raises(IntegrityError) as refusal:
+            async with db_session.begin_nested():
+                await db_session.execute(
+                    sa.text(
+                        "INSERT INTO tournament_event_draw_settings"
+                        " (draw_type_key, qualifiers_per_pool)"
+                        " VALUES (:slug, 2)"
+                    ),
+                    {"slug": slug},
+                )
+        assert "ck_tournament_event_draw_settings_qualifiers_per_pool" in str(
+            refusal.value
+        ), f"{slug} accepted a qualifier count: {refusal.value}"
+
+    await db_session.rollback()
+
+
+async def test_an_rr_then_ko_settings_row_round_trips_its_qualifier_count(
+    db_session: AsyncSession,
+) -> None:
+    """The column is a real, readable configuration for the one draw type that has
+    one: written as 2, read back as 2.
+
+    Driven through raw SQL rather than through the HTTP boundary because the subject
+    is the **column and its CHECK**, not the route: the end-to-end path an
+    ``rr-then-ko`` event now takes is covered in ``test_tournaments.py``.
+    """
+    settings_id = (
+        await db_session.execute(
+            sa.text(
+                "INSERT INTO tournament_event_draw_settings"
+                " (draw_type_key, qualifiers_per_pool)"
+                " VALUES (:key, 2) RETURNING id"
+            ),
+            {"key": RR_THEN_KO},
+        )
+    ).scalar_one()
+
+    db_session.expire_all()
+    stored = (
+        await db_session.execute(
+            select(TournamentEventDrawSettings).where(
+                TournamentEventDrawSettings.id == settings_id
+            )
+        )
+    ).scalar_one()
+    assert stored.draw_type_key == RR_THEN_KO
+    assert stored.qualifiers_per_pool == 2
+
+    await db_session.rollback()
+
+
+async def test_an_rr_then_ko_settings_row_needs_at_least_one_qualifier(
+    db_session: AsyncSession,
+) -> None:
+    """``K >= 1`` is the STATIC half of the ADR's legal configuration space, so it
+    is a floor the row itself carries — zero, negative and absent are all refused.
+
+    A qualifier count of zero advances nobody, which is not a knockout stage; a
+    negative one is not a count at all; and an absent one leaves an ``rr-then-ko``
+    row with no answer to "how many advance", which the cut has no default for. The
+    two bounds that MOVE with the entrant count — ``P × K >= 2`` and ``K <= ⌊N/P⌋``
+    — are deliberately NOT here: they are refused at the cut as ``DegenerateDraw``,
+    because a row that was legal when written must not become unwritable when a
+    player withdraws.
+    """
+    for count in ("0", "-1", "NULL"):
+        with pytest.raises(IntegrityError) as refusal:
+            async with db_session.begin_nested():
+                await db_session.execute(
+                    sa.text(
+                        "INSERT INTO tournament_event_draw_settings"
+                        " (draw_type_key, qualifiers_per_pool)"
+                        f" VALUES (:key, {count})"
+                    ),
+                    {"key": RR_THEN_KO},
+                )
+        assert "ck_tournament_event_draw_settings_qualifiers_per_pool" in str(
+            refusal.value
+        ), f"qualifiers_per_pool={count} was accepted: {refusal.value}"
+
+    # One qualifier per pool IS legal — a two-pool event at K=1 is a single final
+    # between the two pool winners, which the ADR names as a supported shape. So the
+    # floor is at 1, not at 2, and this is what says the refusals above are the
+    # constraint discriminating rather than rejecting everything.
+    accepted = await db_session.execute(
+        sa.text(
+            "INSERT INTO tournament_event_draw_settings"
+            " (draw_type_key, qualifiers_per_pool)"
+            " VALUES (:key, 1) RETURNING qualifiers_per_pool"
+        ),
+        {"key": RR_THEN_KO},
+    )
+    assert accepted.scalar_one() == 1
+
+    await db_session.rollback()
+
+
 async def test_a_seeded_draw_type_cannot_be_deleted_while_an_event_uses_it(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,

--- a/api/tests/test_tournament_event_draw_settings.py
+++ b/api/tests/test_tournament_event_draw_settings.py
@@ -26,7 +26,7 @@ column on ``tournament_events`` to cross-check it against, which is the point.
 
 import uuid
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, get_args
 
 import pytest
 import pytest_asyncio
@@ -42,6 +42,7 @@ from app.models import (
     TournamentEventDrawSettings,
     User,
 )
+from app.schemas.tournament import DrawSettingsWrite
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import grant_permissions, start_session
 
@@ -385,6 +386,35 @@ async def test_a_settings_row_naming_an_unseeded_draw_type_is_refused(
 # ``draw_types`` fixture stands one up per enum member), so these tests no longer
 # have to insert a test-local parent row to reach the constraint's active half.
 RR_THEN_KO = DrawType.rr_then_ko.value
+
+
+def test_every_draw_type_has_an_arm_in_the_write_union() -> None:
+    """``DrawSettingsWrite`` is the request-boundary twin of this table's ``CHECK``:
+    the union says which configuration each draw type may carry, and the constraint
+    says the same thing about the row it lands on.
+
+    Unlike the four dispatch sites (``strategy_for``, ``results_for``, …), a
+    **discriminated union is not exhaustive by construction** — a new ``DrawType``
+    member with no arm type-checks perfectly and surfaces as a 422 in a director's
+    request, at the moment they try to create the event. So the totality those sites
+    get from a catch-all-free ``match`` is asserted here instead, exactly as its
+    siblings do it (``for draw_type in DrawType`` in ``test_draws`` /
+    ``test_results``): a member added without an arm reds in CI, not in production.
+
+    The discriminator is read off each arm's ``draw_type`` **field default** rather
+    than by parsing a payload per arm, because the payloads differ (``rr-then-ko``
+    requires its qualifier count) and the claim here is about the union's *shape*, not
+    about what any one arm accepts.
+    """
+    arms = get_args(get_args(DrawSettingsWrite)[0])
+    discriminators = [arm.model_fields["draw_type"].default for arm in arms]
+
+    assert {discriminator.value for discriminator in discriminators} == {
+        draw_type.value for draw_type in DrawType
+    }
+    # One arm per member, so two arms tagged with the same slug (a copy/paste that
+    # leaves a member uncovered while the set above still matches) also reds.
+    assert len(discriminators) == len(DrawType)
 
 
 async def test_a_new_events_settings_row_carries_no_qualifier_count(

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -5350,6 +5350,15 @@ async def test_creating_an_event_with_an_unimplemented_draw_type_is_422_at_the_b
     strategy, a results strategy and a seeded row, so it is now a slug this boundary
     ACCEPTS, which the create tests beside this one assert. That is the mechanism
     working: the list of refused slugs shrinks by exactly the format that shipped.
+
+    **The accepted slugs are pinned as literals, never re-derived from ``DrawType``.**
+    Pydantic composes that ``expected`` message *out of* the enum, so comparing it back
+    against ``{t.value for t in DrawType}`` is the enum measured against itself: it
+    holds for any set of members, including one somebody added by accident. Written
+    down, this line is the alarm that reds when a member arrives. Adding a draw type
+    takes five coordinated changes (the enum, a strategy, a results strategy, a seeded
+    ``draw_types`` row, the web client's picker), so being made to come and look here is
+    the point.
     """
     client, _ = authed_client
     created = (await client.post("/v1/tournaments", json=_create_payload())).json()
@@ -5363,10 +5372,11 @@ async def test_creating_an_event_with_an_unimplemented_draw_type_is_422_at_the_b
     body = response.json()
     (error,) = [e for e in body["detail"] if e["loc"][-1] == "draw_type"]
     # The 422 names the slugs that run, and nothing else — a client reading it learns
-    # exactly what it may send.
+    # exactly what it may send. Pydantic renders a three-member list as
+    # ``'a', 'b' or 'c'``, so the final " or " becomes a comma before the split.
     assert set(
         error["ctx"]["expected"].replace("'", "").replace(" or ", ", ").split(", ")
-    ) == {t.value for t in DrawType}, error
+    ) == {"round-robin", "single-elim", "rr-then-ko"}, error
     # Refused at the boundary means refused before persistence: no event exists.
     detail = (await client.get(f"/v1/tournaments/{created['id']}")).json()
     assert detail["events"] == []

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -4201,14 +4201,18 @@ async def test_the_detail_payload_carries_the_seeded_draw_types_in_display_order
     seeded one, in ``display_order``, each with the copy to render it.
 
     Order is asserted as a list, not a set: a picker whose options move between two
-    loads is a real defect, and the round-robin/single-elim sequence is the one the seed
-    states."""
+    loads is a real defect, and the round-robin/single-elim/rr-then-ko sequence is the
+    one the seed states."""
     client, _ = authed_client
     tournament_id, _ = await _tournament_with_events(client)
 
     catalogue = await _catalogue_of(client, tournament_id)
 
-    assert [row["key"] for row in catalogue] == ["round-robin", "single-elim"]
+    assert [row["key"] for row in catalogue] == [
+        "round-robin",
+        "single-elim",
+        "rr-then-ko",
+    ]
     assert [row["display_order"] for row in catalogue] == sorted(
         row["display_order"] for row in catalogue
     )
@@ -4225,11 +4229,11 @@ async def test_the_draw_type_catalogue_is_the_table_not_the_draw_type_enum(
     """**The test that makes the design structural.** Delete a ``draw_types`` row and
     the payload loses that option — because the payload is a read of the table.
 
-    A catalogue derived from the ``DrawType`` enum instead would answer both formats
-    here, which is why the enum is asserted to still hold both: the two sources are the
-    same set in every other test in the suite, so this is the only arrangement in which
-    "reads the table" and "iterates the enum" give different answers. If a future
-    refactor swaps one for the other, this is what reds.
+    A catalogue derived from the ``DrawType`` enum instead would answer every format
+    here, which is why the enum is asserted to still hold the deleted one: the two
+    sources are the same set in every other test in the suite, so this is the only
+    arrangement in which "reads the table" and "iterates the enum" give different
+    answers. If a future refactor swaps one for the other, this is what reds.
 
     The event is a ROUND-ROBIN one so the row being deleted is unreferenced — the FK is
     ``ON DELETE RESTRICT`` and would otherwise refuse (see
@@ -4244,10 +4248,10 @@ async def test_the_draw_type_catalogue_is_the_table_not_the_draw_type_enum(
 
     catalogue = await _catalogue_of(client, tournament_id)
 
-    assert [row["key"] for row in catalogue] == ["round-robin"]
-    # And the enum still holds both, so "it followed the table" is the only reading of
-    # the assertion above.
-    assert {t.value for t in DrawType} == {"round-robin", "single-elim"}
+    assert [row["key"] for row in catalogue] == ["round-robin", "rr-then-ko"]
+    # And the enum still holds the deleted one, so "it followed the table" is the only
+    # reading of the assertion above.
+    assert {t.value for t in DrawType} == {"round-robin", "single-elim", "rr-then-ko"}
 
 
 async def test_the_draw_type_copy_and_order_are_the_rows_not_hardcoded(
@@ -4257,9 +4261,10 @@ async def test_the_draw_type_copy_and_order_are_the_rows_not_hardcoded(
     """The other half of the same claim: the label, the help text and the order a client
     renders all come off the row, so a copy change is a seed change and nothing else.
 
-    Rewriting the two rows swaps their order and their words; a catalogue assembled from
-    a Python dict of labels keyed by enum member would answer the old copy in the old
-    order, whatever the table says."""
+    Rewriting two of the rows swaps their order and their words; a catalogue assembled
+    from a Python dict of labels keyed by enum member would answer the old copy in the
+    old order, whatever the table says. The third row is left alone and asserted last,
+    so the rewrite is shown to have moved the two it names and nothing else."""
     client, _ = authed_client
     tournament_id, _ = await _tournament_with_events(client)
     await db_session.execute(
@@ -4291,6 +4296,12 @@ async def test_the_draw_type_copy_and_order_are_the_rows_not_hardcoded(
     assert [(row["key"], row["name"], row["description"]) for row in catalogue] == [
         ("single-elim", "Knockout", "Lose once and you are out."),
         ("round-robin", "Everybody plays everybody", "One pool, every pairing."),
+        (
+            "rr-then-ko",
+            "Round-robin then knockout",
+            "Pools play all-play-all, then the top finishers from each pool meet in "
+            "a knockout bracket.",
+        ),
     ]
 
 
@@ -5317,7 +5328,7 @@ async def test_a_draw_on_a_tournament_or_event_that_does_not_exist_is_404(
 # ----- the draws this event cannot produce (422) ----------------------------
 
 
-@pytest.mark.parametrize("draw_type", ["double-elim", "rr-then-ko", "swiss"])
+@pytest.mark.parametrize("draw_type", ["double-elim", "swiss"])
 async def test_creating_an_event_with_an_unimplemented_draw_type_is_422_at_the_boundary(
     authed_client: tuple[AsyncClient, User],
     draw_type: str,
@@ -5329,12 +5340,16 @@ async def test_creating_an_event_with_an_unimplemented_draw_type_is_422_at_the_b
     This is the ticket's actual complaint (#1086) fixed at the layer that made it. It
     used to be ``test_cutting_an_unimplemented_draw_type_is_422``: a director could
     configure a ``swiss`` event, enter a field, and only discover it was never possible
-    at the moment they cut the draw. ``DrawType`` now holds exactly the two types that
-    run, so Pydantic rejects the slug at the edge with a 422 that NAMES the valid
-    values, no custom validator required — and no event row is written at all.
+    at the moment they cut the draw. ``DrawType`` holds exactly the types that run, so
+    Pydantic rejects the slug at the edge with a 422 that NAMES the valid values, no
+    custom validator required — and no event row is written at all.
 
-    The parametrized subjects are deliberately the three ex-members: they are the
-    values a stale client (or a stale hardcoded picker) would still send.
+    The parametrized subjects are the ex-members that are STILL unimplemented: they are
+    the values a stale client (or a stale hardcoded picker) would still send.
+    ``rr-then-ko`` used to be among them and is deliberately gone — #1227 gave it a
+    strategy, a results strategy and a seeded row, so it is now a slug this boundary
+    ACCEPTS, which the create tests beside this one assert. That is the mechanism
+    working: the list of refused slugs shrinks by exactly the format that shipped.
     """
     client, _ = authed_client
     created = (await client.post("/v1/tournaments", json=_create_payload())).json()
@@ -5347,12 +5362,11 @@ async def test_creating_an_event_with_an_unimplemented_draw_type_is_422_at_the_b
     assert response.status_code == 422, response.text
     body = response.json()
     (error,) = [e for e in body["detail"] if e["loc"][-1] == "draw_type"]
-    # The 422 names the two slugs that run, and nothing else — a client reading it
-    # learns exactly what it may send.
-    assert set(error["ctx"]["expected"].replace("'", "").split(" or ")) == {
-        "round-robin",
-        "single-elim",
-    }, error
+    # The 422 names the slugs that run, and nothing else — a client reading it learns
+    # exactly what it may send.
+    assert set(
+        error["ctx"]["expected"].replace("'", "").replace(" or ", ", ").split(", ")
+    ) == {t.value for t in DrawType}, error
     # Refused at the boundary means refused before persistence: no event exists.
     detail = (await client.get(f"/v1/tournaments/{created['id']}")).json()
     assert detail["events"] == []

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -68,7 +68,7 @@ from app.schemas.tournament import (
 )
 from app.tournament_draws import DrawCurrency, draw_currency_by_event, uncut_draw
 from app.tournament_entry_refusals import EntryRefusal
-from app.tournament_materialization import materialize_live_draw
+from app.tournament_materialization import materialize_event, materialize_live_draw
 from app.tournaments import (
     TOURNAMENT_CREATE,
     TOURNAMENT_VIEW,
@@ -6994,6 +6994,76 @@ async def test_go_live_materialization_is_idempotent(
     assert await _match_count(db_session) == before, (
         "a second advance over already-materialized fixtures must create nothing"
     )
+
+
+async def test_advancing_a_round_robin_event_costs_one_statement_and_no_game_counts(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+) -> None:
+    """``materialize_event`` runs on the **completion seam** — every result submission
+    re-runs it, inside the score-accept transaction, under the match row lock — so what
+    it costs is not a micro-optimization.
+
+    Two things are pinned, and both are invisible in every assertion about the
+    resulting matches. **The game counts are not loaded at all** for a draw type whose
+    ``advance()`` never reads them (``app.draws.reads_fixture_games``): round-robin
+    picks no qualifiers, so the counts were 200–500 score rows fetched and discarded on
+    a mature event. And **the fixtures' match status rides along on the fixture load**
+    rather than costing a second SELECT — the read path already learns it that way
+    (``completed_match_ids`` filters rows it has), so the write seam has no reason to
+    pay a round trip the read seam does not.
+
+    Run against an already-materialized draw with a **completed** match in it, which is
+    exactly what the completion seam sees: nothing is ready, so the whole call is the
+    load — and the completed match is what would make the game-count load fire, without
+    which the "no game counts" half of this pin would be vacuous.
+    ``match_game_scores`` is asserted by name as well as by count, so a regression that
+    folds the game load into the fixture statement still reds.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(client, _rr_payload(POOL_A))
+    await _seed_field(db_session, event["id"], 3)
+    await _cut_the_draw(client, tournament_id, event["id"])
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    assert (await _go_live(client, tournament_id)).status_code == 201
+    played = (
+        (
+            await db_session.execute(
+                select(TournamentFixture).where(
+                    TournamentFixture.event_id == uuid.UUID(event["id"])
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert played is not None and played.match_id is not None
+    match = await db_session.get(Match, played.match_id)
+    assert match is not None
+    match.status = MatchStatus.completed
+    await db_session.commit()
+
+    async with counted_statements(engine) as (session, statements):
+        tournament = (
+            await session.execute(
+                select(Tournament).where(Tournament.id == uuid.UUID(tournament_id))
+            )
+        ).scalar_one()
+        event_row = (
+            await session.execute(
+                select(TournamentEvent).where(
+                    TournamentEvent.id == uuid.UUID(event["id"])
+                )
+            )
+        ).scalar_one()
+        # Only the seam's own statements are counted, not the two loads that stand in
+        # for the caller already holding these rows.
+        statements.clear()
+        await materialize_event(session, tournament, event_row)
+
+    assert len(statements) == 1, statements
+    assert not [s for s in statements if "match_game_scores" in s], statements
 
 
 async def test_a_merge_collision_on_a_played_event_does_not_corrupt_the_draw(

--- a/docs/adr/20260727-rr-then-ko-cuts-both-stages-upfront-and-seeds-qualifiers-rematch-free.md
+++ b/docs/adr/20260727-rr-then-ko-cuts-both-stages-upfront-and-seeds-qualifiers-rematch-free.md
@@ -1,0 +1,214 @@
+# rr-then-ko cuts both stages upfront and seeds qualifiers rematch-free
+
+Date: 2026-07-27 (date-numbered — sequential numbers collide across concurrent
+worktrees; see `scripts/check-adr-numbering.sh`)
+
+## Status
+
+Accepted — decided before implementation, for issue #1227 (split out of #787).
+Builds on ADR 20260726 ("a draw type is a seeded row, and the enum holds only
+what runs"), whose closing paragraph predicted this ticket would be "a seeded
+row, an enum member, a strategy, a results strategy, and a settings variant,
+and the client needs no change." Two of those claims turn out to be wrong; see
+Context.
+
+## Context
+
+`rr-then-ko` runs round-robin pools, then seeds a single-elimination knockout
+from the pool finishers — top *K* from each pool advance. #1219 deleted the
+member from `DrawType`, so the format is currently unconstructible, and #1227
+re-adds it on top of the substrate #1219 landed.
+
+Two premises inherited from the prior ADRs did not survive checking.
+
+**"The client needs no change" is false, and fails silently.** The draw-type
+picker does render the served catalogue, but
+`web-client/src/components/tournaments/data/draw-types.ts:29` holds `DRAW_TYPES`,
+a hardcoded slug allowlist, and the catalogue parser's transform *filters out*
+any served key not in it. Seeding an `rr-then-ko` row therefore makes the type
+appear in OpenAPI and **vanish from the picker** — no error, no warning, just an
+absent option. At least three client edits are required, only one of which
+(`planDraw`'s exhaustive `switch` in the MSW factory) is a compile error.
+
+**The settings discriminated union does not exist.** ADR 20260726's companion
+describes settings as "a Pydantic discriminated union tagged by the slug over
+`RoundRobinSettings | SingleElimSettings`". Those classes were never written —
+`tournament_event_draw_settings` holds only `draw_type_key`. This ticket
+*creates* the union rather than appending to it, and it is the first
+draw-type-conditional control in the event editor: there is no per-draw-type
+settings UI anywhere today, and `PoolsSection` does not so much as mention
+`drawType`.
+
+Three facts about the existing code shaped the decisions below.
+
+**`_seed_slots` pairs seed `s` with seed `B+1−s` in round one.** The function's
+recursion maintains that adjacent slots sum to `2·len + 1`; its own docstring's
+worked 16-slot example (`1,16,9,8,5,12,13,4,…`) has every pair summing to 17.
+This collapses "seed the qualifiers into the bracket" from a bracket-layout
+problem to a much smaller one: choosing which qualifier gets which seed *number*.
+
+**`advance()` cannot see game counts.** Its whole input is `Sequence[FixtureState]`,
+which carries `winner_entry_id` but no per-side games, so it can compute wins and
+head-to-head but neither of the two game tiebreakers a pool's finishing order
+falls through to. And `app.results` already imports `app.draws`, so the obvious
+fix — have the strategy call `RoundRobinResults` — is an import cycle.
+
+**The schedule preview refuses per *tournament*, not per event.** The exhaustive
+`match` at `app/schedule_preview.py:260` sits inside the per-event loop of a
+whole-tournament builder, so a single un-schedulable event aborts the preview for
+every event beside it. That refusal was written when the only un-pooled type was
+single-elim, where the *entire* event is un-schedulable; the reasoning does not
+transfer to a format whose pool stage schedules perfectly well.
+
+## Decision
+
+**Both stages are cut in one stroke, and the knockout bracket is cut upfront with
+TBD sides.** `plan_initial` emits the pool fixtures *and* the full bracket. This
+was pre-committed by ADR-0786's `AdvancePlan`, which can express only `SideFill`
+(fill a side of an *existing* fixture) plus `ready_fixture_ids` — there is
+deliberately no way for `advance()` to create a fixture, and giving it one is a
+far wider blast radius than a new strategy. The cost is nil: the qualifier count
+is `P × K`, known at cut time, so the bracket size `next_power_of_two(P × K)` is
+deterministic. Bracket size is **derived, never configured** — carrying both
+lets them contradict (`api/CLAUDE.md`, "don't carry a field and its own
+derivation in the same model").
+
+**No new fixture columns.** `pool_id IS NULL` is the knockout stage, exactly as
+ADR-0786 pre-committed and as four places already encode.
+
+**The legal configuration space** is: `K ≥ 1` enforced by Pydantic at the request
+boundary (static); `P × K ≥ 2` and `K ≤ ⌊N/P⌋` enforced at the cut as
+`DegenerateDraw` (both depend on the entrant count, which moves). This mirrors
+the split `_snake` already uses for its own pool floor. A **one-pool**
+rr-then-ko is legal — it is "league, then a playoff", a real format — and so is
+`K = ⌊N/P⌋`, where everyone qualifies and the pool stage exists purely to seed.
+
+**Round-one knockout fixtures never pair two entrants from the same pool, for
+`P ≥ 2`, and the guarantee is absolute rather than best-effort.** Qualifiers are
+ordered **place-major** — every pool winner outranks every runner-up — and the
+*pool order within a place* is chosen to avoid conflicts. Three facts make this
+provable rather than hopeful:
+
+- a place block holds each pool exactly once, so an **intra-block** round-one
+  pair is safe automatically;
+- round-one pairing is a perfect matching on seeds, so each seed has **at most
+  one** partner and therefore at most **one forbidden pool**;
+- assigning blocks in order, every position then allows at least `P−1` pools, and
+  Hall's condition holds for `P ≥ 2` — any set `S` of positions with `|S| ≤ P−1`
+  has `|N(S)| ≥ P−1 ≥ |S|`, and `|S| = P` reaches every pool since each position
+  forbids only one. A conflict-free assignment always exists, and a deterministic
+  pass (pools tried in ascending order) finds it.
+
+We rejected the two fixed orderings the issue floated. Ordering by place-then-pool
+pairs `C1` against `C2` at three pools; reversing the runners-up fixes three pools
+and breaks two. Neither can be universal, because *which* pairs are cross-block
+depends on `B − Q`, which jumps around with `P`. A rule that adapts per block is
+the only kind that can be.
+
+`_seed_slots` is **reused unchanged** — it supplies the bracket's shape, and this
+decision only chooses seed numbers.
+
+**Within a finishing place, pools are not ranked against each other.** Every pool
+winner is an equal. This is the same stance `FinishRow` already takes on
+same-round losers: inventing a cross-pool tiebreak would fabricate an order the
+format never produced. It is also precisely what leaves the permutation free for
+the guarantee above.
+
+**With one pool the guarantee is waived, not broken.** Every qualifier shares a
+pool, so every knockout match is a rematch. That is the format working as
+intended.
+
+**Qualifiers are seated per-pool, as each pool finishes.** The seed → (pool,
+place) map depends only on `P`, `K` and `B`, so it is fully determined at cut
+time and is independent of results. A pool's qualifiers therefore go into their
+predetermined slots the moment *that* pool is decided, with other pools still
+playing; the knockout fixture simply is not `ready` until both its sides are
+seated, which `ready_fixtures` already handles. `advance()` stays idempotent
+because `SideFill` only ever fills an empty side.
+
+**The pool finishing order moves to a shared pure module that both `app.draws`
+and `app.results` import.** The tiebreak chain is not reimplemented — it is the
+existing one, relocated so both callers can reach it, which resolves the import
+cycle. `RoundRobinResults` keeps being the standings strategy and calls it for
+its table; the rr-then-ko strategy calls the same function to take the top *K*.
+The claim this protects is that **the qualifiers are exactly the top *K* of the
+standings table the tournament is reading** — structurally, not by two
+implementations agreeing.
+
+`FixtureState` gains the games each side won, which is unavoidable if
+qualification is to match the displayed standings, and lets qualification derive
+from the same live-outcome view the standings use rather than the written-back
+`winner_entry_id` that no read reads. We rejected giving rr-then-ko a *reduced*
+tiebreak chain (wins → head-to-head → entry id) that `FixtureState` already
+supports: it is nearly free and silently disagrees with the standings on screen,
+at the exact moment — a three-way tie for the last qualifying spot — when a
+director is looking hardest.
+
+**Knockout rounds restart at 1.** The unique constraint is
+`(event_id, pool_id, round, position)` declared `NULLS NOT DISTINCT`, so the
+knockout stage has its own numbering namespace. Continuing from the pool rounds
+was rejected as *ill-defined*, not merely ugly: pool rounds run `1..seats−1`, and
+`_snake` lets pools within one event differ in size, so there is no single "last
+pool round" to offset from — and even taking the maximum, "the semifinal" would
+be round 5 in one event and round 7 in another. Restarting also means the
+knockout maths transfers unchanged (`_successor`, and `SingleElimResults`'
+`2 ** (final_round − round) + 1`), and the client's bracket — which names rounds
+relative to the maximum round it is handed, and is handed only the un-pooled
+fixtures — produces "Final / Semifinals / Quarterfinals" with no change at all.
+
+`_round_label` widens to take the fixture's `pool_id`, since `pool_id IS NULL`
+is already the stage discriminator, and reuses the two existing arms' vocabulary
+verbatim: pooled → `"Group match N"`, un-pooled → `"Round N"`.
+
+**Results are a third arm of the wire union, tagged `standings_then_finishes`,**
+carrying one standings block and one finishes block. Restructuring the union into
+a composite was rejected: it would change how the existing two arms are read,
+forcing client changes for round-robin and single-elim that buy nothing. **The
+champion comes from the bracket** — never from a pool — and `complete` is both
+stages decided.
+
+**The schedule preview previews the pool stage and skips the knockout stage,**
+rather than refusing the whole tournament. In the *live* solver this already
+happens for free: `schedule_solves.py` skips un-pooled fixtures and TBD-sided
+ones independently, so an rr-then-ko event's pools schedule today with no new
+code. Only the preview needs a filter. Scheduling the knockout stage is **#1228**,
+deliberately out of scope — a freshly cut bracket is entirely TBD-sided, so
+knockout scheduling is inherently *incremental* (placeable only as pools resolve),
+which is a different solver contract rather than a bigger one.
+
+## Consequences
+
+The client is not free, and one of its failure modes is silent. `DRAW_TYPES` must
+gain the slug or the picker quietly omits the format. `planDraw`'s exhaustive
+`switch` and `ResultsPanel`'s `never` arm *are* compile errors and will catch
+themselves; `parseResults` will not — it **throws** on an unknown `kind`, which
+fails the whole tournament-detail query rather than degrading one panel. **Server
+and client must therefore land in the same PR**, or the app breaks for every
+tournament, not just rr-then-ko ones.
+
+`StandingsPanel` and `FinishesPanel` cannot be reused as they stand: each takes
+the `event` and internally bails unless `results.kind` matches its own, so
+rendering both means refactoring them to accept their data as props.
+
+The MSW store does not derive results at all — every seeded event hardcodes its
+`results` block and `cutDraw` never touches it — so exercising the new shape in
+dev and vitest means hand-seeding a two-stage fixture.
+
+`FixtureState` gaining game counts touches the projection in
+`app.tournament_draws` and adds a query at the materialization seam. The two
+strategies that do not care ignore the new fields.
+
+The "a multi-pool round-robin has no champion" carve-out in `EventResults` and
+`StandingsResultsRead` stays **true** and keeps its meaning; only its
+parenthetical — that a pools-then-knockout draw type "does not exist yet" —
+goes stale. Editing it as though the claim itself had changed would introduce a
+bug.
+
+`_stage_label` needs an arm, and "complete" is ambiguous for a two-stage event.
+It stays minimal (`"Complete"` / `"In play"`); naming which stage is live needs
+more plumbing than this ticket should buy.
+
+Every draw type still reaching an exhaustive `match` means the four dispatch
+sites (`strategy_for`, `results_for`, `schedule_preview`, `dashboard_tournaments`)
+fail to type-check until all are handled — which is the property ADR 20260726
+bought, working as designed.

--- a/docs/adr/20260727-rr-then-ko-cuts-both-stages-upfront-and-seeds-qualifiers-rematch-free.md
+++ b/docs/adr/20260727-rr-then-ko-cuts-both-stages-upfront-and-seeds-qualifiers-rematch-free.md
@@ -93,11 +93,26 @@ provable rather than hopeful:
   pair is safe automatically;
 - round-one pairing is a perfect matching on seeds, so each seed has **at most
   one** partner and therefore at most **one forbidden pool**;
-- assigning blocks in order, every position then allows at least `P−1` pools, and
-  Hall's condition holds for `P ≥ 2` — any set `S` of positions with `|S| ≤ P−1`
-  has `|N(S)| ≥ P−1 ≥ |S|`, and `|S| = P` reaches every pool since each position
-  forbids only one. A conflict-free assignment always exists, and a deterministic
-  pass (pools tried in ascending order) finds it.
+- assigning blocks in order, every position then allows at least `P−1` pools, so
+  Hall's condition holds for any set `S` of positions with `|S| ≤ P−1`
+  (`|N(S)| ≥ P−1 ≥ |S|`). The remaining case, `|S| = P`, is the one that needs
+  the block's *geometry* rather than a counting argument, and the first draft of
+  this ADR got it wrong: "each position forbids only one pool" does **not** by
+  itself reach every pool, because `|N(S)|` collapses to `P−1` precisely when all
+  `P` positions forbid the *same* pool. What rules that out is that a block is
+  `P` **consecutive** seeds and round one pairs `s ↔ B+1−s`, which is
+  order-reversing — so a block's partners are themselves a run of `P` consecutive
+  seeds, spanning at most two blocks, and each block hands each pool to exactly
+  one seed. At most **two** of a block's positions can therefore forbid the same
+  pool, which is fewer than `P` for `P ≥ 3`. `P = 2` is the only size where two
+  would suffice, and there the partner run is `{B−2b−1, B−2b}`, whose lower
+  member is odd because `B` is a power of two — so both partners sit in the *same*
+  block and hold *different* pools.
+
+  A conflict-free assignment therefore always exists, and a deterministic pass
+  (pools tried in ascending order, augmenting when stuck) finds it. Probed over
+  `P` 2..64 × `K` 1..40, the largest number of one block's positions forbidding a
+  single pool is **1**, so the bound proved here is conservative.
 
 We rejected the two fixed orderings the issue floated. Ordering by place-then-pool
 pairs `C1` against `C2` at three pools; reversing the runners-up fixes three pools

--- a/docs/adr/20260727-rr-then-ko-cuts-both-stages-upfront-and-seeds-qualifiers-rematch-free.md
+++ b/docs/adr/20260727-rr-then-ko-cuts-both-stages-upfront-and-seeds-qualifiers-rematch-free.md
@@ -212,6 +212,36 @@ deliberately out of scope — a freshly cut bracket is entirely TBD-sided, so
 knockout scheduling is inherently *incremental* (placeable only as pools resolve),
 which is a different solver contract rather than a bigger one.
 
+**A voided pool pairing is left out of the "pool is finished" test, not counted as
+a missing score.** A voided match is terminal and never produces a result. The
+standings already take this position: `PoolInput.fixture_count` counts only the
+pairings that can still yield a result, so a pool that hit one still reaches
+`complete`. The draw side must agree, because the qualifiers are meant to be the
+top of the table a director is reading. If it counted the voided pairing instead,
+the pool would sit one score short forever. Its qualifiers would never seat, the
+knockout would never become ready, and no director action could clear it, while
+the table on screen called that same pool complete. Two layers would disagree
+about the one fact they exist to share.
+
+The voided pairing's **entrants** still count as seated in the pool. A player
+whose only pairing was voided appears in the finishing order with a row of zeros,
+which is what the standings table shows.
+
+**A pool with no usable result at all is refused, not served.** When every pairing
+in a pool is voided, the only thing left to rank on is the entry-id fallback at
+the end of the tiebreak chain, so the qualifiers would be arbitrary. This is the
+one place the two layers part company on purpose. The standings call such a pool
+complete and show a table of zeros, which is honest to look at. Seating
+qualifiers off it would not be. Voiding has exactly one producer today, an
+account merge's self-play collision (ADR-0013), so reaching this needs every
+pairing in one pool to be voided.
+
+Nothing re-advances a draw at void time. `account_merge` calls `void_match` and
+never `materialize_event`, so the seating catches up on the next result
+completion in that event. If the voided pairing is the last thing outstanding in
+the whole event, no further completion happens and those qualifiers stay
+unseated. Making the void path re-advance the event would close that gap.
+
 ## Consequences
 
 The client is not free, and one of its failure modes is silent. `DRAW_TYPES` must

--- a/docs/adr/20260727-rr-then-ko-cuts-both-stages-upfront-and-seeds-qualifiers-rematch-free.md
+++ b/docs/adr/20260727-rr-then-ko-cuts-both-stages-upfront-and-seeds-qualifiers-rematch-free.md
@@ -126,6 +126,27 @@ playing; the knockout fixture simply is not `ready` until both its sides are
 seated, which `ready_fixtures` already handles. `advance()` stays idempotent
 because `SideFill` only ever fills an empty side.
 
+**A correction that changes who qualified does not re-seat the bracket**, and we
+ship that knowingly. Because `SideFill` only fills an *empty* side, a pool match
+corrected after its pool's qualifiers were seated leaves the original qualifier
+in the bracket while the standings re-order beneath them. Single-elimination
+already behaves this way — a corrected result never un-seats a winner — so this
+is not a new class of behaviour, but rr-then-ko makes it far easier to reach:
+pool corrections are ordinary, and the window between a pool finishing and its
+qualifiers playing out is long.
+
+We considered re-seating while the knockout stage is untouched (allowed only
+before any KO match has materialized) and rejected it for now as new state to
+reason about for a case that has not yet been observed; and refusing the
+correction outright, which makes a genuine scoring error uncorrectable — much
+worse than the disagreement it prevents. If this bites in practice, the
+untouched-bracket re-seat is the option to reach for.
+
+**The seeded row's director-facing copy** is `Round-robin then knockout` /
+`Pools play all-play-all, then the top finishers from each pool meet in a
+knockout bracket.` Recorded here because `draw_types.name` and `.description`
+are seed data, so changing them is a migration.
+
 **The pool finishing order moves to a shared pure module that both `app.draws`
 and `app.results` import.** The tiebreak chain is not reimplemented — it is the
 existing one, relocated so both callers can reach it, which resolves the import

--- a/e2e/page-objects/tournament-detail-page/event-editor.page.ts
+++ b/e2e/page-objects/tournament-detail-page/event-editor.page.ts
@@ -1,0 +1,111 @@
+import { expect, Locator, Page } from '@playwright/test'
+
+/**
+ * The **event editor** — the slide-in sheet the Events tab opens for "New event" and
+ * for any event card. Scoped to what the rr-then-ko spec authors through it: the name,
+ * the draw type, its qualifier count, and the pools the draw will be dealt across.
+ *
+ * ## Why a spec drives this sheet rather than seeding the event over the API
+ *
+ * The event's draw configuration is a **pair** — `draw_type` and `qualifiers_per_pool`
+ * — and the client builds it in exactly one place (`drawSettingsToApi`, shared by the
+ * create POST and the update PATCH). That builder is the seam the arc's 422 lived in:
+ * an event whose type says `rr-then-ko` and whose body carries no qualifier count is
+ * refused at the request boundary, and no mocked suite can observe it, because the mock
+ * accepts whatever it is sent. Seeding the event with hand-written JSON would move the
+ * payload-building out of the client and prove only that the server accepts a body the
+ * test itself composed. So the sheet is driven for real.
+ *
+ * Raw selectors stay here; the spec reads intent-named locators (`e2e/CLAUDE.md`).
+ */
+export class EventEditorPage {
+  constructor(private readonly page: Page) {}
+
+  // ----- Basics -------------------------------------------------------------
+
+  /** The event's name box. Labelled, so this is the label a director reads. */
+  get nameInput(): Locator {
+    return this.page.getByLabel('Event name')
+  }
+
+  /** The draw-type picker. A shadcn/Radix `Select`, so its trigger is a `combobox`
+   * and its options live in a portal — hence the two-step `chooseDrawType` below. */
+  get drawTypeSelect(): Locator {
+    return this.page.getByRole('combobox', { name: 'Draw type' })
+  }
+
+  /** **K** — the per-pool qualifier count. Present for `rr-then-ko` and for nothing
+   * else: the control is ABSENT, not disabled, for a draw type with no knockout stage
+   * to qualify for, so its visibility is itself the assertion that the picker's choice
+   * reached the form. */
+  get qualifiersInput(): Locator {
+    return this.page.getByLabel('Qualifiers per pool')
+  }
+
+  /** The refusal the sheet shows when a save is rejected — the surface a 422 from the
+   * server lands on. A spec asserts it is HIDDEN after a successful create: a create
+   * that failed leaves the sheet open with this alert in it, and "the sheet is still
+   * there" is a far more legible failure than a missing event three steps later. */
+  get errorAlert(): Locator {
+    return this.page.getByTestId('event-editor-error')
+  }
+
+  /** Pick a draw type by the label the **server's catalogue** gives it (ADR 20260726 —
+   * the picker renders the served list, so this is the server's own copy, not the
+   * client's). Exact, because `Round-robin` is a prefix of `Round-robin then knockout`
+   * and a substring match would silently choose the wrong format. */
+  async chooseDrawType(label: string): Promise<void> {
+    await this.drawTypeSelect.click()
+    await this.page.getByRole('option', { name: label, exact: true }).click()
+    // The trigger shows the chosen label — the select actually committed, rather than
+    // the click having landed on a portal that was still animating in.
+    await expect(this.drawTypeSelect).toContainText(label)
+  }
+
+  /** Type the qualifier count. A blank box is a *missing answer* for this draw type
+   * (never `0`), so it is filled with a real number and read back. */
+  async setQualifiersPerPool(count: number): Promise<void> {
+    await this.qualifiersInput.fill(String(count))
+    await expect(this.qualifiersInput).toHaveValue(String(count))
+  }
+
+  // ----- Table pools --------------------------------------------------------
+
+  /** The "Table pools" tab of the sheet — plain component state, no navigation. */
+  get poolsTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Table pools' })
+  }
+
+  /** Every pool card currently in the draft, so a spec can count them. */
+  get poolCards(): Locator {
+    return this.page.getByTestId('pool-card')
+  }
+
+  /**
+   * Add `count` pools, minting each with the section's own defaults (`Pool A`, `Pool B`,
+   * … over the event's window). The first one comes from the empty state's "Add first
+   * pool" and the rest from the header's "Add pool" — two different controls for the
+   * same act, which is a distinction the section makes and a caller should not have to.
+   *
+   * Leaves the pools with **no tables reserved**: `table_ids` may be empty on the wire,
+   * and the draw does not need a table to be *cut* (placement is the scheduler's job).
+   */
+  async addPools(count: number): Promise<void> {
+    await this.poolsTab.click()
+    await this.page.getByRole('button', { name: 'Add first pool' }).click()
+    for (let i = 1; i < count; i += 1) {
+      await this.page.getByRole('button', { name: 'Add pool' }).click()
+    }
+    // The draft really holds `count` pools before anything is submitted — otherwise a
+    // missed click surfaces as a wrong pool count in the *draw*, three steps away.
+    await expect(this.poolCards).toHaveCount(count)
+  }
+
+  // ----- footer -------------------------------------------------------------
+
+  /** The create/save button. Reads "Create event" for a new event and "Save changes"
+   * for an existing one — the same button, so a spec names the act it is performing. */
+  get createEventButton(): Locator {
+    return this.page.getByRole('button', { name: 'Create event' })
+  }
+}

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from '@playwright/test'
 
+import { EventEditorPage } from './tournament-detail-page/event-editor.page'
 import { ScheduleTabPage } from './tournament-detail-page/schedule-tab.page'
 
 /**
@@ -98,6 +99,25 @@ export class TournamentDetailPage {
     return this.page.getByTestId('lifecycle-notice')
   }
 
+  // ----- events (Events tab) ------------------------------------------------
+
+  /** **New event** — opens the editor sheet on a blank draft. Owner-only. */
+  get newEventButton(): Locator {
+    return this.page.getByRole('button', { name: 'New event' })
+  }
+
+  /** Open the event editor on a new draft and return its page object (the
+   * child-composition variant, like `openSchedule`). A tournament with no events yet
+   * offers the invitation from its empty state instead of the section header, so both
+   * controls are accepted — they are one act. */
+  async openNewEvent(): Promise<EventEditorPage> {
+    await this.newEventButton
+      .or(this.page.getByRole('button', { name: 'Add an event' }))
+      .first()
+      .click()
+    return new EventEditorPage(this.page)
+  }
+
   // ----- entry (event card) -------------------------------------------------
 
   /** The self-registration **Enter** button on an event's card, by event name. */
@@ -136,6 +156,42 @@ export class TournamentDetailPage {
   /** A materialized fixture's live match status ("In progress" → "Completed"). */
   fixtureMatchStatus(eventId: string): Locator {
     return this.drawPanel(eventId).getByTestId('fixture-match-status')
+  }
+
+  /** **Every pool section** of a cut draw, so a spec can count them. Addressed by the
+   * testid *pattern* rather than by pool id on purpose: the rr-then-ko spec authors its
+   * pools in the browser, where the ids are minted client-side and never handed back to
+   * the test. What the test knows — and what the format is about — is how MANY pools
+   * the draw was dealt across. */
+  poolDraws(eventId: string): Locator {
+    return this.drawPanel(eventId).getByTestId(/^pool-draw-/)
+  }
+
+  /** One pool section of a cut draw, by the pool's displayed name ("Pool A"). */
+  poolDrawNamed(eventId: string, poolName: string): Locator {
+    return this.poolDraws(eventId).filter({
+      has: this.page.getByRole('heading', { name: poolName, level: 4 }),
+    })
+  }
+
+  /** The **knockout bracket** — the fixtures belonging to no pool, rendered as
+   * rounds-as-columns.
+   *
+   * For an `rr-then-ko` draw this must be present the moment the draw is cut, with its
+   * sides still unknown: both stages are cut in one stroke (ADR 20260727), because an
+   * `advance()` can only ever FILL a side of an existing fixture and so could never
+   * bring a bracket into being later. Pools without this is not a selector problem — it
+   * is the second stage genuinely missing. */
+  bracket(eventId: string): Locator {
+    return this.drawPanel(eventId).getByTestId('draw-unpooled')
+  }
+
+  /** One round-column of the bracket. Its fixtures are `<li>`s, so a spec counts them
+   * with `getByRole('listitem')`; the highest round that exists is the final, which is
+   * how a spec pins the bracket's SIZE (three rounds = eight slots = the smallest power
+   * of two that holds `P × K` qualifiers). */
+  bracketRound(eventId: string, round: number): Locator {
+    return this.bracket(eventId).getByTestId(`bracket-round-${round}`)
   }
 
   // ----- standings (event card) ---------------------------------------------

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -1,5 +1,5 @@
 import type { APIResponse } from '@playwright/test'
-import type { Guest } from './match-api'
+import { findUserId, mintGuest, type Guest } from './match-api'
 
 // Composed-stack API helpers for provisioning the **inert scaffolding** of a
 // tournament directly against the real API (through nginx at `/api`), so a spec
@@ -126,6 +126,61 @@ export interface SeededTournament {
 }
 
 /**
+ * Create a **draft** tournament and nothing else — no events.
+ *
+ * The empty shell is a first-class seed, not half of `seedTournament`: an event is the
+ * subject of some specs rather than their scaffolding. `tournament-rr-then-ko.spec.ts`
+ * authors its event through the **event editor in the browser**, because the payload
+ * that editor builds — specifically whether it carries `qualifiers_per_pool` — is the
+ * exact seam the arc's 422 lived in, and an event seeded here by hand-written JSON
+ * would prove only that the *server* accepts the field.
+ *
+ * The table catalogue is still seeded (a pool references its tables by id, and the
+ * browser has no way to invent one), as is the venue — see `SeedTournamentOptions` for
+ * what `address: null` means.
+ */
+export async function createTournament(
+  director: Guest,
+  name: string,
+  options: SeedTournamentOptions = {},
+): Promise<string> {
+  const tables = options.tables ?? [{ id: TABLE_ID, label: 'Table 1', court: 'A' }]
+  // `??` would be wrong here: `null` is a MEANINGFUL value for this option ("no
+  // venue"), and `null ?? default` would silently give it a venue. Only an
+  // *omitted* option falls back to the default address.
+  const address =
+    options.address === undefined
+      ? {
+          venue: 'Test Arena',
+          street: '1 Test Way',
+          city: 'Testville',
+          region: 'TS',
+          postal: '00000',
+          country: 'Testland',
+        }
+      : options.address
+
+  const res = await director.ctx.post(`${API}/tournaments`, {
+    headers: { [CSRF_HEADER]: director.csrf },
+    data: {
+      name,
+      // No venue = the `address` key is simply absent from the payload. Sending
+      // it as `null` would work too (both mean "no venue" on create), but the
+      // absent key is the shape a non-browser caller produces, and keeping the
+      // two routes distinct is deliberate: the browser's explicit `null` is
+      // covered through the UI in `tournament-no-venue.spec.ts`.
+      ...(address === null ? {} : { address }),
+      // A pool references these tables by id, so the catalogue must carry them.
+      table_catalogue: tables,
+    },
+  })
+  if (res.status() !== 201) {
+    throw new Error(`create tournament failed: ${res.status()} ${await res.text()}`)
+  }
+  return ((await res.json()) as { id: string }).id
+}
+
+/**
  * Create a **draft** tournament with one singles, **round-robin**, **unrated**,
  * best-of-1 event, drawn across a single pool that holds one table — the minimal
  * shape that can go live and produce a champion.
@@ -147,41 +202,13 @@ export async function seedTournament(
 ): Promise<SeededTournament> {
   const slot = options.slot ?? { date: '2026-08-01', start: '09:00', end: '17:00' }
   const tables = options.tables ?? [{ id: TABLE_ID, label: 'Table 1', court: 'A' }]
-  // `??` would be wrong here: `null` is a MEANINGFUL value for this option ("no
-  // venue"), and `null ?? default` would silently give it a venue. Only an
-  // *omitted* option falls back to the default address.
-  const address =
-    options.address === undefined
-      ? {
-          venue: 'Test Arena',
-          street: '1 Test Way',
-          city: 'Testville',
-          region: 'TS',
-          postal: '00000',
-          country: 'Testland',
-        }
-      : options.address
-
-  const tournamentRes = await director.ctx.post(`${API}/tournaments`, {
-    headers: { [CSRF_HEADER]: director.csrf },
-    data: {
-      name,
-      // No venue = the `address` key is simply absent from the payload. Sending
-      // it as `null` would work too (both mean "no venue" on create), but the
-      // absent key is the shape a non-browser caller produces, and keeping the
-      // two routes distinct is deliberate: the browser's explicit `null` is
-      // covered through the UI in `tournament-no-venue.spec.ts`.
-      ...(address === null ? {} : { address }),
-      // The pool references these tables by id, so the catalogue must carry them.
-      table_catalogue: tables,
-    },
+  // Resolve the catalogue HERE and pass it down, rather than letting
+  // `createTournament` default it again: the pool below references these tables
+  // by id, so the two must be the same list by construction.
+  const tournamentId = await createTournament(director, name, {
+    ...options,
+    tables,
   })
-  if (tournamentRes.status() !== 201) {
-    throw new Error(
-      `create tournament failed: ${tournamentRes.status()} ${await tournamentRes.text()}`,
-    )
-  }
-  const tournamentId = ((await tournamentRes.json()) as { id: string }).id
 
   const eventRes = await director.ctx.post(
     `${API}/tournaments/${tournamentId}/events`,
@@ -254,6 +281,93 @@ export async function enterPlayer(
       `director-entry failed: ${res.status()} ${await res.text()}`,
     )
   }
+}
+
+/** The slice of an event the rr-then-ko spec reads back off the tournament detail:
+ * its id, and the **draw configuration as the server stored it**.
+ *
+ * `draw_type` and `qualifiers_per_pool` are one fact in two columns (ADR 20260727), so
+ * they are read as a pair. Reading them back is what turns "the create request did not
+ * 422" into "the server holds the configuration the director typed" — a 201 alone would
+ * also be returned by a server that had quietly dropped K. */
+export interface EventDrawConfig {
+  readonly id: string
+  readonly name: string
+  readonly draw_type: string
+  /** **K**. `null` for every draw type that has no knockout stage to qualify for. */
+  readonly qualifiers_per_pool: number | null
+  /** The server's own count of active entries. Read here rather than counted off the
+   * roster on screen, which **truncates** at eight chips and a `+N more` line: a spec
+   * counting list items there would be counting the truncation, and at nine entrants
+   * the two numbers happen to coincide — a green assertion measuring the wrong thing. */
+  readonly entered: number
+}
+
+/**
+ * Find an event of `tournamentId` **by name** and return its id and draw configuration.
+ *
+ * By name because the spec that needs this created the event *in the browser* — the id
+ * was minted server-side and never crossed back through anything the test can see. The
+ * name is the one handle the test authored itself.
+ *
+ * Throws when no event matches, which is the honest report of a create that silently
+ * did not happen.
+ */
+export async function findEventByName(
+  viewer: Guest,
+  tournamentId: string,
+  eventName: string,
+): Promise<EventDrawConfig> {
+  const res = await viewer.ctx.get(`${API}/tournaments/${tournamentId}`)
+  if (!res.ok()) {
+    throw new Error(`load tournament failed: ${res.status()} ${await res.text()}`)
+  }
+  const detail = (await res.json()) as {
+    events: ReadonlyArray<EventDrawConfig>
+  }
+  const event = detail.events.find((e) => e.name === eventName)
+  if (!event) {
+    const names = detail.events.map((e) => e.name).join(', ') || '(none)'
+    throw new Error(
+      `no event named "${eventName}" on tournament ${tournamentId} — has: ${names}`,
+    )
+  }
+  return event
+}
+
+/**
+ * Mint `count` fresh guests and **director-enter** every one of them into the event,
+ * returning them so the spec can name them (and dispose their contexts).
+ *
+ * The fleet exists because some draw shapes only appear at scale: three pools with three
+ * players each is nine entrants, and nine self-registrations through the browser would
+ * be nine sign-ins to run a test whose subject is the *draw*, not registration. Each
+ * guest is minted the same way `mintGuest` mints one — `GET /v1/session` into its own
+ * cookie jar — and entered by the director (`enterPlayer`), the seam that has no web UI.
+ *
+ * Sequential on purpose: entries land in registration order, which is the order the
+ * draw deals from (ADR-0786), so a serial loop makes the seeded field deterministic
+ * rather than dependent on how nine parallel POSTs happened to interleave.
+ *
+ * Requires the tournament to be **published** — `enterPlayer` says why.
+ */
+export async function seedEntrants(
+  director: Guest,
+  baseURL: string,
+  tournamentId: string,
+  eventId: string,
+  count: number,
+): Promise<Guest[]> {
+  const entrants: Guest[] = []
+  for (let i = 0; i < count; i += 1) {
+    const guest = await mintGuest(baseURL)
+    // Ephemeral guests are searchable, so the typeahead is how one user's id is
+    // resolved from another's session — the same route the opponent picker takes.
+    const userId = await findUserId(director, guest.username)
+    await enterPlayer(director, tournamentId, eventId, userId)
+    entrants.push(guest)
+  }
+  return entrants
 }
 
 /**

--- a/e2e/tests/tournament-rr-then-ko.spec.ts
+++ b/e2e/tests/tournament-rr-then-ko.spec.ts
@@ -1,0 +1,231 @@
+import { test, expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+
+import { TournamentDetailPage } from '../page-objects/tournament-detail.page'
+import { guestFromContext } from '../support/match-api'
+import { grantBetaTester } from '../support/rbac-grant'
+import {
+  createTournament,
+  findEventByName,
+  seedEntrants,
+  type TableSpec,
+} from '../support/tournament-api'
+
+/** The event the director authors in the browser, and the handle the spec finds it by
+ * afterwards — its id is minted server-side and never crosses back through the UI. */
+const EVENT_NAME = 'Open Singles'
+
+/** The draw type's **server-authored** label. The picker renders the served catalogue
+ * (ADR 20260726), so this string is the seed row's `name` column, not the client's. */
+const DRAW_TYPE_LABEL = 'Round-robin then knockout'
+
+/** `P` — three pools, which is the smallest number at which the format's cross-pool
+ * seeding rule has anything to say (with one pool the guarantee is waived, with two it
+ * is nearly free). */
+const POOL_COUNT = 3
+/** `K` — the qualifiers per pool. The number this whole spec exists to get onto the
+ * wire: an `rr-then-ko` create body without it is a **422** at the request boundary. */
+const QUALIFIERS_PER_POOL = 2
+/** `N` — nine entrants, dealt three to a pool. Enough to satisfy the cut's two
+ * entrant-dependent refusals (`K ≤ ⌊N/P⌋` = 3, and `P × K ≥ 2`) with room to spare, and
+ * enough that each pool is a real round-robin rather than a single pairing. */
+const ENTRANT_COUNT = 9
+
+/** `B` — the bracket the cut must derive: the smallest power of two that holds the
+ * `P × K` = 6 qualifiers. **Eight, not sixteen** — the bracket is sized from the
+ * qualifier count, never from the entrant count (ADR 20260727: "derived, never
+ * configured"), so a bracket with a fourth round would mean the server had sized it off
+ * `N` and the two numbers had been allowed to contradict each other. */
+const BRACKET_ROUNDS = 3
+/** Six qualifiers into eight slots is two byes, and **a bye is the ABSENCE of a
+ * fixture** (ADR-0786) — so round one holds two fixtures, not four. */
+const ROUND_ONE_FIXTURES = 2
+
+/** Three tables, one per pool, so the seeded catalogue can furnish the pools the
+ * director adds in the editor. */
+const TABLES: ReadonlyArray<TableSpec> = [
+  { id: 't1', label: 'Table 1', court: 'A' },
+  { id: 't2', label: 'Table 2', court: 'B' },
+  { id: 't3', label: 'Table 3', court: 'C' },
+]
+
+/**
+ * **Round-robin then knockout, through the whole composed stack** (#1227, ADR
+ * "rr-then-ko cuts both stages upfront and seeds qualifiers rematch-free").
+ *
+ * A director creates a tournament, authors an `rr-then-ko` event **in the browser** with
+ * a qualifiers-per-pool count and three pools, publishes, has nine players entered, cuts
+ * the draw, and the page shows **three pools AND a knockout bracket**.
+ *
+ * ## Why this spec is the one that matters for this format
+ *
+ * Every other gate in this arc watched a *mock* answer. The MSW store, the web-client
+ * Playwright suite and the dev server all accept whatever body the client composes, so
+ * all three stayed green while the client shipped a draw type whose create body the real
+ * API refused with a 422 — the client named `rr-then-ko` and sent no
+ * `qualifiers_per_pool`; the server's draw-settings union requires one on that arm and
+ * on no other. Nothing that stubs the network can see that, because the disagreement is
+ * *between* the two halves. So this spec drives the seam for real, twice over:
+ *
+ * 1. **The create.** The event is authored through the editor sheet, so the body on the
+ *    wire is the one `drawSettingsToApi` builds — and the spec asserts the POST's
+ *    status is **201**, not merely that something appeared. A 422 fails here, naming
+ *    itself, rather than surfacing three steps later as a missing event.
+ * 2. **The read-back.** The server is asked what it stored: `draw_type: rr-then-ko` and
+ *    `qualifiers_per_pool: 2`. A 201 alone would also be returned by a server that
+ *    accepted the create and dropped K on the floor.
+ *
+ * ## And the bracket must exist at cut time
+ *
+ * The other half of the ADR is that **both stages are cut in one stroke**: `plan_initial`
+ * emits the pool fixtures *and* the whole bracket, every side of it TBD. That is not an
+ * optimization — an `advance()` can only ever fill a side of an *existing* fixture
+ * (`SideFill`), so a bracket that did not exist at the cut could never come into being
+ * at all. Pools without a bracket is therefore a real product failure and not a
+ * selector miss: the second stage would be unreachable for the life of the event.
+ *
+ * ## Seed vs UI split
+ *
+ * Inert scaffolding over the API (`support/tournament-api.ts`): the tournament shell,
+ * its table catalogue, and the nine entrants — director-entry, which has no web UI, and
+ * nine browser sign-ins to test a *draw* would be nine chances to fail for an unrelated
+ * reason. Load-bearing steps in the browser: authoring the event and its draw
+ * configuration, publishing, and cutting the draw.
+ *
+ * ## RBAC
+ *
+ * As in `tournament-lifecycle.spec.ts`: a minted user holds only the permissionless
+ * default role, so `grantBetaTester` hands the director the tournament bundle over the
+ * stack's own `postgres` container before any tournament write. Skipped against an
+ * external `E2E_BASE_URL` stack, where the caller owns provisioning.
+ */
+test.describe('Tournament — rr-then-ko draw', () => {
+  test('a director cuts an rr-then-ko draw and the page shows three pools and a bracket', async ({
+    page,
+    baseURL,
+  }) => {
+    // Nine minted guests, nine director-entries and a real CP-SAT-free draw cut, on top
+    // of the ordinary page work — comfortably past the 30s default.
+    test.setTimeout(120_000)
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    // The director IS the browser's own session, so page navigations run as them.
+    const director = await guestFromContext(page.request)
+    grantBetaTester(director.username)
+
+    // ----- the shell, over the API: a tournament and its tables, no events ----
+    const name = `RRKO ${faker.string.alphanumeric(8)}`
+    const tournamentId = await createTournament(director, name, { tables: TABLES })
+
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    // `toContainText`, not `toHaveText`: the hero sets its own full stop after the name.
+    //
+    // The long timeout is for the FIRST navigation only, and it is about the stack
+    // rather than the app: the composed web-client is a Vite **dev** server, so the very
+    // first request for a route pays for transforming it on demand — and under the
+    // suite's parallel workers that first paint can take well past the 5s default. Every
+    // later assertion here keeps the default, because by then the route is compiled.
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    // ----- author the rr-then-ko event, in the browser ------------------------
+    const editor = await detail.openNewEvent()
+    await editor.nameInput.fill(EVENT_NAME)
+    await editor.chooseDrawType(DRAW_TYPE_LABEL)
+    // The qualifier box exists ONLY for this draw type — it is absent, not disabled,
+    // for a format with no knockout stage to qualify for. So its appearance is the
+    // proof the picker's choice reached the form, before anything is submitted.
+    await expect(editor.qualifiersInput).toBeVisible()
+    await editor.setQualifiersPerPool(QUALIFIERS_PER_POOL)
+    await editor.addPools(POOL_COUNT)
+
+    // THE 422 GATE. The create body is the client's own, and its status is asserted
+    // directly: a body missing `qualifiers_per_pool` is refused at the request boundary,
+    // and this is the assertion that says so in those terms.
+    const createPost = page.waitForResponse(
+      (r) => r.url().endsWith('/events') && r.request().method() === 'POST',
+    )
+    await editor.createEventButton.click()
+    const createResponse = await createPost
+    expect(
+      createResponse.status(),
+      `create event was refused: ${await createResponse.text()}`,
+    ).toBe(201)
+    // The sheet closes on success alone and keeps its refusal inline, so an empty error
+    // slot is the second, independent word on the same fact.
+    await expect(editor.errorAlert).toBeHidden()
+
+    // ----- and the SERVER holds the configuration the director typed ----------
+    // A 201 says the body was accepted; only the read-back says K survived it.
+    const event = await findEventByName(director, tournamentId, EVENT_NAME)
+    expect(event.draw_type).toBe('rr-then-ko')
+    expect(event.qualifiers_per_pool).toBe(QUALIFIERS_PER_POOL)
+    const eventId = event.id
+
+    // ----- publish, then fill the field --------------------------------------
+    await detail.publishButton.click()
+    await expect(detail.startButton).toBeVisible()
+
+    const entrants = await seedEntrants(
+      director,
+      baseURL!,
+      tournamentId,
+      eventId,
+      ENTRANT_COUNT,
+    )
+    // How many entries landed is asked of the SERVER, not counted off the roster: the
+    // card lists eight chips and collapses the rest into "+1 more", so a list-item count
+    // here would be nine for the wrong reason — the truncation, not the field.
+    const filled = await findEventByName(director, tournamentId, EVENT_NAME)
+    expect(filled.entered).toBe(ENTRANT_COUNT)
+
+    await detail.reload(tournamentId)
+    // The browser's own word that the field is on the page at all, before it is drawn.
+    await expect(detail.entrantsList(EVENT_NAME)).toContainText(entrants[0].username)
+
+    // ----- cut the draw: both stages, in one stroke --------------------------
+    const drawPost = page.waitForResponse(
+      (r) => r.url().endsWith('/draw') && r.request().method() === 'POST',
+    )
+    await detail.generateDrawButton(EVENT_NAME).click()
+    const drawResponse = await drawPost
+    expect(
+      drawResponse.status(),
+      `cutting the draw was refused: ${await drawResponse.text()}`,
+    ).toBe(201)
+
+    // ----- stage one: three pools, three players each ------------------------
+    await expect(detail.poolDraws(eventId)).toHaveCount(POOL_COUNT)
+    for (const poolName of ['Pool A', 'Pool B', 'Pool C']) {
+      const pool = detail.poolDrawNamed(eventId, poolName)
+      await expect(pool).toBeVisible()
+      // Nine entrants snake-dealt across three pools is three apiece — the pool
+      // membership is derived from the pool's own fixtures (ADR-0786), so this is also
+      // the statement that each pool really got a round-robin of its own.
+      await expect(
+        pool.getByRole('list', { name: `Entrants in ${poolName}` }).getByRole('listitem'),
+      ).toHaveCount(ENTRANT_COUNT / POOL_COUNT)
+    }
+
+    // ----- stage two: the bracket, present already, and entirely unknown -----
+    await expect(detail.bracket(eventId)).toBeVisible()
+    // Sized from the qualifiers (6 → 8 slots → 3 rounds), never from the entrants
+    // (9 → 16 → 4 rounds). The absent fourth round is the load-bearing half.
+    await expect(detail.bracketRound(eventId, BRACKET_ROUNDS)).toBeVisible()
+    await expect(detail.bracketRound(eventId, BRACKET_ROUNDS + 1)).toHaveCount(0)
+    // Two byes, so round one is two fixtures — a bye is an absent fixture, not a row.
+    await expect(detail.bracketRound(eventId, 1).getByRole('listitem')).toHaveCount(
+      ROUND_ONE_FIXTURES,
+    )
+    // The final exists and both its sides are unknown: nobody has played, so every
+    // knockout side is TBD and the bracket names NO entrant yet. `SideFill` seats them
+    // later, pool by pool, into slots that already exist.
+    const final = detail.bracketRound(eventId, BRACKET_ROUNDS).getByRole('listitem')
+    await expect(final).toHaveCount(1)
+    await expect(final).toHaveText(/TBD\s*vs\s*TBD/)
+    for (const entrant of entrants) {
+      await expect(detail.bracket(eventId)).not.toContainText(entrant.username)
+    }
+
+    await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
+  })
+})

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -10207,6 +10207,8 @@ internal enum Components {
             internal var format: Components.Schemas.EventFormat
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/draw_type`.
             internal var drawType: Components.Schemas.DrawType
+            /// - Remark: Generated from `#/components/schemas/TournamentEventRead/qualifiers_per_pool`.
+            internal var qualifiersPerPool: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/max_players`.
             internal var maxPlayers: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/entry_fee`.
@@ -10335,6 +10337,7 @@ internal enum Components {
             ///   - name:
             ///   - format:
             ///   - drawType:
+            ///   - qualifiersPerPool:
             ///   - maxPlayers:
             ///   - entryFee:
             ///   - timezone:
@@ -10355,6 +10358,7 @@ internal enum Components {
                 name: Swift.String,
                 format: Components.Schemas.EventFormat,
                 drawType: Components.Schemas.DrawType,
+                qualifiersPerPool: Swift.Int? = nil,
                 maxPlayers: Swift.Int? = nil,
                 entryFee: Swift.Double,
                 timezone: Swift.String,
@@ -10375,6 +10379,7 @@ internal enum Components {
                 self.name = name
                 self.format = format
                 self.drawType = drawType
+                self.qualifiersPerPool = qualifiersPerPool
                 self.maxPlayers = maxPlayers
                 self.entryFee = entryFee
                 self.timezone = timezone
@@ -10396,6 +10401,7 @@ internal enum Components {
                 case name
                 case format
                 case drawType = "draw_type"
+                case qualifiersPerPool = "qualifiers_per_pool"
                 case maxPlayers = "max_players"
                 case entryFee = "entry_fee"
                 case timezone

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -10738,8 +10738,7 @@ internal enum Components {
         ///   state without a per-slot round-trip; it is the match's *current* status, read
         ///   live, not a copy frozen at go-live.
         /// * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
-        ///   un-pooled (single-elim), or this is the knockout stage of a future
-        ///   pools-then-knockout draw type. When
+        ///   un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
         ///   set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
         ///   JSONB, not a foreign key, because pools are value-objects with no table.
         /// * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -4261,6 +4261,7 @@ internal enum Components {
         internal enum DrawType: String, Codable, Hashable, Sendable, CaseIterable {
             case singleElim = "single-elim"
             case roundRobin = "round-robin"
+            case rrThenKo = "rr-then-ko"
         }
         /// One selectable draw format, as the ``draw_types`` table holds it.
         ///
@@ -9482,10 +9483,11 @@ internal enum Components {
         ///
         /// ``champion`` is the leader of a **complete, single-pool** event — a pure
         /// round-robin's winner. A multi-pool round-robin has no single champion without a
-        /// knockout stage to join its pool winners (a pools-then-knockout draw type, a later
-        /// slice), so it is
-        /// ``null`` there even when ``complete``; and ``null`` while any fixture is still to be
-        /// played.
+        /// knockout stage to join its pool winners, so it is ``null`` there even when
+        /// ``complete``; and ``null`` while any fixture is still to be played. An event that
+        /// *does* have a knockout stage to join them is a ``rr-then-ko`` draw, which reads out
+        /// as the ``standings_then_finishes`` arm below and is crowned from its bracket — a
+        /// different shape, not an exception to this one.
         ///
         /// - Remark: Generated from `#/components/schemas/StandingsResultsRead`.
         internal struct StandingsResultsRead: Codable, Hashable, Sendable {
@@ -9522,6 +9524,73 @@ internal enum Components {
             internal enum CodingKeys: String, CodingKey {
                 case kind
                 case pools
+                case complete
+                case champion
+            }
+        }
+        /// The **two-stage** shape of an event's results (ADR 20260727) — the
+        /// round-robin-then-knockout arm of the ``results`` discriminated union, tagged
+        /// ``kind: "standings_then_finishes"``.
+        ///
+        /// One block per stage: ``pools`` is the pool stage's standings, exactly the
+        /// :class:`PoolStandingsRead` a round-robin event reads out, and ``finishes`` is the
+        /// knockout stage's ranked :class:`FinishRowRead`\ s, exactly the ones a
+        /// single-elimination event reads out. They are the *same* models rather than
+        /// two-stage-flavoured near-copies, so a client renders each stage with the panel it
+        /// already has and the two shapes cannot drift apart.
+        ///
+        /// A third arm rather than a restructuring of the union into a composite: making
+        /// ``standings`` and ``finishes`` sub-objects of one wrapper would change how the
+        /// existing two arms are read, forcing round-robin and single-elim client changes that
+        /// buy nothing.
+        ///
+        /// ``champion`` is the **knockout final's winner, never a pool leader** — the pool
+        /// stage only seeds the bracket, so topping a pool wins nothing — and ``null`` until
+        /// that final is decided. ``complete`` is **both stages decided**. Live and partial
+        /// like every other results shape: the pool tables fill in as pool matches land, and
+        /// the finishes list grows as the bracket is played out.
+        ///
+        /// - Remark: Generated from `#/components/schemas/StandingsThenFinishesResultsRead`.
+        internal struct StandingsThenFinishesResultsRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/StandingsThenFinishesResultsRead/kind`.
+            internal enum KindPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case standingsThenFinishes = "standings_then_finishes"
+            }
+            /// - Remark: Generated from `#/components/schemas/StandingsThenFinishesResultsRead/kind`.
+            internal var kind: Components.Schemas.StandingsThenFinishesResultsRead.KindPayload?
+            /// - Remark: Generated from `#/components/schemas/StandingsThenFinishesResultsRead/pools`.
+            internal var pools: [Components.Schemas.PoolStandingsRead]
+            /// - Remark: Generated from `#/components/schemas/StandingsThenFinishesResultsRead/finishes`.
+            internal var finishes: [Components.Schemas.FinishRowRead]
+            /// - Remark: Generated from `#/components/schemas/StandingsThenFinishesResultsRead/complete`.
+            internal var complete: Swift.Bool
+            /// - Remark: Generated from `#/components/schemas/StandingsThenFinishesResultsRead/champion`.
+            internal var champion: Swift.String?
+            /// Creates a new `StandingsThenFinishesResultsRead`.
+            ///
+            /// - Parameters:
+            ///   - kind:
+            ///   - pools:
+            ///   - finishes:
+            ///   - complete:
+            ///   - champion:
+            internal init(
+                kind: Components.Schemas.StandingsThenFinishesResultsRead.KindPayload? = nil,
+                pools: [Components.Schemas.PoolStandingsRead],
+                finishes: [Components.Schemas.FinishRowRead],
+                complete: Swift.Bool,
+                champion: Swift.String? = nil
+            ) {
+                self.kind = kind
+                self.pools = pools
+                self.finishes = finishes
+                self.complete = complete
+                self.champion = champion
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case kind
+                case pools
+                case finishes
                 case complete
                 case champion
             }
@@ -9997,6 +10066,8 @@ internal enum Components {
             internal var format: Components.Schemas.EventFormat
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/draw_type`.
             internal var drawType: Components.Schemas.DrawType
+            /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/qualifiers_per_pool`.
+            internal var qualifiersPerPool: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/max_players`.
             internal var maxPlayers: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/entry_fee`.
@@ -10017,6 +10088,7 @@ internal enum Components {
             ///   - name:
             ///   - format:
             ///   - drawType:
+            ///   - qualifiersPerPool:
             ///   - maxPlayers:
             ///   - entryFee:
             ///   - timezone:
@@ -10028,6 +10100,7 @@ internal enum Components {
                 name: Swift.String,
                 format: Components.Schemas.EventFormat,
                 drawType: Components.Schemas.DrawType,
+                qualifiersPerPool: Swift.Int? = nil,
                 maxPlayers: Swift.Int? = nil,
                 entryFee: Swift.Double,
                 timezone: Swift.String,
@@ -10039,6 +10112,7 @@ internal enum Components {
                 self.name = name
                 self.format = format
                 self.drawType = drawType
+                self.qualifiersPerPool = qualifiersPerPool
                 self.maxPlayers = maxPlayers
                 self.entryFee = entryFee
                 self.timezone = timezone
@@ -10051,6 +10125,7 @@ internal enum Components {
                 case name
                 case format
                 case drawType = "draw_type"
+                case qualifiersPerPool = "qualifiers_per_pool"
                 case maxPlayers = "max_players"
                 case entryFee = "entry_fee"
                 case timezone
@@ -10072,6 +10147,10 @@ internal enum Components {
                 self.drawType = try container.decode(
                     Components.Schemas.DrawType.self,
                     forKey: .drawType
+                )
+                self.qualifiersPerPool = try container.decodeIfPresent(
+                    Swift.Int.self,
+                    forKey: .qualifiersPerPool
                 )
                 self.maxPlayers = try container.decodeIfPresent(
                     Swift.Int.self,
@@ -10105,6 +10184,7 @@ internal enum Components {
                     "name",
                     "format",
                     "draw_type",
+                    "qualifiers_per_pool",
                     "max_players",
                     "entry_fee",
                     "timezone",
@@ -10200,6 +10280,8 @@ internal enum Components {
                 case finishes(Components.Schemas.FinishesResultsRead)
                 /// - Remark: Generated from `#/components/schemas/TournamentEventRead/results/StandingsResultsRead`.
                 case standings(Components.Schemas.StandingsResultsRead)
+                /// - Remark: Generated from `#/components/schemas/TournamentEventRead/results/StandingsThenFinishesResultsRead`.
+                case standingsThenFinishes(Components.Schemas.StandingsThenFinishesResultsRead)
                 internal enum CodingKeys: String, CodingKey {
                     case kind
                 }
@@ -10214,6 +10296,8 @@ internal enum Components {
                         self = .finishes(try .init(from: decoder))
                     case "standings":
                         self = .standings(try .init(from: decoder))
+                    case "standings_then_finishes":
+                        self = .standingsThenFinishes(try .init(from: decoder))
                     default:
                         throw Swift.DecodingError.unknownOneOfDiscriminator(
                             discriminatorKey: CodingKeys.kind,
@@ -10227,6 +10311,8 @@ internal enum Components {
                     case let .finishes(value):
                         try value.encode(to: encoder)
                     case let .standings(value):
+                        try value.encode(to: encoder)
+                    case let .standingsThenFinishes(value):
                         try value.encode(to: encoder)
                     }
                 }
@@ -10390,6 +10476,8 @@ internal enum Components {
             }
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/draw_type`.
             internal var drawType: Components.Schemas.TournamentEventUpdate.DrawTypePayload?
+            /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/qualifiers_per_pool`.
+            internal var qualifiersPerPool: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/max_players`.
             internal var maxPlayers: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/entry_fee`.
@@ -10446,6 +10534,7 @@ internal enum Components {
             ///   - name:
             ///   - format:
             ///   - drawType:
+            ///   - qualifiersPerPool:
             ///   - maxPlayers:
             ///   - entryFee:
             ///   - timezone:
@@ -10457,6 +10546,7 @@ internal enum Components {
                 name: Swift.String? = nil,
                 format: Components.Schemas.TournamentEventUpdate.FormatPayload? = nil,
                 drawType: Components.Schemas.TournamentEventUpdate.DrawTypePayload? = nil,
+                qualifiersPerPool: Swift.Int? = nil,
                 maxPlayers: Swift.Int? = nil,
                 entryFee: Swift.Double? = nil,
                 timezone: Swift.String? = nil,
@@ -10468,6 +10558,7 @@ internal enum Components {
                 self.name = name
                 self.format = format
                 self.drawType = drawType
+                self.qualifiersPerPool = qualifiersPerPool
                 self.maxPlayers = maxPlayers
                 self.entryFee = entryFee
                 self.timezone = timezone
@@ -10480,6 +10571,7 @@ internal enum Components {
                 case name
                 case format
                 case drawType = "draw_type"
+                case qualifiersPerPool = "qualifiers_per_pool"
                 case maxPlayers = "max_players"
                 case entryFee = "entry_fee"
                 case timezone
@@ -10501,6 +10593,10 @@ internal enum Components {
                 self.drawType = try container.decodeIfPresent(
                     Components.Schemas.TournamentEventUpdate.DrawTypePayload.self,
                     forKey: .drawType
+                )
+                self.qualifiersPerPool = try container.decodeIfPresent(
+                    Swift.Int.self,
+                    forKey: .qualifiersPerPool
                 )
                 self.maxPlayers = try container.decodeIfPresent(
                     Swift.Int.self,
@@ -10534,6 +10630,7 @@ internal enum Components {
                     "name",
                     "format",
                     "draw_type",
+                    "qualifiers_per_pool",
                     "max_players",
                     "entry_fee",
                     "timezone",

--- a/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
+++ b/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
@@ -285,6 +285,37 @@ export class TournamentDetailPage {
     return this.eventCard(eventName).locator('[data-testid^="standings-champion-"]')
   }
 
+  // ----- the finishes, and the two-stage block (ADR-0785, ADR 20260727) -----
+
+  /** One event's **finishes** block — the `<section>` headed "Finishes": a bracket's
+   * placement list. On a two-stage card it is the knockout half, below the standings. */
+  finishesPanel(eventName: string): Locator {
+    return this.eventCard(eventName).getByRole('region', { name: 'Finishes' })
+  }
+
+  /** The placement list's rows as `[position, player]` cells, top to bottom — the position
+   * label (`1st`, `T3`) and the name the FE joined from an entry id. */
+  finishesRows(eventName: string): Locator {
+    return this.eventCard(eventName)
+      .getByRole('table', { name: `Finishes for ${eventName}` })
+      .locator('tbody tr')
+  }
+
+  /** A **two-stage** event's one champion callout (ADR 20260727) — rendered above both
+   * stages by the composite, and naming the BRACKET's winner. Its own testid prefix, so a
+   * spec can assert the two stage-level callouts are absent while this one is present. */
+  twoStageChampion(eventName: string): Locator {
+    return this.eventCard(eventName).locator('[data-testid^="two-stage-champion-"]')
+  }
+
+  /** Every champion callout on one card, whoever rendered it — the "**one** banner" check.
+   * All three testids (`standings-champion-…`, `finishes-champion-…`,
+   * `two-stage-champion-…`) share the `-champion-` infix, so this catches a stage that
+   * started crowning somebody of its own. */
+  championCallouts(eventName: string): Locator {
+    return this.eventCard(eventName).locator('[data-testid*="-champion-"]')
+  }
+
   // ----- the event card's entry control ------------------------------------
 
   enterButton(eventName: string): Locator {

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -974,12 +974,12 @@ function planEventDraw(event: TournamentEventRead): DrawPlan {
     drawOrder(event.entrants).map((e) => e.id),
     event.pools.map((p) => p.id),
     // **The event's own K** (ADR 20260727) — the count the director configured and the
-    // PATCH stored, never the planner's default. It is what sizes an `rr-then-ko` draw's
-    // bracket (`P × K`), so passing nothing would cut a `P × 1` bracket for an event
+    // PATCH stored, passed through unchanged. It is what sizes an `rr-then-ko` draw's
+    // bracket (`P × K`), so substituting anything would cut a `P × 1` bracket for an event
     // configured otherwise: a well-formed draw of the wrong size, with nothing anywhere
-    // reporting the substitution. `undefined` (a count-less draw type) leaves the default
-    // standing, where only the arm that never reads it can see it.
-    event.qualifiers_per_pool ?? undefined,
+    // reporting the substitution. `null` is the honest value for a count-less draw type,
+    // and only the arm that never reads it can see it.
+    event.qualifiers_per_pool,
   )
 }
 

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -15,6 +15,7 @@ import {
   buildEventResultsRead,
   buildPoolStandingsRead,
   buildStandingRowRead,
+  buildStandingsThenFinishesResultsRead,
   buildTournamentDetailRead,
   buildTournamentEventRead,
   buildTournamentEntrantRead,
@@ -38,6 +39,8 @@ type Pool = components['schemas']['Pool']
  * hold — the catalogue and the enum are the same set by construction. */
 type DrawTypeRead = components['schemas']['DrawTypeRead']
 type StandingsResultsRead = components['schemas']['StandingsResultsRead']
+type StandingsThenFinishesResultsRead =
+  components['schemas']['StandingsThenFinishesResultsRead']
 type ScheduleSolveRead = components['schemas']['ScheduleSolveRead']
 /** The wire's status enum — the specs drive the store with it, so it is the
  * generated schema's, not a re-typed union of four strings. */
@@ -159,6 +162,12 @@ export const EVENT = {
    * user-reachable path: without it that arm could be reverted to anything at all and
    * this suite would stay green. */
   LONE: 'Novice Singles',
+  /** The **two-stage** seed's event (`twoStage: true`): singles, `rr-then-ko`, six entrants
+   * across two pools, two qualifying from each (ADR 20260727). The only user-reachable path
+   * to the results union's THIRD arm (`kind: "standings_then_finishes"`) in a real browser —
+   * and the one that matters most, because `parseResults` **throws** on a shape it has no
+   * arm for, which fails the whole query rather than degrading one panel. */
+  TWO_STAGE: 'Cup Singles',
 } as const
 
 /** How many people are already in the crowded event before I enter it. Comfortably
@@ -341,6 +350,74 @@ const JOURNEY_RESULTS: StandingsResultsRead = buildEventResultsRead({
   ],
 })
 
+// ----- the TWO-STAGE seed (`rr-then-ko`, ADR 20260727) ----------------------
+
+/** The two pools of `EVENT.TWO_STAGE`. Their ids are `p-a` / `p-b` because that is what
+ * `buildStandingsThenFinishesResultsRead`'s pool blocks name — the results fixture and the
+ * event's own `pools` have to agree, or the tables would title themselves from a raw id. */
+const CUP_POOLS: Pool[] = [
+  {
+    id: 'p-a',
+    name: 'Pool A',
+    slot: { date: '2026-06-13', start: '09:00', end: '11:00' },
+    table_ids: ['t1', 't2'],
+  },
+  {
+    id: 'p-b',
+    name: 'Pool B',
+    slot: { date: '2026-06-13', start: '11:00', end: '13:00' },
+    table_ids: ['t3', 't4'],
+  },
+]
+
+/** The two-stage event's field: six entrants with **plain** ids (`entry-1`…`entry-6`), not
+ * the `crowd()` helper's `entry-crowd-N`, because the results fixture names entries by those
+ * plain ids — and an id the event does not list joins to "Withdrawn", which is exactly the
+ * bug a browser spec about names is meant to catch. */
+const CUP_ENTRANTS: TournamentEntrantRead[] = Array.from({ length: 6 }, (_, i) =>
+  buildTournamentEntrantRead({
+    id: `entry-${i + 1}`,
+    user_id: `u-cup-${i + 1}`,
+    username: `player.${i + 1}`,
+  }),
+)
+
+/** The played-out two-stage result for `EVENT.TWO_STAGE`: both pools decided, the bracket
+ * run to a final, and a champion — `player.4` — who **tops neither pool**. The snake deals
+ * `p-a` entries 1, 4, 5 and `p-b` entries 2, 3, 6, and the fixture's standings stand over
+ * exactly those memberships. */
+const CUP_RESULTS: StandingsThenFinishesResultsRead =
+  buildStandingsThenFinishesResultsRead()
+
+/** The same event one match from home: pools decided, the final seated and unplayed. So
+ * `complete` is false, there is no champion, and the finishes list **starts at position 3**
+ * — the two beaten semifinalists are all the bracket has placed. */
+const CUP_RESULTS_MID_FLIGHT: StandingsThenFinishesResultsRead =
+  buildStandingsThenFinishesResultsRead({
+    complete: false,
+    champion: null,
+    finishes: CUP_RESULTS.finishes.filter((f) => f.position === 3),
+  })
+
+/** The two-stage event (`twoStage: true`), added to the drawable seed rather than replacing
+ * it — opt-in for the same reason `bracket` is: its six entrants would move the
+ * tournament-level Entries total the journey spec narrates. */
+function twoStageEvents(): TournamentEventRead[] {
+  return [
+    buildTournamentEventRead({
+      id: 'ev-cup',
+      name: EVENT.TWO_STAGE,
+      format: 'singles',
+      draw_type: 'rr-then-ko',
+      // The director's own K, which sizes the bracket at the cut (`P × K` = 2 × 2 = 4).
+      qualifiers_per_pool: 2,
+      max_players: 32,
+      entrants: CUP_ENTRANTS,
+      pools: CUP_POOLS,
+    }),
+  ]
+}
+
 /** The round-robin tournament: two events, both cuttable, nothing cut yet. `drawn`
  * decides which of them arrive with a draw already standing.
  *
@@ -368,6 +445,7 @@ function drawableEvents(options: TournamentsStoreOptions): TournamentEventRead[]
       pools: PLAY_POOLS,
     }),
     ...(options.bracket ?? false ? bracketEvents() : []),
+    ...(options.twoStage ?? false ? twoStageEvents() : []),
   ]
 }
 
@@ -670,6 +748,19 @@ export interface TournamentsStoreOptions {
    * event's draw. Its rows name the drawable JOURNEY's own two entrants (`entry-1`,
    * `entry-2`), so the FE's name join lands. */
   standings?: boolean
+  /** Add the **two-stage** (`rr-then-ko`) event to the drawable seed — which it also turns
+   * on, since it extends that seed: `EVENT.TWO_STAGE`, six entrants across two pools.
+   *
+   * Opt-in for the same reason `bracket` is (its entrants would move the Entries total the
+   * journey spec narrates), and it is the ONLY browser-reachable path to the results union's
+   * third arm. Pair it with `twoStageResults` to attach a played-out or mid-flight result;
+   * on its own it is an uncut two-stage event. */
+  twoStage?: boolean
+  /** Attach the **two-stage** result to `EVENT.TWO_STAGE` (ADR 20260727) — `'complete'` for
+   * a bracket run to a final with a champion, `'mid-flight'` for decided pools and an
+   * unplayed final (no champion, finishes starting at position 3). Only meaningful with
+   * `twoStage`. */
+  twoStageResults?: 'complete' | 'mid-flight'
   /** The tournament's latest **schedule solve** ledger row when the page loads (ADR
    * "the schedule is solved") — how a spec starts on a `succeeded`, `infeasible` or
    * `failed` strip without walking the whole run. Built with
@@ -1000,6 +1091,17 @@ export class TournamentsStore {
     if (options.standings ?? false) {
       const event = this.eventNamed(EVENT.JOURNEY)
       this.mutateEvent(event.id, (e) => ({ ...e, results: JOURNEY_RESULTS }))
+    }
+    // The two-stage result (ADR 20260727), on the same footing: it rides on the seeded
+    // `EVENT.TWO_STAGE` draw rather than inventing one, and its pool standings stand over
+    // the pools that draw's snake actually dealt.
+    if (options.twoStageResults) {
+      const event = this.eventNamed(EVENT.TWO_STAGE)
+      const results =
+        options.twoStageResults === 'complete'
+          ? CUP_RESULTS
+          : CUP_RESULTS_MID_FLIGHT
+      this.mutateEvent(event.id, (e) => ({ ...e, results }))
     }
     // The seeded solve ledger row, if any — a terminal strip state the spec starts on.
     if (options.latestSolve) {

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -882,6 +882,13 @@ function planEventDraw(event: TournamentEventRead): DrawPlan {
     event.draw_type,
     drawOrder(event.entrants).map((e) => e.id),
     event.pools.map((p) => p.id),
+    // **The event's own K** (ADR 20260727) — the count the director configured and the
+    // PATCH stored, never the planner's default. It is what sizes an `rr-then-ko` draw's
+    // bracket (`P × K`), so passing nothing would cut a `P × 1` bracket for an event
+    // configured otherwise: a well-formed draw of the wrong size, with nothing anywhere
+    // reporting the substitution. `undefined` (a count-less draw type) leaves the default
+    // standing, where only the arm that never reads it can see it.
+    event.qualifiers_per_pool ?? undefined,
   )
 }
 

--- a/web-client/e2e/tournaments/tournament-draw.spec.ts
+++ b/web-client/e2e/tournaments/tournament-draw.spec.ts
@@ -560,13 +560,17 @@ test.describe('Tournaments · the event editor, with a draw standing', () => {
  * is code the vitest suite stubs past.
  */
 test.describe('Tournaments · the draw types a director is offered', () => {
-  /** The two labels the API SEEDS, verbatim — a copy of the migration's `DRAW_TYPE_SEED`,
+  /** The labels the API SEEDS, verbatim — a copy of the migration's `DRAW_TYPE_SEED`,
    * as the stub's catalogue is. Spelled out here rather than imported for the same reason
    * `SAY` is: an assertion that read the labels out of the fixture it is asserting on
    * could only ever prove the fixture equals itself. */
-  const SEEDED_LABELS = ['Round robin', 'Single elimination']
+  const SEEDED_LABELS = [
+    'Round robin',
+    'Single elimination',
+    'Round-robin then knockout',
+  ]
 
-  test('offers exactly the two seeded draw types, in the server’s words', async ({
+  test('offers exactly the seeded draw types, in the server’s words', async ({
     page,
   }) => {
     // The default seed, whose events are all uncut — so the picker is live rather than
@@ -576,11 +580,15 @@ test.describe('Tournaments · the draw types a director is offered', () => {
     await pom.openEditor(EVENT.JOURNEY)
     await expect(pom.eventEditor).toBeVisible()
 
-    // EXACTLY these, and in this order. `toEqual` is the assertion the claim needs:
-    // "double elimination", "Swiss" and "round robin then knockout" were all on this
-    // menu, and each one let a director author an event nothing could ever cut. They
-    // left the API's enum, so they are not seeded, so they are not here — and a
-    // `toContain` pair would not have noticed if they came back.
+    // EXACTLY these, and in this order. `toEqual` is the assertion the claim needs, and
+    // it cuts both ways. "Double elimination" and "Swiss" were on this menu once, and
+    // each let a director author an event nothing could ever cut: they left the API's
+    // enum, so they are not seeded, so they are not here. **Round-robin then knockout
+    // went the other way** — it left with them in #1219 and came back in #1227 with a
+    // strategy behind it, and a client-side allowlist would have swallowed the served
+    // row without a word (ADR "rr-then-ko cuts both stages upfront…", Context). This is
+    // the browser end of that: the third row really crosses the wire, really survives
+    // the parse, and really reaches the listbox.
     expect(await pom.drawTypeOptions()).toEqual(SEEDED_LABELS)
 
     expect(store.unhandled).toEqual([])

--- a/web-client/e2e/tournaments/tournament-two-stage-results.spec.ts
+++ b/web-client/e2e/tournaments/tournament-two-stage-results.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * A **two-stage** (`rr-then-ko`) event's results (ADR 20260727) through the real browser:
+ * the pool standings above the bracket finishes, under a single champion banner naming the
+ * **bracket's** winner.
+ *
+ * What only a browser proves here, and why the vitest suite could not:
+ *
+ *   1. **The real bundle parses the third arm.** `parseResults` throws on a `kind` it has no
+ *      arm for, and that throw fails the whole tournament query — the error boundary, not a
+ *      missing panel. vitest exercises the parser directly and the component against a
+ *      hand-built view; this drives the served bundle against a stubbed wire payload, which
+ *      is the only place a boundary/BFF mismatch on the new shape shows up.
+ *
+ *   2. **Both stages land on one card, in order, from ONE payload.** The composite selects
+ *      each stage and hands it to the panel a pure round-robin / pure single-elim event
+ *      already uses. A card that rendered only the stage the reader happened to look for
+ *      would pass a weaker check.
+ *
+ *   3. **The champion is the bracket's, and there is exactly one banner.** `player.4` wins
+ *      the final; `player.1` and `player.2` win the pools. A banner reading the top of a
+ *      standings table would still *look* like a champion — so the assertion is the name,
+ *      and the count.
+ *
+ *   4. **This whole surface runs with MSW OFF**, against the inline `page.route` stub.
+ */
+import { expect, test } from '@playwright/test'
+
+import { TournamentDetailPage } from '../page-objects/tournaments/tournament-detail.page'
+import { EVENT } from '../page-objects/tournaments/tournaments-store'
+
+/** The two-stage seed with its draw cut and its bracket played out: six entrants, two pools,
+ * two qualifying from each, a final decided. */
+const PLAYED_OUT = {
+  drawable: true,
+  twoStage: true,
+  drawn: [EVENT.TWO_STAGE],
+  twoStageResults: 'complete',
+} as const
+
+test.describe('Tournaments · a two-stage (rr-then-ko) event’s results', () => {
+  test('shows both pools’ standings above the bracket’s finishes, with one champion — the bracket’s', async ({
+    page,
+  }) => {
+    const { pom, store } = await TournamentDetailPage.navigateTo(page, PLAYED_OUT)
+    const event = EVENT.TWO_STAGE
+
+    // Both stages, on one card.
+    await expect(pom.standingsPanel(event)).toBeVisible()
+    await expect(pom.finishesPanel(event)).toBeVisible()
+
+    // The pool stage: each pool named, its rows joined to usernames, in the server's
+    // finishing order. The memberships are the ones the snake dealt (p-a: 1, 4, 5).
+    await expect(pom.standingsRowNames(event, 'Pool A')).toHaveText([
+      'player.1',
+      'player.4',
+      'player.5',
+    ])
+    await expect(pom.standingsRowNames(event, 'Pool B')).toHaveText([
+      'player.2',
+      'player.3',
+      'player.6',
+    ])
+
+    // The knockout stage: single-elimination's own placement shape, ties and all — the two
+    // beaten semifinalists share 3rd, one of them a pool winner.
+    await expect(pom.finishesRows(event)).toHaveText([
+      /1st\s*player\.4/,
+      /2nd\s*player\.1/,
+      /T3\s*player\.2/,
+      /T3\s*player\.3/,
+    ])
+
+    // ONE champion callout, and it names the FINAL's winner. `player.4` topped no pool —
+    // `player.1` and `player.2` did — so a banner reading the standings would say a
+    // different name here and still look perfectly plausible.
+    await expect(pom.twoStageChampion(event)).toBeVisible()
+    await expect(pom.twoStageChampion(event)).toContainText('player.4')
+    await expect(pom.championCallouts(event)).toHaveCount(1)
+
+    expect(store.unhandled).toEqual([])
+    await expect(pom.toasts).toHaveCount(0)
+  })
+
+  test('a MID-FLIGHT two-stage event shows its stages and crowns nobody', async ({
+    page,
+  }) => {
+    // Pools decided, the final seated and unplayed. Both stages still render — the standings
+    // in full, the finishes holding only the two entrants the bracket has placed, starting at
+    // position 3 — and no banner appears, because nobody has won it yet.
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      ...PLAYED_OUT,
+      twoStageResults: 'mid-flight',
+    })
+    const event = EVENT.TWO_STAGE
+
+    await expect(pom.standingsRowNames(event, 'Pool A')).toHaveText([
+      'player.1',
+      'player.4',
+      'player.5',
+    ])
+    await expect(pom.finishesRows(event)).toHaveText([
+      /T3\s*player\.2/,
+      /T3\s*player\.3/,
+    ])
+    await expect(pom.championCallouts(event)).toHaveCount(0)
+  })
+
+  test('a viewer sees both stages too — results are public', async ({ page }) => {
+    // Read-only for everyone: a non-owner sees the same two stages and the same champion,
+    // and the block carries no control for either of them.
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      ...PLAYED_OUT,
+      canEdit: false,
+    })
+    const event = EVENT.TWO_STAGE
+
+    await expect(pom.standingsPanel(event)).toBeVisible()
+    await expect(pom.finishesPanel(event)).toBeVisible()
+    await expect(pom.twoStageChampion(event)).toContainText('player.4')
+  })
+})

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -4817,8 +4817,7 @@ export interface components {
          *       state without a per-slot round-trip; it is the match's *current* status, read
          *       live, not a copy frozen at go-live.
          *     * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
-         *       un-pooled (single-elim), or this is the knockout stage of a future
-         *       pools-then-knockout draw type. When
+         *       un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
          *       set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
          *       JSONB, not a foreign key, because pools are value-objects with no table.
          *     * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -4670,6 +4670,8 @@ export interface components {
             name: string;
             format: components["schemas"]["EventFormat"];
             draw_type: components["schemas"]["DrawType"];
+            /** Qualifiers Per Pool */
+            qualifiers_per_pool: number | null;
             /** Max Players */
             max_players: number | null;
             /** Entry Fee */

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -2237,7 +2237,7 @@ export interface components {
          * DrawType
          * @enum {string}
          */
-        DrawType: "single-elim" | "round-robin";
+        DrawType: "single-elim" | "round-robin" | "rr-then-ko";
         /**
          * DrawTypeRead
          * @description One selectable draw format, as the ``draw_types`` table holds it.
@@ -4382,10 +4382,11 @@ export interface components {
          *
          *     ``champion`` is the leader of a **complete, single-pool** event — a pure
          *     round-robin's winner. A multi-pool round-robin has no single champion without a
-         *     knockout stage to join its pool winners (a pools-then-knockout draw type, a later
-         *     slice), so it is
-         *     ``null`` there even when ``complete``; and ``null`` while any fixture is still to be
-         *     played.
+         *     knockout stage to join its pool winners, so it is ``null`` there even when
+         *     ``complete``; and ``null`` while any fixture is still to be played. An event that
+         *     *does* have a knockout stage to join them is a ``rr-then-ko`` draw, which reads out
+         *     as the ``standings_then_finishes`` arm below and is crowned from its bracket — a
+         *     different shape, not an exception to this one.
          */
         StandingsResultsRead: {
             /**
@@ -4395,6 +4396,45 @@ export interface components {
             kind: "standings";
             /** Pools */
             pools: components["schemas"]["PoolStandingsRead"][];
+            /** Complete */
+            complete: boolean;
+            /** Champion */
+            champion: string | null;
+        };
+        /**
+         * StandingsThenFinishesResultsRead
+         * @description The **two-stage** shape of an event's results (ADR 20260727) — the
+         *     round-robin-then-knockout arm of the ``results`` discriminated union, tagged
+         *     ``kind: "standings_then_finishes"``.
+         *
+         *     One block per stage: ``pools`` is the pool stage's standings, exactly the
+         *     :class:`PoolStandingsRead` a round-robin event reads out, and ``finishes`` is the
+         *     knockout stage's ranked :class:`FinishRowRead`\ s, exactly the ones a
+         *     single-elimination event reads out. They are the *same* models rather than
+         *     two-stage-flavoured near-copies, so a client renders each stage with the panel it
+         *     already has and the two shapes cannot drift apart.
+         *
+         *     A third arm rather than a restructuring of the union into a composite: making
+         *     ``standings`` and ``finishes`` sub-objects of one wrapper would change how the
+         *     existing two arms are read, forcing round-robin and single-elim client changes that
+         *     buy nothing.
+         *
+         *     ``champion`` is the **knockout final's winner, never a pool leader** — the pool
+         *     stage only seeds the bracket, so topping a pool wins nothing — and ``null`` until
+         *     that final is decided. ``complete`` is **both stages decided**. Live and partial
+         *     like every other results shape: the pool tables fill in as pool matches land, and
+         *     the finishes list grows as the bracket is played out.
+         */
+        StandingsThenFinishesResultsRead: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "standings_then_finishes";
+            /** Pools */
+            pools: components["schemas"]["PoolStandingsRead"][];
+            /** Finishes */
+            finishes: components["schemas"]["FinishRowRead"][];
             /** Complete */
             complete: boolean;
             /** Champion */
@@ -4599,6 +4639,8 @@ export interface components {
             name: string;
             format: components["schemas"]["EventFormat"];
             draw_type: components["schemas"]["DrawType"];
+            /** Qualifiers Per Pool */
+            qualifiers_per_pool?: number | null;
             /** Max Players */
             max_players?: number | null;
             /** Entry Fee */
@@ -4657,7 +4699,7 @@ export interface components {
             /** Fixtures */
             fixtures: components["schemas"]["TournamentFixtureRead"][];
             /** Results */
-            results: (components["schemas"]["StandingsResultsRead"] | components["schemas"]["FinishesResultsRead"]) | null;
+            results: (components["schemas"]["StandingsResultsRead"] | components["schemas"]["FinishesResultsRead"] | components["schemas"]["StandingsThenFinishesResultsRead"]) | null;
             /**
              * Entered
              * @description The registration count. Derived — there is no stored counter (ADR-0016).
@@ -4695,6 +4737,8 @@ export interface components {
             name?: string | null;
             format?: components["schemas"]["EventFormat"] | null;
             draw_type?: components["schemas"]["DrawType"] | null;
+            /** Qualifiers Per Pool */
+            qualifiers_per_pool?: number | null;
             /** Max Players */
             max_players?: number | null;
             /** Entry Fee */

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -7,7 +7,7 @@ import {
   screen,
   waitFor as waitForRaw,
 } from '@testing-library/react'
-import { HttpResponse } from 'msw'
+import { http, HttpResponse } from 'msw'
 import type { StrictResponse } from 'msw'
 import { toast } from 'sonner'
 import { Component, type ReactNode } from 'react'
@@ -43,7 +43,10 @@ import {
 } from '@/mocks/tournaments-store'
 import { ApiError } from '@/api/client'
 import type { components } from '@/api/schema'
+import { buildEvent } from './seed.factory'
 import {
+  apiToEvent,
+  eventToUpdateBody,
   useCreateTournament,
   useCutDraw,
   useEnterEvent,
@@ -53,6 +56,7 @@ import {
   useTournaments,
   useTransitionTournament,
   useUncutDraw,
+  useUpdateEvent,
   useUpdateTournament,
   useWithdrawEntry,
 } from './api'
@@ -323,6 +327,93 @@ describe('useUpdateTournament', () => {
         description: 'You do not have permission to edit this tournament.',
       }),
     )
+  })
+})
+
+/**
+ * **The bytes that leave the client** (ADR 20260727).
+ *
+ * Every other test of the qualifier count stops at a mapper's return value or at a spy's
+ * argument. This one intercepts the real `PATCH` at the fetch boundary and reads the body
+ * off the `Request` — the only assertion in the suite that cannot pass while the field is
+ * dropped somewhere between `eventToUpdateBody` and `openapi-fetch`, and the closest
+ * vitest can get to the e2e suite's `page.route` (which runs with MSW off and would not
+ * catch a mismatch here either way round).
+ */
+describe('useUpdateEvent — the draw configuration on the wire', () => {
+  /** Capture the next event PATCH's decoded body. */
+  function captureEventPatch() {
+    const sent: { body?: Record<string, unknown> } = {}
+    server.use(
+      http.patch(
+        '*/v1/tournaments/:tournamentId/events/:eventId',
+        async ({ request }) => {
+          sent.body = (await request.json()) as Record<string, unknown>
+          return HttpResponse.json(
+            buildTournamentEventRead({
+              draw_type: 'rr-then-ko',
+              qualifiers_per_pool: 2,
+            }),
+          )
+        },
+      ),
+    )
+    return sent
+  }
+
+  it('puts the configured qualifier count in the PATCH body', async () => {
+    const sent = captureEventPatch()
+    const { wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useUpdateEvent('t-1'), { wrapper })
+    result.current.mutate({
+      eventId: 'ev-1',
+      body: eventToUpdateBody(
+        buildEvent({ drawType: 'rr-then-ko', qualifiersPerPool: 2 }),
+      ),
+    })
+
+    await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
+    expect(sent.body).toMatchObject({
+      draw_type: 'rr-then-ko',
+      qualifiers_per_pool: 2,
+    })
+  })
+
+  // …and the negative half, which is the one that would 422: the other two arms of the
+  // server's draw-settings union declare no such field and are `extra="forbid"`, so the
+  // key must be ABSENT from the JSON — not present and null.
+  it('sends no such key at all for a draw type with no knockout stage', async () => {
+    const sent = captureEventPatch()
+    const { wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useUpdateEvent('t-1'), { wrapper })
+    result.current.mutate({
+      eventId: 'ev-1',
+      body: eventToUpdateBody(buildEvent({ drawType: 'round-robin' })),
+    })
+
+    await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
+    expect(sent.body).toHaveProperty('draw_type', 'round-robin')
+    expect(sent.body && 'qualifiers_per_pool' in sent.body).toBe(false)
+  })
+
+  // The round trip, across the real decode: what the handler answered comes back through
+  // `apiToEvent` as the domain's `qualifiersPerPool`.
+  it('reads the stored count back off the response', async () => {
+    captureEventPatch()
+    const { wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useUpdateEvent('t-1'), { wrapper })
+    result.current.mutate({
+      eventId: 'ev-1',
+      body: eventToUpdateBody(
+        buildEvent({ drawType: 'rr-then-ko', qualifiersPerPool: 2 }),
+      ),
+    })
+
+    await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
+    expect(apiToEvent(result.current.data!).qualifiersPerPool).toBe(2)
   })
 })
 

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -739,6 +739,11 @@ const event: TournamentEvent = {
   name: 'U1500 Singles',
   format: 'singles',
   drawType: 'round-robin',
+  // A round-robin event has no knockout stage to qualify for, so it carries NO qualifier
+  // count (ADR 20260727). `null` is the only value its draw settings admit — and the
+  // write bodies below must OMIT the key entirely rather than send this `null`, because
+  // that arm of the server's draw-settings union is `extra="forbid"`.
+  qualifiersPerPool: null,
   maxPlayers: 48,
   entryFee: 30,
   timezone: 'America/Chicago',
@@ -813,6 +818,12 @@ describe('eventToCreateBody', () => {
       // `max_players` is optional on the create body (`null`/absent = no cap,
       // ADR-0935); the read shape is `number | null`.
       max_players: wire.max_players ?? null,
+      // The create body OMITS the qualifier count for a round-robin event (the server's
+      // union forbids the key on that arm), while the read shape carries it as an
+      // explicit `null`. Supplying it here is what makes the round trip land back on
+      // `event` — and the assertion below is therefore also the proof that the omission
+      // and the `null` mean the same thing.
+      qualifiers_per_pool: null,
       id: event.id,
       tournament_id: 't-1',
       // The registrations are server-owned and absent from the create body;
@@ -886,6 +897,72 @@ describe('eventToUpdateBody', () => {
     const body = eventToUpdateBody({ ...event, maxPlayers: null })
     expect('max_players' in body).toBe(true)
     expect(body.max_players).toBeNull()
+  })
+
+  // ⚠️ The claim these make is about **the bytes on the wire**, never about form state:
+  // the whole point of the server-side detour (ADR 20260727) is that the count the
+  // director configured reaches the API, and a director's `2` that a mapper drops is a
+  // bracket cut for a K they never chose — silent, well-formed and wrong.
+  describe('the draw configuration on the wire (ADR 20260727)', () => {
+    const twoStage: TournamentEvent = {
+      ...event,
+      drawType: 'rr-then-ko',
+      qualifiersPerPool: 2,
+    }
+
+    it('SENDS the qualifier count for rr-then-ko, on both verbs', () => {
+      expect(eventToCreateBody(twoStage).qualifiers_per_pool).toBe(2)
+      expect(eventToUpdateBody(twoStage).qualifiers_per_pool).toBe(2)
+    })
+
+    it('sends the DIRECTOR’s count, never a default', () => {
+      // `1` is what the planner falls back to when nobody says otherwise, so a fixture
+      // of 1 could not tell "threaded through" from "fell back". Three is neither the
+      // fallback nor the convention.
+      const body = eventToUpdateBody({ ...twoStage, qualifiersPerPool: 3 })
+      expect(body.qualifiers_per_pool).toBe(3)
+    })
+
+    // The two count-less arms of the server's draw-settings union are `extra="forbid"`
+    // and declare no `qualifiers_per_pool` field at all, so the key is a **422** there —
+    // not a `null` politely ignored. Omission is therefore the only correct spelling, and
+    // `toBeNull()` would pass against the payload that gets refused.
+    it.each(['round-robin', 'single-elim'] as const)(
+      'OMITS the key entirely for %s — where sending it is a 422, not a no-op',
+      (drawType) => {
+        const create = eventToCreateBody({ ...event, drawType })
+        const update = eventToUpdateBody({ ...event, drawType })
+
+        expect('qualifiers_per_pool' in create).toBe(false)
+        expect('qualifiers_per_pool' in update).toBe(false)
+      },
+    )
+
+    // The far half of the round trip the read shape's `qualifiers_per_pool` was added
+    // for: what the server stored comes back, and reaches the control.
+    it('reads the stored count back off the wire', () => {
+      const read = apiToEvent(
+        buildTournamentEventRead({ draw_type: 'rr-then-ko', qualifiers_per_pool: 4 }),
+      )
+
+      expect(read.qualifiersPerPool).toBe(4)
+    })
+
+    it('reads a count-less draw type back as null, never as a number', () => {
+      const read = apiToEvent(buildTournamentEventRead({ draw_type: 'round-robin' }))
+
+      expect(read.qualifiersPerPool).toBeNull()
+    })
+
+    it('round-trips a two-stage event: configure 2, send 2, read 2 back', () => {
+      const sent = eventToUpdateBody(twoStage)
+      const stored = buildTournamentEventRead({
+        draw_type: 'rr-then-ko',
+        qualifiers_per_pool: sent.qualifiers_per_pool,
+      })
+
+      expect(apiToEvent(stored).qualifiersPerPool).toBe(2)
+    })
   })
 
   it('omits the server-owned entered count so a PATCH never clobbers it', () => {

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -136,6 +136,12 @@ export function apiToEvent(e: TournamentEventRead): TournamentEvent {
     name: e.name,
     format: e.format,
     drawType: e.draw_type,
+    // Carried across UNCHANGED, `null` included (ADR 20260727): `null` is not missing
+    // data, it is what the two count-less draw types store, and it is what the read
+    // shape's `NOT NULL`-less column really holds. Coalescing it to a number here would
+    // invent a qualifier count for a format that has no knockout stage — and, on the way
+    // back out, author a body the server 422s.
+    qualifiersPerPool: e.qualifiers_per_pool,
     maxPlayers: e.max_players,
     entryFee: e.entry_fee,
     timezone: e.timezone,
@@ -312,13 +318,43 @@ function eventPoolsToApi(ev: TournamentEvent) {
   }))
 }
 
+/**
+ * The **draw configuration** as the write schemas take it: the draw type, and the
+ * qualifier count *only* for the one draw type that has one (ADR 20260727).
+ *
+ * The pair is flat on the wire and a **discriminated union tagged by `draw_type`** in
+ * the server's interior. Two of its three arms — `round-robin` and `single-elim` — are
+ * `extra="forbid"` and declare no `qualifiers_per_pool` field at all, so the key is a
+ * **422 at the request boundary** on either of them. Not a value silently dropped: the
+ * settings table's `CHECK` says `NULL` for every draw type but `rr-then-ko`, and a
+ * director naming a qualifier count for a format with no knockout stage has
+ * misunderstood something the server would rather say out loud.
+ *
+ * So this omits the key rather than sending `null`, and it is the ONE place that
+ * decision is made — shared by create and update, exactly as `toAddressInput` is,
+ * because the alternative is two write surfaces putting different bytes on the wire for
+ * one intent. (Absent and explicit `null` do mean the same thing to the server's
+ * `_draw_settings_write`, which omits a `None` before validating; but only one of the
+ * two survives `extra="forbid"`, so only one of them is safe to send.)
+ *
+ * For `rr-then-ko` the count is **required** — the union arm has no default — so it is
+ * sent as-is, `null` included. A `null` there is a 422 the form is meant to have caught
+ * first (`qualifiersPerPoolSchema`, `data/event-validation`); sending it is honest, and
+ * far better than inventing a `1` the director never chose.
+ */
+function drawSettingsToApi(ev: TournamentEvent) {
+  return ev.drawType === 'rr-then-ko'
+    ? { draw_type: ev.drawType, qualifiers_per_pool: ev.qualifiersPerPool }
+    : { draw_type: ev.drawType }
+}
+
 /** The event fields shared by the create and update bodies — everything except
  * the server-managed `entered` count. */
 function eventToApiFields(ev: TournamentEvent) {
   return {
     name: ev.name,
     format: ev.format,
-    draw_type: ev.drawType,
+    ...drawSettingsToApi(ev),
     max_players: ev.maxPlayers,
     entry_fee: ev.entryFee,
     timezone: ev.timezone,

--- a/web-client/src/components/tournaments/data/draw-types.test.ts
+++ b/web-client/src/components/tournaments/data/draw-types.test.ts
@@ -23,8 +23,9 @@ const row = (over: Partial<Record<string, unknown>> = {}) => ({
  * `DrawType` used to name five types while the server could plan two, so a director
  * could pick "Swiss" from the picker, create the event, enter a whole field, and only
  * discover at the moment they cut the draw that it was never possible. The API's enum
- * now holds exactly the two that run, and the three that did not are a **422 at the
- * request boundary**.
+ * now holds exactly what runs, and what does not is a **422 at the request boundary** —
+ * a set that moves in both directions: `rr-then-ko` was removed with the other three and
+ * came back in #1227 the moment its strategy landed.
  *
  * What survives on the client is a *vocabulary*, not an offer, and it is declared
  * **once**: `DRAW_TYPES` in `./draw-types`, with `drawTypeSchema` (the event form's
@@ -91,6 +92,30 @@ describe('parseDrawTypeCatalogue', () => {
     ])
 
     expect(options).toEqual([{ value: 'round-robin', label: 'Round robin' }])
+  })
+
+  /** The sharp edge of the rule above, and the reason `DRAW_TYPES` is not a formality:
+   * "unknown slug" and "slug this build simply forgot to list" are indistinguishable
+   * here, and both are dropped **silently**. `rr-then-ko` is the row that proved it —
+   * seeded on the server, in the payload, and absent from the picker with nothing said
+   * (ADR "rr-then-ko cuts both stages upfront and seeds qualifiers rematch-free",
+   * Context). This pins the served row all the way through the filter. */
+  it('keeps the rr-then-ko row the server seeds, rather than dropping it', () => {
+    // The slug is written out, NOT mapped from `DRAW_TYPES` — a test that fed the parser
+    // its own allowlist would agree with itself in every state, including the broken one.
+    const options = parseDrawTypeCatalogue([
+      row({ key: 'round-robin', name: 'Round robin', display_order: 1 }),
+      row({
+        key: 'rr-then-ko',
+        name: 'Round-robin then knockout',
+        display_order: 3,
+      }),
+    ])
+
+    expect(options).toEqual([
+      { value: 'round-robin', label: 'Round robin' },
+      { value: 'rr-then-ko', label: 'Round-robin then knockout' },
+    ])
   })
 
   /** A malformed row is a different thing from an unknown one, and gets the other

--- a/web-client/src/components/tournaments/data/draw-types.ts
+++ b/web-client/src/components/tournaments/data/draw-types.ts
@@ -25,20 +25,29 @@ import type { components } from '@/api/schema'
  * `satisfies` pins it to the generated enum, so a slug the API does not hold is a
  * compile error here; `draw-types.test.ts` pins the other direction (a member of the
  * API's enum *missing* from this array is a compile failure there), so the two
- * cannot drift apart. */
+ * cannot drift apart.
+ *
+ * ⚠️ **This list is the one client edit a new draw type needs that nothing shouts
+ * about.** The catalogue parser below *filters* the served rows against it, silently —
+ * so a slug the server seeds and this array omits does not error, warn or log: the
+ * option simply is not on the menu. That is exactly how `rr-then-ko` was predicted to
+ * need "no client change" and would instead have vanished (ADR "rr-then-ko cuts both
+ * stages upfront and seeds qualifiers rematch-free", Context). Adding the slug here is
+ * step one of adding a draw type to this client; the compiler will find the rest. */
 export const DRAW_TYPES = [
   'round-robin',
   'single-elim',
+  'rr-then-ko',
 ] as const satisfies readonly components['schemas']['DrawType'][]
 
 /** The runtime parser for a single draw-type slug — what the event form validates
  * `drawType` with, so the form cannot accept a slug the catalogue parser would drop. */
 export const drawTypeSchema = z.enum(DRAW_TYPES)
 
-/** The draw types the API accepts — **exactly two**, and deliberately not a
- * roadmap (ADR 20260726 "a draw type is a seeded row"): a member exists iff the
- * server has a strategy that can plan it, so `double-elim`, `rr-then-ko` and
- * `swiss` were removed from the API's enum and are a 422 at the boundary now.
+/** The draw types the API accepts — deliberately not a roadmap (ADR 20260726 "a draw
+ * type is a seeded row"): a member exists iff the server has a strategy that can plan
+ * it. `double-elim` and `swiss` were removed from the API's enum and are a 422 at the
+ * boundary now; `rr-then-ko` came back in #1227 when its strategy landed.
  *
  * Inferred from `DRAW_TYPES` above rather than hand-written, and pinned to the
  * generated `components['schemas']['DrawType']` by a compile-time assertion in

--- a/web-client/src/components/tournaments/data/event-validation.test.ts
+++ b/web-client/src/components/tournaments/data/event-validation.test.ts
@@ -9,6 +9,9 @@ import {
   PLAYERS_MAX,
   poolNameIssues,
   poolNameSchema,
+  QUALIFIERS_PER_POOL_MAX,
+  QUALIFIERS_PER_POOL_MIN,
+  qualifiersPerPoolSchema,
 } from './event-validation'
 
 /** Longer than `tournament_events.name` (`VARCHAR(255)`) — the 422 the organizer used
@@ -95,6 +98,71 @@ describe('the player limit (`EventMaxPlayers | None`, ADR-0935)', () => {
     // The boundary is a real answer: a 512-player draw is nine rounds of single
     // elimination, and an event that big must still save.
     expect(messageFor(maxPlayersSchema, PLAYERS_MAX)).toBeUndefined()
+  })
+})
+
+/**
+ * **K** — the qualifier count (`QualifiersPerPool`: `ge=1`, `le=1000`).
+ *
+ * The floor and its three messages already shipped; what #1231's QA pass found was the
+ * OTHER end, open. The bound is asserted here as a message, not as "it failed", because
+ * the number is the only thing the director can act on.
+ */
+describe('the qualifier count (`QualifiersPerPool`, #1231 QA)', () => {
+  /** The messages that already worked, pinned so the new ceiling cannot quietly take one
+   * of their places: three different faults, three different sentences. */
+  it('keeps the three messages the floor already gave', () => {
+    expect(messageFor(qualifiersPerPoolSchema, null)).toBe(
+      'Say how many players advance from each pool.',
+    )
+    expect(messageFor(qualifiersPerPoolSchema, 0)).toBe(
+      'At least 1 player must advance from each pool.',
+    )
+    expect(messageFor(qualifiersPerPoolSchema, -1)).toBe(
+      'At least 1 player must advance from each pool.',
+    )
+    expect(messageFor(qualifiersPerPoolSchema, 1.5)).toBe(
+      'Qualifiers per pool must be a whole number.',
+    )
+  })
+
+  /**
+   * ⚠️ **The value that DETONATED THE SERVER**, one field over from the player limit's
+   * version of it. `2147483648` is one past what an `Integer` column holds: it satisfied
+   * `ge=1`, went out, and came back a **500** — which the editor reported as "Something
+   * went wrong on our end. Nothing you did caused it". That sentence was false. They
+   * typed a number into a box, and the box had no ceiling.
+   */
+  it('refuses the count that 500’d the server, in words that name the limit', () => {
+    expect(messageFor(qualifiersPerPoolSchema, 2_147_483_648)).toBe(
+      'At most 1,000 players can advance from each pool.',
+    )
+  })
+
+  /** The quieter half of the same fault, and the worse one: `999999999` was **accepted**.
+   * No error anywhere — just an event whose knockout stage could never be cut. */
+  it('refuses a count that saves and then cannot be drawn', () => {
+    expect(messageFor(qualifiersPerPoolSchema, 999_999_999)).toBe(
+      'At most 1,000 players can advance from each pool.',
+    )
+  })
+
+  it('refuses one player past the bound, and accepts the bound itself', () => {
+    expect(messageFor(qualifiersPerPoolSchema, QUALIFIERS_PER_POOL_MAX + 1)).toBe(
+      'At most 1,000 players can advance from each pool.',
+    )
+    // ⚠️ The boundary is the server's, inclusive (`le=1000`) — so it must SAVE. A form
+    // that refused 1,000 would refuse a save the API accepts, which is the mirror image
+    // of the bug and just as wrong.
+    expect(messageFor(qualifiersPerPoolSchema, QUALIFIERS_PER_POOL_MAX)).toBeUndefined()
+    expect(messageFor(qualifiersPerPoolSchema, QUALIFIERS_PER_POOL_MIN)).toBeUndefined()
+  })
+
+  /** The number itself, not just the behaviour: the client's bound and the server's
+   * `le=1000` are the same value stated twice, and a drift either way is a refusal one
+   * layer makes and the other does not. */
+  it('mirrors the server’s number exactly', () => {
+    expect(QUALIFIERS_PER_POOL_MAX).toBe(1000)
   })
 })
 

--- a/web-client/src/components/tournaments/data/event-validation.ts
+++ b/web-client/src/components/tournaments/data/event-validation.ts
@@ -20,9 +20,9 @@
 //   |               | `le=512`, `default=None`              | cap; when present, 1 … 512  |
 //   | `entry_fee`   | `EventEntryFee`: `ge=0`, `le=999…99`, | required; 0 … 999,999.99,   |
 //   |               | whole cents                           | in whole cents              |
-//   | `qualifiers   | `QualifiersPerPool`: `ge=1`, required  | required and ≥ 1 **for      |
-//   |  _per_pool`   | on the `rr-then-ko` union arm, refused | `rr-then-ko` only** — the   |
-//   |               | outright on the other two              | pair, not the field         |
+//   | `qualifiers   | `QualifiersPerPool`: `ge=1`, `le=1000`,| required and 1 … 1,000 **for|
+//   |  _per_pool`   | required on the `rr-then-ko` union arm, | `rr-then-ko` only** — the   |
+//   |               | refused outright on the other two       | pair, not the field         |
 //   | `predicates`  | (permissive — see below)              | `predicate-validation.ts`   |
 //
 // ⚠️ **BLANK IS NOT ZERO — AND THE TWO NUMBER FIELDS DISAGREE ABOUT WHICH IS WHICH**
@@ -235,16 +235,31 @@ export const entryFeeSchema = z
 
 /** The floor on **K** — the server's `QualifiersPerPool = Annotated[int, Field(ge=1)]`,
  * stated once there and mirrored once here. Zero advances nobody into the knockout
- * stage, and a negative count is not a count.
- *
- * ⚠️ There is deliberately **no ceiling**, because the server's two upper bounds move
- * with the entrant count (`P × K >= 2` and `K <= ⌊N/P⌋`) and are refused at the *cut*,
- * not at the write — a configuration that was legal when it was written must not become
- * unwritable when a player withdraws. Mirroring them in the form would refuse saves
- * nothing on the server would ever refuse, and would do it while the director is still
- * filling the event in. The cut's own refusal already says which number to change, in
- * the server's words (`drawRefusalNotice`, `data/draw`). */
+ * stage, and a negative count is not a count. */
 export const QUALIFIERS_PER_POOL_MIN = 1
+
+/** The ceiling on **K** — the server's `QualifiersPerPool = Annotated[int, Field(le=1000)]`,
+ * the same number, stated in both layers on purpose.
+ *
+ * ⚠️ **This is the player limit's bug, one field over** (#1231 QA). `qualifiers_per_pool`
+ * is an `Integer` column, so `2147483648` satisfied every rule either layer stated, hit
+ * Postgres, and came back a **500** — reported to the director as "Something went wrong on
+ * our end. Nothing you did caused it", which was false: they typed a number into a box.
+ * `999999999` was worse, because it *worked*: it saved an event whose knockout stage could
+ * never be cut.
+ *
+ * 1,000 is a bound with a reason, the way 512 is for the player limit: a pool of more than
+ * a thousand finishers is not a pool, and the column's own 2,147,483,647 is not a *limit*,
+ * it is the absence of one.
+ *
+ * It is **not** the same kind of bound as the server's two entrant-dependent ones
+ * (`P × K >= 2` and `K <= ⌊N/P⌋`). Those move with the entrant count and are refused at the
+ * *cut*, not at the write — a configuration that was legal when it was written must not
+ * become unwritable when a player withdraws — so they are deliberately NOT mirrored here.
+ * The cut's own refusal says which number to change, in the server's words
+ * (`drawRefusalNotice`, `data/draw`). This one is fixed, known at write time, and refused
+ * by the API at the request boundary, so the form states it too. */
+export const QUALIFIERS_PER_POOL_MAX = 1000
 
 /**
  * **K** — how many of each pool's finishers advance into an `rr-then-ko` draw's knockout
@@ -272,6 +287,12 @@ export const qualifiersPerPoolSchema = z
   .int({ error: 'Qualifiers per pool must be a whole number.' })
   .min(QUALIFIERS_PER_POOL_MIN, {
     error: `At least ${QUALIFIERS_PER_POOL_MIN} player must advance from each pool.`,
+  })
+  // The floor's sentence, turned over — one bound, two directions, one voice. Stated as
+  // a number the director can act on ("at most 1,000"), not as "invalid": the value they
+  // typed is the only thing they can change.
+  .max(QUALIFIERS_PER_POOL_MAX, {
+    error: `At most ${QUALIFIERS_PER_POOL_MAX.toLocaleString('en-US')} players can advance from each pool.`,
   })
 
 /** The editor's four tabs, of which three can hold something invalid (Match settings

--- a/web-client/src/components/tournaments/data/event-validation.ts
+++ b/web-client/src/components/tournaments/data/event-validation.ts
@@ -20,6 +20,9 @@
 //   |               | `le=512`, `default=None`              | cap; when present, 1 … 512  |
 //   | `entry_fee`   | `EventEntryFee`: `ge=0`, `le=999…99`, | required; 0 … 999,999.99,   |
 //   |               | whole cents                           | in whole cents              |
+//   | `qualifiers   | `QualifiersPerPool`: `ge=1`, required  | required and ≥ 1 **for      |
+//   |  _per_pool`   | on the `rr-then-ko` union arm, refused | `rr-then-ko` only** — the   |
+//   |               | outright on the other two              | pair, not the field         |
 //   | `predicates`  | (permissive — see below)              | `predicate-validation.ts`   |
 //
 // ⚠️ **BLANK IS NOT ZERO — AND THE TWO NUMBER FIELDS DISAGREE ABOUT WHICH IS WHICH**
@@ -228,6 +231,47 @@ export const entryFeeSchema = z
         message: `An entry fee is in whole cents — at most ${FEE_DECIMALS} decimal places.`,
       })
     }
+  })
+
+/** The floor on **K** — the server's `QualifiersPerPool = Annotated[int, Field(ge=1)]`,
+ * stated once there and mirrored once here. Zero advances nobody into the knockout
+ * stage, and a negative count is not a count.
+ *
+ * ⚠️ There is deliberately **no ceiling**, because the server's two upper bounds move
+ * with the entrant count (`P × K >= 2` and `K <= ⌊N/P⌋`) and are refused at the *cut*,
+ * not at the write — a configuration that was legal when it was written must not become
+ * unwritable when a player withdraws. Mirroring them in the form would refuse saves
+ * nothing on the server would ever refuse, and would do it while the director is still
+ * filling the event in. The cut's own refusal already says which number to change, in
+ * the server's words (`drawRefusalNotice`, `data/draw`). */
+export const QUALIFIERS_PER_POOL_MIN = 1
+
+/**
+ * **K** — how many of each pool's finishers advance into an `rr-then-ko` draw's knockout
+ * stage (ADR 20260727).
+ *
+ * NOT `.nullable()`, unlike the player limit, and the difference is the point: a blank
+ * player limit is a real state (an uncapped event), while a blank qualifier count on a
+ * two-stage event is **missing**. The server's `rr-then-ko` arm requires the field with
+ * no default precisely because there is no defensible number to assume — "2" is a
+ * convention, not a fact about the event — so `null` here is the *required* error and
+ * not a value to coalesce. A `null` reaching the wire would be a 422; a `1` invented
+ * here would be a bracket the director never asked for, which is worse, because it looks
+ * like it worked.
+ *
+ * It is applied **only when the draw type is `rr-then-ko`** — see `eventSchema`
+ * (`../tournament-detail-page/event-form`), which runs this parser from the object-level
+ * refinement rather than inlining it as a field rule. The bound belongs to the
+ * `(draw_type, K)` pair, exactly as it does on the server's tagged union, and a field
+ * rule that fired regardless would put a red under a control that is not on screen: for
+ * a round-robin event the box is not rendered at all (the draw type has no knockout
+ * stage), so its error would be a save refused for a reason nobody can see or fix.
+ */
+export const qualifiersPerPoolSchema = z
+  .number({ error: 'Say how many players advance from each pool.' })
+  .int({ error: 'Qualifiers per pool must be a whole number.' })
+  .min(QUALIFIERS_PER_POOL_MIN, {
+    error: `At least ${QUALIFIERS_PER_POOL_MIN} player must advance from each pool.`,
   })
 
 /** The editor's four tabs, of which three can hold something invalid (Match settings

--- a/web-client/src/components/tournaments/data/finishes.test.ts
+++ b/web-client/src/components/tournaments/data/finishes.test.ts
@@ -2,28 +2,26 @@ import { WITHDRAWN_LABEL } from './draw'
 import { eventFinishes } from './finishes'
 import {
   buildEntrants,
-  buildEvent,
   buildFinishesEvent,
   buildFinishesResults,
   buildFinishRow,
-  buildStandingsEvent,
+  finishesResultsOf,
 } from './seed.factory'
+import type { TournamentEvent } from './types'
+
+/** The view for an event's own finishes block — the pairing `ResultsPanel` makes at
+ * runtime, since the selector is handed the block rather than finding one. (The old "returns
+ * null for no results / for the wrong arm" cases are gone: the selector takes a
+ * `FinishesResults`, so neither state can be expressed — the compiler rejects them, and
+ * `ResultsPanel` owns the choice of arm.) */
+const viewOf = (event: TournamentEvent) =>
+  eventFinishes(event, finishesResultsOf(event))
 
 describe('eventFinishes', () => {
-  it('returns null for an event with no results', () => {
-    expect(eventFinishes(buildEvent())).toBeNull()
-  })
-
-  it('returns null for a standings (round-robin) event — the wrong arm', () => {
-    // The finishes view owns only the `finishes` arm of the union; a `standings` result is
-    // `./standings`' job, and this renders nothing off it.
-    expect(eventFinishes(buildStandingsEvent())).toBeNull()
-  })
-
   it('joins each finish’s entry id to a username, in the server’s order', () => {
-    const view = eventFinishes(buildFinishesEvent())
+    const view = viewOf(buildFinishesEvent())
 
-    expect(view?.finishes.map((f) => f.name)).toEqual([
+    expect(view.finishes.map((f) => f.name)).toEqual([
       'player.1',
       'player.2',
       'player.3',
@@ -32,24 +30,24 @@ describe('eventFinishes', () => {
   })
 
   it('labels a solely-held position as an ordinal and marks it untied', () => {
-    const view = eventFinishes(buildFinishesEvent())
+    const view = viewOf(buildFinishesEvent())
 
-    const champ = view?.finishes[0]
-    const runnerUp = view?.finishes[1]
-    expect(champ?.positionLabel).toBe('1st')
-    expect(champ?.tied).toBe(false)
-    expect(champ?.isChampion).toBe(true)
-    expect(runnerUp?.positionLabel).toBe('2nd')
-    expect(runnerUp?.tied).toBe(false)
-    expect(runnerUp?.isChampion).toBe(false)
+    const champ = view.finishes[0]
+    const runnerUp = view.finishes[1]
+    expect(champ.positionLabel).toBe('1st')
+    expect(champ.tied).toBe(false)
+    expect(champ.isChampion).toBe(true)
+    expect(runnerUp.positionLabel).toBe('2nd')
+    expect(runnerUp.tied).toBe(false)
+    expect(runnerUp.isChampion).toBe(false)
   })
 
   it('marks same-position finishes as a tie and labels them T{n}', () => {
     // The two semifinal losers share position 3 — single-elimination does not rank them
     // against each other, so the view renders a tie rather than inventing an order.
-    const view = eventFinishes(buildFinishesEvent())
+    const view = viewOf(buildFinishesEvent())
 
-    const thirds = view?.finishes.filter((f) => f.position === 3) ?? []
+    const thirds = view.finishes.filter((f) => f.position === 3)
     expect(thirds).toHaveLength(2)
     expect(thirds.every((f) => f.tied)).toBe(true)
     expect(thirds.every((f) => f.positionLabel === 'T3')).toBe(true)
@@ -58,7 +56,7 @@ describe('eventFinishes', () => {
   it('carries the server’s finishes order through untouched', () => {
     // The order IS the result (ADR-0785). Feed the finishes out of position order and expect
     // them back in that same order.
-    const view = eventFinishes(
+    const view = viewOf(
       buildFinishesEvent({
         results: buildFinishesResults({
           finishes: [
@@ -70,13 +68,13 @@ describe('eventFinishes', () => {
       }),
     )
 
-    expect(view?.finishes.map((f) => f.entryId)).toEqual(['entry-3', 'entry-1'])
+    expect(view.finishes.map((f) => f.entryId)).toEqual(['entry-3', 'entry-1'])
   })
 
   it('shows a partial (live) bracket’s finishes so far, with no champion', () => {
     // A half-played bracket sends only the entrants eliminated so far; nobody is champion
     // yet. The view renders whatever the server sent — it never computes a placement.
-    const view = eventFinishes(
+    const view = viewOf(
       buildFinishesEvent({
         results: buildFinishesResults({
           complete: false,
@@ -89,24 +87,24 @@ describe('eventFinishes', () => {
       }),
     )
 
-    expect(view?.complete).toBe(false)
-    expect(view?.champion).toBeNull()
-    expect(view?.finishes.map((f) => f.name)).toEqual(['player.3', 'player.4'])
+    expect(view.complete).toBe(false)
+    expect(view.champion).toBeNull()
+    expect(view.finishes.map((f) => f.name)).toEqual(['player.3', 'player.4'])
     // Both alive-until-now losers tie 3rd; the two finalists have no finish yet — absent.
-    expect(view?.finishes.every((f) => f.positionLabel === 'T3')).toBe(true)
+    expect(view.finishes.every((f) => f.positionLabel === 'T3')).toBe(true)
   })
 
   it('joins the champion to a name', () => {
-    const view = eventFinishes(buildFinishesEvent())
+    const view = viewOf(buildFinishesEvent())
 
-    expect(view?.complete).toBe(true)
-    expect(view?.champion).toBe('player.1')
+    expect(view.complete).toBe(true)
+    expect(view.champion).toBe('player.1')
   })
 
   it('shows a finish naming a no-longer-listed entry as Withdrawn', () => {
     // A placed player who withdrew afterward: no username to join, so the word, never a
     // blank and never the raw id.
-    const view = eventFinishes(
+    const view = viewOf(
       buildFinishesEvent({
         entrants: buildEntrants(3), // entry-4 is gone
         results: buildFinishesResults({
@@ -117,6 +115,6 @@ describe('eventFinishes', () => {
       }),
     )
 
-    expect(view?.finishes[0].name).toBe(WITHDRAWN_LABEL)
+    expect(view.finishes[0].name).toBe(WITHDRAWN_LABEL)
   })
 })

--- a/web-client/src/components/tournaments/data/finishes.ts
+++ b/web-client/src/components/tournaments/data/finishes.ts
@@ -41,11 +41,25 @@ export interface FinishLine extends FinishRow {
   positionLabel: string
 }
 
-/** A single-elimination event's results, shaped for the reader: the placement list (names
- * joined, ties marked), whether the bracket is decided, and the champion's *name* when
- * there is one. */
+/**
+ * The fields `eventFinishes` actually reads — a **finishes block**: the placement list,
+ * whether the bracket behind it is decided, and its champion when it has one.
+ *
+ * A whole single-elimination event's `FinishesResults` is one of these; so is the
+ * **knockout stage** of a two-stage event, which is not a `FinishesResults` at all
+ * (`./two-stage`). The `./standings` note applies verbatim: the parameter is this rather
+ * than the tagged arm so a composite hands over the block it genuinely holds instead of
+ * minting a `kind: 'finishes'` value the server would never send.
+ */
+export type FinishesBlock = Omit<FinishesResults, 'kind'>
+
+/** A finishes block, shaped for the reader: the placement list (names joined, ties
+ * marked), whether the bracket is decided, and the champion's *name* when there is one. */
 export interface FinishesView {
   finishes: FinishLine[]
+  /** True when **this bracket** is decided — its final played. For a single-elimination
+   * event that is the event itself; for the knockout stage of a two-stage event it is the
+   * last stage, so it is decided exactly when that event is (`./two-stage`). */
   complete: boolean
   /** The champion's username when the final is decided, else `null` — the server's own
    * `champion`, joined to a name. */
@@ -79,6 +93,10 @@ function ordinal(position: number): string {
  * all. Everything here is a total function of the block plus the `event` the name join
  * needs (entry id → username).
  *
+ * The block is a `FinishesBlock`, not the `finishes` arm itself, so the knockout stage of
+ * a two-stage event can be rendered through this same selector without anybody forging a
+ * `kind` for it.
+ *
  * The rows are mapped **in the order the server sent them** (position ascending, ties
  * together): the server derived the placement from each entrant's elimination round, and
  * re-ordering it here — even by the visible `position` — would be the client second-guessing
@@ -87,7 +105,7 @@ function ordinal(position: number): string {
  */
 export function eventFinishes(
   event: TournamentEvent,
-  results: FinishesResults,
+  results: FinishesBlock,
 ): FinishesView {
   const names = nameByEntryId(event)
 

--- a/web-client/src/components/tournaments/data/finishes.ts
+++ b/web-client/src/components/tournaments/data/finishes.ts
@@ -20,7 +20,7 @@
 // rather than asserted through a DOM.
 
 import { nameByEntryId, nameOf } from './entrant-names'
-import type { FinishRow, TournamentEvent } from './types'
+import type { FinishesResults, FinishRow, TournamentEvent } from './types'
 
 /** One placement line, ready to render: the server's finish row, the entrant's name joined
  * from the event, and the presentation flags the list needs. Every figure is carried
@@ -71,10 +71,13 @@ function ordinal(position: number): string {
 }
 
 /**
- * A single-elimination event's results, shaped for the reader — or `null` when the event has
- * no finishes to show: `results` is `null` (an uncut event), or it is the `standings` arm
- * (a round-robin, rendered by `./standings`). Switch on `results.kind`; this owns only the
- * `finishes` arm.
+ * A **finishes block**, shaped for the reader — always a view, never `null`.
+ *
+ * Like `./standings`, it is handed the block rather than digging one out of the event: it
+ * does not decide whether it applies. **The caller that switches on `results.kind` does**
+ * (`ResultsPanel`), and it is the only place that knows an event may have no results at
+ * all. Everything here is a total function of the block plus the `event` the name join
+ * needs (entry id → username).
  *
  * The rows are mapped **in the order the server sent them** (position ascending, ties
  * together): the server derived the placement from each entrant's elimination round, and
@@ -82,10 +85,10 @@ function ordinal(position: number): string {
  * a result it does not own. The one thing derived is `tied`: a position is a tie exactly when
  * more than one finish shares it (same-round losers), so the list can render it honestly.
  */
-export function eventFinishes(event: TournamentEvent): FinishesView | null {
-  const results = event.results
-  if (results === null || results.kind !== 'finishes') return null
-
+export function eventFinishes(
+  event: TournamentEvent,
+  results: FinishesResults,
+): FinishesView {
   const names = nameByEntryId(event)
 
   // How many finishes share each position — the tie test. A partially-played bracket sends

--- a/web-client/src/components/tournaments/data/fixtures.ts
+++ b/web-client/src/components/tournaments/data/fixtures.ts
@@ -67,8 +67,9 @@ const fixtureTimeSchema = fixtureTimeWireSchema.transform(
  * below so the *runtime* contract is legible next to the generated type it mirrors. */
 const fixtureWireSchema = z.object({
   id: z.string(),
-  /** `null` = an un-pooled draw (single-elim), or the knockout stage of a combined
-   * draw type (#787, not an enum member today).
+  /** `null` = an un-pooled draw (single-elim), or the **knockout stage** of an
+   * `rr-then-ko` one (#1227) — `pool_id IS NULL` *is* the stage discriminator, and there
+   * is no other column that says so.
    * When set it is a **string ref** into the event's own `pools` — not a foreign key,
    * because pools are JSONB value-objects (ADR-0786). */
   pool_id: z.string().nullable(),

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -444,6 +444,11 @@ export function emptyEvent(t: Tournament): TournamentEvent {
     name: '',
     format: 'singles',
     drawType: 'single-elim',
+    // A bracket has no pools to qualify out of, so it carries NO qualifier count — and
+    // `null` is the only value the server's `single-elim` draw-settings arm admits (ADR
+    // 20260727). A new event that pre-filled a number here would be one whose create
+    // body the API 422s the moment the director never touched the draw type.
+    qualifiersPerPool: null,
     maxPlayers: 32,
     entryFee: 30,
     // Anchor the wall-clock windows in the director's own timezone (ADR 20260719):

--- a/web-client/src/components/tournaments/data/results.test.ts
+++ b/web-client/src/components/tournaments/data/results.test.ts
@@ -4,6 +4,8 @@ import { parseResults } from './results'
 
 type StandingsResultsRead = components['schemas']['StandingsResultsRead']
 type FinishesResultsRead = components['schemas']['FinishesResultsRead']
+type StandingsThenFinishesResultsRead =
+  components['schemas']['StandingsThenFinishesResultsRead']
 type StandingRowRead = components['schemas']['StandingRowRead']
 type FinishRowRead = components['schemas']['FinishRowRead']
 
@@ -65,6 +67,31 @@ function wireFinishes(
   }
 }
 
+/** A complete `standings_then_finishes` results block off the wire (ADR 20260727) — one
+ * decided pool and a bracket run to a final. The champion is `entry-2`, who does **not**
+ * top the pool: the pool stage only seeds the bracket. */
+function wireTwoStage(
+  overrides: Partial<StandingsThenFinishesResultsRead> = {},
+): StandingsThenFinishesResultsRead {
+  return {
+    kind: 'standings_then_finishes',
+    pools: [
+      {
+        pool_id: 'p-a',
+        complete: true,
+        rows: [wireRow(), wireRow({ entry_id: 'entry-2', rank: 2 })],
+      },
+    ],
+    finishes: [
+      wireFinish({ entry_id: 'entry-2', position: 1, eliminated_in_round: null }),
+      wireFinish({ entry_id: 'entry-1', position: 2, eliminated_in_round: 2 }),
+    ],
+    complete: true,
+    champion: 'entry-2',
+    ...overrides,
+  }
+}
+
 describe('parseResults', () => {
   it('maps a wire standings block to the camelCase domain shape', () => {
     expect(parseResults(wireStandings())).toEqual({
@@ -106,6 +133,74 @@ describe('parseResults', () => {
       complete: true,
       champion: 'entry-1',
     })
+  })
+
+  it('maps a wire two-stage block to the camelCase domain shape', () => {
+    // The third arm (ADR 20260727): BOTH blocks on one value, each the very model its own
+    // arm carries, and the tag preserved so `ResultsPanel` can narrow to it. Without this
+    // arm the parse THROWS — and since the tournaments list maps every event through it,
+    // that takes the whole page down, not one panel.
+    expect(parseResults(wireTwoStage())).toEqual({
+      kind: 'standings_then_finishes',
+      pools: [
+        {
+          poolId: 'p-a',
+          complete: true,
+          rows: [
+            {
+              entryId: 'entry-1',
+              rank: 1,
+              played: 2,
+              wins: 2,
+              losses: 0,
+              gamesWon: 4,
+              gamesLost: 1,
+              gameDifference: 3,
+            },
+            {
+              entryId: 'entry-2',
+              rank: 2,
+              played: 2,
+              wins: 2,
+              losses: 0,
+              gamesWon: 4,
+              gamesLost: 1,
+              gameDifference: 3,
+            },
+          ],
+        },
+      ],
+      finishes: [
+        { entryId: 'entry-2', position: 1, eliminatedInRound: null },
+        { entryId: 'entry-1', position: 2, eliminatedInRound: 2 },
+      ],
+      complete: true,
+      champion: 'entry-2',
+    })
+  })
+
+  it('keeps a MID-FLIGHT two-stage block’s partial finishes and null champion', () => {
+    // Pools decided, final unplayed: `complete: false`, no champion, and a finishes list
+    // that starts at position 3 — the shape `ev-shield` is seeded in. Nothing is padded and
+    // nothing is invented.
+    const parsed = parseResults(
+      wireTwoStage({
+        complete: false,
+        champion: null,
+        finishes: [
+          wireFinish({ entry_id: 'entry-1', position: 3, eliminated_in_round: 1 }),
+          wireFinish({ entry_id: 'entry-2', position: 3, eliminated_in_round: 1 }),
+        ],
+      }),
+    )
+
+    expect(parsed?.complete).toBe(false)
+    expect(parsed?.champion).toBeNull()
+    expect(
+      parsed?.kind === 'standings_then_finishes'
+        ? parsed.finishes.map((f) => f.position)
+        : null,
+    ).toEqual([3, 3])
   })
 
   it('carries the server’s row order through — it does not sort', () => {
@@ -177,6 +272,39 @@ describe('parseResults', () => {
     expect(() =>
       parseResults({ pools: [], complete: true, champion: null }),
     ).toThrow()
+  })
+
+  it('stays STRICT as arms are added — a near-miss tag is still a throw', () => {
+    // ⚠️ The guard on the fix for #1227, and the reason it is spelled out separately.
+    // Adding the two-stage arm was a widening, and the lazy way to stop a `kind` the client
+    // has never met from throwing is to make the union permissive (a passthrough arm, a
+    // `.catch()`, a `z.record()` fallback). That would satisfy every OTHER test in this
+    // file while silently swallowing real server drift — a future draw type's results would
+    // reach the render path as an unrenderable blob instead of failing loudly here.
+    //
+    // The tags are deliberately a hair away from the real ones: a parser matching on a
+    // prefix, or narrowing to "the shape has pools and finishes", waves these through.
+    for (const kind of [
+      'standings_then_finishes_v2',
+      'finishes_then_standings',
+      'standings-then-finishes',
+      'standings_then_finishes ',
+    ]) {
+      expect(() => parseResults({ ...wireTwoStage(), kind })).toThrow()
+    }
+  })
+
+  it('rejects a two-stage block missing a whole stage', () => {
+    // Both blocks are required — a two-stage arm that accepted a `finishes`-less payload
+    // would hand the panel an undefined stage to render.
+    const withoutKey = (key: 'pools' | 'finishes') => {
+      const block: Record<string, unknown> = { ...wireTwoStage() }
+      delete block[key]
+      return block
+    }
+
+    expect(() => parseResults(withoutKey('finishes'))).toThrow()
+    expect(() => parseResults(withoutKey('pools'))).toThrow()
   })
 
   it('rejects a malformed standings row rather than letting a NaN leak inward', () => {

--- a/web-client/src/components/tournaments/data/results.ts
+++ b/web-client/src/components/tournaments/data/results.ts
@@ -2,8 +2,9 @@
 // being bytes off the wire and become a typed domain value.
 //
 // An event's results are a **discriminated union tagged by shape** — `standings` (a table
-// per pool) for round-robin, `finishes` (a placement list) for single-elimination — plus
-// whether the whole event is decided and its champion, all derived *live* on the server
+// per pool) for round-robin, `finishes` (a placement list) for single-elimination, and
+// `standings_then_finishes` (one of each, ADR 20260727) for round-robin-then-knockout —
+// plus whether the whole event is decided and its champion, all derived *live* on the server
 // from the fixtures' currently-completed matches (never a snapshot). This is the runtime
 // parse that guards them, the twin of `./fixtures` for the draw. The parse switches on
 // `kind`, so an **unknown shape fails HERE**, at the boundary, before it can leak inward.
@@ -18,7 +19,7 @@
 //
 // **`results` is `.nullable()`, and the null is a FACT** (`.nullable()` demands the key be
 // present, unlike `.optional()`): `null` means the event has no results to stand — it has
-// no draw, or its draw type has no results strategy yet (only round-robin does today). An
+// no draw, or its draw type has no results strategy yet. An
 // event whose payload simply *omitted* the field would be one we could not tell apart from
 // one that means "no results", so the schema refuses the absent case and accepts only an
 // explicit `null` or a real results object.
@@ -127,30 +128,85 @@ const finishesResultsWireSchema = z.object({
   champion: z.string().nullable(),
 })
 
+/** The wire shape (`StandingsThenFinishesResultsRead`): the round-robin-then-knockout arm,
+ * tagged `kind: "standings_then_finishes"` — **one block per stage**, and each is the very
+ * model its own arm sends: `pools` are the `PoolStandingsRead`s a round-robin reads out,
+ * `finishes` the `FinishRowRead`s a single-elimination reads out. Reusing the two row
+ * parsers here is the point: the two-stage shape cannot drift from the shapes it composes,
+ * and a malformed row fails at the same boundary whichever arm carried it.
+ *
+ * `complete` is **both** stages decided; `champion` is the **bracket final's** winner (never
+ * a pool leader — the pool stage only seeds), `null` until that final lands. A mid-flight
+ * event is the ordinary case: complete pools, a `finishes` list holding only the entrants
+ * the bracket has placed so far. */
+const standingsThenFinishesResultsWireSchema = z.object({
+  kind: z.literal('standings_then_finishes'),
+  pools: z.array(poolStandingsSchema),
+  finishes: z.array(finishRowSchema),
+  complete: z.boolean(),
+  champion: z.string().nullable(),
+})
+
+/** The parsed wire union — the input to the transform below, named so the transform can
+ * switch on it exhaustively. */
+type EventResultsWire = z.output<
+  | typeof standingsResultsWireSchema
+  | typeof finishesResultsWireSchema
+  | typeof standingsThenFinishesResultsWireSchema
+>
+
+/** Wire → domain, arm by arm. A `switch` with a `never` default rather than a chain of
+ * ternaries: adding a fourth arm to the union above without a mapping here is a **compile
+ * error**, which is the same guarantee `ResultsPanel`'s exhaustive switch gives the render
+ * path. Nothing is re-ordered or recomputed — the order *is* the result. */
+function toDomain(r: EventResultsWire): EventResults {
+  switch (r.kind) {
+    case 'standings':
+      return {
+        kind: 'standings',
+        pools: r.pools,
+        complete: r.complete,
+        champion: r.champion,
+      }
+    case 'finishes':
+      return {
+        kind: 'finishes',
+        finishes: r.finishes,
+        complete: r.complete,
+        champion: r.champion,
+      }
+    case 'standings_then_finishes':
+      return {
+        kind: 'standings_then_finishes',
+        pools: r.pools,
+        finishes: r.finishes,
+        complete: r.complete,
+        champion: r.champion,
+      }
+    default: {
+      const exhaustive: never = r
+      return exhaustive
+    }
+  }
+}
+
 /** The results union, **discriminated on `kind`**: Zod picks the arm by the tag and rejects
  * any other shape (a missing/unknown `kind`, or a `finishes` block carrying `pools`) HERE,
  * at the boundary. The transform switches on the same tag to hand the app a domain value
- * that still carries `kind`, so every consumer narrows the union exhaustively. */
+ * that still carries `kind`, so every consumer narrows the union exhaustively.
+ *
+ * ⚠️ **Adding an arm must never make this permissive.** The union lists exactly the shapes
+ * this client can render; a tag it has never heard of is real server drift, and it fails
+ * here — loudly, in the queryFn — rather than reaching a component that would render half a
+ * page. `results.test.ts` pins that with an unknown `kind`, deliberately one a hair away
+ * from a known one. */
 export const eventResultsSchema = z
   .discriminatedUnion('kind', [
     standingsResultsWireSchema,
     finishesResultsWireSchema,
+    standingsThenFinishesResultsWireSchema,
   ])
-  .transform((r): EventResults =>
-    r.kind === 'standings'
-      ? {
-          kind: 'standings',
-          pools: r.pools,
-          complete: r.complete,
-          champion: r.champion,
-        }
-      : {
-          kind: 'finishes',
-          finishes: r.finishes,
-          complete: r.complete,
-          champion: r.champion,
-        },
-  )
+  .transform(toDomain)
 
 /** An event's `results`, or `null`. **`.nullable()`, never `.optional()`** — the key must
  * be present, and a `null` is the designed "no results here" state, not a missing field

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -21,6 +21,7 @@ import type {
   Predicate,
   StandingRow,
   StandingsResults,
+  StandingsThenFinishesResults,
   Tournament,
   TournamentEvent,
   TournamentTable,
@@ -661,6 +662,81 @@ export function buildFinishesEvent(
 }
 
 /**
+ * A **two-stage** event's results (ADR 20260727) — a played-out `rr-then-ko`: two pools
+ * decided, the bracket run to a final, one champion.
+ *
+ * The numbers are arranged around the claim the format turns on: **the champion is the
+ * bracket's, never a pool's.** `entry-2` wins the final, and `entry-2` tops NO pool —
+ * `entry-5` leads Pool A and `entry-3` leads Pool B, and both of them lose their semifinal
+ * (they are the two tied 3rd). A fixture whose champion also happened to top the first
+ * standings table could not tell a banner that reads the bracket from one that reads the
+ * standings, and that is exactly the bug worth catching.
+ *
+ * The finishes follow single-elimination's own shape, unchanged: 1st, 2nd, then the two
+ * same-round losers **tied 3rd**. A mid-flight event is built by overriding
+ * `complete: false`, `champion: null` and a `finishes` list holding only what the bracket
+ * has settled (see `buildMidFlightTwoStageResults`).
+ */
+export function buildTwoStageResults(
+  overrides: Partial<StandingsThenFinishesResults> = {},
+): StandingsThenFinishesResults {
+  return {
+    kind: 'standings_then_finishes',
+    pools: [
+      buildPoolStandings({
+        poolId: 'p-a',
+        complete: true,
+        rows: [
+          buildStandingRow({ entryId: 'entry-5', rank: 1, played: 3, wins: 3, losses: 0, gamesWon: 6, gamesLost: 1, gameDifference: 5 }),
+          buildStandingRow({ entryId: 'entry-1', rank: 2, played: 3, wins: 2, losses: 1, gamesWon: 5, gamesLost: 2, gameDifference: 3 }),
+          buildStandingRow({ entryId: 'entry-4', rank: 3, played: 3, wins: 1, losses: 2, gamesWon: 2, gamesLost: 5, gameDifference: -3 }),
+          buildStandingRow({ entryId: 'entry-8', rank: 4, played: 3, wins: 0, losses: 3, gamesWon: 1, gamesLost: 6, gameDifference: -5 }),
+        ],
+      }),
+      buildPoolStandings({
+        poolId: 'p-b',
+        complete: true,
+        rows: [
+          buildStandingRow({ entryId: 'entry-3', rank: 1, played: 3, wins: 2, losses: 1, gamesWon: 5, gamesLost: 3, gameDifference: 2 }),
+          buildStandingRow({ entryId: 'entry-2', rank: 2, played: 3, wins: 2, losses: 1, gamesWon: 4, gamesLost: 4, gameDifference: 0 }),
+          buildStandingRow({ entryId: 'entry-6', rank: 3, played: 3, wins: 1, losses: 2, gamesWon: 4, gamesLost: 4, gameDifference: 0 }),
+          buildStandingRow({ entryId: 'entry-7', rank: 4, played: 3, wins: 1, losses: 2, gamesWon: 3, gamesLost: 5, gameDifference: -2 }),
+        ],
+      }),
+    ],
+    finishes: [
+      buildFinishRow({ entryId: 'entry-2', position: 1, eliminatedInRound: null }),
+      buildFinishRow({ entryId: 'entry-1', position: 2, eliminatedInRound: 2 }),
+      buildFinishRow({ entryId: 'entry-5', position: 3, eliminatedInRound: 1 }),
+      buildFinishRow({ entryId: 'entry-3', position: 3, eliminatedInRound: 1 }),
+    ],
+    complete: true,
+    champion: 'entry-2',
+    ...overrides,
+  }
+}
+
+/** The **mid-flight** two-stage read: the same pools, all decided, and a bracket one match
+ * from home — the final seated and unplayed. So `complete` is `false` (both stages decided
+ * is the bar, and one is not), `champion` is `null`, and the finishes list **starts at
+ * position 3**: the two beaten semifinalists are the only entrants the bracket has placed,
+ * and 1st and 2nd do not exist yet. It is the state the seed's `ev-shield` is in, and the
+ * one a partial render must survive. */
+export function buildMidFlightTwoStageResults(
+  overrides: Partial<StandingsThenFinishesResults> = {},
+): StandingsThenFinishesResults {
+  return buildTwoStageResults({
+    complete: false,
+    champion: null,
+    finishes: [
+      buildFinishRow({ entryId: 'entry-5', position: 3, eliminatedInRound: 1 }),
+      buildFinishRow({ entryId: 'entry-3', position: 3, eliminatedInRound: 1 }),
+    ],
+    ...overrides,
+  })
+}
+
+/**
  * A fixture event's own **standings block**, narrowed — what `ResultsPanel` hands
  * `eventStandings` after its switch on `results.kind`.
  *
@@ -692,6 +768,39 @@ export function finishesResultsOf(event: TournamentEvent): FinishesResults {
     )
   }
   return results
+}
+
+/**
+ * A fixture event's own **two-stage block**, narrowed — the `standings_then_finishes` twin
+ * of the two above, and throwing for the same reason.
+ */
+export function twoStageResultsOf(
+  event: TournamentEvent,
+): StandingsThenFinishesResults {
+  const results = event.results
+  if (results === null || results.kind !== 'standings_then_finishes') {
+    throw new Error(
+      `Fixture event '${event.id}' has no two-stage block (results: ${results?.kind ?? 'null'}). Build it with buildTwoStageEvent().`,
+    )
+  }
+  return results
+}
+
+/** A **two-stage** (`rr-then-ko`) event **with results**: the two-pool event
+ * `buildRrThenKoEvent` seeds, played out to a champion (`buildTwoStageResults`). Its eight
+ * entrants (`entry-1`…`entry-8`) are the ones both stages name, so every id joins to a
+ * username; its two pools (`p-a`, `p-b`) are the ones the standings name, so both tables
+ * title themselves.
+ *
+ * The mid-flight state — pools done, final unplayed, no champion — is
+ * `buildTwoStageEvent({ results: buildMidFlightTwoStageResults() })`. */
+export function buildTwoStageEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  return buildRrThenKoEvent({
+    results: buildTwoStageResults(),
+    ...overrides,
+  })
 }
 
 /** A round-robin event **with results**: the drawn U1200 pool play (`buildDrawnEvent`)

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -221,10 +221,10 @@ export function buildFullEvent(
  * A **round-robin-then-knockout** event (ADR 20260727): two pools, and **two** qualifiers
  * out of each into the bracket.
  *
- * `qualifiersPerPool: 2` rather than the smallest legal `1`, deliberately. One is what a
- * planner falls back to when nobody tells it otherwise (`DEFAULT_QUALIFIERS_PER_POOL`,
- * `mocks/factories/tournaments/tournament.factory`), so a fixture built on it could not
- * tell "the director's count was threaded through" from "the default was taken" — the
+ * `qualifiersPerPool: 2` rather than the smallest legal `1`, deliberately. One is the
+ * value any dropped-count bug lands on — the smallest legal K, and the shape of a bracket
+ * cut for a count nobody supplied — so a fixture built on it could not tell "the
+ * director's count was threaded through" from "something substituted the minimum": the
  * exact mock/server mismatch that would cut a K=1 bracket for an event configured at K=2.
  * Two pools, likewise, because `P × K` is what sizes the bracket and a single pool would
  * make the product ambiguous between the two factors.

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -163,6 +163,12 @@ export function buildEvent(
     // `buildEventResults` override (or use `buildStandingsEvent`).
     results: null,
     ...overrides,
+    // **No knockout stage to qualify for, so no qualifier count** (ADR 20260727) —
+    // `null` is the only value a round-robin or single-elim event's draw settings admit,
+    // and it is not "unset". Stated AFTER the spread because `Partial<…>` admits an
+    // explicit `undefined` while the field is required-and-nullable (`number | null`) —
+    // the same reason `entryState` is computed below rather than spread.
+    qualifiersPerPool: overrides.qualifiersPerPool ?? null,
   } satisfies Omit<TournamentEvent, 'entered'>
   // An **uncapped** event (`maxPlayers: null`, ADR-0935) is never `event_full` —
   // the server guarantees it, and so does the fixture. The null check is the whole
@@ -206,6 +212,40 @@ export function buildFullEvent(
     name: 'Championship Singles',
     maxPlayers: 16,
     entrants: buildEntrants(16),
+    ...overrides,
+  })
+}
+
+/**
+ * A **round-robin-then-knockout** event (ADR 20260727): two pools, and **two** qualifiers
+ * out of each into the bracket.
+ *
+ * `qualifiersPerPool: 2` rather than the smallest legal `1`, deliberately. One is what a
+ * planner falls back to when nobody tells it otherwise (`DEFAULT_QUALIFIERS_PER_POOL`,
+ * `mocks/factories/tournaments/tournament.factory`), so a fixture built on it could not
+ * tell "the director's count was threaded through" from "the default was taken" — the
+ * exact mock/server mismatch that would cut a K=1 bracket for an event configured at K=2.
+ * Two pools, likewise, because `P × K` is what sizes the bracket and a single pool would
+ * make the product ambiguous between the two factors.
+ */
+export function buildRrThenKoEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  return buildEvent({
+    id: 'ev-two-stage',
+    name: 'Two-stage Singles',
+    drawType: 'rr-then-ko',
+    qualifiersPerPool: 2,
+    maxPlayers: 32,
+    entrants: buildEntrants(8),
+    pools: [
+      buildPool({ id: 'p-a', name: 'Pool A' }),
+      buildPool({
+        id: 'p-b',
+        name: 'Pool B',
+        slot: { date: '2026-06-13', start: '13:30', end: '17:00' },
+      }),
+    ],
     ...overrides,
   })
 }
@@ -618,6 +658,40 @@ export function buildFinishesEvent(
     results: buildFinishesResults(),
     ...overrides,
   })
+}
+
+/**
+ * A fixture event's own **standings block**, narrowed — what `ResultsPanel` hands
+ * `eventStandings` after its switch on `results.kind`.
+ *
+ * A test reasons in whole events (the results and the entrants they join against travel
+ * together), but the selector and the panel now take the block, so this is the bridge. It
+ * **throws** rather than returning `null`: a fixture that is not a standings event is a
+ * mis-built test, and it should say so at the call site instead of quietly yielding a view
+ * of nothing.
+ */
+export function standingsResultsOf(event: TournamentEvent): StandingsResults {
+  const results = event.results
+  if (results === null || results.kind !== 'standings') {
+    throw new Error(
+      `Fixture event '${event.id}' has no standings block (results: ${results?.kind ?? 'null'}). Build it with buildStandingsEvent().`,
+    )
+  }
+  return results
+}
+
+/**
+ * A fixture event's own **finishes block**, narrowed — the `finishes` twin of
+ * `standingsResultsOf`, and throwing for the same reason.
+ */
+export function finishesResultsOf(event: TournamentEvent): FinishesResults {
+  const results = event.results
+  if (results === null || results.kind !== 'finishes') {
+    throw new Error(
+      `Fixture event '${event.id}' has no finishes block (results: ${results?.kind ?? 'null'}). Build it with buildFinishesEvent().`,
+    )
+  }
+  return results
 }
 
 /** A round-robin event **with results**: the drawn U1200 pool play (`buildDrawnEvent`)

--- a/web-client/src/components/tournaments/data/standings.test.ts
+++ b/web-client/src/components/tournaments/data/standings.test.ts
@@ -1,28 +1,30 @@
 import { WITHDRAWN_LABEL } from './draw'
 import {
   buildEntrants,
-  buildEvent,
   buildEventResults,
   buildPool,
   buildPoolStandings,
   buildStandingRow,
   buildStandingsEvent,
+  standingsResultsOf,
 } from './seed.factory'
 import { eventStandings } from './standings'
+import type { TournamentEvent } from './types'
+
+/** The view for an event's own standings block — the pairing `ResultsPanel` makes at
+ * runtime, since the selector is handed the block rather than finding one. (There is no
+ * "no results" case to test here any more: the selector takes a `StandingsResults`, so
+ * that state cannot be expressed. `ResultsPanel` owns it.) */
+const viewOf = (event: TournamentEvent) =>
+  eventStandings(event, standingsResultsOf(event))
 
 describe('eventStandings', () => {
-  it('returns null for an event with no results', () => {
-    // An uncut or non-round-robin event carries `results: null` — there is nothing to
-    // stand, and the panel renders nothing off this.
-    expect(eventStandings(buildEvent())).toBeNull()
-  })
-
   it('joins each row’s entry id to a username, and titles each pool from the event', () => {
-    const view = eventStandings(buildStandingsEvent())
+    const view = viewOf(buildStandingsEvent())
 
-    expect(view?.pools).toHaveLength(1)
-    expect(view?.pools[0].name).toBe('Pool A')
-    expect(view?.pools[0].rows.map((r) => r.name)).toEqual([
+    expect(view.pools).toHaveLength(1)
+    expect(view.pools[0].name).toBe('Pool A')
+    expect(view.pools[0].rows.map((r) => r.name)).toEqual([
       'player.1',
       'player.4',
       'player.5',
@@ -32,7 +34,7 @@ describe('eventStandings', () => {
   it('carries every server number and order through untouched', () => {
     // The client shows the figures, it does not compute them (ADR-0788). Feed rows out of
     // finishing order and expect them back in that same order, numbers intact.
-    const view = eventStandings(
+    const view = viewOf(
       buildStandingsEvent({
         results: buildEventResults({
           pools: [
@@ -47,32 +49,32 @@ describe('eventStandings', () => {
       }),
     )
 
-    expect(view?.pools[0].rows.map((r) => r.entryId)).toEqual(['entry-5', 'entry-1'])
-    expect(view?.pools[0].rows.map((r) => r.gameDifference)).toEqual([-3, 3])
+    expect(view.pools[0].rows.map((r) => r.entryId)).toEqual(['entry-5', 'entry-1'])
+    expect(view.pools[0].rows.map((r) => r.gameDifference)).toEqual([-3, 3])
   })
 
   it('joins the champion to a name', () => {
-    const view = eventStandings(buildStandingsEvent())
+    const view = viewOf(buildStandingsEvent())
 
-    expect(view?.complete).toBe(true)
-    expect(view?.champion).toBe('player.1')
+    expect(view.complete).toBe(true)
+    expect(view.champion).toBe('player.1')
   })
 
   it('keeps a null champion null — a live or multi-pool event', () => {
-    const view = eventStandings(
+    const view = viewOf(
       buildStandingsEvent({
         results: buildEventResults({ complete: false, champion: null }),
       }),
     )
 
-    expect(view?.champion).toBeNull()
+    expect(view.champion).toBeNull()
   })
 
   it('shows a row naming a no-longer-listed entry as Withdrawn', () => {
     // A player who withdrew after playing: their completed matches still count toward the
     // numbers, but they are no longer an entrant, so the join has no username. It is the
     // withdrawn word, never a blank and never the raw id — shared with the draw.
-    const view = eventStandings(
+    const view = viewOf(
       buildStandingsEvent({
         entrants: buildEntrants(4), // entry-5 is gone
         results: buildEventResults({
@@ -85,13 +87,13 @@ describe('eventStandings', () => {
       }),
     )
 
-    expect(view?.pools[0].rows[0].name).toBe(WITHDRAWN_LABEL)
+    expect(view.pools[0].rows[0].name).toBe(WITHDRAWN_LABEL)
   })
 
   it('falls back to the pool id if the event does not list the pool', () => {
     // A pool the standings name but the event does not carry is a payload the server cannot
     // send; the fallback keeps the table titled rather than blank if it ever did.
-    const view = eventStandings(
+    const view = viewOf(
       buildStandingsEvent({
         pools: [buildPool({ id: 'p-a', name: 'Pool A' })],
         results: buildEventResults({
@@ -100,6 +102,6 @@ describe('eventStandings', () => {
       }),
     )
 
-    expect(view?.pools[0].name).toBe('p-ghost')
+    expect(view.pools[0].name).toBe('p-ghost')
   })
 })

--- a/web-client/src/components/tournaments/data/standings.ts
+++ b/web-client/src/components/tournaments/data/standings.ts
@@ -45,10 +45,26 @@ export interface PoolStandingsView {
   complete: boolean
 }
 
-/** An event's results, shaped for the reader: named pool tables, whether the event is
+/**
+ * The fields `eventStandings` actually reads — a **standings block**: the pool tables,
+ * whether that block is decided, and its champion when it has one.
+ *
+ * A whole round-robin event's `StandingsResults` is one of these; so is the **pool stage**
+ * of a two-stage event, which is not a `StandingsResults` at all (`./two-stage`). The
+ * parameter is this rather than the tagged arm precisely so a composite can hand over the
+ * block it genuinely holds instead of minting a `kind: 'standings'` value the server would
+ * never send — a boundary type is parsed at the edge and carried inward, never constructed
+ * inward (`.claude/rules/parse-at-boundaries.md`).
+ */
+export type StandingsBlock = Omit<StandingsResults, 'kind'>
+
+/** A standings block, shaped for the reader: named pool tables, whether the block is
  * complete, and the champion's *name* (joined) when there is one. */
 export interface StandingsView {
   pools: PoolStandingsView[]
+  /** True when **this standings block** is decided — every fixture of every pool played.
+   * For a round-robin event that is the event itself; for the pool stage of a two-stage
+   * event it is that *stage*, which is decided long before the event is (`./two-stage`). */
   complete: boolean
   /** The champion's username when the event is a complete single pool, else `null` — the
    * server's own `champion`, joined to a name. `null` while any fixture is unplayed, and
@@ -65,6 +81,10 @@ export interface StandingsView {
  * all. Everything here is a total function of the two arguments — the block, plus the
  * `event` the two id joins need (entry id → username, pool id → pool name).
  *
+ * The block is a `StandingsBlock`, not the `standings` arm itself, so the pool stage of a
+ * two-stage event can be rendered through this same selector without anybody forging a
+ * `kind` for it.
+ *
  * The rows are mapped **in the order the server sent them**: standings are a total order
  * the server computed (wins → two-way head-to-head → game difference → games won), and
  * re-sorting them here — even by the same visible keys — would be the client second-
@@ -73,7 +93,7 @@ export interface StandingsView {
  */
 export function eventStandings(
   event: TournamentEvent,
-  results: StandingsResults,
+  results: StandingsBlock,
 ): StandingsView {
   const names = nameByEntryId(event)
   const poolNameById = new Map(event.pools.map((p) => [p.id, p.name]))

--- a/web-client/src/components/tournaments/data/standings.ts
+++ b/web-client/src/components/tournaments/data/standings.ts
@@ -23,7 +23,7 @@
 // rather than asserted through a DOM.
 
 import { nameByEntryId, nameOf } from './entrant-names'
-import type { StandingRow, TournamentEvent } from './types'
+import type { StandingRow, StandingsResults, TournamentEvent } from './types'
 
 /** One standings line, ready to render: the server's row, plus the entrant's name joined
  * from the event. The row's every number is carried through unchanged — see the module
@@ -57,9 +57,13 @@ export interface StandingsView {
 }
 
 /**
- * An event's results, shaped for the reader — or `null` when the event has none (an uncut
- * or non-round-robin event; `results` is `null` on the wire, and this returns `null`
- * straight through, so the panel renders nothing).
+ * A **standings block**, shaped for the reader — always a view, never `null`.
+ *
+ * It is handed the block rather than digging one out of the event, so it does not decide
+ * whether it applies: **the caller that switches on `results.kind` does**
+ * (`ResultsPanel`), and it is the only place that knows an event may have no results at
+ * all. Everything here is a total function of the two arguments — the block, plus the
+ * `event` the two id joins need (entry id → username, pool id → pool name).
  *
  * The rows are mapped **in the order the server sent them**: standings are a total order
  * the server computed (wins → two-way head-to-head → game difference → games won), and
@@ -67,13 +71,10 @@ export interface StandingsView {
  * guessing a result it does not own, and would silently disagree the day a tiebreaker the
  * client cannot see (head-to-head) decides two equal rows.
  */
-export function eventStandings(event: TournamentEvent): StandingsView | null {
-  const results = event.results
-  // Only the `standings` arm of the results union stands here (ADR-0785). `null` (no
-  // results) and the `finishes` arm (single-elimination — a placement list, `./finishes`)
-  // both render nothing off this view-model.
-  if (results === null || results.kind !== 'standings') return null
-
+export function eventStandings(
+  event: TournamentEvent,
+  results: StandingsResults,
+): StandingsView {
   const names = nameByEntryId(event)
   const poolNameById = new Map(event.pools.map((p) => [p.id, p.name]))
 

--- a/web-client/src/components/tournaments/data/two-stage.test.ts
+++ b/web-client/src/components/tournaments/data/two-stage.test.ts
@@ -82,6 +82,11 @@ describe('eventStandingsThenFinishes', () => {
     expect(view.complete).toBe(false)
     expect(view.champion).toBeNull()
     expect(view.standings.pools.every((p) => p.complete)).toBe(true)
+    // …and each stage answers for ITSELF, which is the whole point of this state: the
+    // pool stage IS complete while the event is not, and the bracket is not. A sub-view
+    // handed the event's flag would call the decided pool stage undecided.
+    expect(view.standings.complete).toBe(true)
+    expect(view.finishes.complete).toBe(false)
     expect(view.finishes.finishes.map((f) => [f.positionLabel, f.name])).toEqual([
       ['T3', 'player.5'],
       ['T3', 'player.3'],

--- a/web-client/src/components/tournaments/data/two-stage.test.ts
+++ b/web-client/src/components/tournaments/data/two-stage.test.ts
@@ -1,0 +1,114 @@
+import {
+  buildMidFlightTwoStageResults,
+  buildTwoStageEvent,
+  buildTwoStageResults,
+  twoStageResultsOf,
+} from './seed.factory'
+import { eventStandingsThenFinishes } from './two-stage'
+import type { TournamentEvent } from './types'
+
+/** The view for an event's own two-stage block — the pairing `ResultsPanel` makes at
+ * runtime, since the selector is handed the block rather than finding one. */
+const viewOf = (event: TournamentEvent) =>
+  eventStandingsThenFinishes(event, twoStageResultsOf(event))
+
+describe('eventStandingsThenFinishes', () => {
+  it('crowns the BRACKET’s winner, who tops no pool', () => {
+    // The claim the whole format turns on (ADR 20260727): the pool stage only seeds the
+    // bracket, so the champion is the final's winner and never a standings leader. In this
+    // fixture `entry-2` wins the final while `entry-5` and `entry-3` lead the two pools —
+    // a champion read off the standings would name one of THEM.
+    const view = viewOf(buildTwoStageEvent())
+
+    expect(view.champion).toBe('player.2')
+    expect(view.complete).toBe(true)
+    // …and it is not the top of either pool table, stated explicitly so the assertion above
+    // cannot be satisfied by coincidence.
+    expect(view.standings.pools.map((p) => p.rows[0].name)).toEqual([
+      'player.5',
+      'player.3',
+    ])
+  })
+
+  it('leaves neither stage holding a champion of its own — one banner, not three', () => {
+    // The event's champion is a fact about the EVENT, shown once above both stages. A
+    // sub-view that kept one would print the same name twice on one card.
+    const view = viewOf(buildTwoStageEvent())
+
+    expect(view.standings.champion).toBeNull()
+    expect(view.finishes.champion).toBeNull()
+  })
+
+  it('shapes the pool stage exactly as a round-robin’s standings — named, in order', () => {
+    const view = viewOf(buildTwoStageEvent())
+
+    expect(view.standings.pools.map((p) => p.name)).toEqual(['Pool A', 'Pool B'])
+    expect(view.standings.pools[0].rows.map((r) => r.name)).toEqual([
+      'player.5',
+      'player.1',
+      'player.4',
+      'player.8',
+    ])
+    // The numbers are the server's, carried through untouched.
+    expect(view.standings.pools[0].rows[0]).toMatchObject({
+      rank: 1,
+      wins: 3,
+      losses: 0,
+      gameDifference: 5,
+    })
+  })
+
+  it('shapes the knockout stage exactly as a single-elimination’s finishes — ties and all', () => {
+    const view = viewOf(buildTwoStageEvent())
+
+    expect(view.finishes.finishes.map((f) => [f.positionLabel, f.name])).toEqual([
+      ['1st', 'player.2'],
+      ['2nd', 'player.1'],
+      // The two beaten semifinalists — the pool winners — tie 3rd, because the bracket
+      // never played them off.
+      ['T3', 'player.5'],
+      ['T3', 'player.3'],
+    ])
+  })
+
+  it('renders the MID-FLIGHT event honestly: complete pools, partial finishes, no champion', () => {
+    // Pools decided, the final seated and unplayed. `complete` is BOTH stages, so it is
+    // false; there is no champion yet; and the finishes list starts at position 3 — 1st and
+    // 2nd do not exist. The pool tables are unaffected and still complete.
+    const view = viewOf(
+      buildTwoStageEvent({ results: buildMidFlightTwoStageResults() }),
+    )
+
+    expect(view.complete).toBe(false)
+    expect(view.champion).toBeNull()
+    expect(view.standings.pools.every((p) => p.complete)).toBe(true)
+    expect(view.finishes.finishes.map((f) => [f.positionLabel, f.name])).toEqual([
+      ['T3', 'player.5'],
+      ['T3', 'player.3'],
+    ])
+    // Nobody is flagged champion in the placement list either — position 1 is unclaimed.
+    expect(view.finishes.finishes.some((f) => f.isChampion)).toBe(false)
+  })
+
+  it('carries the server’s order through — it sorts neither stage', () => {
+    // The order IS the result in both stages (ADR-0788, ADR-0785). Feed each one out of
+    // order and expect it back exactly as sent.
+    const decided = buildTwoStageResults()
+    const view = viewOf(
+      buildTwoStageEvent({
+        results: buildTwoStageResults({
+          pools: [decided.pools[1], decided.pools[0]],
+          finishes: [...decided.finishes].reverse(),
+        }),
+      }),
+    )
+
+    expect(view.standings.pools.map((p) => p.poolId)).toEqual(['p-b', 'p-a'])
+    expect(view.finishes.finishes.map((f) => f.entryId)).toEqual([
+      'entry-3',
+      'entry-5',
+      'entry-1',
+      'entry-2',
+    ])
+  })
+})

--- a/web-client/src/components/tournaments/data/two-stage.ts
+++ b/web-client/src/components/tournaments/data/two-stage.ts
@@ -9,6 +9,12 @@
 // of its own beyond the champion's — it hands each block to the selector that already
 // shapes it (`eventStandings`, `eventFinishes`) and composes the two views.
 //
+// It hands over a `StandingsBlock` / `FinishesBlock` — the fields those selectors read —
+// and **never a forged arm of the union**. Tagging this event's pools `kind: 'standings'`
+// to fit a signature would construct a boundary type *inward*, which is the wrong
+// direction (`.claude/rules/parse-at-boundaries.md`): the wire's arms are parsed at the
+// edge and carried in, never minted here to satisfy a parameter.
+//
 // **The champion belongs to the event, not to a stage** (ADR 20260727: "the champion comes
 // from the bracket — never from a pool"), so it is lifted out of both sub-views and named
 // once, here:
@@ -20,9 +26,13 @@
 //   Leaving it on the sub-view would print the same fact twice on one card.
 //
 // Everything else is carried straight through: neither stage is re-ordered or recomputed
-// (the order *is* the result), and `complete` is the server's — **both** stages decided,
-// never either. A mid-flight event is the ordinary case, not an edge: complete pools, a
-// finishes list that starts below 1st, no champion.
+// (the order *is* the result). **`complete` is asked per stage, and the event's is a
+// different question**: `TwoStageView.complete` is the server's — **both** stages decided,
+// never either — while each sub-view carries its own stage's, because that is what
+// `StandingsView.complete` / `FinishesView.complete` mean. A mid-flight event is the
+// ordinary case, not an edge, and it is exactly where the two answers differ: complete
+// pools (so the standings block IS complete), a finishes list that starts below 1st, no
+// champion, and an incomplete event.
 //
 // A pure function of one event, so it is unit-tested (`./two-stage.test.ts`) rather than
 // asserted through a DOM.
@@ -41,7 +51,8 @@ export interface TwoStageView {
   /** The **knockout stage**, exactly as a single-elimination's finishes render — minus a
    * champion, which the composite names once above both stages. */
   finishes: FinishesView
-  /** True when **both** stages are decided. */
+  /** True when **both** stages are decided — the server's own flag. Not either sub-view's
+   * `complete`: the pool stage is decided well before the event is. */
   complete: boolean
   /** The champion's username — the **bracket final's** winner, joined from the server's
    * `champion` entry id — or `null` until that final is decided. Never a pool leader. */
@@ -65,27 +76,38 @@ export function eventStandingsThenFinishes(
   event: TournamentEvent,
   results: StandingsThenFinishesResults,
 ): TwoStageView {
-  const names = nameByEntryId(event)
+  // The BRACKET's winner. Read off `results.champion` — the server's own figure — and
+  // never off the top of a standings table, which would crown whoever led a pool.
+  //
+  // The entrant map is built HERE, inside the branch that needs it: it feeds exactly one
+  // lookup, and a mid-flight event — the ordinary case — has no champion to look up.
+  const champion =
+    results.champion === null
+      ? null
+      : nameOf(results.champion, nameByEntryId(event))
 
   return {
     // `champion: null` on both sub-blocks is the composite's decision, not a claim about
-    // the data — see the module note. The event's champion is named below, once.
+    // the data — see the module note. The event's champion is named above, once.
     standings: eventStandings(event, {
-      kind: 'standings',
       pools: results.pools,
-      complete: results.complete,
+      // The POOL STAGE's own completeness, which is what a `StandingsView.complete`
+      // states. `results.complete` is a different fact — *both* stages — and handing it
+      // over would have this block report an unplayed final as an undecided pool stage.
+      // Every pool decided IS the pool stage decided, the same reading
+      // `StandingsResults.complete` carries for a round-robin event.
+      complete: results.pools.every((pool) => pool.complete),
       champion: null,
     }),
     finishes: eventFinishes(event, {
-      kind: 'finishes',
       finishes: results.finishes,
+      // The knockout stage is the LAST stage, so "this bracket is decided" and "the event
+      // is decided" are the same fact — the event's flag is this block's own, not a
+      // stand-in for it.
       complete: results.complete,
       champion: null,
     }),
     complete: results.complete,
-    // The BRACKET's winner. Read off `results.champion` — the server's own figure — and
-    // never off the top of a standings table, which would crown whoever led a pool.
-    champion:
-      results.champion === null ? null : nameOf(results.champion, names),
+    champion,
   }
 }

--- a/web-client/src/components/tournaments/data/two-stage.ts
+++ b/web-client/src/components/tournaments/data/two-stage.ts
@@ -1,0 +1,91 @@
+// What a **round-robin-then-knockout** event's results look like to a reader (ADR
+// 20260727) — the pure derivation behind the Events tab's two-stage block, and the
+// composite of `./standings` and `./finishes` rather than a third copy of either.
+//
+// The wire gives us the `standings_then_finishes` arm of `EventResults` (parsed at the
+// boundary by `./results`): one **pool-stage** standings block, one **knockout-stage**
+// finishes block, and a single `complete`/`champion` pair describing the event as a whole.
+// Both blocks are the very models the other two arms carry, so this module makes no joins
+// of its own beyond the champion's — it hands each block to the selector that already
+// shapes it (`eventStandings`, `eventFinishes`) and composes the two views.
+//
+// **The champion belongs to the event, not to a stage** (ADR 20260727: "the champion comes
+// from the bracket — never from a pool"), so it is lifted out of both sub-views and named
+// once, here:
+//
+// - the **standings** sub-view is given `champion: null` because a pool stage genuinely
+//   crowns nobody. Topping a pool wins nothing in this format; it seeds a bracket slot.
+// - the **finishes** sub-view is given `champion: null` too — not because the bracket has
+//   no winner, but because this composite shows that winner **once**, above both stages.
+//   Leaving it on the sub-view would print the same fact twice on one card.
+//
+// Everything else is carried straight through: neither stage is re-ordered or recomputed
+// (the order *is* the result), and `complete` is the server's — **both** stages decided,
+// never either. A mid-flight event is the ordinary case, not an edge: complete pools, a
+// finishes list that starts below 1st, no champion.
+//
+// A pure function of one event, so it is unit-tested (`./two-stage.test.ts`) rather than
+// asserted through a DOM.
+
+import { nameByEntryId, nameOf } from './entrant-names'
+import { eventFinishes, type FinishesView } from './finishes'
+import { eventStandings, type StandingsView } from './standings'
+import type { StandingsThenFinishesResults, TournamentEvent } from './types'
+
+/** A two-stage event's results, shaped for the reader: the pool stage's tables, the
+ * knockout stage's placements, and the one champion the two stages produce between them. */
+export interface TwoStageView {
+  /** The **pool stage**, exactly as a round-robin's standings render — minus a champion,
+   * which a pool stage does not award. */
+  standings: StandingsView
+  /** The **knockout stage**, exactly as a single-elimination's finishes render — minus a
+   * champion, which the composite names once above both stages. */
+  finishes: FinishesView
+  /** True when **both** stages are decided. */
+  complete: boolean
+  /** The champion's username — the **bracket final's** winner, joined from the server's
+   * `champion` entry id — or `null` until that final is decided. Never a pool leader. */
+  champion: string | null
+}
+
+/**
+ * A **two-stage results block**, shaped for the reader — always a view, never `null`.
+ *
+ * Like its two halves it is handed the block rather than digging one out of the event: it
+ * does not decide whether it applies. **The caller that switches on `results.kind` does**
+ * (`ResultsPanel`), and it is the only place that knows an event may have no results at
+ * all.
+ *
+ * It composes the existing selectors instead of re-deriving either stage. That is what
+ * keeps a two-stage event's pool table identical to a round-robin's and its placement list
+ * identical to a single-elimination's — including the tie labels and the withdrawn-entrant
+ * join, which would otherwise be a second implementation waiting to disagree.
+ */
+export function eventStandingsThenFinishes(
+  event: TournamentEvent,
+  results: StandingsThenFinishesResults,
+): TwoStageView {
+  const names = nameByEntryId(event)
+
+  return {
+    // `champion: null` on both sub-blocks is the composite's decision, not a claim about
+    // the data — see the module note. The event's champion is named below, once.
+    standings: eventStandings(event, {
+      kind: 'standings',
+      pools: results.pools,
+      complete: results.complete,
+      champion: null,
+    }),
+    finishes: eventFinishes(event, {
+      kind: 'finishes',
+      finishes: results.finishes,
+      complete: results.complete,
+      champion: null,
+    }),
+    complete: results.complete,
+    // The BRACKET's winner. Read off `results.champion` — the server's own figure — and
+    // never off the top of a standings table, which would crown whoever led a pool.
+    champion:
+      results.champion === null ? null : nameOf(results.champion, names),
+  }
+}

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -306,17 +306,56 @@ export interface FinishesResults {
 }
 
 /**
- * An event's **results**, a discriminated union tagged by shape (ADR-0785): `standings`
- * for round-robin, `finishes` for single-elimination. Each draw type's results strategy
- * returns its own shape; the BFF emits the `kind` tag; the client switches on it. A future
- * draw type is a type error until it declares its shape.
+ * A **round-robin-then-knockout** event's results (ADR 20260727): both stages at once —
+ * the pool stage's standings and the knockout stage's finishes. The
+ * `standings_then_finishes` arm of the `EventResults` discriminated union.
+ *
+ * Its two blocks are the **same models** the other two arms send (`PoolStandings[]`,
+ * `FinishRow[]`), not two-stage-flavoured near-copies, so each stage renders through the
+ * panel that already exists and the shapes cannot drift apart. That is also why this is a
+ * third arm rather than a restructuring of the union into a composite: making `standings`
+ * and `finishes` sub-objects of one wrapper would change how the existing two arms are
+ * read, forcing round-robin and single-elim changes that buy nothing.
+ *
+ * Live and partial like every other results shape: the pool tables fill in as pool matches
+ * land, and the finishes list grows as the bracket is played out — so a mid-flight event
+ * has complete pools and a finishes list that **starts below 1st** (only the entrants the
+ * bracket has actually placed).
+ */
+export interface StandingsThenFinishesResults {
+  kind: 'standings_then_finishes'
+  /** The **pool stage**: one standings table per pool, in the server's finishing order. */
+  pools: PoolStandings[]
+  /** The **knockout stage**: the placements so far, position ascending, ties sharing a
+   * position — exactly what a single-elimination event reads out. Empty until the bracket
+   * settles its first fixture. */
+  finishes: FinishRow[]
+  /** True when **both** stages are decided — every pool played out *and* the bracket run to
+   * its final. Not either one: a two-stage event with decided pools and an unplayed final
+   * is not complete. */
+  complete: boolean
+  /** The winning **entry id** — the **knockout final's winner, never a pool leader**. The
+   * pool stage only seeds the bracket, so topping a pool wins nothing here. `null` until
+   * that final is decided. Joined to a username at render, like a row's `entryId`. */
+  champion: string | null
+}
+
+/**
+ * An event's **results**, a discriminated union tagged by shape (ADR-0785, widened by ADR
+ * 20260727): `standings` for round-robin, `finishes` for single-elimination,
+ * `standings_then_finishes` for round-robin-then-knockout. Each draw type's results
+ * strategy returns its own shape; the BFF emits the `kind` tag; the client switches on it.
+ * A future draw type is a type error until it declares its shape.
  *
  * On the event it is `null` for an event with **no draw** — nothing to stand — an honest
  * "no results", never an empty table that would read as a played event with nobody in it.
- * Every draw type a director can pick reads out results of one shape or the other, so
+ * Every draw type a director can pick reads out results of one of these shapes, so
  * "cut, but no results block" is not a state.
  */
-export type EventResults = StandingsResults | FinishesResults
+export type EventResults =
+  | StandingsResults
+  | FinishesResults
+  | StandingsThenFinishesResults
 
 /** One *active* entry in an event. Withdrawn entries are not entrants — they
  * appear in neither this list nor the `entered` count (ADR-0016).

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -394,6 +394,25 @@ export interface TournamentEvent {
   name: string
   format: EventFormat
   drawType: DrawType
+  /** **K** — how many of each pool's finishers advance into the knockout stage of an
+   * `rr-then-ko` draw, or `null` for a draw type that has no knockout stage to qualify
+   * for (ADR 20260727).
+   *
+   * ⚠️ `null` is not "unset" — it is the **only** legal value for `round-robin` and
+   * `single-elim`, and the server says so at the request boundary: the draw
+   * configuration is a union tagged by the draw type, and the two count-less arms are
+   * `extra="forbid"`, so a qualifier count sent alongside either of them is a 422 rather
+   * than a value quietly dropped. That is why `eventToApiFields` (`./api`) **omits** the
+   * key for those two types instead of sending `null` — and why the editor's control for
+   * it is rendered only for `rr-then-ko`.
+   *
+   * For `rr-then-ko` it is **required**, at least 1, and it is not a number this client
+   * may assume: "2" is a convention, not a fact about the event, and a bracket cut for a
+   * K the director never chose is the failure that looks like it worked. It is also what
+   * sizes the bracket (`P × K`), which is why it is carried on the read model at all —
+   * the mock planner and every reader take the director's real value rather than a
+   * default. */
+  qualifiersPerPool: number | null
   /** The entrant cap, or `null` for an uncapped event. `null` means "no cap",
    * never zero (ADR-0935): a blank player-limit field submits `null`, and every
    * reader must handle the no-cap branch rather than dividing by it. */

--- a/web-client/src/components/tournaments/tournament-detail-page.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.factory.tsx
@@ -14,6 +14,7 @@ export function buildTournamentDetailPageProps(
     onCreateEvent: async () => {},
     onUpdateEvent: async () => {},
     onDeleteEvent: () => {},
+    savingEvent: false,
     onBack: () => {},
     ...overrides,
   }

--- a/web-client/src/components/tournaments/tournament-detail-page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.tsx
@@ -45,6 +45,11 @@ export interface TournamentDetailPageProps {
   /** Persist an edited event — same contract as `onCreateEvent`. */
   onUpdateEvent: (event: TournamentEvent) => Promise<void>
   onDeleteEvent: (eventId: string) => void
+  /** Whether the create/update event mutation is still in flight — passed straight to
+   * the `EventEditor`, which disables its one submit control on it. Owned by the route,
+   * because the route owns the mutations; this page only carries it across. See
+   * `EventEditor`'s `saving` prop for why `isSubmitting` alone was not enough (#1231). */
+  savingEvent?: boolean
   onBack: () => void
 }
 
@@ -79,6 +84,7 @@ export const TournamentDetailPage = ({
   onCreateEvent,
   onUpdateEvent,
   onDeleteEvent,
+  savingEvent = false,
   onBack,
 }: TournamentDetailPageProps) => {
   const [tab, setTab] = useState('events')
@@ -300,6 +306,7 @@ export const TournamentDetailPage = ({
         tables={tournamentTables}
         drawTypes={drawTypes}
         canEdit={canEdit}
+        saving={savingEvent}
         onSave={saveEvent}
         onDelete={(id) => {
           const ev = tournament.events.find((e) => e.id === id) ?? null

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.factory.tsx
@@ -12,6 +12,8 @@ export function buildEventEditorProps(
     tables: buildTables(12),
     drawTypes: buildDrawTypes(),
     canEdit: true,
+    // No write in flight — the editor as an organizer first meets it.
+    saving: false,
     onSave: () => {},
     onDelete: () => {},
     ...overrides,

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
@@ -1,3 +1,5 @@
+import userEvent from '@testing-library/user-event'
+
 import { render, screen, type Container } from '@/test/utilities'
 
 import { EventEditor, type EventEditorProps } from './event-editor'
@@ -77,6 +79,27 @@ const scoped = (container: Container) => ({
   },
   getEntryFeeInput() {
     return container.getByLabelText(/Entry fee/)
+  },
+  /** **K** — the qualifier-count box on Basics, which exists only while the draft's draw
+   * type is `rr-then-ko` (ADR 20260727). */
+  getQualifiersInput() {
+    return container.getByLabelText(/Qualifiers per pool/)
+  },
+  /** …and its `query` twin, for the claim that the row is not on screen at all for a
+   * draw type with no knockout stage. */
+  queryQualifiersInput() {
+    return container.queryByLabelText(/Qualifiers per pool/)
+  },
+  /** The draw-type select on Basics. */
+  getDrawTypeTrigger() {
+    return container.getByRole('combobox', { name: 'Draw type' })
+  },
+  /** Pick a draw type the way a director does — open the select, click the option by the
+   * label the SERVER sent (ADR 20260726). The radix listbox portals to the body, so the
+   * option resolves against `screen` rather than the scoped container. */
+  async chooseDrawType(label: string) {
+    await userEvent.click(this.getDrawTypeTrigger())
+    await userEvent.click(await screen.findByRole('option', { name: label }))
   },
   /** An inline validation/server error rendered below a Basics field — the same
    * node `queryFieldError` returns, taking a `RegExp` for the cases that only want

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -1088,4 +1088,40 @@ describe('EventEditor', () => {
       )
     })
   })
+
+  /**
+   * The `saving` prop contract (#1231 QA): five rapid clicks on Create event made
+   * five identical events, because the button's guard was React Hook Form's
+   * `isSubmitting` alone — true only while the `onSave` promise is unsettled — and
+   * `isSubmitting` clears before the underlying mutation actually settles (see
+   * `saving`'s doc comment on `EventEditorProps`). The route now threads
+   * `savingEvent={createEvent.isPending || updateEvent.isPending}` down as `saving`,
+   * so the button disables on the union of both.
+   *
+   * This is deliberately a PROP-CONTRACT test, not a reproduction of the click race
+   * itself: the race is a real, confirmed gap between `isSubmitting` going false and
+   * the mutation's own `isPending` going false (instrumented and observed directly
+   * on the committed DOM during this fix), but nothing yields between those two
+   * commits in jsdom — there's no paint/frame boundary the way a real browser has —
+   * so no `userEvent`/`fireEvent`/`waitFor`-driven double-click can land inside it
+   * deterministically here. What CAN be pinned, and is the thing actually shipped,
+   * is that `saving` independently gates the button — proven by driving it directly
+   * rather than fishing for a race.
+   */
+  describe('the pending-mutation gate (#1231 QA)', () => {
+    it('stays disabled while `saving` is true, even though nothing is mid-submit', () => {
+      // No click happened — `isSubmitting` is false. Only `saving` (the route's
+      // `createEvent.isPending || updateEvent.isPending`) is holding the gate, which
+      // is exactly the window `isSubmitting` alone missed.
+      eventEditorPage.render({ event: buildEvent({ name: 'Open Singles' }), saving: true })
+
+      expect(eventEditorPage.getSaveButton()).toBeDisabled()
+    })
+
+    it('is enabled once `saving` clears — the gate is not a stuck one', () => {
+      eventEditorPage.render({ event: buildEvent({ name: 'Open Singles' }), saving: false })
+
+      expect(eventEditorPage.getSaveButton()).toBeEnabled()
+    })
+  })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -6,11 +6,13 @@ import { ApiError } from '@/api/client'
 import { screen, waitFor } from '@/test/utilities'
 
 import { emptyEvent } from '../data/helpers'
+import { eventToUpdateBody } from '../data/api'
 import {
   buildEvent,
   buildFixture,
   buildPool,
   buildPredicate,
+  buildRrThenKoEvent,
   buildTournament,
 } from '../data/seed.factory'
 import { eventEditorPage } from './event-editor.page'
@@ -37,6 +39,109 @@ describe('EventEditor', () => {
     )
     // The panel closes only after the save resolves.
     expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  /**
+   * **K**, through the whole editor (ADR 20260727) — the picker, the resolver, and the
+   * body that leaves the client.
+   *
+   * The section's own tests prove the row is conditional; these prove the three things
+   * only the *editor* can: that switching the served picker reveals and hides it, that a
+   * bad count is refused BEFORE anything is sent, and — the one that matters most — that
+   * the value a director types is on the object handed to `onSave`, which is what
+   * `eventToUpdateBody` turns into the request. A test that stopped at form state would
+   * pass just as happily against a mapper that dropped the field on the floor.
+   */
+  describe('the qualifier count, end to end', () => {
+    it('reveals the control when the director picks the two-stage format, and hides it again', async () => {
+      eventEditorPage.render({ event: buildEvent({ drawType: 'round-robin' }) })
+      expect(eventEditorPage.queryQualifiersInput()).toBeNull()
+
+      // The label is the SERVER's (`draw_type_catalogue`), not a string this client keeps.
+      await eventEditorPage.chooseDrawType('Round-robin then knockout')
+      expect(await screen.findByLabelText(/Qualifiers per pool/)).toBeInTheDocument()
+
+      await eventEditorPage.chooseDrawType('Round robin')
+      await waitFor(() =>
+        expect(eventEditorPage.queryQualifiersInput()).toBeNull(),
+      )
+    })
+
+    // ⚠️ THE CLAIM IS ABOUT THE REQUEST, not the box. `onSave` receives the event the
+    // page maps with `eventToUpdateBody`, so mapping it here is what the client would
+    // really put on the wire — and 2 is neither the planner's fallback (1) nor absent.
+    it('SENDS the configured count — the value reaches the request body', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({
+        event: buildRrThenKoEvent({ qualifiersPerPool: 1 }),
+        onSave,
+      })
+
+      fireEvent.change(eventEditorPage.getQualifiersInput(), {
+        target: { value: '2' },
+      })
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      expect(eventToUpdateBody(onSave.mock.calls[0][0]).qualifiers_per_pool).toBe(2)
+    })
+
+    // The stale-value case, and the reason the mapper keys off the draw type rather than
+    // off "is there a number in the box": switching away leaves K in form state (RHF does
+    // not clear a field because its control unmounted), and the two count-less arms of the
+    // server's draw-settings union are `extra="forbid"` — so a body that still carried it
+    // would be a **422**, produced by a control the director can no longer even see.
+    it('drops the count from the body when the director switches away from rr-then-ko', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({
+        event: buildRrThenKoEvent({ qualifiersPerPool: 2 }),
+        onSave,
+      })
+
+      await eventEditorPage.chooseDrawType('Round robin')
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      const body = eventToUpdateBody(onSave.mock.calls[0][0])
+      expect(body.draw_type).toBe('round-robin')
+      expect('qualifiers_per_pool' in body).toBe(false)
+    })
+
+    // Refused HERE, so nothing was sent — `onSave` not called at all is the assertion
+    // that separates "told the director" from "asked the server and read the answer out".
+    it.each([
+      ['0', 'At least 1 player must advance from each pool.'],
+      ['-1', 'At least 1 player must advance from each pool.'],
+      ['', 'Say how many players advance from each pool.'],
+    ])(
+      'refuses %s inline and sends NOTHING',
+      async (typed, message) => {
+        const onSave = vi.fn()
+        eventEditorPage.render({
+          event: buildRrThenKoEvent({ qualifiersPerPool: 2 }),
+          onSave,
+        })
+
+        fireEvent.change(eventEditorPage.getQualifiersInput(), {
+          target: { value: typed },
+        })
+        await userEvent.click(eventEditorPage.getSaveButton())
+
+        await waitFor(() =>
+          expect(eventEditorPage.queryFieldError(message)).toBeInTheDocument(),
+        )
+        expect(onSave).not.toHaveBeenCalled()
+      },
+    )
+
+    // The far half of the round trip (chores 3c/3d): what the SERVER stored is what the
+    // control opens on. Without this the editor could show a default while the event ran
+    // at a different K — the quiet failure the whole server-side detour was to prevent.
+    it('opens on the count the server sent back', () => {
+      eventEditorPage.render({ event: buildRrThenKoEvent({ qualifiersPerPool: 3 }) })
+
+      expect(eventEditorPage.getQualifiersInput()).toHaveValue(3)
+    })
   })
 
   /**

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -190,6 +190,10 @@ export const EventEditor = ({
     form.setValue('name', next.name, opts)
     form.setValue('format', next.format, opts)
     form.setValue('drawType', next.drawType, opts)
+    // Written back beside the draw type, because the resolver judges the two as one pair
+    // (ADR 20260727): a draw type set without its count would be validated against a
+    // stale K, and a count without its type against a stale arm.
+    form.setValue('qualifiersPerPool', next.qualifiersPerPool, opts)
     form.setValue('maxPlayers', next.maxPlayers, opts)
     form.setValue('entryFee', next.entryFee, opts)
     form.setValue('timezone', next.timezone, opts)
@@ -225,6 +229,7 @@ export const EventEditor = ({
 
   const basicsErrors = {
     name: errors.name?.message,
+    qualifiersPerPool: errors.qualifiersPerPool?.message,
     maxPlayers: errors.maxPlayers?.message,
     entryFee: errors.entryFee?.message,
     timezone: errors.timezone?.message,

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -64,6 +64,22 @@ export interface EventEditorProps {
    * everything the organizer had typed went with it). */
   onSave: (event: TournamentEvent) => void | Promise<void>
   onDelete: (id: string) => void
+  /**
+   * Whether the save MUTATION is still in flight — the repo's pending-mutation gate
+   * (`mutation.isPending` → `disabled`, as `EnterEventControl` and `LifecycleActions`
+   * do it), threaded down because the mutations live at the route and the editor is
+   * handed an `onSave`.
+   *
+   * ⚠️ It is **not** the same fact as React-Hook-Form's `isSubmitting`, and that is the
+   * whole reason it exists (#1231 QA: five rapid clicks on Create event made five
+   * identical events). `isSubmitting` is true only while the `onSave` promise is
+   * unsettled. `isPending` stays true until the mutation has SETTLED — including
+   * `onSuccess`, which awaits `invalidateTournament`'s refetch — and that is the window
+   * the duplicates came through: the sheet is still on screen (Radix keeps the content
+   * mounted through its close animation) with a button that had already re-enabled
+   * itself. Two windows, one button: it is disabled for the union of them.
+   */
+  saving?: boolean
 }
 
 const SECTIONS = [
@@ -110,6 +126,7 @@ export const EventEditor = ({
   canEdit,
   onSave,
   onDelete,
+  saving = false,
 }: EventEditorProps) => {
   const [section, setSection] = useState('basics')
   const [seenEvent, setSeenEvent] = useState(event)
@@ -378,7 +395,15 @@ export const EventEditor = ({
             // Disabled only while the save is in the air — never on validity
             // (`CLAUDE.md`, `## Forms`): pressing it is how the organizer finds out
             // what is wrong, and a dead button explains nothing.
-            <Button disabled={!draft || isSubmitting} onClick={submit}>
+            //
+            // "In the air" is TWO facts, and one of them is not this component's to
+            // know (see `saving` on the props): `isSubmitting` ends when the `onSave`
+            // promise settles, while the mutation behind it stays pending through its
+            // own success work. Five rapid clicks got five events through the gap
+            // (#1231 QA). Both are asked, so it re-enables only once BOTH are done —
+            // and a rejected save re-enables it, because both go false, which is what
+            // lets the organizer retry the failure the `Alert` above is reporting.
+            <Button disabled={!draft || isSubmitting || saving} onClick={submit}>
               <Check size={16} />
               {isNew ? 'Create event' : 'Save changes'}
             </Button>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
@@ -21,6 +21,24 @@ const scoped = (container: Container) => ({
   getEntryFeeInput() {
     return container.getByLabelText(/Entry fee/)
   },
+  /** **K** — the qualifier-count box, which exists only for an `rr-then-ko` event
+   * (ADR 20260727). `get` for the case that expects it. */
+  getQualifiersInput() {
+    return container.getByLabelText(/Qualifiers per pool/)
+  },
+  /** …and the `query` twin, because "this control is NOT on screen" is the claim for
+   * every other draw type: a qualifier count is not a blank field a round-robin event
+   * has, it is a question that format does not ask. Asked by LABEL rather than by
+   * `getFormElements().length`, so it discriminates "the row is absent" from "some other
+   * row went missing too". */
+  queryQualifiersInput() {
+    return container.queryByLabelText(/Qualifiers per pool/)
+  },
+  /** The qualifier count as a **reader** sees it — the `Field` read-only branch's value
+   * under its label (ADR 0015). Use `queryQualifiersInput` for the "row absent" claim. */
+  getQualifiersValue() {
+    return fieldPage.within(container).getFieldValue('Qualifiers per pool')
+  },
   /** The red message under a field — the `Field` row's `hint`, rendered as an error.
    * Queried by its TEXT because that is what the organizer reads; a test that asked
    * for "the hint node" would pass on a message rendered in the wrong colour under
@@ -85,8 +103,22 @@ const scoped = (container: Container) => ({
 
 /** Test page-object for `BasicsSection`. */
 export const basicsSectionPage = {
+  /** Mount the section. Returns the render result, plus `rerenderWith` — which is the
+   * only honest way to assert that a row **disappears**.
+   *
+   * ⚠️ Calling `render` a second time does NOT replace the first tree: Testing Library
+   * appends a second one, and `screen` spans the whole body, so a "the control is gone"
+   * assertion would find the *previous* mount's control and fail against a component that
+   * unmounts perfectly well (measured: two renders → 2 `basics-section` roots; a
+   * `rerenderWith` → 1 root and the control really gone). Prop-change claims use this. */
   render(overrides: Partial<BasicsSectionProps> = {}) {
-    render(<BasicsSection {...buildBasicsSectionProps(overrides)} />)
+    const utils = render(<BasicsSection {...buildBasicsSectionProps(overrides)} />)
+    return {
+      ...utils,
+      rerenderWith(next: Partial<BasicsSectionProps> = {}) {
+        utils.rerender(<BasicsSection {...buildBasicsSectionProps(next)} />)
+      },
+    }
   },
 
   within(container: Container = screen) {

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
@@ -2,7 +2,12 @@ import userEvent from '@testing-library/user-event'
 
 import { fireEvent, screen } from '@/test/utilities'
 
-import { buildDrawnEvent, buildEvent } from '../../data/seed.factory'
+import { parseDrawTypeCatalogue } from '../../data/draw-types'
+import {
+  buildDrawnEvent,
+  buildEvent,
+  buildRrThenKoEvent,
+} from '../../data/seed.factory'
 import { basicsSectionPage } from './basics-section.page'
 
 describe('BasicsSection', () => {
@@ -33,6 +38,67 @@ describe('BasicsSection', () => {
         'Knockout bracket',
         'Everyone plays everyone',
       ])
+    })
+
+    /**
+     * …and the other direction, which is the one that fails **silently** (#1227, ADR
+     * "rr-then-ko cuts both stages upfront and seeds qualifiers rematch-free", Context).
+     * The catalogue parser filters the served rows against `DRAW_TYPES`, a hardcoded slug
+     * allowlist, and *drops* a slug that is not in it — no error, no warning, just an
+     * absent option. So "seed the row and the picker follows" was predicted to need no
+     * client change and would instead have shown a director two formats out of three.
+     *
+     * ⚠️ This test hands the section **wire rows** run through the real
+     * `parseDrawTypeCatalogue`, not an option list. That is the whole point: a test given
+     * ready-made options bypasses the filter and stays green with the slug taken back out
+     * of the allowlist — which is precisely the defect.
+     */
+    it('offers a draw type the SERVER seeds, rather than dropping it silently', async () => {
+      basicsSectionPage.render({
+        drawTypes:
+          parseDrawTypeCatalogue([
+            {
+              key: 'round-robin',
+              name: 'Round robin',
+              description: 'Everyone in a pool plays everyone else in that pool.',
+              display_order: 1,
+            },
+            {
+              key: 'rr-then-ko',
+              name: 'Round-robin then knockout',
+              description:
+                'Pools play all-play-all, then the top finishers from each pool ' +
+                'meet in a knockout bracket.',
+              display_order: 3,
+            },
+          ]) ?? [],
+      })
+
+      expect(await basicsSectionPage.openDrawTypeOptions()).toEqual([
+        'Round robin',
+        'Round-robin then knockout',
+      ])
+    })
+
+    /** …and picking it emits the **slug**, so the option the parser let through is one
+     * the PATCH can actually carry. An allowlist that offered a word it could not send
+     * would have moved the failure from the menu to the save. */
+    it('emits the slug of a newly-seeded draw type', async () => {
+      const onChange = vi.fn()
+      basicsSectionPage.render({
+        event: buildEvent({ drawType: 'round-robin' }),
+        drawTypes: [
+          { value: 'round-robin', label: 'Round robin' },
+          { value: 'rr-then-ko', label: 'Round-robin then knockout' },
+        ],
+        onChange,
+      })
+
+      await basicsSectionPage.chooseDrawType('Round-robin then knockout')
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ drawType: 'rr-then-ko' }),
+      )
     })
 
     /** The point of serving the catalogue: a format the server does not offer cannot be
@@ -166,6 +232,151 @@ describe('BasicsSection', () => {
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({ entryFee: 5 }),
       )
+    })
+  })
+
+  /**
+   * **K** — the qualifier count (ADR 20260727). Its whole design is that it belongs to
+   * the `(draw_type, K)` PAIR and not to the event: the server parses the two into a
+   * union tagged by the draw type, whose `rr-then-ko` arm requires a count and whose
+   * other two arms are `extra="forbid"` and refuse the key outright.
+   *
+   * So the claim worth pinning is not "there is a number box" — it is that the box is
+   * **on screen for exactly one draw type**, and absent (not disabled, not em-dashed) for
+   * the rest. A control rendered unconditionally would invite a director to answer a
+   * question their event cannot hold the answer to, and would author a 422.
+   */
+  describe('the qualifier count (rr-then-ko only)', () => {
+    it('renders the control for a two-stage event', () => {
+      basicsSectionPage.render({ event: buildRrThenKoEvent({ qualifiersPerPool: 2 }) })
+
+      expect(basicsSectionPage.getQualifiersInput()).toHaveValue(2)
+    })
+
+    // The falsification for the conditional: render it unconditionally and these red.
+    it.each(['round-robin', 'single-elim'] as const)(
+      'does not render it at all for %s — a format with no knockout stage to qualify for',
+      (drawType) => {
+        basicsSectionPage.render({
+          event: buildEvent({ drawType, qualifiersPerPool: null }),
+        })
+
+        expect(basicsSectionPage.queryQualifiersInput()).toBeNull()
+        // …and the rest of the tab is untouched, so this is "one row is absent" rather
+        // than "the section failed to render".
+        expect(basicsSectionPage.getNameInput()).toBeInTheDocument()
+        expect(basicsSectionPage.getDrawTypeTrigger()).toBeInTheDocument()
+      },
+    )
+
+    // Switching the picker is what a director actually does, and the row has to follow
+    // the DRAFT they are building, not the event as it was loaded. (The editor bridges
+    // live form state into `event`, so this is the same value that reaches the section;
+    // the picker-driven version of this claim is in `event-editor.test.tsx`.)
+    //
+    // ⚠️ `rerenderWith`, never a second `render`: Testing Library APPENDS a second tree
+    // rather than replacing the first, and `screen` spans the whole body — so a second
+    // `render` leaves the old rr-then-ko section mounted and "the control is gone" fails
+    // against a component that unmounts it correctly. Measured while writing this: two
+    // renders → 2 `basics-section` roots and the stale input still found; one
+    // `rerenderWith` → 1 root and 0 inputs.
+    it('appears and disappears with the draw type the director picks', () => {
+      const { rerenderWith } = basicsSectionPage.render({
+        event: buildRrThenKoEvent({ qualifiersPerPool: 2 }),
+      })
+      expect(basicsSectionPage.getQualifiersInput()).toBeInTheDocument()
+
+      rerenderWith({
+        event: buildRrThenKoEvent({ drawType: 'round-robin', qualifiersPerPool: null }),
+      })
+
+      expect(basicsSectionPage.queryQualifiersInput()).toBeNull()
+      // One tree, so the absence above is a real unmount and not a query that missed.
+      expect(screen.getAllByTestId('basics-section')).toHaveLength(1)
+    })
+
+    it('emits the typed count', () => {
+      const onChange = vi.fn()
+      basicsSectionPage.render({
+        event: buildRrThenKoEvent({ qualifiersPerPool: 2 }),
+        onChange,
+      })
+
+      fireEvent.change(basicsSectionPage.getQualifiersInput(), {
+        target: { value: '3' },
+      })
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ qualifiersPerPool: 3 }),
+      )
+    })
+
+    // Blank is **missing**, not zero — `Number('')` is `0`, and a bracket nobody advances
+    // into is not what an emptied box means. The resolver turns the `null` into the
+    // required error; a `0` would sail past a "did they answer?" check and be refused
+    // later, by the server, in Pydantic's words.
+    it('emits null — never 0 — when the box is cleared', () => {
+      const onChange = vi.fn()
+      basicsSectionPage.render({
+        event: buildRrThenKoEvent({ qualifiersPerPool: 2 }),
+        onChange,
+      })
+
+      fireEvent.change(basicsSectionPage.getQualifiersInput(), {
+        target: { value: '' },
+      })
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ qualifiersPerPool: null }),
+      )
+    })
+
+    it('prints the form’s message under the box, and marks it invalid', () => {
+      basicsSectionPage.render({
+        event: buildRrThenKoEvent(),
+        errors: {
+          qualifiersPerPool: 'At least 1 player must advance from each pool.',
+        },
+      })
+
+      expect(basicsSectionPage.getQualifiersInput()).toHaveAttribute(
+        'aria-invalid',
+        'true',
+      )
+      expect(
+        basicsSectionPage.queryFieldError(
+          'At least 1 player must advance from each pool.',
+        ),
+      ).toBeInTheDocument()
+    })
+
+    // The count rides the SAME freeze as the draw type, because on the server it is the
+    // same guard: `_enforce_draw_settings_frozen` compares the whole configuration, since
+    // a bracket cut for `P × K` is exactly as contradicted by a changed K as by a changed
+    // type. A live box here would author a 409.
+    it('freezes with the draw type once the draw is cut, pointing at the reason', () => {
+      basicsSectionPage.render({
+        event: buildRrThenKoEvent({
+          fixtures: buildDrawnEvent().fixtures,
+        }),
+      })
+
+      const input = basicsSectionPage.getQualifiersInput()
+      expect(input).toBeDisabled()
+      const describedBy = input.getAttribute('aria-describedby')
+      expect(describedBy).toBeTruthy()
+      expect(document.getElementById(describedBy!)).toHaveTextContent(
+        /Delete the draw/i,
+      )
+    })
+
+    it('leaves it live, with its hint, when no draw is cut', () => {
+      basicsSectionPage.render({ event: buildRrThenKoEvent() })
+
+      expect(basicsSectionPage.getQualifiersInput()).toBeEnabled()
+      expect(
+        basicsSectionPage.queryFieldError(/advance to the knockout stage/i),
+      ).toBeInTheDocument()
     })
   })
 
@@ -370,6 +581,25 @@ describe('BasicsSection', () => {
       basicsSectionPage.render({ event: buildEvent(), canEdit: false })
       expect(basicsSectionPage.getInteractiveControls()).toHaveLength(0)
       expect(basicsSectionPage.getFormElements()).toHaveLength(0)
+    })
+
+    // …and the same sweep over the ONE draw type that renders an extra row. The default
+    // fixture is round-robin, whose qualifier-count row is not rendered at all — so the
+    // guard above passes whether or not that row honours `readOnly`, and a live
+    // `<input type=number>` (a `spinbutton`, invisible to a role-only sweep) could ship
+    // behind it. The DOM sweep over a two-stage event is what actually covers it.
+    it('renders no interactive controls for a two-stage event either', () => {
+      basicsSectionPage.render({
+        event: buildRrThenKoEvent({ qualifiersPerPool: 2 }),
+        canEdit: false,
+      })
+
+      expect(basicsSectionPage.getFormElements()).toHaveLength(0)
+      expect(basicsSectionPage.queryQualifiersInput()).toBeNull()
+      // The value is still THERE — a viewer reads the count, they just cannot type it.
+      // (`Field` requires a `value` beside `readOnly` precisely so a row cannot vanish
+      // into an em-dash and be mistaken for one the organizer left blank.)
+      expect(basicsSectionPage.getQualifiersValue()).toHaveTextContent('2')
     })
 
     it('renders every field as a value', () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
@@ -4,6 +4,7 @@ import type { EditFreeze } from '../../data/draw'
 import {
   ENTRY_FEE_MAX,
   PLAYERS_MAX,
+  QUALIFIERS_PER_POOL_MAX,
   QUALIFIERS_PER_POOL_MIN,
 } from '../../data/event-validation'
 import { fmtDate } from '../../data/helpers'
@@ -239,6 +240,12 @@ export const BasicsSection = ({
                 id={id}
                 type="number"
                 min={QUALIFIERS_PER_POOL_MIN}
+                // Advisory, exactly like the two `max` attributes below — it steers the
+                // spinner and stops nothing that is typed or pasted. The bound that BINDS
+                // is `qualifiersPerPoolSchema`'s. Both are stated so the browser control
+                // and the resolver agree about the same number (#1231 QA: an unbounded box
+                // sent `2147483648`, which overflowed the `Integer` column and 500'd).
+                max={QUALIFIERS_PER_POOL_MAX}
                 aria-invalid={!!errors.qualifiersPerPool}
                 aria-describedby={hintId}
                 disabled={drawTypeFreeze.kind === 'frozen'}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
@@ -1,7 +1,11 @@
 import { Input } from '@/components/ui/input'
 
 import type { EditFreeze } from '../../data/draw'
-import { ENTRY_FEE_MAX, PLAYERS_MAX } from '../../data/event-validation'
+import {
+  ENTRY_FEE_MAX,
+  PLAYERS_MAX,
+  QUALIFIERS_PER_POOL_MIN,
+} from '../../data/event-validation'
 import { fmtDate } from '../../data/helpers'
 import { FORMAT_OPTIONS, labelFor } from '../../data/options'
 import type {
@@ -21,6 +25,10 @@ import { TimezoneSelect } from './timezone-select'
  * drops the hint slot in its read-only branch (ADR 0015). */
 export interface BasicsFieldErrors {
   name?: string
+  /** The qualifier count's inline red — only ever present for an `rr-then-ko` event,
+   * since that is the only draw type the resolver asks the question of (and the only one
+   * whose control is on screen). */
+  qualifiersPerPool?: string
   maxPlayers?: string
   entryFee?: string
   /** The timezone is chosen from a picker that only ever offers real IANA zones, so
@@ -199,6 +207,57 @@ export const BasicsSection = ({
             />
           )}
         </Field>
+        {/* **K**, and only for the one draw type that has a knockout stage to qualify
+            for (ADR 20260727). Not disabled, not em-dashed — ABSENT: a qualifier count
+            is not a field a round-robin event leaves blank, it is a question that format
+            does not ask, and the server says the same thing by refusing the key outright
+            on that arm of its draw-settings union (`extra="forbid"` — a 422, not a
+            silently dropped value). A control that stayed on screen would invite a
+            director to answer a question whose answer their event cannot hold.
+
+            It rides the SAME freeze as the draw type above, because on the server it is
+            the same guard: `_enforce_draw_settings_frozen` compares the whole
+            configuration, since a bracket cut for `P × K` is exactly as contradicted by
+            a changed K as by a changed type. One freeze, one sentence — and the way out
+            of it (delete the draw, then cut it again) is the same way out. */}
+        {event.drawType === 'rr-then-ko' && (
+          <Field
+            label="Qualifiers per pool"
+            required
+            readOnly={readOnly}
+            value={numericValue(event.qualifiersPerPool)}
+            error={!!errors.qualifiersPerPool}
+            hint={
+              errors.qualifiersPerPool ??
+              (drawTypeFreeze.kind === 'frozen'
+                ? drawTypeFreeze.reason
+                : 'How many of each pool’s finishers advance to the knockout stage.')
+            }
+          >
+            {(id, hintId) => (
+              <Input
+                id={id}
+                type="number"
+                min={QUALIFIERS_PER_POOL_MIN}
+                aria-invalid={!!errors.qualifiersPerPool}
+                aria-describedby={hintId}
+                disabled={drawTypeFreeze.kind === 'frozen'}
+                // Hold empty as empty, exactly as the player limit does — but it means
+                // the opposite thing here, and the resolver says so: a blank cap is an
+                // uncapped event, a blank qualifier count is a MISSING answer to a
+                // question this draw type does ask. Never `Number('')`, which is `0`,
+                // which is a bracket nobody advances into.
+                value={event.qualifiersPerPool ?? ''}
+                onChange={(e) =>
+                  set({
+                    qualifiersPerPool:
+                      e.target.value === '' ? null : Number(e.target.value),
+                  })
+                }
+              />
+            )}
+          </Field>
+        )}
       </div>
 
       {/* ⚠️ **Neither box may coerce a blank into a number** — and they blank to two

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
@@ -63,6 +63,31 @@ describe('eventSchema', () => {
       expect(rejectedFields(twoStage(4))).toEqual([])
     })
 
+    /**
+     * ⚠️ **`le=1000` on the server, and the resolver has to know it too** (#1231 QA).
+     * `2147483648` overflows the `Integer` column and came back a 500; `999999999` was
+     * accepted and made an event nobody could draw. Both are refused HERE now, so
+     * neither is ever sent — and the message names the number, since the number is the
+     * only thing the director can change.
+     */
+    it.each([1001, 999_999_999, 2_147_483_648])('refuses %s', (tooMany) => {
+      expect(rejectedFields(twoStage(tooMany))).toEqual(['qualifiersPerPool'])
+    })
+
+    it('speaks the schema’s own sentence about the ceiling', () => {
+      const result = eventSchema.safeParse(twoStage(1001))
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe(
+        'At most 1,000 players can advance from each pool.',
+      )
+    })
+
+    // The server's bound is INCLUSIVE, so the boundary itself must save — a form that
+    // refused 1,000 would refuse a save the API accepts.
+    it('accepts the ceiling itself', () => {
+      expect(rejectedFields(twoStage(1000))).toEqual([])
+    })
+
     // ⚠️ The inverse, and the one a field-level rule would get wrong: a round-robin
     // event carries `null` and must SAVE. A schema that demanded a count regardless
     // would dead-end every single-stage event, with a red nobody could see or fix.

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
@@ -34,6 +34,56 @@ describe('eventSchema', () => {
     expect(rejectedFields(formFor({ maxPlayers: 0 }))).toEqual(['maxPlayers'])
   })
 
+  /**
+   * **K is judged with its draw type, never alone** (ADR 20260727) — the resolver's half
+   * of the server's tagged union.
+   *
+   * The pair is the whole design. A field-level rule would have to answer "is a null
+   * qualifier count wrong?" without knowing the draw type, and both answers are wrong
+   * half the time: for `rr-then-ko`, `null` is a missing answer; for the other two it is
+   * the only legal value — and a red raised there would refuse the save with a message
+   * under a control that is not even rendered.
+   */
+  describe('the qualifier count', () => {
+    const twoStage = (qualifiersPerPool: number | null) =>
+      formFor({ drawType: 'rr-then-ko', qualifiersPerPool })
+
+    it('requires a count for rr-then-ko, and blames the field by name', () => {
+      expect(rejectedFields(twoStage(null))).toEqual(['qualifiersPerPool'])
+    })
+
+    // `ge=1` on the server (`QualifiersPerPool`). Zero advances nobody into the
+    // knockout stage, and a negative count is not a count.
+    it.each([0, -1, 1.5])('refuses %s', (bad) => {
+      expect(rejectedFields(twoStage(bad))).toEqual(['qualifiersPerPool'])
+    })
+
+    it('accepts the smallest legal count, and a larger one', () => {
+      expect(rejectedFields(twoStage(1))).toEqual([])
+      expect(rejectedFields(twoStage(4))).toEqual([])
+    })
+
+    // ⚠️ The inverse, and the one a field-level rule would get wrong: a round-robin
+    // event carries `null` and must SAVE. A schema that demanded a count regardless
+    // would dead-end every single-stage event, with a red nobody could see or fix.
+    it.each(['round-robin', 'single-elim'] as const)(
+      'asks nothing of %s, whose count is null',
+      (drawType) => {
+        expect(rejectedFields(formFor({ drawType, qualifiersPerPool: null }))).toEqual([])
+      },
+    )
+
+    // …and does not complain about a STALE count left behind by a draw-type switch:
+    // the control unmounted, but React-Hook-Form keeps the value, and the write body
+    // omits it anyway (`eventToApiFields`). A rule that fired here would block the save
+    // over a number that is never sent.
+    it('ignores a leftover count once the draw type no longer has a knockout stage', () => {
+      expect(
+        rejectedFields(formFor({ drawType: 'round-robin', qualifiersPerPool: 2 })),
+      ).toEqual([])
+    })
+  })
+
   it('requires an entry fee, and takes zero for a free event', () => {
     expect(rejectedFields(formFor({ entryFee: Number.NaN }))).toEqual(['entryFee'])
     expect(rejectedFields(formFor({ entryFee: 0 }))).toEqual([])
@@ -139,6 +189,14 @@ describe('firstInvalidSection', () => {
     expect(firstInvalidSection({ maxPlayers: { type: 'custom', message: 'x' } })).toBe(
       'basics',
     )
+  })
+
+  // It lives on Basics, beside the draw type that decides whether it is asked at all —
+  // and a save refused on a tab you cannot see is indistinguishable from a dead button.
+  it('sends a broken qualifier count to Basics', () => {
+    expect(
+      firstInvalidSection({ qualifiersPerPool: { type: 'custom', message: 'x' } }),
+    ).toBe('basics')
   })
 
   it('sends a broken timezone to Basics', () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
@@ -7,6 +7,7 @@ import {
   maxPlayersSchema,
   nameSchema,
   poolNameSchema,
+  qualifiersPerPoolSchema,
   type EventSection,
 } from '../data/event-validation'
 import { browserTimezone } from '../data/helpers'
@@ -117,6 +118,13 @@ export const eventSchema = z.object({
   // `data/draw-types`, pinned to the generated schema by a compile-time assertion in
   // `data/draw-types.test.ts`.
   drawType: drawTypeSchema,
+  // **K**, held as `number | null` and judged BELOW, with the draw type beside it — the
+  // shape rule only (ADR 20260727). `null` is the honest value for the two draw types
+  // that have no knockout stage, and it is the *blank box* for the one that does; which
+  // of those two things it is depends on `drawType`, which a field-level rule cannot
+  // see. See `qualifiersPerPoolSchema` (`data/event-validation`) for why the pair, and
+  // not the field, carries the bound.
+  qualifiersPerPool: z.number().nullable(),
   maxPlayers: maxPlayersSchema,
   entryFee: entryFeeSchema,
   // The IANA timezone anchoring the wall-clock windows (ADR 20260719). `NOT NULL`
@@ -153,6 +161,31 @@ export const eventSchema = z.object({
   }),
   pools: z.array(poolSchema),
 })
+  // The **draw configuration** is judged as a pair, because that is what it is: the
+  // server parses `(draw_type, qualifiers_per_pool)` into a union tagged by the draw
+  // type, one arm of which requires a count and two of which forbid the key outright
+  // (ADR 20260727). So the count's bound is asked here, where both halves are in scope,
+  // rather than on the field.
+  //
+  // Only the `rr-then-ko` arm is asked at all: for the other two, `qualifiersPerPool` is
+  // `null`, there is no control on screen (the Basics tab renders it only for the
+  // two-stage type), and the write body omits the key entirely (`eventToApiFields`,
+  // `data/api`) — so a rule that fired there would refuse a save for a reason the
+  // director cannot see, let alone fix. The issue is raised **at the field's own path**,
+  // so React-Hook-Form reports it as `errors.qualifiersPerPool` and the red lands under
+  // the box, exactly as a field-level rule's would.
+  .superRefine((values, ctx) => {
+    if (values.drawType !== 'rr-then-ko') return
+    const result = qualifiersPerPoolSchema.safeParse(values.qualifiersPerPool)
+    if (result.success) return
+    ctx.addIssue({
+      code: 'custom',
+      path: ['qualifiersPerPool'],
+      // The schema's own sentence, never a second one typed beside it — the same rule
+      // `poolNameIssues` follows for the pool names.
+      message: result.error.issues[0].message,
+    })
+  })
 
 // The schema mirrors the domain types (`Predicate`, `Pool`) so the nested-array
 // sub-forms are validated by this one resolver; the section code that rebuilds a
@@ -164,6 +197,9 @@ const EMPTY_FORM_VALUES: EventFormValues = {
   name: '',
   format: 'singles',
   drawType: 'single-elim',
+  // …and a bracket has no pools to qualify out of, so no qualifier count (ADR 20260727).
+  // `null` is the only value the server's `single-elim` arm admits.
+  qualifiersPerPool: null,
   // A new event starts **uncapped**, not at an invented number: `null` is a valid,
   // saveable answer (ADR-0935), so an organizer who never touches the box gets an
   // event with no cap — rather than a form that silently refuses to submit.
@@ -191,6 +227,9 @@ export function eventToFormValues(event: TournamentEvent | null): EventFormValue
     name: event.name,
     format: event.format,
     drawType: event.drawType,
+    // The count the SERVER sent back, straight onto the control — this projection is the
+    // near half of the round trip the read shape's `qualifiers_per_pool` exists for.
+    qualifiersPerPool: event.qualifiersPerPool,
     maxPlayers: event.maxPlayers,
     entryFee: event.entryFee,
     timezone: event.timezone,
@@ -217,7 +256,15 @@ export function eventToFormValues(event: TournamentEvent | null): EventFormValue
 export function firstInvalidSection(
   errors: FieldErrors<EventFormValues>,
 ): EventSection | null {
-  if (errors.name || errors.maxPlayers || errors.entryFee || errors.timezone)
+  // `qualifiersPerPool` lives on Basics beside the draw type that decides whether it is
+  // asked at all, so a refused two-stage save opens the tab holding the empty box.
+  if (
+    errors.name ||
+    errors.qualifiersPerPool ||
+    errors.maxPlayers ||
+    errors.entryFee ||
+    errors.timezone
+  )
     return 'basics'
   if (errors.predicates) return 'eligibility'
   // A pool with a cleared name (`poolNameSchema`). RHF reports it per row

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/finishes/finishes-panel.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/finishes/finishes-panel.factory.tsx
@@ -1,13 +1,36 @@
-import { buildFinishesEvent } from '../../../../data/seed.factory'
+import { eventFinishes } from '../../../../data/finishes'
+import {
+  buildFinishesEvent,
+  finishesResultsOf,
+} from '../../../../data/seed.factory'
+import type { TournamentEvent } from '../../../../data/types'
 import type { FinishesPanelProps } from './finishes-panel'
 
-/** Props for `FinishesPanel`: a single-elimination event **with finishes** — a decided
- * four-entrant bracket with a champion and a tied-3rd pair (`buildFinishesEvent`). The event
- * owns the `results` and the `entrants` the panel joins them against, so a test tweaks the
- * whole event (e.g. `buildEvent()` for the no-results case, or
- * `results: buildFinishesResults({ complete: false })` for a live one). */
-export function buildFinishesPanelProps(
-  overrides: Partial<FinishesPanelProps> = {},
-): FinishesPanelProps {
-  return { event: buildFinishesEvent(), ...overrides }
+/** What a test varies: the whole **event** whose finishes the panel is handed (the natural
+ * unit — the results and the entrants they join against travel together), or a prop
+ * directly. */
+export type FinishesPanelScenario = Partial<FinishesPanelProps> & {
+  event?: TournamentEvent
+}
+
+/**
+ * Props for `FinishesPanel`: by default a single-elimination event **with finishes** — a
+ * decided four-entrant bracket with a champion and a tied-3rd pair (`buildFinishesEvent`).
+ *
+ * The panel no longer takes an event, but a test still reasons in events, so this derives
+ * the props from one **the same way `ResultsPanel` does at runtime** — `eventFinishes` over
+ * the event's own `finishes` block. A test that hands over a differently-built event
+ * therefore exercises the real selection path, not a hand-written view-model that could
+ * drift from it.
+ */
+export function buildFinishesPanelProps({
+  event = buildFinishesEvent(),
+  ...overrides
+}: FinishesPanelScenario = {}): FinishesPanelProps {
+  return {
+    eventId: event.id,
+    eventName: event.name,
+    finishes: eventFinishes(event, finishesResultsOf(event)),
+    ...overrides,
+  }
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/finishes/finishes-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/finishes/finishes-panel.page.tsx
@@ -1,7 +1,11 @@
+import { renderedHtml } from '@/test/rendered-html'
 import { render, screen, within, type Container } from '@/test/utilities'
 
-import { FinishesPanel, type FinishesPanelProps } from './finishes-panel'
-import { buildFinishesPanelProps } from './finishes-panel.factory'
+import { FinishesPanel } from './finishes-panel'
+import {
+  buildFinishesPanelProps,
+  type FinishesPanelScenario,
+} from './finishes-panel.factory'
 
 const scoped = (container: Container) => ({
   /** The whole finishes block, by event id. `query…` because the panel renders NOTHING for
@@ -11,6 +15,19 @@ const scoped = (container: Container) => ({
   },
   queryPanel(eventId: string) {
     return container.queryByTestId(`finishes-panel-${eventId}`)
+  },
+
+  /** The panel's whole rendered DOM (React ids normalized) — the equivalence guard's
+   * subject: an inline snapshot of this reds on ANY rendered change. */
+  getPanelHtml(eventId: string) {
+    return renderedHtml(container.getByTestId(`finishes-panel-${eventId}`))
+  },
+
+  /** The panel's landmark by its accessible name — a `<section>` with `aria-labelledby` is
+   * a `region`, so this only resolves while the heading is still wired to the section.
+   * (The snapshot normalizes the generated id away, so the wiring is asserted here.) */
+  getRegion() {
+    return container.getByRole('region', { name: 'Finishes' })
   },
 
   /** The champion callout, by event id — shown only once the final is decided. `query…`
@@ -43,7 +60,7 @@ const scoped = (container: Container) => ({
 
 /** Test page-object for `FinishesPanel`. */
 export const finishesPanelPage = {
-  render(overrides: Partial<FinishesPanelProps> = {}) {
+  render(overrides: FinishesPanelScenario = {}) {
     render(<FinishesPanel {...buildFinishesPanelProps(overrides)} />)
   },
 

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/finishes/finishes-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/finishes/finishes-panel.test.tsx
@@ -1,7 +1,6 @@
 import { within } from '@/test/utilities'
 
 import {
-  buildEvent,
   buildFinishesEvent,
   buildFinishesResults,
   buildFinishRow,
@@ -13,6 +12,19 @@ const playerCellOf = (entryId: string) =>
   within(page.getRow(entryId)).getAllByRole('cell')[1]
 
 describe('FinishesPanel', () => {
+  // The equivalence guard for the props refactor (the panel is handed its finishes instead
+  // of deriving them from the event). Pinned on the pre-refactor component, so it reds on
+  // ANY rendered difference — a moved wrapper, a dropped class, a changed test id — not just
+  // on the few strings the other tests happen to name.
+  it('renders exactly this DOM for the default single-elimination event', () => {
+    page.render()
+
+    // The heading is wired to the section (`aria-labelledby`), which the snapshot cannot
+    // assert: it normalizes React's generated ids away.
+    expect(page.getRegion()).toBe(page.getPanel('ev-single-elim'))
+    expect(page.getPanelHtml('ev-single-elim')).toMatchInlineSnapshot(`"<section data-testid="finishes-panel-ev-single-elim" aria-labelledby="ID" class="mt-2.5"><h3 id="ID" class="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">Finishes</h3><p data-testid="finishes-champion-ev-single-elim" class="mt-1.5 flex items-center gap-1.5 rounded-[10px] border border-[color:rgba(255,122,26,0.3)] bg-[color:var(--bg-accent-soft)] px-3 py-2 text-[13px] font-medium text-[color:var(--fg-1)] [box-shadow:var(--shadow-glow)]"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trophy text-[color:var(--ball-500)]" aria-hidden="true"><path d="M10 14.66v1.626a2 2 0 0 1-.976 1.696A5 5 0 0 0 7 21.978"></path><path d="M14 14.66v1.626a2 2 0 0 0 .976 1.696A5 5 0 0 1 17 21.978"></path><path d="M18 9h1.5a1 1 0 0 0 0-5H18"></path><path d="M4 22h16"></path><path d="M6 9a6 6 0 0 0 12 0V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1z"></path><path d="M6 9H4.5a1 1 0 0 1 0-5H6"></path></svg><span class="text-[color:var(--fg-3)]">Champion</span><span class="text-[color:var(--ball-500)]">player.1</span></p><div data-slot="table-container" class="relative w-full overflow-x-auto"><table data-slot="table" class="w-full caption-bottom mt-2 text-[13px]" aria-label="Finishes for Championship Singles"><thead data-slot="table-header" class="[&amp;_tr]:border-b"><tr data-slot="table-row" class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted"><th data-slot="table-head" class="h-10 px-2 align-middle font-medium whitespace-nowrap text-foreground [&amp;:has([role=checkbox])]:pr-0 w-12 text-right font-mono tabular-nums"><span aria-hidden="true">#</span><span class="sr-only">Finishing position</span></th><th data-slot="table-head" class="h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&amp;:has([role=checkbox])]:pr-0">Player</th></tr></thead><tbody data-slot="table-body" class="[&amp;_tr:last-child]:border-0"><tr data-slot="table-row" class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-testid="finish-row-entry-1"><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums text-[color:var(--fg-3)]">1st</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 flex items-center gap-1.5 font-medium text-[color:var(--ball-500)]"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trophy text-[color:var(--ball-500)]" aria-hidden="true"><path d="M10 14.66v1.626a2 2 0 0 1-.976 1.696A5 5 0 0 0 7 21.978"></path><path d="M14 14.66v1.626a2 2 0 0 0 .976 1.696A5 5 0 0 1 17 21.978"></path><path d="M18 9h1.5a1 1 0 0 0 0-5H18"></path><path d="M4 22h16"></path><path d="M6 9a6 6 0 0 0 12 0V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1z"></path><path d="M6 9H4.5a1 1 0 0 1 0-5H6"></path></svg>player.1</td></tr><tr data-slot="table-row" class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-testid="finish-row-entry-2"><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums text-[color:var(--fg-3)]">2nd</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-[color:var(--fg-1)]">player.2</td></tr><tr data-slot="table-row" class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-testid="finish-row-entry-3"><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums text-[color:var(--fg-3)]">T3</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-[color:var(--fg-1)]">player.3</td></tr><tr data-slot="table-row" class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-testid="finish-row-entry-4"><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums text-[color:var(--fg-3)]">T3</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-[color:var(--fg-1)]">player.4</td></tr></tbody></table></div></section>"`)
+  })
+
   it('renders the placement list, entrants joined to names, ties shown as T{n}', () => {
     // The default: a decided four-entrant bracket — champion 1st, runner-up 2nd, and the two
     // semifinal losers tied 3rd. The list joins each finish's entry id to a name (a list of
@@ -64,11 +76,8 @@ describe('FinishesPanel', () => {
     ])
   })
 
-  it('renders NOTHING for an event with no results', () => {
-    // An uncut event (and any round-robin one) has no finishes to place — a designed empty
-    // state, not an empty table.
-    page.render({ event: buildEvent() })
-
-    expect(page.queryPanel('ev-open-singles')).toBeNull()
-  })
+  // NOTE: "renders NOTHING for an event with no results" used to live here. The panel is now
+  // handed a `FinishesView` and cannot be given "no results" at all — that state is a compile
+  // error, and the decision belongs to `ResultsPanel`, whose own suite asserts it ("renders
+  // nothing for an event with no results").
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/finishes/finishes-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/finishes/finishes-panel.tsx
@@ -10,23 +10,37 @@ import {
   TableRow,
 } from '@/components/ui/table'
 
-import { eventFinishes } from '../../../../data/finishes'
-import type { TournamentEvent } from '../../../../data/types'
+import type { FinishesView } from '../../../../data/finishes'
 import { ChampionBanner } from '../champion-banner'
 
 export interface FinishesPanelProps {
-  event: TournamentEvent
+  /** The event the finishes belong to — its id is what the panel's own test hooks hang off
+   * (`finishes-panel-…`, `finishes-champion-…`), so a card showing more than one results
+   * block still names each one. */
+  eventId: string
+  /** The event's name, for the table's accessible label ("Finishes for …") — a screen
+   * reader meets the table out of context and needs to know whose finishes these are. */
+  eventName: string
+  /** The finishes to render, already selected and joined to names (`eventFinishes`).
+   * **Never null**: whether an event *has* finishes is the caller's decision, not this
+   * panel's — see the note above. */
+  finishes: FinishesView
 }
 
 /**
- * A single-elimination event's **results** as its **finishes** (ADR-0785): a placement list
- * — each entrant at the finishing position the server derived from the round it was
+ * A **finishes block** on an event's card in the Events tab (ADR-0785): a placement list —
+ * each entrant at the finishing position the server derived from the round it was
  * eliminated in — and, once the final is decided, its champion. The `finishes` twin of
- * `StandingsPanel`; the two are switched between by `ResultsPanel` on the results `kind`.
+ * `StandingsPanel`; which of the two is shown is decided in one place, `ResultsPanel`,
+ * switching on the results `kind`.
  *
- * It renders **nothing** when the event has no finishes (`eventFinishes` returns `null`: no
- * results, or a `standings` round-robin) — a designed data state, not a gap. `ResultsPanel`
- * only mounts it for the `finishes` arm, but the guard keeps it safe to render directly.
+ * ## It renders what it is handed
+ *
+ * Like its twin, it takes its finishes as a prop instead of reading them off an event and
+ * deciding whether they apply — so it can be shown for any event that *has* a finishes
+ * block, whatever the rest of its results look like (a plain single-elimination bracket
+ * today, the knockout stage of a multi-stage event tomorrow). A panel that re-checked
+ * `results.kind` would silently render nothing the moment it met a shape it did not know.
  *
  * ## Live, and never computed here
  *
@@ -38,17 +52,16 @@ export interface FinishesPanelProps {
  * tie** (`T3`, `T5`), because single-elimination genuinely does not rank them against each
  * other (`eventFinishes` marks the tie; this only renders it).
  */
-export const FinishesPanel = ({ event }: FinishesPanelProps) => {
+export const FinishesPanel = ({
+  eventId,
+  eventName,
+  finishes,
+}: FinishesPanelProps) => {
   const headingId = useId()
-  const finishes = eventFinishes(event)
-
-  // No finishes to place: no results, or a round-robin (`standings`). Render nothing — a
-  // designed data state, not a spinner and not a gap.
-  if (finishes === null) return null
 
   return (
     <section
-      data-testid={`finishes-panel-${event.id}`}
+      data-testid={`finishes-panel-${eventId}`}
       aria-labelledby={headingId}
       className="mt-2.5"
     >
@@ -65,13 +78,13 @@ export const FinishesPanel = ({ event }: FinishesPanelProps) => {
       {finishes.complete && finishes.champion !== null && (
         <ChampionBanner
           name={finishes.champion}
-          testId={`finishes-champion-${event.id}`}
+          testId={`finishes-champion-${eventId}`}
         />
       )}
 
       {/* A real `<table>`, like the standings: placement is tabular data (a position and a
           name per row), which a screen reader reads by column. */}
-      <Table aria-label={`Finishes for ${event.name}`} className="mt-2 text-[13px]">
+      <Table aria-label={`Finishes for ${eventName}`} className="mt-2 text-[13px]">
         <TableHeader>
           <TableRow>
             <TableHead className="w-12 text-right font-mono tabular-nums">

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.page.tsx
@@ -15,6 +15,20 @@ const scoped = (container: Container) => ({
   queryFinishesPanel(eventId: string) {
     return container.queryByTestId(`finishes-panel-${eventId}`)
   },
+
+  /** A block's champion callout, by its full test id. The panels are handed their view now,
+   * so this is where "the RIGHT data reached the right panel" is asserted — a section
+   * wrapper alone would render for an empty view too. */
+  getChampion(testId: string) {
+    return container.getByTestId(testId)
+  },
+
+  /** The rendered table's accessible name — for the finishes arm, this is the only place
+   * the **event's name** shows up, and `ResultsPanel` is now the only thing that passes
+   * it. */
+  getTableName() {
+    return container.getByRole('table').getAttribute('aria-label')
+  },
 })
 
 /** Test page-object for `ResultsPanel`. */

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.page.tsx
@@ -16,6 +16,25 @@ const scoped = (container: Container) => ({
     return container.queryByTestId(`finishes-panel-${eventId}`)
   },
 
+  /** The **two-stage** block, by event id — present only when the results are the
+   * `standings_then_finishes` arm. It wraps the other two panels rather than replacing
+   * them, so both of the queries above resolve inside it. */
+  queryTwoStagePanel(eventId: string) {
+    return container.queryByTestId(`two-stage-panel-${eventId}`)
+  },
+
+  /** Each block's own champion callout, by event id. The two-stage arm asserts the STAGE
+   * callouts are absent (it crowns once, itself), so all three need a `query…`. */
+  queryStandingsChampion(eventId: string) {
+    return container.queryByTestId(`standings-champion-${eventId}`)
+  },
+  queryFinishesChampion(eventId: string) {
+    return container.queryByTestId(`finishes-champion-${eventId}`)
+  },
+  queryTwoStageChampion(eventId: string) {
+    return container.queryByTestId(`two-stage-champion-${eventId}`)
+  },
+
   /** A block's champion callout, by its full test id. The panels are handed their view now,
    * so this is where "the RIGHT data reached the right panel" is asserted — a section
    * wrapper alone would render for an empty view too. */

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.test.tsx
@@ -1,4 +1,9 @@
-import { buildEvent, buildFinishesEvent } from '../../../data/seed.factory'
+import {
+  buildEvent,
+  buildFinishesEvent,
+  buildMidFlightTwoStageResults,
+  buildTwoStageEvent,
+} from '../../../data/seed.factory'
 import { resultsPanelPage as page } from './results-panel.page'
 
 describe('ResultsPanel', () => {
@@ -28,6 +33,33 @@ describe('ResultsPanel', () => {
       'player.1',
     )
     expect(page.getTableName()).toBe('Finishes for Championship Singles')
+  })
+
+  it('renders BOTH stages for a two-stage event (kind: standings_then_finishes)', () => {
+    // The third arm (ADR 20260727) routes to the composite, which reuses the same two
+    // panels — so a two-stage card shows a standings block AND a finishes block, under one
+    // champion banner naming the BRACKET's winner (`player.2`), who tops neither pool.
+    page.render({ event: buildTwoStageEvent() })
+
+    expect(page.queryStandingsPanel('ev-two-stage')).not.toBeNull()
+    expect(page.queryFinishesPanel('ev-two-stage')).not.toBeNull()
+    expect(page.getChampion('two-stage-champion-ev-two-stage')).toHaveTextContent(
+      'player.2',
+    )
+    // Neither stage crowned anybody itself — one banner on the card, not three.
+    expect(page.queryStandingsChampion('ev-two-stage')).toBeNull()
+    expect(page.queryFinishesChampion('ev-two-stage')).toBeNull()
+  })
+
+  it('renders a mid-flight two-stage event with no champion at all', () => {
+    // Pools decided, final unplayed: the stages still render, and nothing is crowned.
+    page.render({
+      event: buildTwoStageEvent({ results: buildMidFlightTwoStageResults() }),
+    })
+
+    expect(page.queryStandingsPanel('ev-two-stage')).not.toBeNull()
+    expect(page.queryFinishesPanel('ev-two-stage')).not.toBeNull()
+    expect(page.queryTwoStageChampion('ev-two-stage')).toBeNull()
   })
 
   it('renders nothing for an event with no results', () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.test.tsx
@@ -9,6 +9,12 @@ describe('ResultsPanel', () => {
 
     expect(page.queryStandingsPanel('ev-u1200')).not.toBeNull()
     expect(page.queryFinishesPanel('ev-u1200')).toBeNull()
+    // The panel is handed its data now, so this is where the wiring is checked: the event's
+    // OWN standings (champion `entry-1`, joined to a name) reached it, and its own pool.
+    expect(page.getChampion('standings-champion-ev-u1200')).toHaveTextContent(
+      'player.1',
+    )
+    expect(page.getTableName()).toBe('Standings for Pool A')
   })
 
   it('renders the finishes list for a single-elimination event (kind: finishes)', () => {
@@ -16,6 +22,12 @@ describe('ResultsPanel', () => {
 
     expect(page.queryFinishesPanel('ev-single-elim')).not.toBeNull()
     expect(page.queryStandingsPanel('ev-single-elim')).toBeNull()
+    // Same wiring check for the finishes arm — and the table's accessible name is the only
+    // proof that the event's NAME was threaded through to a panel that no longer reads it.
+    expect(page.getChampion('finishes-champion-ev-single-elim')).toHaveTextContent(
+      'player.1',
+    )
+    expect(page.getTableName()).toBe('Finishes for Championship Singles')
   })
 
   it('renders nothing for an event with no results', () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.tsx
@@ -1,8 +1,10 @@
 import { eventFinishes } from '../../../data/finishes'
 import { eventStandings } from '../../../data/standings'
+import { eventStandingsThenFinishes } from '../../../data/two-stage'
 import type { TournamentEvent } from '../../../data/types'
 import { FinishesPanel } from './finishes/finishes-panel'
 import { StandingsPanel } from './standings/standings-panel'
+import { TwoStagePanel } from './two-stage/two-stage-panel'
 
 export interface ResultsPanelProps {
   event: TournamentEvent
@@ -10,10 +12,12 @@ export interface ResultsPanelProps {
 
 /**
  * An event's **results** on its card in the Events tab — the one render path that switches on
- * the results shape (ADR-0785): a **standings** table for round-robin, a **finishes**
- * placement list for single-elimination. The results are a discriminated union tagged by
- * `kind`, parsed at the boundary (`../../../data/results`), so this switch is exhaustive: a
- * future draw type's shape is a **type error here** until it is given a render arm.
+ * the results shape (ADR-0785, widened by ADR 20260727): a **standings** table for
+ * round-robin, a **finishes** placement list for single-elimination, and **both** — pools
+ * above bracket, one champion — for round-robin-then-knockout. The results are a
+ * discriminated union tagged by `kind`, parsed at the boundary (`../../../data/results`), so
+ * this switch is exhaustive: a future draw type's shape is a **type error here** until it is
+ * given a render arm.
  *
  * It renders **nothing** for an event with no results (`results === null`: an uncut event, or
  * a draw type with no results strategy yet) — the designed data state, so this drops into the
@@ -46,6 +50,17 @@ export const ResultsPanel = ({ event }: ResultsPanelProps) => {
           eventId={event.id}
           eventName={event.name}
           finishes={eventFinishes(event, results)}
+        />
+      )
+    case 'standings_then_finishes':
+      // Both stages, on one card (ADR 20260727): the pool standings above the bracket
+      // finishes, under a single champion banner naming the BRACKET's winner. The two
+      // panels above are reused as they stand — the composite only selects and arranges.
+      return (
+        <TwoStagePanel
+          eventId={event.id}
+          eventName={event.name}
+          twoStage={eventStandingsThenFinishes(event, results)}
         />
       )
     default: {

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.tsx
@@ -1,3 +1,5 @@
+import { eventFinishes } from '../../../data/finishes'
+import { eventStandings } from '../../../data/standings'
 import type { TournamentEvent } from '../../../data/types'
 import { FinishesPanel } from './finishes/finishes-panel'
 import { StandingsPanel } from './standings/standings-panel'
@@ -15,8 +17,13 @@ export interface ResultsPanelProps {
  *
  * It renders **nothing** for an event with no results (`results === null`: an uncut event, or
  * a draw type with no results strategy yet) — the designed data state, so this drops into the
- * panel unconditionally, exactly as the standings panel used to. Each arm is itself a pure
- * view over the event, live off the tournament-detail payload with no machinery of its own.
+ * panel unconditionally, exactly as the standings panel used to.
+ *
+ * **This is the only component that knows which block applies.** It selects each block's view
+ * (`eventStandings` / `eventFinishes`) and hands it to a panel that just renders what it is
+ * given: no panel re-checks `kind`, so none of them can meet a shape it does not recognise and
+ * quietly render nothing. Each block stays a pure view, live off the tournament-detail
+ * payload, with no machinery of its own.
  */
 export const ResultsPanel = ({ event }: ResultsPanelProps) => {
   const results = event.results
@@ -27,9 +34,20 @@ export const ResultsPanel = ({ event }: ResultsPanelProps) => {
 
   switch (results.kind) {
     case 'standings':
-      return <StandingsPanel event={event} />
+      return (
+        <StandingsPanel
+          eventId={event.id}
+          standings={eventStandings(event, results)}
+        />
+      )
     case 'finishes':
-      return <FinishesPanel event={event} />
+      return (
+        <FinishesPanel
+          eventId={event.id}
+          eventName={event.name}
+          finishes={eventFinishes(event, results)}
+        />
+      )
     default: {
       // A results shape without a render arm is a TYPE error here, not a blank section.
       const exhaustive: never = results

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.factory.tsx
@@ -1,13 +1,35 @@
-import { buildStandingsEvent } from '../../../../data/seed.factory'
+import {
+  buildStandingsEvent,
+  standingsResultsOf,
+} from '../../../../data/seed.factory'
+import { eventStandings } from '../../../../data/standings'
+import type { TournamentEvent } from '../../../../data/types'
 import type { StandingsPanelProps } from './standings-panel'
 
-/** Props for `StandingsPanel`: a round-robin event **with results** — a complete single
- * pool and a champion (`buildStandingsEvent`). The event owns the `results` and the
- * `entrants` the panel joins them against, so a test tweaks the whole event (e.g.
- * `buildEvent()` for the no-results case, `results: buildEventResults({ complete: false })`
- * for a live one). */
-export function buildStandingsPanelProps(
-  overrides: Partial<StandingsPanelProps> = {},
-): StandingsPanelProps {
-  return { event: buildStandingsEvent(), ...overrides }
+/** What a test varies: the whole **event** whose standings the panel is handed (the natural
+ * unit — the results and the entrants they join against travel together), or a prop
+ * directly. */
+export type StandingsPanelScenario = Partial<StandingsPanelProps> & {
+  event?: TournamentEvent
+}
+
+/**
+ * Props for `StandingsPanel`: by default a round-robin event **with results** — a complete
+ * single pool and a champion (`buildStandingsEvent`).
+ *
+ * The panel no longer takes an event, but a test still reasons in events, so this derives
+ * the props from one **the same way `ResultsPanel` does at runtime** — `eventStandings`
+ * over the event's own `standings` block. A test that hands over a differently-built event
+ * therefore exercises the real selection path, not a hand-written view-model that could
+ * drift from it.
+ */
+export function buildStandingsPanelProps({
+  event = buildStandingsEvent(),
+  ...overrides
+}: StandingsPanelScenario = {}): StandingsPanelProps {
+  return {
+    eventId: event.id,
+    standings: eventStandings(event, standingsResultsOf(event)),
+    ...overrides,
+  }
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.page.tsx
@@ -1,7 +1,11 @@
+import { renderedHtml } from '@/test/rendered-html'
 import { render, screen, within, type Container } from '@/test/utilities'
 
-import { StandingsPanel, type StandingsPanelProps } from './standings-panel'
-import { buildStandingsPanelProps } from './standings-panel.factory'
+import { StandingsPanel } from './standings-panel'
+import {
+  buildStandingsPanelProps,
+  type StandingsPanelScenario,
+} from './standings-panel.factory'
 
 const scoped = (container: Container) => ({
   /** The whole results block, by event id. `query…` because the panel renders NOTHING for
@@ -11,6 +15,19 @@ const scoped = (container: Container) => ({
   },
   queryPanel(eventId: string) {
     return container.queryByTestId(`standings-panel-${eventId}`)
+  },
+
+  /** The panel's whole rendered DOM (React ids normalized) — the equivalence guard's
+   * subject: an inline snapshot of this reds on ANY rendered change. */
+  getPanelHtml(eventId: string) {
+    return renderedHtml(container.getByTestId(`standings-panel-${eventId}`))
+  },
+
+  /** The panel's landmark by its accessible name — a `<section>` with `aria-labelledby` is
+   * a `region`, so this only resolves while the heading is still wired to the section.
+   * (The snapshot normalizes the generated id away, so the wiring is asserted here.) */
+  getRegion() {
+    return container.getByRole('region', { name: 'Standings' })
   },
 
   /** The champion callout, by event id — shown only for a complete, single-champion event.
@@ -38,7 +55,7 @@ const scoped = (container: Container) => ({
 
 /** Test page-object for `StandingsPanel`. */
 export const standingsPanelPage = {
-  render(overrides: Partial<StandingsPanelProps> = {}) {
+  render(overrides: StandingsPanelScenario = {}) {
     render(<StandingsPanel {...buildStandingsPanelProps(overrides)} />)
   },
 

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.test.tsx
@@ -1,5 +1,4 @@
 import {
-  buildEvent,
   buildEventResults,
   buildPool,
   buildPoolStandings,
@@ -9,6 +8,19 @@ import {
 import { standingsPanelPage as page } from './standings-panel.page'
 
 describe('StandingsPanel', () => {
+  // The equivalence guard for the props refactor (the panel is handed its standings instead
+  // of deriving them from the event). Pinned on the pre-refactor component, so it reds on
+  // ANY rendered difference — a moved wrapper, a dropped class, a changed test id — not just
+  // on the few strings the other tests happen to name.
+  it('renders exactly this DOM for the default round-robin event', () => {
+    page.render()
+
+    // The heading is wired to the section (`aria-labelledby`), which the snapshot cannot
+    // assert: it normalizes React's generated ids away.
+    expect(page.getRegion()).toBe(page.getPanel('ev-u1200'))
+    expect(page.getPanelHtml('ev-u1200')).toMatchInlineSnapshot(`"<section data-testid="standings-panel-ev-u1200" aria-labelledby="ID" class="mt-2.5"><h3 id="ID" class="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">Standings</h3><p data-testid="standings-champion-ev-u1200" class="mt-1.5 flex items-center gap-1.5 rounded-[10px] border border-[color:rgba(255,122,26,0.3)] bg-[color:var(--bg-accent-soft)] px-3 py-2 text-[13px] font-medium text-[color:var(--fg-1)] [box-shadow:var(--shadow-glow)]"><svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trophy text-[color:var(--ball-500)]" aria-hidden="true"><path d="M10 14.66v1.626a2 2 0 0 1-.976 1.696A5 5 0 0 0 7 21.978"></path><path d="M14 14.66v1.626a2 2 0 0 0 .976 1.696A5 5 0 0 1 17 21.978"></path><path d="M18 9h1.5a1 1 0 0 0 0-5H18"></path><path d="M4 22h16"></path><path d="M6 9a6 6 0 0 0 12 0V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1z"></path><path d="M6 9H4.5a1 1 0 0 1 0-5H6"></path></svg><span class="text-[color:var(--fg-3)]">Champion</span><span class="text-[color:var(--ball-500)]">player.1</span></p><div class="mt-2 flex flex-col gap-2.5"><section data-testid="pool-standings-p-a" aria-labelledby="ID" class="rounded-[10px] border border-[color:var(--border-subtle)] p-3"><h4 id="ID" class="text-[13px] font-semibold text-[color:var(--fg-1)]">Pool A</h4><div data-slot="table-container" class="relative w-full overflow-x-auto"><table data-slot="table" class="w-full caption-bottom mt-2 text-[13px]" aria-label="Standings for Pool A"><thead data-slot="table-header" class="[&amp;_tr]:border-b"><tr data-slot="table-row" class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted"><th data-slot="table-head" class="h-10 px-2 align-middle font-medium whitespace-nowrap text-foreground [&amp;:has([role=checkbox])]:pr-0 w-8 text-right font-mono tabular-nums"><span aria-hidden="true">#</span><span class="sr-only">Rank</span></th><th data-slot="table-head" class="h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&amp;:has([role=checkbox])]:pr-0">Player</th><th data-slot="table-head" class="h-10 px-2 align-middle font-medium whitespace-nowrap text-foreground [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums"><span aria-hidden="true">W</span><span class="sr-only">Wins</span></th><th data-slot="table-head" class="h-10 px-2 align-middle font-medium whitespace-nowrap text-foreground [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums"><span aria-hidden="true">L</span><span class="sr-only">Losses</span></th><th data-slot="table-head" class="h-10 px-2 align-middle font-medium whitespace-nowrap text-foreground [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums"><span aria-hidden="true">Diff</span><span class="sr-only">Game difference</span></th><th data-slot="table-head" class="h-10 px-2 align-middle font-medium whitespace-nowrap text-foreground [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums"><span aria-hidden="true">GW</span><span class="sr-only">Games won</span></th></tr></thead><tbody data-slot="table-body" class="[&amp;_tr:last-child]:border-0"><tr data-slot="table-row" class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-testid="standing-row-entry-1"><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums text-[color:var(--fg-3)]">1</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-[color:var(--fg-1)]">player.1</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums">2</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums">0</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums text-[color:var(--fg-2)]">+3</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums">4</td></tr><tr data-slot="table-row" class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-testid="standing-row-entry-4"><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums text-[color:var(--fg-3)]">2</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-[color:var(--fg-1)]">player.4</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums">1</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums">1</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums text-[color:var(--fg-2)]">0</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums">3</td></tr><tr data-slot="table-row" class="border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted" data-testid="standing-row-entry-5"><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums text-[color:var(--fg-3)]">3</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-[color:var(--fg-1)]">player.5</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums">0</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums">2</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums text-[color:var(--fg-2)]">-3</td><td data-slot="table-cell" class="p-2 align-middle whitespace-nowrap [&amp;:has([role=checkbox])]:pr-0 text-right font-mono tabular-nums">1</td></tr></tbody></table></div></section></div></section>"`)
+  })
+
   it('shows a standings table per pool, entrants joined to their names', () => {
     // The default: a complete single-pool U1200 event (`ev-u1200`), Pool A of player.1 /
     // player.4 / player.5. The panel joins each row's entry id to a name off the event's
@@ -81,14 +93,10 @@ describe('StandingsPanel', () => {
     expect(page.queryChampion('ev-u1200')).toBeNull()
   })
 
-  it('renders NOTHING for an event with no results', () => {
-    // An uncut event (and any non-round-robin one) has `results: null` — nothing to stand.
-    // The panel is a designed empty state: it renders no section at all, rather than an
-    // empty table that would read as a played event with nobody in it.
-    page.render({ event: buildEvent() })
-
-    expect(page.queryPanel('ev-open-singles')).toBeNull()
-  })
+  // NOTE: "renders NOTHING for an event with no results" used to live here. The panel is now
+  // handed a `StandingsView` and cannot be given "no results" at all — that state is a
+  // compile error, and the decision belongs to `ResultsPanel`, whose own suite asserts it
+  // ("renders nothing for an event with no results").
 
   it('shows a withdrawn champion as “Withdrawn”, never a raw id', () => {
     // The champion could name an entry the event no longer lists — a winner who withdrew

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.tsx
@@ -1,23 +1,32 @@
 import { useId } from 'react'
 
-import { eventStandings } from '../../../../data/standings'
-import type { TournamentEvent } from '../../../../data/types'
+import type { StandingsView } from '../../../../data/standings'
 import { ChampionBanner } from '../champion-banner'
 import { PoolStandingsTable } from './pool-standings-table'
 
 export interface StandingsPanelProps {
-  event: TournamentEvent
+  /** The event the standings belong to — its id is what the panel's own test hooks hang
+   * off (`standings-panel-…`, `standings-champion-…`), so a card showing more than one
+   * results block still names each one. */
+  eventId: string
+  /** The standings to render, already selected and joined to names (`eventStandings`).
+   * **Never null**: whether an event *has* standings is the caller's decision, not this
+   * panel's — see the note above. */
+  standings: StandingsView
 }
 
 /**
- * An event's **results** on its card in the Events tab (ADR-0788): a standings table per
- * pool, and — once the event is decided — its champion.
+ * A **standings block** on an event's card in the Events tab (ADR-0788): a standings table
+ * per pool, and — once the event is decided — its champion.
  *
- * It renders **nothing** for an event with no results (`event.results === null`, so
- * `eventStandings` returns `null`): an uncut event, or a non-round-robin one, has no
- * standings to show, and an empty table would read as a played event with nobody in it.
- * That is why this can be dropped into the panel unconditionally — it is a designed data
- * state, not a gap.
+ * ## It renders what it is handed
+ *
+ * It takes its standings as a prop instead of reading them off an event and deciding
+ * whether they apply. The switch on the results shape lives in exactly one place
+ * (`ResultsPanel`), so this block can be shown for any event that *has* a standings block,
+ * whatever the rest of its results look like — a plain round-robin today, one stage of a
+ * multi-stage event tomorrow. A panel that re-checked `results.kind` would silently render
+ * nothing the moment it met a shape it did not recognise.
  *
  * ## Live, with no machinery of its own
  *
@@ -25,7 +34,7 @@ export interface StandingsPanelProps {
  * live on the server from the fixtures' completed matches. As matches complete, the
  * completion hook re-derives them and the mutations that drive play invalidate the
  * tournament — so the table fills in on the next read with **no polling and no client
- * recompute** here. This component is a pure view over `event`; it never sorts a row or
+ * recompute** here. This component is a pure view over its props; it never sorts a row or
  * computes a number (the order and the figures *are* the result — ADR-0788).
  *
  * ## The champion
@@ -35,17 +44,12 @@ export interface StandingsPanelProps {
  * stage to join its pool winners (a later slice), so `champion` is `null` there even when
  * complete, and the callout simply does not appear — the pool tables still do.
  */
-export const StandingsPanel = ({ event }: StandingsPanelProps) => {
+export const StandingsPanel = ({ eventId, standings }: StandingsPanelProps) => {
   const headingId = useId()
-  const standings = eventStandings(event)
-
-  // No results to stand: an uncut or non-round-robin event. Render nothing — a designed
-  // data state, not a spinner and not a gap.
-  if (standings === null) return null
 
   return (
     <section
-      data-testid={`standings-panel-${event.id}`}
+      data-testid={`standings-panel-${eventId}`}
       aria-labelledby={headingId}
       className="mt-2.5"
     >
@@ -63,7 +67,7 @@ export const StandingsPanel = ({ event }: StandingsPanelProps) => {
       {standings.complete && standings.champion !== null && (
         <ChampionBanner
           name={standings.champion}
-          testId={`standings-champion-${event.id}`}
+          testId={`standings-champion-${eventId}`}
         />
       )}
 

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/two-stage/two-stage-panel.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/two-stage/two-stage-panel.factory.tsx
@@ -1,0 +1,35 @@
+import {
+  buildTwoStageEvent,
+  twoStageResultsOf,
+} from '../../../../data/seed.factory'
+import { eventStandingsThenFinishes } from '../../../../data/two-stage'
+import type { TournamentEvent } from '../../../../data/types'
+import type { TwoStagePanelProps } from './two-stage-panel'
+
+/** What a test varies: the whole **event** whose two-stage results the panel is handed (the
+ * natural unit — the results and the entrants they join against travel together), or a prop
+ * directly. */
+export type TwoStagePanelScenario = Partial<TwoStagePanelProps> & {
+  event?: TournamentEvent
+}
+
+/**
+ * Props for `TwoStagePanel`: by default a played-out `rr-then-ko` event — two decided pools,
+ * a bracket run to a final, and a champion who tops **no** pool (`buildTwoStageEvent`).
+ *
+ * The props are derived from the event **the same way `ResultsPanel` does at runtime** —
+ * `eventStandingsThenFinishes` over the event's own two-stage block — so a test that hands
+ * over a differently-built event (the mid-flight one, say) exercises the real selection
+ * path, not a hand-written view-model that could drift from it.
+ */
+export function buildTwoStagePanelProps({
+  event = buildTwoStageEvent(),
+  ...overrides
+}: TwoStagePanelScenario = {}): TwoStagePanelProps {
+  return {
+    eventId: event.id,
+    eventName: event.name,
+    twoStage: eventStandingsThenFinishes(event, twoStageResultsOf(event)),
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/two-stage/two-stage-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/two-stage/two-stage-panel.page.tsx
@@ -1,0 +1,82 @@
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import { TwoStagePanel } from './two-stage-panel'
+import {
+  buildTwoStagePanelProps,
+  type TwoStagePanelScenario,
+} from './two-stage-panel.factory'
+
+const scoped = (container: Container) => ({
+  /** The whole two-stage block, by event id. */
+  getPanel(eventId: string) {
+    return container.getByTestId(`two-stage-panel-${eventId}`)
+  },
+
+  /** The **pool stage**, rendered by the shared `StandingsPanel` — addressed by that
+   * panel's own testid, which is the proof it is the shared component and not a fork. */
+  queryStandingsPanel(eventId: string) {
+    return container.queryByTestId(`standings-panel-${eventId}`)
+  },
+
+  /** The **knockout stage**, rendered by the shared `FinishesPanel` — same argument. */
+  queryFinishesPanel(eventId: string) {
+    return container.queryByTestId(`finishes-panel-${eventId}`)
+  },
+
+  /** The one champion callout this block owns. `query…` because a mid-flight event's
+   * assertion is that it is absent. */
+  queryChampion(eventId: string) {
+    return container.queryByTestId(`two-stage-champion-${eventId}`)
+  },
+
+  /** Every champion callout on the card, whoever rendered it — the "**single** banner"
+   * assertion. A sub-panel that crowned a stage of its own would show up here. */
+  getAllChampions() {
+    return container.queryAllByText('Champion')
+  },
+
+  /** The block's stage headings **in rendered order** — `['Standings', 'Finishes']` when
+   * the pools sit above the bracket they seeded. Reading the DOM order is the only way to
+   * assert "above": both sections render either way round. */
+  getStageHeadings() {
+    return container
+      .getAllByRole('heading', { level: 3 })
+      .map((h: HTMLElement) => (h.textContent ?? '').trim())
+  },
+
+  /** One pool table's player names, top to bottom (the rendered order). */
+  getPoolRowNames(poolName: string) {
+    return within(container.getByRole('table', { name: `Standings for ${poolName}` }))
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => (within(row).getAllByRole('cell')[1].textContent ?? '').trim())
+  },
+
+  /** The bracket's placements as `[position, player]`, top to bottom — the position label
+   * (`1st`, `T3`) from the `#` cell, the name from the player cell. */
+  getPlacements(eventName: string) {
+    return within(container.getByRole('table', { name: `Finishes for ${eventName}` }))
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => {
+        const cells = within(row).getAllByRole('cell')
+        return [
+          (cells[0].textContent ?? '').trim(),
+          (cells[1].textContent ?? '').trim(),
+        ] as const
+      })
+  },
+})
+
+/** Test page-object for `TwoStagePanel`. */
+export const twoStagePanelPage = {
+  render(overrides: TwoStagePanelScenario = {}) {
+    render(<TwoStagePanel {...buildTwoStagePanelProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/two-stage/two-stage-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/two-stage/two-stage-panel.test.tsx
@@ -1,0 +1,89 @@
+import { interactiveElementsIn } from '@/test/read-only'
+
+import {
+  buildMidFlightTwoStageResults,
+  buildTwoStageEvent,
+} from '../../../../data/seed.factory'
+import { twoStagePanelPage as page } from './two-stage-panel.page'
+
+const EVENT_ID = 'ev-two-stage'
+const EVENT_NAME = 'Two-stage Singles'
+
+describe('TwoStagePanel', () => {
+  it('shows the pool standings ABOVE the bracket finishes', () => {
+    // The order is the event's own story — pools, then the bracket they seeded. Both
+    // sections render either way round, so this reads the DOM order rather than presence.
+    page.render()
+
+    expect(page.getStageHeadings()).toEqual(['Standings', 'Finishes'])
+    expect(page.queryStandingsPanel(EVENT_ID)).not.toBeNull()
+    expect(page.queryFinishesPanel(EVENT_ID)).not.toBeNull()
+  })
+
+  it('reuses the shared panels — both pools’ tables and the placement list, joined to names', () => {
+    page.render()
+
+    expect(page.getPoolRowNames('Pool A')).toEqual([
+      'player.5',
+      'player.1',
+      'player.4',
+      'player.8',
+    ])
+    expect(page.getPoolRowNames('Pool B')).toEqual([
+      'player.3',
+      'player.2',
+      'player.6',
+      'player.7',
+    ])
+    expect(page.getPlacements(EVENT_NAME)).toEqual([
+      ['1st', 'player.2'],
+      ['2nd', 'player.1'],
+      ['T3', 'player.5'],
+      ['T3', 'player.3'],
+    ])
+  })
+
+  it('crowns the BRACKET winner in a SINGLE champion banner', () => {
+    // `player.2` won the final. `player.5` tops Pool A and `player.3` tops Pool B — a banner
+    // reading the standings would name one of them, and would still look like a champion,
+    // which is exactly why this asserts the NAME and not merely that a banner exists.
+    page.render()
+
+    const champion = page.queryChampion(EVENT_ID)
+    expect(champion).not.toBeNull()
+    expect(champion).toHaveTextContent('player.2')
+    expect(champion).not.toHaveTextContent('player.5')
+    // Exactly one banner on the card: neither stage crowns anybody of its own.
+    expect(page.getAllChampions()).toHaveLength(1)
+  })
+
+  it('shows NO champion mid-flight — pools decided, the final still to play', () => {
+    // The state `ev-shield` is in: both pools complete, the final seated and unplayed. The
+    // standings still render in full, the finishes list starts at position 3 (the two beaten
+    // semifinalists), and nobody is crowned.
+    page.render({
+      event: buildTwoStageEvent({ results: buildMidFlightTwoStageResults() }),
+    })
+
+    expect(page.queryChampion(EVENT_ID)).toBeNull()
+    expect(page.getAllChampions()).toHaveLength(0)
+    expect(page.getPoolRowNames('Pool A')).toEqual([
+      'player.5',
+      'player.1',
+      'player.4',
+      'player.8',
+    ])
+    expect(page.getPlacements(EVENT_NAME)).toEqual([
+      ['T3', 'player.5'],
+      ['T3', 'player.3'],
+    ])
+  })
+
+  it('renders no interactive controls — results are a read-only surface', () => {
+    // Nobody edits a result here, owner or not (ADR-0015: a read-only surface puts no
+    // control in the tree at all).
+    page.render()
+
+    expect(interactiveElementsIn(page.getPanel(EVENT_ID))).toHaveLength(0)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/two-stage/two-stage-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/two-stage/two-stage-panel.tsx
@@ -1,0 +1,71 @@
+import type { TwoStageView } from '../../../../data/two-stage'
+import { ChampionBanner } from '../champion-banner'
+import { FinishesPanel } from '../finishes/finishes-panel'
+import { StandingsPanel } from '../standings/standings-panel'
+
+export interface TwoStagePanelProps {
+  /** The event the results belong to — its id is what every hook on this block hangs off
+   * (`two-stage-champion-…`, and, through the two panels it composes, `standings-panel-…`
+   * and `finishes-panel-…`). */
+  eventId: string
+  /** The event's name, for the finishes table's accessible label ("Finishes for …") — a
+   * screen reader meets that table out of context and needs to know whose placements
+   * these are. */
+  eventName: string
+  /** The two-stage results to render, already selected and joined to names
+   * (`eventStandingsThenFinishes`). **Never null**: whether an event *has* two-stage results
+   * is the caller's decision, not this block's. */
+  twoStage: TwoStageView
+}
+
+/**
+ * A **round-robin-then-knockout** event's results on its card in the Events tab (ADR
+ * 20260727): the champion, then the pool stage's standings, then the knockout stage's
+ * finishes — one event's story in the order it was played.
+ *
+ * ## It composes; it does not fork
+ *
+ * The two stages are rendered by the **same** `StandingsPanel` and `FinishesPanel` a pure
+ * round-robin and a pure single-elimination event get. They take their data as props for
+ * exactly this reason: a two-stage event's pool table is a pool table, and its placement
+ * list is a placement list — a bespoke pair here would be two more implementations to keep
+ * in step, and the day one of them gained a column the other would quietly lack it.
+ *
+ * ## One champion, and it is the BRACKET's
+ *
+ * The banner is rendered **here**, above both stages, and the sub-views arrive with no
+ * champion of their own (`eventStandingsThenFinishes`) — so a card can never show two.
+ * The name in it is the knockout final's winner, never the top of a pool table: in this
+ * format the pool stage only seeds the bracket, so leading a pool wins nothing. The two
+ * are routinely different people, which is precisely why reading it off the standings
+ * would be a bug that still *looks* like a champion.
+ *
+ * It appears only when the event is **complete** — both stages decided — and has a
+ * champion. A mid-flight event (pools done, final unplayed) shows its standings and its
+ * partial finishes with **no banner**, which is the honest read: nobody has won it yet.
+ */
+export const TwoStagePanel = ({
+  eventId,
+  eventName,
+  twoStage,
+}: TwoStagePanelProps) => (
+  <div data-testid={`two-stage-panel-${eventId}`}>
+    {/* The champion — the whole event's result, in the app's "featured" voice (the same
+        `ChampionBanner` the other two blocks use). Above both stages because it is a fact
+        about the event, not about either stage; gated on the event being decided. */}
+    {twoStage.complete && twoStage.champion !== null && (
+      <ChampionBanner
+        name={twoStage.champion}
+        testId={`two-stage-champion-${eventId}`}
+      />
+    )}
+
+    {/* Stage one, then stage two — pools above the bracket they seeded. */}
+    <StandingsPanel eventId={eventId} standings={twoStage.standings} />
+    <FinishesPanel
+      eventId={eventId}
+      eventName={eventName}
+      finishes={twoStage.finishes}
+    />
+  </div>
+)

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -10,6 +10,8 @@ type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
 type TournamentTable = components['schemas']['TournamentTable']
 type StandingsResultsRead = components['schemas']['StandingsResultsRead']
 type FinishesResultsRead = components['schemas']['FinishesResultsRead']
+type StandingsThenFinishesResultsRead =
+  components['schemas']['StandingsThenFinishesResultsRead']
 type FinishRowRead = components['schemas']['FinishRowRead']
 type PoolStandingsRead = components['schemas']['PoolStandingsRead']
 type StandingRowRead = components['schemas']['StandingRowRead']
@@ -915,6 +917,68 @@ export function buildFinishesResultsRead(
     ],
     complete: true,
     champion: 'entry-1',
+    ...overrides,
+  }
+}
+
+/** A wire event's `standings_then_finishes` results (`StandingsThenFinishesResultsRead`,
+ * ADR 20260727): the round-robin-then-knockout arm — **both stages at once**, each block the
+ * very model its own arm carries.
+ *
+ * Built for a **six-entrant, two-pool** event, and the pool memberships are the ones the
+ * snake actually deals (`snakedPools` above: `p-a` takes entries 1, 4, 5; `p-b` takes 2, 3,
+ * 6) — not a tidier split, because a results fixture that stood over pools its own draw
+ * never dealt is a payload the server could not send.
+ *
+ * The champion is **`entry-4`, who tops neither pool.** The pool winners are `entry-1` and
+ * `entry-2`; `entry-4` qualifies second out of `p-a` and wins the bracket, beating `entry-1`
+ * in the final. That is the format working as designed — the pool stage only *seeds* — and
+ * it is what lets a test tell a client reading the bracket from one reading the top of a
+ * standings table. A fixture whose champion also led a pool could not.
+ *
+ * A **mid-flight** event — pools decided, final unplayed — is
+ * `buildStandingsThenFinishesResultsRead({ complete: false, champion: null, finishes: [only
+ * the placed entrants] })`. */
+export function buildStandingsThenFinishesResultsRead(
+  overrides: Partial<StandingsThenFinishesResultsRead> = {},
+): StandingsThenFinishesResultsRead {
+  const finish = (o: Partial<FinishRowRead>): FinishRowRead => ({
+    entry_id: 'entry-1',
+    position: 1,
+    eliminated_in_round: null,
+    ...o,
+  })
+  return {
+    kind: 'standings_then_finishes',
+    pools: [
+      buildPoolStandingsRead({
+        pool_id: 'p-a',
+        complete: true,
+        rows: [
+          buildStandingRowRead({ entry_id: 'entry-1', rank: 1, played: 2, wins: 2, losses: 0, games_won: 4, games_lost: 1, game_difference: 3 }),
+          buildStandingRowRead({ entry_id: 'entry-4', rank: 2, played: 2, wins: 1, losses: 1, games_won: 3, games_lost: 3, game_difference: 0 }),
+          buildStandingRowRead({ entry_id: 'entry-5', rank: 3, played: 2, wins: 0, losses: 2, games_won: 1, games_lost: 4, game_difference: -3 }),
+        ],
+      }),
+      buildPoolStandingsRead({
+        pool_id: 'p-b',
+        complete: true,
+        rows: [
+          buildStandingRowRead({ entry_id: 'entry-2', rank: 1, played: 2, wins: 2, losses: 0, games_won: 4, games_lost: 0, game_difference: 4 }),
+          buildStandingRowRead({ entry_id: 'entry-3', rank: 2, played: 2, wins: 1, losses: 1, games_won: 2, games_lost: 3, game_difference: -1 }),
+          buildStandingRowRead({ entry_id: 'entry-6', rank: 3, played: 2, wins: 0, losses: 2, games_won: 1, games_lost: 4, game_difference: -3 }),
+        ],
+      }),
+    ],
+    finishes: [
+      finish({ entry_id: 'entry-4', position: 1, eliminated_in_round: null }),
+      finish({ entry_id: 'entry-1', position: 2, eliminated_in_round: 2 }),
+      // The two beaten semifinalists — one of them the OTHER pool's winner — tied 3rd.
+      finish({ entry_id: 'entry-2', position: 3, eliminated_in_round: 1 }),
+      finish({ entry_id: 'entry-3', position: 3, eliminated_in_round: 1 }),
+    ],
+    complete: true,
+    champion: 'entry-4',
     ...overrides,
   }
 }

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -685,25 +685,6 @@ function snakeRefusal(
   return null
 }
 
-/** **K** — how many of each pool's finishers advance into an `rr-then-ko` draw's knockout
- * stage, when nothing tells the planner otherwise.
- *
- * One, i.e. "pool winners only", because that is the smallest legal value (`K ≥ 1` is a
- * Pydantic bound at the request boundary) and the least surprising reading of a format
- * whose director has expressed no preference.
- *
- * ⚠️ It is a **default, not the truth**, and by now it is a **fallback nobody should
- * reach**: the count is a real column (`tournament_event_draw_settings.qualifiers_per_pool`),
- * it rides both write bodies, and `TournamentEventRead` now sends it back — so both
- * stubs read a stored event's own value and pass it in (`planEventDraw`, in the MSW store
- * and in the Playwright one alike). What is left for this default is a caller that names
- * no count at all, i.e. a unit test of the planner itself.
- *
- * Do NOT let a store fall back to it. A K=1 bracket cut for an event configured at K=2 is
- * the quietest possible mock/server disagreement: nothing errors, the draw is a perfectly
- * well-formed bracket, and it is simply the wrong size. */
-export const DEFAULT_QUALIFIERS_PER_POOL = 1
-
 /**
  * Plan an event's draw exactly as the cut route does, or say why it cannot be — the
  * planner's 422s, in the server's own words (`app/draws.py`), because for these the
@@ -720,6 +701,14 @@ export const DEFAULT_QUALIFIERS_PER_POOL = 1
  * `entryIds` arrive in **draw order** — seed ascending where one is set, then
  * registration order (ADR-0786) — because that is the list the API's planner is handed.
  *
+ * **`qualifiersPerPool` has no default**, on purpose. It is a real column
+ * (`tournament_event_draw_settings.qualifiers_per_pool`) that rides both write bodies and
+ * comes back on `TournamentEventRead`, so every caller genuinely has an answer: a stored
+ * event's own value, or `null` for the two draw types that take no count. A default here
+ * would let one be omitted by accident, and that is the quietest possible mock/server
+ * disagreement — a K=1 bracket cut for an event configured at K=2 raises nothing, is a
+ * perfectly well-formed draw, and is simply the wrong size.
+ *
  * **Exhaustive over `DrawType`, with no default arm.** Every member of the enum has a
  * server-side strategy by construction (ADR 20260726), so there is no "this type cannot
  * be cut" refusal left to make — and adding a member tomorrow is a *type error* here
@@ -732,7 +721,10 @@ export function planDraw(
   drawType: components['schemas']['DrawType'],
   entryIds: readonly string[],
   poolIds: readonly string[],
-  qualifiersPerPool: number = DEFAULT_QUALIFIERS_PER_POOL,
+  /** **K** — how many of each pool's finishers advance into an `rr-then-ko` draw's
+   * knockout stage. `null` for the two draw types that have no knockout stage to qualify
+   * for, which is what their settings row holds and what their callers pass out loud. */
+  qualifiersPerPool: number | null,
 ): DrawPlan {
   switch (drawType) {
     case 'round-robin': {
@@ -767,6 +759,18 @@ export function planDraw(
       // consulted at all.
       const refusal = snakeRefusal(entryIds, poolIds)
       if (refusal !== null) return { ok: false, detail: refusal }
+      if (qualifiersPerPool === null) {
+        // NOT a refusal, and NOT a default: an `rr-then-ko` event without a count is not
+        // a state the server can be in — the write boundary requires one with no default
+        // (`RrThenKoDrawSettingsWrite`), so the column is never NULL for this draw type.
+        // A stub reaching here has been seeded or patched into a shape the API cannot
+        // hold, and says so instead of quietly cutting a `P × 1` bracket.
+        throw new Error(
+          'planDraw: an “rr-then-ko” draw has no qualifiers_per_pool. The count is ' +
+            'required at the write boundary, so a stored event always has one — pass ' +
+            'the event’s own value, never a fallback.',
+        )
+      }
       const dealt = snakedPools(entryIds, poolIds.length)
       // The snake has already refused a pool of fewer than two, so `smallest` is at
       // least 2 and the noun below never needs inflecting.

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -469,6 +469,13 @@ function seedSlots(bracketSize: number): number[] {
   return slots
 }
 
+/** One seat in a bracket: where a seed **enters** it. */
+interface KnockoutSeat {
+  round: number
+  position: number
+  side: 'a' | 'b'
+}
+
 /** Which side of which next-round slot the winner of `(round, position)` goes to:
  * slot `ceil(position / 2)`, side `a` for an odd `position` else `b` (`_successor`,
  * `api/app/draws.py`).
@@ -482,18 +489,59 @@ function successorSlot(position: number): { position: number; side: 'a' | 'b' } 
 }
 
 /**
- * Plan a **single-elimination** draw the way the API plans one
- * (`SingleElimStrategy.plan_initial`, `api/app/draws.py`): pad the field to the next
- * power of two, lay the seeds in by the standard recursive seeding, and emit every later
- * round up front with its sides TBD.
+ * Where every seed **enters** the bracket that holds `fieldSize` of them:
+ * `seed → (round, position, side)` (`_knockout_seats`, `api/app/draws.py`).
  *
- * `entryIds` arrive in **draw order** (seed ascending, then registration order), so the
- * entrant at index `k` is seed `k + 1` — the position the bracket is laid out by.
+ * ONE description of a bracket's shape, for the two questions that need it: *which
+ * fixtures exist* (`planKnockoutFixtures` below) and *where does a given seed sit*.
  *
- * Faithful rather than convenient, for the same reason the round-robin planner is: a stub
- * that dealt a bracket any old way would still look like a draw on screen, and the panel
- * built against it would be built against a shape the server never sends. The rules it
- * mirrors, each visible on the bracket:
+ * Byes are the top `B − fieldSize` seeds, and a byed seed's entry point is its
+ * **round-2** side — computed from the round-1 position it would have played, so a bye
+ * and a played feeder land on the two sides of the same successor.
+ */
+function knockoutSeats(fieldSize: number): Map<number, KnockoutSeat> {
+  let bracket = 1
+  while (bracket < fieldSize) bracket <<= 1
+  const slots = seedSlots(bracket)
+
+  const seats = new Map<number, KnockoutSeat>()
+  for (let pairIndex = 0; pairIndex < bracket / 2; pairIndex += 1) {
+    const position = pairIndex + 1
+    const first = slots[2 * pairIndex]
+    const second = slots[2 * pairIndex + 1]
+    const top = Math.min(first, second)
+    const bottom = Math.max(first, second)
+    if (bottom <= fieldSize) {
+      // Two real seeds: a genuine round-1 match. The top seat is `entry_a` for
+      // readability only — the successor side is decided by `position`, not by which
+      // seed is `a`.
+      seats.set(top, { round: 1, position, side: 'a' })
+      seats.set(bottom, { round: 1, position, side: 'b' })
+    } else {
+      // One phantom (`bottom` > N; two phantoms cannot happen when `bracket` is the
+      // SMALLEST power of two ≥ N). The real `top` seed byes straight into round 2.
+      const successor = successorSlot(position)
+      seats.set(top, { round: 2, ...successor })
+    }
+  }
+  return seats
+}
+
+/**
+ * The whole un-pooled bracket for `fieldSize` seeds, with each seed's entry taken from
+ * `entryForSeed` — **or left TBD for every seed the map does not name**
+ * (`_knockout_fixtures`, `api/app/draws.py`).
+ *
+ * **Two callers, one bracket**, exactly as on the server. `planSingleElimFixtures`
+ * passes the full seed → entry map, because a single-elim cut knows its field;
+ * `planDraw`'s `rr-then-ko` arm passes an **empty** one, because its qualifiers have not
+ * played yet — and gets the identical shape with every side `null`. That the shape is a
+ * pure function of `fieldSize` is exactly why a pools-then-knockout bracket can be cut in
+ * the same stroke as its pools (ADR "rr-then-ko cuts both stages upfront"): the qualifier
+ * count `P × K` is known at cut time, so *which* slots exist and *which* seeds bye is
+ * settled before anybody has played.
+ *
+ * The rules it mirrors, each visible on the bracket:
  *
  * - **A bye is the ABSENCE of a round-1 fixture** (ADR-0786), never a row with a `null`
  *   side. The `B − N` byes fall on the top `B − N` seeds — a slot drawn against a phantom
@@ -508,9 +556,84 @@ function successorSlot(position: number): { position: number; side: 'a' | 'b' } 
  *   renumbering of the surviving matches: it is what makes the successor arithmetic feed
  *   the right next-round slot, and a byed round-1 slot simply leaves a gap in it.
  * - **`pool_id` is null throughout** — a bracket is un-pooled; the event's pools (if any)
- *   are irrelevant to it, exactly as on the server.
+ *   are irrelevant to it, exactly as on the server. For an `rr-then-ko` draw that is not
+ *   cosmetic: `pool_id IS NULL` **is** the knockout stage, and it is what routes these
+ *   fixtures to the bracket view rather than into a pool's list.
+ * - **Rounds are numbered from 1 for both callers.** For a knockout stage that is a
+ *   *restart*, not a continuation of the pool rounds (ADR): pools may differ in size, so
+ *   "the round after the pools" is ill-defined, and restarting is what lets the client's
+ *   bracket — which names rounds relative to the maximum it is handed — say "Final /
+ *   Semifinals" with no change at all.
  *
- * Returns fixtures in round → position order, as the wire does.
+ * `idPrefix` distinguishes the two callers' fixture ids, so a mixed event's pool and
+ * knockout rows never collide. Returns fixtures in round → position order, as the wire
+ * does.
+ */
+function planKnockoutFixtures(
+  fieldSize: number,
+  entryForSeed: ReadonlyMap<number, string>,
+  idPrefix: string,
+): TournamentFixtureRead[] {
+  // `bracket` = the smallest power of two ≥ the field; `rounds` = its depth (log2).
+  let bracket = 1
+  while (bracket < fieldSize) bracket <<= 1
+  const rounds = Math.log2(bracket)
+  const seats = knockoutSeats(fieldSize)
+
+  /** The sides a seed is known to occupy at cut time, keyed `round:position:side`. A
+   * seed the caller cannot name yet contributes nothing, so its side stays TBD. */
+  const seated = new Map<string, string>()
+  for (const [seed, seat] of seats) {
+    const entryId = entryForSeed.get(seed)
+    if (entryId !== undefined) {
+      seated.set(`${seat.round}:${seat.position}:${seat.side}`, entryId)
+    }
+  }
+  const sideOf = (round: number, position: number, side: 'a' | 'b') =>
+    seated.get(`${round}:${position}:${side}`) ?? null
+
+  const slot = (round: number, position: number) =>
+    buildTournamentFixtureRead({
+      id: `${idPrefix}-r${round}-p${position}`,
+      pool_id: null,
+      round,
+      position,
+      entry_a_id: sideOf(round, position, 'a'),
+      entry_b_id: sideOf(round, position, 'b'),
+    })
+
+  // Only the round-1 positions a bye did NOT empty — that absence IS the bye, so the
+  // position sequence simply has gaps in it.
+  const roundOnePositions = [
+    ...new Set(
+      [...seats.values()].filter((s) => s.round === 1).map((s) => s.position),
+    ),
+  ].sort((a, b) => a - b)
+
+  const fixtures = roundOnePositions.map((position) => slot(1, position))
+  if (rounds >= 2) {
+    for (let position = 1; position <= bracket / 4; position += 1) {
+      fixtures.push(slot(2, position))
+    }
+  }
+  for (let round = 3; round <= rounds; round += 1) {
+    for (let position = 1; position <= bracket >> round; position += 1) {
+      fixtures.push(slot(round, position))
+    }
+  }
+  return fixtures
+}
+
+/**
+ * Plan a **single-elimination** draw the way the API plans one
+ * (`SingleElimStrategy.plan_initial`, `api/app/draws.py`): pad the field to the next
+ * power of two, lay the seeds in by the standard recursive seeding, and emit every later
+ * round up front with its sides TBD.
+ *
+ * `entryIds` arrive in **draw order** (seed ascending, then registration order), so the
+ * entrant at index `k` is seed `k + 1` — the position the bracket is laid out by. The
+ * shape itself is `planKnockoutFixtures` above; all this arm adds is "seed `k + 1` is
+ * this entrant", which is precisely what an `rr-then-ko` cut cannot say yet.
  *
  * ⚠️ Like the round-robin planner it does **not** enforce the API's refusal (a field of
  * fewer than two). That is the *store's* to make, because it is an answer to a request
@@ -519,78 +642,11 @@ function successorSlot(position: number): { position: number; side: 'a' | 'b' } 
 export function planSingleElimFixtures(
   entryIds: readonly string[],
 ): TournamentFixtureRead[] {
-  const size = entryIds.length
-  /** Seeds are 1-based positions into the draw-ordered field. */
-  const seedEntry = (seed: number): string => entryIds[seed - 1]
-
-  // `bracket` = the smallest power of two ≥ N; `rounds` = its depth (log2).
-  let bracket = 1
-  while (bracket < size) bracket <<= 1
-  const rounds = Math.log2(bracket)
-  const slots = seedSlots(bracket)
-
-  const fixtures: TournamentFixtureRead[] = []
-  /** A byed seed, already seated on its round-2 side, keyed `position:side`. */
-  const seatedByBye = new Map<string, string>()
-
-  for (let pairIndex = 0; pairIndex < bracket / 2; pairIndex += 1) {
-    const position = pairIndex + 1
-    const first = slots[2 * pairIndex]
-    const second = slots[2 * pairIndex + 1]
-    const top = Math.min(first, second)
-    const bottom = Math.max(first, second)
-    if (bottom <= size) {
-      // Two real seeds: a genuine round-1 match. The top seat is `entry_a` for
-      // readability only — the successor side is decided by `position`, not by which
-      // seed is `a`.
-      fixtures.push(
-        buildTournamentFixtureRead({
-          id: `fx-se-r1-p${position}`,
-          pool_id: null,
-          round: 1,
-          position,
-          entry_a_id: seedEntry(top),
-          entry_b_id: seedEntry(bottom),
-        }),
-      )
-    } else {
-      // One phantom (`bottom` > N; two phantoms cannot happen when `bracket` is the
-      // SMALLEST power of two ≥ N). The real `top` seed byes straight into round 2 —
-      // and no round-1 row is emitted for it. That absence IS the bye.
-      const successor = successorSlot(position)
-      seatedByBye.set(`${successor.position}:${successor.side}`, seedEntry(top))
-    }
-  }
-
-  if (rounds >= 2) {
-    for (let position = 1; position <= bracket / 4; position += 1) {
-      fixtures.push(
-        buildTournamentFixtureRead({
-          id: `fx-se-r2-p${position}`,
-          pool_id: null,
-          round: 2,
-          position,
-          entry_a_id: seatedByBye.get(`${position}:a`) ?? null,
-          entry_b_id: seatedByBye.get(`${position}:b`) ?? null,
-        }),
-      )
-    }
-  }
-  for (let round = 3; round <= rounds; round += 1) {
-    for (let position = 1; position <= bracket >> round; position += 1) {
-      fixtures.push(
-        buildTournamentFixtureRead({
-          id: `fx-se-r${round}-p${position}`,
-          pool_id: null,
-          round,
-          position,
-          entry_a_id: null,
-          entry_b_id: null,
-        }),
-      )
-    }
-  }
-  return fixtures
+  return planKnockoutFixtures(
+    entryIds.length,
+    new Map(entryIds.map((entryId, index) => [index + 1, entryId])),
+    'fx-se',
+  )
 }
 
 /** A planned draw, or the server's sentence for why this event cannot be cut as it
@@ -600,6 +656,51 @@ export function planSingleElimFixtures(
 export type DrawPlan =
   | { ok: true; fixtures: TournamentFixtureRead[] }
   | { ok: false; detail: string }
+
+/** Why the **pool stage** cannot be dealt as the event stands, or `null` — the two
+ * refusals `_snake` itself raises (`api/app/draws.py`), in its own words.
+ *
+ * Shared by both pooled arms of `planDraw` below because on the server they are literally
+ * the same call: `RrThenKoStrategy.plan_initial` runs `_snake` before it does anything
+ * else, so an `rr-then-ko` event with no pools is refused with the sentence about a
+ * *round-robin* draw. That reads oddly and is nonetheless right — the pool stage of an
+ * rr-then-ko draw **is** a round-robin — and inventing a second wording here would put a
+ * sentence in the server's mouth it never says.
+ *
+ * Asked of the DEALT pools, not of arithmetic on N and P: the refusal is about the pools
+ * the snake actually produced, and it names the numbers the director must change. */
+function snakeRefusal(
+  entryIds: readonly string[],
+  poolIds: readonly string[],
+): string | null {
+  if (poolIds.length === 0) return 'A round-robin draw needs at least one pool.'
+  if (snakedPools(entryIds, poolIds.length).some((pool) => pool.length < 2)) {
+    return (
+      `${entryIds.length} entrants across ${poolIds.length} pool(s) would leave ` +
+      'a pool with fewer than 2 entrants, who would have nobody to play.'
+    )
+  }
+  return null
+}
+
+/** **K** — how many of each pool's finishers advance into an `rr-then-ko` draw's knockout
+ * stage, when nothing tells the planner otherwise.
+ *
+ * One, i.e. "pool winners only", because that is the smallest legal value (`K ≥ 1` is a
+ * Pydantic bound at the request boundary) and the least surprising reading of a format
+ * whose director has expressed no preference.
+ *
+ * ⚠️ It is a **default, not the truth**, and by now it is a **fallback nobody should
+ * reach**: the count is a real column (`tournament_event_draw_settings.qualifiers_per_pool`),
+ * it rides both write bodies, and `TournamentEventRead` now sends it back — so both
+ * stubs read a stored event's own value and pass it in (`planEventDraw`, in the MSW store
+ * and in the Playwright one alike). What is left for this default is a caller that names
+ * no count at all, i.e. a unit test of the planner itself.
+ *
+ * Do NOT let a store fall back to it. A K=1 bracket cut for an event configured at K=2 is
+ * the quietest possible mock/server disagreement: nothing errors, the draw is a perfectly
+ * well-formed bracket, and it is simply the wrong size. */
+export const DEFAULT_QUALIFIERS_PER_POOL = 1
 
 /**
  * Plan an event's draw exactly as the cut route does, or say why it cannot be — the
@@ -629,24 +730,12 @@ export function planDraw(
   drawType: components['schemas']['DrawType'],
   entryIds: readonly string[],
   poolIds: readonly string[],
+  qualifiersPerPool: number = DEFAULT_QUALIFIERS_PER_POOL,
 ): DrawPlan {
   switch (drawType) {
     case 'round-robin': {
-      if (poolIds.length === 0) {
-        return { ok: false, detail: 'A round-robin draw needs at least one pool.' }
-      }
-      // Asked of the DEALT pools, not of arithmetic on N and P — the refusal is about
-      // the pools the snake actually produced, and it names the numbers the director
-      // must change.
-      const dealt = snakedPools(entryIds, poolIds.length)
-      if (dealt.some((pool) => pool.length < 2)) {
-        return {
-          ok: false,
-          detail:
-            `${entryIds.length} entrants across ${poolIds.length} pool(s) would leave ` +
-            'a pool with fewer than 2 entrants, who would have nobody to play.',
-        }
-      }
+      const refusal = snakeRefusal(entryIds, poolIds)
+      if (refusal !== null) return { ok: false, detail: refusal }
       return { ok: true, fixtures: planRoundRobinFixtures(entryIds, poolIds) }
     }
     case 'single-elim': {
@@ -663,6 +752,63 @@ export function planDraw(
         }
       }
       return { ok: true, fixtures: planSingleElimFixtures(entryIds) }
+    }
+    case 'rr-then-ko': {
+      // BOTH STAGES IN ONE STROKE (ADR "rr-then-ko cuts both stages upfront and seeds
+      // qualifiers rematch-free"): the pool fixtures *and* the whole bracket, the latter
+      // entirely TBD-sided. Not a convenience — `advance()` can only ever FILL a side of
+      // an existing fixture, never create one, so a bracket that did not exist at the cut
+      // could never come into being.
+      //
+      // The refusals, in the server's order (`RrThenKoStrategy.plan_initial`): the
+      // snake's two first, because the pool stage is dealt before the qualifier count is
+      // consulted at all.
+      const refusal = snakeRefusal(entryIds, poolIds)
+      if (refusal !== null) return { ok: false, detail: refusal }
+      const dealt = snakedPools(entryIds, poolIds.length)
+      // The snake has already refused a pool of fewer than two, so `smallest` is at
+      // least 2 and the noun below never needs inflecting.
+      const smallest = Math.min(...dealt.map((pool) => pool.length))
+      if (qualifiersPerPool > smallest) {
+        return {
+          ok: false,
+          detail:
+            `Taking ${qualifiersPerPool} qualifiers from each pool is more than the ` +
+            `${smallest} entrants in the smallest pool — take fewer qualifiers from ` +
+            'each pool, or add entrants.',
+        }
+      }
+      if (poolIds.length * qualifiersPerPool < 2) {
+        // `K ≥ 1` is a bound at the request boundary and the snake guarantees `P ≥ 1`,
+        // so the ONLY way to arrive here is one pool taking one qualifier: the sentence
+        // is fully determined, and interpolating the counts would add branches no input
+        // can reach.
+        return {
+          ok: false,
+          detail:
+            'Taking 1 qualifier from a single pool leaves one player in the knockout ' +
+            'stage, who would have nobody to play — take more qualifiers from each ' +
+            'pool, or configure more pools.',
+        }
+      }
+      return {
+        ok: true,
+        fixtures: [
+          // The pool stage IS round-robin's — the same call, not a second copy of the
+          // snake and the circle — so "the pools of an rr-then-ko draw are laid out
+          // exactly as a round-robin draw's" is structural rather than two
+          // implementations agreeing.
+          ...planRoundRobinFixtures(entryIds, poolIds),
+          // …and the knockout stage is single-elim's bracket, sized `P × K` (derived,
+          // never configured, so it cannot contradict the qualifier count) with an EMPTY
+          // seed map: nobody has qualified, so every side is TBD.
+          ...planKnockoutFixtures(
+            poolIds.length * qualifiersPerPool,
+            new Map(),
+            'fx-ko',
+          ),
+        ],
+      }
     }
   }
 }
@@ -860,6 +1006,13 @@ export function buildTournamentEventRead(
     created_at: '2026-06-01T09:05:00Z',
     updated_at: '2026-06-09T12:00:00Z',
     ...overrides,
+    // **No knockout stage to qualify for, so NO qualifier count** (ADR 20260727): `null`
+    // is the only value the settings table's `CHECK` admits for a round-robin or
+    // single-elim event, and "unset" is not a state that column has. Stated AFTER the
+    // spread because the field is required-and-nullable on the read shape (`number |
+    // null`, no `?`) while `Partial<…>` admits an explicit `undefined` — so the spread
+    // alone would widen it to a type the wire cannot hold.
+    qualifiers_per_pool: overrides.qualifiers_per_pool ?? null,
   } satisfies Omit<TournamentEventRead, 'entered'>
   return {
     ...event,
@@ -881,9 +1034,13 @@ export function buildTournamentEventRead(
  * ⚠️ The `name`/`description` strings are a **verbatim copy of the migration's
  * `DRAW_TYPE_SEED`** (`api/migrations/versions/20260617_0000_0010_create_tournaments_table.py`),
  * not copy invented here. They are the sentences a director actually reads when choosing
- * between the two formats, so a mock that paraphrased them would let the picker be built
+ * between the formats, so a mock that paraphrased them would let the picker be built
  * against words the server never sends — and this copy is DB seed data, so a wording
  * change is a migration and has to be re-copied here in the same change.
+ *
+ * ⚠️ A row here is only half the job: `DRAW_TYPES` (`components/tournaments/data`) is a
+ * hardcoded allowlist the catalogue parser filters against **silently**, so a row added
+ * here and not there is dropped on the floor with no error and the picker never offers it.
  */
 export const DRAW_TYPE_CATALOGUE: DrawTypeRead[] = [
   {
@@ -905,6 +1062,17 @@ export const DRAW_TYPE_CATALOGUE: DrawTypeRead[] = [
       'or a tight schedule — but half the entrants are finished after one ' +
       'match, and a field that is not a power of two gives the top seeds byes.',
     display_order: 2,
+  },
+  {
+    key: 'rr-then-ko',
+    // Pinned by the ADR "rr-then-ko cuts both stages upfront and seeds qualifiers
+    // rematch-free" — seed data, so changing either string is a migration there and a
+    // re-copy here.
+    name: 'Round-robin then knockout',
+    description:
+      'Pools play all-play-all, then the top finishers from each pool meet in a ' +
+      'knockout bracket.',
+    display_order: 3,
   },
 ]
 

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -986,6 +986,10 @@ export const DRAW_SETTINGS_REFUSALS = {
   countTooSmall:
     'qualifiers_per_pool must be a whole number of 1 or more: a knockout stage ' +
     'nobody qualifies for is not a stage.',
+  /** `K ≤ 1000`, the same ceiling the server enforces. */
+  countTooLarge:
+    'qualifiers_per_pool must be 1,000 or fewer: no pool advances more players ' +
+    'than that into the knockout stage.',
   /** The two count-less arms declare no such field, so the key is refused outright —
    * never silently dropped on the way to a column whose `CHECK` says `NULL`. */
   countForbidden: (drawType: string) =>
@@ -1043,6 +1047,9 @@ function validateEventBody(
         body.qualifiers_per_pool < 1
       ) {
         return detail(DRAW_SETTINGS_REFUSALS.countTooSmall, 422)
+      }
+      if (body.qualifiers_per_pool > 1000) {
+        return detail(DRAW_SETTINGS_REFUSALS.countTooLarge, 422)
       }
     } else if (
       body.qualifiers_per_pool !== undefined &&

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -961,6 +961,8 @@ function detail(message: string, status = 422) {
 /** Mirror the server's event-body constraints (ADR-0935) so an invalid event is
  * a 422 the editor surfaces inline, not a value the store silently accepts:
  *   • name — required, at most 255 chars.
+ *   • the draw configuration — `(draw_type, qualifiers_per_pool)` as a pair (ADR
+ *     20260727): required and ≥ 1 for `rr-then-ko`, refused outright on the other two.
  *   • max_players — when present, a positive integer (`null` = no cap is fine).
  *   • entry_fee — when present, non-negative.
  * Returns a 422 response for the first violation, or `null` when the body is OK.
@@ -979,6 +981,58 @@ function validateEventBody(
     if (name.length > 255) {
       return detail('Name must be 255 characters or fewer.', 422)
     }
+  }
+  // The **draw configuration**, judged as the pair it is (ADR 20260727). On the server
+  // `(draw_type, qualifiers_per_pool)` is flat on the wire and a discriminated union in
+  // the interior: the `rr-then-ko` arm REQUIRES a count with no default, and the other
+  // two arms are `extra="forbid"` and declare no such field — so a count sent with either
+  // of them is a 422, not a value quietly dropped on the way to a column whose `CHECK`
+  // says `NULL`.
+  //
+  // Mirrored here because a mock more permissive than the server is a trap: a client that
+  // sent `qualifiers_per_pool: null` on a round-robin event, or a bare `rr-then-ko` with
+  // no count, would look perfectly healthy in `npm run dev` and in vitest, and 422 in
+  // production. (The store below then keeps whatever survives this — see `createEvent`.)
+  if (body.draw_type !== undefined && body.draw_type !== null) {
+    if (body.draw_type === 'rr-then-ko') {
+      if (body.qualifiers_per_pool === undefined || body.qualifiers_per_pool === null) {
+        return detail(
+          '“rr-then-ko” draw settings: qualifiers_per_pool: Field required.',
+          422,
+        )
+      }
+      if (
+        !Number.isInteger(body.qualifiers_per_pool) ||
+        body.qualifiers_per_pool < 1
+      ) {
+        return detail(
+          '“rr-then-ko” draw settings: qualifiers_per_pool: Input should be greater ' +
+            'than or equal to 1.',
+          422,
+        )
+      }
+    } else if (
+      body.qualifiers_per_pool !== undefined &&
+      body.qualifiers_per_pool !== null
+    ) {
+      return detail(
+        `“${body.draw_type}” draw settings: qualifiers_per_pool: Extra inputs are ` +
+          'not permitted.',
+        422,
+      )
+    }
+  } else if (
+    body.qualifiers_per_pool !== undefined &&
+    body.qualifiers_per_pool !== null
+  ) {
+    // A count with no draw type beside it: judging it would mean reading the event's
+    // STORED draw type, two layers past the boundary. The server refuses it there
+    // (`_parse_draw_settings`) and so does this.
+    return detail(
+      'qualifiers_per_pool is part of an event’s draw configuration and is patched ' +
+        'with it: send draw_type alongside it.',
+      422,
+    )
   }
   if (body.max_players !== undefined && body.max_players !== null) {
     if (!Number.isInteger(body.max_players) || body.max_players <= 0) {

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -958,6 +958,45 @@ function detail(message: string, status = 422) {
   return HttpResponse.json({ detail: message }, { status })
 }
 
+/**
+ * Why a **draw configuration** is refused (ADR 20260727) — the mock's own sentences for
+ * the server's own rules.
+ *
+ * The RULES are mirrored exactly, and must be: a mock more permissive than the server is
+ * how a client ships a body the API 422s (it already happened on this arc). The WORDS are
+ * not. The server renders these three through pydantic — `Field required`,
+ * `Input should be greater than or equal to 1`, `Extra inputs are not permitted`, joined
+ * `loc: msg` — and reproducing a library's prose here pins nothing: no test, on either
+ * side, holds pydantic to those strings, so a minor bump would silently desynchronise
+ * `npm run dev` and vitest from production with everything still green.
+ *
+ * So these are authored, in the app's voice, and each names `qualifiers_per_pool` — the
+ * field the director has to fix, which is the part that IS load-bearing. Tests pin the
+ * rule that fired by referring to the constant, never by retyping a sentence.
+ *
+ * `countUnpaired` is the exception, verbatim on purpose: that one is a **human-written**
+ * sentence in `_parse_draw_settings` (`api/app/schemas/tournament.py`), not a library's.
+ */
+export const DRAW_SETTINGS_REFUSALS = {
+  /** `rr-then-ko` requires a count, and has no default to fall back on. */
+  countRequired:
+    'An “rr-then-ko” event needs a qualifiers_per_pool: how many of each pool’s ' +
+    'finishers advance into the knockout stage. There is no default — name a count.',
+  /** `K ≥ 1`, and a whole number of players. */
+  countTooSmall:
+    'qualifiers_per_pool must be a whole number of 1 or more: a knockout stage ' +
+    'nobody qualifies for is not a stage.',
+  /** The two count-less arms declare no such field, so the key is refused outright —
+   * never silently dropped on the way to a column whose `CHECK` says `NULL`. */
+  countForbidden: (drawType: string) =>
+    `A “${drawType}” draw has no knockout stage to qualify for, so it takes no ` +
+    'qualifiers_per_pool. Remove the count.',
+  /** A count arriving with no `draw_type` beside it — the server's own words. */
+  countUnpaired:
+    'qualifiers_per_pool is part of an event’s draw configuration and is patched ' +
+    'with it: send draw_type alongside it.',
+} as const
+
 /** Mirror the server's event-body constraints (ADR-0935) so an invalid event is
  * a 422 the editor surfaces inline, not a value the store silently accepts:
  *   • name — required, at most 255 chars.
@@ -993,33 +1032,23 @@ function validateEventBody(
   // sent `qualifiers_per_pool: null` on a round-robin event, or a bare `rr-then-ko` with
   // no count, would look perfectly healthy in `npm run dev` and in vitest, and 422 in
   // production. (The store below then keeps whatever survives this — see `createEvent`.)
+  // The rules are the server's; the sentences are ours — see `DRAW_SETTINGS_REFUSALS`.
   if (body.draw_type !== undefined && body.draw_type !== null) {
     if (body.draw_type === 'rr-then-ko') {
       if (body.qualifiers_per_pool === undefined || body.qualifiers_per_pool === null) {
-        return detail(
-          '“rr-then-ko” draw settings: qualifiers_per_pool: Field required.',
-          422,
-        )
+        return detail(DRAW_SETTINGS_REFUSALS.countRequired, 422)
       }
       if (
         !Number.isInteger(body.qualifiers_per_pool) ||
         body.qualifiers_per_pool < 1
       ) {
-        return detail(
-          '“rr-then-ko” draw settings: qualifiers_per_pool: Input should be greater ' +
-            'than or equal to 1.',
-          422,
-        )
+        return detail(DRAW_SETTINGS_REFUSALS.countTooSmall, 422)
       }
     } else if (
       body.qualifiers_per_pool !== undefined &&
       body.qualifiers_per_pool !== null
     ) {
-      return detail(
-        `“${body.draw_type}” draw settings: qualifiers_per_pool: Extra inputs are ` +
-          'not permitted.',
-        422,
-      )
+      return detail(DRAW_SETTINGS_REFUSALS.countForbidden(body.draw_type), 422)
     }
   } else if (
     body.qualifiers_per_pool !== undefined &&
@@ -1028,11 +1057,7 @@ function validateEventBody(
     // A count with no draw type beside it: judging it would mean reading the event's
     // STORED draw type, two layers past the boundary. The server refuses it there
     // (`_parse_draw_settings`) and so does this.
-    return detail(
-      'qualifiers_per_pool is part of an event’s draw configuration and is patched ' +
-        'with it: send draw_type alongside it.',
-      422,
-    )
+    return detail(DRAW_SETTINGS_REFUSALS.countUnpaired, 422)
   }
   if (body.max_players !== undefined && body.max_players !== null) {
     if (!Number.isInteger(body.max_players) || body.max_players <= 0) {

--- a/web-client/src/mocks/tournaments-handlers.test.ts
+++ b/web-client/src/mocks/tournaments-handlers.test.ts
@@ -21,6 +21,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type { components } from '@/api/schema'
+import { DRAW_SETTINGS_REFUSALS } from './handlers'
 import { resetTournamentsStore } from './tournaments-store'
 
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
@@ -160,12 +161,14 @@ describe('GET /v1/tournaments — the near-me filter', () => {
  * real API refuses — which is exactly how a silent 422 shipped earlier in this arc).
  *
  * WHAT IS ASSERTED, AND WHAT IS DELIBERATELY NOT. The load-bearing claims are the
- * **status** and the **offending field** — pinning the mock's full sentences would be a
- * fragile test of wording rather than a robust test of the rule. Each case additionally
- * pins the short fragment naming *which* rule fired ("Field required", "Extra inputs are
- * not permitted", "greater than or equal to 1"), and those are **Pydantic's own**
- * vocabulary — what the real server emits — not copy invented here. That is what makes a
- * branch red *for its own reason* rather than merely red.
+ * **status**, the **offending field**, and **which rule fired** — the last one pinned by
+ * naming the mock's own `DRAW_SETTINGS_REFUSALS` entry, so a branch reds for its own
+ * reason and not merely reds. No sentence is retyped here: re-asserting the words would
+ * be a fragile test of wording rather than a robust test of the rule, and the wording is
+ * free to change without touching a test. In particular these do NOT quote **Pydantic's**
+ * vocabulary ("Field required", "Extra inputs are not permitted", …): nothing pins the
+ * real server to those strings either, so a library bump could desynchronise the mock
+ * from production with the suite still green.
  *
  * The ACCEPT cases are not padding. A mirror mutated to refuse everything satisfies every
  * refusal case above and would ship a boundary that rejects valid events; the same shape
@@ -209,8 +212,9 @@ describe('the event write boundary — the draw configuration (ADR 20260727)', (
     return { status: res.status, body: await res.json() }
   }
 
-  /** The refusal, checked the robust way: a 422 that names the field the director must
-   * fix, and the fragment identifying which of the union's rules fired. */
+  /** The refusal, checked the robust way: a 422 whose detail names the field the director
+   * must fix, and IS the refusal for the rule that should have fired — identified by the
+   * constant, so the assertion survives any rewording of it. */
   function expectRefusal(
     result: { status: number; body: unknown },
     rule: string,
@@ -218,7 +222,7 @@ describe('the event write boundary — the draw configuration (ADR 20260727)', (
     expect(result.status).toBe(422)
     const { detail } = result.body as { detail: string }
     expect(detail).toContain('qualifiers_per_pool')
-    expect(detail).toContain(rule)
+    expect(detail).toBe(rule)
   }
 
   // ----- the rr-then-ko arm: required, and ge=1 ------------------------------
@@ -226,19 +230,21 @@ describe('the event write boundary — the draw configuration (ADR 20260727)', (
     it('is refused with NO qualifier count — the arm requires one, with no default', async () => {
       // There is no defensible number to assume ("2" is a convention, not a fact about
       // the event), so the server refuses rather than cutting a draw for a K nobody chose.
-      expectRefusal(await createEvent({ draw_type: 'rr-then-ko' }), 'Field required')
-      expectRefusal(await patchEvent({ draw_type: 'rr-then-ko' }), 'Field required')
+      const rule = DRAW_SETTINGS_REFUSALS.countRequired
+      expectRefusal(await createEvent({ draw_type: 'rr-then-ko' }), rule)
+      expectRefusal(await patchEvent({ draw_type: 'rr-then-ko' }), rule)
     })
 
     it.each([0, -1])('is refused with a count of %i — K >= 1', async (bad) => {
       // Zero advances nobody into the knockout stage; a negative count is not a count.
+      const rule = DRAW_SETTINGS_REFUSALS.countTooSmall
       expectRefusal(
         await createEvent({ draw_type: 'rr-then-ko', qualifiers_per_pool: bad }),
-        'greater than or equal to 1',
+        rule,
       )
       expectRefusal(
         await patchEvent({ draw_type: 'rr-then-ko', qualifiers_per_pool: bad }),
-        'greater than or equal to 1',
+        rule,
       )
     })
 
@@ -272,13 +278,14 @@ describe('the event write boundary — the draw configuration (ADR 20260727)', (
         // ⚠️ NOT a value silently dropped: the settings table's CHECK says NULL for every
         // draw type but rr-then-ko, and a director naming a count for a format with no
         // knockout stage has misunderstood something worth being told about.
+        const rule = DRAW_SETTINGS_REFUSALS.countForbidden(drawType)
         expectRefusal(
           await createEvent({ draw_type: drawType, qualifiers_per_pool: 2 }),
-          'Extra inputs are not permitted',
+          rule,
         )
         expectRefusal(
           await patchEvent({ draw_type: drawType, qualifiers_per_pool: 2 }),
-          'Extra inputs are not permitted',
+          rule,
         )
       },
     )
@@ -311,7 +318,10 @@ describe('the event write boundary — the draw configuration (ADR 20260727)', (
     // boundary and after the request has been accepted — so the server refuses it at the
     // edge (`_parse_draw_settings`). The editor always sends both: it PATCHes the whole
     // form it rendered.
-    expectRefusal(await patchEvent({ qualifiers_per_pool: 2 }), 'send draw_type alongside it')
+    expectRefusal(
+      await patchEvent({ qualifiers_per_pool: 2 }),
+      DRAW_SETTINGS_REFUSALS.countUnpaired,
+    )
   })
 
   // ✅ ACCEPT — the discriminating twin of the case above. A patch that touches neither

--- a/web-client/src/mocks/tournaments-handlers.test.ts
+++ b/web-client/src/mocks/tournaments-handlers.test.ts
@@ -248,6 +248,20 @@ describe('the event write boundary — the draw configuration (ADR 20260727)', (
       )
     })
 
+    it('is refused with a count over 1000 — the same ceiling the server enforces', async () => {
+      // A mock more permissive than the server here is exactly how a client ships a
+      // body the API 422s: the server's `qualifiers_per_pool` field is `le=1000`.
+      const rule = DRAW_SETTINGS_REFUSALS.countTooLarge
+      expectRefusal(
+        await createEvent({ draw_type: 'rr-then-ko', qualifiers_per_pool: 1001 }),
+        rule,
+      )
+      expectRefusal(
+        await patchEvent({ draw_type: 'rr-then-ko', qualifiers_per_pool: 1001 }),
+        rule,
+      )
+    })
+
     // ✅ ACCEPT. Without this, a mirror mutated to refuse everything passes every case
     // above — and the boundary would reject the very events it exists to admit.
     it('ACCEPTS a count of 1 or more, and stores it', async () => {

--- a/web-client/src/mocks/tournaments-handlers.test.ts
+++ b/web-client/src/mocks/tournaments-handlers.test.ts
@@ -10,11 +10,13 @@
 //   • Bay Area Open  — Berkeley   (37.8715, -122.273)   published, owned  → visible
 //   • Summer Slam    — Palo Alto  (37.4419, -122.143)   draft,     owned  → visible
 //   • Club Champs    — San Jose   (37.3382, -121.8863)  published, foreign→ visible
+//   • Golden State   — Los Angeles(34.0522, -118.2437)  live,      owned  → visible
 //   • Garage Invit.  — NO VENUE   (address: null)       published, owned  → visible
 //   • League Office  — San Jose   draft, foreign                          → HIDDEN
-// From Berkeley: Palo Alto ≈ 30.5 mi, San Jose ≈ 42.5 mi. So a 10-mile radius isolates
-// Berkeley, a 35-mile one adds Palo Alto, and a wide one returns all four visible rows —
-// except that the venue-less one is never a near-me result at all (see the last test).
+// From Berkeley: Palo Alto ≈ 30.5 mi, San Jose ≈ 42.5 mi, Los Angeles ≈ 345 mi. So a
+// 10-mile radius isolates Berkeley, a 35-mile one adds Palo Alto, and a wide one returns
+// all five visible rows — except that the venue-less one is never a near-me result at all
+// (see the last test).
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -34,6 +36,9 @@ const CLUB_CHAMPS = 'club-champs-2026' // San Jose, ~42.5 mi
 /** The seed's venue-less tournament (`address: null`) — visible in the plain list,
  * and never in a near-me one. */
 const GARAGE = 'garage-invitational-2026'
+/** The seed's two-stage tournament (ADR 20260727) — Los Angeles, ~345 mi, i.e. outside
+ * every radius these tests search and inside the deliberately absurd one below. */
+const GOLDEN_STATE = 'golden-state-classic-2026'
 
 async function listTournaments(query = ''): Promise<{
   status: number
@@ -88,11 +93,11 @@ describe('GET /v1/tournaments — the near-me filter', () => {
     const { status, body } = await listTournaments()
 
     expect(status).toBe(200)
-    // All four VISIBLE rows (the foreign draft stays hidden regardless), each with the
+    // All five VISIBLE rows (the foreign draft stays hidden regardless), each with the
     // designed "no location asked about" distance — the venue-less one INCLUDED: having
     // no venue keeps a tournament out of proximity searches, not out of the list.
     expect(idsOf(body).sort()).toEqual(
-      [BAY_AREA, CLUB_CHAMPS, GARAGE, SUMMER_SLAM].sort(),
+      [BAY_AREA, CLUB_CHAMPS, GARAGE, GOLDEN_STATE, SUMMER_SLAM].sort(),
     )
     for (const t of body) {
       expect(t.distance_miles).toBeNull()
@@ -121,7 +126,7 @@ describe('GET /v1/tournaments — the near-me filter', () => {
     // …while every VENUED row is inside a radius that large — so the assertion above
     // is about the missing venue and not about a filter that dropped everything.
     expect(idsOf(wholeEarth).sort()).toEqual(
-      [BAY_AREA, CLUB_CHAMPS, SUMMER_SLAM].sort(),
+      [BAY_AREA, CLUB_CHAMPS, GOLDEN_STATE, SUMMER_SLAM].sort(),
     )
   })
 

--- a/web-client/src/mocks/tournaments-handlers.test.ts
+++ b/web-client/src/mocks/tournaments-handlers.test.ts
@@ -22,6 +22,7 @@ import type { components } from '@/api/schema'
 import { resetTournamentsStore } from './tournaments-store'
 
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
+type TournamentEventRead = components['schemas']['TournamentEventRead']
 
 // The dev user's own venue — a point ON the Bay Area Open's coordinates, so its distance
 // rounds to 0 and the radii read like a map.
@@ -135,5 +136,190 @@ describe('GET /v1/tournaments — the near-me filter', () => {
       `?lat=${BERKELEY.lat}&lng=${BERKELEY.lng}`,
     )
     expect(twoOfThree).toBe(422)
+  })
+})
+
+/**
+ * The event write boundary's **draw configuration** check (ADR 20260727) — the mock's
+ * mirror of the server's tagged union, exercised over the same MSW server the app and
+ * `npm run dev` use.
+ *
+ * WHY THIS IS TESTED AT ALL. The rule lives on the server as a discriminated union
+ * (`api/app/schemas/tournament.py`): `RrThenKoDrawSettingsWrite` requires
+ * `qualifiers_per_pool` with `ge=1` and no default, the `round-robin`/`single-elim` arms
+ * declare no such field and are `extra="forbid"`, and `TournamentEventUpdate`'s
+ * `_parse_draw_settings` refuses a count arriving without a `draw_type` beside it. The
+ * mock restates that by hand, and a hand-maintained mirror drifts **both** ways with a
+ * green suite: too strict and it invents 422s that only appear in `npm run dev`; too lax
+ * and it stops catching the class of bug it exists for (a client authoring a body the
+ * real API refuses — which is exactly how a silent 422 shipped earlier in this arc).
+ *
+ * WHAT IS ASSERTED, AND WHAT IS DELIBERATELY NOT. The load-bearing claims are the
+ * **status** and the **offending field** — pinning the mock's full sentences would be a
+ * fragile test of wording rather than a robust test of the rule. Each case additionally
+ * pins the short fragment naming *which* rule fired ("Field required", "Extra inputs are
+ * not permitted", "greater than or equal to 1"), and those are **Pydantic's own**
+ * vocabulary — what the real server emits — not copy invented here. That is what makes a
+ * branch red *for its own reason* rather than merely red.
+ *
+ * The ACCEPT cases are not padding. A mirror mutated to refuse everything satisfies every
+ * refusal case above and would ship a boundary that rejects valid events; the same shape
+ * of corruption (an `ELSE FALSE` in a database constraint) has already been caught on
+ * this arc only by an accept case.
+ */
+describe('the event write boundary — the draw configuration (ADR 20260727)', () => {
+  /** A valid event create body, minus the draw configuration the cases supply. */
+  const baseCreate = {
+    name: 'Two-stage Singles',
+    format: 'singles' as const,
+    entry_fee: 20,
+    timezone: 'America/Chicago',
+    slot: { date: '2026-06-13', start: '09:00', end: '18:00' },
+    match_settings: { rated: true, length_games: 5 as const },
+  }
+
+  /** `POST …/events` against the seeded, owned tournament. */
+  async function createEvent(
+    draw: Partial<components['schemas']['TournamentEventCreate']>,
+  ) {
+    const res = await fetch(`http://localhost/v1/tournaments/${BAY_AREA}/events`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...baseCreate, ...draw }),
+    })
+    return { status: res.status, body: await res.json() }
+  }
+
+  /** `PATCH …/events/{id}` against a seeded event with **no draw cut**, so the draw-type
+   * freeze (a 409, a different rule) can never be what answers these. */
+  async function patchEvent(patch: components['schemas']['TournamentEventUpdate']) {
+    const res = await fetch(
+      `http://localhost/v1/tournaments/${BAY_AREA}/events/ev-open-singles`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(patch),
+      },
+    )
+    return { status: res.status, body: await res.json() }
+  }
+
+  /** The refusal, checked the robust way: a 422 that names the field the director must
+   * fix, and the fragment identifying which of the union's rules fired. */
+  function expectRefusal(
+    result: { status: number; body: unknown },
+    rule: string,
+  ) {
+    expect(result.status).toBe(422)
+    const { detail } = result.body as { detail: string }
+    expect(detail).toContain('qualifiers_per_pool')
+    expect(detail).toContain(rule)
+  }
+
+  // ----- the rr-then-ko arm: required, and ge=1 ------------------------------
+  describe('an rr-then-ko event', () => {
+    it('is refused with NO qualifier count — the arm requires one, with no default', async () => {
+      // There is no defensible number to assume ("2" is a convention, not a fact about
+      // the event), so the server refuses rather than cutting a draw for a K nobody chose.
+      expectRefusal(await createEvent({ draw_type: 'rr-then-ko' }), 'Field required')
+      expectRefusal(await patchEvent({ draw_type: 'rr-then-ko' }), 'Field required')
+    })
+
+    it.each([0, -1])('is refused with a count of %i — K >= 1', async (bad) => {
+      // Zero advances nobody into the knockout stage; a negative count is not a count.
+      expectRefusal(
+        await createEvent({ draw_type: 'rr-then-ko', qualifiers_per_pool: bad }),
+        'greater than or equal to 1',
+      )
+      expectRefusal(
+        await patchEvent({ draw_type: 'rr-then-ko', qualifiers_per_pool: bad }),
+        'greater than or equal to 1',
+      )
+    })
+
+    // ✅ ACCEPT. Without this, a mirror mutated to refuse everything passes every case
+    // above — and the boundary would reject the very events it exists to admit.
+    it('ACCEPTS a count of 1 or more, and stores it', async () => {
+      const created = await createEvent({
+        draw_type: 'rr-then-ko',
+        qualifiers_per_pool: 2,
+      })
+
+      expect(created.status).toBe(201)
+      // Round-tripped, not merely accepted: the value comes back on the read shape,
+      // which is what the next cut sizes its bracket from.
+      expect((created.body as TournamentEventRead).qualifiers_per_pool).toBe(2)
+
+      const patched = await patchEvent({
+        draw_type: 'rr-then-ko',
+        qualifiers_per_pool: 1,
+      })
+      expect(patched.status).toBe(200)
+      expect((patched.body as TournamentEventRead).qualifiers_per_pool).toBe(1)
+    })
+  })
+
+  // ----- the two count-less arms: extra="forbid" -----------------------------
+  describe('a draw type with no knockout stage', () => {
+    it.each(['round-robin', 'single-elim'] as const)(
+      'refuses a qualifier count sent with %s — that arm forbids the key outright',
+      async (drawType) => {
+        // ⚠️ NOT a value silently dropped: the settings table's CHECK says NULL for every
+        // draw type but rr-then-ko, and a director naming a count for a format with no
+        // knockout stage has misunderstood something worth being told about.
+        expectRefusal(
+          await createEvent({ draw_type: drawType, qualifiers_per_pool: 2 }),
+          'Extra inputs are not permitted',
+        )
+        expectRefusal(
+          await patchEvent({ draw_type: drawType, qualifiers_per_pool: 2 }),
+          'Extra inputs are not permitted',
+        )
+      },
+    )
+
+    // ✅ ACCEPT — and the discriminating half of the rule above: it is the *key* that is
+    // refused, never the draw type. An explicit `null` is accepted too, because absent and
+    // null mean the same thing to the server's `_draw_settings_write` (it omits a `None`
+    // before validating), and the client's own mapper sends neither.
+    it.each(['round-robin', 'single-elim'] as const)(
+      'ACCEPTS %s with no count at all, and stores null',
+      async (drawType) => {
+        const created = await createEvent({ draw_type: drawType })
+
+        expect(created.status).toBe(201)
+        expect((created.body as TournamentEventRead).qualifiers_per_pool).toBeNull()
+
+        const withNull = await createEvent({
+          draw_type: drawType,
+          qualifiers_per_pool: null,
+        })
+        expect(withNull.status).toBe(201)
+        expect((withNull.body as TournamentEventRead).qualifiers_per_pool).toBeNull()
+      },
+    )
+  })
+
+  // ----- the pair rule: a count never travels alone --------------------------
+  it('refuses a qualifier count PATCHed with no draw type beside it', async () => {
+    // Judging it would mean reading the event's *stored* draw type, two layers past the
+    // boundary and after the request has been accepted — so the server refuses it at the
+    // edge (`_parse_draw_settings`). The editor always sends both: it PATCHes the whole
+    // form it rendered.
+    expectRefusal(await patchEvent({ qualifiers_per_pool: 2 }), 'send draw_type alongside it')
+  })
+
+  // ✅ ACCEPT — the discriminating twin of the case above. A patch that touches neither
+  // half of the draw configuration is the ordinary edit (renaming an event, moving its
+  // window), and a mirror that fired on the absence of a draw type would refuse ALL of
+  // them while every refusal case above still passed.
+  it('ACCEPTS a patch that names neither half of the draw configuration', async () => {
+    const { status, body } = await patchEvent({ name: 'Renamed Singles' })
+
+    expect(status).toBe(200)
+    expect((body as TournamentEventRead).name).toBe('Renamed Singles')
+    // …and the stored configuration is untouched by an edit that never mentioned it.
+    expect((body as TournamentEventRead).draw_type).toBe('round-robin')
+    expect((body as TournamentEventRead).qualifiers_per_pool).toBeNull()
   })
 })

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildFixtureTimeRead,
   DRAW_TYPE_CATALOGUE,
+  planDraw,
 } from '@/mocks/factories/tournaments/tournament.factory'
 import {
   createEvent,
@@ -1296,6 +1297,293 @@ describe('cutting a single-elimination draw', () => {
   })
 })
 
+// Cutting a ROUND-ROBIN-THEN-KNOCKOUT draw (#1227, ADR "rr-then-ko cuts both stages
+// upfront and seeds qualifiers rematch-free"). The format the enum lost in #1219 and got
+// back once it had a strategy — and the one whose two stages live in one event, so the
+// claims worth pinning are all about the SEAM: that a single cut produces pools *and* a
+// bracket, that the bracket is un-pooled (which is what routes it to the bracket view
+// rather than into a pool's list), and that its rounds restart at 1.
+describe('cutting a round-robin-then-knockout draw', () => {
+  beforeEach(() => resetTournamentsStore())
+
+  /** Sixteen entrants — enough to deal four pools of four (a full 4-slot bracket) or
+   * three of 6/5/5 (a 3-qualifier bracket, where a bye is visible). */
+  const TWO_STAGE = FULL_SINGLES
+
+  const eventOf = (eventId: string) =>
+    findTournament(TOURNAMENT)!.events.find((e) => e.id === eventId)!
+
+  const poolNamed = (id: string) => ({ id, name: id, slot: SLOT, table_ids: [] })
+
+  /** Re-type an event as two-stage, across `poolCount` pools, taking `qualifiers` out of
+   * each. The draw type and the pool set both FREEZE while a draw stands (ADR-0786), so
+   * any standing draw comes off first — the route a director would take through the UI.
+   *
+   * The qualifier count is patched **with** the draw type, because that is the only way
+   * it can be: the two are one configuration (ADR 20260727), and the server 422s a count
+   * that arrives without its type. It defaults to `1` so the cases below that predate it
+   * still describe the field they were written for — but it is now genuinely STORED and
+   * read back out at the cut, rather than a planner default nobody chose. */
+  function asRrThenKo(eventId: string, poolCount: number, qualifiers = 1) {
+    expect(uncutDraw(TOURNAMENT, eventId).ok).toBe(true)
+    const patched = updateEvent(TOURNAMENT, eventId, {
+      draw_type: 'rr-then-ko',
+      qualifiers_per_pool: qualifiers,
+      pools: Array.from({ length: poolCount }, (_, i) => poolNamed(`p-${i + 1}`)),
+    })
+    if (!patched.ok) throw new Error(`could not re-type ${eventId}`)
+  }
+
+  /** Cut `eventId`, failing loudly on a refusal — so a test that meant to assert about a
+   * two-stage draw never quietly asserts about `undefined`. */
+  function cut(eventId: string) {
+    const result = cutDraw(TOURNAMENT, eventId)
+    if (!result.ok) {
+      throw new Error(
+        `expected a cut, got ${result.status}: ${'detail' in result ? result.detail : ''}`,
+      )
+    }
+    return result.fixtures
+  }
+
+  /** The two stages, split the way the wire splits them: `pool_id IS NULL` **is** the
+   * knockout stage (ADR-0786), and there is no other column that says so. */
+  const pooled = (fixtures: ReturnType<typeof cut>) =>
+    fixtures.filter((f) => f.pool_id !== null)
+  const knockout = (fixtures: ReturnType<typeof cut>) =>
+    fixtures.filter((f) => f.pool_id === null)
+
+  it('cuts BOTH stages in one stroke — the pools and the whole bracket', () => {
+    // Not a convenience (ADR): `advance()` can only ever FILL a side of an existing
+    // fixture, never create one, so a bracket that did not exist at the cut could never
+    // come into being. The qualifier count is `P × K` = 4 × 1, known before anybody
+    // plays, so the bracket's size is settled at cut time.
+    asRrThenKo(TWO_STAGE, 4) // 16 entrants → four pools of four
+
+    const fixtures = cut(TWO_STAGE)
+
+    // Four pools of four: C(4,2) = 6 pairs each.
+    expect(pooled(fixtures)).toHaveLength(24)
+    // Four qualifiers → a 4-slot bracket: two semis and a final.
+    expect(knockout(fixtures)).toHaveLength(3)
+    // …and the store really kept them — a plan that never landed is not a draw.
+    expect(eventOf(TWO_STAGE).fixtures).toEqual(fixtures)
+  })
+
+  it('lays the pool stage out exactly as a round-robin draw', () => {
+    asRrThenKo(TWO_STAGE, 4)
+
+    const stage = pooled(cut(TWO_STAGE))
+
+    // Every fixture names one of THIS event's pools…
+    expect(new Set(stage.map((f) => f.pool_id))).toEqual(
+      new Set(eventOf(TWO_STAGE).pools.map((p) => p.id)),
+    )
+    // …every pair meets exactly once…
+    const pairs = stage.map((f) => [f.entry_a_id, f.entry_b_id].sort().join('|'))
+    expect(new Set(pairs).size).toBe(pairs.length)
+    // …nobody plays twice in a (pool, round), and no pool fixture is ever TBD: the pool
+    // stage is fully known at the cut, unlike the bracket hanging off it.
+    for (const fixture of stage) {
+      const sameRound = stage.filter(
+        (f) => f.pool_id === fixture.pool_id && f.round === fixture.round,
+      )
+      const players = sameRound.flatMap((f) => [f.entry_a_id, f.entry_b_id])
+      expect(new Set(players).size).toBe(players.length)
+      expect(fixture.entry_a_id).not.toBeNull()
+      expect(fixture.entry_b_id).not.toBeNull()
+    }
+  })
+
+  it('leaves the knockout stage UN-POOLED and entirely TBD', () => {
+    asRrThenKo(TWO_STAGE, 4)
+
+    const bracket = knockout(cut(TWO_STAGE))
+
+    // `pool_id IS NULL` is not cosmetic — it is the whole stage discriminator, and what
+    // sends these rows to the bracket view instead of a pool's fixture list.
+    expect(bracket.every((f) => f.pool_id === null)).toBe(true)
+    // Nobody has qualified yet, so every side is TBD. A bracket cut with entrants
+    // already in it would be seating people the pools have not chosen.
+    for (const fixture of bracket) {
+      expect([fixture.entry_a_id, fixture.entry_b_id]).toEqual([null, null])
+    }
+  })
+
+  it('restarts the knockout rounds at 1, rather than continuing the pool numbering', () => {
+    // Continuing was rejected as ill-defined, not merely ugly (ADR): pools may differ in
+    // size, so there is no single "last pool round" to offset from. Restarting is also
+    // what lets the client's bracket — which names rounds relative to the maximum it is
+    // handed — say "Final / Semifinals" with no change at all.
+    asRrThenKo(TWO_STAGE, 3) // 16 → pools of 6, 5, 5: the pool rounds differ in length
+
+    const fixtures = cut(TWO_STAGE)
+
+    // The longest pool runs to round 5, so a continuation would start the bracket at 6.
+    expect(Math.max(...pooled(fixtures).map((f) => f.round))).toBe(5)
+    expect(
+      [...new Set(knockout(fixtures).map((f) => f.round))].sort(),
+    ).toEqual([1, 2])
+  })
+
+  it('renders a bye as a MISSING round-1 slot, never an extra null-sided row', () => {
+    // Three pools taking one qualifier each → three qualifiers in a 4-slot bracket, so
+    // the top seed byes. A planner that emitted a "bye" row would give TWO round-1
+    // fixtures here; a bye is the ABSENCE of one (ADR-0786), leaving a gap in the
+    // position sequence — position 1 is simply not there.
+    asRrThenKo(TWO_STAGE, 3)
+
+    const bracket = knockout(cut(TWO_STAGE))
+    const roundOne = bracket.filter((f) => f.round === 1)
+
+    expect(roundOne).toHaveLength(1)
+    expect(roundOne[0].position).toBe(2)
+    expect(bracket.filter((f) => f.round === 2)).toHaveLength(1)
+  })
+
+  it('refuses a single pool taking a single qualifier, in the server’s words', () => {
+    // The one `P × K < 2` shape reachable at all (`K ≥ 1` is a bound at the request
+    // boundary, and the snake guarantees `P ≥ 1`): one pool, one qualifier, one player
+    // alone in the knockout stage.
+    asRrThenKo(TWO_STAGE, 1)
+
+    const result = cutDraw(TOURNAMENT, TWO_STAGE)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status).toBe(422)
+    expect(result.status === 422 && result.detail).toContain(
+      'leaves one player in the knockout stage',
+    )
+  })
+
+  it('makes the POOL stage’s refusals first, in round-robin’s own words', () => {
+    // The server runs `_snake` before it consults the qualifier count at all, so an
+    // rr-then-ko event with no pools is refused with the sentence about a *round-robin*
+    // draw. That reads oddly and is right: the pool stage of an rr-then-ko draw IS a
+    // round-robin, and inventing a second wording would put a sentence in the server's
+    // mouth it never says.
+    const patched = updateEvent(TOURNAMENT, EMPTY_SINGLES, {
+      draw_type: 'rr-then-ko',
+      pools: [],
+    })
+    expect(patched.ok).toBe(true)
+
+    const result = cutDraw(TOURNAMENT, EMPTY_SINGLES)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.status === 422 && result.detail).toContain('at least one pool')
+  })
+
+  /**
+   * **The store's K reaches the planner** (ADR 20260727) — the seam that was missing, and
+   * the reason the count had to be stored at all.
+   *
+   * ⚠️ This is the *silent* mismatch, which is why it needs pinning by size rather than
+   * by an error: with the count dropped on the way to `planDraw`, the arm falls back to
+   * `DEFAULT_QUALIFIERS_PER_POOL` (1) and cuts a perfectly well-formed bracket — just one
+   * sized for a K nobody chose. Nothing throws, nothing warns, and `npm run dev` and
+   * vitest both look healthy while an event configured at K=2 runs a K=1 knockout.
+   *
+   * Two pools of sixteen entrants, so the two candidate brackets are unmistakably
+   * different: `P × K` = 2 × 2 = 4 slots (2 semis + 1 final = **3** fixtures) against the
+   * default's 2 × 1 = 2 slots (**1** fixture).
+   */
+  it('cuts the bracket from the event’s OWN qualifier count, not the planner’s default', () => {
+    asRrThenKo(TWO_STAGE, 2, 2)
+
+    const bracket = knockout(cut(TWO_STAGE))
+
+    // 4 qualifiers → two semifinals and a final. A K=1 fallback would give exactly 1.
+    expect(bracket).toHaveLength(3)
+    expect(bracket.filter((f) => f.round === 1)).toHaveLength(2)
+  })
+
+  it('keeps the count on the stored event, so a re-read still knows it', () => {
+    asRrThenKo(TWO_STAGE, 2, 2)
+
+    // Not merely accepted by the PATCH — actually held, which is what the *next* cut
+    // (and the editor re-opening on this event) reads.
+    expect(eventOf(TWO_STAGE).qualifiers_per_pool).toBe(2)
+  })
+
+  // The pair moves together (ADR 20260727): a draw type with no knockout stage has no
+  // count, so re-typing away from rr-then-ko must not strand the old K on the event —
+  // that is a configuration the server's tagged union cannot even represent.
+  it('clears the count when the event is re-typed to a format with no knockout stage', () => {
+    asRrThenKo(TWO_STAGE, 2, 2)
+    expect(uncutDraw(TOURNAMENT, TWO_STAGE).ok).toBe(true)
+
+    const patched = updateEvent(TOURNAMENT, TWO_STAGE, { draw_type: 'round-robin' })
+
+    expect(patched.ok).toBe(true)
+    expect(eventOf(TWO_STAGE).qualifiers_per_pool).toBeNull()
+  })
+
+  it('survives a re-cut and an un-cut like any other draw', () => {
+    asRrThenKo(TWO_STAGE, 4)
+
+    const first = cut(TWO_STAGE)
+    // Nothing about either stage is random, so the same field cuts the same draw —
+    // bracket included, because its shape is a pure function of `P × K`.
+    expect(cut(TWO_STAGE)).toEqual(first)
+    expect(uncutDraw(TOURNAMENT, TWO_STAGE)).toEqual({ ok: true })
+    // Both stages go: a draw is just fixtures, whichever stage they belong to.
+    expect(eventOf(TWO_STAGE).fixtures).toEqual([])
+  })
+})
+
+// The qualifier count as a PARAMETER of the rr-then-ko planner. The store now stores it
+// and passes it in (see "cuts the bracket from the event's OWN qualifier count" above),
+// so the seam is covered end to end; these stay because they exercise `planDraw` directly
+// at counts the store's fixtures would need contorting to reach, and because the two
+// refusals that depend on K read most clearly next to the arithmetic that produces them.
+describe('planDraw, rr-then-ko, with a qualifier count', () => {
+  const entrants = (n: number) => Array.from({ length: n }, (_, i) => `entry-${i + 1}`)
+  const pools = (n: number) => Array.from({ length: n }, (_, i) => `p-${i + 1}`)
+
+  it('defaults to pool winners only — one qualifier from each pool', () => {
+    // 8 entrants across 2 pools of 4; K defaults to 1, so 2 qualifiers meet in a
+    // one-fixture bracket.
+    const plan = planDraw('rr-then-ko', entrants(8), pools(2))
+
+    if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
+    expect(plan.fixtures.filter((f) => f.pool_id === null)).toHaveLength(1)
+  })
+
+  it('sizes the bracket from P × K — derived, never configured', () => {
+    // 2 pools × 3 qualifiers = 6, padded to an 8-slot bracket: 7 slots, of which the two
+    // byed seeds' round-1 rows are absent → 2 round-1 + 2 semis + 1 final.
+    const plan = planDraw('rr-then-ko', entrants(12), pools(2), 3)
+
+    if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
+    expect(plan.fixtures.filter((f) => f.pool_id === null)).toHaveLength(5)
+  })
+
+  it('refuses taking more qualifiers than the smallest pool holds', () => {
+    // 9 entrants across 2 pools → 5 and 4; taking 5 from each is more than the 4 the
+    // smaller pool has, and the sentence names both numbers.
+    const plan = planDraw('rr-then-ko', entrants(9), pools(2), 5)
+
+    expect(plan.ok).toBe(false)
+    if (plan.ok) return
+    expect(plan.detail).toBe(
+      'Taking 5 qualifiers from each pool is more than the 4 entrants in the ' +
+        'smallest pool — take fewer qualifiers from each pool, or add entrants.',
+    )
+  })
+
+  it('allows a ONE-POOL draw once more than one player qualifies', () => {
+    // "League, then a playoff" is a real format (ADR), and so is K = ⌊N/P⌋, where
+    // everyone qualifies and the pool stage exists purely to seed.
+    const plan = planDraw('rr-then-ko', entrants(4), pools(1), 4)
+
+    if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
+    expect(plan.fixtures.filter((f) => f.pool_id === null)).toHaveLength(3)
+  })
+})
+
 // The DRAW-TYPE CATALOGUE (ADR 20260726) — the `draw_types` table, served on the page
 // that picks one. It is served rather than hardcoded client-side precisely so that "the
 // table gates what a director can pick" is a fact about the running system; a mock that
@@ -1307,10 +1595,14 @@ describe('the draw-type catalogue', () => {
     const catalogue = findTournament(TOURNAMENT)!.draw_type_catalogue
 
     expect(catalogue).toEqual(DRAW_TYPE_CATALOGUE)
-    // A row exists exactly when the type has an implementation, so the keys are the two
-    // members of `DrawType` — both of which `cutDraw` above can now plan.
-    expect(catalogue!.map((d) => d.key)).toEqual(['round-robin', 'single-elim'])
-    expect(catalogue!.map((d) => d.display_order)).toEqual([1, 2])
+    // A row exists exactly when the type has an implementation, so the keys are the
+    // members of `DrawType` — every one of which `cutDraw` above can now plan.
+    expect(catalogue!.map((d) => d.key)).toEqual([
+      'round-robin',
+      'single-elim',
+      'rr-then-ko',
+    ])
+    expect(catalogue!.map((d) => d.display_order)).toEqual([1, 2, 3])
     // The copy is what a director reads while choosing; neither field is ever empty.
     for (const drawType of catalogue!) {
       expect(drawType.name.length).toBeGreaterThan(0)

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -1481,10 +1481,11 @@ describe('cutting a round-robin-then-knockout draw', () => {
    * the reason the count had to be stored at all.
    *
    * ⚠️ This is the *silent* mismatch, which is why it needs pinning by size rather than
-   * by an error: with the count dropped on the way to `planDraw`, the arm falls back to
-   * `DEFAULT_QUALIFIERS_PER_POOL` (1) and cuts a perfectly well-formed bracket — just one
-   * sized for a K nobody chose. Nothing throws, nothing warns, and `npm run dev` and
-   * vitest both look healthy while an event configured at K=2 runs a K=1 knockout.
+   * by an error: a count substituted on the way to `planDraw` cuts a perfectly well-formed
+   * bracket — just one sized for a K nobody chose. Nothing throws, nothing warns, and
+   * `npm run dev` and vitest both look healthy while an event configured at K=2 runs a
+   * K=1 knockout. (The planner having no default is what makes *dropping* the argument a
+   * type error; this pins the value that actually arrives.)
    *
    * Two pools of sixteen entrants, so the two candidate brackets are unmistakably
    * different: `P × K` = 2 × 2 = 4 slots (2 semis + 1 final = **3** fixtures) against the
@@ -1543,10 +1544,11 @@ describe('planDraw, rr-then-ko, with a qualifier count', () => {
   const entrants = (n: number) => Array.from({ length: n }, (_, i) => `entry-${i + 1}`)
   const pools = (n: number) => Array.from({ length: n }, (_, i) => `p-${i + 1}`)
 
-  it('defaults to pool winners only — one qualifier from each pool', () => {
-    // 8 entrants across 2 pools of 4; K defaults to 1, so 2 qualifiers meet in a
-    // one-fixture bracket.
-    const plan = planDraw('rr-then-ko', entrants(8), pools(2))
+  it('takes pool winners only at K = 1 — the smallest legal count', () => {
+    // 8 entrants across 2 pools of 4, K = 1, so 2 qualifiers meet in a one-fixture
+    // bracket. The count is passed explicitly like every other: the planner has no
+    // default, so "pool winners only" is a configuration, never an omission.
+    const plan = planDraw('rr-then-ko', entrants(8), pools(2), 1)
 
     if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
     expect(plan.fixtures.filter((f) => f.pool_id === null)).toHaveLength(1)
@@ -2047,7 +2049,9 @@ describe('the seeded two-stage (rr-then-ko) events', () => {
         'rr-then-ko',
         event.entrants.map((e) => e.id),
         event.pools.map((p) => p.id),
-        event.qualifiers_per_pool!,
+        // The event's own count, unasserted: the planner takes `number | null` and
+        // refuses the impossible pair loudly, so there is nothing here to talk past.
+        event.qualifiers_per_pool,
       )
       if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
 

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -1942,3 +1942,274 @@ describe('the venue on a create/update', () => {
     })
   })
 })
+
+// ----- the seeded TWO-STAGE events (ADR 20260727) --------------------------------
+//
+// `rr-then-ko` reads out as the results union's THIRD arm,
+// `kind: "standings_then_finishes"` — one standings block per pool plus the bracket's
+// finishes — and this store derives none of it: every seeded event hardcodes its own
+// `results`, and `cutDraw` never writes one. So the shape exists in `npm run dev` and in
+// vitest only because the seed spells it out, and a hand-written block with nothing
+// checking it is a block whose arithmetic rots the first time somebody edits a row.
+//
+// These are the checks that stop that. Each one is a claim the server really makes and
+// that slice 4c's rendering leans on:
+//
+//   - the champion is the **bracket final's winner** — never a pool leader, because the
+//     pool stage only seeds the bracket (topping a pool wins nothing);
+//   - the finishes follow single-elimination's own placement shape
+//     (`2 ** (final_round − round) + 1`), so same-round losers SHARE a position;
+//   - each pool's standings add up across that pool's own fixtures;
+//   - `complete` is **both** stages decided, not either.
+//
+// They are asserted against the STORE, not through `apiToTournament`: `parseResults` does
+// not know this `kind` yet (that is 4c), and the seed's honesty is a fact about the
+// payload regardless of who can currently read it.
+describe('the seeded two-stage (rr-then-ko) events', () => {
+  beforeEach(() => resetTournamentsStore())
+
+  const GOLDEN_STATE = 'golden-state-classic-2026'
+  const FINISHED = 'ev-challenge-cup' // pools decided, bracket decided, champion crowned
+  const MID_FLIGHT = 'ev-shield' // pools decided, the final still to be played
+
+  type Fixture = components['schemas']['TournamentFixtureRead']
+  type TwoStageResults =
+    components['schemas']['StandingsThenFinishesResultsRead']
+
+  const eventOf = (eventId: string) =>
+    findTournament(GOLDEN_STATE)!.events.find((e) => e.id === eventId)!
+
+  /** The event's results, having first asserted they really are the two-stage arm — so
+   * every check below is reading the shape it claims to read. */
+  function resultsOf(eventId: string): TwoStageResults {
+    const results = eventOf(eventId).results
+    expect(results?.kind).toBe('standings_then_finishes')
+    return results as TwoStageResults
+  }
+
+  /** The knockout stage: `pool_id IS NULL` IS the bracket (ADR-0786), which is exactly
+   * how the server tells the two stages apart. */
+  const bracketOf = (eventId: string): Fixture[] =>
+    eventOf(eventId).fixtures.filter((f) => f.pool_id === null)
+
+  /** The FINAL — the single fixture in the bracket's last round. Its winner is the
+   * event's champion, and `null` there is why an unfinished event has none. */
+  function finalOf(eventId: string): Fixture {
+    const bracket = bracketOf(eventId)
+    const lastRound = Math.max(...bracket.map((f) => f.round))
+    const final = bracket.filter((f) => f.round === lastRound)
+    expect(final).toHaveLength(1)
+    return final[0]
+  }
+
+  /** Wins and losses per entry, counted off a pool's FIXTURES — the independent reading
+   * the hardcoded standings block is checked against. */
+  function recordFromFixtures(fixtures: Fixture[]) {
+    const record = new Map<string, { wins: number; losses: number }>()
+    const bump = (id: string, key: 'wins' | 'losses') => {
+      const row = record.get(id) ?? { wins: 0, losses: 0 }
+      row[key] += 1
+      record.set(id, row)
+    }
+    for (const fixture of fixtures) {
+      const { entry_a_id: a, entry_b_id: b, winner_entry_id: winner } = fixture
+      expect(a).not.toBeNull()
+      expect(b).not.toBeNull()
+      expect(winner).not.toBeNull()
+      bump(winner!, 'wins')
+      bump(winner === a ? b! : a!, 'losses')
+    }
+    return record
+  }
+
+  it.each([FINISHED, MID_FLIGHT])(
+    '%s is an rr-then-ko event whose results are the standings_then_finishes arm',
+    (eventId) => {
+      const event = eventOf(eventId)
+
+      expect(event.draw_type).toBe('rr-then-ko')
+      // The count that sized the bracket at the cut — NOT null, unlike every count-less
+      // draw type in the seed.
+      expect(event.qualifiers_per_pool).toBe(2)
+      const results = resultsOf(eventId)
+      // Both blocks, always: a two-stage event that sent only one of them would be a
+      // shape neither existing panel can read.
+      expect(results.pools.length).toBeGreaterThan(0)
+      expect(Array.isArray(results.finishes)).toBe(true)
+    },
+  )
+
+  it.each([FINISHED, MID_FLIGHT])(
+    "%s's bracket is the one planDraw would cut — played out, not hand-drawn",
+    (eventId) => {
+      const event = eventOf(eventId)
+      const plan = planDraw(
+        'rr-then-ko',
+        event.entrants.map((e) => e.id),
+        event.pools.map((p) => p.id),
+        event.qualifiers_per_pool!,
+      )
+      if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
+
+      // The SHAPE — every fixture's id, stage, round and position — is the cut's. Only
+      // the sides and the winners differ, which is precisely what playing an event does
+      // to a draw. A bracket of a different size (or one that renumbered its rounds)
+      // would be a draw this store could never have produced.
+      const shapeOf = (fixtures: Fixture[]) =>
+        fixtures.map((f) => ({
+          id: f.id,
+          pool_id: f.pool_id,
+          round: f.round,
+          position: f.position,
+        }))
+      expect(shapeOf(event.fixtures)).toEqual(shapeOf(plan.fixtures))
+    },
+  )
+
+  it.each([FINISHED, MID_FLIGHT])(
+    "%s's pool standings add up across that pool's own fixtures",
+    (eventId) => {
+      const event = eventOf(eventId)
+      const results = resultsOf(eventId)
+
+      for (const pool of results.pools) {
+        const fixtures = event.fixtures.filter((f) => f.pool_id === pool.pool_id)
+        expect(fixtures.length).toBeGreaterThan(0)
+        const played = recordFromFixtures(fixtures)
+
+        // The table names exactly the pool's players, once each, ranked 1..n.
+        expect(pool.rows.map((r) => r.rank)).toEqual(
+          pool.rows.map((_, i) => i + 1),
+        )
+        expect(new Set(pool.rows.map((r) => r.entry_id)).size).toBe(
+          pool.rows.length,
+        )
+        expect(new Set(pool.rows.map((r) => r.entry_id))).toEqual(
+          new Set(played.keys()),
+        )
+
+        for (const row of pool.rows) {
+          const actual = played.get(row.entry_id)!
+          // The wins/losses a director reads are the ones the fixtures RECORD…
+          expect({ entry: row.entry_id, ...actual }).toEqual({
+            entry: row.entry_id,
+            wins: row.wins,
+            losses: row.losses,
+          })
+          // …every match counts as played exactly once…
+          expect(row.played).toBe(row.wins + row.losses)
+          // …and the difference is the server's own reduction of the two counts beside
+          // it, never a third independent number.
+          expect(row.game_difference).toBe(row.games_won - row.games_lost)
+        }
+
+        // Every game won by somebody was lost by somebody else, so a pool's two game
+        // columns balance. This is the check a typo in one cell cannot survive.
+        const sum = (pick: (r: (typeof pool.rows)[number]) => number) =>
+          pool.rows.reduce((total, row) => total + pick(row), 0)
+        expect(sum((r) => r.games_won)).toBe(sum((r) => r.games_lost))
+        // …and one win is one loss.
+        expect(sum((r) => r.wins)).toBe(fixtures.length)
+        expect(sum((r) => r.losses)).toBe(fixtures.length)
+      }
+    },
+  )
+
+  it.each([FINISHED, MID_FLIGHT])(
+    "%s's finishes follow single-elimination's tie shape",
+    (eventId) => {
+      const results = resultsOf(eventId)
+      const finalRound = finalOf(eventId).round
+
+      // `2 ** (final_round − round) + 1` for a loser, 1 for the champion — the SAME
+      // arithmetic `SingleElimResults` uses, which is what makes the two-stage arm's
+      // finishes block the single-elim one rather than a near-copy of it.
+      for (const finish of results.finishes) {
+        const expected =
+          finish.eliminated_in_round === null
+            ? 1
+            : 2 ** (finalRound - finish.eliminated_in_round) + 1
+        expect({ entry: finish.entry_id, position: finish.position }).toEqual({
+          entry: finish.entry_id,
+          position: expected,
+        })
+      }
+
+      // Same round out ⇒ same position, and no two entrants share a position without
+      // sharing a round: inventing an order between two semifinal losers would fabricate
+      // a result the bracket never produced.
+      const roundsByPosition = new Map<number, Set<number | null>>()
+      for (const finish of results.finishes) {
+        const rounds = roundsByPosition.get(finish.position) ?? new Set()
+        rounds.add(finish.eliminated_in_round)
+        roundsByPosition.set(finish.position, rounds)
+      }
+      for (const rounds of roundsByPosition.values()) {
+        expect(rounds.size).toBe(1)
+      }
+
+      // Ordered by position, as the wire sends it — the client renders it untouched.
+      const positions = results.finishes.map((f) => f.position)
+      expect(positions).toEqual([...positions].sort((a, b) => a - b))
+      // Nobody is placed twice.
+      expect(new Set(results.finishes.map((f) => f.entry_id)).size).toBe(
+        results.finishes.length,
+      )
+    },
+  )
+
+  // THE decision of ADR 20260727, and the one property 4c's rendering hangs on: the
+  // champion comes from the BRACKET. A fixture whose champion also happened to top a pool
+  // would leave "crowned from the knockout" and "crowned from the standings"
+  // indistinguishable on screen — and a renderer that read the wrong one would look
+  // right.
+  it('crowns the FINAL’s winner — who is nobody’s pool leader', () => {
+    const results = resultsOf(FINISHED)
+    const final = finalOf(FINISHED)
+
+    expect(final.winner_entry_id).not.toBeNull()
+    expect(results.champion).toBe(final.winner_entry_id)
+    // …and that entrant tops NO pool.
+    const poolLeaders = results.pools.map((p) => p.rows[0].entry_id)
+    expect(poolLeaders).not.toContain(results.champion)
+    // The champion is a real entrant of this event and is placed 1st in the finishes.
+    expect(eventOf(FINISHED).entrants.map((e) => e.id)).toContain(
+      results.champion,
+    )
+    expect(results.finishes[0]).toMatchObject({
+      entry_id: results.champion,
+      position: 1,
+      eliminated_in_round: null,
+    })
+    // Both pool leaders are still IN the finishes — they just lost, and are tied 3rd.
+    for (const leader of poolLeaders) {
+      expect(results.finishes.map((f) => f.entry_id)).toContain(leader)
+    }
+  })
+
+  // `complete` is BOTH stages decided. The mid-flight event is what makes that a real
+  // claim rather than a restatement of "the pools are done": every one of its pools says
+  // `complete`, and the event does not.
+  it('is complete only when the pools AND the bracket are decided', () => {
+    const finished = resultsOf(FINISHED)
+    expect(finished.pools.every((p) => p.complete)).toBe(true)
+    expect(finalOf(FINISHED).winner_entry_id).not.toBeNull()
+    expect(finished.complete).toBe(true)
+
+    const midFlight = resultsOf(MID_FLIGHT)
+    // Stage one: done, every pool of it.
+    expect(midFlight.pools.every((p) => p.complete)).toBe(true)
+    // Stage two: the final is SEATED — both sides known, `advance()` carried the
+    // semifinal winners in — and unplayed.
+    const final = finalOf(MID_FLIGHT)
+    expect(final.entry_a_id).not.toBeNull()
+    expect(final.entry_b_id).not.toBeNull()
+    expect(final.winner_entry_id).toBeNull()
+    // …so there is no champion, and the event is NOT complete.
+    expect(midFlight.champion).toBeNull()
+    expect(midFlight.complete).toBe(false)
+    // The finishes hold only what the bracket has actually settled: the two beaten
+    // semifinalists, tied 3rd. No 1st, no 2nd — those do not exist yet.
+    expect(midFlight.finishes.map((f) => f.position)).toEqual([3, 3])
+  })
+})

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -74,7 +74,13 @@ type ScheduleSolveRead = components['schemas']['ScheduleSolveRead']
  * so `[]` is the real state of an event nobody has cut a draw for, and the only things
  * that ever change it are the two draw verbs (`cutDraw` / `uncutDraw` below). An event
  * PATCH deliberately leaves it alone — a director editing an event's name has not
- * thrown their draw away. */
+ * thrown their draw away.
+ *
+ * `qualifiers_per_pool` is stored too, and it has to be: it is what sizes an
+ * `rr-then-ko` draw's bracket at the cut (`P × K`, ADR 20260727). Before it had a home
+ * here, `planEventDraw` passed nothing and every two-stage event was cut at the planner's
+ * default of one qualifier per pool — a well-formed bracket of the wrong size, for an
+ * event the director had configured otherwise, with nothing reporting the substitution. */
 type StoredEvent = Omit<TournamentEventRead, 'entered' | 'entry_state'> & {
   /** Seeded: the dev user is refused by this rule, at this rating. */
   ineligible?: { predicate_id: string; rating: number }
@@ -220,6 +226,9 @@ function seed(): StoredTournament[] {
           name: 'Open Singles',
           format: 'singles',
           draw_type: 'round-robin',
+          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
+          // value this draw type's settings row admits.
+          qualifiers_per_pool: null,
           max_players: 64,
           entry_fee: 45,
           timezone: 'America/Chicago',
@@ -255,15 +264,18 @@ function seed(): StoredTournament[] {
           //
           // It is ALSO the seed's **uncuttable** event, and it stays uncuttable for a
           // reason that survives (ADR 20260726): round-robin with **NO POOLS**. It used
-          // to be `rr-then-ko`, refused because nothing could plan that type — but that
-          // slug left the enum, and "an unplannable type" is no longer a state a valid
-          // event can be in. `pools: []` is the refusal that replaces it, and it is
+          // to be `rr-then-ko`, refused because nothing could plan that type — but "an
+          // unplannable type" is no longer a state a valid event can be in (that slug is
+          // back, with a strategy, since #1227). `pools: []` replaces it, and it is
           // permanent: "A round-robin draw needs at least one pool." Do not give it pools.
           id: 'ev-u1500',
           tournament_id: 'bay-area-open-2026',
           name: 'U1500 Singles',
           format: 'singles',
           draw_type: 'round-robin',
+          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
+          // value this draw type's settings row admits.
+          qualifiers_per_pool: null,
           max_players: 48,
           entry_fee: 30,
           timezone: 'America/Los_Angeles',
@@ -287,6 +299,9 @@ function seed(): StoredTournament[] {
           name: 'Championship Singles',
           format: 'singles',
           draw_type: 'single-elim',
+          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
+          // value this draw type's settings row admits.
+          qualifiers_per_pool: null,
           max_players: 16,
           entry_fee: 60,
           timezone: 'America/Los_Angeles',
@@ -321,6 +336,9 @@ function seed(): StoredTournament[] {
           name: 'U1200 Singles',
           format: 'singles',
           draw_type: 'round-robin',
+          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
+          // value this draw type's settings row admits.
+          qualifiers_per_pool: null,
           max_players: 24,
           entry_fee: 20,
           timezone: 'America/Los_Angeles',
@@ -384,6 +402,9 @@ function seed(): StoredTournament[] {
           name: 'Mixed Doubles',
           format: 'doubles',
           draw_type: 'single-elim',
+          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
+          // value this draw type's settings row admits.
+          qualifiers_per_pool: null,
           max_players: 32,
           entry_fee: 25,
           timezone: 'America/Los_Angeles',
@@ -442,6 +463,9 @@ function seed(): StoredTournament[] {
           name: 'Slam Open Singles',
           format: 'singles',
           draw_type: 'round-robin',
+          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
+          // value this draw type's settings row admits.
+          qualifiers_per_pool: null,
           max_players: 16,
           entry_fee: 20,
           timezone: 'America/New_York',
@@ -503,6 +527,9 @@ function seed(): StoredTournament[] {
           name: "Women's Championship Singles",
           format: 'singles',
           draw_type: 'single-elim',
+          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
+          // value this draw type's settings row admits.
+          qualifiers_per_pool: null,
           max_players: 32,
           entry_fee: 40,
           timezone: 'America/Los_Angeles',
@@ -596,6 +623,9 @@ function seed(): StoredTournament[] {
           name: 'Garage Singles',
           format: 'singles',
           draw_type: 'round-robin',
+          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
+          // value this draw type's settings row admits.
+          qualifiers_per_pool: null,
           max_players: 8,
           entry_fee: 0,
           timezone: 'America/Los_Angeles',
@@ -1330,6 +1360,13 @@ export function createEvent(
     name: body.name,
     format: body.format,
     draw_type: body.draw_type,
+    // **K**, stored beside the draw type it belongs to (ADR 20260727). Absent means the
+    // draw type has no knockout stage to qualify for, which is `null` — the value the
+    // settings row really holds — never `undefined`, and never an invented `1`: the day
+    // this event's draw is cut, this is the number the bracket is sized from
+    // (`planEventDraw` below), so a fallback here would deal a bracket for a K the
+    // director never chose.
+    qualifiers_per_pool: body.qualifiers_per_pool ?? null,
     // A missing cap is "no cap" (ADR-0935), stored as null — never undefined.
     max_players: body.max_players ?? null,
     entry_fee: body.entry_fee,
@@ -1387,6 +1424,17 @@ export function updateEvent(
     name: patch.name ?? event.name,
     format: patch.format ?? event.format,
     draw_type: patch.draw_type ?? event.draw_type,
+    // **The draw configuration is patched as a UNIT** (ADR 20260727): the server refuses
+    // a `qualifiers_per_pool` with no `draw_type` beside it (422), so a patch that names
+    // a draw type carries the whole pair — including the `null` that *removes* a count
+    // when the type moves to one that has no knockout stage. Reading it with `??` would
+    // strand the old K on the new type, which is precisely the contradiction the union
+    // exists to make unrepresentable. A patch that names no draw type is not touching the
+    // configuration at all, and leaves both halves alone.
+    qualifiers_per_pool:
+      patch.draw_type === undefined || patch.draw_type === null
+        ? event.qualifiers_per_pool
+        : (patch.qualifiers_per_pool ?? null),
     // An explicit `null` clears the cap (ADR-0935); only an *absent* key leaves
     // the stored cap untouched. `??` would conflate the two, silently keeping a
     // cap the editor meant to remove.
@@ -1531,6 +1579,16 @@ function planEventDraw(event: StoredEvent): DrawPlan {
     event.draw_type,
     ordered.map((e) => e.id),
     event.pools.map((p) => p.id),
+    // **The event's own K** (ADR 20260727) — the number the director configured, not the
+    // planner's default. `undefined` (a count-less draw type) lets the default stand,
+    // where it is never read: only the `rr-then-ko` arm consults it, and an `rr-then-ko`
+    // event always has one (its create/patch body is a 422 without it).
+    //
+    // ⚠️ Passing nothing here is the whole bug this argument closes, and it is a SILENT
+    // one: an event configured at K=2 would be cut into a `P × 1` bracket — a perfectly
+    // well-formed draw of the wrong size, with nothing anywhere reporting the
+    // substitution.
+    event.qualifiers_per_pool ?? undefined,
   )
 }
 
@@ -1543,12 +1601,12 @@ function planEventDraw(event: StoredEvent): DrawPlan {
  *
  * The 422s are the planner's (see `planDraw` in the tournament factory, shared with the
  * Playwright store), and they are the ones a director actually meets: a round-robin with
- * no pools, a pool the snake would leave with fewer than two entrants, and a bracket of
- * fewer than two. **There is no draw-TYPE refusal**: both
- * members of `DrawType` have a strategy on the server (ADR 20260726) and both have a
- * planner here, so a mock that still refused single-elim would be putting a sentence in
- * the server's mouth that it can no longer say — and would make a single-elim cut
- * untestable in `npm run dev`, in vitest and in the browser at once. */
+ * no pools, a pool the snake would leave with fewer than two entrants, a bracket of
+ * fewer than two, and a two-stage draw whose knockout would hold one player.
+ * **There is no draw-TYPE refusal**: every member of `DrawType` has a strategy on the
+ * server (ADR 20260726) and a planner here, so a mock that still refused one would be
+ * putting a sentence in the server's mouth that it can no longer say — and would make
+ * that draw untestable in `npm run dev`, in vitest and in the browser at once. */
 export function cutDraw(tournamentId: string, eventId: string): CutDrawResult {
   const owned = requireOwned(tournamentId)
   if (!owned.ok) return owned

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -79,9 +79,14 @@ type ScheduleSolveRead = components['schemas']['ScheduleSolveRead']
  *
  * `qualifiers_per_pool` is stored too, and it has to be: it is what sizes an
  * `rr-then-ko` draw's bracket at the cut (`P × K`, ADR 20260727). Before it had a home
- * here, `planEventDraw` passed nothing and every two-stage event was cut at the planner's
- * default of one qualifier per pool — a well-formed bracket of the wrong size, for an
- * event the director had configured otherwise, with nothing reporting the substitution. */
+ * here, `planEventDraw` passed nothing and every two-stage event was cut at one qualifier
+ * per pool — a well-formed bracket of the wrong size, for an event the director had
+ * configured otherwise, with nothing reporting the substitution.
+ *
+ * **It is `null` for every draw type but `rr-then-ko`** (ADR 20260727), which is why the
+ * seed below states the bare literal and says no more: no knockout stage to qualify for,
+ * so no qualifier count — `null` is the only value those draw types' settings row admits,
+ * and it is not "unset". */
 type StoredEvent = Omit<TournamentEventRead, 'entered' | 'entry_state'> & {
   /** Seeded: the dev user is refused by this rule, at this rating. */
   ineligible?: { predicate_id: string; rating: number }
@@ -519,8 +524,6 @@ function seed(): StoredTournament[] {
           name: 'Open Singles',
           format: 'singles',
           draw_type: 'round-robin',
-          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
-          // value this draw type's settings row admits.
           qualifiers_per_pool: null,
           max_players: 64,
           entry_fee: 45,
@@ -566,8 +569,6 @@ function seed(): StoredTournament[] {
           name: 'U1500 Singles',
           format: 'singles',
           draw_type: 'round-robin',
-          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
-          // value this draw type's settings row admits.
           qualifiers_per_pool: null,
           max_players: 48,
           entry_fee: 30,
@@ -592,8 +593,6 @@ function seed(): StoredTournament[] {
           name: 'Championship Singles',
           format: 'singles',
           draw_type: 'single-elim',
-          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
-          // value this draw type's settings row admits.
           qualifiers_per_pool: null,
           max_players: 16,
           entry_fee: 60,
@@ -629,8 +628,6 @@ function seed(): StoredTournament[] {
           name: 'U1200 Singles',
           format: 'singles',
           draw_type: 'round-robin',
-          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
-          // value this draw type's settings row admits.
           qualifiers_per_pool: null,
           max_players: 24,
           entry_fee: 20,
@@ -695,8 +692,6 @@ function seed(): StoredTournament[] {
           name: 'Mixed Doubles',
           format: 'doubles',
           draw_type: 'single-elim',
-          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
-          // value this draw type's settings row admits.
           qualifiers_per_pool: null,
           max_players: 32,
           entry_fee: 25,
@@ -756,8 +751,6 @@ function seed(): StoredTournament[] {
           name: 'Slam Open Singles',
           format: 'singles',
           draw_type: 'round-robin',
-          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
-          // value this draw type's settings row admits.
           qualifiers_per_pool: null,
           max_players: 16,
           entry_fee: 20,
@@ -820,8 +813,6 @@ function seed(): StoredTournament[] {
           name: "Women's Championship Singles",
           format: 'singles',
           draw_type: 'single-elim',
-          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
-          // value this draw type's settings row admits.
           qualifiers_per_pool: null,
           max_players: 32,
           entry_fee: 40,
@@ -916,8 +907,6 @@ function seed(): StoredTournament[] {
           name: 'Garage Singles',
           format: 'singles',
           draw_type: 'round-robin',
-          // No knockout stage, so no qualifier count (ADR 20260727): `null` is the only
-          // value this draw type's settings row admits.
           qualifiers_per_pool: null,
           max_players: 8,
           entry_fee: 0,
@@ -2075,16 +2064,15 @@ function planEventDraw(event: StoredEvent): DrawPlan {
     event.draw_type,
     ordered.map((e) => e.id),
     event.pools.map((p) => p.id),
-    // **The event's own K** (ADR 20260727) — the number the director configured, not the
-    // planner's default. `undefined` (a count-less draw type) lets the default stand,
-    // where it is never read: only the `rr-then-ko` arm consults it, and an `rr-then-ko`
-    // event always has one (its create/patch body is a 422 without it).
+    // **The event's own K** (ADR 20260727) — the stored number, passed through unchanged.
+    // `null` is the honest answer for a count-less draw type, and only the `rr-then-ko`
+    // arm reads it at all; an `rr-then-ko` event always has one (its create/patch body is
+    // a 422 without it), so that arm never meets the null.
     //
-    // ⚠️ Passing nothing here is the whole bug this argument closes, and it is a SILENT
-    // one: an event configured at K=2 would be cut into a `P × 1` bracket — a perfectly
-    // well-formed draw of the wrong size, with nothing anywhere reporting the
-    // substitution.
-    event.qualifiers_per_pool ?? undefined,
+    // ⚠️ Substituting anything here is the whole bug this argument closes, and it is a
+    // SILENT one: an event configured at K=2 would be cut into a `P × 1` bracket — a
+    // perfectly well-formed draw of the wrong size, with nothing anywhere reporting it.
+    event.qualifiers_per_pool,
   )
 }
 

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -21,6 +21,7 @@
 import type { components } from '@/api/schema'
 import { FORTYMM_LEAGUE_ID } from '@/mocks/factories/players/player-league.factory'
 import {
+  buildTournamentFixtureRead,
   DRAW_TYPE_CATALOGUE,
   entryStateFor,
   planDraw,
@@ -186,6 +187,298 @@ const SLAM_POOLS: Pool[] = [
     slot: { date: '2026-08-22', start: '11:00', end: '13:00' },
     table_ids: ['t3', 't4'],
   },
+]
+
+// ----- the seed's TWO-STAGE events (`rr-then-ko`, ADR 20260727) -------------------
+//
+// Two of them, on their own tournament (`GOLDEN_STATE` below): the **Challenge Cup**,
+// played out to a champion, and the **Shield**, whose pools are decided while its bracket
+// is still mid-flight. Between them they are the only place the results union's third arm
+// (`kind: "standings_then_finishes"`) exists outside the server — complete and partial.
+//
+// They are hand-seeded, and that is not laziness: **this store derives no results at
+// all.** Every seeded event states its own `results` block and `cutDraw` never writes one
+// (the same seam `ev-u1200`'s standings come through), so without fixtures that spell the
+// shape out, the two-stage arm is a thing only the server has ever produced.
+//
+// ⚠️ A results shape the client has no arm for is NOT contained by parking it on a
+// tournament of its own, and believing it was cost this seed a broken app. `parseResults`
+// throws on an unknown `kind` (by design — ADR 20260727 says so out loud), and the
+// tournaments **list** handler returns full detail rows, results included, which the list
+// query maps through that same parser. So while the third arm was seeded and unparsed, the
+// throw failed the LIST query and took the entire `/tournaments` section down — every
+// tournament, not just this one. The separate row buys isolation for the *detail* query
+// only; nothing isolates the list.
+//
+// The lesson, for the next arm: **the parser and the fixture that exercises it must land
+// together.** (vitest stayed green throughout, because every list test stubs the endpoint
+// with a hand-built row — the suite was green about a stub. `npm run dev` was not.)
+//
+// The numbers below are consistent by construction and `tournaments-store.test.ts` holds
+// them to it: the standings' wins and losses are the ones the POOL FIXTURES record, the
+// finishes follow single-elimination's tie shape, and the champion is the FINAL's winner
+// — never a pool leader.
+
+/** The tournament both two-stage events run at: **live**, mid-weekend, with one event
+ * finished and one still playing. It is also the seed's only `live` row, so `npm run dev`
+ * gets a started tournament for free. */
+const GOLDEN_STATE_ID = 'golden-state-classic-2026'
+
+const CUP_EVENT_ID = 'ev-challenge-cup'
+const SHIELD_EVENT_ID = 'ev-shield'
+
+/** An event's entrant ids in registration order — read off `otherEntrants` rather than
+ * spelled out, so the ids a results block names and the ids the event actually holds
+ * cannot drift apart. `player.N`'s id is at index `N − 1`, which is what lets the outcome
+ * tables below read as the matches a director would recognise (`cup(5)` beat `cup(1)`)
+ * instead of as array indices. */
+const CUP_ENTRY_IDS = otherEntrants(CUP_EVENT_ID, 8).map((e) => e.id)
+const SHIELD_ENTRY_IDS = otherEntrants(SHIELD_EVENT_ID, 6).map((e) => e.id)
+
+const cup = (n: number): string => CUP_ENTRY_IDS[n - 1]
+const shield = (n: number): string => SHIELD_ENTRY_IDS[n - 1]
+
+/** The Challenge Cup's two pools. Pulled out of the seed for the reason `U1200_POOLS` is
+ * — the fixtures are planned against these very ids, so they cannot be spelled twice and
+ * spelled differently. */
+const CUP_POOLS: Pool[] = [
+  {
+    id: 'p-cup-a',
+    name: 'Pool A',
+    slot: { date: '2026-06-06', start: '09:00', end: '11:00' },
+    table_ids: ['t1', 't2'],
+  },
+  {
+    id: 'p-cup-b',
+    name: 'Pool B',
+    slot: { date: '2026-06-06', start: '11:00', end: '13:00' },
+    table_ids: ['t3', 't4'],
+  },
+]
+
+/** The Shield's two pools — a day later and on the other four tables, so the tournament
+ * raises no double-booking diagnostic (`findPoolConflicts`). */
+const SHIELD_POOLS: Pool[] = [
+  {
+    id: 'p-shield-a',
+    name: 'Pool A',
+    slot: { date: '2026-06-07', start: '09:00', end: '10:30' },
+    table_ids: ['t5', 't6'],
+  },
+  {
+    id: 'p-shield-b',
+    name: 'Pool B',
+    slot: { date: '2026-06-07', start: '10:30', end: '12:00' },
+    table_ids: ['t7', 't8'],
+  },
+]
+
+/** One played pool match: `[winner, loser, winner's games, loser's games]` over an
+ * event's `player.N` numbering. Best-of-three throughout (`length_games: 3`), so every
+ * score is `2–0` or `2–1`. */
+type PoolPlay = readonly [number, number, number, number]
+
+/**
+ * Every pool match the **Challenge Cup** played — the play its standings block reports.
+ *
+ * Written out as OUTCOMES rather than as the standings themselves, because the two are
+ * the seed's two independent statements about the same pool stage: this table stamps each
+ * planned pool fixture with its `winner_entry_id`, the results block states the table a
+ * director reads, and the store's test derives the first into the second and fails if they
+ * disagree. A single hand-written standings block with nothing to check it against is a
+ * block whose arithmetic rots the first time somebody edits a row.
+ */
+const CUP_POOL_PLAY: readonly PoolPlay[] = [
+  // Pool A (`player.1`, `.4`, `.5`, `.8` — the snake's deal): `player.5` unbeaten,
+  // `player.1` second on 2–1, then `player.4`, then a winless `player.8`. No tie, so the
+  // finishing order is wins alone.
+  [5, 1, 2, 1],
+  [1, 4, 2, 0],
+  [1, 8, 2, 0],
+  [5, 4, 2, 0],
+  [4, 8, 2, 1],
+  [5, 8, 2, 0],
+  // Pool B (`player.2`, `.3`, `.6`, `.7`): TWO ties, both broken by **two-way
+  // head-to-head** — the first tiebreak the finishing order falls through to
+  // (`player.3` over `player.2` at 2–1 each, `player.6` over `player.7` at 1–2 each).
+  // Seeded deliberately: a pool where wins alone settle everything leaves the chain the
+  // qualifiers are chosen by completely unexercised. The game difference agrees with
+  // head-to-head in both cases, so the table still reads top-to-bottom without a director
+  // having to know why.
+  [3, 2, 2, 0],
+  [2, 6, 2, 1],
+  [2, 7, 2, 1],
+  [3, 6, 2, 1],
+  [7, 3, 2, 1],
+  [6, 7, 2, 0],
+]
+
+/**
+ * Every pool match the **Shield** played. Both pools are decided; the knockout stage is
+ * not (see `SHIELD_KNOCKOUT_FIXTURES`).
+ *
+ * Pool A is a **three-way tie** — everybody 1–1 — which head-to-head cannot break (it
+ * only settles a *two*-way one), so the order falls through to game difference:
+ * `player.1` (+1), `player.5` (0), `player.4` (−1). That is the next link of the same
+ * chain the Cup's Pool B exercises, and between them the two events cover it.
+ */
+const SHIELD_POOL_PLAY: readonly PoolPlay[] = [
+  // Pool A — `player.1`, `.4`, `.5`.
+  [1, 4, 2, 0],
+  [5, 1, 2, 1],
+  [4, 5, 2, 1],
+  // Pool B — `player.2`, `.3`, `.6`: no tie at all. `player.2` unbeaten, `player.6`
+  // winless.
+  [2, 3, 2, 1],
+  [3, 6, 2, 0],
+  [2, 6, 2, 0],
+]
+
+/** `entry id | entry id` (sorted) → the winner's entry id, for every pool match of one
+ * event. The lookup `stampPoolWinners` uses to record play on the PLANNED fixtures, so
+ * the draw the store would have cut and the play the results report are one thing. */
+function poolWinnersOf(
+  play: readonly PoolPlay[],
+  entryOf: (n: number) => string,
+): Map<string, string> {
+  return new Map(
+    play.map(([winner, loser]) => [
+      [entryOf(winner), entryOf(loser)].sort().join('|'),
+      entryOf(winner),
+    ]),
+  )
+}
+
+const CUP_POOL_WINNERS = poolWinnersOf(CUP_POOL_PLAY, cup)
+const SHIELD_POOL_WINNERS = poolWinnersOf(SHIELD_POOL_PLAY, shield)
+
+/** Record an event's play on its planned pool fixtures — the state a decided pool's
+ * fixtures are really in. The play table names every pairing exactly once, so a fixture
+ * with no entry in the map is a planner/seed disagreement rather than an unplayed match,
+ * and it throws here rather than seeding a half-played pool nobody notices. */
+function stampPoolWinners(
+  fixtures: TournamentFixtureRead[],
+  winners: ReadonlyMap<string, string>,
+): TournamentFixtureRead[] {
+  return fixtures.map((fixture) => {
+    const key = [fixture.entry_a_id, fixture.entry_b_id].sort().join('|')
+    const winner = winners.get(key)
+    if (winner === undefined) {
+      throw new Error(`seed: no pool result for fixture ${fixture.id}`)
+    }
+    return { ...fixture, winner_entry_id: winner }
+  })
+}
+
+/**
+ * The Challenge Cup's knockout stage, **played out** — the state the bracket reaches once
+ * every pool has finished, `advance()` has seated its qualifiers, and all three matches
+ * have been won.
+ *
+ * Written out rather than planned, because seating a qualifier and carrying a winner
+ * forward are `advance()`'s job on the server and this store implements neither. What
+ * keeps it honest is a test: the seeded bracket's `(id, pool_id, round, position)` shape
+ * is asserted equal to the one `planDraw('rr-then-ko', …)` cuts for this very field, so
+ * this is that bracket with its sides filled in — never a differently-shaped one.
+ *
+ * **Who plays whom is the ADR's seeding, not a choice made here.** Qualifiers are ordered
+ * place-major — both pool winners (`player.5`, `player.3`) outrank both runners-up
+ * (`player.1`, `player.2`) — and the pool order *within* a place is picked so round one
+ * pairs nobody with a pool-mate: seeds 1–4 are `player.5`, `player.3`, `player.1`,
+ * `player.2`, and a 4-bracket pairs 1 v 4 and 2 v 3, i.e. A-winner v B-runner-up and
+ * B-winner v A-runner-up.
+ *
+ * **And both pool winners lose in round one.** That is the point of the fixture: the
+ * champion is `player.2`, who came SECOND in pool B, and the two entrants who topped
+ * their pools finish tied 3rd. Crown the pool leader instead and nothing on screen can
+ * tell "champion from the bracket" (the ADR's decision) from "champion from the
+ * standings".
+ */
+const CUP_KNOCKOUT_FIXTURES: TournamentFixtureRead[] = [
+  // Semifinal 1 — seed 1 (`player.5`, pool A's winner) v seed 4 (`player.2`, pool B's
+  // runner-up). The runner-up wins.
+  buildTournamentFixtureRead({
+    id: 'fx-ko-r1-p1',
+    pool_id: null,
+    round: 1,
+    position: 1,
+    entry_a_id: cup(5),
+    entry_b_id: cup(2),
+    winner_entry_id: cup(2),
+  }),
+  // Semifinal 2 — seed 2 (`player.3`, pool B's winner) v seed 3 (`player.1`, pool A's
+  // runner-up). The runner-up wins again.
+  buildTournamentFixtureRead({
+    id: 'fx-ko-r1-p2',
+    pool_id: null,
+    round: 1,
+    position: 2,
+    entry_a_id: cup(3),
+    entry_b_id: cup(1),
+    winner_entry_id: cup(1),
+  }),
+  // The final — two runners-up, and `player.2` takes it. THIS fixture's winner is the
+  // event's champion; the standings have no say in it.
+  buildTournamentFixtureRead({
+    id: 'fx-ko-r2-p1',
+    pool_id: null,
+    round: 2,
+    position: 1,
+    entry_a_id: cup(2),
+    entry_b_id: cup(1),
+    winner_entry_id: cup(2),
+  }),
+]
+
+/**
+ * The Shield's knockout stage, **mid-flight** — both semifinals won, the final seated and
+ * still to be played.
+ *
+ * This is the state the two-stage results shape spends most of a tournament in, and the
+ * reason it is seeded alongside the finished Cup: `complete` is false because the SECOND
+ * stage is undecided even though every pool is done, `champion` is `null` because no
+ * final has been won, and `finishes` holds only the two entrants the bracket has actually
+ * placed — the beaten semifinalists, tied 3rd. A results panel built solely against the
+ * finished event would never meet a finishes list that starts at position 3.
+ *
+ * Seeds 1–4 are `player.1`, `player.2` (the pool winners) then `player.5`, `player.3`
+ * (the runners-up), by the same place-major, pool-mate-avoiding rule the Cup uses.
+ */
+const SHIELD_KNOCKOUT_FIXTURES: TournamentFixtureRead[] = [
+  // Semifinal 1 — seed 1 (`player.1`, pool A) v seed 4 (`player.3`, pool B). The top
+  // seed holds.
+  buildTournamentFixtureRead({
+    id: 'fx-ko-r1-p1',
+    pool_id: null,
+    round: 1,
+    position: 1,
+    entry_a_id: shield(1),
+    entry_b_id: shield(3),
+    winner_entry_id: shield(1),
+  }),
+  // Semifinal 2 — seed 2 (`player.2`, pool B's winner) v seed 3 (`player.5`, pool A's
+  // runner-up), and the runner-up takes it.
+  buildTournamentFixtureRead({
+    id: 'fx-ko-r1-p2',
+    pool_id: null,
+    round: 1,
+    position: 2,
+    entry_a_id: shield(2),
+    entry_b_id: shield(5),
+    winner_entry_id: shield(5),
+  }),
+  // The final: both sides SEATED — `advance()` has carried the semifinal winners in — and
+  // no winner recorded. A ready fixture waiting to be played, which is precisely why this
+  // event has no champion yet.
+  buildTournamentFixtureRead({
+    id: 'fx-ko-r2-p1',
+    pool_id: null,
+    round: 2,
+    position: 1,
+    entry_a_id: shield(1),
+    entry_b_id: shield(5),
+    winner_entry_id: null,
+  }),
 ]
 
 function seed(): StoredTournament[] {
@@ -638,6 +931,209 @@ function seed(): StoredTournament[] {
           results: null,
           created_at: '2026-06-13T18:01:00Z',
           updated_at: '2026-06-13T18:01:00Z',
+        },
+      ],
+    },
+    {
+      // The seed's **two-stage** tournament (ADR 20260727) — and its only `live` one.
+      //
+      // Both of its events are `rr-then-ko`, and between them they hold the two states
+      // the results union's third arm (`kind: "standings_then_finishes"`) has: the
+      // Challenge Cup finished on the Saturday and has a champion; the Shield's pools are
+      // decided and its final is still to be played. Everything they are built from — the
+      // pools, the play, the brackets, and why the champion is who it is — is in the
+      // block above `seed()`.
+      //
+      // It is Los Angeles, ~345 miles from Berkeley, on purpose: every near-me test in
+      // the suite searches around Berkeley at 10 or 35 miles, so a venue placed anywhere
+      // in the Bay would silently join their expected result sets.
+      id: GOLDEN_STATE_ID,
+      name: 'Golden State Classic 2026',
+      description: 'Pools on the Saturday, knockout on the Sunday.',
+      status: 'live',
+      start_date: '2026-06-06',
+      end_date: '2026-06-07',
+      league_id: DEFAULT_LEAGUE_ID,
+      address: {
+        venue: 'Golden State TT Center',
+        street: '3900 W Sixth St',
+        city: 'Los Angeles',
+        region: 'CA',
+        postal: '90020',
+        country: 'USA',
+        latitude: 34.0522,
+        longitude: -118.2437,
+      },
+      table_catalogue: tables(8),
+      created_by_user_id: DEV_USER_ID,
+      created_by_username: DEV_USERNAME,
+      can_edit: true,
+      created_at: '2026-05-02T10:00:00Z',
+      updated_at: '2026-06-07T11:20:00Z',
+      latest_schedule_solve: null,
+      events: [
+        {
+          // FINISHED: both pools decided, the bracket run to a final, a champion crowned.
+          //
+          // FULL (8 of 8), deliberately: a finished event must not offer the dev user an
+          // Enter button, and an entry would make its draw *stale* — a decided event
+          // whose draw no longer seats its field is a state the server could never be in.
+          id: CUP_EVENT_ID,
+          tournament_id: GOLDEN_STATE_ID,
+          name: 'Challenge Cup',
+          format: 'singles',
+          draw_type: 'rr-then-ko',
+          // TWO qualifiers per pool — the number that sizes the bracket at the cut
+          // (`P × K` = 2 × 2 = 4, derived and never configured, ADR 20260727). Unlike
+          // every other event in this seed it is NOT null: a knockout stage to qualify
+          // for is exactly what this draw type has.
+          qualifiers_per_pool: 2,
+          max_players: 8,
+          entry_fee: 35,
+          timezone: 'America/Los_Angeles',
+          entrants: otherEntrants(CUP_EVENT_ID, 8),
+          slot: { date: '2026-06-06', start: '09:00', end: '16:00' },
+          match_settings: { rated: true, length_games: 3 },
+          predicates: [],
+          pools: CUP_POOLS,
+          // BOTH STAGES, in the order the wire sends them: the pool fixtures planned by
+          // the same function `cutDraw` uses — then stamped with the winners they were
+          // actually played to — followed by the knockout bracket, seated and decided.
+          // `tournaments-store.test.ts` asserts this whole list has the shape
+          // `planDraw('rr-then-ko', …)` cuts for this very field, so it is that draw
+          // played out rather than a hand-drawn one no cut would produce.
+          fixtures: [
+            ...stampPoolWinners(
+              planRoundRobinFixtures(
+                CUP_ENTRY_IDS,
+                CUP_POOLS.map((p) => p.id),
+              ),
+              CUP_POOL_WINNERS,
+            ),
+            ...CUP_KNOCKOUT_FIXTURES,
+          ],
+          // The third arm of the results union (ADR 20260727), tagged
+          // `standings_then_finishes`: ONE standings block per pool and ONE finishes
+          // block for the bracket — the very models the round-robin and single-elim arms
+          // send, so each stage renders with the panel that already exists.
+          //
+          // `complete: true` is BOTH stages decided, not either: every pool says
+          // `complete`, and the bracket has run to a final. `champion` is that final's
+          // winner (`player.2`) — and `player.2` tops NO pool, which is the whole point.
+          // Topping a pool wins nothing here; the pool stage only seeds the bracket.
+          results: {
+            kind: 'standings_then_finishes',
+            complete: true,
+            champion: cup(2),
+            pools: [
+              {
+                pool_id: 'p-cup-a',
+                complete: true,
+                rows: [
+                  { entry_id: cup(5), rank: 1, played: 3, wins: 3, losses: 0, games_won: 6, games_lost: 1, game_difference: 5 },
+                  { entry_id: cup(1), rank: 2, played: 3, wins: 2, losses: 1, games_won: 5, games_lost: 2, game_difference: 3 },
+                  { entry_id: cup(4), rank: 3, played: 3, wins: 1, losses: 2, games_won: 2, games_lost: 5, game_difference: -3 },
+                  { entry_id: cup(8), rank: 4, played: 3, wins: 0, losses: 3, games_won: 1, games_lost: 6, game_difference: -5 },
+                ],
+              },
+              {
+                // Both of this pool's ties are broken by two-way head-to-head, so the
+                // rank column is NOT a re-reading of the wins column: `player.3` and
+                // `player.2` both went 2–1, and `player.3` won the match between them.
+                pool_id: 'p-cup-b',
+                complete: true,
+                rows: [
+                  { entry_id: cup(3), rank: 1, played: 3, wins: 2, losses: 1, games_won: 5, games_lost: 3, game_difference: 2 },
+                  { entry_id: cup(2), rank: 2, played: 3, wins: 2, losses: 1, games_won: 4, games_lost: 4, game_difference: 0 },
+                  { entry_id: cup(6), rank: 3, played: 3, wins: 1, losses: 2, games_won: 4, games_lost: 4, game_difference: 0 },
+                  { entry_id: cup(7), rank: 4, played: 3, wins: 1, losses: 2, games_won: 3, games_lost: 5, game_difference: -2 },
+                ],
+              },
+            ],
+            // Single-elimination's own placement shape (`2 ** (final_round − round) + 1`):
+            // 1st, 2nd, then the two semifinal losers **tied 3rd** — same round out, same
+            // position, because the bracket never played them off. Those two losers are
+            // the pool winners.
+            finishes: [
+              { entry_id: cup(2), position: 1, eliminated_in_round: null },
+              { entry_id: cup(1), position: 2, eliminated_in_round: 2 },
+              { entry_id: cup(5), position: 3, eliminated_in_round: 1 },
+              { entry_id: cup(3), position: 3, eliminated_in_round: 1 },
+            ],
+          },
+          created_at: '2026-05-02T10:05:00Z',
+          updated_at: '2026-06-06T17:12:00Z',
+        },
+        {
+          // MID-FLIGHT: the same shape, one round from home. Every pool is decided and
+          // the final is seated and unplayed, so `complete` is false, `champion` is null,
+          // and `finishes` holds only what the bracket has actually settled.
+          id: SHIELD_EVENT_ID,
+          tournament_id: GOLDEN_STATE_ID,
+          name: 'Shield Singles',
+          format: 'singles',
+          draw_type: 'rr-then-ko',
+          // Two pools of three, two qualifiers from each — `K = ⌊N/P⌋`, the legal
+          // maximum, where everyone but the pool's last qualifies and the pool stage
+          // exists purely to seed (ADR 20260727).
+          qualifiers_per_pool: 2,
+          max_players: 6,
+          entry_fee: 25,
+          timezone: 'America/Los_Angeles',
+          entrants: otherEntrants(SHIELD_EVENT_ID, 6),
+          slot: { date: '2026-06-07', start: '09:00', end: '16:00' },
+          match_settings: { rated: true, length_games: 3 },
+          predicates: [],
+          pools: SHIELD_POOLS,
+          fixtures: [
+            ...stampPoolWinners(
+              planRoundRobinFixtures(
+                SHIELD_ENTRY_IDS,
+                SHIELD_POOLS.map((p) => p.id),
+              ),
+              SHIELD_POOL_WINNERS,
+            ),
+            ...SHIELD_KNOCKOUT_FIXTURES,
+          ],
+          // The PARTIAL two-stage read. Note what is and is not true of it: both pools
+          // say `complete`, and the event still does not — `complete` is *both* stages
+          // decided, and one final stands between this event and its champion. The
+          // finishes list therefore starts at position **3**: the two beaten
+          // semifinalists are the only entrants the bracket has placed, and 1st and 2nd
+          // do not exist yet.
+          results: {
+            kind: 'standings_then_finishes',
+            complete: false,
+            champion: null,
+            pools: [
+              {
+                // A THREE-way tie — everyone 1–1 — which two-way head-to-head cannot
+                // break, so the order is game difference: +1, 0, −1.
+                pool_id: 'p-shield-a',
+                complete: true,
+                rows: [
+                  { entry_id: shield(1), rank: 1, played: 2, wins: 1, losses: 1, games_won: 3, games_lost: 2, game_difference: 1 },
+                  { entry_id: shield(5), rank: 2, played: 2, wins: 1, losses: 1, games_won: 3, games_lost: 3, game_difference: 0 },
+                  { entry_id: shield(4), rank: 3, played: 2, wins: 1, losses: 1, games_won: 2, games_lost: 3, game_difference: -1 },
+                ],
+              },
+              {
+                pool_id: 'p-shield-b',
+                complete: true,
+                rows: [
+                  { entry_id: shield(2), rank: 1, played: 2, wins: 2, losses: 0, games_won: 4, games_lost: 1, game_difference: 3 },
+                  { entry_id: shield(3), rank: 2, played: 2, wins: 1, losses: 1, games_won: 3, games_lost: 2, game_difference: 1 },
+                  { entry_id: shield(6), rank: 3, played: 2, wins: 0, losses: 2, games_won: 0, games_lost: 4, game_difference: -4 },
+                ],
+              },
+            ],
+            finishes: [
+              { entry_id: shield(3), position: 3, eliminated_in_round: 1 },
+              { entry_id: shield(2), position: 3, eliminated_in_round: 1 },
+            ],
+          },
+          created_at: '2026-05-02T10:06:00Z',
+          updated_at: '2026-06-07T11:20:00Z',
         },
       ],
     },

--- a/web-client/src/routes/_app/tournaments.$tournamentId.test.tsx
+++ b/web-client/src/routes/_app/tournaments.$tournamentId.test.tsx
@@ -181,3 +181,27 @@ describe('tournament detail route — a missing tournament is a not-found, not a
     ).not.toBeInTheDocument()
   })
 })
+
+// #1231 QA note: rapid clicks on the event editor's Create button created
+// duplicate events in production. The fix (`EventEditor`'s `saving` prop, wired
+// here as `savingEvent={createEvent.isPending || updateEvent.isPending}`) is
+// covered by a PROP-CONTRACT test at `EventEditor` — see "the pending-mutation
+// gate (#1231 QA)" in `event-editor.test.tsx`.
+//
+// A literal click-race reproduction was attempted here first and deliberately
+// dropped: instrumenting the real commits showed the gap between React Hook
+// Form's `isSubmitting` clearing and the mutation's own `isPending` clearing is
+// real (confirmed on the committed DOM — the button was briefly present AND
+// enabled while `open` was already `false`), but nothing in jsdom yields
+// between those two commits — there is no paint/frame boundary the way a real
+// browser has — so no `userEvent`/`fireEvent`/`waitFor`-driven double click
+// could land inside it. Four independent reproduction shapes (simultaneous
+// `userEvent.click`s, synchronous `fireEvent.click`s, a `waitFor`-timed second
+// click on the re-enable edge, and a `MutationObserver`-driven catch) all
+// produced exactly one POST under BOTH the fixed and the deliberately-broken
+// (`savingEvent={false}`) wiring — i.e. a test built that way could not tell
+// the two apart, so it would not have caught a regression. Reproducing the
+// real animation-held window would need a Radix `Presence`/CSS-animation
+// stand-in, which risks asserting a state the code path doesn't actually
+// reach — see `.claude/rules/verify-the-artifact-under-test.md` on a red built
+// from a fabricated setup proving nothing.

--- a/web-client/src/routes/_app/tournaments.$tournamentId.tsx
+++ b/web-client/src/routes/_app/tournaments.$tournamentId.tsx
@@ -112,6 +112,13 @@ function TournamentDetailRoute() {
         })
       }}
       onDeleteEvent={(id) => deleteEvent.mutate(id)}
+      // One in-flight write at a time, the way `EnterEventControl` does it: the editor
+      // disables its submit control while this is true. It covers a window
+      // React-Hook-Form's `isSubmitting` does not — `isPending` stays true through
+      // `onSuccess`, which awaits the tournament refetch — and that gap is how five
+      // rapid clicks on Create event made five identical events (#1231 QA). Both
+      // mutations, one flag: only one of them can be the open editor's.
+      savingEvent={createEvent.isPending || updateEvent.isPending}
       onBack={back}
     />
   )

--- a/web-client/src/test/rendered-html.ts
+++ b/web-client/src/test/rendered-html.ts
@@ -1,0 +1,29 @@
+// The **equivalence guard** for a refactor that must not change what a user sees.
+//
+// A behaviour-preserving refactor claims the rendered output is unchanged. Assertions that
+// spell out a few strings and test ids prove far less than that claim — they stay green
+// while a wrapper, a class, an `aria-*` or a whole cell quietly moves. This takes the
+// component's entire DOM, so an inline snapshot of it reds on *any* rendered difference,
+// however small.
+//
+// The one thing normalized away is React's generated ids (`useId` — `_r_0_` on React 19.2,
+// `«r0»`/`:r0:` in other versions). They are an implementation detail of render order, not something a
+// user or a screen reader ever sees as a value: what matters is that the two ends of an
+// `aria-labelledby` still point at each other, which is an *accessible-name* assertion
+// (`getByRole('region', { name: … })`) and belongs beside the snapshot, not inside it.
+// Left un-normalized they would make the snapshot fragile against unrelated renders.
+
+/** Every React-generated id: the React 19.2 (`_r_0_`, `_r_1a_`), the `«r0»` and the older
+ * `:r0:` spelling. */
+const REACT_GENERATED_ID = /_r_[0-9a-z_]*_|«[^»]+»|:r[0-9a-z]+:/g
+
+/**
+ * An element's whole rendered DOM as a string, with React's generated ids replaced by a
+ * stable placeholder — for a `toMatchInlineSnapshot()` equivalence guard.
+ *
+ * Pin it **before** the refactor, on the untouched code, and it will red on any DOM, text,
+ * class, attribute or test-id change the refactor causes.
+ */
+export function renderedHtml(element: HTMLElement): string {
+  return element.outerHTML.replace(REACT_GENERATED_ID, 'ID')
+}


### PR DESCRIPTION
Closes #1227.

Runs round-robin pools, then seeds a single-elimination knockout from the pool finishers — top *K* from each pool advance. Design captured in `docs/adr/20260727-rr-then-ko-cuts-both-stages-upfront-and-seeds-qualifiers-rematch-free.md`; the glossary gains **Stage** and **Qualifier**.

## What a director sees

Pick **Round-robin then knockout**, set qualifiers per pool, cut the draw once — and get every pool's fixtures *plus* the full bracket, sized `next_power_of_two(P × K)`, with byes as absent fixtures rather than null-sided rows. As each pool finishes, its qualifiers take their predetermined bracket slots while the other pools are still playing. The tournament page shows pool standings above bracket finishes, under one champion banner naming the **knockout** winner — never a pool leader.

## The decisions worth knowing

**Round-one is rematch-free for two or more pools, and it is proven, not tested-and-hoped.** Round-one pairing is always seed `s` vs `B+1−s`, so the problem reduces to choosing which qualifier gets which seed number. A place block holds each pool once (intra-block pairs are safe automatically) and each seed has exactly one partner (so at most one forbidden pool), which makes a conflict-free assignment always exist. Verified across the legal space and independently to 40 pools × 16 qualifiers. **A single pool is an explicit waiver** — every knockout match there is a rematch by construction, which is the format working as intended.

**Both stages are cut in one stroke.** `AdvancePlan` can only express `SideFill`; it has no way to create a fixture, and giving it one is a far wider blast radius than a new strategy. Bracket size is derived, never configured.

**Knockout rounds restart at 1**, because the unique constraint is `NULLS NOT DISTINCT` over `(event_id, pool_id, round, position)`. Continuing from the pool rounds is ill-defined, not merely ugly: pools differ in size, so "the semifinal" would be a different number in every event.

**The schedule preview now covers the pool stage** instead of refusing. Previously one such event aborted the preview for every unrelated round-robin event beside it. The knockout stage is honestly reported as unscheduled — driven by a *count of dropped fixtures*, so it cannot claim an omission that didn't happen. Scheduling it is #1228.

**Known limitation, shipped deliberately and documented:** a pool correction landing *after* its qualifiers were seated re-orders the standings but leaves the bracket seated as it was. Single-elimination already behaves this way.

## Where the risk was

Three things were caught by verification that every green suite had missed:

- The client never sent `qualifiers_per_pool` while the server required it — so the format was selectable and **422'd against the real API**, with vitest, the web-client Playwright suite and the dev server all green. Fixing it needed the event *read* shape widened, because sending the field blind would have been worse than the bug: every PATCH carries the pair as a unit, so an unrelated rename would have overwritten the director's setting or tripped the freeze with a spurious 409.
- The materialization seam didn't load game counts, so the strategy would have ordered pools on **wins alone** — picking different qualifiers than the standings on screen, with nothing failing.
- Seeding a two-stage fixture took down the **entire tournaments list page**, because the list handler returns full detail rows and the list query parses every one. vitest couldn't see it: every list test stubs the endpoint.

A `/simplify` pass then found the game-count load running on *every* result submission for draw types that never read it (completion cost: 3 statements → 1), and a bye rule re-stated six lines from the function that owns it — a silent-drift path under the rematch guarantee. It also caught a flaw in the ADR's own proof: the conclusion held, but the stated reason was wrong in exactly the case that matters. Corrected in this PR.

## Testing

| Suite | Result |
| --- | --- |
| api — ruff, ruff format, mypy `--strict` | clean, 165 source files |
| api — pytest | **2063 passed** |
| web-client — vitest | **3331 passed** (318 files) |
| web-client — eslint, `tsc -b && vite build` | clean (1 pre-existing warning in a generated file) |
| web-client — Playwright | **316 passed**, matching `--list`'s 316 |
| root e2e — composed stack, real API, no mocks | **22/22 collected ran**; green at constrained concurrency |
| iOS — clean simulator build | `** BUILD SUCCEEDED **` |
| Migration | `alembic upgrade head` against fresh Postgres, seed + CHECK inspected |

The root e2e suite reds under host contention (14 failures at 12 workers → 2 at 2 workers → 0 isolated) on specs this branch touches no code for. Discriminated rather than assumed; the rr-then-ko spec passes throughout.

Also filed while working: **#1228** (schedule the knockout stage), **#1229** (tournament detail unreachable in dev — slug ids vs a UUID route), **#1230** (near-me silently drops venues inside the radius — an antimeridian bug in the bounding box, reproduced deterministically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
