### PR TITLE
Wire up dependency installs for Claude Code cloud sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,35 @@ Full stack via Docker: `docker compose -f docker-compose.dev.yml up`. Nginx on *
 
 **Always reap a QA stack once its branch merges** (`land-the-plane` Step 8). `docker compose down -v` is *not* enough — it leaves the stack's locally-built images and buildx cache behind. Skipping this grew `Docker.raw` to 230 GB and wedged the daemon; with ~78 worktrees each able to spawn a `fortymm-qa-<id>` stack, it compounds fast. Use `scripts/qa-down.sh` (`--all` for every QA stack, `--dry-run` to preview, opt-in `--prune-cache` for the global build cache). **Never** blanket-`prune`: `fortymm-uat_postgres-data` is unattached and would be silently destroyed along with the k3d `tailscale-state` Secrets.
 
+## Cloud sessions
+
+This repo runs in Claude Code cloud sessions (claude.ai/code). `.claude/settings.json` wires a
+SessionStart hook, `scripts/install_tools.sh`. On a cloud session, the hook installs `mise`'s
+`node` and `python` tools. It then installs project dependencies: `api/.venv`, root
+`node_modules`, `web-client/node_modules`, and `e2e/node_modules`.
+
+The cloud environment lives in your claude.ai account, not in this repo. It holds network access,
+environment variables, and a setup script that installs `mise`. Configure or check it at
+claude.ai/code, under the cloud icon above the message box.
+
+A setup script for this repo already exists, based on comments in `scripts/install_tools.sh`.
+Before you create a new one, open the existing environment and check its setup script.
+
+If you create a new setup script, note one gap. Trusted network access covers npm, PyPI, and
+Docker Hub, but not `mise.run`, the domain `mise`'s own installer uses. Add `mise.run` under
+Custom network access, or install `mise` through a method that stays inside the Trusted list.
+
+What runs in a cloud session, unmodified:
+- `pytest` in `api/`. Docker comes pre-installed, so testcontainers can start Postgres.
+- The root `e2e/` Docker Compose suite.
+- `scripts/qa-up.sh`. The session's disk is disposable, so you do not need to run
+  `scripts/qa-down.sh` there.
+
+What does not run, by design:
+- `ios/` work. Cloud sessions run Ubuntu. The iOS build needs Xcode.
+- `mise run redeploy-uat`. It targets the shared k3d/Tailscale cluster, not a throwaway session.
+  The cloud-session hook skips `helm` and `k3d` for this reason.
+
 ## Cross-cutting invariants
 
 **OpenAPI is the source of truth for client/server types.** `web-client/src/api/schema.d.ts` is generated from the API's `openapi.json` (`npm run gen:api`, consumed by `openapi-fetch` in `web-client/src/api/client.ts`). The `openapi-schema` CI workflow fails if the committed file drifts. Whenever you change FastAPI routes or pydantic schemas (docstrings count — they become OpenAPI descriptions), run `mise run regen-api-types` and commit `schema.d.ts` in the same PR.

--- a/scripts/install_tools.sh
+++ b/scripts/install_tools.sh
@@ -52,11 +52,22 @@ cd "$CLAUDE_PROJECT_DIR"
 # Trust the config (mise refuses to auto-install from untrusted files)
 mise trust --yes
 
-# Idempotent: skips anything already installed
-mise install
+# node + python only. helm and k3d are UAT-only (mise run redeploy-uat), which
+# is out of scope for a cloud session anyway (targets the persistent shared
+# k3d/Tailscale cluster). Skipping them also sidesteps a real download risk: a
+# cloud session's GitHub release-asset requests only reach repos attached to
+# the session, and helm/k3d's release assets live in unattached repos.
+mise install node python
 
 # Persist mise's env into subsequent bash calls in this session.
 # $CLAUDE_ENV_FILE is sourced by Claude Code before each Bash tool call.
 mise env -s bash >> "$CLAUDE_ENV_FILE"
+
+# Project dependencies. Guarded so a resumed session (hook reruns every
+# startup/resume) doesn't reinstall on every turn.
+[ -d api/.venv ] || (cd api && python -m venv .venv && .venv/bin/pip install -e '.[dev]')
+[ -d node_modules ] || npm ci
+[ -d web-client/node_modules ] || (cd web-client && npm ci)
+[ -d e2e/node_modules ] || (cd e2e && npm ci)
 
 exit 0


### PR DESCRIPTION
## Summary
- `scripts/install_tools.sh` already bootstrapped `mise` for cloud sessions (`CLAUDE_CODE_REMOTE` gate) but stopped at toolchains — a fresh cloud session had no `api/.venv`, `node_modules`, `web-client/node_modules`, or `e2e/node_modules`. Add guarded installs for each.
- Scope the cloud-session `mise install` to `node` + `python` only. `helm`/`k3d` are UAT-only (`mise run redeploy-uat`, a persistent shared k3d/Tailscale cluster) and their release assets risk a 403 in a cloud session, since GitHub release-asset requests there only reach repos attached to the session.
- Document cloud sessions in `CLAUDE.md`: what already works unmodified (`pytest` + testcontainers, the root `e2e/` compose suite, `scripts/qa-up.sh` — disk is disposable so no `qa-down.sh` needed there), and what's out of scope by design (`ios/`, `redeploy-uat`).

## Context
The cloud *environment* itself (network access, env vars, the setup script that installs `mise`) lives in the claude.ai account, not the repo, and already exists per the "mise binary itself was installed by the env setup script" comment in `install_tools.sh` — this PR only closes the repo-side gap (project dependencies), not the account-level config. One open flag, called out in `CLAUDE.md`: Trusted network access doesn't list `mise.run`, the domain `mise`'s own installer script uses, so if a new environment's setup script fails to install `mise`, that's the likely cause.

## Test plan
- [x] `bash -n scripts/install_tools.sh` — syntax check
- [ ] Start a fresh Claude Code cloud session on this branch and confirm the hook installs deps without error
- [ ] Confirm `pytest` in `api/` and the root `e2e/` suite run in that session

https://claude.ai/code/session_018YFSBpZe15199TwvozRq9F