### PR TITLE
Record the pool/table normalization decisions before building them (#1226)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -550,17 +550,30 @@ One match's spot in the **schedule**: a **table** and a **predicted start time**
 lives on the **fixture** (not the match), so it can be set before the match even
 exists and survives **materialization**. The time is a real moment but a **prediction,
 not a promise** — a match beginning earlier or later than its placement is normal, not
-an error. It is stored as a **naive local timestamp** in the venue's wall-clock frame —
-the *same* frame as a pool's **Slot** window (also naive), so "is this placement inside
-its window" is a plain comparison; matching Slot's frame is why it is not `timestamptz`
-(that would need a venue timezone this domain does not model, and a Slot migration to
-match). Its constraints (table belongs to the pool, time inside the window, no table or
-player double-booked) are **not invariants** and never hard-block: a pool's tables and
-window even stay editable under a standing draw, stranding placements a later edit
-outranges. They are judged as **flags derived on read**, never silently rewritten.
+an error. It is stored as a **timezone-aware instant**, composed from the event's
+wall-clock **Slot** components anchored by the event's own timezone, so "is this
+placement inside its window" is answered in the event's frame. Its constraints (table
+belongs to the pool, time inside the window, no table or player double-booked) are
+**not invariants** and never hard-block: a pool's tables and window even stay editable
+under a standing draw, stranding placements a later edit outranges. They are judged as
+**flags derived on read**, never silently rewritten. The one exception is the **table
+itself**: a placement always names a real **table**, because a reference that resolves
+to nothing is a dangling pointer rather than a state a director chose.
 _Avoid_: schedule slot, booking, appointment, start time (it is a *predicted* start),
 finish (a **Finish** is an *entrant*'s finishing position in a bracket's **results** —
 an outcome, not a schedule cell).
+
+**Table**:
+One physical playing surface at the **venue** — what a match is actually played on,
+identified by a label and the court it stands on. Tables belong to the **tournament**,
+not to any one **event**, and the tournament's whole set of them is its **catalogue**.
+A **pool** *reserves* a subset of the catalogue for its window; a **placement** *names*
+one. The venue changes under a running tournament — a table breaks, a table frees up —
+so a table can be removed from the catalogue mid-event: pools that reserved it simply
+stop reserving it, while a **placement** standing on it blocks the removal until the
+director unplaces it.
+_Avoid_: court (a table *stands on* a court; several tables may share one), board,
+station, "table" for the database sense (say **catalogue** for the tournament's set).
 
 **Pinned / free** (scheduler-era):
 Once the **scheduler** exists, a **placement** is **free** — the solver may move it —

--- a/docs/adr/20260801-a-placement-names-a-real-table-and-only-that-is-an-invariant.md
+++ b/docs/adr/20260801-a-placement-names-a-real-table-and-only-that-is-an-invariant.md
@@ -1,0 +1,100 @@
+# A placement names a real table, and only that is an invariant
+
+Date: 2026-08-01 (date-numbered — sequential numbers collide across concurrent
+worktrees; see `scripts/check-adr-numbering.sh`)
+
+## Status
+
+Accepted. **Supersedes one narrow clause of ADR-0790** ("a called match holds its
+table and slides later") and the corresponding sentence of `CONTEXT.md`'s
+**Placement** entry. Everything else in ADR-0790 stands. Decided during the grill
+for #1226, which normalizes pools and tables into real tables.
+
+## Context
+
+ADR-0790 made a placement **soft**: a table and a predicted start, whose
+constraints — the table belongs to the fixture's pool, the time falls inside the
+pool's window, nothing is double-booked — are **flags derived on read, never
+invariants**. That was the right call and remains so. A pool's tables and window
+stay editable under a standing draw precisely because the venue changes under a
+running tournament, and a placement a later edit outranges is a flag, not a
+refusal.
+
+But ADR-0790 also swept a fourth, weaker claim into the same rule.
+`TournamentFixturePlacementUpdate` says it outright: this write "does **not**
+reject … a `table_id` that names no table in the tournament's `table_catalogue`
+(a later pool/catalogue edit can dangle the ref; that is a flag-on-read
+concern)". A placement naming a table that does not exist was **stored, not
+rejected** — measured, deliberate, documented.
+
+That was defensible while the catalogue was JSONB and `table_id` was a string ref
+with nothing to foreign-key. #1226 removes that excuse: `tournament_tables`
+becomes a real table. A real FK on `tournament_fixtures.table_id` makes the
+dangling ref unrepresentable — which reads, without this ADR, as a straight
+violation of a decision the codebase states in three places.
+
+The catalogue's write semantics make it sharper still. `table_catalogue`
+"replaces wholesale when present" on PATCH, so *every* catalogue edit today is a
+delete-and-recreate of the whole list. Under a FK that stops being implementable
+as a replace at all.
+
+## Decision
+
+**"Names a real table" is an invariant. Everything else about a placement stays a
+flag.** The two claims are different in kind and get different enforcement:
+
+| Claim | Kind | Enforcement |
+| --- | --- | --- |
+| the table **exists** | invariant | FK — a bogus `table_id` is a **422**, not a store |
+| the table belongs to the fixture's pool | flag | derived on read, as today |
+| the start falls inside the pool's window | flag | derived on read, as today |
+| nothing is double-booked | flag | derived on read, as today |
+
+The three flags are all statements about a *relationship* between things that
+each legitimately move — a pool's tables, its window, another match's time. They
+have to stay soft, because the director edits one side while the other stands.
+
+"This id names a table" is not that. It is a statement about whether the
+reference **resolves at all**, and a placement whose table does not exist is not
+a placement in a state the director chose — it is a dangling pointer. Nothing
+downstream can render it, no flag can repair it, and the only honest thing to
+show for it is the absence of a table. It should always have been an invariant;
+it was soft only because there was no table to point at.
+
+**Removing a table behaves differently depending on who is holding it**, and the
+split is the point:
+
+- **A pool that reserves it** → `ON DELETE CASCADE` on
+  `tournament_event_pool_tables`. The table quietly drops out of the pools that
+  reserved it. This is the case `CONTEXT.md` names by hand — "a table breaks, a
+  table frees up" — and it is why a pool's tables stay editable mid-event.
+- **A fixture placed at it** → `ON DELETE RESTRICT`, surfaced as a **named 409**
+  in the same house style as the pool-set freeze (name the things, then name the
+  way out), with an explicit unplace-and-remove opt-in on the verb.
+
+Placements get the louder treatment because silently `SET NULL`-ing one destroys
+information on an *unrelated* write: the fixture stops being "placed at a table
+that vanished" and becomes indistinguishable from "nobody ever placed this", as
+an invisible side effect of editing the venue. The database refuses by default;
+the director says yes on purpose.
+
+## Consequences
+
+`table_catalogue`'s wholesale replace becomes a **diff**. A PATCH that omits a
+table is now a delete, and a delete can be refused, so the verb has to compute
+what changed rather than assign a list.
+
+The refusal is new API surface — a 409 the web client must handle and a confirm
+step in the tables tab that does not exist today. That is the honest cost of the
+decision, and it is smaller than the alternative: a director who cannot remove a
+broken table at all, or one whose schedule silently emptied itself.
+
+`ValueObjectId`'s reason for existing goes with it. It was an
+`Annotated[str, Field(min_length=1)]` whose docstring says it exists *only*
+because "pools and tables have no tables of their own". They do now.
+
+This ADR does **not** reopen ADR-0790's soft-placement rule in general. A
+placement is still a prediction rather than a promise; a match beginning earlier
+or later is still normal; a pool edit that outranges a placement is still a flag.
+The one thing that changes is that the table it names is now guaranteed to be a
+table.

--- a/docs/adr/20260801-a-pool-belongs-to-its-event-not-to-the-events-draw-settings.md
+++ b/docs/adr/20260801-a-pool-belongs-to-its-event-not-to-the-events-draw-settings.md
@@ -1,0 +1,131 @@
+# A pool belongs to its event, not to the event's draw settings
+
+Date: 2026-08-01 (date-numbered — sequential numbers collide across concurrent
+worktrees; see `scripts/check-adr-numbering.sh`)
+
+## Status
+
+Accepted. **Amends the table sketch in "An event's draw configuration is a row,
+not a column"** (2026-07-26), which placed `tournament_event_pools` under
+`draw_settings_id`. That ADR's substance — draw configuration is a row, the enum
+holds only what runs, per-type and per-event data are different tables — is
+unaffected. Decided during the grill for #1226.
+
+## Context
+
+The 2026-07-26 ADR scoped a follow-on ticket to normalize pools and tables, and
+sketched the new tables. Pools were to hang off the settings row:
+
+> `tournament_event_pools` (id, **draw_settings_id**, name, `slot_date DATE`,
+> `slot_start TIME`, `slot_end TIME`)
+
+The same ADR flagged, two paragraphs later, a trap that ticket must not walk
+into:
+
+> a fixture's pool must belong to *that fixture's own event* — a plain FK to
+> `tournament_event_pools.id` does not say so, and needs a composite FK.
+
+Both are right individually. Together they do not work, and nobody noticed until
+someone tried to write the DDL.
+
+A composite FK needs a **column in common** between the referencing and
+referenced tables. `tournament_fixtures` is event-scoped through and through: it
+carries `event_id`, its identity constraint is
+`UNIQUE (event_id, pool_id, round, position)`, its index is on `event_id`, and
+every read of a draw is "the fixtures of this event".
+`tournament_event_draw_settings`, by contrast, deliberately carries **no
+`event_id`** — the FK points parent→child (`tournament_events.draw_settings_id`),
+and its docstring is emphatic that "that direction is the whole point", because a
+`NOT NULL` FK on the parent is what keeps a 1:1 side table mandatory in a schema
+that cannot say "exactly one child row".
+
+So a pool keyed by `draw_settings_id` shares no column with a fixture, and the
+composite FK the ADR demanded cannot be written. The ways to force it are all
+worse: give fixtures a `draw_settings_id` too (denormalizing the fixture table
+and needing a *second* composite FK, `(event_id, draw_settings_id) →
+tournament_events (id, draw_settings_id)`, to stop the two disagreeing), or give
+pools both parents and a composite FK proving they agree (one permanently
+redundant column). Two composite FKs, or a redundant column, to say one thing.
+
+## Decision
+
+**`tournament_event_pools` hangs off `event_id`.**
+
+```sql
+tournament_event_pools (
+  id          uuid PRIMARY KEY,
+  event_id    uuid NOT NULL REFERENCES tournament_events (id) ON DELETE CASCADE,
+  name        text NOT NULL,
+  position    int  NOT NULL,
+  slot_date   date NOT NULL,
+  slot_start  time NOT NULL,
+  slot_end    time NOT NULL,
+  UNIQUE (event_id, id),
+  UNIQUE (event_id, position)
+)
+```
+
+and the fixture says what the 2026-07-26 ADR wanted it to say, in one line:
+
+```sql
+FOREIGN KEY (event_id, pool_id) REFERENCES tournament_event_pools (event_id, id)
+```
+
+`UNIQUE (event_id, id)` is redundant against the primary key and exists purely as
+the target that composite FK needs.
+
+**Why the settings row is the wrong parent.** `tournament_event_draw_settings` is
+a **1:1 side table holding a settings blob** — a draw type and the per-type
+scalars that go with it (`qualifiers_per_pool`, and whatever #787 adds). Pools
+are not scalars of a configuration. They are a **1:N collection of entities**
+with their own identity, their own join table to tables, and fixtures
+foreign-keying into them. Hanging that off the 1:1 side table adds a hop that
+buys nothing and costs exactly the composite FK the ADR itself flagged.
+
+The 2026-07-26 ADR's own principle — "per-type reference data and per-event
+configuration are different tables, and stay that way" — was drawn between
+`draw_types` and `tournament_event_draw_settings`. A pool is a third kind of
+thing that neither box fits: not reference data, not a configuration scalar, but
+an entity the event owns.
+
+It is also what the code already believes. Pools live on the event today and
+survive a draw-type change; the settings row is mutated in place
+(`event.draw_settings.configure(...)`), never replaced. `event_id` preserves that
+exactly.
+
+**Pools carry an explicit `position`.** This is not in the 2026-07-26 sketch and
+it is the column most likely to be dropped as incidental, so: it is load-bearing.
+Pool *order* is currently carried implicitly, by two things that both disappear
+in this change — the JSONB array's order, and the lexicographic sort of
+client-minted ids like `p-1-…`, `p-2-…`. Three sites depend on it, including
+`DrawConfig.pool_ids`, which is documented as "in the event's own pool order —
+that order is what the snake seeds against, so it must not be re-sorted". Under
+random UUIDv4 primary keys, sorting by id is **arbitrary**: pools render in a
+random order and the snake seeds against a random order, producing a draw that
+still cuts but seeds differently. That is exactly the failure the 2026-07-26 ADR
+predicted for this half of the work — "a draw that still cuts but places matches
+wrongly: invisible to the type checker, findable only by QA". An explicit
+ordering column is the only thing that survives the id change.
+
+**The tournament-scoping stops at the join table.** A pool reserving another
+tournament's table is the same illegal state one level deeper, and
+`tournament_event_pool_tables` carries `tournament_id` with composite FKs to both
+sides so it cannot be constructed. It is not pushed further than that — the join
+row is the only place a cross-tournament reference could be written, so keying it
+is sufficient and anything beyond is redundancy for its own sake.
+
+## Consequences
+
+The 2026-07-26 ADR's table sketch is wrong on one row and should be read through
+this one. Its reasoning is not wrong; the sketch simply predated anyone trying to
+spell the composite FK out, which is what the grill is for.
+
+Draw settings stay exactly as thin as that ADR said they would be — draw type
+plus `qualifiers_per_pool` — rather than growing pools. That ADR called the thin
+row "not empty" and justified it on the draw type alone, so nothing it promised
+depends on pools moving in.
+
+`ON DELETE CASCADE` from `tournament_events` gives pools the same lifecycle
+fixtures and entries already have, so the existing event-delete path
+(`passive_deletes`, one cascading statement) keeps working without learning about
+a new parent.


### PR DESCRIPTION
Base of the **#1226 stack**. Docs only — the decisions from the grill, landed first so every slice above can point at them via `Read first:` instead of re-deriving them. No schema, no code.

Two of the three exist because **#1226 as written would have contradicted a decision already in the repo.**

## 1. A placement names a real table, and only that is an invariant

Supersedes one clause of **ADR-0790**, which made a placement's constraints *flags derived on read, never invariants*. That stays true for "belongs to the pool", "inside the window" and "not double-booked" — all statements about a relationship between two things that each legitimately move.

But ADR-0790 also swept in a fourth claim: `TournamentFixturePlacementUpdate` says a `table_id` naming no table "is STORED, not rejected". That is a different kind of claim — not a relationship, but whether the reference **resolves at all**. #1226's FK makes it unrepresentable, which without this ADR reads as a straight violation of a decision stated in three places.

The split this settles:

| Who holds the table | On removal |
|---|---|
| a **pool** that reserves it | `CASCADE` — it drops out of the pool. This is `CONTEXT.md`'s "a table breaks, a table frees up" |
| a **fixture** placed at it | `RESTRICT`, surfaced as a named 409 with an explicit unplace-and-remove opt-in |

Placements get the louder treatment because a silent `SET NULL` destroys information on an *unrelated* write — the fixture stops being "placed at a table that vanished" and becomes indistinguishable from "nobody ever placed this", as a side effect of editing the venue.

## 2. A pool belongs to its event, not to the event's draw settings

Amends the **2026-07-26 ADR's** table sketch, which put pools under `draw_settings_id` **and** required a composite FK proving a fixture's pool belongs to that fixture's own event.

Both are reasonable. Together they are **unsatisfiable**: a composite FK needs a column in common, and `tournament_event_draw_settings` deliberately carries no `event_id` — its docstring is emphatic that the parent→child FK direction "is the whole point". So a pool keyed by `draw_settings_id` shares no column with a fixture.

Pools hang off `event_id`, and the FK is one line:

```sql
FOREIGN KEY (event_id, pool_id) REFERENCES tournament_event_pools (event_id, id)
```

**This ADR also pins the `position` column** — in neither the issue nor the original sketch, and the one most likely to be dropped as incidental. Pool order is currently carried implicitly by JSONB array order and by the lexicographic sort of client-minted ids (`p-1-…`, `p-2-…`). Both vanish under UUID primary keys, and three sites depend on that order — including `DrawConfig.pool_ids`, documented as *"in the event's own pool order — that order is what the snake seeds against, so it must not be re-sorted."* Without it the draw still cuts and seeds differently: exactly the failure the 2026-07-26 ADR predicted for this half of the work, *"invisible to the type checker, findable only by QA."*

## 3. A `Table` glossary entry

The domain's most physically concrete noun had none, while `Pool`, `Fixture`, `Slot`, `Stage` and `Placement` all did — and #1226 promotes it to a first-class entity. The entry also disambiguates the overload the issue title trips over ("normalize tournament **tables** into real **tables**").

Also corrects the **Placement** entry, which still described the start as a *naive local timestamp* after the 2026-07-19 ADR moved it to a timezone-aware instant.

## Verification

`scripts/check-adr-numbering.sh` passes — both ADRs are date-prefixed. Nothing executable changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCCG5jQq19dG8SDPFcmTwh)_