### PR TITLE
Slice 1: a director with ten pools sees their draw in the order they set, not 1, 10, 2

### DIFF
--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -334,12 +334,16 @@ class FixtureState:
     #:
     #: ``None`` means "no pool order to sort on", which is true of an **un-pooled**
     #: fixture (``pool_id is None``) and of a caller that did not resolve the event's
-    #: pools — a strategy test built from literals, or a pool stored before the field
-    #: existed. It is deliberately not defaulted to ``0``: a real position of ``0`` is
-    #: the *first* pool, and "unknown" collapsing onto "first" would silently promote
-    #: every unresolved fixture to the head of the draw. Unknown sorts after every known
-    #: pool instead, where the id tie-break decides it — which is exactly the order
-    #: :func:`ready_fixtures` had before positions existed.
+    #: pools at all — a strategy test built straight from :class:`FixtureState`
+    #: literals, or :func:`~app.tournament_draws.fixture_state` called with no
+    #: ``pool_positions`` map. A pool stored before the field existed still resolves to
+    #: a real int here — :func:`~app.tournament_draws.pool_order`'s stable sort leaves
+    #: it at its array index. It is deliberately not defaulted to ``0``: a real
+    #: position of ``0`` is the *first* pool, and "unknown" collapsing onto "first"
+    #: would silently promote every unresolved fixture to the head of the draw.
+    #: Unknown sorts after every known pool instead, where the id tie-break decides it
+    #: — which is exactly the order :func:`ready_fixtures` had before positions
+    #: existed.
     pool_position: int | None = None
     #: Set when the fixture's match completed — the fixture is then **decided**.
     winner_entry_id: EntryId | None = None

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -249,14 +249,21 @@ class DrawConfig:
     picked the strategy. Its absence is what makes that unsayable.
 
     ``pool_ids`` are the ids of the event's configured pools, **in the event's own pool
-    order** — that order is what the snake seeds against, so it must not be re-sorted.
+    order** — ascending ``Pool.position``, which is what the caller
+    (:func:`app.tournament_draws.draw_config`) sorts them by, and which this tuple then
+    carries *as* its sequence. That order is what the snake seeds against, so nothing
+    downstream may re-sort it: an ``sorted(config.pool_ids)`` anywhere below here would
+    seed the draw against the ids' lexicographic order, which is not the director's
+    (``p-10-`` sorts between ``p-1-`` and ``p-2-``) and, once pools are rows with random
+    UUID ids, is not anybody's.
+
     Empty for an un-pooled draw type (single-elim), where every fixture's ``pool_id``
     is ``NULL``. The pool *id set* freezes while a draw exists, which is what lets a
     fixture's string ref stay valid without a foreign key. No id among them is ever the
     empty string — ``Pool.id`` is a ``ValueObjectId`` (``min_length=1``) at the write
     boundary, which is what keeps ``ready_fixtures``' "pooled?" test (``pool_id is
-    None``) and its sort key (``pool_id or ""``) answering the same question the same
-    way.
+    None``) and its id tie-break (``pool_id or ""``) answering the same question the
+    same way.
     """
 
     pool_ids: tuple[PoolId, ...] = ()
@@ -319,6 +326,21 @@ class FixtureState:
     position: int
     entry_a_id: EntryId | None
     entry_b_id: EntryId | None
+    #: Where this fixture's **pool** sits in its event's pool order — 0-based, the
+    #: ``Pool.position`` the write boundary stamped (ADR 20260801, "Pools carry an
+    #: explicit ``position``"). NOT to be confused with :attr:`position` above, which is
+    #: this fixture's slot within its own round; the two are different axes of the same
+    #: draw and the sort key below reads both.
+    #:
+    #: ``None`` means "no pool order to sort on", which is true of an **un-pooled**
+    #: fixture (``pool_id is None``) and of a caller that did not resolve the event's
+    #: pools — a strategy test built from literals, or a pool stored before the field
+    #: existed. It is deliberately not defaulted to ``0``: a real position of ``0`` is
+    #: the *first* pool, and "unknown" collapsing onto "first" would silently promote
+    #: every unresolved fixture to the head of the draw. Unknown sorts after every known
+    #: pool instead, where the id tie-break decides it — which is exactly the order
+    #: :func:`ready_fixtures` had before positions existed.
+    pool_position: int | None = None
     #: Set when the fixture's match completed — the fixture is then **decided**.
     winner_entry_id: EntryId | None = None
     #: Set once the fixture **materialized** into a real match. ``None`` before that.
@@ -943,24 +965,68 @@ def ready_fixtures(fixtures: Sequence[FixtureState]) -> tuple[FixtureId, ...]:
     (``match_id`` is ``ON DELETE SET NULL``) from rising from the dead and being played
     twice. Ordered by ``(pool, round, position)`` so the plan itself is deterministic.
 
-    The sort key asks two questions of ``pool_id`` — "is it pooled?" (``pool_id is
-    None``, which sorts the un-pooled last) and "which pool?" (``pool_id or ""``) — and
-    the two agree only because an id is never ``""``. It was: ``Pool.id`` was a bare
+    **"Pool" is the pool's** :attr:`~FixtureState.pool_position` — its place in the
+    event's own pool order — **not its id.** The ids are client-minted strings
+    (``p-1-…``, ``p-2-…``, ``p-10-…``) whose lexicographic order is not the director's:
+    ``p-10-`` sorts between ``p-1-`` and ``p-2-``, so a ten-pool draw's plan ran pool 1,
+    pool 10, pool 2. For a pool that **has** a position it is the same key the read
+    path's ``fixtures_by_event`` sorts on and the same one :attr:`DrawConfig.pool_ids`
+    is ordered by, so the sequence a director sees, the sequence the snake dealt
+    against, and the sequence matches are created in are one order rather than three
+    that agree by luck.
+
+    **The exception is a pool written before positions existed**, and it is worth
+    stating because the two fallbacks are not the same one. ``pools`` is JSONB and no
+    migration backfilled it, so rows predating this field survive in any long-lived
+    database (UAT's ``fortymm-uat_postgres-data`` volume, a standing QA stack). For
+    those, the read path's SQL reads a missing key as ``NULL``, every pool ties, and it
+    falls through to ``pool_id`` — **id order**; while this sort and
+    :attr:`DrawConfig.pool_ids` parse through :class:`~app.schemas.tournament.Pool`,
+    where ``position`` defaults to ``0``, so every pool ties there too and a stable sort
+    leaves them in **array order**. Two different fallbacks for the same absent field.
+    It bites only an event with ten or more pre-field pools, and it changes the order
+    matches are *created* in rather than which fixtures exist or who plays whom — but
+    it is a real disagreement, not a documented equivalence. It stops existing when
+    pools become rows with a ``NOT NULL`` position, where the column cannot be absent.
+
+    The sort key asks three questions, in this order:
+
+    1. "Is it pooled?" — ``pool_id is None``, which sorts the un-pooled (single-elim, or
+       an rr-then-ko draw's KO stage) LAST, behind the pools that feed them.
+    2. "Where in the event's order is its pool?" — ``pool_position``, with a ``None``
+       (an unresolved pool order; see the field) sorting after every pool that has one.
+    3. "Which pool?" — ``pool_id or ""``, the tie-break that keeps the order **total**
+       when the positions cannot decide it, and which is exactly the order this had
+       before positions existed.
+
+    (1) and (3) agree only because an id is never ``""``. It was: ``Pool.id`` was a bare
     ``str``, and a fixture drawn into an empty-id pool answered *pooled* to the first
-    question while colliding with the un-pooled group's ``""`` in the second. The floor
+    question while colliding with the un-pooled group's ``""`` in the third. The floor
     that closes it is at the write boundary (``ValueObjectId``, ``min_length=1``), not
     here — an ``if not pool_id`` in this sort would be a runtime check standing in for a
-    state that should not exist. Which is why the ``""`` fallback is now *unobservable*:
+    state that should not exist. Which is why the ``""`` fallback is *unobservable*:
     it is reached only by the ``None`` group, which the first key element has already
     partitioned off, so its value cannot change an order. (Mutation testing agrees —
     replacing it with any other string survives, and after this it is *supposed* to.)
+    The ``or 0`` beside it is unobservable for the same reason and by the same argument:
+    the element before it has already partitioned the ``None`` positions off, so what
+    the ``None`` group collapses to cannot change an order.
     """
     ready = [
         f
         for f in fixtures
         if not f.is_pending and f.match_id is None and f.winner_entry_id is None
     ]
-    ready.sort(key=lambda f: (f.pool_id is None, f.pool_id or "", f.round, f.position))
+    ready.sort(
+        key=lambda f: (
+            f.pool_id is None,
+            f.pool_position is None,
+            f.pool_position or 0,
+            f.pool_id or "",
+            f.round,
+            f.position,
+        )
+    )
     return tuple(f.fixture_id for f in ready)
 
 

--- a/api/app/models/tournament.py
+++ b/api/app/models/tournament.py
@@ -305,7 +305,7 @@ class TournamentEvent(Base):
     # draw is cut; a re-cut replaces the set wholesale, which is what
     # ``delete-orphan`` buys.
     #
-    # Ordered pool → round → position — the SAME total order the read path's
+    # Ordered pool → round → position — the same total order the read path's
     # ``fixtures_by_event`` loader applies, and the one the fixtures' own
     # ``UNIQUE (event_id, pool_id, round, position)`` makes a total order at all. The
     # ``pool_id`` used to be missing from this list, which left the relationship
@@ -318,6 +318,16 @@ class TournamentEvent(Base):
     # ``pool_id`` is a real value here ("this fixture belongs to no pool" —
     # single-elim, or this is the KO stage of an rr-then-ko event), and it belongs
     # after the pools that feed it.
+    #
+    # It orders the pools by ``pool_id``, where ``fixtures_by_event`` orders them by the
+    # pool's ``position`` in the event's own pool order (ADR 20260801) — a relationship
+    # ``order_by`` is an expression over *this* table, and the position lives in the
+    # event's ``pools`` JSONB, so saying it here would take a correlated subquery in a
+    # string. The two agree wherever the ids sort as the director ordered them and part
+    # company where they do not (``p-10-`` sorts between ``p-1-`` and ``p-2-``). Nothing
+    # in the app reads this relationship's order today — every draw a client sees comes
+    # through the loader — and when pools become rows the ``position`` is joinable and
+    # this becomes sayable.
     fixtures: Mapped[list["TournamentFixture"]] = relationship(
         back_populates="event",
         cascade="all, delete-orphan",

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -626,6 +626,43 @@ class TournamentTable(BaseModel):
     court: str
 
 
+PoolPosition = Annotated[
+    int,
+    Field(
+        ge=0,
+        description=(
+            "Where this pool sits in its event's pool order: 0-based, and **assigned "
+            "by the server** from the pool's index in the `pools` list you sent. It "
+            "is read-only — a non-negative `position` on a write payload is "
+            "overwritten rather than honoured, so to reorder an event's pools, send "
+            "them in the order you want. (A negative one is a 422: the bound is "
+            "checked before the reordering, so it is refused rather than corrected.) "
+            "Two pools of one event never share a position."
+        ),
+    ),
+]
+"""A pool's place in its event's pool order — 0-based, server-assigned, never
+client-supplied.
+
+Pool order is a **fact about the event**, and until this field existed it was carried by
+two things that are both about to disappear (ADR 20260801, "Pools carry an explicit
+``position``"): the JSONB array's order, and the lexicographic sort of the client-minted
+``p-1-…``/``p-2-…`` ids. Under the random UUID primary keys the pools table will have,
+sorting by id is *arbitrary* — pools would render in a random order and the snake would
+seed against a random order, producing a draw that still cuts but seeds differently.
+Invisible to the type checker; findable only by QA. An explicit ordering column is the
+only thing that survives the id change, so it is written now, while the array order is
+still there to derive it from.
+
+It is **not** a field a client sets. The write boundary
+(:func:`_positions_are_the_event_pool_order`, on the :data:`EventPools` alias both write
+verbs share) stamps it from the index on the way in, so a client that echoes a stored
+``position`` back — which the event editor does, it PATCHes the whole form — gets the
+order it actually sent rather than a 422 for a field it never authored. That is also
+what makes "two pools of one event share a position" unrepresentable through the API:
+the positions are ``range(len(pools))`` by construction, not by review."""
+
+
 class Pool(BaseModel):
     """A slice of tables reserved for a window of time within an event.
 
@@ -640,12 +677,21 @@ class Pool(BaseModel):
     something — it is what the director clicks, what the conflict warnings quote, and
     what a player reads off a wall. ``""`` is not a name, and an event whose pools list
     is three blank rows is not a thing anyone could act on.
+
+    Its ``position`` is the pool's place in the event's pool ORDER, and it is the one
+    field here the client does not author: the server stamps it from the index of the
+    list it was sent in (:data:`PoolPosition`). It defaults to ``0`` so that pools
+    stored before this field existed stay *readable* — a read boundary must not turn a
+    history it cannot change into a ``ValidationError`` (the same asymmetry
+    :data:`AddressComponent` is about) — and every pool written through
+    :data:`EventPools` carries a real one.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     id: ValueObjectId
     name: str = Field(min_length=1)
+    position: PoolPosition = 0
     slot: Slot
     table_ids: list[str]
 
@@ -715,18 +761,66 @@ def _pool_ids_are_unique(pools: list[Pool]) -> list[Pool]:
     return pools
 
 
-EventPools = Annotated[list[Pool], AfterValidator(_pool_ids_are_unique)]
-"""An event's pools: any number of them, no two sharing an ``id``.
+def _positions_are_the_event_pool_order(pools: list[Pool]) -> list[Pool]:
+    """Stamp each pool's ``position`` with its index in the list the client sent.
+
+    The pool order an event has is the order its pools arrived in — that is what the
+    director dragged into place, and it is what every ordered read has always meant.
+    This is the one place that fact becomes a stored value (ADR 20260801, "Pools carry
+    an explicit ``position``"), so that the order stops being carried by things that are
+    about to stop existing: the JSONB array's order, and the lexicographic sort of the
+    client-minted pool ids.
+
+    It **overwrites** rather than validates, and that is deliberate on both counts:
+
+    * *Overwrites*, so a ``position`` on the payload cannot decide anything. The event
+      editor PATCHes the whole event form back — pools included, positions and all — so
+      refusing a client-sent ``position`` with a 422 would break the ordinary round trip
+      of a page that is only echoing what we handed it. Ignoring it is the same rule
+      (the client does not get to choose) without the collateral damage.
+    * *From the index*, so two pools of one event cannot share a position: what is
+      written is ``range(len(pools))``, by construction. There is no pools table yet
+      and so no ``UNIQUE (event_id, position)`` to catch a duplicate — the constraint
+      the ADR specifies arrives with the table — which is exactly why the value must
+      not be assembled from anything a caller could repeat.
+
+    It lives on :data:`EventPools`, the alias **both** write verbs share, for the reason
+    ``_pool_ids_are_unique`` does: "the patch path is the hole" is the same bug wearing
+    a different verb, and an event born with positions and then patched without them
+    would be an event whose order silently reverted to whatever the ids sorted as.
+
+    ``model_copy(update=…)`` rather than a mutation, and that detail is load-bearing on
+    the patch path: it marks ``position`` as **explicitly set**, and the update verb
+    serializes its payload with ``model_dump(exclude_unset=True)``. A stamp that left
+    the field merely defaulted would be dropped from that dump, and the column would
+    come back from a PATCH with no ``position`` key at all.
+    """
+    return [
+        pool.model_copy(update={"position": index}) for index, pool in enumerate(pools)
+    ]
+
+
+EventPools = Annotated[
+    list[Pool],
+    AfterValidator(_pool_ids_are_unique),
+    AfterValidator(_positions_are_the_event_pool_order),
+]
+"""An event's pools: any number of them, no two sharing an ``id``, each carrying the
+server-assigned ``position`` of its place in this very list
+(:func:`_positions_are_the_event_pool_order`).
 
 Shared verbatim by ``TournamentEventCreate`` and ``TournamentEventUpdate``, so the
 uniqueness rule cannot drift between the two verbs — sharing the alias is what makes
-them impossible to drift apart, exactly as it is for ``EventMaxPlayers``.
+them impossible to drift apart, exactly as it is for ``EventMaxPlayers``. The position
+stamp is on the same alias for the same reason, and it is why a *patch* re-orders an
+event's pools by simply sending them re-ordered.
 
-An ``AfterValidator``, deliberately: it runs on the parsed ``list[Pool]`` (so it reads
-``pool.id``, not ``pool["id"]``) and it contributes **nothing** to the JSON schema, so
-the OpenAPI shape of ``pools`` is unchanged and the generated clients keep the array
-they already had. A rule a client cannot express in a schema keyword is not a reason to
-let the server hold a state it cannot survive."""
+Both are ``AfterValidator``s, deliberately: they run on the parsed ``list[Pool]`` (so
+they read ``pool.id``, not ``pool["id"]``) and they contribute **nothing** to the JSON
+schema — the array keyword-for-keyword is what it was, and what the generated clients
+learn about ``position`` they learn from the field on :class:`Pool`, not from here. A
+rule a client cannot express in a schema keyword is not a reason to let the server hold
+a state it cannot survive."""
 
 
 # ----- read models ----------------------------------------------------------

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -1,5 +1,6 @@
 import uuid
 from collections import Counter
+from collections.abc import Sequence
 from datetime import date, datetime
 from decimal import ROUND_DOWN, Decimal
 from typing import Annotated, Any, Literal
@@ -631,18 +632,16 @@ PoolPosition = Annotated[
     Field(
         ge=0,
         description=(
-            "Where this pool sits in its event's pool order: 0-based, and **assigned "
-            "by the server** from the pool's index in the `pools` list you sent. It "
-            "is read-only — a non-negative `position` on a write payload is "
-            "overwritten rather than honoured, so to reorder an event's pools, send "
-            "them in the order you want. (A negative one is a 422: the bound is "
-            "checked before the reordering, so it is refused rather than corrected.) "
-            "Two pools of one event never share a position."
+            "Where this pool sits in its event's pool order: 0-based, contiguous, and "
+            "**assigned by the server** from the pool's index in the `pools` list it "
+            "arrived in. Read-only, and not merely by convention — it is absent from "
+            "the pool shape the write verbs take, so sending one is a `422` for an "
+            "unknown field. To reorder an event's pools, send them in the order you "
+            "want. Two pools of one event never share a position."
         ),
     ),
 ]
-"""A pool's place in its event's pool order — 0-based, server-assigned, never
-client-supplied.
+"""A pool's place in its event's pool order — 0-based, server-assigned, read-only.
 
 Pool order is a **fact about the event**, and until this field existed it was carried by
 two things that are both about to disappear (ADR 20260801, "Pools carry an explicit
@@ -654,17 +653,18 @@ Invisible to the type checker; findable only by QA. An explicit ordering column 
 only thing that survives the id change, so it is written now, while the array order is
 still there to derive it from.
 
-It is **not** a field a client sets. The write boundary
-(:func:`_positions_are_the_event_pool_order`, on the :data:`EventPools` alias both write
-verbs share) stamps it from the index on the way in, so a client that echoes a stored
-``position`` back — which the event editor does, it PATCHes the whole form — gets the
-order it actually sent rather than a 422 for a field it never authored. That is also
-what makes "two pools of one event share a position" unrepresentable through the API:
-the positions are ``range(len(pools))`` by construction, not by review."""
+It lives on :class:`Pool`, the shape a client **reads**, and deliberately not on
+:class:`PoolWrite`, the shape it **sends**. The server stamps it in :func:`stored_pools`
+— the one seam between the two — from the pool's index in the list it was sent, so an
+event's positions are ``range(len(pools))`` by construction. That is what makes "two
+pools of one event share a position" unrepresentable through the API, and it is why
+"server-assigned" is a property of the schema here rather than a claim in prose: the
+field a client cannot send is a field it cannot decide."""
 
 
-class Pool(BaseModel):
-    """A slice of tables reserved for a window of time within an event.
+class PoolWrite(BaseModel):
+    """A slice of tables reserved for a window of time within an event, as a client
+    **sends** it.
 
     Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
     by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
@@ -678,22 +678,46 @@ class Pool(BaseModel):
     what a player reads off a wall. ``""`` is not a name, and an event whose pools list
     is three blank rows is not a thing anyone could act on.
 
-    Its ``position`` is the pool's place in the event's pool ORDER, and it is the one
-    field here the client does not author: the server stamps it from the index of the
-    list it was sent in (:data:`PoolPosition`). It defaults to ``0`` so that pools
-    stored before this field existed stay *readable* — a read boundary must not turn a
-    history it cannot change into a ``ValidationError`` (the same asymmetry
-    :data:`AddressComponent` is about) — and every pool written through
-    :data:`EventPools` carries a real one.
+    What is **absent** is as deliberate as what is here: ``position`` is the server's to
+    assign (:data:`PoolPosition`), so it is simply not a field of this model, and
+    ``extra="forbid"`` turns an attempt to send one into a 422 that names it. This is
+    the treatment ``entered`` already gets on the event schemas — a server-managed value
+    is kept **off** the write shape rather than accepted and then ignored. Accepting it
+    would be worse than useless in both directions: a client cannot tell from the schema
+    that the number it sent decided nothing, and a boundary that silently discards half
+    of a payload has to be documented to be understood. The order a client *does*
+    control is the order of the list itself.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     id: ValueObjectId
     name: str = Field(min_length=1)
-    position: PoolPosition = 0
     slot: Slot
     table_ids: list[str]
+
+
+class Pool(PoolWrite):
+    """A pool as it is **read back**: everything a client wrote, plus the ``position``
+    the server stamped on it.
+
+    It is also the model every interior read of an event's ``pools`` JSONB parses
+    through — ``_ordered_pools``, ``draw_config``, ``event_pools``, the schedule
+    snapshots — so the column becomes typed values at the read boundary rather than
+    stringly-keyed dict lookups (api/CLAUDE.md — "parse, don't validate"). Deriving it
+    from :class:`PoolWrite` is what keeps the two shapes one shape plus a field: a
+    column added to the write side is readable without a second edit, and the two can
+    never disagree about what a pool *is*.
+
+    ``position`` defaults to ``0`` so that pools stored before the field existed stay
+    *readable* — a read boundary must not turn a history it cannot change into a
+    ``ValidationError`` (the same asymmetry :data:`AddressComponent` is about). Every
+    pool written since goes through :func:`stored_pools` and carries a real one. The
+    default is a **read** concession only; it is not a way to write one, because there
+    is no way to write one.
+    """
+
+    position: PoolPosition = 0
 
 
 def named_list(names: list[str]) -> str:
@@ -719,7 +743,7 @@ def named_list(names: list[str]) -> str:
     return f"{', '.join(quoted[:-1])} and {quoted[-1]}"
 
 
-def _pool_ids_are_unique(pools: list[Pool]) -> list[Pool]:
+def _pool_ids_are_unique(pools: list[PoolWrite]) -> list[PoolWrite]:
     """Refuse an event's pools when two of them claim the same ``id`` (422).
 
     A pool id is an **identity**, and everything downstream of these value-objects is
@@ -734,10 +758,10 @@ def _pool_ids_are_unique(pools: list[Pool]) -> list[Pool]:
     validator existed). A boundary that admits what the interior cannot hold is not a
     boundary.
 
-    It is a rule about the **list**, not about a ``Pool``, so it is a validator on the
-    list type — and it is stated **once**, on the alias both write schemas share, for
-    the reason the numeric bounds are shared (see ``EventMaxPlayers``): "the patch path
-    is the hole" is the same bug wearing a different verb. Guarding only ``create``
+    It is a rule about the **list**, not about a ``PoolWrite``, so it is a validator on
+    the list type — and it is stated **once**, on the alias both write schemas share,
+    for the reason the numeric bounds are shared (see ``EventMaxPlayers``): "the patch
+    path is the hole" is the same bug wearing a different verb. Guarding only ``create``
     would leave the event to be born clean and then edited into the 500 — and the patch
     path is the *worse* of the two, because the pool-set freeze that protects a cut draw
     compares **sets**: ``[A, A, B]`` against a cut event holding ``{A, B}`` is the same
@@ -761,66 +785,61 @@ def _pool_ids_are_unique(pools: list[Pool]) -> list[Pool]:
     return pools
 
 
-def _positions_are_the_event_pool_order(pools: list[Pool]) -> list[Pool]:
-    """Stamp each pool's ``position`` with its index in the list the client sent.
-
-    The pool order an event has is the order its pools arrived in — that is what the
-    director dragged into place, and it is what every ordered read has always meant.
-    This is the one place that fact becomes a stored value (ADR 20260801, "Pools carry
-    an explicit ``position``"), so that the order stops being carried by things that are
-    about to stop existing: the JSONB array's order, and the lexicographic sort of the
-    client-minted pool ids.
-
-    It **overwrites** rather than validates, and that is deliberate on both counts:
-
-    * *Overwrites*, so a ``position`` on the payload cannot decide anything. The event
-      editor PATCHes the whole event form back — pools included, positions and all — so
-      refusing a client-sent ``position`` with a 422 would break the ordinary round trip
-      of a page that is only echoing what we handed it. Ignoring it is the same rule
-      (the client does not get to choose) without the collateral damage.
-    * *From the index*, so two pools of one event cannot share a position: what is
-      written is ``range(len(pools))``, by construction. There is no pools table yet
-      and so no ``UNIQUE (event_id, position)`` to catch a duplicate — the constraint
-      the ADR specifies arrives with the table — which is exactly why the value must
-      not be assembled from anything a caller could repeat.
-
-    It lives on :data:`EventPools`, the alias **both** write verbs share, for the reason
-    ``_pool_ids_are_unique`` does: "the patch path is the hole" is the same bug wearing
-    a different verb, and an event born with positions and then patched without them
-    would be an event whose order silently reverted to whatever the ids sorted as.
-
-    ``model_copy(update=…)`` rather than a mutation, and that detail is load-bearing on
-    the patch path: it marks ``position`` as **explicitly set**, and the update verb
-    serializes its payload with ``model_dump(exclude_unset=True)``. A stamp that left
-    the field merely defaulted would be dropped from that dump, and the column would
-    come back from a PATCH with no ``position`` key at all.
-    """
-    return [
-        pool.model_copy(update={"position": index}) for index, pool in enumerate(pools)
-    ]
-
-
-EventPools = Annotated[
-    list[Pool],
-    AfterValidator(_pool_ids_are_unique),
-    AfterValidator(_positions_are_the_event_pool_order),
-]
-"""An event's pools: any number of them, no two sharing an ``id``, each carrying the
-server-assigned ``position`` of its place in this very list
-(:func:`_positions_are_the_event_pool_order`).
+EventPools = Annotated[list[PoolWrite], AfterValidator(_pool_ids_are_unique)]
+"""An event's pools **as a client sends them**: any number of them, no two sharing an
+``id``, none of them carrying a ``position`` (:class:`PoolWrite`).
 
 Shared verbatim by ``TournamentEventCreate`` and ``TournamentEventUpdate``, so the
 uniqueness rule cannot drift between the two verbs — sharing the alias is what makes
-them impossible to drift apart, exactly as it is for ``EventMaxPlayers``. The position
-stamp is on the same alias for the same reason, and it is why a *patch* re-orders an
-event's pools by simply sending them re-ordered.
+them impossible to drift apart, exactly as it is for ``EventMaxPlayers``. It is also
+what makes the *shape* impossible to drift: create and patch take the same pool, so
+there is no verb through which a ``position`` could be smuggled in.
 
-Both are ``AfterValidator``s, deliberately: they run on the parsed ``list[Pool]`` (so
-they read ``pool.id``, not ``pool["id"]``) and they contribute **nothing** to the JSON
-schema — the array keyword-for-keyword is what it was, and what the generated clients
-learn about ``position`` they learn from the field on :class:`Pool`, not from here. A
-rule a client cannot express in a schema keyword is not a reason to let the server hold
-a state it cannot survive."""
+The list's **order** is the payload's one statement about pool order, and it is honoured
+on both verbs: :func:`stored_pools` turns it into the stored positions, so a patch
+re-orders an event's pools by simply sending them re-ordered.
+
+An ``AfterValidator``, deliberately: it runs on the parsed ``list[PoolWrite]`` (so it
+reads ``pool.id``, not ``pool["id"]``) and it contributes **nothing** to the JSON
+schema, so the OpenAPI shape of ``pools`` is the array it always was. A rule a client
+cannot express in a schema keyword is not a reason to let the server hold a state it
+cannot survive."""
+
+
+def stored_pools(pools: Sequence[PoolWrite]) -> list[dict[str, Any]]:
+    """The rows an event's ``pools`` JSONB column holds, composed from the pools a
+    client sent — each stamped with the ``position`` of its index in that list.
+
+    This is the seam between the two pool shapes, and **the only place a ``position`` is
+    ever assigned**. The pool order an event has is the order its pools arrived in —
+    that is what the director dragged into place, and it is what every ordered read has
+    always meant — so here is where that fact stops being the array's order and becomes
+    a stored value (ADR 20260801, "Pools carry an explicit ``position``"), before the
+    array order and the lexicographic sort of client-minted ids both stop existing.
+
+    Stamping *from the index* is what makes two pools of one event unable to share a
+    position: what is written is ``range(len(pools))``, by construction. There is no
+    pools table yet and so no ``UNIQUE (event_id, position)`` underneath to catch a
+    duplicate — that constraint arrives with the table — which is exactly why the value
+    must not be assembled from anything a caller could repeat, or send.
+
+    Called by **both** write verbs (``create_event`` and ``update_event``), for the
+    reason ``_pool_ids_are_unique`` lives on the shared alias: "the patch path is the
+    hole" is the same bug wearing a different verb, and an event born with positions and
+    then patched without them would be an event whose order silently reverted to
+    whatever its ids sorted as. That is why this is a function over the *list* rather
+    than a per-pool conversion — an index only exists relative to the whole list, and a
+    caller holding one pool has nothing to stamp it with.
+
+    Returns plain ``dict``s because the column is plain JSONB, but composes them through
+    :class:`Pool` rather than by hand: what is written is by construction something the
+    read boundary (``Pool.model_validate``, in ``event_pools`` / ``draw_config`` /
+    ``_ordered_pools``) can parse back.
+    """
+    return [
+        Pool(**pool.model_dump(), position=index).model_dump()
+        for index, pool in enumerate(pools)
+    ]
 
 
 # ----- read models ----------------------------------------------------------
@@ -1704,9 +1723,11 @@ class TournamentEventCreate(BaseModel):
     slot: Slot
     match_settings: MatchSettings
     predicates: list[Predicate] = Field(default_factory=list)
-    # ``EventPools``, not ``list[Pool]``: no two of an event's pools may share an ``id``
-    # (a fixture names its pool by that string, and a duplicate id 500'd the cut). The
-    # same alias the patch schema carries, so the rule holds on both verbs.
+    # ``EventPools``, not ``list[PoolWrite]``: no two of an event's pools may share an
+    # ``id`` (a fixture names its pool by that string, and a duplicate id 500'd the
+    # cut). The same alias the patch schema carries, so the rule — and the write
+    # *shape*, which has no ``position`` on it — holds on both verbs. The list's ORDER
+    # is what the server reads the pool order off (``stored_pools``).
     pools: EventPools = Field(default_factory=list)
 
     #: The arm :meth:`_parse_draw_settings` parsed, kept rather than re-derived. Set by
@@ -1788,7 +1809,10 @@ class TournamentEventUpdate(BaseModel):
     # The create schema's pools, exactly: a payload that could smuggle a duplicate id in
     # by PATCH would defeat create's boundary entirely — and it is the patch path the
     # pool-set freeze cannot cover, since it compares SETS and ``[A, A, B]`` is the same
-    # set as ``{A, B}``. See ``_pool_ids_are_unique``.
+    # set as ``{A, B}``. See ``_pool_ids_are_unique``. A pool's ``position`` is not on
+    # this shape either (``PoolWrite``), so an editor that echoes one back gets a 422
+    # naming the field rather than a value that quietly decided nothing; the order it
+    # sends the list in is what re-orders the pools.
     pools: EventPools | None = None
 
     @field_validator(

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -92,10 +92,46 @@ async def active_draw_entrants(db: AsyncSession, event_id: uuid.UUID) -> list[En
     ]
 
 
+def pool_order(event: TournamentEvent) -> dict[PoolId, int]:
+    """Each of this event's pool ids mapped to its **0-based place in the event's pool
+    order** — the lookup :func:`fixture_state` resolves a fixture's ``pool_id`` through.
+
+    Computed once per event rather than per fixture: a fixture carries a string ref into
+    the event's ``pools`` JSONB, not an index, so somebody has to do the join and a
+    200-fixture round-robin should not re-parse the pools 200 times.
+
+    The rank is the pool's index *after* sorting on ``Pool.position`` (ADR 20260801),
+    not the stored ``position`` read straight off: it is then the same sequence
+    :func:`draw_config` hands the snake, by construction and not by two functions
+    agreeing — including on an event whose pools predate the field, where every stored
+    position is ``0`` and the stable sort leaves the array order standing.
+    """
+    return {PoolId(pool.id): index for index, pool in enumerate(_ordered_pools(event))}
+
+
+def _ordered_pools(event: TournamentEvent) -> list[Pool]:
+    """This event's pools, parsed, in the director's order — ascending ``position``.
+
+    One definition of "the event's pool order", shared by :func:`draw_config` (which
+    seeds the snake against it) and :func:`pool_order` (which the read of a persisted
+    fixture resolves through), so a draw is cut in the same order it is advanced in.
+
+    Parsed through :class:`Pool` rather than indexed as ``p["position"]`` on an untyped
+    JSONB dict (api/CLAUDE.md — "parse, don't validate"), which is also where a pool
+    stored before ``position`` existed picks up its ``0`` default. ``sorted`` is stable,
+    so a whole event of those keeps the array order it has always had.
+    """
+    return sorted(
+        (Pool.model_validate(pool) for pool in event.pools),
+        key=lambda pool: pool.position,
+    )
+
+
 def fixture_state(
     fixture: TournamentFixture,
     game_counts: Mapping[uuid.UUID, tuple[int, int]] | None = None,
     voided_match_ids: frozenset[uuid.UUID] = frozenset(),
+    pool_positions: Mapping[PoolId, int] | None = None,
 ) -> FixtureState:
     """Project a persisted :class:`~app.models.tournament_fixture.TournamentFixture` row
     into the pure :class:`~app.draws.FixtureState` a strategy's ``advance()`` reads.
@@ -132,6 +168,16 @@ def fixture_state(
     strategy a mirrored scoreline that still looks like a plausible result, which is
     what ``tests/test_tournament_draws.py`` asserts with an asymmetric one.
 
+    ``pool_positions`` maps this event's pool ids to their places in the event's pool
+    order (:func:`pool_order`), and is what fills
+    :attr:`~app.draws.FixtureState.pool_position` — the key ``ready_fixtures`` groups a
+    plan by. It rides in from the caller for the same reason the games do: it is one
+    fact about the *event*, and resolving it here would mean re-parsing the pools JSONB
+    once per fixture. Passing nothing means "the pool order was not resolved", which
+    projects a ``None`` position — the fixture is then ordered by its pool *id*, the
+    order this had before positions existed. Un-pooled fixtures resolve to ``None``
+    whatever is passed: there is no pool to place.
+
     It is the caller — not this function — that loads the counts, because
     ``advance()``'s current caller
     (:func:`app.tournament_materialization.materialize_event`) loads fixtures and
@@ -143,11 +189,17 @@ def fixture_state(
         if game_counts is not None and fixture.match_id is not None
         else None
     )
+    pool_id = PoolId(fixture.pool_id) if fixture.pool_id is not None else None
     return FixtureState(
         fixture_id=FixtureId(fixture.id),
-        pool_id=PoolId(fixture.pool_id) if fixture.pool_id is not None else None,
+        pool_id=pool_id,
         round=fixture.round,
         position=fixture.position,
+        pool_position=(
+            pool_positions.get(pool_id)
+            if pool_positions is not None and pool_id is not None
+            else None
+        ),
         entry_a_id=(
             EntryId(fixture.entry_a_id) if fixture.entry_a_id is not None else None
         ),
@@ -192,10 +244,17 @@ def draw_config(event: TournamentEvent) -> DrawConfig:
     (single-elim, #785) ignores them and writes ``NULL`` pool refs; a pooled one deals
     the field across exactly these ids — which is what makes a fixture's ``pool_id`` a
     string ref that resolves against the event the client is already holding.
+
+    The order is read off each pool's ``position`` (ADR 20260801, "Pools carry an
+    explicit ``position``") rather than taken from the JSONB array's incidental
+    sequence. Both say the same thing today — the position *is* stamped from the array
+    index at the write boundary — and saying it out loud is the point: this order is
+    what the snake seeds against, so once pools become rows the order has to come from
+    the column that carries it, not from whatever sequence a query happened to return
+    them in. A ``sorted`` is stable, so pools stored before the field existed (every
+    ``position`` defaulting to ``0``) keep the array order they have always had.
     """
-    return DrawConfig(
-        pool_ids=tuple(PoolId(Pool.model_validate(pool).id) for pool in event.pools),
-    )
+    return DrawConfig(pool_ids=tuple(PoolId(pool.id) for pool in _ordered_pools(event)))
 
 
 def strategy_for_event(event: TournamentEvent) -> DrawStrategy:

--- a/api/app/tournament_events.py
+++ b/api/app/tournament_events.py
@@ -42,6 +42,7 @@ from app.schemas.tournament import (
     TournamentEventCreate,
     TournamentEventUpdate,
     named_list,
+    stored_pools,
 )
 from app.tournament_draws import event_has_draw, event_pools
 from app.tournament_edit import _load_owned_tournament_for_update
@@ -97,11 +98,12 @@ async def create_event(
       (``created_by_user_id == actor.id``), not RBAC-gated.
 
     Then it writes the event exactly as the HTTP handler did inline — the nested
-    value-objects (``slot``, ``match_settings``, ``predicates``, ``pools``) persist as
-    plain JSONB via ``model_dump``. Commits and refreshes before returning. Never
-    raises ``HTTPException`` — the caller adapts each domain exception to its
-    transport and shapes the read (a just-created event has no entrants, draw or
-    results, so those are all empty without a query).
+    value-objects (``slot``, ``match_settings``, ``predicates``) persist as plain JSONB
+    via ``model_dump``, and ``pools`` through :func:`stored_pools`, which is the same
+    dump plus the server-assigned ``position`` the write shape has no field for. Commits
+    and refreshes before returning. Never raises ``HTTPException`` — the caller adapts
+    each domain exception to its transport and shapes the read (a just-created event has
+    no entrants, draw or results, so those are all empty without a query).
 
     The tournament's ``league_id`` — already in hand from the owner-load — is returned
     beside the event so the adapter can shape the caller's ``entry_state`` (the ladder
@@ -132,7 +134,12 @@ async def create_event(
         slot=payload.slot.model_dump(),
         match_settings=payload.match_settings.model_dump(),
         predicates=[p.model_dump() for p in payload.predicates],
-        pools=[p.model_dump() for p in payload.pools],
+        # The one nested value-object that is not a straight ``model_dump``: what the
+        # client sent is the WRITE shape, which carries no ``position``, and the column
+        # holds the stored shape, which does. ``stored_pools`` is that conversion, and
+        # the only place a position is assigned — from each pool's index in the list
+        # this payload sent (ADR 20260801, "Pools carry an explicit ``position``").
+        pools=stored_pools(payload.pools),
     )
     db.add(event)
     await db.commit()
@@ -496,8 +503,9 @@ async def update_event(
 
     Then the partial apply (``model_dump(exclude_unset=True)`` serializes the nested
     value-objects to plain dicts/lists, so one ``setattr`` loop covers the JSONB and
-    scalar columns alike), with three side effects — the first new, the other two
-    preserved exactly from the router:
+    scalar columns alike — with ``pools`` recomposed through :func:`stored_pools` first,
+    since the write shape carries no ``position`` and the column does), with three side
+    effects — the first new, the other two preserved exactly from the router:
 
     * a **draw-configuration** edit (the draw type and, for ``rr-then-ko``, its
       qualifier count) is applied to the event's ``draw_settings`` row, the only place
@@ -549,6 +557,18 @@ async def update_event(
     # them leaves the loop below touching mapped columns only.
     changes.pop("draw_type", None)
     changes.pop("qualifiers_per_pool", None)
+    if updates.pools is not None:
+        # Recomposed rather than dumped, and on this verb as much as on create: the
+        # dump above is of the WRITE shape, which has no ``position``, so leaving it
+        # alone would store a pool set with no order at all — an event born positioned
+        # and then patched flat, which is the "the patch path is the hole" bug this
+        # repo keeps rediscovering. ``stored_pools`` stamps the order the patch sent,
+        # which is also how a director re-orders pools: send them re-ordered.
+        #
+        # ``is not None`` is exactly "the key was sent": an explicit ``null`` is already
+        # a 422 (``TournamentEventUpdate._reject_explicit_null``), so this cannot be
+        # mistaking a clear for an absence.
+        changes["pools"] = stored_pools(updates.pools)
     # The parsed union arm, not the loose keys: it is ``None`` exactly when the patch
     # does not touch the draw configuration, and when it is not, the pair it carries is
     # one the settings table's ``CHECK`` accepts (ADR 20260727).

--- a/api/app/tournament_materialization.py
+++ b/api/app/tournament_materialization.py
@@ -35,7 +35,7 @@ from app.models import (
     TournamentFixture,
 )
 from app.schemas.tournament import MatchSettings as EventMatchSettings
-from app.tournament_draws import fixture_state, strategy_for_event
+from app.tournament_draws import fixture_state, pool_order, strategy_for_event
 from app.tournament_queries import game_counts_by_match
 
 
@@ -129,8 +129,12 @@ async def materialize_event(
         if reads_fixture_games(event.draw_settings.draw_type)
         else {}
     )
+    # The event's pool order, resolved once and handed to every projection: it is what
+    # fills ``FixtureState.pool_position``, and so what makes an ``advance()`` plan's
+    # ready list run pool 1, 2, … 10 rather than the ids' 1, 10, 2 (ADR 20260801).
+    pools = pool_order(event)
     plan = strategy.advance(
-        [fixture_state(f, game_counts, voided_match_ids) for f in fixtures]
+        [fixture_state(f, game_counts, voided_match_ids, pools) for f in fixtures]
     )
     # Apply the side-fills a decided fixture implies BEFORE the readiness pass, so a
     # fixture made whole by them seats its match in this same transaction. A fill only
@@ -149,7 +153,7 @@ async def materialize_event(
     # plan's and needs no second side-fill pass beyond the loop above.
     ready = set(
         ready_fixtures(
-            [fixture_state(f, game_counts, voided_match_ids) for f in fixtures]
+            [fixture_state(f, game_counts, voided_match_ids, pools) for f in fixtures]
         )
     )
     ready_fixture_rows = [f for f in fixtures if f.id in ready]

--- a/api/app/tournament_queries.py
+++ b/api/app/tournament_queries.py
@@ -15,8 +15,10 @@ import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime
 
-from sqlalchemy import ColumnElement, and_, func, or_, select
+from sqlalchemy import ColumnElement, and_, column, func, or_, select
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.expression import ScalarSelect
 
 from app.models import (
     DrawTypeOption,
@@ -231,6 +233,37 @@ async def active_entrants_by_event(
     return entrants
 
 
+def _pool_position() -> ScalarSelect[int | None]:
+    """The ``position`` of a fixture's pool within its own event — the correlated
+    subquery the draw order below sorts on.
+
+    A fixture holds a **string ref** into its event's ``pools`` JSONB, not an FK, so
+    "where does this fixture's pool sit in the director's order?" is a lookup into that
+    array: find the element whose ``id`` matches ``tournament_fixtures.pool_id``, and
+    read its ``position`` (:data:`app.schemas.tournament.PoolPosition` — 0-based,
+    stamped by the server from the order the pools were sent in).
+    ``jsonb_array_elements`` unnests the array; the pool ids of one event are unique
+    (``_pool_ids_are_unique`` at the write boundary), so the subquery is scalar by
+    construction rather than by a ``LIMIT`` papering over duplicates.
+
+    It is ``NULL`` in exactly two cases, and both want to sort at the end of the pooled
+    group: an **un-pooled** fixture (``pool_id IS NULL`` — single-elim, or the KO stage
+    of an rr-then-ko draw) matches no element, and a pool stored **before** ``position``
+    existed carries no such key. The second is why the id remains a secondary sort key
+    below: a whole event of position-less pools degrades to exactly the id order this
+    used to have, rather than to no order at all.
+    """
+    pool = func.jsonb_array_elements(TournamentEvent.pools).table_valued(
+        column("value", JSONB)
+    )
+    return (
+        select(pool.c.value["position"].as_integer())
+        .where(pool.c.value["id"].as_string() == TournamentFixture.pool_id)
+        .correlate(TournamentEvent, TournamentFixture)
+        .scalar_subquery()
+    )
+
+
 async def fixtures_by_event(
     db: AsyncSession, event_ids: Sequence[uuid.UUID]
 ) -> dict[uuid.UUID, list[TournamentFixtureRead]]:
@@ -256,15 +289,28 @@ async def fixtures_by_event(
     then round, then position — over columns that ``UNIQUE (event_id, pool_id, round,
     position)`` already guarantees are unique together, so the sequence is the same on
     every read and a client can render a bracket without sorting it first. A NULL
-    ``pool_id`` sorts LAST, which would put a pools-then-knockout draw type's KO stage
-    after the pools it is fed from once #787 adds one (and costs an un-pooled draw
-    nothing today — every row is NULL there, so round
-    and position decide it alone).
+    ``pool_id`` sorts LAST, which puts a pools-then-knockout draw type's KO stage
+    after the pools it is fed from (and costs an un-pooled draw nothing — every row is
+    NULL there, so round and position decide it alone).
 
-    Sorted in Postgres rather than in Python because a NULL is not comparable to a
-    string: ``sorted(key=lambda f: (f.pool_id, ...))`` is a ``TypeError`` the moment an
-    un-pooled fixture meets a pooled one, and the defensive coalesce that usually
-    follows (``f.pool_id or ""``) would quietly sort the KO stage FIRST.
+    "Pool" here means the pool's **position in the event's own pool order**
+    (:func:`_pool_position`), not its id. The id is a client-minted string —
+    ``p-1-…``, ``p-2-…``, ``p-10-…`` — and *lexicographically* ``p-10-`` falls between
+    ``p-1-`` and ``p-2-``, so a ten-pool event rendered its draw as pool 1, pool 10,
+    pool 2. Sorting on the stored ``position`` (ADR 20260801, "Pools carry an explicit
+    ``position``") is also the only key that survives pools becoming rows with random
+    UUID primary keys, under which an id sort is not merely wrong but *arbitrary*.
+    The id stays on as a secondary key so the order is still total when the positions
+    cannot decide it — an event whose pools predate the field carries no ``position``
+    at all, and degrades to precisely the id order this used to have.
+
+    Sorted in Postgres rather than in Python because a NULL is not comparable to an
+    ``int`` (nor, before it, to a string): ``sorted(key=lambda f: (f.pool_position,
+    ...))`` is a ``TypeError`` the moment an un-pooled fixture meets a pooled one, and
+    the defensive coalesce that usually follows (``f.pool_position or 0``) would
+    quietly sort the KO stage FIRST — in front of the pools that feed it. The position
+    is also not a column on the fixture at all: it lives in the event's ``pools``
+    JSONB, so resolving it in Python would mean parsing every event's pools per read.
 
     A materialized fixture carries its match's **live status** (``match_status``), read
     by LEFT-joining ``matches`` on ``fixture.match_id`` (#788) — still ONE statement,
@@ -305,6 +351,7 @@ async def fixtures_by_event(
             .outerjoin(Match, Match.id == TournamentFixture.match_id)
             .where(TournamentFixture.event_id.in_(fixtures.keys()))
             .order_by(
+                _pool_position().asc().nulls_last(),
                 TournamentFixture.pool_id.asc().nulls_last(),
                 TournamentFixture.round,
                 TournamentFixture.position,

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -672,14 +672,83 @@ class TestReadyFixtures:
         pool_id: PoolId | None,
         round: int,
         position: int,
+        pool_position: int | None = None,
     ) -> FixtureState:
         return FixtureState(
             fixture_id=FixtureId(uuid.UUID(int=n)),
             pool_id=pool_id,
             round=round,
             position=position,
+            pool_position=pool_position,
             entry_a_id=_entry_id(1),
             entry_b_id=_entry_id(2),
+        )
+
+    def test_the_plan_runs_the_pools_in_the_events_order_not_the_ids(self) -> None:
+        """Ten pools, and the plan runs 1..10 — not the ids' 1, 10, 2, 3…
+
+        Pool ids are client-minted strings (``p-1-…``, ``p-2-…``, ``p-10-…``) and
+        lexicographically ``p-10-`` falls between ``p-1-`` and ``p-2-``, so the id sort
+        this used to do materialized a ten-pool event's matches with pool 10's wedged
+        between pool 1's and pool 2's. The order the plan runs in is the director's
+        (``pool_position``, ADR 20260801) — the same order the read path renders and the
+        same one the snake dealt against.
+
+        The ids are handed in *deliberately mismatched* to the positions: pool 1 is
+        ``p-10-…`` and pool 10 is ``p-1-…``. So the two rules do not merely differ,
+        they are opposites — an implementation that fell back to the id could not
+        accidentally agree with this assertion on any prefix of it.
+        """
+        pools = [(f"p-{10 - index}-x", index) for index in range(10)]
+        states = [
+            self._state(
+                index + 1,
+                pool_id=PoolId(pool_id),
+                round=1,
+                position=1,
+                pool_position=position,
+            )
+            for index, (pool_id, position) in enumerate(pools)
+        ]
+
+        ready = ready_fixtures(list(reversed(states)))
+
+        assert ready == tuple(state.fixture_id for state in states)
+
+    def test_a_pool_of_unknown_position_sorts_behind_the_placed_ones_by_id(
+        self,
+    ) -> None:
+        """A fixture whose pool order was not resolved — a caller that passed no pool
+        positions, or a pool stored before ``position`` existed — still has a *defined*
+        place: after every pool that has a position, ordered among its own kind by id.
+
+        That is the pre-position order preserved exactly where the position cannot
+        speak, rather than an unresolved fixture jumping the queue. It matters because
+        ``0`` is a real position (the *first* pool), so "unknown" must not collapse
+        onto it: the
+        placed pool below sits at 0, holds the id that sorts *last*, and still comes
+        first.
+
+        The un-pooled fixture is here to pin the other end. Its position is ``None``
+        too — it is in no pool, so there is nothing to place — which is exactly why
+        "pooled?" has to stay the *outermost* question: decided on position alone the
+        KO fixture would tie with the unplaced pools and win the id tie-break outright
+        (no id sorts before ``""``), landing in front of the pools that feed it.
+        """
+        placed = self._state(
+            1, pool_id=PoolId("z"), round=1, position=1, pool_position=0
+        )
+        unplaced_b = self._state(2, pool_id=PoolId("b"), round=1, position=1)
+        unplaced_a = self._state(3, pool_id=PoolId("a"), round=1, position=1)
+        ko = self._state(4, pool_id=None, round=1, position=1)
+
+        ready = ready_fixtures([ko, unplaced_b, unplaced_a, placed])
+
+        assert ready == (
+            placed.fixture_id,
+            unplaced_a.fixture_id,
+            unplaced_b.fixture_id,
+            ko.fixture_id,
         )
 
     def test_pooled_fixtures_are_ready_before_un_pooled_ones(self) -> None:

--- a/api/tests/test_tournament_draws.py
+++ b/api/tests/test_tournament_draws.py
@@ -36,7 +36,7 @@ from app.models import (
     User,
 )
 from app.models.tournament import DrawType, EventFormat
-from app.tournament_draws import fixture_state
+from app.tournament_draws import draw_config, fixture_state, pool_order
 from app.tournament_queries import (
     completed_match_ids,
     fixtures_by_event,
@@ -288,3 +288,101 @@ async def test_a_match_that_has_not_completed_projects_no_games(
 
     assert state.match_id is not None, "the fixture HAS materialized into a match"
     assert state.games is None, "an in-progress board is not a result"
+
+
+# --- the event's pool ORDER --------------------------------------------------------
+#
+# ``draw_config`` seeds the snake against it, ``pool_order`` is what a persisted
+# fixture's ``pool_position`` is resolved through, and both read it off
+# ``Pool.position`` (ADR 20260801) rather than off the pool id. The ids below are
+# minted the way the client mints them — ``p-1-…``, ``p-2-…``, ``p-10-…`` — whose
+# lexicographic order (1, 10, 2, 3…) is deliberately not the director's, so a sort
+# that fell back to the id cannot pass.
+
+TEN_POOL_IDS = [f"p-{n}-x" for n in range(1, 11)]
+
+
+def _pools(ids: list[str], *, positions: bool = True) -> list[dict[str, object]]:
+    """These pool ids as stored JSONB, in this list's order — with or without the
+    ``position`` key, the latter being how every pool written before the field existed
+    still sits in the database today."""
+    return [
+        {
+            "id": pool_id,
+            "name": f"Pool {index + 1}",
+            "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+            "table_ids": [],
+            **({"position": index} if positions else {}),
+        }
+        for index, pool_id in enumerate(ids)
+    ]
+
+
+def test_draw_config_orders_the_pools_by_position_not_by_id() -> None:
+    """``DrawConfig.pool_ids`` is the sequence the snake deals against, so its order is
+    the draw's seeding — get it wrong and the draw still cuts, still looks like a draw,
+    and seats the wrong people together.
+
+    The pools are stored in *reverse* positional order here, so the array order and the
+    positions disagree: what comes back has to be the positions' order, which is neither
+    the array's nor the ids'.
+    """
+    stored = _pools(TEN_POOL_IDS)
+    event = TournamentEvent(pools=list(reversed(stored)))
+
+    assert draw_config(event).pool_ids == tuple(TEN_POOL_IDS)
+
+
+def test_draw_config_keeps_the_array_order_of_pools_that_have_no_position() -> None:
+    """Pools stored before ``position`` existed all parse to the default ``0``, and a
+    stable sort leaves them exactly where they were — the array order, which is the only
+    thing that ever carried their order. A read boundary must not re-seed a standing
+    draw's pools just because it cannot see their positions."""
+    event = TournamentEvent(pools=_pools(TEN_POOL_IDS, positions=False))
+
+    assert draw_config(event).pool_ids == tuple(TEN_POOL_IDS)
+
+
+def test_pool_order_ranks_every_pool_id_by_the_events_order() -> None:
+    """The lookup the fixture projection resolves through: id → 0-based place, the same
+    sequence ``draw_config`` hands the snake, so a draw is advanced in the order it was
+    cut in."""
+    event = TournamentEvent(pools=list(reversed(_pools(TEN_POOL_IDS))))
+
+    assert pool_order(event) == {
+        pool_id: index for index, pool_id in enumerate(TEN_POOL_IDS)
+    }
+
+
+def test_fixture_state_projects_its_pools_place_in_the_event_order() -> None:
+    """The bridge fills ``pool_position`` from the passed lookup — the fact
+    ``ready_fixtures`` groups a plan by. Pool ``p-10-x`` is *last* in the director's
+    order and *second* in the ids', which is the discriminating case."""
+    event = TournamentEvent(pools=_pools(TEN_POOL_IDS))
+    fixture = TournamentFixture(
+        id=uuid.uuid4(), event_id=uuid.uuid4(), pool_id="p-10-x", round=1, position=1
+    )
+
+    assert (
+        fixture_state(fixture, None, frozenset(), pool_order(event)).pool_position == 9
+    )
+
+
+def test_fixture_state_projects_no_pool_position_when_there_is_no_pool() -> None:
+    """An un-pooled fixture (single-elim, or an rr-then-ko draw's KO stage) is in no
+    pool, so there is no place to project — ``None``, whatever lookup is passed. And a
+    caller that passes no lookup at all gets ``None`` for a *pooled* fixture too: the
+    order was not resolved, which is a different thing from position zero."""
+    event = TournamentEvent(pools=_pools(TEN_POOL_IDS))
+    un_pooled = TournamentFixture(
+        id=uuid.uuid4(), event_id=uuid.uuid4(), pool_id=None, round=1, position=1
+    )
+    pooled = TournamentFixture(
+        id=uuid.uuid4(), event_id=uuid.uuid4(), pool_id="p-1-x", round=1, position=1
+    )
+
+    assert (
+        fixture_state(un_pooled, None, frozenset(), pool_order(event)).pool_position
+        is None
+    )
+    assert fixture_state(pooled).pool_position is None

--- a/api/tests/test_tournament_events.py
+++ b/api/tests/test_tournament_events.py
@@ -19,6 +19,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 import pytest
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -60,9 +61,12 @@ def _address() -> Address:
     )
 
 
-def _event_payload(**overrides: Any) -> TournamentEventCreate:
-    """A valid create-event body (same shape as ``test_tournaments._event_payload``),
-    parsed through the same ``TournamentEventCreate`` schema the HTTP route uses."""
+def _event_body(**overrides: Any) -> dict[str, Any]:
+    """A valid create-event body as **JSON**, before any parse.
+
+    Split out of :func:`_event_payload` because a refusal test needs the body the client
+    would send, not the model — a payload the schema rejects is one ``_event_payload``
+    cannot return."""
     body: dict[str, Any] = {
         "name": "Open Singles",
         "format": "singles",
@@ -83,7 +87,13 @@ def _event_payload(**overrides: Any) -> TournamentEventCreate:
         ],
     }
     body.update(overrides)
-    return TournamentEventCreate.model_validate(body)
+    return body
+
+
+def _event_payload(**overrides: Any) -> TournamentEventCreate:
+    """A valid create-event body (same shape as ``test_tournaments._event_payload``),
+    parsed through the same ``TournamentEventCreate`` schema the HTTP route uses."""
+    return TournamentEventCreate.model_validate(_event_body(**overrides))
 
 
 async def _make_tournament(
@@ -212,14 +222,20 @@ async def test_create_on_a_missing_tournament_raises_not_found(
 
 # ----- pool positions ------------------------------------------------------
 #
-# A pool's ``position`` is the one field on it the client does not author: the write
-# boundary stamps it from the pool's index in the list that was sent, on BOTH verbs
-# (ADR 20260801, "Pools carry an explicit ``position``"). These tests are what says the
-# stamp is the *order sent* and nothing else — every pool below is named and id'd so
-# that alphabetical order (by either) is a DIFFERENT answer from the order sent, which
-# is what makes them able to fail. Asserting "each pool has a position" would pass
-# against an implementation that assigned all zeros, sorted by name, or wrote back
-# whatever the client asked for.
+# A pool's ``position`` is the one field on it the client cannot author: it is not on
+# the write shape at all (``PoolWrite``), and the server stamps it from the pool's index
+# in the list that was sent — on BOTH verbs (ADR 20260801, "Pools carry an explicit
+# ``position``"). So there are two claims here, and they need each other:
+#
+#   * a payload that CARRIES a position is refused, naming the unknown field, rather
+#     than having it silently overwritten. "Server-assigned" is then a property of the
+#     schema, which a client can read, instead of a sentence in a docstring, which it
+#     cannot; and
+#   * a payload that does not is stored in the *order sent*, and nothing else. Every
+#     pool below is named and id'd so that alphabetical order (by either) is a DIFFERENT
+#     answer from the order sent, which is what makes these able to fail — asserting
+#     "each pool has a position" would pass against an implementation that assigned all
+#     zeros or sorted by name.
 
 
 def _pool(pool_id: str, name: str, **extra: Any) -> dict[str, Any]:
@@ -287,35 +303,64 @@ async def test_create_positions_pools_by_the_order_they_were_sent(
     assert len(set(positions)) == len(positions)
 
 
-async def test_create_overwrites_a_client_supplied_pool_position(
-    db_session: AsyncSession,
-    default_league: League,
-) -> None:
-    """``position`` is server-assigned: three pools that all claim position ``7`` are
-    stored as 0, 1, 2.
+_POOLS_CLAIMING_A_POSITION = [
+    _pool("p-c", "Pool C", position=7),
+    _pool("p-a", "Pool A", position=7),
+    _pool("p-b", "Pool B", position=7),
+]
+"""Three pools that each claim position ``7`` — the payload a client writes when it
+mistakes a server-assigned field for one of its own."""
 
-    The event editor PATCHes the whole event form back, pools included, so a client
-    *will* send this field once it can read it — and the values it sends must decide
-    nothing. There is no pools table yet and so no ``UNIQUE (event_id, position)``
-    underneath to catch three sevens; the boundary is the whole enforcement.
-    """
-    owner = await make_user(db_session, "events-create-pool-position-override")
-    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
 
-    event, _ = await create_event(
-        db_session,
-        tournament_id=tournament.id,
-        actor=owner,
-        payload=_event_payload(
-            pools=[
-                _pool("p-c", "Pool C", position=7),
-                _pool("p-a", "Pool A", position=7),
-                _pool("p-b", "Pool B", position=7),
-            ]
+@pytest.mark.parametrize(
+    ("schema", "body"),
+    [
+        pytest.param(
+            TournamentEventCreate,
+            _event_body(pools=_POOLS_CLAIMING_A_POSITION),
+            id="create",
         ),
-    )
+        pytest.param(
+            TournamentEventUpdate,
+            {"pools": _POOLS_CLAIMING_A_POSITION},
+            id="patch",
+        ),
+    ],
+)
+def test_a_write_payload_carrying_a_pool_position_is_refused(
+    schema: type[BaseModel], body: dict[str, Any]
+) -> None:
+    """A ``position`` on a pool a client **sends** is an unknown field, on both verbs —
+    refused by name, not accepted and quietly overwritten.
 
-    assert _named_positions(event) == [("Pool C", 0), ("Pool A", 1), ("Pool B", 2)]
+    ``position`` is not on ``PoolWrite``, and both write schemas are
+    ``extra="forbid"``, so this is the boundary saying "server-assigned" in the one
+    register a client can actually read: the field is unsendable, so a client cannot
+    believe it decided the order. The alternative — take it and ignore it — is the
+    ``entered`` mistake in a different key: a value the caller watched itself send and
+    the server watched itself discard, discoverable only in prose.
+
+    Both verbs, because "the patch path is the hole" is this repo's recurring bug: the
+    event editor PATCHes the whole form back, so the patch is the verb that would
+    actually carry an echoed position. They share one alias (``EventPools``) over one
+    pool shape, which is what makes that impossible to get wrong on only one of them.
+
+    The **loc** is asserted, not just the refusal: a 422 that named ``pools`` and
+    nothing more would leave a client hunting through its own payload for a field it
+    was never told about.
+    """
+    with pytest.raises(ValidationError) as refusal:
+        schema.model_validate(body)
+
+    errors = refusal.value.errors()
+    # Every pool that claimed one is named — not merely the first — so the director's
+    # client can strip the field everywhere it put it, in one round trip.
+    assert [error["loc"] for error in errors] == [
+        ("pools", 0, "position"),
+        ("pools", 1, "position"),
+        ("pools", 2, "position"),
+    ]
+    assert {error["type"] for error in errors} == {"extra_forbidden"}
 
 
 async def test_update_repositions_pools_by_the_order_they_were_patched(

--- a/api/tests/test_tournament_events.py
+++ b/api/tests/test_tournament_events.py
@@ -210,6 +210,172 @@ async def test_create_on_a_missing_tournament_raises_not_found(
         )
 
 
+# ----- pool positions ------------------------------------------------------
+#
+# A pool's ``position`` is the one field on it the client does not author: the write
+# boundary stamps it from the pool's index in the list that was sent, on BOTH verbs
+# (ADR 20260801, "Pools carry an explicit ``position``"). These tests are what says the
+# stamp is the *order sent* and nothing else — every pool below is named and id'd so
+# that alphabetical order (by either) is a DIFFERENT answer from the order sent, which
+# is what makes them able to fail. Asserting "each pool has a position" would pass
+# against an implementation that assigned all zeros, sorted by name, or wrote back
+# whatever the client asked for.
+
+
+def _pool(pool_id: str, name: str, **extra: Any) -> dict[str, Any]:
+    """One pool payload, valid but for whatever ``extra`` the caller adds."""
+    return {
+        "id": pool_id,
+        "name": name,
+        "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+        "table_ids": ["t1"],
+        **extra,
+    }
+
+
+def _named_positions(event: TournamentEvent) -> list[tuple[str, int]]:
+    """``(name, position)`` per stored pool, read off the JSONB in **column order**.
+
+    Names, not ids, because a pool named "Pool C" sitting at position 0 is the whole
+    claim: it is the pool the director put first, and it is not the alphabetically first
+    one. Read from the raw column rather than through ``Pool`` so a default the schema
+    supplies could not stand in for a value the write path failed to store.
+    """
+    return [(pool["name"], pool["position"]) for pool in event.pools]
+
+
+async def test_create_positions_pools_by_the_order_they_were_sent(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """Three pools sent as **C, A, B** are stored as positions 0, 1, 2 *in that order*.
+
+    Sorted by name — or by id, which is how pool order used to be recovered — the
+    answer would be C=2, A=0, B=1. Sorted by nothing at all it would be three zeros.
+    The event's pool order is the order the director sent, and this is the assertion
+    that distinguishes the three.
+    """
+    owner = await make_user(db_session, "events-create-pool-positions")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+
+    event, _ = await create_event(
+        db_session,
+        tournament_id=tournament.id,
+        actor=owner,
+        payload=_event_payload(
+            pools=[
+                _pool("p-c", "Pool C"),
+                _pool("p-a", "Pool A"),
+                _pool("p-b", "Pool B"),
+            ]
+        ),
+    )
+    event_id = event.id
+
+    assert _named_positions(event) == [("Pool C", 0), ("Pool A", 1), ("Pool B", 2)]
+
+    # Persisted, not merely returned — and read back off the row.
+    db_session.expire_all()
+    row = (
+        await db_session.execute(
+            select(TournamentEvent).where(TournamentEvent.id == event_id)
+        )
+    ).scalar_one()
+    assert _named_positions(row) == [("Pool C", 0), ("Pool A", 1), ("Pool B", 2)]
+    # No two pools of one event share a position.
+    positions = [pool["position"] for pool in row.pools]
+    assert len(set(positions)) == len(positions)
+
+
+async def test_create_overwrites_a_client_supplied_pool_position(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """``position`` is server-assigned: three pools that all claim position ``7`` are
+    stored as 0, 1, 2.
+
+    The event editor PATCHes the whole event form back, pools included, so a client
+    *will* send this field once it can read it — and the values it sends must decide
+    nothing. There is no pools table yet and so no ``UNIQUE (event_id, position)``
+    underneath to catch three sevens; the boundary is the whole enforcement.
+    """
+    owner = await make_user(db_session, "events-create-pool-position-override")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+
+    event, _ = await create_event(
+        db_session,
+        tournament_id=tournament.id,
+        actor=owner,
+        payload=_event_payload(
+            pools=[
+                _pool("p-c", "Pool C", position=7),
+                _pool("p-a", "Pool A", position=7),
+                _pool("p-b", "Pool B", position=7),
+            ]
+        ),
+    )
+
+    assert _named_positions(event) == [("Pool C", 0), ("Pool A", 1), ("Pool B", 2)]
+
+
+async def test_update_repositions_pools_by_the_order_they_were_patched(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """The patch path is the other half of the same rule: the event is born C, A, B and
+    patched to B, C, A, and its stored positions follow the payload.
+
+    Guarding only ``create`` would leave the order to rot on the first edit — an event
+    born with positions and then patched without them would silently fall back to
+    whatever the ids happened to sort as, which is the exact failure the explicit
+    position exists to end. The event is deliberately **un-drawn**, so the pool-set
+    freeze is not what is being tested here: the same three ids go in, re-ordered.
+    """
+    owner = await make_user(db_session, "events-update-pool-positions")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event, _ = await create_event(
+        db_session,
+        tournament_id=tournament.id,
+        actor=owner,
+        payload=_event_payload(
+            pools=[
+                _pool("p-c", "Pool C"),
+                _pool("p-a", "Pool A"),
+                _pool("p-b", "Pool B"),
+            ]
+        ),
+    )
+    event_id = event.id
+
+    updated, _ = await update_event(
+        db_session,
+        tournament_id=tournament.id,
+        event_id=event_id,
+        actor=owner,
+        updates=TournamentEventUpdate.model_validate(
+            {
+                "pools": [
+                    _pool("p-b", "Pool B"),
+                    _pool("p-c", "Pool C"),
+                    _pool("p-a", "Pool A"),
+                ]
+            }
+        ),
+    )
+
+    assert _named_positions(updated) == [("Pool B", 0), ("Pool C", 1), ("Pool A", 2)]
+
+    db_session.expire_all()
+    row = (
+        await db_session.execute(
+            select(TournamentEvent).where(TournamentEvent.id == event_id)
+        )
+    ).scalar_one()
+    assert _named_positions(row) == [("Pool B", 0), ("Pool C", 1), ("Pool A", 2)]
+    positions = [pool["position"] for pool in row.pools]
+    assert len(set(positions)) == len(positions)
+
+
 # ----- delete --------------------------------------------------------------
 
 

--- a/api/tests/test_tournament_queries.py
+++ b/api/tests/test_tournament_queries.py
@@ -1,0 +1,286 @@
+"""The draw read path's **order**: ``app.tournament_queries.fixtures_by_event``.
+
+A draw has one order, and the loader is where it is decided (in SQL, because a NULL
+``pool_id`` is not comparable to anything in Python). What that order sorts pools by is
+the subject here: the pool's ``position`` in its event's own pool order — the
+server-stamped, 0-based field pools carry (ADR 20260801, "Pools carry an explicit
+``position``") — and *not* the pool's id.
+
+The distinction is not academic and is not about the future. Pool ids are client-minted
+strings, ``p-1-…``, ``p-2-…``, ``p-10-…``, and lexicographically ``p-10-`` falls between
+``p-1-`` and ``p-2-``: an event with ten or more pools rendered its draw as pool 1, pool
+10, pool 2, pool 3, … Every test below is written to fail against an id sort, which is
+why the ids are chosen so their lexicographic order differs from the director's.
+
+These go through the database, because the ordering *is* the query — asserting it
+against anything else would be asserting about a different artifact.
+"""
+
+import uuid
+from decimal import Decimal
+from typing import Any
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.leagues import get_default_league
+from app.models import (
+    DrawType,
+    EventFormat,
+    Tournament,
+    TournamentEvent,
+    TournamentEventDrawSettings,
+    TournamentFixture,
+    TournamentStatus,
+)
+from app.tournament_queries import fixtures_by_event
+from tests._helpers import make_user
+
+#: Ten pool ids in the **director's** order, minted the way the client mints them. Their
+#: lexicographic order is ``p-1-…, p-10-…, p-2-…, p-3-…`` — deliberately not this one,
+#: which is the whole point: a test whose ids happened to sort right could not tell an
+#: id sort from a position sort.
+POOL_IDS = [f"p-{n}-{uuid.uuid4().hex[:6]}" for n in range(1, 11)]
+
+
+def _pool(pool_id: str, position: int) -> dict[str, Any]:
+    """One pool as it is stored — the JSONB shape the write boundary produces."""
+    return {
+        "id": pool_id,
+        "name": f"Pool {position + 1}",
+        "position": position,
+        "slot": {},
+        "table_ids": [],
+    }
+
+
+async def _make_event(
+    db_session: AsyncSession, pools: list[dict[str, Any]]
+) -> TournamentEvent:
+    """A published round-robin event carrying exactly these pools.
+
+    Written straight to the database: nothing here is about who may create a tournament,
+    and the pools are seeded in shapes (a stored ``position``, and a legacy one with no
+    such key) that only the write boundary can produce or refuse.
+    """
+    owner = await make_user(db_session, f"director-{uuid.uuid4().hex[:8]}")
+    league = await get_default_league(db_session)
+    assert league is not None, "the autouse default_league fixture seeds this"
+
+    tournament = Tournament(
+        name="Spring Open",
+        status=TournamentStatus.published,
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "1 Shattuck Ave",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94704",
+            "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
+        },
+        league_id=league.id,
+        created_by_user_id=owner.id,
+    )
+    db_session.add(tournament)
+    await db_session.flush()
+
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Open Singles",
+        format=EventFormat.singles,
+        draw_settings=TournamentEventDrawSettings.for_draw_type(DrawType.round_robin),
+        max_players=64,
+        entry_fee=Decimal("20.00"),
+        timezone="America/Chicago",
+        slot={"date": "2026-08-01", "start": "09:00", "end": "17:00"},
+        match_settings={"rated": True, "length_games": 5},
+        pools=pools,
+    )
+    db_session.add(event)
+    await db_session.commit()
+    await db_session.refresh(event)
+    return event
+
+
+async def _seed_fixtures(
+    db_session: AsyncSession,
+    event: TournamentEvent,
+    rows: list[tuple[str | None, int, int]],
+) -> None:
+    """Write ``(pool_id, round, position)`` fixtures — in the order given, which every
+    caller below deliberately scrambles: insertion order is what an unsorted read
+    returns, so rows seeded in the right order could not tell a broken ``ORDER BY`` from
+    a working one."""
+    for pool_id, round_number, position in rows:
+        db_session.add(
+            TournamentFixture(
+                event_id=event.id,
+                pool_id=pool_id,
+                round=round_number,
+                position=position,
+            )
+        )
+    await db_session.commit()
+
+
+@pytest_asyncio.fixture
+async def ten_pool_event(db_session: AsyncSession) -> TournamentEvent:
+    """An event with ten pools, positions 0..9, in the director's order."""
+    return await _make_event(
+        db_session,
+        [_pool(pool_id, position) for position, pool_id in enumerate(POOL_IDS)],
+    )
+
+
+async def test_ten_pools_come_back_in_the_directors_pool_order(
+    db_session: AsyncSession, ten_pool_event: TournamentEvent
+) -> None:
+    """The one this exists for: ten pools read back 1..10, not 1, 10, 2, 3…
+
+    Ten is the smallest field that tells the two rules apart, because ``p-10-`` is the
+    first client-minted id whose lexicographic place is not its director's place — it
+    sorts between ``p-1-`` and ``p-2-``. Under the old ``ORDER BY pool_id`` this event's
+    draw came back with pool 10's fixtures wedged between pool 1's and pool 2's, on
+    every read, for every client. Nothing about the response looked wrong; it was simply
+    the wrong draw on screen.
+
+    The assertion is the **full sequence**, so it fails on an id sort rather than merely
+    on an unsorted one — a "the pools are contiguous" check would pass against both.
+    """
+    await _seed_fixtures(
+        db_session,
+        ten_pool_event,
+        # Scrambled: the ids' own lexicographic order, which is the order the broken
+        # rule produced and the one a re-broken implementation would fall back into.
+        [(pool_id, 1, 1) for pool_id in sorted(POOL_IDS)],
+    )
+
+    fixtures = (await fixtures_by_event(db_session, [ten_pool_event.id]))[
+        ten_pool_event.id
+    ]
+
+    assert [fixture.pool_id for fixture in fixtures] == POOL_IDS
+
+
+async def test_a_pools_round_and_position_still_decide_within_the_pool(
+    db_session: AsyncSession, ten_pool_event: TournamentEvent
+) -> None:
+    """Pool order is the *outermost* key, not the only one: inside a pool the order is
+    still round then position, and the pools do not interleave."""
+    first, second = POOL_IDS[0], POOL_IDS[1]
+    await _seed_fixtures(
+        db_session,
+        ten_pool_event,
+        [
+            (second, 1, 1),
+            (first, 2, 1),
+            (first, 1, 2),
+            (first, 1, 1),
+        ],
+    )
+
+    fixtures = (await fixtures_by_event(db_session, [ten_pool_event.id]))[
+        ten_pool_event.id
+    ]
+
+    assert [(f.pool_id, f.round, f.position) for f in fixtures] == [
+        (first, 1, 1),
+        (first, 1, 2),
+        (first, 2, 1),
+        (second, 1, 1),
+    ]
+
+
+async def test_un_pooled_fixtures_sort_last_behind_every_pool(
+    db_session: AsyncSession, ten_pool_event: TournamentEvent
+) -> None:
+    """A NULL ``pool_id`` is a real value — "this fixture belongs to no pool" — and it
+    belongs LAST, after the pools that feed it: that is a pools-then-knockout draw's KO
+    stage following its pool stage, and it is the claim the ``NULLS LAST`` in the loader
+    exists for.
+
+    It survives the move onto ``position`` unchanged, and needs saying again *because*
+    it moved: the new key is a subquery that returns NULL for an un-pooled fixture (it
+    matches no pool), so the un-pooled would sort wherever NULLs land by default —
+    which, for a ``DESC`` or a different dialect, is first, in front of the pools.
+    """
+    await _seed_fixtures(
+        db_session,
+        ten_pool_event,
+        [
+            (None, 1, 1),
+            (None, 1, 2),
+            (POOL_IDS[9], 1, 1),
+            (POOL_IDS[0], 1, 1),
+        ],
+    )
+
+    fixtures = (await fixtures_by_event(db_session, [ten_pool_event.id]))[
+        ten_pool_event.id
+    ]
+
+    assert [(f.pool_id, f.position) for f in fixtures] == [
+        (POOL_IDS[0], 1),
+        (POOL_IDS[9], 1),
+        (None, 1),
+        (None, 2),
+    ]
+
+
+async def test_pools_stored_before_positions_existed_keep_their_id_order(
+    db_session: AsyncSession,
+) -> None:
+    """A pool written before ``position`` existed carries no such key, so the subquery
+    reads NULL for it — and the whole event degrades to exactly the id order the loader
+    had before this change, rather than to no order at all.
+
+    That is what the pool **id** is still doing as a secondary sort key. A read boundary
+    must not turn a history it cannot change into a scrambled draw, and there is no
+    migration in this slice: these rows exist today.
+    """
+    legacy = [
+        {"id": pool_id, "name": pool_id, "slot": {}, "table_ids": []}
+        for pool_id in POOL_IDS
+    ]
+    event = await _make_event(db_session, legacy)
+    await _seed_fixtures(
+        db_session, event, [(pool_id, 1, 1) for pool_id in reversed(POOL_IDS)]
+    )
+
+    fixtures = (await fixtures_by_event(db_session, [event.id]))[event.id]
+
+    assert [fixture.pool_id for fixture in fixtures] == sorted(POOL_IDS)
+
+
+async def test_each_events_pool_order_is_read_from_its_own_pools(
+    db_session: AsyncSession, ten_pool_event: TournamentEvent
+) -> None:
+    """The loader is batched over many events at once, so the pool-order lookup has to
+    be correlated to *each fixture's own event* — a subquery that leaked across events
+    would resolve one event's pool ref against another's pools and read a position that
+    is not its own (or, with a shared id, the wrong one entirely).
+
+    The second event reuses the **same ids in the opposite order**, which is the input
+    that tells a correlated lookup from a leaky one: under a leak both events come back
+    in one of the two orders, and the two assertions cannot both hold.
+    """
+    reversed_event = await _make_event(
+        db_session,
+        [
+            _pool(pool_id, position)
+            for position, pool_id in enumerate(reversed(POOL_IDS))
+        ],
+    )
+    for event in (ten_pool_event, reversed_event):
+        await _seed_fixtures(
+            db_session, event, [(pool_id, 1, 1) for pool_id in sorted(POOL_IDS)]
+        )
+
+    fixtures = await fixtures_by_event(
+        db_session, [ten_pool_event.id, reversed_event.id]
+    )
+
+    assert [f.pool_id for f in fixtures[ten_pool_event.id]] == POOL_IDS
+    assert [f.pool_id for f in fixtures[reversed_event.id]] == list(reversed(POOL_IDS))

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -4795,14 +4795,18 @@ POOL_B: dict[str, Any] = {
 
 def _positioned(*pools: dict[str, Any]) -> list[dict[str, Any]]:
     """The pools as the server **stores and returns** them: the payload's own dicts,
-    each carrying the ``position`` the write boundary stamped on it from its index in
-    the list that was sent (ADR 20260801, "Pools carry an explicit ``position``").
+    each carrying the ``position`` the server stamped on it from its index in the list
+    that was sent (ADR 20260801, "Pools carry an explicit ``position``").
 
-    A pool goes in without a position and comes back with one, so an expectation written
-    as the request payload verbatim is off by exactly this field. Deriving it here, from
-    the same order the payload states, keeps these assertions about *what was sent* —
-    write ``_positioned(POOL_B, POOL_A)`` and it says pool B is first, which is the
-    claim — rather than hard-coding a number into each of the literals below."""
+    A pool goes in *without* a position — it cannot be sent one; the write shape has no
+    such field — and comes back *with* one, so an expectation written as the request
+    payload verbatim is off by exactly this field. Deriving it here, from the same order
+    the payload states, keeps these assertions about *what was sent* — write
+    ``_positioned(POOL_B, POOL_A)`` and it says pool B is first, which is the claim —
+    rather than hard-coding a number into each of the literals below.
+
+    Which also makes it the ``pools`` payload a client must **not** send: the two
+    refusal tests below post exactly this, and get a 422 naming ``position``."""
     return [{**pool, "position": index} for index, pool in enumerate(pools)]
 
 
@@ -5899,6 +5903,69 @@ async def test_an_events_pools_are_read_back_in_the_order_they_were_posted(
     # And no two of one event's pools share a position.
     positions = [pool["position"] for pool in event["pools"]]
     assert sorted(positions) == list(range(len(positions)))
+
+
+async def test_posting_an_event_whose_pools_carry_a_position_is_refused(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """The other half of the round trip above, over the wire: a ``pools`` payload
+    carrying the field the server assigns is a **422 naming it**, and creates no event.
+
+    A read field and a write field are different fields here, and this is the request
+    that tells them apart. The read above hands the client a ``position``; sending one
+    back is refused rather than ignored, so a client that mistakes "what I read" for
+    "what I may write" is told exactly which key to drop — at the boundary, in the same
+    request — instead of being handed a 201 for a number that decided nothing.
+    """
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+
+    response = await client.post(
+        f"/v1/tournaments/{created['id']}/events",
+        json=_rr_payload(*_positioned(POOL_C, POOL_A, POOL_B)),
+    )
+
+    assert response.status_code == 422, response.text
+    assert _error_locs(response) == [
+        ["body", "pools", 0, "position"],
+        ["body", "pools", 1, "position"],
+        ["body", "pools", 2, "position"],
+    ]
+    # Refused, not half-written: the tournament has no events at all.
+    assert await _events_of(client, created["id"]) == []
+
+
+async def test_patching_pools_that_carry_a_position_is_refused_and_writes_nothing(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The patch path is the one that would actually carry an echoed ``position`` — the
+    event editor PATCHes the whole form back, pools included — so it is refused there
+    too, and the stored pools are untouched.
+
+    Written as a **re-send of what the GET handed back** (``_positioned``), because that
+    is the exact round trip a client makes: read the event, edit a pool's name, PATCH it
+    all back. The stored assertion is what makes this more than a schema test — a guard
+    that refused *after* writing would still 422, and would still have moved the pools.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"pools": _positioned(POOL_B, POOL_A)},
+    )
+
+    assert response.status_code == 422, response.text
+    assert _error_locs(response) == [
+        ["body", "pools", 0, "position"],
+        ["body", "pools", 1, "position"],
+    ]
+    # The order the event was created with, unmoved: nothing about this request was
+    # applied, not even the re-ordering the payload also asked for.
+    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
 
 
 async def test_a_draw_of_one_fixture_still_freezes_the_pool_set(

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -673,10 +673,13 @@ async def test_create_event_round_trips_jsonb(
     assert body["predicates"] == [
         {"id": "pr-1", "field": "rating", "op": "<", "value": 1500}
     ]
+    # The pool round-trips with one field it was not sent: ``position``, stamped by the
+    # write boundary from its index in the ``pools`` list (ADR 20260801).
     assert body["pools"] == [
         {
             "id": "p-os-1",
             "name": "Pool A",
+            "position": 0,
             "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
             "table_ids": ["t1", "t2"],
         }
@@ -1231,7 +1234,7 @@ async def test_patch_event_by_creator_updates_jsonb(
     assert response.status_code == 200
     body = response.json()
     assert body["draw_type"] == "single-elim"
-    assert body["pools"] == new_pools
+    assert body["pools"] == _positioned(*new_pools)
     assert body["predicates"] == new_predicates
     # Untouched fields survive.
     assert body["name"] == "Open Singles"
@@ -4790,6 +4793,19 @@ POOL_B: dict[str, Any] = {
 }
 
 
+def _positioned(*pools: dict[str, Any]) -> list[dict[str, Any]]:
+    """The pools as the server **stores and returns** them: the payload's own dicts,
+    each carrying the ``position`` the write boundary stamped on it from its index in
+    the list that was sent (ADR 20260801, "Pools carry an explicit ``position``").
+
+    A pool goes in without a position and comes back with one, so an expectation written
+    as the request payload verbatim is off by exactly this field. Deriving it here, from
+    the same order the payload states, keeps these assertions about *what was sent* —
+    write ``_positioned(POOL_B, POOL_A)`` and it says pool B is first, which is the
+    claim — rather than hard-coding a number into each of the literals below."""
+    return [{**pool, "position": index} for index, pool in enumerate(pools)]
+
+
 def _rr_payload(*pools: dict[str, Any], **overrides: Any) -> dict[str, Any]:
     """A **round-robin** event over ``pools`` — the pooled draw type (ADR-0786). The
     shared ``_event_payload`` is deliberately a ``single-elim``, which is un-pooled, so
@@ -5854,6 +5870,37 @@ async def _pools_of(db_session: AsyncSession, event_id: str) -> list[dict[str, A
     return list(pools)
 
 
+async def test_an_events_pools_are_read_back_in_the_order_they_were_posted(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """The wire round trip of a pool's ``position``: **POST** an event whose pools are
+    sent C, A, B and **GET** it back carrying 0, 1, 2 — in the order sent, not in
+    alphabetical order (ADR 20260801, "Pools carry an explicit ``position``").
+
+    Every other position test drives the verb directly (``test_tournament_events.py``);
+    this one is the claim a client can actually see, over HTTP, through the read that
+    the tournament page uses. Sorted by name or by id — which is how a pool's place in
+    the order used to be recovered, and what is about to become an arbitrary UUID sort —
+    the answer would be A, B, C, so the three named pools here are what makes this
+    assertion able to fail.
+    """
+    client, _ = authed_client
+    tournament_id, _ = await _tournament_with_events(
+        client, _rr_payload(POOL_C, POOL_A, POOL_B)
+    )
+
+    (event,) = await _events_of(client, tournament_id)
+
+    assert [(pool["name"], pool["position"]) for pool in event["pools"]] == [
+        ("Pool C", 0),
+        ("Pool A", 1),
+        ("Pool B", 2),
+    ]
+    # And no two of one event's pools share a position.
+    positions = [pool["position"] for pool in event["pools"]]
+    assert sorted(positions) == list(range(len(positions)))
+
+
 async def test_a_draw_of_one_fixture_still_freezes_the_pool_set(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
@@ -5888,7 +5935,7 @@ async def test_a_draw_of_one_fixture_still_freezes_the_pool_set(
     )
 
     assert response.status_code == 409, response.text
-    assert await _pools_of(db_session, event["id"]) == [POOL_A]
+    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A)
     assert _snapshot(await _fixture_rows(db_session, event["id"])) == fixtures_before
 
 
@@ -5953,8 +6000,8 @@ async def test_a_cut_draw_still_lets_a_pools_venue_attributes_be_edited(
     )
 
     assert response.status_code == 200, response.text
-    assert response.json()["pools"] == edited
-    assert await _pools_of(db_session, event["id"]) == edited
+    assert response.json()["pools"] == _positioned(*edited)
+    assert await _pools_of(db_session, event["id"]) == _positioned(*edited)
     assert _snapshot(await _fixture_rows(db_session, event["id"])) == before
 
 
@@ -6006,7 +6053,7 @@ async def test_a_cut_draw_refuses_a_pools_patch_that_changes_which_pools_exist(
     tournament_id, event = await _cut_two_pool_event(client, db_session)
     fixtures_before = _snapshot(await _fixture_rows(db_session, event["id"]))
     pools_before = await _pools_of(db_session, event["id"])
-    assert pools_before == [POOL_A, POOL_B]
+    assert pools_before == _positioned(POOL_A, POOL_B)
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event['id']}",
@@ -6056,7 +6103,7 @@ async def test_a_refused_pools_patch_writes_none_of_the_rest_of_the_payload_eith
         .all()
     )
     assert name == event["name"]
-    assert await _pools_of(db_session, event["id"]) == [POOL_A, POOL_B]
+    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
 
 
 async def test_an_event_with_no_draw_replaces_its_pools_wholesale(
@@ -6082,7 +6129,7 @@ async def test_an_event_with_no_draw_replaces_its_pools_wholesale(
     )
 
     assert response.status_code == 200, response.text
-    assert await _pools_of(db_session, event["id"]) == [POOL_C]
+    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_C)
 
 
 async def test_removing_the_draw_un_freezes_the_pool_set(
@@ -6111,7 +6158,7 @@ async def test_removing_the_draw_un_freezes_the_pool_set(
     accepted = await client.patch(url, json={"pools": repooled})
 
     assert accepted.status_code == 200, accepted.text
-    assert await _pools_of(db_session, event["id"]) == repooled
+    assert await _pools_of(db_session, event["id"]) == _positioned(*repooled)
     assert await _fixture_rows(db_session, event["id"]) == []
 
 
@@ -6137,7 +6184,7 @@ async def test_a_patch_that_does_not_send_pools_is_untouched_by_the_freeze(
 
     assert response.status_code == 200, response.text
     assert response.json()["name"] == "Open Singles (redrawn)"
-    assert await _pools_of(db_session, event["id"]) == [POOL_A, POOL_B]
+    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
     assert _snapshot(await _fixture_rows(db_session, event["id"])) == before
 
 
@@ -6173,7 +6220,7 @@ async def test_the_pool_freeze_is_scoped_to_the_event_being_patched(
         json={"pools": [POOL_C]},
     )
     assert free.status_code == 200, free.text
-    assert await _pools_of(db_session, undrawn["id"]) == [POOL_C]
+    assert await _pools_of(db_session, undrawn["id"]) == _positioned(POOL_C)
 
 
 async def test_the_event_patch_takes_the_tournaments_row_lock(
@@ -6327,7 +6374,7 @@ async def test_a_pools_patch_that_duplicates_an_id_never_reaches_the_cut_draw(
     assert "“p-a”" in _pools_error(response)
     # Nothing written: the pools are the two they were, and the fixtures are the same
     # rows, column for column.
-    assert await _pools_of(db_session, event["id"]) == [POOL_A, POOL_B]
+    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
     assert _snapshot(await _fixture_rows(db_session, event["id"])) == fixtures_before
     # And the cut the duplicate would have detonated still works.
     re_cut = await client.post(_draw_url(tournament_id, event["id"]))
@@ -6359,7 +6406,7 @@ async def test_an_undrawn_event_also_refuses_a_pools_patch_that_duplicates_an_id
 
     assert response.status_code == 422, response.text
     assert "“p-c”" in _pools_error(response)
-    assert await _pools_of(db_session, event["id"]) == [POOL_A, POOL_B]
+    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
 
 
 # ----- an id is not the empty string (422) -----------------------------------
@@ -6465,7 +6512,7 @@ async def test_a_pools_patch_that_empties_a_pool_id_or_name_is_refused(
 
     assert response.status_code == 422, response.text
     assert ["body", "pools", 0, field] in _error_locs(response), response.text
-    assert await _pools_of(db_session, event["id"]) == [POOL_A, POOL_B]
+    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
 
 
 async def test_creating_a_tournament_with_an_empty_table_id_is_refused(
@@ -6674,7 +6721,7 @@ async def test_re_sending_the_same_draw_type_with_a_venue_edit_still_succeeds(
     assert response.status_code == 200, response.text
     assert response.json()["draw_type"] == "round-robin"
     assert await _draw_type_of(db_session, event["id"]) is DrawType.round_robin
-    assert await _pools_of(db_session, event["id"]) == moved
+    assert await _pools_of(db_session, event["id"]) == _positioned(*moved)
     assert _snapshot(await _fixture_rows(db_session, event["id"])) == fixtures_before
 
 

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -167,11 +167,45 @@ export class TournamentDetailPage {
     return this.drawPanel(eventId).getByTestId(/^pool-draw-/)
   }
 
-  /** One pool section of a cut draw, by the pool's displayed name ("Pool A"). */
+  /** One pool section of a cut draw, by the pool's displayed name ("Pool A").
+   *
+   * **`exact`** is load-bearing, not tidiness: `getByRole`'s name match is a substring
+   * match by default, so "Pool 1" also selects "Pool 10" — and a ten-pool event is
+   * precisely where this accessor gets used (`tournament-pool-order.spec.ts`). Without
+   * it the locator quietly resolves to two sections and every assertion scoped through
+   * it is measuring both. */
   poolDrawNamed(eventId: string, poolName: string): Locator {
     return this.poolDraws(eventId).filter({
-      has: this.page.getByRole('heading', { name: poolName, level: 4 }),
+      has: this.page.getByRole('heading', { name: poolName, level: 4, exact: true }),
     })
+  }
+
+  /** **Every pool's heading, in the order the page lays them out** — the draw's pool
+   * order as a director reads it, top to bottom.
+   *
+   * Scoped *inside* the pool sections rather than to the panel's `h4`s at large, so the
+   * bracket's own "Bracket" heading (a sibling `h4`, present for any draw with a
+   * knockout stage) can never join the list and turn an ordering assertion into a
+   * position-of-the-bracket assertion.
+   *
+   * Asserted with `toHaveText([...])`, which pins the count AND the order in one
+   * statement — the only shape that can catch a draw rendering `Pool 1, Pool 10,
+   * Pool 2 …` (ADR 20260801: pool ids are client-minted `p-1-…`, `p-10-…`, and `p-10-`
+   * sorts between `p-1-` and `p-2-`). */
+  poolDrawHeadings(eventId: string): Locator {
+    return this.poolDraws(eventId).getByRole('heading', { level: 4 })
+  }
+
+  /** One pool's entrant chips — the pool's *membership*, derived from its own fixtures
+   * (ADR-0786) and listed in draw order. What the deal put in this pool, which is a
+   * different fact from where the pool sits on the page: a draw dealt against the wrong
+   * pool order renders the right headings over the wrong fields. */
+  poolEntrants(eventId: string, poolName: string): Locator {
+    return this.poolDrawNamed(eventId, poolName)
+      // `exact` for the same reason as `poolDrawNamed`: "Entrants in Pool 1" is a
+      // substring of "Entrants in Pool 10".
+      .getByRole('list', { name: `Entrants in ${poolName}`, exact: true })
+      .getByRole('listitem')
   }
 
   /** The **knockout bracket** — the fixtures belonging to no pool, rendered as

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -69,6 +69,26 @@ export interface TableSpec {
   readonly court: string
 }
 
+/** One pool of the event's draw, as a **client sends it** (`PoolWrite` on the wire).
+ *
+ * It carries no `position`, and that is not an omission this helper could choose to fix:
+ * `PoolWrite` is `extra="forbid"`, so a create/patch body carrying a `position` is a
+ * **422** naming the field. The server stamps the position from the pool's index in the
+ * list it was sent (ADR 20260801, "Pools carry an explicit `position`"), which makes the
+ * **order of `SeedTournamentOptions.pools`** the payload's one statement about pool
+ * order — and the thing `tournament-pool-order.spec.ts` seeds deliberately at odds with
+ * the ids' lexicographic order.
+ *
+ * `tableIds` is optional because the single-pool default reserves the whole catalogue; a
+ * multi-pool seed usually wants a table each, so ten pools raise no double-booking
+ * warning over one shared table. */
+export interface PoolSpec {
+  readonly id: string
+  readonly name: string
+  /** The catalogue tables this pool reserves. Omitted = **every** seeded table. */
+  readonly tableIds?: ReadonlyArray<string>
+}
+
 /** A venue's six free-text address components (`AddressInput` on the wire). The
  * server geocodes these to coordinates at write time via the injected
  * `Geocoder` — the e2e compose stack declares `GEOCODER: fake`
@@ -118,6 +138,14 @@ export interface SeedTournamentOptions {
   readonly slot?: SlotSpec
   /** The table catalogue; the pool references every listed table. */
   readonly tables?: ReadonlyArray<TableSpec>
+  /** The event's pools, **in the director's order** — omitted = the original single
+   * `Pool A` over the whole catalogue, so existing specs are untouched.
+   *
+   * The list's order is the whole point of the option: it is what the server turns into
+   * the stored `position`s, and therefore what the draw, the deal and the rendered pool
+   * sections are all ordered by. A caller seeding several pools is making a statement
+   * about their order whether it means to or not. */
+  readonly pools?: ReadonlyArray<PoolSpec>
   /** The event's `max_players` cap. Omitted = uncapped (the original minimal
    * shape). The schedule-preview spec sets a small cap so the synthetic field a
    * preview auto-fills to (an uncapped event defaults to 16) is small enough that
@@ -144,8 +172,12 @@ export interface SeedTournamentOptions {
 export interface SeededTournament {
   readonly tournamentId: string
   readonly eventId: string
-  /** The event's single pool id, so a spec can scope its standings assertions. */
+  /** The event's **first** pool id — its only one under the default seed — so a spec
+   * can scope its standings assertions. */
   readonly poolId: string
+  /** Every seeded pool id, **in the order they were sent** — which is the order the
+   * server stamped their positions from, and so the order the draw must read in. */
+  readonly poolIds: ReadonlyArray<string>
 }
 
 /**
@@ -206,7 +238,8 @@ export async function createTournament(
 /**
  * Create a **draft** tournament with one singles, **round-robin**, **unrated**,
  * best-of-1 event, drawn across a single pool that holds one table — the minimal
- * shape that can go live and produce a champion.
+ * shape that can go live and produce a champion. `options.pools` seeds several
+ * instead, in the order given (see `PoolSpec`).
  *
  * `rated: false` + `length_games: 1` is load-bearing, not incidental: an unrated
  * tournament match takes the immediate self-accept completion path, so recording
@@ -229,6 +262,7 @@ export async function seedTournament(
     end: '17:00',
   }
   const tables = options.tables ?? [{ id: TABLE_ID, label: 'Table 1', court: 'A' }]
+  const pools = options.pools ?? [{ id: POOL_ID, name: 'Pool A' }]
   // Resolve the catalogue HERE and pass it down, rather than letting
   // `createTournament` default it again: the pool below references these tables
   // by id, so the two must be the same list by construction.
@@ -260,14 +294,17 @@ export async function seedTournament(
         slot,
         match_settings: { rated: false, length_games: 1 },
         predicates: [],
-        pools: [
-          {
-            id: POOL_ID,
-            name: 'Pool A',
-            slot,
-            table_ids: tables.map((table) => table.id),
-          },
-        ],
+        // Sent in the caller's order and NEVER re-sorted here: this array's order is
+        // what `stored_pools` stamps the pools' `position`s from, so re-ordering it —
+        // even "tidily", by id — would silently seed a different event than the one the
+        // spec asked for. No pool carries a `position` key either; sending one is a 422
+        // (`PoolWrite` is `extra="forbid"`).
+        pools: pools.map((pool) => ({
+          id: pool.id,
+          name: pool.name,
+          slot,
+          table_ids: [...(pool.tableIds ?? tables.map((table) => table.id))],
+        })),
       },
     },
   )
@@ -278,7 +315,12 @@ export async function seedTournament(
   }
   const eventId = ((await eventRes.json()) as { id: string }).id
 
-  return { tournamentId, eventId, poolId: POOL_ID }
+  return {
+    tournamentId,
+    eventId,
+    poolId: pools[0].id,
+    poolIds: pools.map((pool) => pool.id),
+  }
 }
 
 /**
@@ -360,6 +402,47 @@ export async function findEventByName(
     )
   }
   return event
+}
+
+/** A pool as the event **reads back** (`Pool` on the wire): what the client sent, plus
+ * the 0-based `position` the server stamped on it from its index in the list it was sent
+ * (ADR 20260801). Only the three fields an ordering assertion is about are named; the
+ * window and tables ride along untyped. */
+export interface StoredPool {
+  readonly id: string
+  readonly name: string
+  readonly position: number
+}
+
+/**
+ * Read an event's pools back off the tournament detail, **as stored**.
+ *
+ * This is the one seam that can say whether the server took the order the director sent
+ * and made it a fact: a client cannot send a `position` at all (`PoolWrite` is
+ * `extra="forbid"` — it is a 422), so every position on the wire was assigned here. A
+ * spec that only read the rendered page could not tell "the server ordered them" from
+ * "the client re-derived an order that happened to agree".
+ *
+ * The pools are returned **exactly as the payload carries them**, unsorted, so a caller
+ * asserting on the order is asserting on the server's, not on this helper's.
+ */
+export async function getEventPools(
+  viewer: Guest,
+  tournamentId: string,
+  eventId: string,
+): Promise<ReadonlyArray<StoredPool>> {
+  const res = await viewer.ctx.get(`${API}/tournaments/${tournamentId}`)
+  if (!res.ok()) {
+    throw new Error(`load tournament failed: ${res.status()} ${await res.text()}`)
+  }
+  const detail = (await res.json()) as {
+    events: ReadonlyArray<{ id: string; pools: ReadonlyArray<StoredPool> }>
+  }
+  const event = detail.events.find((e) => e.id === eventId)
+  if (!event) {
+    throw new Error(`no event ${eventId} on tournament ${tournamentId}`)
+  }
+  return event.pools
 }
 
 /**
@@ -454,6 +537,11 @@ export interface FixtureTime {
 
 export interface FixtureDetail {
   readonly id: string
+  /** The pool this fixture was drawn into, or `null` for an un-pooled one (a knockout
+   * slot). Read because the detail's fixtures arrive **ordered by their pool's
+   * position** (ADR 20260801) — so the order these ids first appear in *is* the
+   * server's statement of the event's pool order, before any client touches it. */
+  readonly pool_id: string | null
   readonly entry_a_id: string | null
   readonly entry_b_id: string | null
   readonly match_id: string | null

--- a/e2e/tests/tournament-pool-order.spec.ts
+++ b/e2e/tests/tournament-pool-order.spec.ts
@@ -1,0 +1,245 @@
+import { test, expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+
+import { TournamentDetailPage } from '../page-objects/tournament-detail.page'
+import { guestFromContext } from '../support/match-api'
+import { grantBetaTester } from '../support/rbac-grant'
+import {
+  getEventPools,
+  getScheduleDetail,
+  seedEntrants,
+  seedTournament,
+  transitionTournament,
+  type PoolSpec,
+  type TableSpec,
+} from '../support/tournament-api'
+
+const EVENT_NAME = 'Open Singles'
+
+/** **Ten** pools — the smallest number that reproduces the bug, and not negotiable.
+ * The collision needs a two-digit pool number: `p-10-` sorts between `p-1-` and `p-2-`,
+ * so ten pools ordered by id read 1, 10, 2, 3 … 9. With nine, the id order and the
+ * position order coincide exactly and the spec would prove nothing. */
+const POOL_COUNT = 10
+
+/** Two entrants per pool — the round-robin cut refuses a pool of fewer than two
+ * (`_snake`: "a lone entrant has nobody to play"), so this is the floor. Twenty guests
+ * is already the expensive part of this spec; a third per pool would buy no new fact
+ * about ordering. */
+const ENTRANTS_PER_POOL = 2
+const ENTRANT_COUNT = POOL_COUNT * ENTRANTS_PER_POOL
+
+/** The base-36 suffix `genId('p')` appends — one shared "timestamp" for a burst of pools
+ * added in the editor, which is exactly how a real ten-pool event's ids look. Fixing it
+ * here keeps the ids' lexicographic order a property of the *index*, which is the thing
+ * under test, rather than of when the spec happened to run. */
+const ID_SUFFIX = 'mkq1x'
+
+/** Ten tables, one per pool: ten pools sharing one table is a double-booking the editor
+ * warns about, and this spec's subject is the order, not the warning. */
+const TABLES: ReadonlyArray<TableSpec> = Array.from(
+  { length: POOL_COUNT },
+  (_, i) => ({ id: `t${i + 1}`, label: `Table ${i + 1}`, court: 'A' }),
+)
+
+/**
+ * The ten pools **in the director's order**, `Pool 1` … `Pool 10`, with the ids the
+ * event editor would have minted for them (`p-1-…` … `p-10-…`).
+ *
+ * The list's order is the payload's only statement about pool order — the server stamps
+ * each pool's `position` from its index here (ADR 20260801) — and it is deliberately at
+ * odds with both the ids' and the names' lexicographic order. That disagreement is the
+ * entire experiment: a seed whose id order matched its intended order could not tell a
+ * stack that orders by position from one that orders by id.
+ */
+const POOLS: ReadonlyArray<PoolSpec> = Array.from(
+  { length: POOL_COUNT },
+  (_, i) => ({
+    id: `p-${i + 1}-${ID_SUFFIX}`,
+    name: `Pool ${i + 1}`,
+    tableIds: [`t${i + 1}`],
+  }),
+)
+
+/** What the draw must read, top to bottom: `Pool 1`, `Pool 2`, … `Pool 10`. */
+const NAMES_BY_POSITION = POOLS.map((pool) => pool.name)
+
+/** The same ten pools sorted by **id**, by codepoint — the wrong answer, and the one
+ * this stack actually produced before pools carried a position: `Pool 1`, `Pool 10`,
+ * `Pool 2` … `Pool 9`. Compared against, not asserted on: it is how the spec proves its
+ * own fixture is capable of failing. (`localeCompare` is deliberately avoided — it
+ * collates digits by locale rules and would quietly stop reproducing the bug.) */
+const NAMES_BY_ID = [...POOLS]
+  .sort((a, b) => (a.id < b.id ? -1 : 1))
+  .map((pool) => pool.name)
+
+/**
+ * Which entrants the snake deals into each pool, by **registration index**.
+ *
+ * Twenty entrants across ten pools is one pass forward and one back (`_snake`): pool `i`
+ * takes registration `i` on the way out and registration `19 − i` on the way home. So
+ * Pool 1 holds the 1st and 20th to register, Pool 2 the 2nd and 19th, and so on.
+ *
+ * This is the half of the ordering that a heading assertion cannot see. The deal seeds
+ * against `DrawConfig.pool_ids`, so a stack that ordered those by id would deal the 2nd
+ * registration into *Pool 10* while still rendering the ten headings in the right
+ * order — "a draw that still cuts but seeds differently" (ADR 20260801), invisible on
+ * the page unless you read the membership.
+ */
+const dealtTo = (poolIndex: number): [number, number] => [
+  poolIndex,
+  ENTRANT_COUNT - 1 - poolIndex,
+]
+
+/**
+ * **A ten-pool event's draw reads 1 … 10, through the whole composed stack** (#1226,
+ * ADR 20260801 "Pools carry an explicit `position`").
+ *
+ * Pool ids are client-minted strings — `p-1-…`, `p-2-…`, `p-10-…` — and sorted as
+ * strings `p-10-` falls *between* `p-1-` and `p-2-`. Every site that ordered pools by id
+ * therefore read a ten-pool event as 1, 10, 2, 3 … 9: the read query that returns the
+ * fixtures, the `ready_fixtures` grouping, and `DrawConfig.pool_ids` — the order the
+ * snake seeds against. A director with ten pools got a draw whose sections were in one
+ * order and whose deal was in another.
+ *
+ * ## Why this claim needs the composed stack
+ *
+ * The api tests prove the server orders by position in isolation; the web-client tests
+ * prove the renderer sorts correctly *given* pools that carry one. Neither can see the
+ * two halves disagree — and the disagreement is the whole bug, because `position` is a
+ * field the client is **forbidden** to send (`PoolWrite` is `extra="forbid"`; a create
+ * body carrying one is a 422). The order the director typed survives only if the server
+ * derives it from the list, stores it, serializes it, and the browser reads it back the
+ * same way. This is the only suite where all four are the real thing.
+ *
+ * So the order is asserted at three places along that path, on one seeded event:
+ *
+ * 1. **The server stamped it.** The pools read back carry positions 0…9 matching the
+ *    order they were sent — the fact a client cannot manufacture, since it cannot send
+ *    the field at all.
+ * 2. **The wire carries it.** The detail's fixtures arrive grouped by pool in position
+ *    order, so the pool ids' first appearances read `p-1-…` … `p-10-…` and not
+ *    `p-1-…, p-10-…, p-2-…`.
+ * 3. **The browser renders it** — the ten headings top to bottom, *and* the membership
+ *    the deal put under each one. The second is the assertion that would red for a stack
+ *    that ordered `DrawConfig.pool_ids` by id, which the headings alone would not.
+ *
+ * ## Seed vs UI split
+ *
+ * Over the API (`support/tournament-api.ts`): the tournament, the ten-pool event, the
+ * publish, and twenty director-entered guests — twenty browser sign-ins to test a *draw*
+ * would be twenty chances to fail for an unrelated reason, and director-entry has no web
+ * UI at all. In the browser: **cutting the draw** and reading it, which is the surface
+ * whose order is the subject.
+ *
+ * ## RBAC
+ *
+ * As in `tournament-lifecycle.spec.ts`: a minted user holds only the permissionless
+ * default role, so `grantBetaTester` hands the director the tournament bundle over the
+ * stack's own `postgres` container before any tournament write. Skipped against an
+ * external `E2E_BASE_URL` stack, where the caller owns provisioning.
+ */
+test.describe('Tournament — ten-pool draw order', () => {
+  test('a ten-pool draw reads Pool 1 through Pool 10, and is dealt in that order', async ({
+    page,
+    baseURL,
+  }) => {
+    // Twenty minted guests, each a session + a typeahead + a director-entry, then a real
+    // cut across ten pools — far past the 30s default.
+    test.setTimeout(300_000)
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    // The fixture's own falsification guard: if the ids ever came to sort the way the
+    // positions do, every assertion below would still pass and none of them would mean
+    // anything. Fail here, where the reason is legible, rather than three screens away.
+    expect(
+      NAMES_BY_ID,
+      'the seeded pool ids must sort DIFFERENTLY from their positions, or this spec cannot fail',
+    ).not.toEqual(NAMES_BY_POSITION)
+
+    // The director IS the browser's own session, so page navigations run as them.
+    const director = await guestFromContext(page.request)
+    grantBetaTester(director.username)
+
+    // ----- seed: a tournament whose event has ten pools, in order -------------
+    const name = `Pools ${faker.string.alphanumeric(8)}`
+    const { tournamentId, eventId, poolIds } = await seedTournament(director, name, {
+      tables: TABLES,
+      pools: POOLS,
+    })
+
+    // ----- 1. the SERVER stamped the order the director sent ------------------
+    // Positions 0…9 against the pools in the sent order. A client could not have
+    // produced this: `position` is not a field it may send.
+    const storedPools = await getEventPools(director, tournamentId, eventId)
+    expect(storedPools.map((pool) => pool.id)).toEqual(poolIds)
+    expect(storedPools.map((pool) => pool.position)).toEqual(
+      POOLS.map((_, index) => index),
+    )
+
+    // ----- publish, then fill the field --------------------------------------
+    await transitionTournament(director, tournamentId, 'published')
+    const entrants = await seedEntrants(
+      director,
+      baseURL!,
+      tournamentId,
+      eventId,
+      ENTRANT_COUNT,
+    )
+
+    // ----- cut the draw, in the browser --------------------------------------
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    // `toContainText`, not `toHaveText`: the hero sets its own full stop after the name.
+    // The long timeout is for the FIRST navigation only, and it is about the stack rather
+    // than the app — the composed web-client is a Vite **dev** server, so the first
+    // request for a route pays for transforming it on demand.
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    const drawPost = page.waitForResponse(
+      (r) => r.url().endsWith('/draw') && r.request().method() === 'POST',
+    )
+    await detail.generateDrawButton(EVENT_NAME).click()
+    const drawResponse = await drawPost
+    expect(
+      drawResponse.status(),
+      `cutting the draw was refused: ${await drawResponse.text()}`,
+    ).toBe(201)
+
+    // ----- 3. the BROWSER renders the ten pools in the director's order -------
+    // One statement, and it pins both the count and the order: ten headings reading
+    // Pool 1 … Pool 10, top to bottom. Ordered by id they would read Pool 1, Pool 10,
+    // Pool 2 …, which is what this stack did before positions existed.
+    await expect(detail.poolDrawHeadings(eventId)).toHaveText(NAMES_BY_POSITION)
+
+    // ----- …and the DEAL followed the same order -----------------------------
+    // The headings can be right while the field under them is wrong: the snake seeds
+    // against the event's pool order, so a stack ordering that by id deals the 2nd
+    // registration into Pool 10. Membership is derived from each pool's own fixtures
+    // (ADR-0786), so this also says the fixtures were written into the right pools.
+    for (const [index, poolName] of NAMES_BY_POSITION.entries()) {
+      const [first, second] = dealtTo(index)
+      await expect(
+        detail.poolEntrants(eventId, poolName),
+        `${poolName} holds the wrong entrants — the draw was dealt in the wrong pool order`,
+      ).toHaveText([entrants[first].username, entrants[second].username])
+    }
+
+    // ----- 2. and the WIRE carried that order to get here ---------------------
+    // Read last, of the draw the browser just cut: the detail's fixtures come back
+    // ordered by their pool's position, so the pool ids in first-appearance order are the
+    // server's own statement of the event's pool order — the one the page above rendered.
+    const schedule = await getScheduleDetail(director, tournamentId)
+    const fixtures = schedule.events.find((e) => e.id === eventId)?.fixtures ?? []
+    expect(fixtures).toHaveLength(POOL_COUNT)
+    const poolIdsOnTheWire = [
+      ...new Set(
+        fixtures.flatMap((fixture) =>
+          fixture.pool_id === null ? [] : [fixture.pool_id],
+        ),
+      ),
+    ]
+    expect(poolIdsOnTheWire).toEqual(poolIds)
+
+    await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
+  })
+})

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -7592,19 +7592,23 @@ internal enum Components {
                 case rank
             }
         }
-        /// A slice of tables reserved for a window of time within an event.
+        /// A pool as it is **read back**: everything a client wrote, plus the ``position``
+        /// the server stamped on it.
         ///
-        /// Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
-        /// by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
-        /// these ids. Which is only a coherent thing to say if an id names one pool — see
-        /// ``EventPools``, the type the event's list of them actually has — and if an id is a
-        /// thing at all, which is what ``ValueObjectId`` says: the empty string is not one, and
-        /// a fixture drawn into it is pooled by one rule and un-pooled by another.
+        /// It is also the model every interior read of an event's ``pools`` JSONB parses
+        /// through — ``_ordered_pools``, ``draw_config``, ``event_pools``, the schedule
+        /// snapshots — so the column becomes typed values at the read boundary rather than
+        /// stringly-keyed dict lookups (api/CLAUDE.md — "parse, don't validate"). Deriving it
+        /// from :class:`PoolWrite` is what keeps the two shapes one shape plus a field: a
+        /// column added to the write side is readable without a second edit, and the two can
+        /// never disagree about what a pool *is*.
         ///
-        /// Its ``name`` has the same floor for the plainer reason: a pool is *called*
-        /// something — it is what the director clicks, what the conflict warnings quote, and
-        /// what a player reads off a wall. ``""`` is not a name, and an event whose pools list
-        /// is three blank rows is not a thing anyone could act on.
+        /// ``position`` defaults to ``0`` so that pools stored before the field existed stay
+        /// *readable* — a read boundary must not turn a history it cannot change into a
+        /// ``ValidationError`` (the same asymmetry :data:`AddressComponent` is about). Every
+        /// pool written since goes through :func:`stored_pools` and carries a real one. The
+        /// default is a **read** concession only; it is not a way to write one, because there
+        /// is no way to write one.
         ///
         /// - Remark: Generated from `#/components/schemas/Pool`.
         internal struct Pool: Codable, Hashable, Sendable {
@@ -7616,6 +7620,10 @@ internal enum Components {
             internal var slot: Components.Schemas.Slot
             /// - Remark: Generated from `#/components/schemas/Pool/table_ids`.
             internal var tableIds: [Swift.String]
+            /// Where this pool sits in its event's pool order: 0-based, contiguous, and **assigned by the server** from the pool's index in the `pools` list it arrived in. Read-only, and not merely by convention — it is absent from the pool shape the write verbs take, so sending one is a `422` for an unknown field. To reorder an event's pools, send them in the order you want. Two pools of one event never share a position.
+            ///
+            /// - Remark: Generated from `#/components/schemas/Pool/position`.
+            internal var position: Swift.Int?
             /// Creates a new `Pool`.
             ///
             /// - Parameters:
@@ -7623,22 +7631,26 @@ internal enum Components {
             ///   - name:
             ///   - slot:
             ///   - tableIds:
+            ///   - position: Where this pool sits in its event's pool order: 0-based, contiguous, and **assigned by the server** from the pool's index in the `pools` list it arrived in. Read-only, and not merely by convention — it is absent from the pool shape the write verbs take, so sending one is a `422` for an unknown field. To reorder an event's pools, send them in the order you want. Two pools of one event never share a position.
             internal init(
                 id: Swift.String,
                 name: Swift.String,
                 slot: Components.Schemas.Slot,
-                tableIds: [Swift.String]
+                tableIds: [Swift.String],
+                position: Swift.Int? = nil
             ) {
                 self.id = id
                 self.name = name
                 self.slot = slot
                 self.tableIds = tableIds
+                self.position = position
             }
             internal enum CodingKeys: String, CodingKey {
                 case id
                 case name
                 case slot
                 case tableIds = "table_ids"
+                case position
             }
             internal init(from decoder: any Swift.Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -7658,11 +7670,16 @@ internal enum Components {
                     [Swift.String].self,
                     forKey: .tableIds
                 )
+                self.position = try container.decodeIfPresent(
+                    Swift.Int.self,
+                    forKey: .position
+                )
                 try decoder.ensureNoAdditionalProperties(knownKeys: [
                     "id",
                     "name",
                     "slot",
-                    "table_ids"
+                    "table_ids",
+                    "position"
                 ])
             }
         }
@@ -7792,6 +7809,91 @@ internal enum Components {
                 case poolId = "pool_id"
                 case rows
                 case complete
+            }
+        }
+        /// A slice of tables reserved for a window of time within an event, as a client
+        /// **sends** it.
+        ///
+        /// Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
+        /// by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
+        /// these ids. Which is only a coherent thing to say if an id names one pool — see
+        /// ``EventPools``, the type the event's list of them actually has — and if an id is a
+        /// thing at all, which is what ``ValueObjectId`` says: the empty string is not one, and
+        /// a fixture drawn into it is pooled by one rule and un-pooled by another.
+        ///
+        /// Its ``name`` has the same floor for the plainer reason: a pool is *called*
+        /// something — it is what the director clicks, what the conflict warnings quote, and
+        /// what a player reads off a wall. ``""`` is not a name, and an event whose pools list
+        /// is three blank rows is not a thing anyone could act on.
+        ///
+        /// What is **absent** is as deliberate as what is here: ``position`` is the server's to
+        /// assign (:data:`PoolPosition`), so it is simply not a field of this model, and
+        /// ``extra="forbid"`` turns an attempt to send one into a 422 that names it. This is
+        /// the treatment ``entered`` already gets on the event schemas — a server-managed value
+        /// is kept **off** the write shape rather than accepted and then ignored. Accepting it
+        /// would be worse than useless in both directions: a client cannot tell from the schema
+        /// that the number it sent decided nothing, and a boundary that silently discards half
+        /// of a payload has to be documented to be understood. The order a client *does*
+        /// control is the order of the list itself.
+        ///
+        /// - Remark: Generated from `#/components/schemas/PoolWrite`.
+        internal struct PoolWrite: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/PoolWrite/id`.
+            internal var id: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PoolWrite/name`.
+            internal var name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PoolWrite/slot`.
+            internal var slot: Components.Schemas.Slot
+            /// - Remark: Generated from `#/components/schemas/PoolWrite/table_ids`.
+            internal var tableIds: [Swift.String]
+            /// Creates a new `PoolWrite`.
+            ///
+            /// - Parameters:
+            ///   - id:
+            ///   - name:
+            ///   - slot:
+            ///   - tableIds:
+            internal init(
+                id: Swift.String,
+                name: Swift.String,
+                slot: Components.Schemas.Slot,
+                tableIds: [Swift.String]
+            ) {
+                self.id = id
+                self.name = name
+                self.slot = slot
+                self.tableIds = tableIds
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case id
+                case name
+                case slot
+                case tableIds = "table_ids"
+            }
+            internal init(from decoder: any Swift.Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.id = try container.decode(
+                    Swift.String.self,
+                    forKey: .id
+                )
+                self.name = try container.decode(
+                    Swift.String.self,
+                    forKey: .name
+                )
+                self.slot = try container.decode(
+                    Components.Schemas.Slot.self,
+                    forKey: .slot
+                )
+                self.tableIds = try container.decode(
+                    [Swift.String].self,
+                    forKey: .tableIds
+                )
+                try decoder.ensureNoAdditionalProperties(knownKeys: [
+                    "id",
+                    "name",
+                    "slot",
+                    "table_ids"
+                ])
             }
         }
         /// An eligibility rule. ``field`` names the one fact we actually hold about a
@@ -10170,7 +10272,7 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/predicates`.
             internal var predicates: [Components.Schemas.Predicate]?
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/pools`.
-            internal var pools: [Components.Schemas.Pool]?
+            internal var pools: [Components.Schemas.PoolWrite]?
             /// Creates a new `TournamentEventCreate`.
             ///
             /// - Parameters:
@@ -10196,7 +10298,7 @@ internal enum Components {
                 slot: Components.Schemas.Slot,
                 matchSettings: Components.Schemas.MatchSettings,
                 predicates: [Components.Schemas.Predicate]? = nil,
-                pools: [Components.Schemas.Pool]? = nil
+                pools: [Components.Schemas.PoolWrite]? = nil
             ) {
                 self.name = name
                 self.format = format
@@ -10266,7 +10368,7 @@ internal enum Components {
                     forKey: .predicates
                 )
                 self.pools = try container.decodeIfPresent(
-                    [Components.Schemas.Pool].self,
+                    [Components.Schemas.PoolWrite].self,
                     forKey: .pools
                 )
                 try decoder.ensureNoAdditionalProperties(knownKeys: [
@@ -10622,7 +10724,7 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/predicates`.
             internal var predicates: [Components.Schemas.Predicate]?
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/pools`.
-            internal var pools: [Components.Schemas.Pool]?
+            internal var pools: [Components.Schemas.PoolWrite]?
             /// Creates a new `TournamentEventUpdate`.
             ///
             /// - Parameters:
@@ -10648,7 +10750,7 @@ internal enum Components {
                 slot: Components.Schemas.TournamentEventUpdate.SlotPayload? = nil,
                 matchSettings: Components.Schemas.TournamentEventUpdate.MatchSettingsPayload? = nil,
                 predicates: [Components.Schemas.Predicate]? = nil,
-                pools: [Components.Schemas.Pool]? = nil
+                pools: [Components.Schemas.PoolWrite]? = nil
             ) {
                 self.name = name
                 self.format = format
@@ -10718,7 +10820,7 @@ internal enum Components {
                     forKey: .predicates
                 )
                 self.pools = try container.decodeIfPresent(
-                    [Components.Schemas.Pool].self,
+                    [Components.Schemas.PoolWrite].self,
                     forKey: .pools
                 )
                 try decoder.ensureNoAdditionalProperties(knownKeys: [

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -281,6 +281,7 @@ const JOURNEY_POOLS: Pool[] = [
     name: 'Pool A',
     slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
     table_ids: ['t1', 't2'],
+    position: 0,
   },
 ]
 
@@ -295,12 +296,14 @@ const PLAY_POOLS: Pool[] = [
     name: 'Pool A',
     slot: { date: '2026-06-13', start: '09:00', end: '11:00' },
     table_ids: ['t1', 't2'],
+    position: 0,
   },
   {
     id: 'p-play-b',
     name: 'Pool B',
     slot: { date: '2026-06-13', start: '11:00', end: '13:00' },
     table_ids: ['t3', 't4'],
+    position: 1,
   },
 ]
 
@@ -361,12 +364,14 @@ const CUP_POOLS: Pool[] = [
     name: 'Pool A',
     slot: { date: '2026-06-13', start: '09:00', end: '11:00' },
     table_ids: ['t1', 't2'],
+    position: 0,
   },
   {
     id: 'p-b',
     name: 'Pool B',
     slot: { date: '2026-06-13', start: '11:00', end: '13:00' },
     table_ids: ['t3', 't4'],
+    position: 1,
   },
 ]
 
@@ -1817,6 +1822,12 @@ export class TournamentsStore {
     const fields = body as Partial<Omit<TournamentEventRead, 'entered'>>
     const created = buildTournamentEventRead({
       ...fields,
+      // Positions assigned from the array index, as the server assigns them — the create
+      // body carries none (`PoolWrite` forbids the key), so the order of the list is what
+      // says which pool is first. See the same stamp in `updateEvent` below.
+      ...(fields.pools
+        ? { pools: fields.pools.map((pool, index) => ({ ...pool, position: index })) }
+        : {}),
       id: `ev-created-${this.detail.events.length + 1}`,
       entrants: [],
     })
@@ -1852,7 +1863,21 @@ export class TournamentsStore {
     // `entrants` and `entered` are the server's, not the editor's — the write body
     // does not carry them, and echoing the client's view back would clobber
     // registrations it never saw.
-    this.mutateEvent(eventId, (e) => ({ ...e, ...fields, entrants: e.entrants }))
+    //
+    // Each pool's `position` is the server's too, and in a sharper way: `PoolWrite`
+    // FORBIDS the key, so the body carries no positions at all and the **order of the
+    // array** is the only thing saying which pool comes first. The server re-derives the
+    // positions from that order on every pools patch, so this stub does the same —
+    // spreading the write shape straight through would strip a required read field and
+    // leave the editor (which seeds its cards from `position`) sorting by nothing.
+    this.mutateEvent(eventId, (e) => ({
+      ...e,
+      ...fields,
+      pools: fields.pools
+        ? fields.pools.map((pool, index) => ({ ...pool, position: index }))
+        : e.pools,
+      entrants: e.entrants,
+    }))
     return json(route, 200, this.read(this.eventNamed(fields.name ?? event.name)))
   }
 

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -3640,12 +3640,26 @@ export interface components {
          *     something — it is what the director clicks, what the conflict warnings quote, and
          *     what a player reads off a wall. ``""`` is not a name, and an event whose pools list
          *     is three blank rows is not a thing anyone could act on.
+         *
+         *     Its ``position`` is the pool's place in the event's pool ORDER, and it is the one
+         *     field here the client does not author: the server stamps it from the index of the
+         *     list it was sent in (:data:`PoolPosition`). It defaults to ``0`` so that pools
+         *     stored before this field existed stay *readable* — a read boundary must not turn a
+         *     history it cannot change into a ``ValidationError`` (the same asymmetry
+         *     :data:`AddressComponent` is about) — and every pool written through
+         *     :data:`EventPools` carries a real one.
          */
         Pool: {
             /** Id */
             id: string;
             /** Name */
             name: string;
+            /**
+             * Position
+             * @description Where this pool sits in its event's pool order: 0-based, and **assigned by the server** from the pool's index in the `pools` list you sent. It is read-only — a non-negative `position` on a write payload is overwritten rather than honoured, so to reorder an event's pools, send them in the order you want. (A negative one is a 422: the bound is checked before the reordering, so it is refused rather than corrected.) Two pools of one event never share a position.
+             * @default 0
+             */
+            position: number;
             slot: components["schemas"]["Slot"];
             /** Table Ids */
             table_ids: string[];

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -3627,42 +3627,38 @@ export interface components {
         };
         /**
          * Pool
-         * @description A slice of tables reserved for a window of time within an event.
+         * @description A pool as it is **read back**: everything a client wrote, plus the ``position``
+         *     the server stamped on it.
          *
-         *     Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
-         *     by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
-         *     these ids. Which is only a coherent thing to say if an id names one pool — see
-         *     ``EventPools``, the type the event's list of them actually has — and if an id is a
-         *     thing at all, which is what ``ValueObjectId`` says: the empty string is not one, and
-         *     a fixture drawn into it is pooled by one rule and un-pooled by another.
+         *     It is also the model every interior read of an event's ``pools`` JSONB parses
+         *     through — ``_ordered_pools``, ``draw_config``, ``event_pools``, the schedule
+         *     snapshots — so the column becomes typed values at the read boundary rather than
+         *     stringly-keyed dict lookups (api/CLAUDE.md — "parse, don't validate"). Deriving it
+         *     from :class:`PoolWrite` is what keeps the two shapes one shape plus a field: a
+         *     column added to the write side is readable without a second edit, and the two can
+         *     never disagree about what a pool *is*.
          *
-         *     Its ``name`` has the same floor for the plainer reason: a pool is *called*
-         *     something — it is what the director clicks, what the conflict warnings quote, and
-         *     what a player reads off a wall. ``""`` is not a name, and an event whose pools list
-         *     is three blank rows is not a thing anyone could act on.
-         *
-         *     Its ``position`` is the pool's place in the event's pool ORDER, and it is the one
-         *     field here the client does not author: the server stamps it from the index of the
-         *     list it was sent in (:data:`PoolPosition`). It defaults to ``0`` so that pools
-         *     stored before this field existed stay *readable* — a read boundary must not turn a
-         *     history it cannot change into a ``ValidationError`` (the same asymmetry
-         *     :data:`AddressComponent` is about) — and every pool written through
-         *     :data:`EventPools` carries a real one.
+         *     ``position`` defaults to ``0`` so that pools stored before the field existed stay
+         *     *readable* — a read boundary must not turn a history it cannot change into a
+         *     ``ValidationError`` (the same asymmetry :data:`AddressComponent` is about). Every
+         *     pool written since goes through :func:`stored_pools` and carries a real one. The
+         *     default is a **read** concession only; it is not a way to write one, because there
+         *     is no way to write one.
          */
         Pool: {
             /** Id */
             id: string;
             /** Name */
             name: string;
-            /**
-             * Position
-             * @description Where this pool sits in its event's pool order: 0-based, and **assigned by the server** from the pool's index in the `pools` list you sent. It is read-only — a non-negative `position` on a write payload is overwritten rather than honoured, so to reorder an event's pools, send them in the order you want. (A negative one is a 422: the bound is checked before the reordering, so it is refused rather than corrected.) Two pools of one event never share a position.
-             * @default 0
-             */
-            position: number;
             slot: components["schemas"]["Slot"];
             /** Table Ids */
             table_ids: string[];
+            /**
+             * Position
+             * @description Where this pool sits in its event's pool order: 0-based, contiguous, and **assigned by the server** from the pool's index in the `pools` list it arrived in. Read-only, and not merely by convention — it is absent from the pool shape the write verbs take, so sending one is a `422` for an unknown field. To reorder an event's pools, send them in the order you want. Two pools of one event never share a position.
+             * @default 0
+             */
+            position: number;
         };
         /**
          * PoolHasNoTablesRead
@@ -3720,6 +3716,42 @@ export interface components {
             rows: components["schemas"]["StandingRowRead"][];
             /** Complete */
             complete: boolean;
+        };
+        /**
+         * PoolWrite
+         * @description A slice of tables reserved for a window of time within an event, as a client
+         *     **sends** it.
+         *
+         *     Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
+         *     by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
+         *     these ids. Which is only a coherent thing to say if an id names one pool — see
+         *     ``EventPools``, the type the event's list of them actually has — and if an id is a
+         *     thing at all, which is what ``ValueObjectId`` says: the empty string is not one, and
+         *     a fixture drawn into it is pooled by one rule and un-pooled by another.
+         *
+         *     Its ``name`` has the same floor for the plainer reason: a pool is *called*
+         *     something — it is what the director clicks, what the conflict warnings quote, and
+         *     what a player reads off a wall. ``""`` is not a name, and an event whose pools list
+         *     is three blank rows is not a thing anyone could act on.
+         *
+         *     What is **absent** is as deliberate as what is here: ``position`` is the server's to
+         *     assign (:data:`PoolPosition`), so it is simply not a field of this model, and
+         *     ``extra="forbid"`` turns an attempt to send one into a 422 that names it. This is
+         *     the treatment ``entered`` already gets on the event schemas — a server-managed value
+         *     is kept **off** the write shape rather than accepted and then ignored. Accepting it
+         *     would be worse than useless in both directions: a client cannot tell from the schema
+         *     that the number it sent decided nothing, and a boundary that silently discards half
+         *     of a payload has to be documented to be understood. The order a client *does*
+         *     control is the order of the list itself.
+         */
+        PoolWrite: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            slot: components["schemas"]["Slot"];
+            /** Table Ids */
+            table_ids: string[];
         };
         /**
          * Predicate
@@ -4697,7 +4729,7 @@ export interface components {
             /** Predicates */
             predicates?: components["schemas"]["Predicate"][];
             /** Pools */
-            pools?: components["schemas"]["Pool"][];
+            pools?: components["schemas"]["PoolWrite"][];
         };
         /** TournamentEventRead */
         TournamentEventRead: {
@@ -4797,7 +4829,7 @@ export interface components {
             /** Predicates */
             predicates?: components["schemas"]["Predicate"][] | null;
             /** Pools */
-            pools?: components["schemas"]["Pool"][] | null;
+            pools?: components["schemas"]["PoolWrite"][] | null;
         };
         /**
          * TournamentFixturePlacementUpdate

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -43,7 +43,7 @@ import {
 } from '@/mocks/tournaments-store'
 import { ApiError } from '@/api/client'
 import type { components } from '@/api/schema'
-import { buildEvent } from './seed.factory'
+import { buildEvent, buildTenPools } from './seed.factory'
 import {
   apiToEvent,
   eventToUpdateBody,
@@ -414,6 +414,41 @@ describe('useUpdateEvent — the draw configuration on the wire', () => {
 
     await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
     expect(apiToEvent(result.current.data!).qualifiersPerPool).toBe(2)
+  })
+
+  /**
+   * **A pool's `position` must not leave the client.** It is the server's to assign —
+   * from the index of the pool in this very array — and `PoolWrite` is `extra="forbid"`,
+   * so a `position` key here is a 422 naming the field and the director's whole save is
+   * refused.
+   *
+   * Asserted on the bytes rather than on `eventToUpdateBody`'s return value for the same
+   * reason the qualifier count is: the domain `Pool` the editor holds *does* carry a
+   * position, so a spread anywhere between the mapper and `openapi-fetch` would put it
+   * back, and nothing else in the suite would notice.
+   */
+  it('sends each pool WITHOUT a position — the server assigns it from the order', async () => {
+    const sent = captureEventPatch()
+    const { wrapper } = setupClient()
+
+    const { result } = renderHookRaw(() => useUpdateEvent('t-1'), { wrapper })
+    result.current.mutate({
+      eventId: 'ev-1',
+      // Ten pools, so a dropped position could not hide behind a single `0`.
+      body: eventToUpdateBody(buildEvent({ pools: buildTenPools() })),
+    })
+
+    await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
+    const pools = sent.body?.pools as Record<string, unknown>[]
+    expect(pools).toHaveLength(10)
+    for (const pool of pools) {
+      expect(Object.keys(pool).sort()).toEqual([
+        'id',
+        'name',
+        'slot',
+        'table_ids',
+      ])
+    }
   })
 })
 

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -112,7 +112,7 @@ describe('apiToEvent', () => {
     expect(event.entered).toBe(0)
   })
 
-  it('maps a pool, renaming table_ids to tableIds', () => {
+  it('maps a pool, renaming table_ids to tableIds and carrying its position', () => {
     const event = apiToEvent(
       buildTournamentEventRead({
         pools: [
@@ -121,6 +121,10 @@ describe('apiToEvent', () => {
             name: 'Pool A',
             slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
             table_ids: ['t1', 't2'],
+            // Not 0: the server's number, carried across as sent. A mapper that
+            // recomputed it from the array index would look right on a first pool and be
+            // wrong on every event whose pools arrived in any other order.
+            position: 3,
           },
         ],
       }),
@@ -132,6 +136,7 @@ describe('apiToEvent', () => {
         name: 'Pool A',
         slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
         tableIds: ['t1', 't2'],
+        position: 3,
       },
     ])
   })
@@ -770,6 +775,10 @@ const event: TournamentEvent = {
       name: 'Pool A',
       slot: { date: '2026-06-14', start: '09:00', end: '12:00' },
       tableIds: ['t1', 't2'],
+      // The server's number, held on the read model. The write bodies below must NOT
+      // carry it — `PoolWrite` forbids the key — which is what the create/update
+      // assertions pin.
+      position: 0,
     },
   ],
   // No draw cut (ADR-0786). The write bodies below must not carry one either — a draw
@@ -814,7 +823,12 @@ describe('eventToCreateBody', () => {
       // eventToCreateBody always populates these, but they're typed optional on
       // the *create* body — coalesce so the value satisfies the *read* shape.
       predicates: wire.predicates ?? [],
-      pools: wire.pools ?? [],
+      // The create body carries NO `position` (`PoolWrite` forbids it), and the read
+      // shape requires one — so the round trip has to close the gap the way the SERVER
+      // closes it: each pool takes the position of its index in the list that was sent.
+      // A `0` typed in here instead would make the round trip pass while the app and the
+      // API disagreed about which pool is first.
+      pools: (wire.pools ?? []).map((pool, index) => ({ ...pool, position: index })),
       // `max_players` is optional on the create body (`null`/absent = no cap,
       // ADR-0935); the read shape is `number | null`.
       max_players: wire.max_players ?? null,

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -174,8 +174,18 @@ export function apiToEvent(e: TournamentEventRead): TournamentEvent {
   }
 }
 
+/** Map an API pool to the prototype's `Pool`. `position` is carried across as the server
+ * assigned it — it is the *read* shape's field and appears on no write body (see
+ * `eventPoolsToApi`). The order of `e.pools` is NOT relied on here: whoever lays pools out
+ * sorts by `position` itself (`poolsInOrder`, `./helpers`). */
 function apiToPool(p: ApiPool): Pool {
-  return { id: p.id, name: p.name, slot: p.slot, tableIds: p.table_ids }
+  return {
+    id: p.id,
+    name: p.name,
+    slot: p.slot,
+    tableIds: p.table_ids,
+    position: p.position,
+  }
 }
 
 /** The server returns `distance_miles` on each tournament — a non-negative haversine
@@ -309,6 +319,21 @@ export function tournamentToUpdateBody(
   }
 }
 
+/**
+ * The pools as a write body takes them (`PoolWrite`) — **without `position`**.
+ *
+ * Same category of field as `entered` one function down: server-managed, and echoing the
+ * client's copy back is at best noise and at worst a lie. It is stronger here, though.
+ * `entered` is merely *ignored* by the write schema; `PoolWrite` is `extra="forbid"` and
+ * declares no `position` at all, so sending it is a **422 naming the field** — the whole
+ * save refused, for a key the director never typed.
+ *
+ * **The order of this array IS the ordering.** The server assigns each pool the position
+ * of its index in this very list, so reordering pools is done by sending them in the
+ * order you want, and nothing else. That is why the editor's form value is seeded in
+ * position order (`eventToFormValues`, `../event-form`): the array a save serializes has
+ * to be the array the director was looking at, or the pools shuffle on the round trip.
+ */
 function eventPoolsToApi(ev: TournamentEvent) {
   return ev.pools.map((p) => ({
     id: p.id,
@@ -348,8 +373,9 @@ function drawSettingsToApi(ev: TournamentEvent) {
     : { draw_type: ev.drawType }
 }
 
-/** The event fields shared by the create and update bodies — everything except
- * the server-managed `entered` count. */
+/** The event fields shared by the create and update bodies — everything except the
+ * server-managed values: the `entered` count, and each pool's `position`
+ * (`eventPoolsToApi` above). */
 function eventToApiFields(ev: TournamentEvent) {
   return {
     name: ev.name,

--- a/web-client/src/components/tournaments/data/draw.ts
+++ b/web-client/src/components/tournaments/data/draw.ts
@@ -23,6 +23,7 @@
 import { ApiError } from '@/api/client'
 import type { MatchStatus } from '@/api/matches'
 
+import { poolsInOrder } from './helpers'
 import { fallbackNotice, type Notice } from './notice'
 import { labelFor } from './options'
 import type {
@@ -233,7 +234,11 @@ export function drawState(event: TournamentEvent): DrawState {
     else byPool.set(poolId, [fixture])
   }
 
-  const pools: PoolDraw[] = event.pools.flatMap((pool) => {
+  // **In POSITION order** (`poolsInOrder`), which is the order the director arranged them
+  // in and the order the event editor shows them in — not the order they arrived in, and
+  // emphatically not by id: pool ids are minted `p-1-…`, `p-2-…`, `p-10-…`, so a sort by
+  // id puts `p-10-` between `p-1-` and `p-2-` and a ten-pool event reads 1, 10, 2, 3 …
+  const pools: PoolDraw[] = poolsInOrder(event.pools).flatMap((pool) => {
     const fixtures = byPool.get(pool.id)
     if (!fixtures) return []
     // Membership is the entry ids the pool's own fixtures name — the derivation

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -370,6 +370,41 @@ export function predicateSentence(p: Predicate): string {
   return `${schema.label} ${op} ${valueText(p)}`
 }
 
+/**
+ * An event's pools in **position order** — the one answer to "which pool comes first?",
+ * shared by everything that lays pools out (the editor's form value, `eventToFormValues`;
+ * the draw, `drawState`).
+ *
+ * It exists because the two plausible alternatives are both wrong:
+ *
+ * - **By id** is the bug this field was added to kill. Ids are minted client-side
+ *   (`genId('p')`), so a ten-pool event holds `p-1-…` … `p-10-…`, and sorted as strings
+ *   `p-10-` lands between `p-1-` and `p-2-`: the draw rendered 1, 10, 2, 3 …
+ * - **Whatever order the array is in** is not an answer at all, only a coincidence. The
+ *   server does send its pools in position order, but a client that merely *inherited*
+ *   that order would state no rule, so nothing would fail when the order stopped holding.
+ *
+ * Stable (`sort` is stable in every engine we target), so pools that somehow shared a
+ * position keep their relative order rather than shuffling between renders. Copies rather
+ * than sorting in place: the input is usually form state or a query's cached payload, and
+ * neither is ours to reorder.
+ */
+export function poolsInOrder<T extends { position: number }>(
+  pools: readonly T[],
+): T[] {
+  return [...pools].sort((a, b) => a.position - b.position)
+}
+
+/** The position a pool appended to `pools` takes: **one past the highest**, never the
+ * count. The two differ the moment a pool is removed from the middle — nine pools
+ * numbered 0…4, 6…9 would hand a tenth the position `9`, a duplicate, and the two would
+ * then order by nothing. (The server renumbers from the array index on the next write,
+ * so this only has to hold until the save; "only until the save" is still long enough for
+ * a director to add a pool and watch it jump.) */
+export function nextPoolPosition(pools: readonly { position: number }[]): number {
+  return pools.reduce((max, p) => Math.max(max, p.position + 1), 0)
+}
+
 export interface PoolConflict {
   table: string
   poolA: string

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -71,13 +71,20 @@ export function buildPredicate(overrides: Partial<Predicate> = {}): Predicate {
   return { id: 'pr-1', field: 'rating', op: '<', value: 1500, ...overrides }
 }
 
-/** A four-table morning pool. */
+/** A four-table morning pool, **first** in its event (`position: 0`).
+ *
+ * `position` is 0-based and server-assigned from the pool's index in the list a write
+ * sent, so a fixture with several pools must number them 0, 1, 2 … in the order it means
+ * them — and must NOT let them collide. Nothing orders by id (`poolsInOrder`,
+ * `data/helpers`), so a second pool left on the default `0` is not "second", it is tied
+ * for first and lands wherever a stable sort leaves it. */
 export function buildPool(overrides: Partial<Pool> = {}): Pool {
   return {
     id: 'p-1',
     name: 'Pool A',
     slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
     tableIds: ['t1', 't2', 't3', 't4'],
+    position: 0,
     ...overrides,
   }
 }
@@ -245,6 +252,10 @@ export function buildRrThenKoEvent(
         id: 'p-b',
         name: 'Pool B',
         slot: { date: '2026-06-13', start: '13:30', end: '17:00' },
+        // SECOND, said out loud. Pool B does not follow Pool A because it is written
+        // second or because `p-b` sorts after `p-a` — nothing reads either (`poolsInOrder`,
+        // `data/helpers`). Left on the factory's default `0` it would tie with Pool A.
+        position: 1,
       }),
     ],
     ...overrides,
@@ -487,6 +498,10 @@ export function buildDrawnEvent(
         id: 'p-b',
         name: 'Pool B',
         slot: { date: '2026-06-13', start: '13:30', end: '17:00' },
+        // SECOND, said out loud. Pool B does not follow Pool A because it is written
+        // second or because `p-b` sorts after `p-a` — nothing reads either (`poolsInOrder`,
+        // `data/helpers`). Left on the factory's default `0` it would tie with Pool A.
+        position: 1,
       }),
     ],
     fixtures: [
@@ -526,6 +541,99 @@ export function buildDrawnEvent(
         entryBId: 'entry-3',
       }),
     ],
+    ...overrides,
+  })
+}
+
+/** How many pools `buildTenPools` builds — ten, because ten is the smallest count at
+ * which a client-minted id (`p-10-…`) sorts into the middle of the single digits. Nine
+ * pools would order identically by id and by position, and prove nothing. */
+const TEN = 10
+
+/**
+ * **Ten pools whose ids sort differently from their positions** — the fixture the whole
+ * ordering rule is about, and the only pool fixture that can falsify it.
+ *
+ * The ids are minted the way the editor mints them (`genId('p')` — `p-1-<ts>`,
+ * `p-2-<ts>` … `p-10-<ts>`, one timestamp for the burst), and as strings `p-10-` falls
+ * between `p-1-` and `p-2-`. So anything that sorted these by id renders **1, 10, 2, 3 …
+ * 9** — which is not a hypothetical: it is exactly what a ten-pool event's draw did
+ * before pools carried a position.
+ *
+ * They are returned **in that wrong order on purpose**, positions 0–9 telling the truth
+ * underneath. A fixture handed over already sorted cannot tell "orders by position" from
+ * "inherited the order it was given", so it would keep passing after the sort was
+ * deleted. This one reds for both.
+ *
+ * Each pool gets its own table and its own half-hour window, so ten pools raise no
+ * double-booking diagnostic — the claim under test is the order, and a warning banner
+ * would be noise inside it.
+ */
+export function buildTenPools(): Pool[] {
+  const inPositionOrder = Array.from({ length: TEN }, (_, i) => {
+    const n = i + 1
+    return buildPool({
+      // The `genId('p')` shape: index, then the shared base-36 timestamp.
+      id: `p-${n}-mkq1x`,
+      name: `Pool ${n}`,
+      position: i,
+      tableIds: [`t${n}`],
+      slot: {
+        date: '2026-06-13',
+        start: `${String(9 + i).padStart(2, '0')}:00`,
+        end: `${String(9 + i).padStart(2, '0')}:30`,
+      },
+    })
+  })
+  // Sorted by **id**, by codepoint (not `localeCompare`, which collates digits and
+  // punctuation by locale rules and would quietly stop reproducing the bug).
+  return [...inPositionOrder].sort((a, b) => (a.id < b.id ? -1 : 1))
+}
+
+/** The ten pools' names in **position** order — `Pool 1` … `Pool 10`. What every surface
+ * that lays them out must show. */
+export const TEN_POOLS_BY_POSITION = Array.from(
+  { length: TEN },
+  (_, i) => `Pool ${i + 1}`,
+)
+
+/** The same ten names in **id** order — `Pool 1`, `Pool 10`, `Pool 2` … The wrong answer,
+ * named, so a test can assert it is not the one being given. */
+export const TEN_POOLS_BY_ID = buildTenPools().map((p) => p.name)
+
+/**
+ * A **drawn** ten-pool event: `buildTenPools`, each pool holding one fixture between two
+ * entrants of its own (20 entrants, `player.1`…`player.20`).
+ *
+ * One fixture per pool because `drawState` renders only the pools the draw actually used
+ * — a pool with no fixtures is not part of the draw and would simply vanish, taking the
+ * ordering claim with it. Two players a pool is the smallest thing that makes a fixture.
+ */
+export function buildTenPoolDrawnEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  const pools = buildTenPools()
+  return buildEvent({
+    id: 'ev-ten-pools',
+    name: 'Ten-pool Singles',
+    drawType: 'round-robin',
+    maxPlayers: 32,
+    entrants: buildEntrants(TEN * 2),
+    pools,
+    // Built off the pools **in position order**, so the fixture list is in the server's
+    // own order (pool → round → position) and the panel is never handed a hint.
+    fixtures: [...pools]
+      .sort((a, b) => a.position - b.position)
+      .map((pool, i) =>
+        buildFixture({
+          id: `fx-${pool.id}`,
+          poolId: pool.id,
+          round: 1,
+          position: 1,
+          entryAId: `entry-${i * 2 + 1}`,
+          entryBId: `entry-${i * 2 + 2}`,
+        }),
+      ),
     ...overrides,
   })
 }

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -91,6 +91,21 @@ export interface Pool {
   name: string
   slot: Slot
   tableIds: string[]
+  /**
+   * Where this pool sits in its event's ordering — **0-based, and assigned by the
+   * server** from the index of the pool in the list a write body sent. To reorder
+   * pools you send them in the order you want; you never send a position (the write
+   * schema is `extra="forbid"`, so a `position` key on a write body is a 422 that
+   * names the field — see `eventPoolsToApi`, `data/api`).
+   *
+   * It exists because **pool ids do not order pools**. They are minted client-side
+   * (`genId('p')` → `p-1-…`, `p-2-…`, `p-10-…`), and sorted as strings `p-10-` falls
+   * between `p-1-` and `p-2-` — so a ten-pool event read its draw back as 1, 10, 2, 3.
+   * That was a live bug, not a hypothetical. Everything that puts pools in an order
+   * therefore orders them by THIS field (`poolsInOrder`, `data/helpers`) — never by id,
+   * and never by whatever order the array happened to arrive in.
+   */
+  position: number
 }
 
 /**

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
@@ -1,5 +1,5 @@
 import { interactiveControlsIn, interactiveElementsIn } from '@/test/read-only'
-import { render, screen, type Container } from '@/test/utilities'
+import { render, screen, within, type Container } from '@/test/utilities'
 
 import type { Pool } from '../../data/types'
 import {
@@ -25,6 +25,20 @@ const scoped = (container: Container) => ({
   },
   queryPoolCards() {
     return container.queryAllByTestId('pool-card')
+  },
+  /** Every pool's name, **in the order the cards render** — the claim `Pool.position`
+   * exists to make (`poolsInOrder`, `data/helpers`), and one no name-addressed accessor
+   * can state: `getPoolNameInputs()` returns boxes without saying which pool each holds.
+   *
+   * Reads the box when there is one and the read-back text when there is not, so the
+   * editor's order and the viewer's are the same assertion. */
+  getPoolNames(): string[] {
+    return container.queryAllByTestId('pool-card').map((card: HTMLElement) => {
+      const box = within(card).queryByLabelText<HTMLInputElement>('Pool name')
+      return box
+        ? box.value
+        : (within(card).getByTestId('pool-name').textContent ?? '').trim()
+    })
   },
   /** Every pool's name box, in card order — the card-scoped `getNameInput()` throws
    * once there is more than one pool, and "which card is red?" is a question about the

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
@@ -7,6 +7,9 @@ import {
   buildEvent,
   buildFixture,
   buildPool,
+  buildTenPools,
+  TEN_POOLS_BY_ID,
+  TEN_POOLS_BY_POSITION,
 } from '../../data/seed.factory'
 import { poolsSectionPage } from './pools-section.page'
 
@@ -27,12 +30,14 @@ const twoPools = () => [
     name: 'Pool A',
     slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
     tableIds: ['t1', 't2'],
+    position: 0,
   }),
   buildPool({
     id: 'p-2',
     name: 'Pool B',
     slot: { date: '2026-06-13', start: '13:00', end: '17:00' },
     tableIds: ['t3'],
+    position: 1,
   }),
 ]
 
@@ -44,12 +49,14 @@ const conflictingPools = () => [
     name: 'Pool A',
     slot: { date: '2026-06-13', start: '09:00', end: '12:00' },
     tableIds: ['t1'],
+    position: 0,
   }),
   buildPool({
     id: 'b',
     name: 'Pool B',
     slot: { date: '2026-06-13', start: '11:00', end: '14:00' },
     tableIds: ['t1'],
+    position: 1,
   }),
 ]
 
@@ -85,15 +92,111 @@ describe('PoolsSection', () => {
     })
   })
 
+  /**
+   * **Ten pools read 1 … 10** — the claim `Pool.position` was added to make.
+   *
+   * The fixture (`buildTenPools`) hands the section its pools in the order a sort by ID
+   * would produce, because a sorted fixture cannot falsify anything: it would pass just
+   * as happily against a section that trusted the array it was given, and against one
+   * that sorted by id. Here both of those render `Pool 1, Pool 10, Pool 2 …`, which is
+   * the real ten-pool bug, spelled out in the guard below.
+   */
+  describe('ten pools, in position order', () => {
+    // The fixture's own shape, asserted rather than assumed — if this ever stops being
+    // the id order, every claim below quietly stops discriminating.
+    it('is built from a fixture whose id order is the WRONG order', () => {
+      expect(TEN_POOLS_BY_ID).toEqual([
+        'Pool 1',
+        'Pool 10',
+        'Pool 2',
+        'Pool 3',
+        'Pool 4',
+        'Pool 5',
+        'Pool 6',
+        'Pool 7',
+        'Pool 8',
+        'Pool 9',
+      ])
+      expect(TEN_POOLS_BY_ID).not.toEqual(TEN_POOLS_BY_POSITION)
+    })
+
+    it('renders the cards in position order, not in id order', () => {
+      poolsSectionPage.render({ event: buildEvent({ pools: buildTenPools() }) })
+
+      expect(poolsSectionPage.getPoolNames()).toEqual(TEN_POOLS_BY_POSITION)
+    })
+
+    // …and the same for a reader, whose cards are text rather than boxes (ADR-0015).
+    it('reads back in position order for a viewer too', () => {
+      poolsSectionPage.render({
+        event: buildEvent({ pools: buildTenPools() }),
+        canEdit: false,
+      })
+
+      expect(poolsSectionPage.getPoolNames()).toEqual(TEN_POOLS_BY_POSITION)
+    })
+
+    /**
+     * The order the cards are in is the order the FORM is in — which matters because the
+     * form array is what a save serializes, and the server re-derives each position from
+     * that array's index. A section that sorted only its render would round-trip the
+     * director's pools into a different order than the one they were looking at.
+     */
+    it('seeds the form array in position order, so the save sends that order', () => {
+      poolsSectionPage.render({ event: buildEvent({ pools: buildTenPools() }) })
+
+      expect(poolsSectionPage.getPools().map((p) => p.name)).toEqual(
+        TEN_POOLS_BY_POSITION,
+      )
+      expect(poolsSectionPage.getPools().map((p) => p.position)).toEqual([
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+      ])
+    })
+
+    it('gives a pool added at the end the NEXT position, never a reused one', async () => {
+      poolsSectionPage.render({ event: buildEvent({ pools: buildTenPools() }) })
+
+      await userEvent.click(poolsSectionPage.getAddPoolButton())
+
+      const positions = poolsSectionPage.getPools().map((p) => p.position)
+      expect(positions).toHaveLength(11)
+      // 10 — one past the highest, and NOT a duplicate of any pool already there. (It is
+      // also the count here, which is why the interesting case is the one below.)
+      expect(positions.at(-1)).toBe(10)
+      expect(new Set(positions).size).toBe(11)
+    })
+
+    /**
+     * The case the count and the next position part company: remove a pool from the
+     * MIDDLE, then add one. Ten pools minus one is nine, so `fields.length` would hand
+     * the newcomer position 9 — which pool 10 already holds. Two pools tied for last is
+     * an order that is no order, and it would show up as a pair of cards swapping places
+     * on the next read.
+     */
+    it('does not reuse a position freed by removing a pool from the middle', async () => {
+      poolsSectionPage.render({ event: buildEvent({ pools: buildTenPools() }) })
+
+      // The third card is Pool 3 (position 2).
+      await userEvent.click(poolsSectionPage.getRemovePoolButtons()[2])
+      await userEvent.click(poolsSectionPage.getAddPoolButton())
+
+      const positions = poolsSectionPage.getPools().map((p) => p.position)
+      expect(positions).toEqual([0, 1, 3, 4, 5, 6, 7, 8, 9, 10])
+      // Nine pools were left, so the default name is the tenth letter — the naming and
+      // the positioning are independent, and only the positioning is load-bearing.
+      expect(poolsSectionPage.getPoolNames().at(-1)).toBe('Pool J')
+    })
+  })
+
   it('counts distinct double-booked tables, not conflict pairs', () => {
     // One table (t1) shared across three mutually-overlapping pools yields
     // three conflict pairs but is still a single double-booked table.
     poolsSectionPage.render({
       event: buildEvent({
         pools: [
-          buildPool({ id: 'a', name: 'A', slot: { date: '2026-06-13', start: '09:00', end: '12:00' }, tableIds: ['t1'] }),
-          buildPool({ id: 'b', name: 'B', slot: { date: '2026-06-13', start: '10:00', end: '13:00' }, tableIds: ['t1'] }),
-          buildPool({ id: 'c', name: 'C', slot: { date: '2026-06-13', start: '11:00', end: '14:00' }, tableIds: ['t1'] }),
+          buildPool({ id: 'a', name: 'A', slot: { date: '2026-06-13', start: '09:00', end: '12:00' }, tableIds: ['t1'], position: 0 }),
+          buildPool({ id: 'b', name: 'B', slot: { date: '2026-06-13', start: '10:00', end: '13:00' }, tableIds: ['t1'], position: 1 }),
+          buildPool({ id: 'c', name: 'C', slot: { date: '2026-06-13', start: '11:00', end: '14:00' }, tableIds: ['t1'], position: 2 }),
         ],
       }),
     })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
@@ -6,7 +6,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 
 import type { EditFreeze } from '../../data/draw'
-import { findPoolConflicts, genId } from '../../data/helpers'
+import { findPoolConflicts, genId, nextPoolPosition } from '../../data/helpers'
 import type { Pool, TournamentTable } from '../../data/types'
 import { EmptyState } from '../../empty-state'
 import type { EventFormValues } from '../event-form'
@@ -104,11 +104,18 @@ export const PoolsSection = ({
 
   // Clean domain pools (no `rhfKey`) for the conflict check and the cards, so an
   // edit never writes the field array's internal key back into form state.
+  //
+  // NOT re-sorted here. The field array arrived in position order (`eventToFormValues`
+  // seeds it that way) and its order is the director's, kept across every add and remove
+  // — and it is the order a save puts on the wire, from which the server re-derives the
+  // positions. Sorting the *render* while `update(i, …)` / `remove(i)` still addressed
+  // the underlying array by index would edit the wrong card.
   const pools: Pool[] = fields.map((f) => ({
     id: f.id,
     name: f.name,
     slot: f.slot,
     tableIds: f.tableIds,
+    position: f.position,
   }))
 
   // Double-booking is a diagnostic only the organizer can act on, so a viewer
@@ -124,6 +131,13 @@ export const PoolsSection = ({
       name: `Pool ${String.fromCharCode(65 + fields.length)}`,
       slot: { ...eventSlot },
       tableIds: [],
+      // One past the highest position in the list, never `fields.length` — the two part
+      // company as soon as a pool is removed from the middle, and a duplicate position is
+      // an order that is no order (`nextPoolPosition`, `data/helpers`). A new pool joins
+      // at the END, which is also where `append` puts it, so the array order and the
+      // positions agree — and they must, because the array order is what the save sends
+      // and the positions are what the next read comes back sorted by.
+      position: nextPoolPosition(pools),
     })
 
   return (

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
@@ -10,7 +10,7 @@ import {
   qualifiersPerPoolSchema,
   type EventSection,
 } from '../data/event-validation'
-import { browserTimezone } from '../data/helpers'
+import { browserTimezone, poolsInOrder } from '../data/helpers'
 import { PRED_OPS_BY_TYPE, type PredicateOp } from '../data/options'
 import { eligibilityIssues } from '../data/predicate-validation'
 import type {
@@ -80,12 +80,19 @@ const predicateSchema: z.ZodType<Predicate, Predicate> = z.object({
  *
  * `name` carries the server's floor (`poolNameSchema`, `data/event-validation`) — the
  * one field of a pool the organizer can *clear*. Its `id` is minted and boxless, so it
- * is left alone: see the note on `poolNameSchema`. */
+ * is left alone: see the note on `poolNameSchema`.
+ *
+ * `position` is here because it is part of a `Pool` and the form holds whole pools, not
+ * because there is anything to check: it has no box either, it is the SERVER's to assign
+ * (`eventPoolsToApi`, `data/api` — a `position` on a write body is a 422), and the value
+ * the form carries is only what keeps the cards in the order the director left them in
+ * until the next read. So the rule is a shape, not a floor. */
 const poolSchema: z.ZodType<Pool, Pool> = z.object({
   id: z.string(),
   name: poolNameSchema,
   slot: slotSchema,
   tableIds: z.array(z.string()),
+  position: z.number().int().nonnegative(),
 })
 
 /**
@@ -236,7 +243,16 @@ export function eventToFormValues(event: TournamentEvent | null): EventFormValue
     slot: event.slot,
     match: event.match,
     predicates: event.predicates,
-    pools: event.pools,
+    // **In POSITION order** (`poolsInOrder`, `data/helpers`), and this is the ONE place
+    // the pools editor's order is decided. From here on the field array's order IS the
+    // order: the cards render in it, `addPool` appends to the end of it, and — the reason
+    // it has to be settled here rather than at render time — a save serializes it, from
+    // which the server re-derives each pool's position (`eventPoolsToApi`, `data/api`).
+    //
+    // So sorting for *display* alone would be a bug with a delay on it: the director
+    // would see A, B, C, save, and get back whatever order the array was really in. The
+    // list they were looking at has to be the list that goes on the wire.
+    pools: poolsInOrder(event.pools),
   }
 }
 

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
@@ -15,6 +15,9 @@ import {
   buildEvent,
   buildFixture,
   buildPool,
+  buildTenPoolDrawnEvent,
+  TEN_POOLS_BY_ID,
+  TEN_POOLS_BY_POSITION,
 } from '../../data/seed.factory'
 import { drawPanelPage as page } from './draw-panel.page'
 
@@ -44,6 +47,26 @@ describe('DrawPanel', () => {
       expect(page.getPoolHeading('Pool A')).toBeInTheDocument()
       expect(page.getPoolHeading('Pool B')).toBeInTheDocument()
       expect(page.queryEmptyState()).toBeNull()
+    })
+
+    /**
+     * **Ten pools read 1 … 10, top to bottom** — the bug `Pool.position` was added to
+     * kill, at the surface it was actually seen on.
+     *
+     * Pool ids are minted client-side (`genId('p')`), so a ten-pool event holds
+     * `p-1-…` … `p-10-…`; sorted as strings `p-10-` lands between `p-1-` and `p-2-` and
+     * the draw rendered **1, 10, 2, 3 …**. The fixture hands the panel its pools in that
+     * very order (`buildTenPools`), so the assertion reds for a panel that sorts by id
+     * AND for one that merely renders whatever order it was handed. A nine-pool event
+     * could not tell any of these apart — the two orders coincide below ten.
+     */
+    it('renders ten pools 1 … 10 — by position, not by id', () => {
+      page.render({ event: buildTenPoolDrawnEvent() })
+
+      expect(page.getPoolNames()).toEqual(TEN_POOLS_BY_POSITION)
+      // Said the other way round too, because "not this" is the actual regression: the
+      // wrong answer is a specific, recognisable sequence, not just "some other order".
+      expect(page.getPoolNames()).not.toEqual(TEN_POOLS_BY_ID)
     })
 
     it('lists each pool’s entrants by name — the membership its fixtures imply', () => {
@@ -355,9 +378,9 @@ describe('DrawPanel', () => {
           drawType: 'round-robin',
           entrants: buildEntrants(5),
           pools: [
-            buildPool({ id: 'p-1', name: 'Pool A' }),
-            buildPool({ id: 'p-2', name: 'Pool B' }),
-            buildPool({ id: 'p-3', name: 'Pool C' }),
+            buildPool({ id: 'p-1', name: 'Pool A', position: 0 }),
+            buildPool({ id: 'p-2', name: 'Pool B', position: 1 }),
+            buildPool({ id: 'p-3', name: 'Pool C', position: 2 }),
           ],
         }),
       })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/pool-draw.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/pool-draw.page.tsx
@@ -19,6 +19,17 @@ const scoped = (container: Container) => ({
   getPoolHeading(poolName: string) {
     return container.getByRole('heading', { name: poolName })
   },
+  /** Every pool's heading, **in DOM order** — the sequence a director reads top to
+   * bottom, which is the whole claim `Pool.position` exists to make (`poolsInOrder`,
+   * `data/helpers`). Named accessors cannot state it: `getPoolHeading('Pool 2')` passes
+   * just as happily when Pool 2 is rendered tenth. */
+  getPoolNames(): string[] {
+    return container
+      .queryAllByTestId(/^pool-draw-/)
+      .map((pool: HTMLElement) =>
+        (within(pool).getByRole('heading').textContent ?? '').trim(),
+      )
+  },
   /** The pool's entrants, in the order they render (draw order: seed, then
    * registration). Names, not ids — a chip list of uuids would pass a "renders the
    * roster" assertion and tell a director nothing. */

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -1065,6 +1065,12 @@ export function buildTournamentEventRead(
         name: 'Pool A',
         slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
         table_ids: ['t1', 't2', 't3', 't4'],
+        // The pool's place in the event, 0-based — on the READ shape only. The server
+        // assigns it from the index of the pool in the list a write body sent, and
+        // `PoolWrite` forbids the key outright, so an override here is describing what
+        // came back, never what was asked for. A fixture with several pools numbers them
+        // 0, 1, 2 …: nothing orders pools by id (see `Pool.position`, `data/types`).
+        position: 0,
       },
     ],
     // NO RESULTS (ADR-0788) — `null` is the designed state of an event with no draw (and of

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -599,6 +599,72 @@ describe('the rest of the event surface still holds', () => {
     if (!result.ok) throw new Error('update failed')
     expect(result.event.max_players).toBeNull()
   })
+
+  /**
+   * **The pool positions come from the array index, and nowhere else** — the store half
+   * of the rule the editor and the draw panel both depend on.
+   *
+   * `PoolWrite` has no `position` (it is `extra="forbid"`, so sending one is a 422), so
+   * the ORDER of the list is the only thing that says which pool is first. The server
+   * turns that order into numbers; if the mock did not, the app would look right in
+   * `npm run dev` while every pool came back tied for first — a mock/server disagreement
+   * about a rule the UI reads on every load.
+   *
+   * Ten pools, with ids whose lexicographic order is 1, 10, 2, 3 …, so a store that
+   * numbered them by id (or handed back a default `0`) cannot pass by coincidence.
+   */
+  const TEN_WRITE_POOLS = Array.from({ length: 10 }, (_, i) => ({
+    id: `p-${i + 1}-mkq1x`,
+    name: `Pool ${i + 1}`,
+    slot: SLOT,
+    table_ids: [],
+  }))
+
+  it('stamps a created event’s pools with the position of their index', () => {
+    const result = createEvent(TOURNAMENT, {
+      name: 'Ten-pool Singles',
+      format: 'singles',
+      draw_type: 'round-robin',
+      entry_fee: 0,
+      timezone: 'America/Chicago',
+      slot: SLOT,
+      match_settings: { rated: false, length_games: 3 },
+      pools: TEN_WRITE_POOLS,
+    })
+    if (!result.ok) throw new Error('create failed')
+
+    expect(result.event.pools.map((p) => p.position)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    ])
+    expect(result.event.pools.map((p) => p.name)).toEqual(
+      TEN_WRITE_POOLS.map((p) => p.name),
+    )
+  })
+
+  // …and RE-stamps on every pools patch, because that is the whole reordering API:
+  // send them in the order you want and the positions follow.
+  it('re-positions a patched event’s pools from the new order', () => {
+    const reversed = [...TEN_WRITE_POOLS].reverse()
+    const result = updateEvent(TOURNAMENT, EMPTY_SINGLES, { pools: reversed })
+    if (!result.ok) throw new Error('update failed')
+
+    expect(result.event.pools.map((p) => p.name)).toEqual(
+      reversed.map((p) => p.name),
+    )
+    expect(result.event.pools.map((p) => p.position)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    ])
+  })
+
+  // An absent `pools` is not touching them, so the stored positions stand — the same
+  // "absent means unchanged" the cap follows one test up.
+  it('leaves the stored positions alone when a PATCH names no pools', () => {
+    const before = event(FULLISH_SINGLES).pools.map((p) => p.position)
+    const result = updateEvent(TOURNAMENT, FULLISH_SINGLES, { name: 'Renamed' })
+    if (!result.ok) throw new Error('update failed')
+
+    expect(result.event.pools.map((p) => p.position)).toEqual(before)
+  })
 })
 
 // The lifecycle (ADR-0017). The store enforces the SERVER's edge table, not a

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -54,7 +54,13 @@ type TournamentEventUpdate = components['schemas']['TournamentEventUpdate']
 type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
 type TournamentTable = components['schemas']['TournamentTable']
 type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
+/** The **read** pool — it carries `position`. Its write twin below deliberately does
+ * not; see `positionPools`. */
 type Pool = components['schemas']['Pool']
+/** A pool as a create/update body carries it: no `position`, because the server assigns
+ * it from the pool's index in the list. `extra="forbid"`, so a `position` key on the way
+ * in is a 422 that names the field. */
+type PoolWrite = components['schemas']['PoolWrite']
 type ScheduleSolveRead = components['schemas']['ScheduleSolveRead']
 
 /** What the store actually holds for an event: everything the wire shape has
@@ -167,12 +173,14 @@ const U1200_POOLS: Pool[] = [
     name: 'Pool A',
     slot: { date: '2026-06-14', start: '09:00', end: '10:30' },
     table_ids: ['t1', 't2'],
+    position: 0,
   },
   {
     id: 'p-u1200-b',
     name: 'Pool B',
     slot: { date: '2026-06-14', start: '10:30', end: '12:00' },
     table_ids: ['t3', 't4'],
+    position: 1,
   },
 ]
 
@@ -185,12 +193,14 @@ const SLAM_POOLS: Pool[] = [
     name: 'Pool A',
     slot: { date: '2026-08-22', start: '09:00', end: '11:00' },
     table_ids: ['t1', 't2'],
+    position: 0,
   },
   {
     id: 'p-slam-b',
     name: 'Pool B',
     slot: { date: '2026-08-22', start: '11:00', end: '13:00' },
     table_ids: ['t3', 't4'],
+    position: 1,
   },
 ]
 
@@ -252,12 +262,14 @@ const CUP_POOLS: Pool[] = [
     name: 'Pool A',
     slot: { date: '2026-06-06', start: '09:00', end: '11:00' },
     table_ids: ['t1', 't2'],
+    position: 0,
   },
   {
     id: 'p-cup-b',
     name: 'Pool B',
     slot: { date: '2026-06-06', start: '11:00', end: '13:00' },
     table_ids: ['t3', 't4'],
+    position: 1,
   },
 ]
 
@@ -269,12 +281,14 @@ const SHIELD_POOLS: Pool[] = [
     name: 'Pool A',
     slot: { date: '2026-06-07', start: '09:00', end: '10:30' },
     table_ids: ['t5', 't6'],
+    position: 0,
   },
   {
     id: 'p-shield-b',
     name: 'Pool B',
     slot: { date: '2026-06-07', start: '10:30', end: '12:00' },
     table_ids: ['t7', 't8'],
+    position: 1,
   },
 ]
 
@@ -538,12 +552,14 @@ function seed(): StoredTournament[] {
               name: 'Pool A',
               slot: { date: '2026-06-13', start: '09:00', end: '12:30' },
               table_ids: ['t1', 't2', 't3', 't4'],
+              position: 0,
             },
             {
               id: 'p-os-2',
               name: 'Pool B',
               slot: { date: '2026-06-13', start: '13:30', end: '17:00' },
               table_ids: ['t1', 't2', 't3', 't4', 't5', 't6'],
+              position: 1,
             },
           ],
           // NO DRAW CUT (ADR-0786) — the state every event starts in, and the state
@@ -844,18 +860,21 @@ function seed(): StoredTournament[] {
               name: 'Group A',
               slot: { date: '2026-07-01', start: '17:00', end: '19:00' },
               table_ids: ['t1', 't2', 't3'],
+              position: 0,
             },
             {
               id: 'p-cc-2',
               name: 'Group B',
               slot: { date: '2026-07-01', start: '17:00', end: '19:00' },
               table_ids: ['t4', 't5', 't6'],
+              position: 1,
             },
             {
               id: 'p-cc-3',
               name: 'Knockout',
               slot: { date: '2026-07-01', start: '19:15', end: '21:00' },
               table_ids: ['t1', 't2'],
+              position: 2,
             },
           ],
           // Un-drawn, and it stays that way through the UI: the dev user does not own
@@ -1827,6 +1846,25 @@ export function deleteTournament(id: string): DeleteResult {
   return { ok: true }
 }
 
+/**
+ * Stamp each pool with the **position of its index in the list the client sent** — the
+ * server's rule (`_write_pools`, `api/app/…/tournament.py`), reproduced here because a
+ * mock that is more permissive than the server it stands in for is a trap.
+ *
+ * The write schema (`PoolWrite`) has no `position`: it is `extra="forbid"`, so sending
+ * one is a 422 naming the field, and **the order of the array is the only thing that
+ * says which pool comes first**. The read schema (`Pool`) has it, so this is the seam
+ * where the order the client expressed becomes the number the client reads back.
+ *
+ * Defaulting to `0`, or casting the write shape through, would make the mock disagree
+ * with the API about a rule the app depends on — the pools editor seeds its cards from
+ * `position` and the draw renders in it, so every pool would come back tied for first and
+ * `npm run dev` would order them by nothing at all.
+ */
+function positionPools(pools: PoolWrite[]): Pool[] {
+  return pools.map((pool, index) => ({ ...pool, position: index }))
+}
+
 let eventCounter = 0
 
 /** Create an event on a tournament. Creator-only (403 on a non-owned row). */
@@ -1864,7 +1902,10 @@ export function createEvent(
     slot: body.slot,
     match_settings: body.match_settings,
     predicates: body.predicates ?? [],
-    pools: body.pools ?? [],
+    // The write body carries no positions, so the store assigns them here — from the
+    // index, exactly as the server does (`positionPools`). The order the editor sent its
+    // pools in IS the order, and this is where that becomes a number.
+    pools: positionPools(body.pools ?? []),
     // A brand-new event has NO DRAW (ADR-0786). Cutting one is an explicit act against
     // a field that does not exist yet — there is nobody entered to draw.
     fixtures: [],
@@ -1935,7 +1976,11 @@ export function updateEvent(
     slot: patch.slot ?? event.slot,
     match_settings: patch.match_settings ?? event.match_settings,
     predicates: patch.predicates ?? event.predicates,
-    pools: patch.pools ?? event.pools,
+    // RE-POSITIONED on every pools patch, from the array index (`positionPools`) — the
+    // server re-derives them the same way, which is what makes "send them in the order
+    // you want" the whole reordering API. An absent `pools` is not touching them at all,
+    // and the stored positions stand.
+    pools: patch.pools ? positionPools(patch.pools) : event.pools,
     // The DRAW survives an edit (ADR-0786): a PATCH is not a re-cut. `fixtures` is not
     // in the write body at all, and answering `[]` here would tell the director their
     // draw had just been thrown away by a rename.

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -1848,8 +1848,8 @@ export function deleteTournament(id: string): DeleteResult {
 
 /**
  * Stamp each pool with the **position of its index in the list the client sent** — the
- * server's rule (`_write_pools`, `api/app/…/tournament.py`), reproduced here because a
- * mock that is more permissive than the server it stands in for is a trap.
+ * server's rule (`stored_pools`, `api/app/schemas/tournament.py`), reproduced here
+ * because a mock that is more permissive than the server it stands in for is a trap.
  *
  * The write schema (`PoolWrite`) has no `position`: it is `extra="forbid"`, so sending
  * one is a 422 naming the field, and **the order of the array is the only thing that


### PR DESCRIPTION
**Slice 1 of the #1226 stack.** Stacked on #1235 (the ADRs) — `--base` is `claude/github-issue-1226-afo16g`, not `main`, so this diff is only this slice.

## This fixes a live bug

Pool ids are client-minted strings: `p-1-…`, `p-2-…`, `p-10-…`. Sorted lexicographically, **`p-10-` falls between `p-1-` and `p-2-`** — so an event with ten or more pools has been rendering, dealing and materializing its draw as pool 1, pool 10, pool 2, pool 3…

Reproduced against the pre-slice code on the real stack:

```
stored positions : [null,null,…,null]
wire order       : p-1-…, p-10-…, p-2-…, p-3-…
```

It is also the **prefactor** the rest of the arc needs. Pool order is currently carried implicitly by two things that both vanish when pools become uuid rows: the JSONB array's order, and the id's lexicographic sort. Slice 3 switches to uuid primary keys; without an explicit ordering column, that would silently randomise the snake seeding — the failure the ADR predicts as "invisible to the type checker, findable only by QA".

## The chores

| | | |
|---|---|---|
| `1a` | `[api]` | pool carries a server-stamped 0-based `position` |
| `1b` | `[api]` | all three ordering sites move off the id |
| `1c` | `[main]` | regen (superseded by `1c2`) |
| `1a2` | `[api]` | `position` off the **write** schema — sending it is now a 422 |
| `1c2` | `[main]` + `[ios]` | regen against the split, both generated clients |
| `1d` | `[web-client]` | editor, draw panel, and mock/server parity |
| `1e` | `[e2e]` | ten pools, real stack, real browser |

## Two design decisions worth review

**`position` is read-only by schema, not by convention.** `1a` first put it on the shared `Pool` model; because it has a default, `openapi-typescript` promoted it to *required* and the generated client became obliged to send a server-assigned field, breaking `tsc -b` in five files. `1a2` split it — `PoolWrite` (what a client sends, no `position`) and `Pool(PoolWrite)` (what a read returns). Since the models are `extra="forbid"`, sending `position` is now a 422 naming the field:

```json
{"type":"extra_forbidden","loc":["body","pools",0,"position"],"input":7}
```

This follows the `entered` precedent already in `data/api.ts` — a server-managed field simply is not on the write shape.

**`pool_id` survives as a secondary sort key.** Not decoration: no migration backfilled `position`, `pools` is JSONB, and long-lived databases (UAT's persistent volume, standing QA stacks) hold rows written before the field. Those degrade to today's id order rather than to no order.

## Known limitation, stated rather than buried

The two fallbacks for an absent `position` are **not the same one**. SQL reads a missing JSONB key as `NULL` and falls through to id order; the Python paths parse through `Pool`, where `position` defaults to `0`, so a stable sort leaves array order. Pre-slice these agreed; now they don't. It bites only an event with ten or more *pre-field* pools, and changes the order matches are created in — not which fixtures exist or who plays whom.

It is documented in `ready_fixtures`' docstring rather than asserted away, and it **stops existing in Slice 3**, where pools become rows with a `NOT NULL position`. Deliberately not ticketed: this arc closes it.

## How much of this the e2e spec would actually have caught

Verified by running the spec against the genuine pre-slice source, not by reasoning:

- **server** and **wire** assertions → **red** (positions `null`; wire order `p-1, p-10, p-2`)
- **DOM heading and membership** assertions → **pass**

Pre-slice rendering used the array's incidental order, which equals the director's order on a create — and that coincidence cannot be seeded away, since positions are stamped *from* the array index. So this spec would have caught the original bug **on the wire, not in the browser**. The DOM assertions earn their place forward: once pools are uuid rows, array order stops meaning anything.

## Verification

Every chore was implemented by a domain expert and then graded by a **separate** agent with no edit tools, which re-ran the command, adversarially attacked the `Proves` claim, and ran the demo. Highlights:

- `1b` red-before/green-after reproduced at all three ordering sites individually
- `1a2` coverage **grew** (307 → 310 collected); the one deleted test is replaced by four stronger ones
- `1d` survived six mutations, including removing the sort entirely — so the fixture catches "no sort", not just "wrong sort"
- `1e`'s second falsification reproduced the ADR's predicted failure exactly: reverting the api ordering leaves every **heading** correct while **membership** goes wrong

Suites: api `2093 passed`, mypy + ruff clean; web-client `318 files / 3355 tests`, `npm run build` clean; root e2e `tournament-pool-order` passes on a self-managed docker stack.

## Also fixed here

Playwright's `getByRole` name matching is substring by default, so `Pool 1` also matched `Pool 10` and the shared `poolDrawNamed` page object silently resolved to **two** sections. Now `exact: true` — confirmed live (2 matches before, 1 after), with `tournament-rr-then-ko` unaffected.

## Follow-ups filed, not folded in

- #1236 — DOM snapshots inline third-party icon paths, so any lucide bump reds `main`
- #1237 — the `Pool`/`PoolWrite` inheritance can yield a 500 rather than a 422 for an in-process caller
- #1229 (pre-existing) — tournament detail unreachable in local dev; the `1d` agent hit it cold while trying to demo, and had to use the e2e harness instead

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCCG5jQq19dG8SDPFcmTwh)_