### PR TITLE
Compute the e2e seed's default pool window instead of hardcoding a date

### DIFF
--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -39,6 +39,29 @@ export interface SlotSpec {
   readonly end: string
 }
 
+/** Tomorrow, `YYYY-MM-DD`, UTC — the date the default pool window sits on.
+ *
+ * **Computed, never a literal.** This used to be the string `'2026-08-01'`, which
+ * was comfortably far-future when it was written and then arrived: from 17:00 UTC
+ * that day every seeded window was in the *past*, and from the next day it was
+ * permanently so. The schedule preview solves fixtures into their pool's window,
+ * and a window behind `now` admits no placement — so the solve is honestly
+ * infeasible and the verdict reads `Doesn't fit · peak 0 tables`. The solver was
+ * right; the fixture had expired.
+ *
+ * It is a poor bug to inherit: the message points at *tables*, the failure is
+ * total rather than flaky, and it reds every branch at once, so it reads like
+ * whatever change happens to be in flight. Tomorrow keeps the window genuinely
+ * ahead of any run, at any hour, forever.
+ *
+ * UTC because the compose stack's clock is UTC and `seedTournament` anchors its
+ * events to `timezone: 'UTC'` — the date and the frame have to agree, or the
+ * window drifts by a day either side of midnight. */
+function tomorrowUtc(): string {
+  const DAY_MS = 24 * 60 * 60 * 1000
+  return new Date(Date.now() + DAY_MS).toISOString().slice(0, 10)
+}
+
 /** One table of the tournament's catalogue (`TournamentTable` on the wire). */
 export interface TableSpec {
   readonly id: string
@@ -200,7 +223,11 @@ export async function seedTournament(
   name: string,
   options: SeedTournamentOptions = {},
 ): Promise<SeededTournament> {
-  const slot = options.slot ?? { date: '2026-08-01', start: '09:00', end: '17:00' }
+  const slot = options.slot ?? {
+    date: tomorrowUtc(),
+    start: '09:00',
+    end: '17:00',
+  }
   const tables = options.tables ?? [{ id: TABLE_ID, label: 'Table 1', court: 'A' }]
   // Resolve the catalogue HERE and pass it down, rather than letting
   // `createTournament` default it again: the pool below references these tables


### PR DESCRIPTION
Fixes #1239. **`compose-e2e` is broken on `main` and on every open branch as of today**, and will stay broken until this lands.

## The bug

`e2e/support/tournament-api.ts:203`

```ts
const slot = options.slot ?? { date: '2026-08-01', start: '09:00', end: '17:00' }
```

Every seeded tournament's pool window is that literal date. It was far-future when written; **today it arrived**. From 17:00 UTC the window was in the past, and from tomorrow it is in the past permanently.

The schedule preview solves fixtures into their pool's window. A window behind `now` admits no placement, so the solve is *genuinely* infeasible — and `peak_concurrent_tables`, derived from an empty placement set, renders it as:

```
Doesn't fit · peak 0 tables
```

**The solver is correct. The fixture expired.**

## Evidence it is the clock, not any diff

| Run | Time (UTC) | Window open? | Result |
|---|---|---|---|
| #1233 `compose-e2e` | 15:11 | yes | ✅ |
| #1235 `compose-e2e` | 15:14 | yes | ✅ |
| #1238 attempt 1 | 22:19 | **no** | ❌ |
| #1238 attempt 2 | 22:31 | **no** | ❌ |
| #1238 attempt 3 *(rebased head, identical tree)* | 22:34 | **no** | ❌ |

Three failures across two different commits — one a rebase carrying a byte-identical tree — with both Playwright retries failing each time. Passes earlier the same day on branches containing none of the code under suspicion.

## Proof of the fix, under the failing condition

Not "it passes" — *it passes at the hour it fails*:

```
$ cd e2e && npm test -- schedule-preview     # run at 22:4x UTC
  1 passed (50.2s)
```

Same spec, same box, same time of day that produces three consecutive CI failures without this change.

## The change

One line, plus the reasoning. `tomorrowUtc()` — computed, never a literal.

**UTC deliberately:** the compose stack's clock is UTC and `seedTournament` anchors its events to `timezone: 'UTC'`. The date and the frame have to agree, or the window drifts a day either side of midnight.

Scope is one file, one call site. `grep -rn "2026-08-01" e2e/` returned only that line, and no spec overrides `slot` in a way that depended on the literal. The helper's own doc comment already called it a *"far-future default window"* — the intent was always relative; only the encoding was absolute.

## Why it was mis-diagnosed once

`peak 0 tables` points squarely at **table resolution**. It surfaced on #1238 — a slice that changes how pools resolve tables — so it read as a regression there. I hunted it as one, then reproduced it at the branch point and concluded (rightly) that it predated the branch, but attributed it to the CP-SAT 5s cap under CPU load. That was wrong: a timeout surfaces as `unknown`, not `infeasible`, and I should have treated that as the discriminator. The timestamps settled it.

Worth a follow-up: the infeasibility *reason* exists in the domain (ADR *"an infeasible solve explains itself with a resolved reason"*). A verdict reading *"window is in the past"* would have made this a two-minute diagnosis instead of an hour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCCG5jQq19dG8SDPFcmTwh)_