### PR TITLE
Fix iOS dashboard decode crash for non-RATED users

### DIFF
--- a/ios/Fortymm/Dashboard/DashboardModels.swift
+++ b/ios/Fortymm/Dashboard/DashboardModels.swift
@@ -19,7 +19,10 @@ struct DashboardResponse: Decodable {
     /// never a row.
     let waitingCount: Int
     let recentResults: [DashboardRecentResult]
-    let rating: DashboardRating?
+    /// ALWAYS emitted for a signed-in user (see `DashboardRating`'s doc comment) —
+    /// no longer `| None` server-side, per ADR 20260725. Its `state` says which of
+    /// four stories the card tells; only `.rated` carries the rating payload.
+    let rating: DashboardRating
     let completedMatchCount: Int
     /// Every LIVE tournament the caller holds an active entry in, newest first —
     /// the panel that sits at the very top of the dashboard while they're playing
@@ -110,26 +113,65 @@ struct RatingChange: Decodable {
     let delta: Double?
 }
 
-/// The "Current rating" card payload. Emitted only for automatic-strategy
-/// leagues with a rated user — `nil` otherwise (manual league / unrated).
+/// WHICH rating story the card tells — mirrors the API's `DashboardRatingState`
+/// (`api/app/schemas/dashboard.py`, ADR 20260725). A `nil`/absent `rating` used to
+/// collapse three distinct non-rated facts into one signal; the state names the
+/// situation so the client can say the true thing per arm instead of one
+/// one-string-fits-all fallback. `unknown` is the forward-compat landing pad for a
+/// state added after this build shipped — treated the same as `.notRatedLeague`
+/// by call sites, mirroring the web's fallback.
+enum DashboardRatingState: String, LenientRawDecodable {
+    /// Has a rating: the value + delta, plus the rank-or-percentile line below.
+    case rated = "RATED"
+    /// In an automatic-strategy league but hasn't finished a rated match yet.
+    case unrated = "UNRATED"
+    /// Manual-strategy league whose external ratings haven't been imported yet.
+    case awaitingImport = "AWAITING_IMPORT"
+    /// Not a member of any rated league at all.
+    case notRatedLeague = "NOT_RATED_LEAGUE"
+    case unknown
+}
+
+/// The "Current rating" card payload — ALWAYS emitted for a signed-in user (the
+/// parent `DashboardResponse.rating` is no longer optional). `state` says which
+/// of four stories the card tells; only the `.rated` arm carries the payload
+/// below (`current` / `delta` / `peak` / the rank-or-percentile line /
+/// `sparkData` / `streak` / `stats`) — every other arm sends `null` for them, so
+/// they're optional here even though `DashboardRatingCard` only ever renders for
+/// `.rated` (see `DashboardView.yourGame`).
 struct DashboardRating: Decodable {
-    let leagueId: UUID
-    let leagueName: String
-    let strategyKey: String
-    let current: Double
+    let state: DashboardRatingState
+    /// The league context. Present for `.rated` / `.unrated` / `.awaitingImport`;
+    /// `nil` for `.notRatedLeague` (there is no league to name).
+    let leagueId: UUID?
+    let leagueName: String?
+    let strategyKey: String?
+    /// The headline rating — `nil` on every non-`.rated` arm.
+    let current: Double?
     /// What the player's last rated match did to them — the "+12 last match"
     /// chip. `nil` means THERE IS NO MOVE TO REPORT and the card must render
     /// nothing (no chip, no arrow, no tone) rather than a zero: either that
     /// match ESTABLISHED this rating instead of moving it, or no rated match
     /// lies behind the current value at all (a `manual` override / `import`).
+    /// Also `nil` on every non-`.rated` arm.
     ///
     /// Optional for the same wire reason as `RatingChange.delta` — the API sends
     /// `float | None` (`Generated/Types.swift`) with the key always present — and
     /// it is a SECOND, independent decode blocker: `recentResults` is decoded
     /// first, so its failure masked this one entirely.
     let delta: Double?
-    let peak: Double
+    /// `nil` on every non-`.rated` arm — a peak is a rating they held, and they
+    /// hold none.
+    let peak: Double?
+    /// "Top N%" — only once the rated population clears the server's threshold.
+    /// Below that the card shows `rank`/`population` instead; `nil` on every
+    /// non-`.rated` arm too.
     let percentile: Int?
+    /// The player's 1-based position among the league's rated members, and how
+    /// many rated members there are — the fallback "#N of M" line when
+    /// `percentile` is suppressed. `nil` on every non-`.rated` arm.
+    let rank: Int?
+    let population: Int?
     let sparkData: [Double]
     let streak: DashboardStreak?
     let stats: [DashboardRatingStat]
@@ -147,8 +189,11 @@ struct DashboardRatingStat: Decodable {
 
 extension DashboardRating {
     /// Human label for the rating strategy, mirroring `ratingStrategyLabel`
-    /// in `web-client/src/components/dashboard/dashboard-page.tsx`.
-    var strategyLabel: String {
+    /// in `web-client/src/components/dashboard/your-game-row.tsx`. `nil` when
+    /// `strategyKey` is `nil` (any non-`.rated`/`.unrated`/`.awaitingImport`
+    /// arm), so the subtitle can fall back to a bare window instead of a label.
+    var strategyLabel: String? {
+        guard let strategyKey else { return nil }
         switch strategyKey {
         case "glicko2": return "Glicko-2"
         case "manual": return "Manual"

--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -211,26 +211,42 @@ struct DashboardView: View {
                 Spacer()
             }
 
-            if let rating = data.rating {
-                DashboardRatingCard(rating: rating)
-            } else {
-                FMCard {
-                    VStack(alignment: .leading, spacing: FMSpace.s3) {
-                        DashOverline(text: "Current rating")
-                        Text("Not in a rated league yet.")
-                            .font(FMFont.ui(FMFont.sm))
-                            .foregroundStyle(FMColor.fg3)
-                    }
-                }
+            switch data.rating.state {
+            case .rated:
+                DashboardRatingCard(rating: data.rating)
+            case .unrated:
+                emptyRatingCard("Unrated — finish a rated match to start your rating")
+            case .awaitingImport:
+                emptyRatingCard("Ratings haven't been imported for this league yet")
+            case .notRatedLeague, .unknown:
+                // `.unknown` (a state added after this build shipped) falls back
+                // to the same copy as `.notRatedLeague`, mirroring the web
+                // client's default-to-`NOT_RATED_LEAGUE` behaviour.
+                emptyRatingCard("Not in a rated league yet.")
             }
 
             DashboardRecentResultsCard(rows: data.recentResults)
         }
     }
 
-    private func yourGameSubtitle(_ rating: DashboardRating?) -> String {
-        guard let rating else { return "Last 30 days" }
-        return "\(rating.strategyLabel) · last 30 days"
+    private func yourGameSubtitle(_ rating: DashboardRating) -> String {
+        guard let label = rating.strategyLabel else { return "Last 30 days" }
+        return "\(label) · last 30 days"
+    }
+
+    /// The non-`.rated` empty state for the "Current rating" card — same
+    /// `FMCard`/`DashOverline` shell as the `.rated` card, with per-state copy
+    /// (mirrors the web's `EmptyCard` + `EMPTY_RATING_COPY`,
+    /// `web-client/src/components/dashboard/your-game-row.tsx`).
+    private func emptyRatingCard(_ body: String) -> some View {
+        FMCard {
+            VStack(alignment: .leading, spacing: FMSpace.s3) {
+                DashOverline(text: "Current rating")
+                Text(body)
+                    .font(FMFont.ui(FMFont.sm))
+                    .foregroundStyle(FMColor.fg3)
+            }
+        }
     }
 
     private var loadingCard: some View {

--- a/ios/Fortymm/Dashboard/DashboardWidgets.swift
+++ b/ios/Fortymm/Dashboard/DashboardWidgets.swift
@@ -93,6 +93,13 @@ private func plainRating(_ value: Double) -> String {
     String(Int(value.rounded()))
 }
 
+/// `"#N of M"` — the rank fallback for `percentileLine` below the server's
+/// percentile threshold. Mirrors the web's `formatRankOfPopulation`
+/// (`web-client/src/lib/rating.ts`).
+private func formatRankOfPopulation(rank: Int, population: Int) -> String {
+    "#\(rank) of \(population)"
+}
+
 private extension View {
     /// The inset "well" shared by the sparkline panel and the stat tiles: a
     /// darker fill with a hairline border.
@@ -107,9 +114,16 @@ private extension View {
 struct DashboardRatingCard: View {
     let rating: DashboardRating
 
+    // The `.rated` arm always carries these; the `?? 0` only satisfies the
+    // type, which is nullable across all four states (`DashboardView.yourGame`
+    // renders this card for `.rated` only — ADR 20260725). Mirrors the web
+    // `RatingCard`'s identical `?? 0` unwrap.
+    private var current: Double { rating.current ?? 0 }
+    private var peak: Double { rating.peak ?? 0 }
+
     // Peak tile, then up to two strategy-specific stats (the grid is 3-up).
     private var tiles: [(label: String, value: String)] {
-        [("Peak", plainRating(rating.peak))]
+        [("Peak", plainRating(peak))]
             + rating.stats.prefix(2).map { ($0.label, $0.value) }
     }
 
@@ -128,7 +142,7 @@ struct DashboardRatingCard: View {
                 }
 
                 HStack(alignment: .firstTextBaseline, spacing: FMSpace.s3) {
-                    Text(verbatim: plainRating(rating.current))
+                    Text(verbatim: plainRating(current))
                         .font(FMFont.mono(56, weight: .bold))
                         .foregroundStyle(FMColor.fg1)
                     VStack(alignment: .leading, spacing: 5) {
@@ -160,15 +174,28 @@ struct DashboardRatingCard: View {
 
     @ViewBuilder
     private var percentileLine: some View {
+        // `.rated` always carries a league name; `?? ""` only satisfies the
+        // type, same reasoning as `current`/`peak` above.
+        let leagueName = rating.leagueName ?? ""
         if let percentile = rating.percentile {
             (Text("Top ").foregroundStyle(FMColor.fgMuted)
                 + Text("\(percentile)%")
                     .font(FMFont.mono(FMFont.xs))
                     .foregroundStyle(FMColor.fg3)
-                + Text(" in \(rating.leagueName)").foregroundStyle(FMColor.fgMuted))
+                + Text(" in \(leagueName)").foregroundStyle(FMColor.fgMuted))
+                .font(FMFont.ui(FMFont.xs))
+        } else if let rank = rating.rank, let population = rating.population {
+            // Below the percentile threshold the server suppresses percentile
+            // and sends rank instead: "#N of M" is honest at any position and
+            // league size, where "Top 100%" for the last-place player was a
+            // compliment-shaped lie (#959, ADR 20260725).
+            (Text(formatRankOfPopulation(rank: rank, population: population))
+                .font(FMFont.mono(FMFont.xs))
+                .foregroundStyle(FMColor.fg3)
+                + Text(" in \(leagueName)").foregroundStyle(FMColor.fgMuted))
                 .font(FMFont.ui(FMFont.xs))
         } else {
-            Text(rating.leagueName)
+            Text(leagueName)
                 .font(FMFont.ui(FMFont.xs))
                 .foregroundStyle(FMColor.fgMuted)
         }
@@ -180,7 +207,7 @@ struct DashboardRatingCard: View {
             HStack {
                 Text("30 days ago")
                 Spacer()
-                Text(verbatim: "Today · peak \(plainRating(rating.peak))")
+                Text(verbatim: "Today · peak \(plainRating(peak))")
             }
             .font(FMFont.mono(10))
             .tracking(0.8)


### PR DESCRIPTION
## Summary

Fixes #1243 — the iOS Dashboard tab showed "Couldn't load your dashboard" / "Couldn't read the server's response" for any signed-in user whose rating state wasn't `RATED` (new users, guests, unrated-league players, anyone awaiting import).

**Root cause**: `GET /v1/dashboard`'s `rating` object is always present now and carries a `state` discriminator (`RATED`/`UNRATED`/`AWAITING_IMPORT`/`NOT_RATED_LEAGUE`, introduced in #1193 per ADR `20260725-a-rating-block-names-its-state-and-shows-rank-below-threshold`). On every non-`RATED` state the server sends `null` for `current`, `peak`, `league_id`, `league_name`, `strategy_key`. `ios/Fortymm/Dashboard/DashboardModels.swift` — the hand-written model the app actually decodes with (`Generated/Types.swift` is reference-only) — still declared those fields non-optional, so `JSONDecoder` threw and `DashboardStore` surfaced the error card.

- **`DashboardModels.swift`**: added `DashboardRatingState` (mirrors the API enum, decodes leniently via the existing `LenientRawDecodable` idiom); made `leagueId`/`leagueName`/`strategyKey`/`current`/`peak` optional; added the new `rank`/`population` pair; made `DashboardResponse.rating` non-optional to match the server.
- **`DashboardView.swift`**: switches on `rating.state` to render the rating card only for `.rated`, with true per-state copy for the other three states (mirroring the web client's `your-game-row.tsx`) instead of collapsing them into one "Not in a rated league yet." string.
- **`DashboardWidgets.swift`**: `DashboardRatingCard` safely unwraps the now-optional fields for its `.rated`-only render path, and `percentileLine` adds the rank/population fallback below the percentile threshold (ADR 20260725).

`Generated/Types.swift` already reflected the correct shape — no OpenAPI regen needed.

## Test plan

- [ ] `cd ios && xcodebuild build -project Fortymm.xcodeproj -scheme Fortymm -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` — **not run**: this cloud session has no Xcode/Swift toolchain (by design, see root `CLAUDE.md`). Changes were manually cross-checked against `Generated/Types.swift` and `api/app/schemas/dashboard.py` line-by-line instead. Please run the build before merging.
- [ ] Manually verify the Dashboard tab loads for a non-RATED user (new/guest account) on a simulator, and shows the correct per-state copy for UNRATED / AWAITING_IMPORT / NOT_RATED_LEAGUE.
- [ ] Verify a RATED user's dashboard still renders the rating card correctly, including the rank/population fallback line for a league below the percentile threshold.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzSqoQHygMY3W7yfqrZ3CC)_