### PR TITLE
Simplify land-the-plane to CI checks + QA review

### DIFF
--- a/.claude/commands/land-the-plane.md
+++ b/.claude/commands/land-the-plane.md
@@ -1,62 +1,34 @@
 ---
-description: Ship the current branch end-to-end — run /simplify, all test suites, commit, push, open a PR, /code-review, /security-review and /qa-review it, then merge if everything passes (raising any issues to the user first). Walks a stacked-PR work order bottom-up, one PR at a time.
+description: Ship the current branch end-to-end — commit, push, open a PR, wait for CI to go green, /qa-review it, then merge if everything passes (raising any issues to the user first). Walks a stacked-PR work order bottom-up, one PR at a time.
 ---
 
 End-to-end "ship it" workflow. Run the steps below **in order**. If any step fails, stop and report the failure to the user — do not skip ahead.
 
+CI (`.github/workflows/`) already runs lint, typecheck, unit tests, e2e, the OpenAPI drift check, and the iOS build — this workflow does not duplicate any of that locally. It also does not run `/simplify`, `code-review`, or `security-review` — those are separate, opt-in skills; run them yourself first if you want that pass before shipping.
+
 ## Two modes
 
-**Single branch** — no work order, or a work order with one slice. Run Steps 1–9 once for the current branch. This is the original behaviour and the rest of this document is written for it.
+**Single branch** — no work order, or a work order with one slice. Run Steps 1–6 once for the current branch. This is the original behaviour and the rest of this document is written for it.
 
-**Stacked** — `.claude/work-order.md` exists with more than one slice, each carrying a `Branch:` and `PR:` line (see `.claude/skills/to-chores/work-order-format.md` §The stack). Then this command walks the stack **bottom-up, one PR at a time**, running Steps 1–8 for each slice before moving to the next. Read [§Walking a stack](#walking-a-stack) first; it overrides the preflight and Steps 3, 4 and 8.
+**Stacked** — `.claude/work-order.md` exists with more than one slice, each carrying a `Branch:` and `PR:` line (see `.claude/skills/to-chores/work-order-format.md` §The stack). Then this command walks the stack **bottom-up, one PR at a time**, running Steps 1–5 for each slice before moving to the next. Read [§Walking a stack](#walking-a-stack) first; it overrides the preflight and Steps 1, 2 and 5.
 
 ## Preflight
 
 1. Confirm you're in a git repository and on a feature branch (not `main`). If on `main`, stop and tell the user.
 2. **Detect the mode.** If `.claude/work-order.md` exists, read its slices. More than one slice with a `Branch:` line ⇒ stacked mode; check out the **lowest slice whose PR is not yet merged** and work from there. Otherwise single-branch mode on the current branch.
 3. Run `git status` and `git diff --stat <base>...HEAD` — where `<base>` is `origin/main` in single-branch mode, and the slice's **base branch** in stacked mode. Using `origin/main` for a stacked slice shows every slice beneath it and makes the diff unreviewable.
-4. If there are uncommitted changes unrelated to the branch's work-in-progress, surface them and ask the user whether to commit or abort — do **not** auto-commit pre-existing work without acknowledgement. (Edits produced by Step 1's `simplify` are pre-authorized to commit, since the user invoked this command expecting that.)
+4. If there are uncommitted changes unrelated to the branch's work-in-progress, surface them and ask the user whether to commit or abort — do **not** auto-commit pre-existing work without acknowledgement.
 
-## Step 1 — Simplify
+## Step 1 — Commit & push
 
-Invoke the `simplify` skill on the changed code:
-
-```
-Skill(skill="simplify")
-```
-
-Apply any fixes it identifies. When `simplify` produces edits, stage and commit them with a clear message (e.g. `simplify: remove unused fallback in <file>`).
-
-## Step 2 — Run all tests
-
-Run each suite the project ships. Use the project root as cwd. Run independent suites in parallel via separate Bash tool calls in one message. Skip any suite whose directory is absent.
-
-- **API (ruff + mypy + pytest):** from `api/`, run the same gates as CI (`.github/workflows/api.yml`) **in order** — `ruff check app tests`, `ruff format --check app tests`, `mypy` (strict; config in `pyproject.toml`), then `pytest`. Assumes `pip install -e '.[dev]'` has been run in `api/.venv`; if the tools aren't on PATH, prefix with `api/.venv/bin/` (e.g. `api/.venv/bin/mypy`). A ruff failure is usually auto-fixable (`ruff check --fix`, `ruff format`) — apply, then re-run; mypy/pytest failures stop the workflow.
-- **Web client unit tests (vitest):** `cd web-client && npm run test:run`
-- **Web client lint + typecheck/build:** `cd web-client && npm run lint && npm run build` (the `build` script is `tsc -b && vite build` — it's the only typecheck.)
-- **Web client e2e (Playwright):** `cd web-client && npm run test:e2e`. Playwright defaults to port 5174 which collides with the dev compose web-client; set `PLAYWRIGHT_PORT` to a free port when the dev compose stack is up.
-- **Root e2e (Playwright + docker stack):** `cd e2e && npm test`. This suite drives the full docker compose stack; it self-manages the stack, so just run it. It is the only **automated** coverage for the tournament create → go-live → play → crown lifecycle. A browser QA pass can reach those flows once it grants itself the Beta tester role (see `qa-review.md` §2b), but that is a hand-driven exploratory pass, not a regression gate — it proves the flow worked once, for one operator, on one stack.
-
-  **Never scope it out because "the branch didn't touch `e2e/`".** A web-client-only or api-only change absolutely can break it; that is precisely what it is for, and skipping it on that reasoning once already shipped a break that CI then caught, costing a full merge cycle. Run it whenever the branch touches **`api/`, `web-client/`, `ios/`, `e2e/`, `deploy/`, `nginx/`, or any `docker-compose*.yml`**.
-
-  The one case you may skip: a branch that touches **only** `*.md`, `docs/`, or `.claude/` — no application code, no stack config. Charging a cold docker stack build to a README edit buys nothing. Say explicitly that you skipped it and why.
-- **OpenAPI schema drift:** if `api/**` or `web-client/src/api/**` changed, run `mise run regen-api-types` then `git diff --exit-code web-client/src/api/schema.d.ts`. A non-empty diff means the committed schema is stale — commit the regenerated file.
-- **iOS app build (xcodebuild):** if `ios/**` changed, the compile is the gate (the app ships no XCTest target). Clean-build for the simulator **from the worktree's own `ios/` dir** (a worktree has its own checkout — building the main repo's `ios/` tests the wrong code): `rm -rf ios/build/sim && xcodebuild -project ios/Fortymm.xcodeproj -scheme Fortymm -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath ios/build/sim build`. The `rm -rf` matters — incremental builds report `BUILD SUCCEEDED` while serving a stale dylib. A non-`** BUILD SUCCEEDED **` result stops the workflow.
-
-If any suite fails: stop, report the failure, do not push.
-
-## Step 3 — Commit & push
-
-Only after every suite is green:
-
-1. Commit the branch's work. Run `git status`; if anything is uncommitted (the branch changes, plus any `simplify` / schema-regen edits from Steps 1–2), stage and commit it with a clear message describing the change. Pre-existing changes unrelated to this branch that you flagged in Preflight stay out of the commit unless the user said to include them.
+1. Commit the branch's work. Run `git status`; if anything is uncommitted, stage and commit it with a clear message describing the change. Pre-existing changes unrelated to this branch that you flagged in Preflight stay out of the commit unless the user said to include them.
 2. `git push -u origin HEAD` (the `-u` is a no-op if already tracking).
-3. If the push is rejected because the remote moved, **do not** force-push. Pull/rebase, re-run tests, then push.
+3. If the push is rejected because the remote moved, **do not** force-push. Pull/rebase, then push.
 4. Never use `--no-verify`, `--force-with-lease`, or `--force` here unless the user explicitly asks for it.
 
-## Step 4 — Open a PR
+## Step 2 — Open a PR
 
-Create a pull request for the branch with `gh pr create`. Write a title and body that summarize the change and its testing (you already know the diff and which suites passed). Target `main` unless the user said otherwise. Capture the PR URL/number from the output — you need it for Step 5. If a PR for this branch already exists, reuse it (`gh pr view`) rather than creating a duplicate.
+Create a pull request for the branch with `gh pr create`. Write a title and body that summarize the change. Target `main` unless the user said otherwise. Capture the PR URL/number from the output — you need it for Step 3. If a PR for this branch already exists, reuse it (`gh pr view`) rather than creating a duplicate.
 
 **In stacked mode the PR already exists** — `/do-chores` opened it as a draft, and its number is on the slice's `PR:` line. Do not create a second one. Instead:
 
@@ -64,36 +36,28 @@ Create a pull request for the branch with `gh pr create`. Write a title and body
 2. Mark it ready for review now that the gates below are about to run: `gh pr ready <n>`.
 3. Add a line to the body naming what it stacks on (`Stacked on #<parent-PR>`) so a reviewer arriving cold knows not to read it against `main`.
 
-## Step 5 — Code review
+## Step 3 — Wait for CI
 
-Invoke the `code-review:code-review` skill on the PR you just opened:
+Poll the PR's checks until every required check has finished:
 
-```
-Skill(skill="code-review:code-review")
-```
-
-- **If it surfaces issues:** stop and raise them to the user. Ask what they want to do (e.g. fix now, fix later, or proceed anyway). Do **not** auto-fix without acknowledgement — simplify + tests already passed and any further edits need their own re-test/push cycle. Only continue to Step 6 once the user has decided; if they choose to fix first, that resets the workflow (re-run the relevant suites and re-push before resuming).
-- **If it's clean:** continue to Step 6.
-
-## Step 6 — Security review
-
-Invoke the built-in `security-review` skill — a security audit of the pending changes on the branch:
-
-```
-Skill(skill="security-review")
+```bash
+gh pr checks <n> --watch
 ```
 
-- **If it surfaces vulnerabilities:** stop and raise them to the user, same as code review — report each finding (severity, location, why it matters) and ask what they want to do. Do **not** auto-fix without acknowledgement; fixing resets the workflow (re-run the relevant suites and re-push before resuming).
-- **If it's clean:** continue to Step 7.
+(`--watch` blocks and re-polls; if it's unavailable, poll `gh pr checks <n>` manually every 30–60s instead of sleeping in a tight loop.)
 
-## Step 7 — QA review
+- **If any check fails:** stop and report which check failed, with a link and a short excerpt of the failure (`gh run view <run-id> --log-failed` or `mcp__github__get_job_logs`). Ask the user how they want to proceed. Do **not** auto-fix without acknowledgement — once fixed, re-push and re-run this step before continuing.
+- **If a check is skipped because the branch didn't touch the trees it gates** (e.g. the iOS workflow on a web-client-only change), that's expected — CI's own path filters already scoped it, so treat "skipped" as passing, not blocking.
+- **If everything required is green:** continue to Step 4.
+
+## Step 4 — QA review
 
 Pick the QA pass that matches what the branch actually changed — the `qa-review`
 skill drives a **web browser**, so it can only exercise web-client changes. A
 branch that touched `ios/**` needs the **iOS Simulator**; a browser pass against
 the web app would test code the branch never touched.
 
-### 7a. Web changes (`web-client/**`) → browser QA
+### 4a. Web changes (`web-client/**`) → browser QA
 
 Run the `qa-review` workflow — the adversarial "Quinn" black-box pass against the prod-like QA stack:
 
@@ -101,22 +65,31 @@ Run the `qa-review` workflow — the adversarial "Quinn" black-box pass against 
 Skill(skill="qa-review")
 ```
 
-### 7b. iOS changes (`ios/**`) → Simulator QA
+### 4b. iOS changes (`ios/**`) → Simulator QA
 
 Drive the real built app in the iOS Simulator against the **real QA-stack API**
 (not MSW, not a unit test). The app reads `FMM_API_BASE_URL` at runtime and mints
 a **guest session automatically on launch** — so no email/magic-link auth is
 needed to reach an authenticated dashboard. Steps:
 
-1. **Stand up the QA API.** Same stack as 7a — `docker-compose.qa.yml`, launched
+1. **Build the app for the simulator** (CI doesn't ship you a build artifact
+   to reuse — build fresh from this checkout):
+   ```bash
+   rm -rf ios/build/sim
+   xcodebuild -project ios/Fortymm.xcodeproj -scheme Fortymm -configuration Debug \
+     -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' \
+     -derivedDataPath ios/build/sim build
+   ```
+   The `rm -rf` matters — incremental builds report `BUILD SUCCEEDED` while
+   serving a stale dylib. A non-`** BUILD SUCCEEDED **` result stops the workflow.
+2. **Stand up the QA API.** `docker-compose.qa.yml`, launched
    via `scripts/qa-up.sh` so it picks a free port instead of hardcoding 8085
    (several stacks may already be running). Capture the assigned URL:
    `[ -f .env ] || cp <main-checkout>/.env .env` then
    `eval "$(scripts/qa-up.sh "$(git rev-parse --abbrev-ref HEAD)" | tee /dev/stderr | tail -n1)"`.
-   The launcher reuses the stack if its id already maps to a running project, so
-   re-running for an iOS-only change won't rebuild the web/API images needlessly.
+   The launcher reuses the stack if its id already maps to a running project.
    Use `$QA_URL` below.
-2. **Build + install + launch** (reuse the clean build from Step 2's iOS gate).
+3. **Install + launch.**
    Find the bundle id with `grep PRODUCT_BUNDLE_IDENTIFIER ios/Fortymm.xcodeproj/project.pbxproj`
    (currently `com.fortymm.ios-client`). On a booted simulator
    (`xcrun simctl list devices booted`; boot one if none):
@@ -129,8 +102,8 @@ needed to reach an authenticated dashboard. Steps:
    ```
    `SIMCTL_CHILD_*` forwards the env var into the app; the base must include `/api`
    (QA's nginx serves the API under `/api`, unlike UAT). `$QA_URL` comes from the
-   launcher in step 1.
-3. **Drive + screenshot.** Capture with `xcrun simctl io booted screenshot <file>`
+   launcher in step 2.
+4. **Drive + screenshot.** Capture with `xcrun simctl io booted screenshot <file>`
    and tap/type with `idb ui tap <x> <y> --udid <udid>` (points, not pixels).
    Save evidence to `.qa-review/` (gitignore it). Exercise the screens the branch
    touched at the states that matter — e.g. for a conditional-render change,
@@ -140,12 +113,12 @@ needed to reach an authenticated dashboard. Steps:
 
 ### Both paths
 
-- **If bugs are found:** relay the report (with screenshots via SendUserFile) and raise them to the user. Ask what they want to do. Do **not** auto-fix without acknowledgement.
-- **If it's clean:** continue to Step 8.
+- **If bugs are found:** relay the report (with screenshots via SendUserFile) and raise them to the user. Ask what they want to do. Do **not** auto-fix without acknowledgement — fixing resets the workflow (re-push and re-run Step 3 before resuming).
+- **If it's clean:** continue to Step 5.
 
-## Step 8 — Merge
+## Step 5 — Merge
 
-Only reach this step if **every** prior step passed clean — green tests, no code-review issues, no QA bugs (or the user explicitly chose to proceed despite something). Merge the PR:
+Only reach this step if **every** prior step passed clean — green required checks, no QA bugs (or the user explicitly chose to proceed despite something). Merge the PR:
 
 ```bash
 gh pr merge --squash --delete-branch
@@ -163,9 +136,9 @@ Only in stacked mode. The stack is a straight line — `main ← s1 ← s2 ← s
 
 For each slice, lowest first:
 
-1. **Check it out** and run Steps 1–7 against it, diffing against **its own base branch**, not `origin/main`.
-2. **Scale the gates to the slice's diff, not the stack's.** Step 2 already conditions each suite on which trees changed; apply that per slice. A slice touching only `web-client/**` does not owe an iOS build; a generated-types-only slice has no user-observable surface, so Step 7's QA pass has nothing to drive — say so and skip it rather than running a hollow pass. What you must **not** scale away is the root `e2e/` suite whenever the slice touches the trees Step 2 lists: a mid-stack slice is exactly where an integration break hides.
-3. **Merge it** (Step 8) — but capture the tip first:
+1. **Check it out** and run Steps 1–4 against it, diffing against **its own base branch**, not `origin/main`.
+2. **Scale Step 4 to the slice's diff, not the stack's.** A slice touching only `web-client/**` does not owe an iOS Simulator pass; a generated-types-only slice has no user-observable surface, so Step 4's QA pass has nothing to drive — say so and skip it rather than running a hollow pass. CI itself already scales Step 3's checks to the slice's diff via its own path filters.
+3. **Merge it** (Step 5) — but capture the tip first:
 
    ```bash
    OLD_BASE=$(git rev-parse <this-slice-branch>)   # BEFORE the merge deletes it
@@ -190,7 +163,7 @@ For each slice, lowest first:
 
 If a gate failure requires a fix, the fix belongs in **the slice that owns the code**, not in a later one. Commit it there, re-run that slice's gates, and continue — then rebase everything above it, because you have just rewritten a branch the rest of the stack sits on.
 
-## Step 9 — Collect the garbage
+## Step 6 — Collect the garbage
 
 Only after the merge is confirmed. `--delete-branch` removes the *branch*; nothing has ever removed the *worktree*. Left alone this accumulates fast — it reached 311 worktrees and 82 GB, 77% of them on already-merged branches, and that sprawl is what causes `/epic` to resume into a stale checkout, ADR numbers to be computed against old trees, and QA stacks to OOM a host with no headroom.
 
@@ -205,6 +178,6 @@ You are standing in the worktree that was just merged, so the script will skip i
 
 ## Reporting
 
-End with a single-line summary listing: simplify outcome, each suite's result, commit + push status, the PR URL, code-review outcome, security-review outcome, QA-review verdict, and merge status. Keep it terse — the user can read the diff.
+End with a single-line summary listing: commit + push status, the PR URL, CI outcome, QA-review verdict, and merge status. Keep it terse — the user can read the diff.
 
 In stacked mode, give one such line **per slice**, bottom-up, plus a final line naming how many PRs merged and which (if any) are still open and why.

--- a/.claude/skills/epic/SKILL.md
+++ b/.claude/skills/epic/SKILL.md
@@ -21,7 +21,7 @@ false premise, right-sizes the decomposition, and decides what ships. This skill
 summarises what the phase produced, states the decision that's now the user's,
 and **waits for an explicit go-ahead** before starting the next phase. It never
 skips a gate and never retries a blocked phase in a loop; the one merge in the
-arc is `/land-the-plane`'s own gated Step 8, not a decision `/epic` makes itself.
+arc is `/land-the-plane`'s own gated Step 5, not a decision `/epic` makes itself.
 
 If you find yourself wanting to "just push through" a gate to save a round-trip:
 don't. The one time the gate cost a round-trip this arc was designed for, it
@@ -91,10 +91,11 @@ every slice has a draft PR do you offer to land.
 
 ### 4. `/land-the-plane` — review and ship
 
-Runs `/simplify`, all applicable test suites, commits + pushes, opens the PR, then
-`/code-review`, `/security-review`, and the QA pass **that matches what changed**
-(browser for `web-client/**`, Simulator for `ios/**`, skip when neither was
-touched). Its review depth should track the change's risk, not a fixed ceremony.
+Commits + pushes, opens the PR, waits for CI to go green (lint, typecheck, unit
+tests, e2e, OpenAPI drift, iOS build all live in CI now — this phase does not
+duplicate them locally, nor does it run `/simplify`, `/code-review`, or
+`/security-review`), then runs the QA pass **that matches what changed** (browser
+for `web-client/**`, Simulator for `ios/**`, skip when neither was touched).
 
 **With a multi-slice work order it walks the stack bottom-up**, running those gates
 per PR against that slice's own diff and merging each before starting the next. So
@@ -107,11 +108,11 @@ adversarial edge-case exploration, never instead of it. When the notes say the
 change is *not observable in the UI*, skip the browser pass rather than run a
 hollow one, and say so.
 
-**Gate:** it stops at any surfaced code-review issue, security finding, or QA bug —
-raise them to the user, don't auto-fix; resolving one may take a separate
-conversation, at which point `/epic` picks back up from its resumability rules
-below. If every step lands clean, `/land-the-plane`'s own Step 8 **merges the PR
-itself** — there is no separate confirmation pause once the gates are clear.
+**Gate:** it stops at any red CI check or surfaced QA bug — raise them to the
+user, don't auto-fix; resolving one may take a separate conversation, at which
+point `/epic` picks back up from its resumability rules below. If every step
+lands clean, `/land-the-plane`'s own Step 5 **merges the PR itself** — there is
+no separate confirmation pause once the gates are clear.
 Because the Skill tool runs a sub-skill's steps inline, control returns to this
 arc automatically the moment `/land-the-plane` finishes (merged, or stopped at a
 gate) — continue straight into Step 5 rather than treating the hand-off as
@@ -157,10 +158,10 @@ testing-notes ledger, the tickets moved to Done, and hand off.
 ## Invariants (hold these across every phase)
 
 - **Don't merge directly.** `/epic` never runs `gh pr merge` itself — merging is
-  `/land-the-plane`'s own Step 8, reached only once every one of its gates
-  (tests, code review, security review, QA) is clean, and repeated once per slice
-  when the work order is a stack. If a gate finds something, the merge waits for
-  the user's decision, same as any other phase gate.
+  `/land-the-plane`'s own Step 5, reached only once every one of its gates
+  (CI, QA) is clean, and repeated once per slice when the work order is a stack.
+  If a gate finds something, the merge waits for the user's decision, same as
+  any other phase gate.
 - **Never skip a gate**, even for a "small" change — right-size the *work*, not the
   checkpoints.
 - **Carry the artifact chain**: the agreed plan (+ ADRs) → `.claude/work-order.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Full stack via Docker: `docker compose -f docker-compose.dev.yml up`. Nginx on *
 | QA | up: `scripts/qa-up.sh [id]` · **down: `scripts/qa-down.sh [id]`** | :8085 | captured in **Mailpit** :8087 — never sends real mail |
 | UAT | `mise run redeploy-uat` — Helm + **k3d**, *not* compose, chart at `deploy/uat/` | :8084, `uat.fortymm.com`, and `https://fortymm-uat.<tailnet>.ts.net` | **real Postmark** — lands in real inboxes |
 
-**Always reap a QA stack once its branch merges** (`land-the-plane` Step 8). `docker compose down -v` is *not* enough — it leaves the stack's locally-built images and buildx cache behind. Skipping this grew `Docker.raw` to 230 GB and wedged the daemon; with ~78 worktrees each able to spawn a `fortymm-qa-<id>` stack, it compounds fast. Use `scripts/qa-down.sh` (`--all` for every QA stack, `--dry-run` to preview, opt-in `--prune-cache` for the global build cache). **Never** blanket-`prune`: `fortymm-uat_postgres-data` is unattached and would be silently destroyed along with the k3d `tailscale-state` Secrets.
+**Always reap a QA stack once its branch merges** (`land-the-plane` Step 5). `docker compose down -v` is *not* enough — it leaves the stack's locally-built images and buildx cache behind. Skipping this grew `Docker.raw` to 230 GB and wedged the daemon; with ~78 worktrees each able to spawn a `fortymm-qa-<id>` stack, it compounds fast. Use `scripts/qa-down.sh` (`--all` for every QA stack, `--dry-run` to preview, opt-in `--prune-cache` for the global build cache). **Never** blanket-`prune`: `fortymm-uat_postgres-data` is unattached and would be silently destroyed along with the k3d `tailscale-state` Secrets.
 
 ## Cloud sessions
 
@@ -125,6 +125,6 @@ The iOS app mirrors this with `ios/Fortymm/Generated/Types.swift`, generated fro
 
 **Verify the artifact under test is the one you changed** — see `.claude/rules/verify-the-artifact-under-test.md`.
 
-**Collect the garbage you create** — `land-the-plane` Step 9 runs `scripts/reap-worktrees.sh` (see its header for why).
+**Collect the garbage you create** — `land-the-plane` Step 6 runs `scripts/reap-worktrees.sh` (see its header for why).
 
 Layer-specific architecture and conventions live in `api/CLAUDE.md` and `web-client/CLAUDE.md` (loaded automatically when working in those directories).


### PR DESCRIPTION
## Summary

- `/land-the-plane` no longer runs `/simplify`, local test suites, `/code-review`, or `/security-review`. Those either duplicate what CI already gates (lint, typecheck, unit tests, e2e, OpenAPI/iOS drift), or are separate opt-in skills, per the requester.
- The workflow is now: commit & push → open PR → poll `gh pr checks <n>` until every required check is green (stop and report on any failure) → run `qa-review` (browser or iOS Simulator, matching what changed) → merge → reap worktrees.
- Renumbered the remaining steps (1–6) and updated the stale step-number cross-references in `.claude/skills/epic/SKILL.md` and root `CLAUDE.md`.

## Test plan

- [x] Read through the rewritten `.claude/commands/land-the-plane.md` end-to-end for internal consistency (preflight → steps → walking-a-stack → reporting).
- [x] Grepped the repo for other `land-the-plane`/`Step N` cross-references and updated all of them (`epic/SKILL.md`, `CLAUDE.md`).
- This is a docs/skill-instruction-only change — no application code, so no test suites apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdTzziYaNvnkMykieFKQPA)_