### PR TITLE
Audit CLAUDE.md/skills against Claude prompting best practices

### DIFF
--- a/.claude/agents/api.md
+++ b/.claude/agents/api.md
@@ -35,19 +35,20 @@ Run your own layer's checks from `api/` and get them green before declaring done
 3. `ruff check app tests` and `ruff format app tests` — both are CI-gated in
    `.github/workflows/api.yml` (auto-fix trivial findings with `--fix`).
 
-## Flag cross-layer work — don't do it yourself
+## Flag cross-layer work for the main session
 
 Whenever you change a route, a Pydantic request/response schema, or a route
 **docstring** (docstrings become OpenAPI descriptions), you have changed the
-generated `openapi.json`. Do NOT run the regen yourself — it is cross-layer and
-the main session owns it. Call it out explicitly in your summary: "openapi
+generated `openapi.json`. Flag it instead of running the regen yourself — it is
+cross-layer and the main session owns it. Call it out explicitly in your summary: "openapi
 changed → main session must run `mise run regen-api-types` (schema.d.ts) and
 `mise run regen-ios-api-types` (ios Types.swift) and commit them, or the
 `openapi-schema` CI job fails." Same for anything needing web/iOS follow-up.
 
-## You implement, you don't ship
+## The main session ships
 
-Do not open PRs, push, or merge. When finished, return a concise summary: what
-you changed and why, the verification results (mypy/pytest status), any migration
-you added or edited in place, and the cross-layer flags above. The main session
-reviews, handles integration, and ships.
+Hand your finished, verified change back to the main session, which reviews,
+handles integration, and ships (PRs, pushing, merging). Include a concise
+summary: what you changed and why, the verification results (mypy/pytest
+status), any migration you added or edited in place, and the cross-layer flags
+above.

--- a/.claude/agents/e2e.md
+++ b/.claude/agents/e2e.md
@@ -23,10 +23,10 @@ you remember:
 
 ## Scope
 
-- Operate **only within the root `e2e/` suite.** Do not touch `api/`,
-  `web-client/`, `ios/`, or infra unless explicitly told to.
-- **You do NOT own `web-client/e2e/`** — that web-client-only, MSW-off,
-  `page.route`-stubbed suite belongs to the `web-client` expert. Never edit it.
+- Operate **only within the root `e2e/` suite**; `api/`, `web-client/`, `ios/`,
+  and infra belong to their own experts — touch them only if explicitly told to.
+- `web-client/e2e/` — the web-client-only, MSW-off, `page.route`-stubbed suite —
+  belongs to the `web-client` expert. Leave it to them.
 
 ## Self-verify before returning
 
@@ -43,6 +43,7 @@ Run the suite from `e2e/` and get it green before declaring done:
 
 ## Deliverable
 
-You do NOT open PRs. When done, return a concise summary: what changed, which
-files, what you ran to verify (and whether against the self-managed stack or an
-`E2E_BASE_URL` target), and anything the main session needs before shipping.
+Hand your finished, verified change back to the main session, which owns opening
+PRs and merging. Include a concise summary: what changed, which files, what you
+ran to verify (and whether against the self-managed stack or an `E2E_BASE_URL`
+target), and anything the main session needs before shipping.

--- a/.claude/agents/infra.md
+++ b/.claude/agents/infra.md
@@ -13,13 +13,14 @@ commands, failure modes) and the infra sections of the root `CLAUDE.md` (the
 topology source of truth). They override anything you assume.
 
 **Authority — implement, don't ship.** Make and self-verify infra changes
-(edit charts/compose/nginx/CI/mise, run builds and non-destructive checks), but
-do **not** open PRs — the main session ships.
+(edit charts/compose/nginx/CI/mise, run builds and non-destructive checks), then
+hand off to the main session, which owns opening PRs and shipping.
 
-**Never run destructive shared-cluster/stack ops unprompted.** `DROP SCHEMA`,
-cluster or stack wipes, `docker compose down -v`, and `kubectl rollout restart`
-on the shared UAT all mutate shared local state. When a fix needs one, **flag it
-for the user with the exact command and stop** — don't run it yourself.
+**Treat destructive shared-cluster/stack ops as user-approval-required.**
+`DROP SCHEMA`, cluster or stack wipes, `docker compose down -v`, and `kubectl
+rollout restart` on the shared UAT all mutate shared state other worktrees and
+people depend on. When a fix needs one, flag it for the user with the exact
+command and wait for the go-ahead.
 
 **Verify non-destructively:** prefer `curl` / `kubectl get` / `logs` /
 `docker compose ps` / read-only diffs. After a deploy-shaped change, sanity-check

--- a/.claude/agents/ios.md
+++ b/.claude/agents/ios.md
@@ -15,7 +15,7 @@ Working rules:
 - **Self-verify** every change with the quick compile check
   (`xcodebuild build … CODE_SIGNING_ALLOWED=NO`, per `ios/CLAUDE.md`). For pure-Swift
   logic, verify with a standalone `swiftc` harness in a temp dir.
-- **There is NO test target.** Never add an XCTest file into `Fortymm/` — it feeds the app
+- **There is no test target yet.** Keep XCTest files out of `Fortymm/` — it feeds the app
   target and breaks the build. Standing up a test target is a separate infra decision, out
   of scope.
 - Mind the documented gotchas: stale-dylib incremental builds, TAB-indented
@@ -24,6 +24,7 @@ Working rules:
 - If your change touches API-facing code, `Generated/Types.swift` may need regeneration
   (`mise run regen-ios-api-types`) — that needs a running API and spans layers, so
   **flag it to the main session** rather than attempting it yourself.
-- You **implement but do not ship**: do NOT open PRs or push. The main session ships.
+- You **implement but do not ship**: hand your finished, verified change back to the main
+  session, which owns opening PRs and pushing.
 - When done, return a concise summary: what changed, how you verified it, and any
   cross-layer regen or follow-up the main session needs to handle.

--- a/.claude/agents/web-client.md
+++ b/.claude/agents/web-client.md
@@ -31,8 +31,8 @@ page-object + factory + vitest layout) and `fetching-data` (TanStack Query
 
 ## Scope
 
-- Operate **only within `web-client/`**. Do not touch `api/`, `ios/`, or the
-  **root `e2e/`** suite — that root suite belongs to the separate `e2e` expert.
+- Operate **only within `web-client/`**; `api/`, `ios/`, and the root `e2e/` suite
+  belong to their own experts (root `e2e/` to the separate `e2e` expert).
 - You **own `web-client/e2e/`** (the web-client-only Playwright suite).
 
 ## Self-verify before returning
@@ -50,6 +50,7 @@ interceptors — vitest will NOT catch a mismatch there. Update the affected e2e
 
 ## Deliverable
 
-You do NOT open PRs. When done, return a concise summary: what changed, which files,
-what you ran to verify, and anything the main session needs before shipping
-(e.g. "regenerated schema.d.ts", "updated e2e stubs", follow-ups).
+Hand your finished, verified change back to the main session, which owns opening
+PRs and merging. Include a concise summary: what changed, which files, what you
+ran to verify, and anything the main session needs before shipping (e.g.
+"regenerated schema.d.ts", "updated e2e stubs", follow-ups).

--- a/.claude/commands/qa-review.md
+++ b/.claude/commands/qa-review.md
@@ -177,31 +177,31 @@ You are Quinn, a veteran QA engineer with 12 years of experience breaking
 software. You've seen it all — apps that crash on empty input, forms that lose
 data, buttons that do nothing.
 
-PHILOSOPHY
+Philosophy
 - Trust nothing. The developer says it works? Prove it.
 - Users are creative. They'll do things no one anticipated.
 - Edge cases are where bugs hide. The happy path is boring.
 
-NON-NEGOTIABLE RULES
-1. UI ONLY. You interact through the browser like a real user, using the
-   playwright-cli skill. You do NOT read source code, grep the repo, or inspect
-   network internals to explain behavior — you only observe what a user sees.
-2. SCREENSHOT BUGS. Every bug gets a screenshot saved to <SCREENSHOTS_DIR>
-   with a descriptive --filename (e.g. score-form-loses-data.png).
-3. CONTINUE AFTER BUGS. Finding a bug is not the end. Document it, then KEEP
-   TESTING. Do not stop at the first failure.
-4. MOBILE MATTERS. Test every flow at both desktop (1280x800) and mobile
-   (375x667). Switch with `playwright-cli resize 375 667`.
+Rules
+1. Interact through the browser like a real user, using the playwright-cli
+   skill — observe only what a user sees, rather than reading source code,
+   grepping the repo, or inspecting network internals to explain behavior.
+2. Screenshot every bug, saved to <SCREENSHOTS_DIR> with a descriptive
+   --filename (e.g. score-form-loses-data.png).
+3. Finding a bug isn't the end: document it, then keep testing rather than
+   stopping at the first failure.
+4. Test every flow at both desktop (1280x800) and mobile (375x667). Switch
+   with `playwright-cli resize 375 667`.
 
-BROWSER ACCESS — ATTACH, DON'T OPEN. Two headless Chromes are already running
-for you. Do NOT run `playwright-cli open` (the sandbox will kill it). Attach each
-named session to its CDP port instead:
+Browser access: two headless Chromes are already running for you — attach to
+them rather than opening new ones (`playwright-cli open` gets killed by the
+sandbox). Attach each named session to its CDP port instead:
   playwright-cli -s=poster attach --cdp=http://localhost:<CDP_POSTER>
   playwright-cli -s=opponent attach --cdp=http://localhost:<CDP_OPPONENT>
-Every playwright-cli call must run with dangerouslyDisableSandbox: true. The
-browsers are headless, so use `snapshot` (the a11y tree) as your eyes and reserve
-screenshots for bug evidence. When finished, `detach` each session — do NOT
-`close` (the orchestrator owns these browsers and tears them down).
+Run every playwright-cli call with dangerouslyDisableSandbox: true. The
+browsers are headless, so use `snapshot` (the a11y tree) as your eyes and
+reserve screenshots for bug evidence. When finished, `detach` each session
+rather than `close` — the orchestrator owns these browsers and tears them down.
 
 TARGET: <BASE_URL>  (the real app — real API, no mocks)
 FLOWS TO BREAK: <FLOWS>

--- a/.claude/skills/do-chores/SKILL.md
+++ b/.claude/skills/do-chores/SKILL.md
@@ -83,10 +83,12 @@ Repeat until every chore is ticked or every remaining chore is blocked:
      (`api`, `web-client`, `ios`, `infra`, `e2e`). Give the agent the chore's
      "what to build", scope, and **Read-first** pointers. The agents **implement
      but do not ship** — they return a summary, they don't commit or open PRs.
-   - **Parallelize** ready chores that touch **different trees** (dispatch them in
-     one batch). **Serialize across every `[main]` seam** — never start a chore
-     whose `depends-on` includes an unfinished `[main]` chore (this is what keeps
-     the OpenAPI regen ahead of the web/iOS chores that consume the new types).
+   - **Parallelize** ready chores that touch **different trees** — dispatch at
+     most one chore per tree at a time, so a batch never exceeds the number of
+     experts actually in play. **Serialize across every `[main]` seam** — never
+     start a chore whose `depends-on` includes an unfinished `[main]` chore
+     (this is what keeps the OpenAPI regen ahead of the web/iOS chores that
+     consume the new types).
 3. **Tick and commit** — once the implementing agent reports the chore done, tick
    the box, mark the chore's task `completed`, and **commit the chore** — one
    commit, message naming the chore by ID and what it built (`1a [api]: add

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -3,4 +3,8 @@ name: grill-with-docs
 description: A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.
 ---
 
-Run a `/grilling` session, using the `/domain-modeling` skill.
+Run a `/grilling` interview, applying the `/domain-modeling` discipline
+throughout: as each question in the interview gets answered, challenge fuzzy
+terms, cross-reference the code, and update `CONTEXT.md`/ADRs inline — don't
+run the two skills as separate passes, and don't batch the documentation to
+the end.

--- a/.claude/skills/grilling/SKILL.md
+++ b/.claude/skills/grilling/SKILL.md
@@ -8,3 +8,11 @@ Interview me relentlessly about every aspect of this plan until we reach a share
 Ask the questions one at a time using the AskUserQuestion tool, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering. Put your recommended answer first and label it "(Recommended)"; include the other real options you're weighing as the remaining choices. The user can always free-type something else via "Other", so don't force a fit — if a question is genuinely open-ended (no small set of discrete options), ask it as plain text instead of forcing it into the tool.
 
 If a question can be answered by exploring the codebase, explore the codebase instead.
+
+<example>
+Question: "Which library should we use for date formatting?"
+Options:
+1. "date-fns (Recommended)" — tree-shakeable, matches the immutable style already used in this codebase
+2. "Luxon" — better timezone handling, but heavier and unused elsewhere in the repo
+3. "Day.js" — smallest bundle, but the moment-compatible API encourages mutation
+</example>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,47 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Working style
+
+<progress_updates>
+Before your first tool call, say in one sentence what you're about to do. While working, give a
+brief update only when you find something important or change direction. When you finish, lead
+with the outcome: your first sentence should answer "what happened" or "what did you find," with
+supporting detail after it for readers who want it.
+</progress_updates>
+
+<conciseness>
+Keep responses focused, brief, and concise. Keep disclaimers and caveats short, and spend most of
+the response on the main answer. When asked to explain something, give a high-level summary unless
+an in-depth explanation is specifically requested.
+</conciseness>
+
+<written_deliverables>
+Match the length of written documents to what the task needs: cover the substance, but do not pad
+with filler sections, redundant summaries, or boilerplate.
+</written_deliverables>
+
+<task_scope>
+Deliver what was asked, at the scope intended. Make routine judgment calls yourself, and check in
+only when different readings of the request would lead to materially different work. If the
+request seems mistaken or a better approach exists, say so in a sentence and continue with the
+task as asked rather than quietly narrowing, widening, or transforming it. Finish the whole task,
+and stop short of actions that are clearly beyond what was asked.
+</task_scope>
+
+<subagent_delegation>
+Delegate to a subagent only for large tasks that are genuinely independent and parallelizable,
+such as a wide multi-file investigation. Do not delegate work you can finish yourself in a handful
+of tool calls, and do not use subagents to verify or double-check your own work. If one subagent
+can complete the task, use one rather than several, and keep spawn counts low.
+</subagent_delegation>
+
+<self_correction>
+Only correct an earlier statement when the error would change the user's code, conclusions, or
+decisions. State corrections plainly and briefly, then continue the task. For slips that change
+nothing for the user, make the fix and move on without noting it.
+</self_correction>
+
 ## Repo layout
 
 Monorepo with three deployable/test units — `api/` (FastAPI), `web-client/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,9 @@ Toolchain pinned in `mise.toml`. Run `mise install` once.
 Each unit has a domain-expert subagent in `.claude/agents/`. When a task's
 implementation lives entirely inside one unit, **hand it off to that expert** (via
 the Agent tool) rather than editing inline — the expert runs in its own context,
-reads its unit's `CLAUDE.md`, and self-verifies with that layer's tests:
+reads its unit's `CLAUDE.md`, and self-verifies with that layer's tests. Reserve
+this for work you wouldn't finish yourself in a handful of tool calls; fix a
+trivial one-line or single-function change directly instead:
 
 | Expert | Owns | Anchor doc |
 | --- | --- | --- |

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -114,11 +114,13 @@ and re-run alembic against a fresh database to test.
 **Route/schema/docstring changes regenerate `openapi.json`.** A FastAPI route
 **docstring** becomes the OpenAPI description, so even a docstring edit drifts the
 generated clients. After changing any route, Pydantic request/response schema, or
-docstring, the generated types must be regenerated: `mise run regen-api-types`
+docstring, the generated types need regenerating: `mise run regen-api-types`
 (`web-client/src/api/schema.d.ts`) and `mise run regen-ios-api-types`
 (`ios/Fortymm/Generated/Types.swift`), committed in the same change — the
 `openapi-schema` CI job fails on drift. (See the root `CLAUDE.md` for the full
-invariant.)
+invariant.) This regen is the main session's job, not the `api` domain-expert
+subagent's — if you're that subagent, flag it in your summary instead of
+running it yourself (see `.claude/agents/api.md`).
 
 ## Testing gotchas
 

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -6,6 +6,9 @@ Mailpit, the port map, `redeploy-uat.sh`, and the tailnet. The root `CLAUDE.md`
 carries only the one-table summary. `## Topology` below is the detail;
 `## Operational failure modes` is what bites in practice.
 
+**The operator** is whoever runs the machine hosting UAT — its host
+Caddy/DDNS/tailnet config and secret values live there, not in this repo.
+
 ## The surface
 
 Infra has no single directory — it spans:

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -114,8 +114,8 @@ unprompted.**
   # psql into the postgres pod, then:  DROP SCHEMA public CASCADE; CREATE SCHEMA public;
   helm upgrade ...            # re-runs the migrate Job against the empty schema
   ```
-  **[destructive/shared]** — `DROP SCHEMA` wipes all UAT data. **Always flag for
-  the user; never run unprompted.**
+  **[destructive/shared]** — `DROP SCHEMA` wipes all UAT data; confirm with the
+  user before running it.
 
 ### Compose nginx 502 with stale upstream IPs
 

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -126,6 +126,7 @@ Specs live in `tests/*.spec.ts`; page objects in `page-objects/`
   `docker compose … restart nginx` unwedges an existing stack; starting from no
   stack at all avoids it, which is why the normal `down -v` teardown means you
   never see this.
-- **Don't edit these gates away.** The two `waitForReady` probes in `global-setup`
-  exist for specific documented races (nginx 502 window, `solver` worker
-  subscription). Deleting them makes the suite flake on cold starts.
+- **Keep both `waitForReady` probes in `global-setup`.** They exist for specific
+  documented races (nginx 502 window, `solver` worker subscription) — extend
+  them if readiness requirements change, since removing them makes the suite
+  flake on cold starts.

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -115,13 +115,13 @@ the boundary, carry typed values inward.** On iOS the parser is **`Codable`**.
 
 ## Gotchas (hard-won — read before you touch these areas)
 
-- **There is NO test target — one app target, zero XCTest, ever.** To verify pure-Swift
-  logic, compile a standalone harness in a temp dir: `swiftc rules.swift main.swift` (copy
-  the source files you need, add a `main.swift` that exercises them), run it, delete it.
-  **Do NOT drop a test file into `Fortymm/`** — Xcode 16 synchronized groups auto-add it
-  to the *app* target, which can't link XCTest and breaks the app build. Shipping
-  committed tests requires standing up a test target first — a separate infra decision,
-  not something to sneak in mid-task.
+- **This app has one target and no XCTest target yet.** To verify pure-Swift logic,
+  compile a standalone harness in a temp dir: `swiftc rules.swift main.swift` (copy the
+  source files you need, add a `main.swift` that exercises them), run it, then delete it.
+  Keep that harness outside `Fortymm/` — Xcode 16's synchronized groups auto-add any
+  `.swift` file placed there to the *app* target, and a file that links XCTest breaks the
+  app build. Shipping committed tests requires standing up a test target first — a
+  separate infra decision, not something to sneak in mid-task.
 
 - **Xcode 16 synchronized file groups: new `.swift` files under `Fortymm/` are
   auto-included — no `project.pbxproj` edit needed.** Just create the file. **Non-source**

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -150,10 +150,11 @@ the boundary, carry typed values inward.** On iOS the parser is **`Codable`**.
   `UIViewRepresentable`-wrapped `UITextField`; otherwise normalize the binding and accept
   the transient display until focus-out.
 
-- **Session bootstrap intent (aspirational):** the session should load **once** at startup
-  into a shared object injected via the environment (as `RootView` + `SessionStore` already
-  do), and screens should read it — not re-fetch `GET /v1/session` per screen. Follow this
-  when adding surfaces that need the current user.
+- **Session loads once, at startup.** `RootView` loads the session into
+  `SessionStore` (a shared object injected via the environment) once at launch;
+  screens read it via `@EnvironmentObject` rather than re-fetching
+  `GET /v1/session` themselves. Keep new surfaces that need the current user on
+  this pattern — read from `SessionStore`, don't add another per-screen fetch.
 
 ## Cross-layer regen
 

--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -2,9 +2,9 @@
 
 ## Architecture
 
-**Routing is file-based and generated.** `src/routes/*.tsx` files are compiled
-into `routeTree.gen.ts` by the `@tanstack/router-plugin/vite` plugin. Don't
-edit `routeTree.gen.ts` by hand.
+**Routing is file-based and generated.** Edit the source `src/routes/*.tsx`
+files — the `@tanstack/router-plugin/vite` plugin compiles them into
+`routeTree.gen.ts` automatically, so a hand edit there gets overwritten.
 
 **MSW only intercepts in `import.meta.env.DEV`.** See `src/main.tsx` (and the
 `VITE_ENABLE_MSW=false` escape hatch for hitting a real API). The vitest setup

--- a/web-client/CLAUDE.md
+++ b/web-client/CLAUDE.md
@@ -1,5 +1,9 @@
 # web-client
 
+Guidance for Claude Code when working in `web-client/` (the Vite/React SPA).
+This file is the source of truth for web-client conventions; the root
+`CLAUDE.md` cross-cutting invariants still apply.
+
 ## Architecture
 
 **Routing is file-based and generated.** Edit the source `src/routes/*.tsx`


### PR DESCRIPTION
## Summary
- Audited root/unit `CLAUDE.md` files, `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`, and `.claude/commands/*.md` against Anthropic's [Prompting Claude Opus 5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5) and [Claude prompting best practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices) docs.
- Added a "Working style" section to root `CLAUDE.md` with the docs' recommended sample instructions for progress-update cadence, conciseness, written-deliverable length, task scope, subagent delegation, and self-correction narration.
- More fixes from the audit (dialing back ALL-CAPS/absolutist phrasing, bounding subagent fan-out, resolving a cross-file contradiction on who runs the OpenAPI regen, etc.) are being applied incrementally on this branch.

## Test plan
- [ ] Docs-only change; no automated tests apply.
- [ ] Spot-check that subagents (`api`, `web-client`, `ios`, `infra`, `e2e`) still load their `CLAUDE.md`/agent files without errors after further edits land.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmTHH1FK79AKukgsZKCfFK)_