### PR TITLE
iOS: add its first XCUITest UI test target + a fresh-guest Dashboard spec

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -161,6 +161,6 @@ jobs:
           xcodebuild test \
             -project Fortymm.xcodeproj \
             -scheme Fortymm \
-            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
             -only-testing:FortymmUITests \
             CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -157,6 +157,17 @@ jobs:
 
       - name: Run FortymmUITests
         working-directory: ios
+        env:
+          # A plain env var set for `xcodebuild test` only reaches the
+          # xcodebuild process itself -- the UI test's actual host process
+          # (FortymmUITests-Runner.app) runs inside the simulator as a
+          # separate process tree that does NOT inherit it. The
+          # `TEST_RUNNER_` prefix is Xcode's documented mechanism for
+          # forwarding a CI-supplied env var into that test-host process,
+          # with the prefix stripped -- so the test's own
+          # `ProcessInfo.processInfo.environment["FMM_API_BASE_URL"]` read
+          # (see DashboardEmptyStateTests.swift) sees it.
+          TEST_RUNNER_FMM_API_BASE_URL: ${{ env.FMM_API_BASE_URL }}
         run: |
           xcodebuild test \
             -project Fortymm.xcodeproj \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -32,3 +32,135 @@ jobs:
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
             build
+
+  # Runs FortymmUITests against a REAL backend -- no mocks, same philosophy as
+  # the root e2e/ Playwright suite. GitHub-hosted macos-latest runners cannot
+  # run Docker (no nested virtualization), so unlike every other e2e suite in
+  # this repo this job cannot boot docker-compose.dev.yml -- it stands the API
+  # up as native processes instead: Postgres via Homebrew, then `uvicorn`
+  # directly against it. See
+  # docs/adr/20260802-ios-e2e-ci-runs-the-backend-as-native-processes-not-docker.md.
+  ui-tests:
+    runs-on: macos-latest
+    env:
+      # Mirrors docker-compose.dev.yml's postgres service (POSTGRES_USER,
+      # POSTGRES_PASSWORD, POSTGRES_DB=postgres/postgres/fortymm) exactly, just
+      # on localhost instead of a compose network hostname -- this is also
+      # api/app/db.py's own DEFAULT_DATABASE_URL, so it needs no override
+      # there, but it's spelled out for the alembic/uvicorn steps below.
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/fortymm
+      # Ask for the deterministic, network-free FakeGeocoder BY NAME (same
+      # reasoning as scripts/ensure-api-up.sh and openapi-schema.yml): the
+      # default geocoder is `google`, and Settings() raises at construction
+      # -- which the FastAPI lifespan hits at boot -- if it's `google` with no
+      # GOOGLE_GEOCODING_API_KEY. This job never geocodes anything.
+      GEOCODER: fake
+      # uvicorn here serves plain HTTP (no TLS, no reverse proxy) and the
+      # simulator app talks to it directly, so the session cookie must not
+      # carry the Secure flag -- otherwise URLSession drops it and every
+      # request after GET /v1/session looks signed-out. Matches
+      # docker-compose.dev.yml's api service.
+      SESSION_COOKIE_SECURE: "false"
+      # Read by both this job's own steps (the health-check poll) and by
+      # FortymmUITests' setUpWithError, which forwards it onto the launched
+      # app's launchEnvironment (see FortymmUITests/DashboardEmptyStateTests.swift).
+      # Points straight at uvicorn -- no nginx in front of it in this job, so
+      # the app's un-prefixed `/v1/...` paths resolve directly.
+      FMM_API_BASE_URL: http://127.0.0.1:8000
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: api/pyproject.toml
+
+      - name: Install and start Postgres (Homebrew)
+        run: |
+          set -euo pipefail
+          brew install postgresql@16
+
+          # postgresql@16 is keg-only -- its binaries aren't linked onto the
+          # default PATH. Export for the rest of *this* step, and also hand
+          # later steps in this job the same PATH entry via GITHUB_PATH.
+          PG_PREFIX="$(brew --prefix postgresql@16)"
+          export PATH="$PG_PREFIX/bin:$PATH"
+          echo "$PG_PREFIX/bin" >> "$GITHUB_PATH"
+
+          # Defensive: most recent postgresql@ formulae initdb automatically
+          # as part of `brew install`, but fall back to doing it ourselves if
+          # the data directory came up empty.
+          PGDATA="$PG_PREFIX/var/postgresql@16"
+          if [ ! -s "$PGDATA/PG_VERSION" ]; then
+            initdb --locale=C -E UTF-8 "$PGDATA"
+          fi
+
+          brew services start postgresql@16
+
+          echo "Waiting for Postgres to accept connections..."
+          for _ in $(seq 1 30); do
+            if pg_isready -q; then break; fi
+            sleep 1
+          done
+          pg_isready
+
+          # Homebrew's postgresql@16 bootstraps its one superuser as the
+          # invoking OS user (the runner account), not "postgres" -- create
+          # the postgres/postgres role + fortymm db that DATABASE_URL above
+          # expects, so the api/worker code needs no macOS-specific carve-out.
+          psql -d postgres -tc "SELECT 1 FROM pg_roles WHERE rolname = 'postgres'" | grep -q 1 \
+            || psql -d postgres -c "CREATE ROLE postgres WITH LOGIN SUPERUSER PASSWORD 'postgres';"
+          psql -d postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'fortymm'" | grep -q 1 \
+            || psql -d postgres -c "CREATE DATABASE fortymm OWNER postgres;"
+
+      - name: Install API dependencies
+        working-directory: api
+        run: pip install -e '.[dev]'
+
+      - name: Run Alembic migrations + RBAC/league seed
+        working-directory: api
+        run: |
+          set -euo pipefail
+          alembic upgrade head
+          # Same boot-time seeds docker-compose.dev.yml's api command chains
+          # after `alembic upgrade head` -- GET /v1/session 500s without the
+          # default "User" RBAC role (app/roles.py:grant_default_role raises
+          # if it's missing), so this isn't optional even though the
+          # Dashboard empty-state spec itself never touches a league.
+          python scripts/seed_rbac.py
+          python scripts/seed_leagues.py
+
+      - name: Start the API (uvicorn, native process -- no Docker)
+        working-directory: api
+        run: |
+          set -euo pipefail
+          nohup uvicorn app.main:app --host 127.0.0.1 --port 8000 \
+            > /tmp/fortymm-api.log 2>&1 &
+          echo "Started uvicorn (pid $!)"
+
+      - name: Wait for the API to answer GET /v1/health
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 60); do
+            if curl -fs -o /dev/null "$FMM_API_BASE_URL/v1/health"; then
+              echo "API answered /v1/health at $FMM_API_BASE_URL"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::API never answered GET /v1/health -- last log lines:"
+          tail -n 100 /tmp/fortymm-api.log || true
+          exit 1
+
+      - run: xcodebuild -version
+
+      - name: Run FortymmUITests
+        working-directory: ios
+        run: |
+          xcodebuild test \
+            -project Fortymm.xcodeproj \
+            -scheme Fortymm \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -only-testing:FortymmUITests \
+            CODE_SIGNING_ALLOWED=NO

--- a/docs/adr/20260802-ios-e2e-ci-runs-the-backend-as-native-processes-not-docker.md
+++ b/docs/adr/20260802-ios-e2e-ci-runs-the-backend-as-native-processes-not-docker.md
@@ -1,0 +1,18 @@
+# iOS E2E CI runs the backend as native processes, not Docker
+
+Every other e2e suite in this repo (root `e2e/`, and local iOS runs via
+`FMM_API_BASE_URL`) boots the backend with `docker-compose.dev.yml`. The
+`ios.yml` CI job runs on GitHub-hosted `macos-latest`, and GitHub-hosted macOS
+runners do not support running Docker containers (no nested virtualization) —
+this is a platform limitation, not a missing setup step. A third-party
+Docker-on-macOS action (e.g. Colima-based) exists but is unofficial and
+adds a fragile dependency to CI.
+
+Instead, the `ios.yml` XCUITest job starts the API as native processes on the
+runner: Postgres via Homebrew (already present on GitHub's macOS images), the
+API run directly with `uvicorn` against it. This mirrors the escape hatch
+`api/CLAUDE.md` already documents for skipping testcontainers
+(`TEST_DATABASE_URL` against an existing Postgres) — same real-API-no-mocks
+philosophy, just without a container layer. Local runs and this project's
+cloud sessions keep using `docker-compose.dev.yml`, since both have working
+Docker; CI is the only environment that needs the native path.

--- a/docs/adr/20260802-ios-e2e-tests-live-in-a-new-xcuitest-ui-test-target.md
+++ b/docs/adr/20260802-ios-e2e-tests-live-in-a-new-xcuitest-ui-test-target.md
@@ -21,8 +21,20 @@ suites rather than invent new ones:
   no MSW equivalent.
 
 The first spec is deliberately narrow: launch → guest session mints →
-Dashboard renders its first-match empty state. It needs no seeded data and
+Dashboard renders its empty state for a fresh guest. It needs no seeded data and
 proves the pipeline (test target, screen objects, backend wiring, CI) end to
 end before more flows are added. Full magic-link login automation is out of
 scope for this decision — there's no email-capture (Mailpit-equivalent) wired
 into the dev backend yet.
+
+**Correction (same day, during `/do-chores`):** the first spec was originally
+written against web's single "Log your first match." hero
+(`web-client/src/components/dashboard/first-match/`), assumed without checking
+the iOS view code. iOS has no such hero — `DashboardView.swift` always renders
+the normal "Your game" section. A fresh guest instead sees two independent,
+already-existing empty states once loaded: the rating card reads "Unrated —
+finish a rated match to start your rating" (`DashboardView.swift:218`) and the
+recent-results card reads "No completed matches yet."
+(`DashboardWidgets.swift:254`). The first spec targets these two instead —
+still zero seeded data, still deterministic, still proves the same pipeline.
+Building a web-parity first-match hero on iOS is out of scope for this arc.

--- a/docs/adr/20260802-ios-e2e-tests-live-in-a-new-xcuitest-ui-test-target.md
+++ b/docs/adr/20260802-ios-e2e-tests-live-in-a-new-xcuitest-ui-test-target.md
@@ -1,0 +1,28 @@
+# iOS E2E tests live in a new XCUITest UI test target
+
+`ios/CLAUDE.md` previously stated "one app target, zero XCTest, ever" — no test
+target existed because none had been needed yet. Adding end-to-end coverage
+requires driving real screens through the Simulator, which only a UI test
+target (XCUITest) can do; a lighter unit-only XCTest target was considered and
+rejected because it can't exercise actual taps/navigation and so wouldn't be
+"end to end" in the sense the rest of the repo uses that word (root `e2e/`
+drives the real UI against a real backend, no mocks).
+
+Conventions for the new target, chosen to mirror the existing Playwright
+suites rather than invent new ones:
+
+- **Screen objects**, one Swift type per screen wrapping `XCUIElement`
+  queries/actions — the XCUITest analog of `e2e/page-objects/DashboardPage`.
+- **Explicit `.accessibilityIdentifier()`** on the views a spec touches, added
+  incrementally as screens gain coverage, rather than matching on visible
+  text/labels. No view in the app set one before this decision.
+- Specs target the **real backend** (guest session via `GET /v1/session`,
+  same auto-provision behavior as web), not a mocked network layer — iOS has
+  no MSW equivalent.
+
+The first spec is deliberately narrow: launch → guest session mints →
+Dashboard renders its first-match empty state. It needs no seeded data and
+proves the pipeline (test target, screen objects, backend wiring, CI) end to
+end before more flows are added. Full magic-link login automation is out of
+scope for this decision — there's no email-capture (Mailpit-equivalent) wired
+into the dev backend yet.

--- a/ios/CLAUDE.md
+++ b/ios/CLAUDE.md
@@ -7,8 +7,8 @@ invariants still apply.
 ## Repo layout
 
 Native SwiftUI app. The `Fortymm.xcodeproj` is managed directly by Xcode — no
-xcodegen / Tuist / SPM-only setup. One app target (`Fortymm`), **no test target**
-(see Gotchas).
+xcodegen / Tuist / SPM-only setup. Two targets: the app (`Fortymm`) and a
+`FortymmUITests` XCUITest UI-testing target (see Gotchas).
 
 Sources live in `Fortymm/`, one folder per page-level feature (`Dashboard/`,
 `Matches/`, `Login/`, `Profile/`, `MatchFlow/`), each holding its views, its
@@ -115,13 +115,49 @@ the boundary, carry typed values inward.** On iOS the parser is **`Codable`**.
 
 ## Gotchas (hard-won — read before you touch these areas)
 
-- **This app has one target and no XCTest target yet.** To verify pure-Swift logic,
-  compile a standalone harness in a temp dir: `swiftc rules.swift main.swift` (copy the
-  source files you need, add a `main.swift` that exercises them), run it, then delete it.
-  Keep that harness outside `Fortymm/` — Xcode 16's synchronized groups auto-add any
-  `.swift` file placed there to the *app* target, and a file that links XCTest breaks the
-  app build. Shipping committed tests requires standing up a test target first — a
-  separate infra decision, not something to sneak in mid-task.
+- **There IS now a `FortymmUITests` XCUITest UI-testing target** (added to automate the
+  Dashboard empty-state flow end to end — see
+  `docs/adr/20260802-ios-e2e-tests-live-in-a-new-xcuitest-ui-test-target.md`). It's wired
+  via a `PBXFileSystemSynchronizedRootGroup` at `ios/FortymmUITests/`, so new `.swift`
+  files dropped there auto-attach to that target — same Xcode-16 sync-group mechanism as
+  the app target, just scoped to a different target: dropping a file in `Fortymm/` still
+  only ever reaches the app target, dropping one in `FortymmUITests/` only ever reaches
+  the test target. Run it with:
+  ```bash
+  xcodebuild test -project Fortymm.xcodeproj -scheme Fortymm \
+    -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:FortymmUITests
+  ```
+  (omit `-only-testing` to run everything; or from Xcode, select the
+  `FortymmUITests`-inclusive `Fortymm` scheme and Product > Test). To point a run at a
+  backend, set `FMM_API_BASE_URL` — same mechanism as a normal run
+  (`Fortymm/Networking/APIClient.swift:24`), but for UI tests it must be explicitly
+  forwarded from the test process's own environment onto
+  `XCUIApplication().launchEnvironment[...]` before `.launch()`, since XCUITest launches
+  the app as a separate process and the test's own env isn't automatically visible to it
+  — see `FortymmUITests/DashboardEmptyStateTests.swift`'s `setUpWithError` for the
+  pattern. Locally/in cloud sessions, point it at `docker-compose.dev.yml` as usual; CI
+  (`ios.yml`, `macos-latest`) instead boots the backend as native processes (Postgres via
+  Homebrew + `uvicorn`, no Docker) because GitHub-hosted macOS runners can't run Docker
+  containers — see
+  `docs/adr/20260802-ios-e2e-ci-runs-the-backend-as-native-processes-not-docker.md`; don't
+  try to add `docker compose` to `ios.yml`.
+
+  **Screen-object + accessibilityIdentifier convention:** one Swift type per screen
+  wrapping `XCUIElement` queries/actions (e.g. `FortymmUITests/ScreenObjects/DashboardScreen.swift`),
+  mirroring the Playwright `page-objects/` pattern in root `e2e/`. Query elements by an
+  explicit `.accessibilityIdentifier(...)` added to the view, not by visible text/label,
+  wherever practical — text/label matching (e.g. matching a `Text`'s literal string) is a
+  documented fallback only for elements that don't yet have an identifier. Add identifiers
+  to a screen's views incrementally, as that screen gains XCUITest coverage — don't
+  blanket-tag a whole screen up front.
+
+  This is still not a general-purpose unit-test target — for pure-Swift, non-UI logic, a
+  standalone `swiftc` harness in a temp dir remains the fastest check and needs no
+  simulator: `swiftc rules.swift main.swift` (copy the source files you need, add a
+  `main.swift` that exercises them), run it, delete it. Keep UI/XCUITest specs in
+  `FortymmUITests/` instead — a file dropped into `Fortymm/` auto-attaches to the app
+  target via the same Xcode 16 sync groups, which can't link XCTest and breaks the app
+  build.
 
 - **Xcode 16 synchronized file groups: new `.swift` files under `Fortymm/` are
   auto-included — no `project.pbxproj` edit needed.** Just create the file. **Non-source**

--- a/ios/Fortymm.xcodeproj/project.pbxproj
+++ b/ios/Fortymm.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXFileReference section */
 		9433A8502FBC9443009F0F63 /* Fortymm.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fortymm.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		88EE73CB6C834D70BD3D533F /* FortymmUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FortymmUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -16,10 +17,22 @@
 			path = Fortymm;
 			sourceTree = "<group>";
 		};
+		786B38CE285C464D96D300E5 /* FortymmUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = FortymmUITests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		9433A84D2FBC9443009F0F63 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		64B4C772C9444386AC348D1E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -33,6 +46,7 @@
 			isa = PBXGroup;
 			children = (
 				9433A8522FBC9443009F0F63 /* Fortymm */,
+				786B38CE285C464D96D300E5 /* FortymmUITests */,
 				9433A8512FBC9443009F0F63 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -41,6 +55,7 @@
 			isa = PBXGroup;
 			children = (
 				9433A8502FBC9443009F0F63 /* Fortymm.app */,
+				88EE73CB6C834D70BD3D533F /* FortymmUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -71,6 +86,27 @@
 			productReference = 9433A8502FBC9443009F0F63 /* Fortymm.app */;
 			productType = "com.apple.product-type.application";
 		};
+		924B088384C04AF4A9EB4E0F /* FortymmUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F9D472D6B0E2417C93BA2A06 /* Build configuration list for PBXNativeTarget "FortymmUITests" */;
+			buildPhases = (
+				B3D932ED6FAE4E2EB37BAA0F /* Sources */,
+				64B4C772C9444386AC348D1E /* Frameworks */,
+				7D35DA2D4FDA47B7992ED789 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F5B37D95B41B4BFD8CCB5B91 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				786B38CE285C464D96D300E5 /* FortymmUITests */,
+			);
+			name = FortymmUITests;
+			productName = FortymmUITests;
+			productReference = 88EE73CB6C834D70BD3D533F /* FortymmUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -83,6 +119,10 @@
 				TargetAttributes = {
 					9433A84F2FBC9443009F0F63 = {
 						CreatedOnToolsVersion = 26.5;
+					};
+					924B088384C04AF4A9EB4E0F = {
+						CreatedOnToolsVersion = 26.5;
+						TestTargetID = 9433A84F2FBC9443009F0F63;
 					};
 				};
 			};
@@ -104,12 +144,20 @@
 			projectRoot = "";
 			targets = (
 				9433A84F2FBC9443009F0F63 /* Fortymm */,
+				924B088384C04AF4A9EB4E0F /* FortymmUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		9433A84E2FBC9443009F0F63 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7D35DA2D4FDA47B7992ED789 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -126,7 +174,32 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B3D932ED6FAE4E2EB37BAA0F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXContainerItemProxy section */
+		49172E79427A46BFAE6EEA7B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9433A8482FBC9443009F0F63 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9433A84F2FBC9443009F0F63;
+			remoteInfo = Fortymm;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXTargetDependency section */
+		F5B37D95B41B4BFD8CCB5B91 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9433A84F2FBC9443009F0F63 /* Fortymm */;
+			targetProxy = 49172E79427A46BFAE6EEA7B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		9433A8592FBC9445009F0F63 /* Debug */ = {
@@ -320,6 +393,41 @@
 			};
 			name = Release;
 		};
+		8963D8C4F07249C7BD1BAAD9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3A8872P8KP;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.fortymm.ios-client.FortymmUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Fortymm;
+			};
+			name = Debug;
+		};
+		F25174B41C7B43A58D95C270 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 3A8872P8KP;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.fortymm.ios-client.FortymmUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Fortymm;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -337,6 +445,15 @@
 			buildConfigurations = (
 				9433A85C2FBC9445009F0F63 /* Debug */,
 				9433A85D2FBC9445009F0F63 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F9D472D6B0E2417C93BA2A06 /* Build configuration list for PBXNativeTarget "FortymmUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8963D8C4F07249C7BD1BAAD9 /* Debug */,
+				F25174B41C7B43A58D95C270 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Fortymm.xcodeproj/xcshareddata/xcschemes/Fortymm.xcscheme
+++ b/ios/Fortymm.xcodeproj/xcshareddata/xcschemes/Fortymm.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Fortymm.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "924B088384C04AF4A9EB4E0F"
+               BuildableName = "FortymmUITests.xctest"
+               BlueprintName = "FortymmUITests"
+               ReferencedContainer = "container:Fortymm.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "924B088384C04AF4A9EB4E0F"
+               BuildableName = "FortymmUITests.xctest"
+               BlueprintName = "FortymmUITests"
+               ReferencedContainer = "container:Fortymm.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/ios/Fortymm/Dashboard/DashboardView.swift
+++ b/ios/Fortymm/Dashboard/DashboardView.swift
@@ -245,6 +245,7 @@ struct DashboardView: View {
                 Text(body)
                     .font(FMFont.ui(FMFont.sm))
                     .foregroundStyle(FMColor.fg3)
+                    .accessibilityIdentifier("dashboard.rating.empty")
             }
         }
     }

--- a/ios/Fortymm/Dashboard/DashboardWidgets.swift
+++ b/ios/Fortymm/Dashboard/DashboardWidgets.swift
@@ -256,6 +256,7 @@ struct DashboardRecentResultsCard: View {
                     .foregroundStyle(FMColor.fg3)
                     .padding(FMSpace.s4)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityIdentifier("dashboard.recentResults.empty")
             } else {
                 ForEach(Array(rows.enumerated()), id: \.element.id) { i, row in
                     if i > 0 { Rectangle().fill(FMColor.ink700).frame(height: 1) }

--- a/ios/FortymmUITests/DashboardEmptyStateTests.swift
+++ b/ios/FortymmUITests/DashboardEmptyStateTests.swift
@@ -1,0 +1,111 @@
+//
+//  DashboardEmptyStateTests.swift
+//  FortymmUITests
+//
+//  Tracer-bullet spec (chore 1c): proves the whole XCUITest pipeline — test
+//  target, screen object, real-backend wiring, CI — with the narrowest
+//  scenario available. A fresh guest launching the app mints a session
+//  (`GET /v1/session`, same auto-provision behavior as web) and the Dashboard
+//  settles into its empty state without ever getting stuck on the loading
+//  placeholder.
+//
+//  Per the ADR's same-day correction, iOS has no first-match hero like web's
+//  — a fresh guest instead sees two independent, already-existing empty
+//  states once `GET /v1/dashboard` resolves: the rating card's `.unrated`
+//  copy ("Unrated — finish a rated match to start your rating",
+//  DashboardView.swift:218) and the recent-results card's empty copy ("No
+//  completed matches yet.", DashboardWidgets.swift:254). See
+//  docs/adr/20260802-ios-e2e-tests-live-in-a-new-xcuitest-ui-test-target.md.
+//
+//  Requires a running backend. Point it at one via `FMM_API_BASE_URL` in the
+//  environment `xcodebuild test` (or the `FortymmUITests` scheme's Test
+//  action) runs with — see `setUpWithError` for exactly how that reaches the
+//  app process.
+//
+
+import XCTest
+
+final class DashboardEmptyStateTests: XCTestCase {
+    /// Fallback backend URL when the test runner's own environment carries no
+    /// `FMM_API_BASE_URL` override — the docker-compose dev stack's nginx
+    /// port (`docker-compose.dev.yml`), the same default a local Xcode run of
+    /// the app documents in `ios/CLAUDE.md`.
+    private static let defaultAPIBaseURL = "http://localhost:8080"
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        app = XCUIApplication()
+
+        // `ProcessInfo.processInfo.environment` here is *this test runner
+        // process's* environment — inherited from whatever invoked
+        // `xcodebuild test` (a shell's `env FMM_API_BASE_URL=... xcodebuild
+        // test ...`, or the `FortymmUITests` scheme's own Test-action
+        // environment variables in Xcode). XCUITest launches the app under
+        // test as a *separate* process, so that value does not reach it on
+        // its own — it must be copied onto `XCUIApplication.launchEnvironment`
+        // explicitly, which XCUITest *does* deliver to the launched process's
+        // environment. `APIClient.baseURL` (Networking/APIClient.swift) reads
+        // the same `FMM_API_BASE_URL` key via `ProcessInfo.processInfo
+        // .environment` inside the app, so this is the one hop that gets a
+        // CI- or locally-chosen backend URL from the test invocation into the
+        // running app. Falls back to the compose dev stack's URL so a bare
+        // `xcodebuild test` run (no override set) still targets something
+        // real rather than silently hitting the UAT default baked into
+        // `APIClient`.
+        let apiBaseURL = ProcessInfo.processInfo.environment["FMM_API_BASE_URL"]
+            ?? Self.defaultAPIBaseURL
+        app.launchEnvironment["FMM_API_BASE_URL"] = apiBaseURL
+
+        // Fresh-guest assumption: this test does not itself clear any
+        // Keychain-held session token (`SessionTokenStore`) or reinstall the
+        // app — doing so would need app-side hooks, out of scope for this
+        // screen-object + spec chore. Two things make "fresh guest" hold
+        // anyway:
+        //   1. In CI (chore 1e), `FortymmUITests` runs on a freshly
+        //      provisioned macOS runner + simulator, so there is no
+        //      pre-existing Keychain entry for this app's bundle id to begin
+        //      with — every run mints a brand-new guest.
+        //   2. Locally, on a simulator that has already run this app, erase
+        //      its content first (Simulator > Device > Erase All Content and
+        //      Settings) or uninstall the app so a stale guest token from a
+        //      previous run isn't reused.
+        // Note the assertions below don't actually depend on literal
+        // freshness — they hold for *any* guest with zero completed rated
+        // matches — but a genuinely fresh guest is what this spec is meant to
+        // exercise end to end (guest-session mint included).
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+    }
+
+    func testFreshGuestSeesDashboardEmptyState() throws {
+        let dashboard = DashboardScreen(app: app)
+
+        XCTAssertTrue(
+            dashboard.ratingEmpty.waitForExistence(timeout: 15),
+            "Expected the rating card's empty-state copy "
+                + "(\"Unrated — finish a rated match to start your rating\") to appear"
+        )
+        XCTAssertTrue(
+            dashboard.recentResultsEmpty.waitForExistence(timeout: 15),
+            "Expected the recent-results card's empty-state copy "
+                + "(\"No completed matches yet.\") to appear"
+        )
+
+        XCTAssertTrue(dashboard.ratingEmpty.isHittable, "Rating empty state should be visible on screen")
+        XCTAssertTrue(
+            dashboard.recentResultsEmpty.isHittable,
+            "Recent-results empty state should be visible on screen"
+        )
+
+        XCTAssertFalse(
+            dashboard.loadingText.exists,
+            "Dashboard should have settled past \"Loading your dashboard…\" by now"
+        )
+    }
+}

--- a/ios/FortymmUITests/FortymmUITests.swift
+++ b/ios/FortymmUITests/FortymmUITests.swift
@@ -1,0 +1,24 @@
+//
+//  FortymmUITests.swift
+//  FortymmUITests
+//
+//  Scaffold smoke test proving the FortymmUITests target is wired up correctly:
+//  launches the app and asserts it comes to the foreground without crashing.
+//  Real screen-object-based specs land in a later chore (see
+//  docs/adr/20260802-ios-e2e-tests-live-in-a-new-xcuitest-ui-test-target.md).
+//
+
+import XCTest
+
+final class FortymmUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testAppLaunchesWithoutCrashing() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 5))
+    }
+}

--- a/ios/FortymmUITests/ScreenObjects/DashboardScreen.swift
+++ b/ios/FortymmUITests/ScreenObjects/DashboardScreen.swift
@@ -1,0 +1,59 @@
+//
+//  DashboardScreen.swift
+//  FortymmUITests
+//
+//  Screen object for the Dashboard tab (`Fortymm/Dashboard/DashboardView.swift`)
+//  — the XCUITest analog of `e2e/page-objects/dashboard.page.ts`. One Swift
+//  type per screen, exposing named element accessors so specs read intent
+//  ("the rating card's empty state") rather than raw XCUIElement predicates.
+//  See docs/adr/20260802-ios-e2e-tests-live-in-a-new-xcuitest-ui-test-target.md
+//  for the screen-object + accessibilityIdentifier convention this follows.
+//
+
+import XCTest
+
+/// Wraps the Dashboard's `XCUIElement` queries/actions. Home is the app's
+/// default selected tab (`MainTabView`), so no navigation step is needed to
+/// reach it — construct this right after `app.launch()`.
+struct DashboardScreen {
+    private let app: XCUIApplication
+
+    init(app: XCUIApplication) {
+        self.app = app
+    }
+
+    /// The empty rating card's copy for a fresh/unrated player: "Unrated —
+    /// finish a rated match to start your rating"
+    /// (`DashboardView.swift`'s `emptyRatingCard`, `.unrated` case). Tagged
+    /// `dashboard.rating.empty` in chore 1b.
+    var ratingEmpty: XCUIElement {
+        app.staticTexts["dashboard.rating.empty"]
+    }
+
+    /// The recent-results card's empty copy: "No completed matches yet."
+    /// (`DashboardWidgets.swift`'s `DashboardRecentResultsCard`). Tagged
+    /// `dashboard.recentResults.empty` in chore 1b.
+    var recentResultsEmpty: XCUIElement {
+        app.staticTexts["dashboard.recentResults.empty"]
+    }
+
+    /// The loading placeholder shown while the session/dashboard bootstrap is
+    /// still in flight (`DashboardView.swift`'s `loadingCard`). It is plain
+    /// `Text("Loading your dashboard…")` with no `.accessibilityIdentifier` —
+    /// querying `staticTexts` by this string falls back to matching the
+    /// element's accessibility label, since SwiftUI `Text` has no identifier
+    /// of its own until one is set explicitly.
+    var loadingText: XCUIElement {
+        app.staticTexts["Loading your dashboard…"]
+    }
+
+    /// Waits (up to `timeout` each) for both fresh-guest empty-state elements
+    /// to appear. Returns whether both showed up in time — callers still do
+    /// their own `XCTAssert` so failures point at *which* element was missing.
+    @discardableResult
+    func waitForEmptyState(timeout: TimeInterval = 15) -> Bool {
+        let ratingAppeared = ratingEmpty.waitForExistence(timeout: timeout)
+        let recentResultsAppeared = recentResultsEmpty.waitForExistence(timeout: timeout)
+        return ratingAppeared && recentResultsAppeared
+    }
+}


### PR DESCRIPTION
## Summary

- Stands up the iOS app's first-ever XCUITest UI test target, `FortymmUITests` (`ios/CLAUDE.md` previously said "one app target, zero XCTest, ever" — that's now out of date, and this PR updates it).
- Adds `.accessibilityIdentifier()` to two Dashboard empty-state elements, establishing identifier-based querying as the go-forward XCUITest convention.
- Adds a `DashboardScreen` screen-object + one tracer-bullet spec (`DashboardEmptyStateTests`): a fresh guest launches the app, the Dashboard settles into its empty state ("Unrated — finish a rated match to start your rating" + "No completed matches yet."), and the loading text never shows.
- Wires the new target into `ios.yml` CI. GitHub-hosted `macos-latest` runners can't run Docker (no nested virtualization), so the new job boots the backend as native processes instead — Postgres via Homebrew, migrations + seeding, `uvicorn` — rather than `docker-compose`.
- Records both decisions as ADRs (`docs/adr/20260802-*`), including a same-day correction: the plan originally assumed iOS mirrors web's "Log your first match." hero, which turned out not to exist on iOS — the spec was retargeted to the empty-state copy iOS actually renders.

## Why

Requested: give the iOS app end-to-end test coverage. Scoped deliberately narrow (infra + one spec, not a feature build-out) per an agreed plan — see the ADRs for the full decision trail.

## Verification

This session has no Xcode, so nothing here could be compiled or run on a simulator locally. Every chore was independently reviewed by a separate `verifier` agent:
- The `project.pbxproj`/scheme edits, the Swift source, and the identifier/string matching (including the exact ellipsis character) were checked structurally and cross-referenced against the real source — no defects found.
- The CI job's non-Xcode bootstrap (Postgres → migrations → seeds → `uvicorn` → health) was **independently re-executed end-to-end on Linux**, including confirming `GET /v1/session` + `GET /v1/dashboard` produce the exact fresh-guest state the spec asserts on, and that skipping the RBAC seed reproduces the 500 it exists to prevent.
- The one thing that cannot be verified outside a real macOS runner is the actual `xcodebuild test` invocation — that's this PR's CI run (the new `ui-tests` job) to confirm, and/or a local Simulator run.

## Testing notes (for the QA/merge gate)

- **Happy path:** a first-time app user sees the Dashboard settle into its empty state immediately, never stuck on "Loading your dashboard…" — now covered by `FortymmUITests`.
- **Regression risk:** the two new `.accessibilityIdentifier()` calls are additive-only — the Dashboard should look identical before/after.
- **Not observable in the UI:** the CI backend bootstrap — confirmed by the `ui-tests` job log, not by driving the app.
- **Deferred to a human:** actually running `FortymmUITests` in the Simulator — confirm this PR's CI run goes green, and/or run the suite locally before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_013J8yaCRQf6LYTcjuzB4HWV)_