### PR TITLE
Add TestFlight link to sidebar footer

### DIFF
--- a/web-client/src/components/app-shell.page.tsx
+++ b/web-client/src/components/app-shell.page.tsx
@@ -165,6 +165,15 @@ const scoped = (container: Container) => {
         .queryAllByRole('button')
         .map((el) => el.getAttribute('aria-label') ?? labelOf(el))
     },
+
+    /**
+     * The TestFlight link pinned to the bottom of the sidebar, below the nav
+     * list. Not a router `<Link>` — a plain external `<a>` — so it needs no
+     * stub route in `NAV_LINK_PATHS`.
+     */
+    getTestFlightLink() {
+      return within(sidebar()).getByRole('link', { name: 'Get the iOS App' })
+    },
   }
 }
 

--- a/web-client/src/components/app-shell.test.tsx
+++ b/web-client/src/components/app-shell.test.tsx
@@ -256,6 +256,25 @@ describe('AppShell sidebar', () => {
  *   later adds an `onEscapeKeyDown` preventDefault or a global key handler that
  *   swallows it. It is deliberately non-discriminating today.
  */
+/**
+ * The TestFlight link pinned to the bottom of the sidebar, below the nav
+ * list — a plain external link, not a route the router owns.
+ */
+describe('AppShell sidebar footer', () => {
+  it('links to the public TestFlight beta, opening in a new tab', async () => {
+    appShellPage.render('/dashboard')
+    await appShellPage.findNavLink('Dashboard')
+
+    const link = appShellPage.getTestFlightLink()
+    expect(link).toHaveAttribute(
+      'href',
+      'https://testflight.apple.com/join/5pGVbku3',
+    )
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+})
+
 describe('AppShell alpha notice', () => {
   it('offers a labelled close control that dismisses it (#891)', async () => {
     appShellPage.render('/dashboard')

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -10,6 +10,7 @@ import {
   Megaphone,
   Shield,
   SlidersHorizontal,
+  Smartphone,
   TriangleAlert,
   Trophy,
   Users,
@@ -47,6 +48,9 @@ type NavSection = {
   label?: string
   items: NavItem[]
 }
+
+/** The app's public TestFlight beta — anyone with the link can join, no invite needed. */
+const TESTFLIGHT_URL = 'https://testflight.apple.com/join/5pGVbku3'
 
 const NAV_SECTIONS: NavSection[] = [
   {
@@ -407,6 +411,20 @@ export function AppShell({ children }: AppShellProps) {
             </div>
           ))}
         </nav>
+
+        <div className="app-shell__sidebar-footer">
+          <a
+            href={TESTFLIGHT_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="app-shell__nav-link"
+          >
+            <span className="app-shell__nav-icon">
+              <Smartphone size={18} strokeWidth={2} />
+            </span>
+            Get the iOS App
+          </a>
+        </div>
       </aside>
 
       <div className="app-shell__main">

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -978,6 +978,12 @@ body.dark.fortymm-theme {
   background: var(--ball-500);
 }
 
+.app-shell__sidebar-footer {
+  flex-shrink: 0;
+  padding: 12px;
+  border-top: 1px solid var(--border-subtle);
+}
+
 .rbac-row {
   transition: background 120ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }


### PR DESCRIPTION
## Summary
- Adds a "Get the iOS App" link pinned to the bottom of the web app's sidebar, below the nav list
- Links out to the public TestFlight beta (`https://testflight.apple.com/join/5pGVbku3`) in a new tab
- Adds a colocated page-object accessor and vitest coverage for the new link

## Test plan
- [x] `vitest` for `app-shell.test.tsx`
- [ ] CI (lint/typecheck/unit/e2e) green
- [ ] QA review of the sidebar link (desktop + mobile)

---
_Generated by [Claude Code](https://claude.ai/code/session_0169mC1MHPkwBo7nW8vQ8qGj)_