### PR TITLE
api: write-schema fields take `X | None = None`, never a non-null default

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -257,6 +257,32 @@ interior should never traffic in `Any` or untyped `dict`.
   schema rather than a promise in a docstring, and `extra="forbid"` turns an
   attempt into a 422 naming the field.
 
+  **`default_factory` is not the same trap** — Pydantic emits no `default` key
+  into the JSON schema for one, so `table_catalogue: list[TableWrite] =
+  Field(default_factory=list)` already generates as `table_catalogue?:`. The
+  rule is about the *default's* nullness in the emitted document, so read the
+  document, not the Python, when you're unsure: no `default` key, or a `null`
+  one, means optional.
+
+- **Collapse a nullable wire field to a total value at the boundary.** Making a
+  write field optional buys the client a third value it did not have, and
+  `bool | None` reaching the interior is exactly the tri-state boolean the rule
+  above forbids. Answer the question once, on the schema, and let the interior
+  hold the real type:
+
+  ```python
+  unplace_fixtures_on_removed_tables: bool | None = None
+
+  @property
+  def unplacing_is_confirmed(self) -> bool:
+      return self.unplace_fixtures_on_removed_tables is True
+  ```
+
+  Omitted, `false` and `null` are one answer — nobody opted in — and they are
+  merged where they arrive, so no caller downstream can ask and get three.
+  `RoundRobinDrawSettingsWrite.qualifiers_per_pool` is the same shape. Optional
+  on the wire, total inside.
+
 - **Don't use `assert x is not None` as control flow after a DB load.** A
   loader typed `-> Match | None` forces the caller to handle the `None`; an
   `assert` is stripped under `python -O` and is not a guarantee. If a path

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -235,6 +235,28 @@ interior should never traffic in `Any` or untyped `dict`.
   with real fields and `KeyError` is impossible. New code must not introduce
   another `dict[str, Any]` that crosses more than one function.
 
+- **An optional field on a *write* schema takes `X | None = None`, never a
+  non-null default.** The two look equally optional in Python and generate
+  opposite contracts. `openapi-typescript` promotes any property carrying a
+  **non-null** default to **required** in the generated TypeScript, so
+  `position: int = 0` and `unplace_fixtures_on_removed_tables: bool = False`
+  both arrive in the client as fields every caller must send — while
+  `description: str | None = None` generates the `field?:` you wanted. On a
+  PATCH body, where omitting a key means "unchanged", that is simply wrong: it
+  compels a rename to send a whole table catalogue, or an unrelated edit to
+  restate a destructive opt-in.
+
+  It is not caught by anything local. `mypy` is happy, `pytest` is happy, and
+  the damage only appears after `mise run regen-api-types` when the web client
+  stops compiling — which is a chore or two later, in someone else's diff.
+  #1226 hit it twice in two slices before it was named.
+
+  If a field is genuinely server-assigned, the stronger move is to keep it off
+  the write schema altogether — a read model that extends the write model
+  (`class Pool(PoolWrite)`) makes "the client cannot send this" a fact of the
+  schema rather than a promise in a docstring, and `extra="forbid"` turns an
+  attempt into a 422 naming the field.
+
 - **Don't use `assert x is not None` as control flow after a DB load.** A
   loader typed `-> Match | None` forces the caller to handle the `None`; an
   `assert` is stripped under `python -O` and is not a guarantee. If a path


### PR DESCRIPTION
A convention learned the expensive way — twice, in two consecutive slices of #1226.

## The bug it prevents

These two shipped past `mypy`, `pytest` and `ruff` without complaint, and broke the web client's typecheck a chore later:

```python
position: int = 0                                  # slice 1
unplace_fixtures_on_removed_tables: bool = False   # slice 2
```

`openapi-typescript` promotes any property carrying a **non-null default** to **required** in the generated TypeScript. So both arrived in the client as fields every caller must send — on **PATCH bodies**, where omitting a key is the documented way to say *"unchanged"*.

Concretely: renaming a tournament had to restate the entire table catalogue, and an unrelated edit had to restate a destructive opt-in. `{name: "..."}` stopped typechecking.

Meanwhile `description: str | None = None` generates exactly the `field?:` that was intended.

**The discriminator is the default's nullness, not the field's optionality** — and the two spellings read as equally optional in Python. That's what makes it worth writing down rather than remembering.

## Why nothing catches it

There is no local signal. `mypy` is happy, `pytest` is happy, `ruff` is happy. The damage appears only after `mise run regen-api-types`, when the web client stops compiling — typically a chore or two later, in a diff that didn't cause it. In #1226 that meant the `[main]` regen chore looked like the culprit both times.

Cost so far: **one extra chore in each of the two slices that hit it** (`1a2`, and `2c2`).

## It also records the stronger move

Where the field is genuinely server-assigned, the better answer isn't a nullable default — it's keeping the field **off the write schema entirely**, with the read model extending the write model:

```python
class Pool(PoolWrite):        # read carries `position`; PoolWrite does not
    position: PoolPosition = 0
```

Combined with `extra="forbid"`, "the client cannot send this" becomes a fact of the schema and an attempt becomes a 422 naming the field — rather than a promise in a docstring that the generated client contradicts.

## Two corollaries, added after `2c2` landed

**`default_factory` is not the same trap.** Pydantic emits no `default` key into the JSON schema for one, so `Field(default_factory=list)` already generates as `field?:`. Without saying so, the rule reads as a blanket ban on defaults and the next reader "fixes" a field that was never broken. The test is the emitted document — no `default` key, or a `null` one, means optional — not the Python.

**Making a write field optional buys the client a third value.** `bool | None` reaching the interior is exactly the tri-state boolean this file already forbids. So the rule now carries the other half: collapse it once, where it arrives.

```python
unplace_fixtures_on_removed_tables: bool | None = None

@property
def unplacing_is_confirmed(self) -> bool:
    return self.unplace_fixtures_on_removed_tables is True
```

Omitted, `false` and `null` are one answer, merged at the boundary, so nothing downstream can ask and get three. Optional on the wire, total inside.

## Placement

Added to `api/CLAUDE.md` §"Type the I/O boundaries", next to the existing rules about `response_model`, `extra="forbid"` and parse-don't-validate. It's a boundary-contract rule and that's where a reader looking for one would go.

Docs-only; no application code, so no suite applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCCG5jQq19dG8SDPFcmTwh)_