### PR TITLE
Regenerate the MSW service worker for msw 2.15.0

### DIFF
--- a/web-client/public/mockServiceWorker.js
+++ b/web-client/public/mockServiceWorker.js
@@ -7,8 +7,8 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.14.6'
-const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const PACKAGE_VERSION = '2.15.0'
+const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -137,8 +137,18 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
   if (client && activeClientIds.has(client.id)) {
     const serializedRequest = await serializeRequest(requestCloneForEvents)
 
+    // Omit the body of server-sent event stream responses.
+    // Cloning such responses would prevent client-side stream cancelations
+    // from reaching the original stream (a teed stream only cancels its
+    // source once both of its branches cancel) and would buffer the
+    // entire stream into the unconsumed clone indefinitely.
+    const isEventStreamResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .startsWith('text/event-stream')
+
     // Clone the response so both the client and the library could consume it.
-    const responseClone = response.clone()
+    const responseClone = isEventStreamResponse ? null : response.clone()
 
     sendToClient(
       client,
@@ -151,15 +161,17 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
             ...serializedRequest,
           },
           response: {
-            type: responseClone.type,
-            status: responseClone.status,
-            statusText: responseClone.statusText,
-            headers: Object.fromEntries(responseClone.headers.entries()),
-            body: responseClone.body,
+            type: response.type,
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: responseClone ? responseClone.body : null,
           },
         },
       },
-      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+      responseClone && responseClone.body
+        ? [serializedRequest.body, responseClone.body]
+        : [],
     )
   }
 


### PR DESCRIPTION
Found while rebasing #1226's stack onto current `main` — `npm ci` produced a dirty working tree, which is the symptom.

## The drift

#1246 bumped `msw` but did not regenerate the worker it ships:

```
main package.json:  "msw": "^2.15.0"
main worker file:   PACKAGE_VERSION = '2.14.6'
```

`public/mockServiceWorker.js` is a generated artifact carrying its own `PACKAGE_VERSION` and `INTEGRITY_CHECKSUM`. When they don't match the installed library, msw warns at registration and the browser can go on serving the older worker. That's a stale artifact of exactly the kind `.claude/rules/verify-the-artifact-under-test.md` is about — it fails quietly, and what runs is not what the manifest says.

It also means every `npm ci` leaves the tree dirty, since msw's postinstall regenerates the file. Anyone who installs picks up an uncommitted change they didn't make.

## The fix

Regenerated by `npm ci`. The diff is whatever the 2.15.0 worker ships — substantively, it now omits the body of server-sent event stream responses when serializing a request for the client.

Not hand-edited; the file says "Please do NOT modify this file" and I didn't.

## Verification

`npm run test:run` → **319 files, 3391 tests, all passing** (run on the rebased #1226 stack, which carries this same regenerated worker plus main's dependency set).

Worth noting this class of drift is invisible to CI today: nothing checks the committed worker against the installed msw version. A guard would be a separate change, and I haven't made one here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCCG5jQq19dG8SDPFcmTwh)_