### PR TITLE
Slice 1: publish multi-arch api and web-client images to GHCR on every push to main

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,173 @@
+name: publish-images
+
+# Builds the two images UAT actually runs -- `api/Dockerfile.dev` and
+# `web-client/Dockerfile.uat` -- and pushes them to GHCR, so a deploy pulls a
+# published artifact instead of one built on the operator's laptop. See
+# docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md.
+#
+# Trigger: push to `main` only. Deliberately NOT on `pull_request` -- an image
+# built from a PR head is not deployable (`redeploy-uat.sh` refuses any ref but
+# `main`), so a PR build would burn ~25 minutes of emulated-arm64 runner to
+# produce something nothing can consume. The accepted cost is that a broken
+# build is discovered after merge rather than before it.
+#
+# Also deliberately NOT path-filtered, but for a different reason than
+# `api.yml`'s (which is about required status checks). Here it is because
+# `redeploy-uat.sh` looks the image up by the deploying commit's short SHA:
+# every commit on `main` must therefore have images published under its own
+# SHA, including commits that touch only docs. A path filter would leave holes
+# on `main` that are simply undeployable.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# One publish at a time per ref. Two overlapping runs would race the moving
+# `:main` tag and could leave it pointing at the older of the two commits.
+# Never cancel in progress: every commit on `main` needs its own images.
+concurrency:
+  group: publish-images-${{ github.ref }}
+  cancel-in-progress: false
+
+# `packages: write` is what pushes to GHCR; the built-in GITHUB_TOKEN covers
+# it, so the push side needs no secret of its own.
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  API_IMAGE: ghcr.io/mightymoose/fortymm-api
+  WEB_IMAGE: ghcr.io/mightymoose/fortymm-web-client
+  # UAT's k3d cluster runs on the operator's (arm64) machine, not on a runner,
+  # so amd64 alone would not run there; a later Hetzner box is amd64. One
+  # manifest list per tag serves both. The arm64 leg is QEMU-emulated here and
+  # dominates the run time -- that cost is accepted deliberately.
+  PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+  tag:
+    name: Resolve the image tag
+    runs-on: ubuntu-latest
+    outputs:
+      short-sha: ${{ steps.sha.outputs.short-sha }}
+    steps:
+      - name: Refuse to publish from a non-main ref
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::publish-images only publishes main (got ${GITHUB_REF}); a non-main run would move the :main tag onto an unreviewed commit."
+            exit 1
+          fi
+
+      # A FIXED 12-character truncation of the full SHA -- deliberately NOT
+      # `git rev-parse --short`. That command picks its length from the
+      # repository's object count (`core.abbrev=auto`), so the same commit
+      # abbreviates to 7 in a shallow CI clone, 8 in a full clone of this repo
+      # today, and 9 once it grows -- and an operator who has set `core.abbrev`
+      # gets something else again. The deploy script looks the image up by this
+      # exact string, so a length that drifts between the two clones is a
+      # tag-not-found on a commit that was published perfectly well.
+      #
+      # Truncating $GITHUB_SHA is immune to all of that: no git config, no
+      # object count, no checkout. It is why this job clones nothing.
+      # `scripts/redeploy-uat.sh` MUST use the same 12-char truncation.
+      - name: Compute the image tag
+        id: sha
+        run: |
+          set -euo pipefail
+          short="${GITHUB_SHA::12}"
+          echo "short-sha=${short}" >> "$GITHUB_OUTPUT"
+          echo "Publishing \`${GITHUB_SHA}\` as \`:${short}\` (and moving \`:main\`)." >> "$GITHUB_STEP_SUMMARY"
+
+  api:
+    name: fortymm-api
+    needs: tag
+    runs-on: ubuntu-latest
+    # The emulated arm64 leg is slow; ~25 min is normal, so allow headroom
+    # without letting a wedged build hold a runner all day.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: api
+          file: api/Dockerfile.dev
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: |
+            ${{ env.API_IMAGE }}:${{ needs.tag.outputs.short-sha }}
+            ${{ env.API_IMAGE }}:main
+          # Distinct scope per image. A shared scope makes the two builds
+          # overwrite each other's cache manifest, so each run starts cold --
+          # which is exactly what we cannot afford with an emulated arm64 leg.
+          cache-from: type=gha,scope=api
+          cache-to: type=gha,mode=max,scope=api
+          # No provenance attestation: it adds an `unknown/unknown` entry to the
+          # manifest list, and the deploy pins that list by digest. Keep the
+          # index to exactly the two platform manifests it claims to hold.
+          provenance: false
+
+  web-client:
+    name: fortymm-web-client
+    needs: tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: web-client
+          file: web-client/Dockerfile.uat
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: |
+            ${{ env.WEB_IMAGE }}:${{ needs.tag.outputs.short-sha }}
+            ${{ env.WEB_IMAGE }}:main
+          # `VITE_*` values are baked into the bundle at build time, so they are
+          # fixed here rather than by the operator's `.env`.
+          #
+          # The Faro collector is a same-origin path, not a secret, and is
+          # passed unconditionally: where nginx has no `/faro/` block (the QA
+          # shape) the beacons simply 404, which is harmless.
+          #
+          # The Maps key is a *browser* key -- readable in the shipped bundle
+          # either way. If the repository secret is unset it expands to empty,
+          # which matches the Dockerfile's own default: the build still
+          # succeeds and the map degrades to its text fallback. Nothing here
+          # fails on a missing key.
+          build-args: |
+            VITE_FARO_COLLECTOR_URL=/faro/collect
+            VITE_GOOGLE_MAPS_API_KEY=${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
+          cache-from: type=gha,scope=web-client
+          cache-to: type=gha,mode=max,scope=web-client
+          provenance: false

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -12,12 +12,20 @@ name: publish-images
 # build is discovered after merge rather than before it.
 #
 # Also deliberately NOT path-filtered, but for a different reason than
-# `api.yml`'s (which is about required status checks). Here it is because
-# `redeploy-uat.sh` is being changed to look images up by the deploying commit's
-# SHA: every commit on `main` must therefore have images published under its own
-# SHA, including commits that touch only docs, or a path filter would leave holes
-# on `main` that are simply undeployable. That script still builds locally as of
-# this commit -- the consuming half lands separately.
+# `api.yml`'s (which is about required status checks). `redeploy-uat.sh` is
+# being changed to merge `origin/main` and deploy its TIP, looking the images up
+# by that commit's SHA -- so whatever commit is currently the tip must have
+# images, no matter what it touched. A path filter would skip docs-only commits,
+# and a docs-only commit is very often the tip, which would leave `main`
+# undeployable until something else landed on top of it. (That script still
+# builds locally as of this commit -- the consuming half lands separately.)
+#
+# Note what this does NOT promise: that *every* commit on `main` gets images.
+# The concurrency group below supersedes a PENDING run when a newer one queues,
+# so merging three times inside one ~25min build window skips the middle commit.
+# That is tolerable only because the tip is the sole thing ever deployed, and
+# the tip is always the run that survives. Do not read this workflow as
+# guaranteeing per-commit coverage.
 
 on:
   push:
@@ -25,8 +33,16 @@ on:
   workflow_dispatch:
 
 # One publish at a time per ref. Two overlapping runs would race the moving
-# `:main` tag and could leave it pointing at the older of the two commits.
-# Never cancel in progress: every commit on `main` needs its own images.
+# `:main` tag and could leave it pointing at the older of the two commits;
+# serializing them means `:main` always ends up on the newest.
+#
+# `cancel-in-progress: false` keeps a running publish from being killed by the
+# next merge, so a commit that has STARTED building always finishes. It does not
+# protect a run that is merely queued: GitHub cancels a pending run when a newer
+# one queues into the same group, so under rapid merges an intermediate commit
+# can end up with no images at all. Accepted deliberately -- only the tip is ever
+# deployed, and the newest queued run is the one that survives, so the tip always
+# publishes. See the header comment.
 concurrency:
   group: publish-images-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -41,8 +41,10 @@ env:
   REGISTRY: ghcr.io
   API_IMAGE: ghcr.io/mightymoose/fortymm-api
   WEB_IMAGE: ghcr.io/mightymoose/fortymm-web-client
-  # UAT's k3d cluster runs on the operator's (arm64) machine, not on a runner,
-  # so amd64 alone would not run there; a later Hetzner box is amd64. One
+  # UAT's k3d cluster runs on the operator's own machine, not on a runner, and
+  # this repo neither pins nor can check that machine's architecture -- an
+  # amd64-only image would either fail to run there or run under emulation,
+  # depending on whose machine it is. A later Hetzner box is amd64, so one
   # manifest list per tag serves both. The arm64 leg is QEMU-emulated here and
   # dominates the run time -- that cost is accepted deliberately.
   PLATFORMS: linux/amd64,linux/arm64

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -13,10 +13,11 @@ name: publish-images
 #
 # Also deliberately NOT path-filtered, but for a different reason than
 # `api.yml`'s (which is about required status checks). Here it is because
-# `redeploy-uat.sh` looks the image up by the deploying commit's short SHA:
-# every commit on `main` must therefore have images published under its own
-# SHA, including commits that touch only docs. A path filter would leave holes
-# on `main` that are simply undeployable.
+# `redeploy-uat.sh` is being changed to look images up by the deploying commit's
+# SHA: every commit on `main` must therefore have images published under its own
+# SHA, including commits that touch only docs, or a path filter would leave holes
+# on `main` that are simply undeployable. That script still builds locally as of
+# this commit -- the consuming half lands separately.
 
 on:
   push:

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -78,9 +78,9 @@ docker pull "ghcr.io/mightymoose/fortymm-api:$(git rev-parse HEAD | cut -c1-12)"
 UAT's k3d cluster runs on the operator's own machine rather than on an amd64
 runner, and that machine's architecture is not something this repo pins or can
 check — an amd64-only image would either fail to run there or run under
-emulation, depending on whose machine it is. A later Hetzner box is amd64. One manifest list per tag serves both. The arm64 leg is QEMU-emulated
-on the amd64 runner and dominates the run — **~25 min is normal** (the jobs allow
-90). Provenance attestations are off, so each index holds exactly the two
+emulation, depending on whose machine it is. A later Hetzner box is amd64, so
+one manifest list per tag serves both. The arm64 leg is QEMU-emulated on the
+amd64 runner and dominates the run — **~25 min is normal** (the jobs allow 90). Provenance attestations are off, so each index holds exactly the two
 platform manifests it claims and nothing pinning it by digest sees an
 `unknown/unknown` entry.
 

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -25,7 +25,9 @@ Infra has no single directory — it spans:
   read this file — it renders an **inline copy** in
   `deploy/uat/templates/_helpers.tpl` (`fortymm-uat.nginxConf`, which also adds a
   `/faro/` block). When you touch `uat.conf`, update the helper copy too.
-- `.github/workflows/*.yml` — CI (api, web-client, e2e, openapi-schema, ios, …).
+- `.github/workflows/*.yml` — CI (api, web-client, e2e, openapi-schema, ios, …),
+  including **`publish-images.yml`**, which pushes the api/web images to GHCR on
+  every push to `main` (see `## Published images (GHCR)`).
 - `mise.toml` — toolchain pins + task runner (`redeploy-uat`, `regen-*-types`).
 
 ## Stacks at a glance
@@ -35,6 +37,100 @@ Infra has no single directory — it spans:
 | dev   | `docker compose -f docker-compose.dev.yml up` | :8080 | dev servers, MSW off; real API |
 | QA    | up `scripts/qa-up.sh [id]` / down `scripts/qa-down.sh [id]` | :8085 (auto) | built artifacts, MSW off, **Mailpit :8087** captures all mail; multi-stack; **reap on merge** |
 | UAT   | `mise run redeploy-uat` | host :8084 → NodePort 30084 | **k3d/Helm — the one prod-like stack NOT on compose**; sends REAL Postmark email |
+
+## Published images (GHCR)
+
+`.github/workflows/publish-images.yml` builds the two Dockerfiles UAT runs —
+`api/Dockerfile.dev` and `web-client/Dockerfile.uat` — and pushes them to two
+GHCR packages:
+
+- `ghcr.io/mightymoose/fortymm-api`
+- `ghcr.io/mightymoose/fortymm-web-client`
+
+**Trigger: every push to `main`** (plus a manual `workflow_dispatch`, which the
+first job rejects on any ref but `main`, since a non-main run would move the
+`:main` tag onto an unreviewed commit). Deliberately **not** on `pull_request` —
+an image built from a PR head is not deployable, so it would burn ~25 minutes of
+runner to produce something nothing can consume. Also deliberately **not**
+path-filtered: every commit on `main`, docs-only ones included, must have images
+under its own SHA, because the deploy path this is groundwork for looks images up
+by the deploying commit's SHA and a path filter would leave undeployable holes.
+Runs are serialized per ref and never cancelled in progress.
+
+**Two tags per image per run:** `:<12-char sha>` (one per commit — nothing
+registry-side pins it, so a re-run for the same commit overwrites it) and
+`:main` (moving, always the newest `main`). Push credentials are the built-in
+`GITHUB_TOKEN` with `packages: write` — there is no registry secret to rotate.
+
+**The tag is a fixed 12-character truncation of the full commit SHA**
+(`${GITHUB_SHA::12}`), deliberately **not** `git rev-parse --short`. `--short`
+picks its length from the repository's object count (`core.abbrev=auto`) and from
+any `core.abbrev` the operator has set, so the same commit abbreviates to 7 in a
+shallow CI clone, 8 in a full clone of this repo today, and 9 once it grows.
+Anything looking an image up by tag must use the same fixed truncation or it gets
+a tag-not-found on a commit that published perfectly well. Hand-pulling:
+
+```bash
+docker pull "ghcr.io/mightymoose/fortymm-api:$(git rev-parse HEAD | cut -c1-12)"
+```
+
+**Each tag is a multi-arch manifest list — `linux/amd64` *and* `linux/arm64`.**
+UAT's k3d cluster runs on the operator's own machine rather than on an amd64
+runner, and that machine's architecture is not something this repo pins or can
+check — an amd64-only image would either fail to run there or run under
+emulation, depending on whose machine it is. A later Hetzner box is amd64. One manifest list per tag serves both. The arm64 leg is QEMU-emulated
+on the amd64 runner and dominates the run — **~25 min is normal** (the jobs allow
+90). Provenance attestations are off, so each index holds exactly the two
+platform manifests it claims and nothing pinning it by digest sees an
+`unknown/unknown` entry.
+
+Nothing consumes these images yet: `mise run redeploy-uat` still builds locally
+and `k3d image import`s (see `## Topology`). This section documents the
+publishing half only.
+
+### One-time per package: flip visibility to public
+
+**GHCR publishes a package private on its first push — even from a public
+repository. Visibility is not inherited from the repo.** After the first
+successful run that creates a package, someone with admin on the repo must flip
+it by hand:
+
+> repository → **Packages** → the package → **Package settings** → **Change
+> visibility** → **Public**
+
+This is needed **once per package**, so twice in total (`fortymm-api`,
+`fortymm-web-client`), and never again — subsequent pushes keep the visibility
+the package already has. **The workflow cannot do it:** `GITHUB_TOKEN` can push
+to a package with `packages: write` but cannot change its visibility, so there is
+no way to automate this from CI with the built-in token.
+
+Until the flip, **nothing can pull these images anonymously** — an
+unauthenticated `docker pull` / `docker buildx imagetools inspect` fails with
+`denied` or `unauthorized`, and it fails that way whether or not the repo itself
+is public. If a pull is denied, check package visibility *before* you suspect the
+tag. Public packages are also why no downstream consumer will need registry
+credentials or an `imagePullSecrets` entry.
+
+### `VITE_GOOGLE_MAPS_API_KEY` — optional repository secret
+
+`VITE_*` values are baked into the bundle at build time, so the web image's are
+fixed by the workflow rather than by the operator's `.env`. It passes two build
+args: `VITE_FARO_COLLECTOR_URL=/faro/collect` unconditionally (a same-origin
+path, not a secret — where nginx has no `/faro/` block the beacons just 404), and
+`VITE_GOOGLE_MAPS_API_KEY` from the repository secret of the same name.
+
+That secret is **optional**. Unset, it expands to empty, which matches
+`web-client/Dockerfile.uat`'s own default (`ARG VITE_GOOGLE_MAPS_API_KEY=""`):
+the build still succeeds and the shipped bundle degrades the venue map to a text
+fallback. Nothing here fails on a missing key.
+
+It is the **browser** Maps JS key — readable in the shipped bundle either way —
+and is *not* the server-side `GOOGLE_GEOCODING_API_KEY`, which stays a runtime
+secret in `.env`. Because one published bundle is served from every origin we
+deploy it to, its Google-console restrictions must cover **all** of them
+(`uat.fortymm.com`, the host `:8084` origin, the `https://fortymm-uat.<tailnet>.ts.net`
+name, plus any later prod origin) — a restriction list that misses one origin
+breaks the map only on that origin.
 
 ## Topology
 

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -52,10 +52,20 @@ first job rejects on any ref but `main`, since a non-main run would move the
 `:main` tag onto an unreviewed commit). Deliberately **not** on `pull_request` —
 an image built from a PR head is not deployable, so it would burn ~25 minutes of
 runner to produce something nothing can consume. Also deliberately **not**
-path-filtered: every commit on `main`, docs-only ones included, must have images
-under its own SHA, because the deploy path this is groundwork for looks images up
-by the deploying commit's SHA and a path filter would leave undeployable holes.
-Runs are serialized per ref and never cancelled in progress.
+path-filtered: the deploy path this is groundwork for deploys **main's tip** and
+looks the images up by that commit's SHA, so whatever commit is currently the tip
+needs images no matter what it touched — and a docs-only commit is very often the
+tip.
+
+**It does not follow that every commit on `main` gets images, and nothing here
+promises that.** Runs are serialized per ref and a run already in progress is
+never cancelled, but GitHub *does* cancel a **pending** run when a newer one
+queues into the same concurrency group. Merge three times inside one ~25-minute
+build window and the middle commit publishes nothing. That is tolerable only
+because the tip is the sole thing ever deployed and the newest queued run is the
+one that survives — so the tip always publishes. If you ever need to deploy a
+specific historical commit rather than the tip, check that its tag actually
+exists before assuming it does.
 
 **Two tags per image per run:** `:<12-char sha>` (one per commit — nothing
 registry-side pins it, so a re-run for the same commit overwrites it) and
@@ -80,9 +90,10 @@ runner, and that machine's architecture is not something this repo pins or can
 check — an amd64-only image would either fail to run there or run under
 emulation, depending on whose machine it is. A later Hetzner box is amd64, so
 one manifest list per tag serves both. The arm64 leg is QEMU-emulated on the
-amd64 runner and dominates the run — **~25 min is normal** (the jobs allow 90). Provenance attestations are off, so each index holds exactly the two
-platform manifests it claims and nothing pinning it by digest sees an
-`unknown/unknown` entry.
+amd64 runner and dominates the run — **~25 min is normal** (the jobs allow 90).
+Provenance attestations are off, so each index holds exactly the two platform
+manifests it claims and nothing pinning it by digest sees an `unknown/unknown`
+entry.
 
 Nothing consumes these images yet: `mise run redeploy-uat` still builds locally
 and `k3d image import`s (see `## Topology`). This section documents the

--- a/docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md
+++ b/docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md
@@ -16,10 +16,21 @@ this change exists to remove.
 
 ## The pod template names a digest, not a tag
 
-The publish workflow tags each image `<git-short-sha>` (plus a moving `main`),
-but the chart deploys `repository@sha256:…`: `redeploy-uat.sh` resolves the tag
-to its manifest-list digest at deploy time and passes
-`--set images.{api,web}.digest=`.
+The publish workflow tags each image with a **fixed 12-character truncation of
+the full commit SHA** (plus a moving `main`), but the chart deploys
+`repository@sha256:…`: `redeploy-uat.sh` resolves that tag to its manifest-list
+digest at deploy time and passes `--set images.{api,web}.digest=`.
+
+The truncation is deliberately **not** `git rev-parse --short`, and that is a
+decision rather than an implementation detail, because the two sides of it live
+in different repositories' worth of state. `--short` picks its length from the
+local object count (`core.abbrev=auto`) and from any `core.abbrev` the operator
+has set, so the same commit abbreviates to 7 in a shallow CI clone, 8 in a full
+clone of this repo today, and 9 once it grows. CI writes the tag and the deploy
+script reads it, so a length that drifts between those two clones is a
+tag-not-found on a commit that published perfectly well — and it would surface
+only on the operator's machine, after the merge, where no CI check can see it.
+Truncating the full SHA depends on no git configuration at all.
 
 This supersedes the `$(git rev-parse --short HEAD)-$(date +%s)` tag scheme, and
 the reasoning is worth keeping because the old scheme's rationale no longer
@@ -35,7 +46,7 @@ A digest is content-addressed, so the guarantee stops being a convention and
 becomes structural: two replicas naming the same digest **cannot** be running
 different content, and re-running the publish workflow for an
 already-published commit cannot silently change what UAT is running the way
-overwriting a `:<short-sha>` tag would. It also makes a same-commit redeploy a
+overwriting that SHA tag would. It also makes a same-commit redeploy a
 correct no-op rather than a pointless roll of both replicas — which is now the
 desired behaviour, since byte-identical content has nothing to roll to.
 

--- a/docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md
+++ b/docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md
@@ -1,0 +1,79 @@
+# UAT deploys published images, pinned by digest
+
+Until now `scripts/redeploy-uat.sh` built `api/Dockerfile.dev` and
+`web-client/Dockerfile.uat` on the operator's own machine and `k3d image
+import`ed them straight into the cluster, so the artifact UAT ran existed
+nowhere else and had never been through CI. As the first step toward a Hetzner
+production deploy (issue #1255), CI now builds those same two Dockerfiles once
+per commit on `main` and pushes them to `ghcr.io/mightymoose/fortymm-api` and
+`ghcr.io/mightymoose/fortymm-web-client`; UAT — and, later, prod — pulls the
+published image rather than building its own. **`redeploy-uat.sh` no longer
+builds anything**, and there is no `--local` escape hatch back to an
+unvalidated image: the script already refused to deploy from any branch but
+`main`, so the local build could never produce anything that wasn't already on
+`main` anyway, and keeping the path alive would only preserve the failure mode
+this change exists to remove.
+
+## The pod template names a digest, not a tag
+
+The publish workflow tags each image `<git-short-sha>` (plus a moving `main`),
+but the chart deploys `repository@sha256:…`: `redeploy-uat.sh` resolves the tag
+to its manifest-list digest at deploy time and passes
+`--set images.{api,web}.digest=`.
+
+This supersedes the `$(git rev-parse --short HEAD)-$(date +%s)` tag scheme, and
+the reasoning is worth keeping because the old scheme's rationale no longer
+applies. That epoch suffix existed to force a *new* image string on every
+deploy, because a local rebuild could produce different content under the same
+commit, and an unchanged pod template plus `pullPolicy: IfNotPresent` meant
+`helm upgrade` would leave both replicas on stale code — the incident recorded
+in `deploy/CLAUDE.md` as "UAT redeploy lands stale code — blank white page",
+where two `web-client` replicas served two different content-hashed bundles
+behind a round-robin nginx and ~half of page loads 404'd their JS chunk.
+
+A digest is content-addressed, so the guarantee stops being a convention and
+becomes structural: two replicas naming the same digest **cannot** be running
+different content, and re-running the publish workflow for an
+already-published commit cannot silently change what UAT is running the way
+overwriting a `:<short-sha>` tag would. It also makes a same-commit redeploy a
+correct no-op rather than a pointless roll of both replicas — which is now the
+desired behaviour, since byte-identical content has nothing to roll to.
+
+## Images are multi-arch; packages are public
+
+Both images are built for `linux/amd64` **and** `linux/arm64` via buildx, and
+published as a manifest list. UAT's k3d cluster runs on the operator's machine
+rather than a runner, so an amd64-only image would either fail to run there or
+run under emulation; the arm64 leg costs real CI time (it is QEMU-emulated on
+the amd64 runner) and is paid deliberately so that one published artifact
+serves both the operator's cluster today and an amd64 Hetzner box later,
+without a second decision.
+
+The packages are **public**, so nothing downstream needs credentials and the
+chart carries no `imagePullSecrets`. GHCR publishes packages **private on first
+push even from a public repository**, so this requires a one-time manual
+visibility flip per package after the first successful run; `redeploy-uat.sh`
+preflights anonymous pullability and fails with the exact click-path rather
+than letting the deploy die as an `ErrImagePull` five minutes into `helm
+--wait`.
+
+## Consequences
+
+- **Deploying UAT now depends on CI.** A merge is not deployable until the
+  publish workflow finishes (~20–30 min, dominated by the emulated arm64 leg).
+  `redeploy-uat.sh` waits for the digest with a bounded timeout and then exits
+  non-zero naming the commit and the workflow run, rather than deploying
+  something older without saying so.
+- **`VITE_*` build args are fixed at publish time.** `web-client/Dockerfile.uat`
+  bakes `VITE_FARO_COLLECTOR_URL` and `VITE_GOOGLE_MAPS_API_KEY` into the
+  bundle, and the operator's `.env` is no longer in that loop. Faro's collector
+  is a same-origin path (`/faro/collect`) and is passed unconditionally; the
+  Maps key becomes a repository secret. It is a *browser* key — readable in the
+  shipped bundle either way — so this moves where it is stored, not how exposed
+  it is, but its Google-console referrer restrictions must now cover every
+  origin that will serve this one bundle.
+- **`api/Dockerfile.dev` is still the published API image**, unchanged and
+  deliberately out of scope here. Its `--reload` CMD is already overridden by
+  the chart's explicit `command:`, so the only real cost is that `.[dev]` test
+  dependencies ship in the image. Slimming or renaming it belongs with the
+  Hetzner production work, not with this groundwork.


### PR DESCRIPTION
Slice 1 of 2 for #1255. Stacked PR — slice 2 (`…-s2`) makes UAT actually deploy from these images, and targets this branch.

## What this does

Adds `.github/workflows/publish-images.yml`, which builds the two Dockerfiles UAT already runs — `api/Dockerfile.dev` and `web-client/Dockerfile.uat`, no new Dockerfiles — for `linux/amd64` **and** `linux/arm64`, and pushes one manifest list per tag to `ghcr.io/mightymoose/fortymm-api` and `ghcr.io/mightymoose/fortymm-web-client`.

Nothing consumes these images yet. `mise run redeploy-uat` still builds locally and `k3d image import`s, exactly as before. That is deliberate — see "Why this is split in two" below.

Commits:
- `1a` — the publish workflow
- `1b` — the deploy runbook's new **Published images (GHCR)** section
- plus the ADR the whole arc was designed against, `docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md`

## Decisions, and why

The issue left two decisions open and didn't raise a third that turned out to matter more than either.

**Trigger: every push to `main`.** UAT tracks main's tip today (`redeploy-uat.sh` merges `origin/main` and deploys that commit), so publishing per-commit is what preserves current behaviour with no new release ceremony. Deliberately *not* path-filtered: every commit on `main` must carry images under its own SHA or it is undeployable, so filtering would leave undeployable holes on `main`. Deliberately *not* on `pull_request` either — an image built from a PR head is not deployable, so it would burn ~25 min of emulated-arm64 runner to produce something nothing can consume.

**Package visibility: public** — so nothing downstream needs credentials and no `imagePullSecrets` are required anywhere. **This needs a one-time manual step after the first successful run** (see below).

**Multi-arch, which the issue didn't mention.** UAT's k3d cluster runs on the operator's machine, not on an amd64 runner. An amd64-only image would either fail to run there or run under emulation, and the failure mode is a CrashLooping pod rather than a clear error. One manifest list serves both that machine today and an amd64 Hetzner box later. The arm64 leg is QEMU-emulated and dominates the run (~25 min); that cost is accepted deliberately.

**The tag is a fixed 12-character truncation of the commit SHA, not `git rev-parse --short`.** `--short` derives its length from the repository's object count and from any `core.abbrev` the operator has set — the same commit abbreviates to 7 in a shallow CI clone and 8 in a full clone of this repo today. Since slice 2's deploy script looks images up by exactly this string, a length that drifts between the two clones would read as a tag-not-found on a commit that published perfectly well — and it would only ever fail on the operator's machine, post-merge, where no pre-merge check can see it.

## ⚠️ Required manual step after merging

**GHCR publishes packages private on first push, even from a public repository — visibility is not inherited, and `GITHUB_TOKEN` cannot change it.** After the first successful run creates the packages, someone with repo admin must flip each one by hand:

> repository → **Packages** → the package → **Package settings** → **Change visibility** → **Public**

Once per package, so twice total (`fortymm-api`, `fortymm-web-client`). Until then nothing can pull them anonymously and slice 2's deploy path cannot work. This is documented in `deploy/CLAUDE.md` along with the `denied`/`unauthorized` symptom, so whoever hits it can find the cause by searching for what they saw.

**Optional:** a `VITE_GOOGLE_MAPS_API_KEY` repository secret. If unset the build still succeeds and the shipped bundle degrades the venue map to a text fallback — nothing fails. It is the *browser* Maps key, not the server-side geocoding key, and because one published bundle is served from every origin, its Google-console restrictions must cover all of them.

## Why this is split in two

Merging this slice is what *triggers the first publish*, which is what *creates the packages*, which is what makes the visibility flip possible at all. Slice 2's deploy path cannot work until that flip has happened. Shipping both at once would leave UAT undeployable between merge and flip.

## Verification — please read before approving

**A green CI run on this PR is not evidence that this works.** Nothing here is reachable by the existing suites, and by design the workflow does not run on pull requests. What was actually checked:

- `actionlint` (with `shellcheck`) clean on the new workflow — and **falsified**: injecting a bad `needs.tag.outputs.*` reference reds it for the stated reason, confirming the file is genuinely being type-checked rather than skipped.
- Every factual claim in the new runbook section re-read line by line against the workflow as written.

Still unproven, and only provable after merge: that the GHCR push succeeds, that the `type=gha` cache backend negotiates, that the emulated arm64 legs finish inside the 90-minute timeout, and that the resulting packages are usable. Mitigating evidence only — both Dockerfiles already build on amd64 (dev/e2e compose in CI) and on arm64 (the operator's current local `redeploy-uat` build), so per-arch base-image and wheel availability is not a new risk; behaviour under QEMU is.

Post-merge verification is a deliberate choice, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsJbh2ejf7tNLAGd6h3H5a

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsJbh2ejf7tNLAGd6h3H5a)_