### PR TITLE
Slice 2: deploy UAT from the published images, pinned by digest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,8 +69,12 @@ GOOGLE_GEOCODING_API_KEY=
 # Browser Google Maps JS API key, exposed to the web client via
 # import.meta.env.VITE_GOOGLE_MAPS_API_KEY. OPTIONAL: leave blank and the map
 # degrades to a text fallback (the intended default for dev, CI, e2e, and QA).
-# Being VITE_-prefixed it is baked into the bundle at build time, so
-# redeploy-uat.sh passes it as a --build-arg to the web image (and the QA/dev
-# compose stacks accept it as a build arg / dev-server env). Distinct from the
-# server-side GOOGLE_GEOCODING_API_KEY above.
+# Being VITE_-prefixed it is baked into the bundle at build time, which is why
+# this line no longer reaches UAT: UAT runs the web image CI publishes, and that
+# image was built before this file was ever read. For UAT/prod the key is the
+# `VITE_GOOGLE_MAPS_API_KEY` REPOSITORY SECRET consumed by
+# .github/workflows/publish-images.yml — setting it here has no effect there.
+# This line still applies to the QA/dev compose stacks, which do build locally
+# and accept it as a build arg / dev-server env. Distinct from the server-side
+# GOOGLE_GEOCODING_API_KEY above.
 VITE_GOOGLE_MAPS_API_KEY=

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -12,13 +12,12 @@ name: publish-images
 # build is discovered after merge rather than before it.
 #
 # Also deliberately NOT path-filtered, but for a different reason than
-# `api.yml`'s (which is about required status checks). `redeploy-uat.sh` is
-# being changed to merge `origin/main` and deploy its TIP, looking the images up
-# by that commit's SHA -- so whatever commit is currently the tip must have
-# images, no matter what it touched. A path filter would skip docs-only commits,
-# and a docs-only commit is very often the tip, which would leave `main`
-# undeployable until something else landed on top of it. (That script still
-# builds locally as of this commit -- the consuming half lands separately.)
+# `api.yml`'s (which is about required status checks). `redeploy-uat.sh` merges
+# `origin/main` and deploys its TIP, looking the images up by that commit's SHA
+# -- so whatever commit is currently the tip must have images, no matter what it
+# touched. A path filter would skip docs-only commits, and a docs-only commit is
+# very often the tip, which would leave `main` undeployable until something else
+# landed on top of it.
 #
 # Note what this does NOT promise: that *every* commit on `main` gets images.
 # The concurrency group below supersedes a PENDING run when a newer one queues,

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -105,28 +105,32 @@ half). The practical consequence is that **a merge is not deployable until this
 workflow has finished for it** — the deploy script waits for the digest rather
 than quietly deploying an older commit.
 
-### One-time per package: flip visibility to public
+### Package visibility — public automatically, no manual step
 
-**GHCR publishes a package private on its first push — even from a public
-repository. Visibility is not inherited from the repo.** After the first
-successful run that creates a package, someone with admin on the repo must flip
-it by hand:
+**Both packages came out public on the very first publish, with no manual
+step.** A package pushed by a workflow using `GITHUB_TOKEN` with
+`packages: write` is automatically *linked* to the repository that published it
+and inherits that repository's visibility — and this repo is public. Verified
+against the first run (commit `b17a29fa`): an unauthenticated pull of both
+`fortymm-api` and `fortymm-web-client` returned their manifests immediately.
 
-> repository → **Packages** → the package → **Package settings** → **Change
-> visibility** → **Public**
+This corrects what this file and
+`docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md` originally
+claimed. Both said GHCR publishes private on first push even from a public repo
+and that someone must flip each package by hand under *Package settings →
+Change visibility*. **That rule is real but does not apply here** — it governs
+packages published with a *personal access token* that are not linked to a
+repository. Nothing was flipped by hand for these two, and nothing needs to be.
 
-This is needed **once per package**, so twice in total (`fortymm-api`,
-`fortymm-web-client`), and never again — subsequent pushes keep the visibility
-the package already has. **The workflow cannot do it:** `GITHUB_TOKEN` can push
-to a package with `packages: write` but cannot change its visibility, so there is
-no way to automate this from CI with the built-in token.
+Public packages are why no downstream consumer needs registry credentials and
+why the chart carries no `imagePullSecrets`.
 
-Until the flip, **nothing can pull these images anonymously** — an
-unauthenticated `docker pull` / `docker buildx imagetools inspect` fails with
-`denied` or `unauthorized`, and it fails that way whether or not the repo itself
-is public. If a pull is denied, check package visibility *before* you suspect the
-tag. Public packages are also why no downstream consumer will need registry
-credentials or an `imagePullSecrets` entry.
+If an anonymous pull ever *is* denied (`denied` / `unauthorized` from
+`docker pull` or `docker buildx imagetools inspect`), the likely causes are that
+the package's visibility was changed by hand afterwards, or that the repository
+itself went private — check visibility before you suspect the tag.
+`redeploy-uat.sh` preflights this on every deploy and prints the click-path,
+so the guard remains even though the routine case needs it.
 
 ### `VITE_GOOGLE_MAPS_API_KEY` — optional repository secret
 

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -14,8 +14,10 @@ Caddy/DDNS/tailnet config and secret values live there, not in this repo.
 Infra has no single directory — it spans:
 
 - `deploy/uat/` — Helm chart for the prod-like **UAT** stack on a local **k3d**
-  cluster (postgres, redis, api ×5, worker, web-client ×2, routing nginx,
-  optional tailscale proxy; migrate+seed as a `post-install,post-upgrade` hook Job).
+  cluster (postgres, redis, api ×2, worker, web-client ×2, routing nginx,
+  optional tailscale proxy; migrate+seed as a `post-install,post-upgrade` hook
+  Job, retirement sweep as a CronJob). The api and web images are **pulled from
+  GHCR and pinned by digest** — nothing in this chart is built locally.
 - `deploy/observability/` — umbrella chart (kube-prometheus-stack + loki-stack
   + tempo) in the `monitoring` namespace, tailnet-only.
 - `docker-compose.{dev,qa,e2e}.yml` — the compose stacks. There is **no**
@@ -28,7 +30,9 @@ Infra has no single directory — it spans:
 - `.github/workflows/*.yml` — CI (api, web-client, e2e, openapi-schema, ios, …),
   including **`publish-images.yml`**, which pushes the api/web images to GHCR on
   every push to `main` (see `## Published images (GHCR)`).
-- `mise.toml` — toolchain pins + task runner (`redeploy-uat`, `regen-*-types`).
+- `mise.toml` — toolchain pins (node, python, `helm`, `k3d`) + task runner:
+  `redeploy-uat` (deploy published, digest-pinned images to k3d), `qa-down`,
+  `regen-*-types`, `ios-testflight`, and `release-beta` (UAT then TestFlight).
 
 ## Stacks at a glance
 
@@ -36,7 +40,7 @@ Infra has no single directory — it spans:
 |-------|-----|----------|-------|
 | dev   | `docker compose -f docker-compose.dev.yml up` | :8080 | dev servers, MSW off; real API |
 | QA    | up `scripts/qa-up.sh [id]` / down `scripts/qa-down.sh [id]` | :8085 (auto) | built artifacts, MSW off, **Mailpit :8087** captures all mail; multi-stack; **reap on merge** |
-| UAT   | `mise run redeploy-uat` | host :8084 → NodePort 30084 | **k3d/Helm — the one prod-like stack NOT on compose**; sends REAL Postmark email |
+| UAT   | `mise run redeploy-uat` | host :8084 → NodePort 30084 | **k3d/Helm — the one prod-like stack NOT on compose**; deploys **CI-published GHCR images pinned by digest** (builds nothing, so a merge isn't deployable until `publish-images` finishes); sends REAL Postmark email |
 
 ## Published images (GHCR)
 
@@ -52,10 +56,9 @@ first job rejects on any ref but `main`, since a non-main run would move the
 `:main` tag onto an unreviewed commit). Deliberately **not** on `pull_request` —
 an image built from a PR head is not deployable, so it would burn ~25 minutes of
 runner to produce something nothing can consume. Also deliberately **not**
-path-filtered: the deploy path this is groundwork for deploys **main's tip** and
-looks the images up by that commit's SHA, so whatever commit is currently the tip
-needs images no matter what it touched — and a docs-only commit is very often the
-tip.
+path-filtered: `redeploy-uat.sh` deploys **main's tip** and looks the images up
+by that commit's SHA, so whatever commit is currently the tip needs images no
+matter what it touched — and a docs-only commit is very often the tip.
 
 **It does not follow that every commit on `main` gets images, and nothing here
 promises that.** Runs are serialized per ref and a run already in progress is
@@ -95,9 +98,12 @@ Provenance attestations are off, so each index holds exactly the two platform
 manifests it claims and nothing pinning it by digest sees an `unknown/unknown`
 entry.
 
-Nothing consumes these images yet: `mise run redeploy-uat` still builds locally
-and `k3d image import`s (see `## Topology`). This section documents the
-publishing half only.
+**UAT consumes these images.** `mise run redeploy-uat` builds nothing: it
+resolves the deploying commit's `:<12-char sha>` tag to that manifest list's
+digest and deploys `repository@sha256:…` (see `## Topology` for the consuming
+half). The practical consequence is that **a merge is not deployable until this
+workflow has finished for it** — the deploy script waits for the digest rather
+than quietly deploying an older commit.
 
 ### One-time per package: flip visibility to public
 
@@ -145,7 +151,11 @@ breaks the map only on that origin.
 
 ## Topology
 
-**UAT runs on Kubernetes (Helm + k3d).** UAT is the one prod-like stack that does *not* use docker-compose. `scripts/redeploy-uat.sh` (a.k.a. `mise run redeploy-uat`) provisions a single-node **k3d** cluster `fortymm-uat`, builds the api/web images (same `api/Dockerfile.dev` + `web-client/Dockerfile.uat`), `k3d image import`s them, syncs Secrets from the gitignored `.env` + `secrets/*.p8`, and `helm upgrade --install`s the chart at **`deploy/uat/`**. The chart reproduces the old compose topology (postgres, redis, api, worker, web-client, routing nginx); migrations + seeds run as a `post-install,post-upgrade` Helm hook **Job** (not in the api boot command). Routing nginx is a **NodePort** (30084); k3d maps host **:8084** → that NodePort, so host Caddy (still pointing at `127.0.0.1:8084`) fronts uat.fortymm.com unchanged. Needs `helm` + `k3d` (`brew install helm k3d`). Inspect with `KUBECONFIG=$(k3d kubeconfig write fortymm-uat) kubectl get pods -n fortymm-uat`.
+**UAT runs on Kubernetes (Helm + k3d).** UAT is the one prod-like stack that does *not* use docker-compose. `scripts/redeploy-uat.sh` (a.k.a. `mise run redeploy-uat`) **builds nothing** — it deploys the images CI already published for the commit being deployed. It refuses any branch but `main` (or the legacy `uat-deploy` worktree), merges `origin/main` into it first so the deploy names the newest main, provisions a single-node **k3d** cluster `fortymm-uat`, resolves each package's `:<12-char sha>` tag to its **manifest-list digest** over the GHCR v2 API, syncs Secrets from the gitignored `.env` + `secrets/*.p8`, and `helm upgrade --install`s the chart at **`deploy/uat/`** with `--set images.api.digest=sha256:… --set images.web.digest=sha256:…` (`--wait --timeout 5m`). The chart reproduces the old compose topology (postgres, redis, api, worker, web-client, routing nginx); migrations + seeds run as a `post-install,post-upgrade` Helm hook **Job** (not in the api boot command). Routing nginx is a **NodePort** (30084); k3d maps host **:8084** → that NodePort, so host Caddy (still pointing at `127.0.0.1:8084`) fronts uat.fortymm.com unchanged. Needs `helm` + `k3d` (`brew install helm k3d`). Inspect with `KUBECONFIG=$(k3d kubeconfig write fortymm-uat) kubectl get pods -n fortymm-uat`.
+
+**Why a digest and not the tag.** `fortymm-uat.imageRef` in `_helpers.tpl` renders `repository@sha256:…` whenever a digest is set, and every workload that runs app code (api, worker, migrate Job, retirement CronJob, web-client) goes through it. A digest is content-addressed, so "every replica runs the same bytes" stops being a convention the deploy script has to maintain and becomes structural — two pods naming one digest *cannot* be running different content, and re-running the publish workflow for an already-published commit cannot change what UAT is serving the way overwriting a `:<sha>` tag would. Empty `digest` in `values.yaml` falls back to `repository:tag` (the moving `:main`) purely so `helm template deploy/uat` renders on its own; a real deploy always passes digests, and a set-but-malformed one fails the render rather than being tolerated. The old `$(short-sha)-$(epoch)` unique-tag scheme is gone and should not come back — it existed because a *local* rebuild could produce different content under one commit, so the pod template had to change to force a roll. Published images are immutable, so a same-commit redeploy is a correct no-op. See `docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md`.
+
+**Deploying now depends on CI.** The images for a commit exist only once `publish-images.yml` has finished for it (~25 min, dominated by the emulated arm64 leg), so a just-merged commit is not immediately deployable. The script polls GHCR every 30s for up to `DIGEST_WAIT_TIMEOUT_S` (default `2400`, i.e. 40 min) and then fails naming the commit and linking the workflow runs, rather than deploying an older commit without saying so. `DIGEST_WAIT_TIMEOUT_S=0` fails immediately instead of waiting. The anonymous digest read doubles as the public-visibility preflight (see the one-time flip under `## Published images (GHCR)`): if it resolves, the cluster can pull, which is why the chart carries no `imagePullSecrets` — and a package still private fails here with the click-path instead of dying as an `ErrImagePull` five minutes into `helm --wait`.
 
 **UAT is also on the tailnet.** The chart runs a `tailscale/tailscale` proxy (`deploy/uat/templates/tailscale.yaml`, `tailscale.enabled` in values, on by default) that fronts the routing nginx via `tailscale serve`, so UAT is reachable privately at **`https://fortymm-uat.<tailnet>.ts.net`** with auto-HTTPS — independent of the DDNS/router/Caddy chain (which still serves `uat.fortymm.com` unchanged; Tailscale is purely additive). It reads `TS_AUTHKEY` (a reusable, non-ephemeral key from the Tailscale admin console) straight from the `.env`-backed secret, so just add a `TS_AUTHKEY=tskey-...` line to `.env`; `redeploy-uat.sh` errors early if it's missing. The proxy persists its node identity in the `tailscale-state` Secret (survives restarts; no re-auth). Requires HTTPS certs + MagicDNS enabled in the tailnet. Set `tailscale.enabled=false` to skip it.
 
@@ -159,8 +169,9 @@ Prod-like compose stacks (built artifacts, no dev server, isolated volumes; only
 ## Common commands
 
 ```bash
-mise run redeploy-uat                 # rebuild + helm upgrade the k3d UAT stack, smoke-check uat.fortymm.com
+mise run redeploy-uat                 # helm upgrade the k3d UAT stack onto this commit's published GHCR images (digest-pinned); smoke-check uat.fortymm.com
 DEPLOY_OBSERVABILITY=false mise run redeploy-uat   # skip the monitoring chart
+DIGEST_WAIT_TIMEOUT_S=0 mise run redeploy-uat      # don't wait on publish-images; fail now if this commit has no images
 scripts/qa-up.sh [id]                 # bring up an isolated QA stack on a free port trio; prints QA_URL / Mailpit URL
 scripts/qa-down.sh [id]               # reap that stack: containers, volumes (named + anonymous), networks, built images
 scripts/qa-down.sh --dry-run [id]     # preview what would be removed
@@ -188,23 +199,71 @@ unprompted.**
   `index.html` from one web pod but its hashed JS chunk 404s because it was
   routed (round-robin, no session affinity) to the *other* web pod running a
   different built bundle.
-- **Cause:** The two `web-client` replicas are on **different image digests**.
-  This happens when the unique-tag scheme is bypassed — re-importing content
-  under the mutable `:uat` tag (still the `values.yaml` default) that only one
-  pod picks up, a manual `helm upgrade` without `--set images.*.tag=<unique>`,
-  or a single web pod rescheduling and drifting from its sibling. `helm upgrade`
-  then sees an unchanged pod template (`pullPolicy: IfNotPresent`) and keeps old
-  pods running stale code.
-- **`mise run redeploy-uat` prevents this by design:** it tags every build
-  `$(git short-sha)-$(epoch)` and passes `--set images.{api,web}.tag`, so the pod
-  template changes and both deployments roll atomically (zero-downtime
-  RollingUpdate, `maxUnavailable: 0`). **Use the script, not a bare
-  `helm upgrade`.**
-- **Fix (if it bites):** diagnose by comparing `imageID` across the two web pods
-  (`kubectl get pods -n fortymm-uat -l ... -o jsonpath` / describe) — if they
-  differ, `kubectl rollout restart deploy/web-client -n fortymm-uat` converges
-  them. **[destructive/shared]** — a rollout restart on shared UAT is the user's
-  call.
+- **Cause:** The two `web-client` replicas are serving **different builds**.
+  Kubernetes cannot see this — the readiness probe is `GET /`, which any bundle
+  answers 200 — so both pods are Ready and the Service round-robins between two
+  incompatible SPAs.
+- **The original cause is now structurally impossible.** It was a *mutable tag*:
+  content re-imported under `:uat`, which only one pod ever picked up, plus
+  `pullPolicy: IfNotPresent` leaving `helm upgrade` with an unchanged pod
+  template and no reason to roll. Pods now name `repository@sha256:<digest>`
+  (`fortymm-uat.imageRef`), and a digest is content-addressed: two replicas
+  naming one digest cannot be running different bytes, whenever either of them
+  was scheduled. That also retires the `$(short-sha)-$(epoch)` tag scheme that
+  used to be the countermeasure — see `## Topology`.
+- **What can still produce it:**
+  1. **A deploy that reached the chart's tag fallback instead of a digest.**
+     With `images.*.digest` empty the chart renders `repository:main` — and
+     `:main` moves on every push to `main`. Under `IfNotPresent` each pod
+     resolves that string only when it actually pulls, so a pod created before a
+     merge and its replacement created after one sit on different images with an
+     identical pod template, and Helm rolls nothing. This is the old failure
+     mode wearing a new tag. Reached by a bare `helm upgrade`/`helm install`
+     without `--set images.{api,web}.digest=`, or by `helm template` piped into
+     `kubectl apply`. `redeploy-uat.sh` is the **only** thing that supplies the
+     digests, and it asserts their shape before deploying precisely because an
+     *empty* digest is not malformed to the chart — it is the documented
+     render-only fallback, so it would deploy the moving tag in silence.
+     **Use the script, not a bare `helm upgrade`** — more load-bearing now, not
+     less.
+  2. **Mid-rollout, briefly and legitimately.** `maxUnavailable: 0` +
+     `maxSurge: 1` means old and new Ready pods overlap by design, so the entry
+     hash flips while a deploy is in flight. It is only a bug if it persists
+     after `kubectl rollout status deploy/web-client -n fortymm-uat` returns.
+  3. **Not the pods at all.** If both pods share one `imageID` and the hash
+     still flips, the divergence is above them: a PWA service worker holding an
+     old `index.html` browser-side (see the QA entry below), or a second stack
+     answering on the same host port.
+- **Fix (if it bites):** compare `imageID` across the two web pods
+  (`kubectl get pods -n fortymm-uat -l app.kubernetes.io/component=web -o
+  jsonpath='{.items[*].status.containerStatuses[*].imageID}'`). If they differ,
+  check what the pod template actually names:
+  `kubectl get deploy/web-client -n fortymm-uat -o jsonpath='{.spec.template.spec.containers[0].image}'`
+  — a `…:main` there rather than `…@sha256:…` means the deploy bypassed the
+  script, and the fix is to re-run `mise run redeploy-uat`, which pins both
+  deployments to one digest and rolls them atomically. `kubectl rollout restart
+  deploy/web-client -n fortymm-uat` also converges them, but onto whatever the
+  tag resolves to *now*, so it treats the symptom and leaves the cause.
+  **[destructive/shared]** — a rollout restart on shared UAT is the user's call.
+
+### `redeploy-uat` won't deploy: "no image published for … after 2400s"
+
+- **Symptom:** The script prints `ghcr.io/mightymoose/fortymm-<pkg>:<12-char
+  sha> not published yet — waiting up to 2400s`, then eventually
+  `ERROR: no image published for … after 2400s` and exits without deploying.
+- **Cause:** `publish-images.yml` has not produced images for the commit at
+  HEAD (after the script's `git merge origin/main`). Either the run is still
+  going (~25 min, emulated arm64), or it failed for that commit, or HEAD is not
+  a commit that exists on `origin/main` — only pushed `main` commits are ever
+  published.
+- **Fix:** check the workflow runs, then re-run the script. It deliberately does
+  **not** fall back to an older commit's images: silently running something other
+  than the commit you asked for is the failure mode this path exists to remove.
+  `DIGEST_WAIT_TIMEOUT_S=0` turns the wait into an immediate failure when you
+  only want to know whether images exist.
+- **Not this:** `ERROR: anonymous pull DENIED for ghcr.io/…` is the *other*
+  registry failure — a package that is still private (or does not exist yet),
+  fixed by the one-time visibility flip above, not by waiting.
 
 ### UAT DB keeps the OLD schema — every endpoint on a changed table 500s
 
@@ -218,14 +277,18 @@ unprompted.**
   already in `alembic_version` and no-ops — so the schema never advances while
   the new code expects it.
 - **Fix (wipe + re-migrate):** scale api/worker to 0, drop and recreate the
-  schema, then `helm upgrade` to re-fire the post-upgrade migrate+seed hook Job:
+  schema, then re-deploy to re-fire the post-upgrade migrate+seed hook Job:
   ```bash
   kubectl scale deploy/api deploy/worker --replicas=0 -n fortymm-uat
   # psql into the postgres pod, then:  DROP SCHEMA public CASCADE; CREATE SCHEMA public;
-  helm upgrade ...            # re-runs the migrate Job against the empty schema
+  mise run redeploy-uat       # re-runs the migrate Job against the empty schema
   ```
   **[destructive/shared]** — `DROP SCHEMA` wipes all UAT data; confirm with the
   user before running it.
+  Re-deploy through the script, not a bare `helm upgrade`: an upgrade with no
+  `--set images.*.digest=` resets those values to the chart's empty defaults and
+  drops the whole release back onto the moving `:main` tag — the blank-page entry
+  above. (`--reuse-values` keeps them, but the script is the fewer-footguns path.)
 
 ### Compose nginx 502 with stale upstream IPs
 
@@ -278,9 +341,11 @@ unprompted.**
 3. Authed BFF endpoints return **200, not 500**.
 4. Web entry hash is stable across reloads (`curl -s <url>/` in a loop — the
    `assets/index-*.js` hash must not flip).
-5. On k3d UAT, both `web-client` pods share **one `imageID`** (no digest drift) —
-   this is exactly what the unique-tag scheme guarantees and a manual
-   `helm upgrade` breaks.
+5. On k3d UAT, both `web-client` pods share **one `imageID`** (no digest drift).
+   Digest pinning makes this true by construction, so the check is now a check
+   *that the deploy went through the script*: a bare `helm upgrade` falls back to
+   the moving `:main` tag, where drift is possible again. Confirm the pod
+   template names `…@sha256:…`, not `…:main`.
 
 ## Note on host-specific details
 

--- a/deploy/uat/templates/_helpers.tpl
+++ b/deploy/uat/templates/_helpers.tpl
@@ -11,14 +11,49 @@ app.kubernetes.io/name: fortymm-uat
 app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 
-{{/* Fully-qualified api image reference. */}}
+{{/*
+Image reference for one of the two app images. Pass the image's values dict
+(e.g. .Values.images.api), which carries `repository`, `tag` and `digest`.
+
+Renders `repository@sha256:…` whenever a digest is set, because a digest is
+content-addressed: every workload that includes this helper is then provably
+running the same bytes, instead of trusting that a tag still points where it
+did when the last replica pulled it. That guarantee is the whole point — see
+docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md and the
+"UAT redeploy lands stale code" incident in deploy/CLAUDE.md, where two
+web-client replicas resolved one mutable tag to two different images and half
+of all page loads 404'd their JS chunk.
+
+With no digest it falls back to `repository:tag` so the chart stays renderable
+on its own (`helm template deploy/uat`) — but a digest that is set and
+malformed is NOT tolerated: it would silently produce a reference that either
+fails to pull or, worse, resolves to something other than what the deployer
+meant. Values are input from outside the chart, so parse them here at the
+boundary and fail the render loudly instead.
+*/}}
+{{- define "fortymm-uat.imageRef" -}}
+{{- if .digest -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" .digest) -}}
+{{- fail (printf "images digest for %s must be a full manifest digest of the form sha256:<64 hex chars>, got %q" .repository .digest) -}}
+{{- end -}}
+{{ .repository }}@{{ .digest }}
+{{- else -}}
+{{ .repository }}:{{ .tag }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Fully-qualified api image reference. Shared by the api Deployment, the worker
+Deployment, the migrate hook Job and the retirement-sweep CronJob — they must
+resolve through this one helper so they cannot end up on different artifacts.
+*/}}
 {{- define "fortymm-uat.apiImage" -}}
-{{ .Values.images.api.repository }}:{{ .Values.images.api.tag }}
+{{- include "fortymm-uat.imageRef" .Values.images.api -}}
 {{- end -}}
 
 {{/* Fully-qualified web image reference. */}}
 {{- define "fortymm-uat.webImage" -}}
-{{ .Values.images.web.repository }}:{{ .Values.images.web.tag }}
+{{- include "fortymm-uat.imageRef" .Values.images.web -}}
 {{- end -}}
 
 {{/*

--- a/deploy/uat/values.yaml
+++ b/deploy/uat/values.yaml
@@ -1,19 +1,45 @@
 # Values for the fortymm-uat chart. Most knobs mirror the prod-like QA
 # compose stack (docker-compose.qa.yml).
-# Images are built locally and `k3d image import`-ed, so pullPolicy is
-# IfNotPresent and no registry/repository prefix is used.
 
+# The api and web images are the ones CI publishes to GHCR from
+# api/Dockerfile.dev and web-client/Dockerfile.uat on every push to `main`
+# (.github/workflows/publish-images.yml). UAT deploys what CI built; it no
+# longer builds its own. The package names are NOT the repo's internal
+# `fortymm/{api,web}` — they are what the workflow pushes.
+#
+# `digest` is empty here and filled in at deploy time
+# (`--set images.api.digest=sha256:…` from scripts/redeploy-uat.sh), which is
+# what a real deploy always does. Naming the manifest digest rather than the
+# tag makes "every replica runs the same code" structural instead of
+# conventional: a tag can be moved or resolved differently by two nodes, a
+# digest cannot. The blank-white-page incident in deploy/CLAUDE.md is what
+# that costs when it isn't true. See
+# docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md.
+#
+# The tag is only the fallback for rendering the chart without a deploy
+# (`helm template deploy/uat`), so it names the moving `:main` tag the same
+# workflow publishes — something that actually exists and is pullable, rather
+# than a label no registry would answer for.
 images:
   api:
-    repository: fortymm/api
-    tag: uat
+    repository: ghcr.io/mightymoose/fortymm-api
+    tag: main
+    digest: ""
   web:
-    repository: fortymm/web
-    tag: uat
+    repository: ghcr.io/mightymoose/fortymm-web-client
+    tag: main
+    digest: ""
   postgres: postgres:16-alpine
   redis: redis:7-alpine
   nginx: nginx:1.27-alpine
 
+# IfNotPresent stays correct now that images come from a registry, for a
+# different reason than before: it used to mean "never pull, the image was
+# `k3d image import`-ed and exists nowhere else", and it now means "a digest
+# already on the node is by definition the exact bytes requested, so re-pulling
+# it can only cost time". `Always` would buy nothing against a content-addressed
+# reference while making every pod start — including postgres/redis/nginx, which
+# share this value — depend on registry reachability.
 pullPolicy: IfNotPresent
 
 # Stateless request-serving tiers scale horizontally with a zero-downtime

--- a/docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md
+++ b/docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md
@@ -61,12 +61,24 @@ serves both the operator's cluster today and an amd64 Hetzner box later,
 without a second decision.
 
 The packages are **public**, so nothing downstream needs credentials and the
-chart carries no `imagePullSecrets`. GHCR publishes packages **private on first
-push even from a public repository**, so this requires a one-time manual
-visibility flip per package after the first successful run; `redeploy-uat.sh`
-preflights anonymous pullability and fails with the exact click-path rather
-than letting the deploy die as an `ErrImagePull` five minutes into `helm
---wait`.
+chart carries no `imagePullSecrets`.
+
+This ADR originally said that would require a one-time manual visibility flip
+per package, because GHCR publishes packages private on first push even from a
+public repository. **That turned out not to apply here, and the correction is
+worth recording rather than quietly deleting.** The private-by-default rule
+governs packages published with a personal access token that are not linked to
+a repository; a package pushed by a workflow using `GITHUB_TOKEN` with
+`packages: write` is automatically linked to the publishing repository and
+inherits its visibility. Verified against the first real publish (commit
+`b17a29fa`): both packages were anonymously pullable immediately, and nothing
+was flipped by hand.
+
+`redeploy-uat.sh` still preflights anonymous pullability and fails with the
+click-path rather than letting the deploy die as an `ErrImagePull` five minutes
+into `helm --wait`. That guard is worth keeping even though the routine case no
+longer needs it — it still catches a package whose visibility is changed later,
+or a repository that goes private.
 
 ## Consequences
 

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ helm = "latest"
 k3d = "latest"
 
 [tasks.redeploy-uat]
-description = "Rebuild images and helm-deploy the fortymm-uat k3d cluster; smoke-check https://uat.fortymm.com"
+description = "Helm-deploy this commit's published GHCR images (pinned by digest) to the fortymm-uat k3d cluster; smoke-check https://uat.fortymm.com"
 run = "./scripts/redeploy-uat.sh"
 
 [tasks.qa-down]

--- a/scripts/redeploy-uat.sh
+++ b/scripts/redeploy-uat.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-# Rebuild and (re)deploy the fortymm-uat stack on a local k3d Kubernetes
-# cluster via Helm, then smoke-check https://uat.fortymm.com. Run from
-# anywhere — the script cd's to the repo root.
+# (Re)deploy the fortymm-uat stack on a local k3d Kubernetes cluster via Helm,
+# then smoke-check https://uat.fortymm.com. Run from anywhere — the script cd's
+# to the repo root.
+#
+# This script BUILDS NOTHING. The api and web-client images come from GHCR,
+# published per commit on `main` by .github/workflows/publish-images.yml, and
+# are deployed pinned by manifest digest. A merge is therefore not deployable
+# until that workflow finishes (~20-30 min, dominated by the emulated arm64
+# leg). See docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md.
 #
 # Run from `main` or the legacy `uat-deploy` worktree. The UAT-only config
 # (this script, deploy/uat/ Helm chart, Dockerfiles) lives on main, so
@@ -13,7 +19,7 @@
 # which fans out to the api / web-client Services. So no Caddyfile change is
 # needed when moving from docker-compose to k8s.
 #
-# Requirements: docker, kubectl, helm, k3d (brew install helm k3d).
+# Requirements: docker, curl, kubectl, helm, k3d (brew install helm k3d).
 
 set -euo pipefail
 
@@ -26,10 +32,26 @@ RELEASE="fortymm-uat"
 CHART="deploy/uat"
 HOST_PORT=8084
 NODE_PORT=30084
-API_REPO="fortymm/api"
-WEB_REPO="fortymm/web"
 APNS_KEY="secrets/AuthKey_68VYRLMWWR.p8"
 UAT_URL="${UAT_URL:-https://uat.fortymm.com}"
+
+# The two GHCR packages publish-images.yml pushes. These three files must name
+# the same packages: the workflow's API_IMAGE/WEB_IMAGE env, deploy/uat/values.yaml's
+# images.{api,web}.repository, and here. (A mismatch is loud, not silent: the
+# digest resolved from one package does not exist in another, so the pull fails.)
+GHCR_OWNER="mightymoose"
+API_PACKAGE="fortymm-api"
+WEB_PACKAGE="fortymm-web-client"
+PUBLISH_RUNS_URL="https://github.com/${GHCR_OWNER}/fortymm/actions/workflows/publish-images.yml"
+
+# How long to wait for the deploying commit's images to appear in GHCR before
+# giving up. The publish is multi-arch and its arm64 leg is QEMU-emulated on an
+# amd64 runner, so ~20-30 min is normal and the jobs themselves allow 90; 40
+# minutes covers a normal run plus queue time without hanging a terminal all
+# day. Deploying straight after a merge is the case this exists for. Override
+# with DIGEST_WAIT_TIMEOUT_S=0 to fail immediately instead of waiting.
+DIGEST_WAIT_TIMEOUT_S="${DIGEST_WAIT_TIMEOUT_S:-2400}"
+DIGEST_POLL_INTERVAL_S="${DIGEST_POLL_INTERVAL_S:-30}"
 
 # Observability stack (kube-prometheus-stack + loki-stack + tempo) in its own
 # namespace/release. Set DEPLOY_OBSERVABILITY=false to skip it.
@@ -41,7 +63,7 @@ DEPLOY_OBSERVABILITY="${DEPLOY_OBSERVABILITY:-true}"
 # Read a single value from .env, stripping one layer of surrounding quotes.
 read_env() { grep "^$1=" .env | head -1 | cut -d= -f2- | sed -e "s/^[\"']//" -e "s/[\"']\$//"; }
 
-for bin in docker kubectl helm k3d; do
+for bin in docker curl kubectl helm k3d; do
   command -v "$bin" >/dev/null 2>&1 || { echo "ERROR: '$bin' not found on PATH." >&2; exit 1; }
 done
 
@@ -66,22 +88,23 @@ else
   echo "(advanced $branch: $before -> $after)"
 fi
 
-# Tag every build with a unique id (post-merge commit + build epoch) instead of
-# a static `:uat`. The tag is the image string in the pod template, so a unique
-# tag makes `helm upgrade` see a changed template and roll both deployments
-# atomically (honoring the zero-downtime RollingUpdate). With the old mutable
-# `:uat` tag the template never changed, so a redeploy re-imported new content
-# under the same tag but never rolled — and when only one web replica later
-# restarted on its own it drifted onto the new build while its sibling stayed on
-# the old one. The two content-hashed SPA bundles then sat behind the
-# round-robin routing nginx, so ~half of loads fetched index.html from one pod
-# but got its `assets/index-*.js` chunk routed to the other → 404 → blank page.
-# The epoch suffix forces a fresh roll even on a same-commit rebuild. (Old
-# unique tags accumulate in the k3d image store; prune with `k3d image` /
-# `docker image prune` if it grows.)
-IMAGE_TAG="$(git rev-parse --short HEAD)-$(date +%s)"
-API_IMAGE="${API_REPO}:${IMAGE_TAG}"
-WEB_IMAGE="${WEB_REPO}:${IMAGE_TAG}"
+# The tag CI published this commit's images under: a FIXED 12-character
+# truncation of the full SHA, computed AFTER the merge above so it names what is
+# actually about to be deployed.
+#
+# Deliberately NOT `git rev-parse --short`. That picks its length from the
+# repository's object count (`core.abbrev=auto`) and from any `core.abbrev` the
+# operator has set — 8 characters in this clone today, 9 once it grows, 7 in a
+# shallow clone. publish-images.yml tags with `${GITHUB_SHA::12}`, and the two
+# MUST agree exactly: a length that drifts turns a commit that published
+# perfectly well into a tag-not-found. Keep this line and that one in lockstep.
+#
+# There is no epoch suffix any more, and reintroducing one would be a mistake.
+# It existed because a LOCAL rebuild could produce different content under one
+# commit, so the pod template had to change to force a roll. Published images
+# are immutable and pinned below by digest, so a same-commit redeploy is a
+# correct no-op — byte-identical content has nothing to roll to.
+IMAGE_TAG="$(git rev-parse HEAD | cut -c1-12)"
 
 # --- cluster ----------------------------------------------------------------
 echo
@@ -106,31 +129,168 @@ KUBECONFIG="$(k3d kubeconfig write "$CLUSTER")"
 kubectl get namespace "$NAMESPACE" >/dev/null 2>&1 || kubectl create namespace "$NAMESPACE"
 
 # --- images -----------------------------------------------------------------
-echo
-echo "==> Building images"
-docker build -t "$API_IMAGE" -f api/Dockerfile.dev api
-# Enable Grafana Faro in the UAT bundle: telemetry posts same-origin to
-# /faro/collect, which the routing nginx forwards to Alloy in `monitoring`.
-WEB_BUILD_ARGS=()
-if [ "$DEPLOY_OBSERVABILITY" = "true" ]; then
-  WEB_BUILD_ARGS+=(--build-arg "VITE_FARO_COLLECTOR_URL=/faro/collect")
-fi
-# Bake the browser Google Maps key into the UAT bundle when the operator has set
-# it in .env. OPTIONAL: unset/blank => no build arg, the bundle ships without a
-# Maps key and the map component falls back to a text render (keyless build stays
-# valid). This is the *browser* key; the server-side GOOGLE_GEOCODING_API_KEY is
-# synced into the fortymm-uat-env Secret below, not passed as a build arg.
-# `|| true`: read_env greps .env under `set -e -o pipefail`, so an absent
-# (optional) line would otherwise abort the deploy — swallow that miss.
-VITE_GOOGLE_MAPS_API_KEY="$(read_env VITE_GOOGLE_MAPS_API_KEY || true)"
-if [ -n "$VITE_GOOGLE_MAPS_API_KEY" ]; then
-  WEB_BUILD_ARGS+=(--build-arg "VITE_GOOGLE_MAPS_API_KEY=$VITE_GOOGLE_MAPS_API_KEY")
-fi
-docker build -t "$WEB_IMAGE" "${WEB_BUILD_ARGS[@]+"${WEB_BUILD_ARGS[@]}"}" -f web-client/Dockerfile.uat web-client
+# Nothing is built here. Each package's `:<12-char sha>` tag is resolved to the
+# digest of its MANIFEST LIST (the multi-arch index, not one platform's
+# manifest) through the registry v2 API, anonymously — the packages are public,
+# which is also why the chart carries no imagePullSecrets. The pods then name
+# `repository@sha256:…`, so "every replica runs the same bytes" is structural
+# rather than conventional; see the "UAT redeploy lands stale code" incident in
+# deploy/CLAUDE.md for what it costs when it isn't.
+#
+# That one anonymous read doubles as the public-visibility preflight, at no
+# extra request: GHCR publishes a package PRIVATE on its first push even from a
+# public repo, and an anonymous read of a private package is refused — so if the
+# resolve succeeds, the cluster can pull. Failing here with the click-path beats
+# an ErrImagePull discovered five minutes into `helm --wait`.
+
+# Mint an anonymous pull token for one package. GHCR wants a bearer token even
+# for public packages. A package that is private — or that no successful publish
+# has created yet — gets no token at all: the endpoint answers with an
+# {"errors":[{"code":"DENIED",…}]} body carrying no `token` field. That absence
+# is the visibility signal.
+#
+# Returns: 0 + token on stdout, 2 if ghcr.io was unreachable (curl already said
+# why on stderr, and that is NOT a visibility problem), 1 if access was denied.
+ghcr_pull_token() {
+  local pkg="$1" body token
+  body="$(curl -sS --max-time 20 \
+    "https://ghcr.io/token?scope=repository:${GHCR_OWNER}/${pkg}:pull")" || return 2
+  token="$(printf '%s' "$body" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+  [ -n "$token" ] || return 1
+  printf '%s' "$token"
+}
+
+# The one-time-per-package manual step, printed wherever the registry says no.
+ghcr_visibility_help() {
+  local pkg="$1"
+  echo "ERROR: anonymous pull DENIED for ghcr.io/${GHCR_OWNER}/${pkg}." >&2
+  echo "       Either no publish has created this package yet, or it is still private." >&2
+  echo "       GHCR publishes a package private on its first push even from a public repo," >&2
+  echo "       and visibility is not inherited from the repo. Flip it BY HAND, once per" >&2
+  echo "       package (never again after that):" >&2
+  echo "         github.com/${GHCR_OWNER}/fortymm -> Packages -> ${pkg} ->" >&2
+  echo "         Package settings -> Change visibility -> Public" >&2
+  echo "       The workflow cannot do this: GITHUB_TOKEN can push to a package but cannot" >&2
+  echo "       change its visibility. Runs: $PUBLISH_RUNS_URL" >&2
+}
+
+# HEAD one manifest and print its Docker-Content-Digest. HEAD is enough — the
+# digest is a response header — and skips pulling a body we would discard.
+#
+# The Accept header is load-bearing, and its failure mode is nastier than it
+# looks. It names the OCI image index and the Docker manifest-list media types,
+# so the registry answers for the multi-arch INDEX and returns the index's
+# digest. GHCR does not content-negotiate down to a platform manifest when those
+# types are missing — measured against a public multi-arch package, dropping
+# this header (or sending only the single-manifest type) returns a flat **404**.
+# That would read here as "not published yet" and send the operator into a
+# 40-minute wait for an image that has existed all along. Do not trim it.
+#
+# Returns: 0 + digest on stdout, 2 if the tag is not there (404), 3 if the
+# registry refused the read (401/403), 1 otherwise. The 401/403 case is
+# defensive: GHCR refuses a package we may not read at the TOKEN endpoint above,
+# and answers this endpoint 404 — not 403 — when the token is valid but scoped
+# to another package, so in practice a refusal never reaches here. It is kept so
+# an unauthenticated or differently-behaved registry read reports "denied"
+# rather than being mistaken for "not published yet" and waited on.
+ghcr_manifest_digest() {
+  local pkg="$1" tag="$2" token="$3" headers status digest
+  headers="$(mktemp)"
+  status="$(curl -sS --max-time 20 --head -o /dev/null -D "$headers" -w '%{http_code}' \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+    "https://ghcr.io/v2/${GHCR_OWNER}/${pkg}/manifests/${tag}")" || { rm -f "$headers"; return 1; }
+  # Header names are case-insensitive and the line ends in CRLF; awk (not grep)
+  # so a no-match can't abort the pipeline under `set -o pipefail`.
+  digest="$(tr -d '\r' <"$headers" | awk 'tolower($1) == "docker-content-digest:" { print $2 }' | tail -1)"
+  rm -f "$headers"
+  case "$status" in
+    200)
+      # A 200 with no digest header would leave $digest empty, and an empty
+      # digest is the one bad value the chart tolerates (it falls back to the
+      # tag). Refuse to print it.
+      [ -n "$digest" ] || { echo "ERROR: ${pkg}:${tag} returned 200 with no Docker-Content-Digest header." >&2; return 1; }
+      printf '%s' "$digest"
+      ;;
+    404) return 2 ;;
+    401 | 403) return 3 ;;
+    *) echo "ERROR: unexpected HTTP $status resolving ghcr.io/${GHCR_OWNER}/${pkg}:${tag}." >&2; return 1 ;;
+  esac
+}
+
+# Resolve one package's tag to its manifest-list digest, waiting out a publish
+# that is still running. Prints ONLY the digest on stdout — every progress and
+# error line goes to stderr, because callers capture this in `$(…)`.
+resolve_published_digest() {
+  local pkg="$1" tag="$2" token digest rc started deadline now attempt=0
+  started="$(date +%s)"
+  deadline=$(( started + DIGEST_WAIT_TIMEOUT_S ))
+  while :; do
+    # Re-minted every attempt on purpose: these tokens are short-lived, and a
+    # wait measured in tens of minutes would otherwise start 401ing halfway
+    # through and read as a registry error.
+    rc=0
+    token="$(ghcr_pull_token "$pkg")" || rc=$?
+    case "$rc" in
+      0) ;;
+      2) echo "ERROR: could not reach ghcr.io for a pull token (see curl's message above)." >&2
+         return 1 ;;
+      *) ghcr_visibility_help "$pkg"; return 1 ;;
+    esac
+
+    rc=0
+    digest="$(ghcr_manifest_digest "$pkg" "$tag" "$token")" || rc=$?
+    case "$rc" in
+      0) printf '%s' "$digest"; return 0 ;;
+      2) ;;  # tag not there yet — fall through to the wait below
+      3) ghcr_visibility_help "$pkg"; return 1 ;;
+      *) return 1 ;;  # already explained itself; not worth retrying
+    esac
+
+    now="$(date +%s)"
+    if [ "$now" -ge "$deadline" ]; then
+      echo "ERROR: no image published for ghcr.io/${GHCR_OWNER}/${pkg}:${tag} after ${DIGEST_WAIT_TIMEOUT_S}s." >&2
+      echo "       Commit $(git rev-parse HEAD) has no images. Either publish-images is still" >&2
+      echo "       running or it failed for this commit, or HEAD is not a commit that exists on" >&2
+      echo "       origin/main (only pushed main commits are ever published)." >&2
+      echo "       Check $PUBLISH_RUNS_URL, then re-run this script." >&2
+      echo "       NOT deploying an older commit instead: silently running something other than" >&2
+      echo "       the commit you asked for is the failure mode this whole path exists to remove." >&2
+      return 1
+    fi
+
+    attempt=$((attempt + 1))
+    if [ "$attempt" -eq 1 ]; then
+      echo "    ghcr.io/${GHCR_OWNER}/${pkg}:${tag} not published yet — waiting up to ${DIGEST_WAIT_TIMEOUT_S}s." >&2
+      echo "    (multi-arch publish takes ~20-30 min: $PUBLISH_RUNS_URL)" >&2
+    elif [ $((attempt % 4)) -eq 0 ]; then
+      echo "    still waiting for ${pkg}:${tag} ($(( now - started ))s elapsed of ${DIGEST_WAIT_TIMEOUT_S}s)" >&2
+    fi
+    sleep "$DIGEST_POLL_INTERVAL_S"
+  done
+}
+
+# Belt and braces on top of the chart's own validation. The chart FAILS the
+# render on a malformed digest, but an EMPTY one is not malformed there — it is
+# the documented "render without a deploy" fallback, so it would quietly deploy
+# the moving `:main` tag instead of this commit. Check the shape here, where an
+# unset digest is unambiguously a bug in this script.
+assert_digest() {
+  local what="$1" value="$2"
+  [[ "$value" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+    echo "ERROR: resolved $what digest is not a sha256 manifest digest: '${value}'" >&2
+    exit 1
+  }
+}
 
 echo
-echo "==> Importing images into k3d"
-k3d image import "$API_IMAGE" "$WEB_IMAGE" -c "$CLUSTER"
+echo "==> Resolving published image digests for $IMAGE_TAG"
+API_DIGEST="$(resolve_published_digest "$API_PACKAGE" "$IMAGE_TAG")" || exit 1
+assert_digest "$API_PACKAGE" "$API_DIGEST"
+echo "    ${API_PACKAGE}: $API_DIGEST"
+WEB_DIGEST="$(resolve_published_digest "$WEB_PACKAGE" "$IMAGE_TAG")" || exit 1
+assert_digest "$WEB_PACKAGE" "$WEB_DIGEST"
+echo "    ${WEB_PACKAGE}: $WEB_DIGEST"
 
 # --- secrets ----------------------------------------------------------------
 # Created from the gitignored source-of-truth files, never committed and never
@@ -179,10 +339,15 @@ kubectl create secret generic fortymm-uat-apns \
 # --- deploy -----------------------------------------------------------------
 echo
 echo "==> helm upgrade --install $RELEASE"
+# Pin by digest, not tag. Both replicas of each deployment then name the same
+# content-addressed reference, so they cannot end up on different bytes even if
+# one reschedules later or the `:main` tag moves under us. If this is the same
+# commit that is already deployed the pod templates are unchanged and helm
+# rolls nothing — correct, not a missed deploy.
 helm upgrade --install "$RELEASE" "$CHART" \
   --namespace "$NAMESPACE" \
-  --set images.api.tag="$IMAGE_TAG" \
-  --set images.web.tag="$IMAGE_TAG" \
+  --set images.api.digest="$API_DIGEST" \
+  --set images.web.digest="$WEB_DIGEST" \
   --wait --timeout 5m
 
 # The migrate Job is a post-* Helm hook; --wait above already blocks on it.
@@ -257,3 +422,6 @@ echo "==> Health"
 curl -fsS "$UAT_URL/api/v1/health"
 echo
 echo "Redeployed: $UAT_URL"
+echo "  commit $(git rev-parse HEAD) (published as :$IMAGE_TAG)"
+echo "  ${API_PACKAGE}@${API_DIGEST}"
+echo "  ${WEB_PACKAGE}@${WEB_DIGEST}"

--- a/scripts/redeploy-uat.sh
+++ b/scripts/redeploy-uat.sh
@@ -164,14 +164,16 @@ ghcr_pull_token() {
 ghcr_visibility_help() {
   local pkg="$1"
   echo "ERROR: anonymous pull DENIED for ghcr.io/${GHCR_OWNER}/${pkg}." >&2
-  echo "       Either no publish has created this package yet, or it is still private." >&2
-  echo "       GHCR publishes a package private on its first push even from a public repo," >&2
-  echo "       and visibility is not inherited from the repo. Flip it BY HAND, once per" >&2
-  echo "       package (never again after that):" >&2
+  echo "       Either no publish has ever created this package, or it is not public." >&2
+  echo "       Normally it IS public without anyone doing anything: a package pushed by a" >&2
+  echo "       workflow using GITHUB_TOKEN is linked to the publishing repo and inherits" >&2
+  echo "       its visibility, and this repo is public. So seeing this means something" >&2
+  echo "       changed -- the package's visibility was edited by hand, or the repository" >&2
+  echo "       itself went private. Check, and set it back if needed:" >&2
   echo "         github.com/${GHCR_OWNER}/fortymm -> Packages -> ${pkg} ->" >&2
   echo "         Package settings -> Change visibility -> Public" >&2
-  echo "       The workflow cannot do this: GITHUB_TOKEN can push to a package but cannot" >&2
-  echo "       change its visibility. Runs: $PUBLISH_RUNS_URL" >&2
+  echo "       (CI cannot do this for you: GITHUB_TOKEN can push to a package but cannot" >&2
+  echo "       change its visibility.) Runs: $PUBLISH_RUNS_URL" >&2
 }
 
 # HEAD one manifest and print its Docker-Content-Digest. HEAD is enough — the


### PR DESCRIPTION
Slice 2 of 2 for #1255. **Stacked on #1257** — this PR targets `claude/github-issue-1255-amngq4-s1`, so the diff shows only this slice. Merge #1257 first.

## What this does

`mise run redeploy-uat` builds nothing. It resolves the deploying commit's published tag to the digest of its multi-arch manifest list and deploys `repository@sha256:…`.

Commits:
- `2a` — the chart names images by content digest, falling back to the tag
- `2b` — the redeploy script resolves a GHCR digest instead of building locally
- `2d` — `.env.example` stops claiming the script passes the browser Maps key as a build arg
- `2c` — the deploy runbook rewritten for the digest-pinned world
- `2e` — drops a caveat in the publish workflow that slice 1 needed and this slice makes false

## Why a digest rather than a tag

This is the load-bearing decision, and it supersedes the `$(git short-sha)-$(date +%s)` scheme.

That epoch suffix existed to force a new image string on every deploy, because a *local* rebuild could produce different content under one commit. An unchanged pod template plus `pullPolicy: IfNotPresent` meant `helm upgrade` would leave both replicas on stale code — the incident `deploy/CLAUDE.md` records as "UAT redeploy lands stale code — blank white page", where two `web-client` replicas served two different content-hashed bundles behind a round-robin nginx and roughly half of page loads 404'd their JS chunk.

A digest is content-addressed, so that guarantee stops being a convention the deploy script has to maintain and becomes structural: two replicas naming one digest **cannot** be running different bytes. It also makes a same-commit redeploy a correct no-op rather than a pointless roll of both replicas.

**The api image reference is shared by four workloads**, not the three originally scoped — the api Deployment, the worker, the migrate hook Job, and the retirement-sweep CronJob. All four resolve through one helper; one drifting off it is exactly how replicas split across artifacts.

## No escape hatch back to a local build

There is deliberately no `--local` flag. The script already refuses any branch but `main`, so a local build could never produce anything not already on `main` — keeping the path alive would only preserve the unvalidated-artifact failure mode this arc removes.

## Failure modes are kept distinct

An operator hitting a problem gets a message that tells them which problem they have:

- **Package still private** → the one-time visibility click-path, not an `ErrImagePull` five minutes into `helm --wait`. The anonymous digest read doubles as the visibility preflight at no extra request.
- **Publish still running** → a bounded wait (`DIGEST_WAIT_TIMEOUT_S`, default 40 min, `0` fails fast) reporting progress, then a failure naming the commit and linking the runs. **It never falls back to an older commit** — silently running something other than what you asked for is the failure this whole path exists to remove.
- **Registry unreachable** → says so, rather than blaming visibility.

## What can still cause the blank page

`2c` rewrites that failure mode rather than deleting it, because "this can no longer happen" would have been wrong. With `images.*.digest` empty the chart renders the moving `:main` tag, and under `IfNotPresent` two pods created either side of a merge resolve that one string to two different images behind an *identical* pod template — the old failure wearing a new tag. Reachable by a bare `helm upgrade` without `--set images.*.digest=`.

That reasoning caught a hazard this arc introduced: **the documented `DROP SCHEMA` recovery procedure ended in exactly such a bare `helm upgrade`**, which would have reset the digests to empty and dropped the whole release onto `:main`. It now routes through the script.

## Verification — please read before approving

**A green CI run here is not evidence that this works**, for the same reason as #1257: nothing in this diff is reachable by the existing suites, and the deploy path needs the operator's k3d cluster plus packages that don't exist until #1257 merges and someone flips their visibility.

What was actually checked, independently re-run rather than taken on report:

- **Chart**: rendered with `helm template`. Stock values produce the tag form with no stray `@`; both digests set produce `@sha256:…` across **all five** image references (api, worker, migrate Job, retirement CronJob, web); a malformed digest exits 1 naming the offending value. **Falsified** by drifting `worker.yaml` off the shared helper — the per-file check reds for that file alone, where a whole-render grep would have passed.
- **Script**: `shellcheck` clean, and **falsified** with an injected unquoted expansion. The resolver was run against a real public multi-arch package and returns the **OCI index** digest — confirmed by fetching it and reading `mediaType`, not by inspecting the string. The auth-denied branch fires against both real `fortymm-*` package names, which genuinely do not exist yet. Every other branch driven with a stubbed `curl`.
- **A measured correction:** GHCR does **not** content-negotiate down to a platform manifest when the `Accept` header omits the index media types — it returns a flat **404** (verified: correct header → 200, missing or single-manifest header → 404). That is a nastier failure than assumed, since it would read as "not published yet" and buy a 40-minute wait for an image that already existed. The header is load-bearing; the comment says so.

Unproven until the first real deploy: that CI's 12-char tag and the script's agree in practice (both are `${SHA::12}` by inspection), that a flipped-public package resolves anonymously, that containerd picks the right arch from the index, and the whole chain after `helm upgrade`.

## Note for bisecting

`redeploy-uat` is deliberately broken between commits `2a` and `2b` — `2a` repoints the chart at GHCR while the script still builds locally. Inherent to splitting chart and script into separate commits; both land in this PR, and `2a`'s message says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsJbh2ejf7tNLAGd6h3H5a

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsJbh2ejf7tNLAGd6h3H5a)_