### PR TITLE
Tables are rows: a placement names a real table, and removing one in use is refused

### DIFF
--- a/api/app/dashboard_tournaments.py
+++ b/api/app/dashboard_tournaments.py
@@ -127,18 +127,19 @@ async def build_tournament_panels(
 
     by_tournament: dict[uuid.UUID, list[DashboardTournamentEvent]] = defaultdict(list)
     tournaments: dict[uuid.UUID, Tournament] = {}
-    # The table catalogue is a per-TOURNAMENT value-object, so it is parsed once per
-    # tournament rather than once per event — a caller entered in two events of one
-    # tournament (singles + doubles) would otherwise re-decode the identical JSONB.
+    # The table catalogue is per-TOURNAMENT, so it is parsed once per tournament rather
+    # than once per event — a caller entered in two events of one tournament (singles +
+    # doubles) would otherwise re-decode the identical rows. Keyed by the id's *text*:
+    # a fixture's ``table_id`` is still carried as a string ref (ADR 20260801 makes the
+    # table a row; the foreign key on the placement is the step after).
     tables_by_tournament: dict[uuid.UUID, dict[str, TournamentTable]] = {}
     for entry_id, event, tournament in entries:
         tournaments[tournament.id] = tournament
         if tournament.id not in tables_by_tournament:
             tables_by_tournament[tournament.id] = {
-                table.id: table
+                str(table.id): table
                 for table in (
-                    TournamentTable.model_validate(raw)
-                    for raw in tournament.table_catalogue
+                    TournamentTable.model_validate(row) for row in tournament.tables
                 )
             }
         by_tournament[tournament.id].append(

--- a/api/app/match_calls.py
+++ b/api/app/match_calls.py
@@ -1047,11 +1047,12 @@ async def load_copy_ingredients(
         .scalars()
         .all()
     }
+    # The catalogue is rows now (ADR 20260801), eagerly loaded on the tournament. The
+    # fixture's ``table_id`` is still carried as a string ref, so the lookup is keyed by
+    # the table id's text.
     table_labels = {
-        table.id: table.label
-        for table in (
-            TournamentTable.model_validate(raw) for raw in tournament.table_catalogue
-        )
+        str(table.id): table.label
+        for table in (TournamentTable.model_validate(row) for row in tournament.tables)
     }
     pool_names = {
         event.id: {pool.id: pool.name for pool in event_pools(event)}

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -168,6 +168,8 @@ from app.tournament_errors import (
     PlayerNotFoundError,
     PoolSetFrozenError,
     ScheduleQueueUnavailableError,
+    TableInUseError,
+    TableNotInCatalogueError,
     TournamentAlreadyInStatusError,
     TournamentNotFoundError,
     TournamentNotPreLiveError,
@@ -1046,10 +1048,22 @@ async def edit_tournament(
     placeholder address to fill the field.
 
     ``table_catalogue``, when present, is the venue catalogue IN FULL and IN ORDER, and
-    each entry is a ``label`` and a ``court`` only — a table's id is minted by the
-    server, so sending one is rejected. It is applied BY POSITION: the i-th table sent
-    updates the i-th table stored, a longer list adds tables and a shorter one removes
-    from the end. Send the catalogue you read back, edited, rather than a fresh list.
+    it is applied as an ID-KEYED DIFF. So SEND BACK THE CATALOGUE YOU READ, EDITED — a
+    fresh list is not an edit of the old one, it is a request to remove every table the
+    tournament has and add new ones. Each entry either carries the ``id`` of a table
+    this tournament already has (keeping that table, with the ``label``, ``court``
+    and place this list gives it) or omits the ``id`` to ADD a table, whose id the
+    server mints. A stored table no entry names is REMOVED. An ``id`` this tournament
+    does not have is rejected — it is never taken as a request for a new table.
+
+    REMOVING A TABLE THAT MATCHES ARE PLACED AT IS REFUSED, and nothing is written. The
+    refusal names the table and how many matches are on it. To go through with it, send
+    the SAME edit again with ``unplace_fixtures_on_removed_tables`` set to true: the
+    table goes and those matches are unplaced — table, predicted start and call all
+    cleared. Do not set it pre-emptively "just in case"; it exists so that losing a
+    director's schedule is something they said yes to. Removing a table that only a POOL
+    reserves is not refused and needs no opt-in — the pool simply reserves one fewer.
+
     ``league_id`` is editable ONLY while the tournament is a ``draft`` — once it is
     published the ladder is settled. ``status`` is not editable here (it moves only
     across the guarded lifecycle transitions). Returns the updated
@@ -1058,7 +1072,9 @@ async def edit_tournament(
     Raises a ``ToolError`` when no tournament with that id exists, when you are not
     the tournament's owner (only the creator may edit it), when you try to change
     the league of a tournament that has left ``draft``, when ``league_id`` names
-    no league, or when a changed venue ``address`` cannot be geocoded (the
+    no league, when a ``table_catalogue`` entry names a table id this tournament does
+    not have, when it would remove a table matches are placed at without the opt-in, or
+    when a changed venue ``address`` cannot be geocoded (the
     ``[address_not_geocodable]`` refusal — coordinates are geocoded server-side, and
     an address that has them cannot be stored without them). Removing the venue
     geocodes nothing and so can never raise that one.
@@ -1090,6 +1106,17 @@ async def edit_tournament(
             raise ToolError(str(exc)) from exc
         except LeagueNotFoundError as exc:
             raise ToolError("No league found with that id.") from exc
+        except TableInUseError as exc:
+            # The catalogue's named 409, as prose: the sentence already names the tables
+            # and the way out (``unplace_fixtures_on_removed_tables``), which is exactly
+            # what an agent needs to decide whether to ask its director and retry.
+            raise ToolError(str(exc)) from exc
+        except TableNotInCatalogueError as exc:
+            # The HTTP surface answers this on the field; an agent reads prose, so the
+            # offending id rides in the sentence rather than in a ``loc``.
+            raise ToolError(
+                f"{exc} (table_catalogue entry {exc.index} names “{exc.table_id}”)."
+            ) from exc
         except AddressNotGeocodableError as exc:
             raise _map_address_not_geocodable_tool_error(exc) from exc
         # The core raised ``NotTournamentOwnerError`` unless the caller is the owner,

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -164,6 +164,7 @@ from app.tournament_errors import (
     NotAllowedToEnterError,
     NotAllowedToWithdrawError,
     NotTournamentOwnerError,
+    PlacementTableNotFoundError,
     PlayerNotFoundError,
     PoolSetFrozenError,
     ScheduleQueueUnavailableError,
@@ -1872,9 +1873,9 @@ async def place_fixture(
     so the MCP and HTTP surfaces can never drift. You address the fixture by its
     ``tournament_id`` + ``fixture_id`` (the fixture must belong to that tournament).
 
-    ``placement`` is the placement in full: ``table_id`` (a string ref into the
-    tournament's ``table_catalogue``) and ``scheduled_start`` (a **naive** wall-clock
-    time in the venue's local frame). ``null`` on either clears that half;
+    ``placement`` is the placement in full: ``table_id`` (the id of one of the
+    tournament's ``table_catalogue`` tables) and ``scheduled_start`` (a **naive**
+    wall-clock time in the venue's local frame). ``null`` on either clears that half;
     ``(null, null)`` unassigns the fixture entirely.
 
     **A manual placement is a PIN.** A full placement (both halves set, both entrants
@@ -1887,16 +1888,21 @@ async def place_fixture(
     UNPINS (and, if the players had been called, cancels the call). Every successful
     write also queues a re-solve.
 
+    **The table must EXIST** (ADR 20260801): a ``table_id`` naming no table in this
+    tournament's ``table_catalogue`` is refused, not stored — a placement whose table
+    does not exist is a dangling reference, not a state the director chose.
+
     **The placement is otherwise SOFT** (ADR-0790): ``scheduled_start`` is a
-    prediction, and the constraints (table-in-pool, time-in-window, no double-booking)
-    are flags derived on read, NOT invariants — so an out-of-window time, or a
-    ``table_id`` that names no table in the catalogue, is STORED, not rejected. The one
-    hard rule: a fixture whose linked match is ``completed`` or ``voided`` is history,
-    so its placement can no longer be changed. Owner-gated: only the tournament's
-    creator may place its fixtures.
+    prediction, and the other constraints (table-in-pool, time-in-window, no
+    double-booking) are flags derived on read, NOT invariants — so an out-of-window
+    time, or a table outside the fixture's pool, is STORED, not rejected. The one hard
+    rule about the fixture itself: one whose linked match is ``completed`` or ``voided``
+    is history, so its placement can no longer be changed. Owner-gated: only the
+    tournament's creator may place its fixtures.
 
     Raises a ``ToolError`` when no tournament with that id exists, when you are not the
-    tournament's owner, when no fixture with that id belongs to the tournament, or when
+    tournament's owner, when no fixture with that id belongs to the tournament, when the
+    placement's ``table_id`` names no table in the tournament's catalogue, or when
     the fixture's match is already completed/voided (its placement is frozen)."""
     user_id = _authenticated_user_id()
     async with mcp_session() as db:
@@ -1921,6 +1927,11 @@ async def place_fixture(
             # Carries the exact, domain-authored 409 sentence — the played-out fixture's
             # freeze — surfaced as the ``ToolError`` prose verbatim.
             raise ToolError(str(exc)) from exc
+        except PlacementTableNotFoundError as exc:
+            # The HTTP route's 422 on ``body.table_id`` (ADR 20260801): a placement must
+            # name a real table. Named with the offending id, because an MCP caller
+            # composed it rather than clicked it.
+            raise ToolError(f"{exc} (table_id: {exc.table_id})") from exc
 
 
 @mcp.tool

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -1031,10 +1031,10 @@ async def edit_tournament(
     surfaces can never drift on what a valid edit is.
 
     ``updates`` is a PARTIAL patch: an OMITTED field is left unchanged; a supplied
-    field replaces the current value. ``name``, ``table_catalogue`` and ``league_id``
-    back NOT NULL columns, so an explicit ``null`` for any of them is rejected (send
-    them only to set a real value); ``description`` / ``start_date`` / ``end_date``
-    are nullable and may be cleared with ``null``.
+    field replaces the current value. ``name`` and ``league_id`` back NOT NULL columns
+    and ``table_catalogue`` backs a whole child table, so an explicit ``null`` for any
+    of them is rejected (send them only to set a real value); ``description`` /
+    ``start_date`` / ``end_date`` are nullable and may be cleared with ``null``.
 
     ``address`` (the venue) has THREE cases, so read this before sending one: OMIT it
     to leave the current venue and its coordinates untouched; send a real address to
@@ -1044,7 +1044,11 @@ async def edit_tournament(
     booked, or a private tournament withholding its address), so do not invent a
     placeholder address to fill the field.
 
-    ``table_catalogue`` replaces wholesale when present.
+    ``table_catalogue``, when present, is the venue catalogue IN FULL and IN ORDER, and
+    each entry is a ``label`` and a ``court`` only — a table's id is minted by the
+    server, so sending one is rejected. It is applied BY POSITION: the i-th table sent
+    updates the i-th table stored, a longer list adds tables and a shorter one removes
+    from the end. Send the catalogue you read back, edited, rather than a fresh list.
     ``league_id`` is editable ONLY while the tournament is a ``draft`` — once it is
     published the ladder is settled. ``status`` is not editable here (it moves only
     across the guarded lifecycle transitions). Returns the updated

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -37,6 +37,7 @@ from app.models.tournament import (
 from app.models.tournament_entry import TournamentEntry, TournamentEntryStatus
 from app.models.tournament_event_draw_settings import TournamentEventDrawSettings
 from app.models.tournament_fixture import TournamentFixture
+from app.models.tournament_table import VenueTable
 from app.models.user import User
 from app.models.user_league_rating import UserLeagueRating
 from app.models.user_role import UserRole
@@ -84,5 +85,6 @@ __all__ = [
     "UserLeagueRating",
     "UserRole",
     "UserToken",
+    "VenueTable",
     "VerificationPolicy",
 ]

--- a/api/app/models/tournament.py
+++ b/api/app/models/tournament.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from app.models.tournament_entry import TournamentEntry
     from app.models.tournament_event_draw_settings import TournamentEventDrawSettings
     from app.models.tournament_fixture import TournamentFixture
+    from app.models.tournament_table import VenueTable
 
 
 class TournamentStatus(enum.Enum):
@@ -71,9 +72,10 @@ class Tournament(Base):
     "standalone, not tied to a league" until an event's rating predicate needed a
     ladder to mean anything; ``league_id`` is NOT NULL, and an omitted one resolves
     to the default league at create. Names are owner-scoped, not globally unique,
-    so there's no unique constraint on ``name``. ``address`` and
-    ``table_catalogue`` are typed JSONB value-objects decoded to Pydantic models at
-    the API boundary."""
+    so there's no unique constraint on ``name``. ``address`` is a typed JSONB
+    value-object decoded to a Pydantic model at the API boundary; the venue catalogue
+    is **not** — it is ``tables``, a real child table (ADR 20260801 "a placement names
+    a real table")."""
 
     __tablename__ = "tournaments"
     __table_args__ = (
@@ -120,9 +122,11 @@ class Tournament(Base):
     address: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB(none_as_null=True), nullable=True
     )
-    table_catalogue: Mapped[list[dict[str, Any]]] = mapped_column(
-        JSONB, nullable=False, server_default=text("'[]'::jsonb")
-    )
+    # There is deliberately no ``table_catalogue`` column. The venue catalogue was a
+    # NOT NULL JSONB list of ``{id, label, court}`` value-objects keyed by
+    # client-supplied strings; it is the ``tables`` relationship below now, so a
+    # placement can foreign-key the table it names (ADR 20260801).
+    #
     # The ladder that judges this tournament's eligibility rules (ADR-0783).
     # RESTRICT on delete, like ``Match.league_id``: the league a tournament is run
     # on cannot be deleted out from under it.
@@ -151,6 +155,41 @@ class Tournament(Base):
         cascade="all, delete-orphan",
         passive_deletes=True,
         order_by="TournamentEvent.created_at",
+    )
+
+    # The venue catalogue (ADR 20260801). Ordered by the director's own order, which
+    # is what ``VenueTable.position`` carries.
+    #
+    # ``lazy="selectin"``, and eagerly rather than by an option at each call site, for
+    # the reason ``TournamentEvent.draw_settings`` is eager: async SQLAlchemy raises
+    # instead of emitting a lazy load, so every one of the ~10 places that loads a
+    # ``Tournament`` and reads its catalogue (the serializer, the dashboard panel, the
+    # call copy, the solver's input load, the preview) would need to remember an
+    # option. ``selectin`` and not ``joined`` because this is a one-to-many: joined
+    # would multiply the parent rows, which the list endpoint's ordering could not
+    # survive. It batches over the whole result set, so the tournament LIST pays ONE
+    # extra statement however many tournaments it returns — the statement-count pins
+    # in ``tests/test_tournaments.py`` moved by exactly one.
+    #
+    # ``passive_deletes`` + the FK's ``ON DELETE CASCADE`` is the delete path, the same
+    # shape ``events`` uses: deleting a tournament takes its tables with it.
+    #
+    # With one honest difference from ``events``, caused by the eager load above: the
+    # collection is already in the session when the delete runs, so the unit of work
+    # issues the child ``DELETE`` itself and the database cascade never fires on the
+    # ORM path. It is not decoration — it is what covers every path that does NOT load
+    # the collection first (a raw ``DELETE``, psql, a future bulk reap), and
+    # ``test_the_venue_tables_fk_cascades_in_the_database`` is one of those paths
+    # precisely because the ORM-path test stays green without it.
+    #
+    # ``delete-orphan`` is what the catalogue *write* leans on — a table dropped from
+    # the submitted list is removed by taking it out of this collection.
+    tables: Mapped[list["VenueTable"]] = relationship(
+        back_populates="tournament",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        lazy="selectin",
+        order_by="VenueTable.position",
     )
 
 

--- a/api/app/models/tournament_fixture.py
+++ b/api/app/models/tournament_fixture.py
@@ -144,11 +144,13 @@ class TournamentFixture(Base):
         ForeignKey("matches.id", ondelete="SET NULL"),
         nullable=True,
     )
-    #: A **placement**'s table: a *string ref* into the tournament's
-    #: ``table_catalogue`` JSONB (names a ``TournamentTable.id``), the same string-ref
-    #: pattern as ``pool_id`` — deliberately not a foreign key, there is no tables
-    #: table. ``NULL`` = unassigned. ``(table_id, scheduled_start) = (NULL, NULL)``
-    #: means the fixture is unplaced (ADR-0790).
+    #: A **placement**'s table: a *string ref* naming a ``tournament_tables`` row's id,
+    #: the same string-ref pattern as ``pool_id``. Not a foreign key **yet** — the
+    #: catalogue only became a real table in ADR 20260801, which also makes "the table
+    #: exists" an invariant, so the key (and the ``ON DELETE RESTRICT`` behind its
+    #: named 409) is the step after this one. ``NULL`` = unassigned.
+    #: ``(table_id, scheduled_start) = (NULL, NULL)`` means the fixture is unplaced
+    #: (ADR-0790).
     table_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     #: A **placement**'s predicted start — a ``timestamptz`` **instant**
     #: (``TIMESTAMP WITH TIME ZONE``), the server composes it from the event's Slot

--- a/api/app/models/tournament_fixture.py
+++ b/api/app/models/tournament_fixture.py
@@ -74,6 +74,12 @@ class TournamentFixture(Base):
         # A completed match is the trigger to write ``winner_entry_id`` back and re-run
         # ``advance()``, and that path arrives holding a match id, not a fixture id.
         Index("ix_tournament_fixtures_match_id", "match_id"),
+        # The index Postgres does NOT create for a REFERENCING column, and under
+        # ``ON DELETE RESTRICT`` it is the one that pays for itself: every delete of a
+        # ``tournament_tables`` row must prove no fixture references it, which unindexed
+        # is a sequential scan of every fixture on the platform per table removed. The
+        # same argument ``VenueTable`` makes for its own ``tournament_id``.
+        Index("ix_tournament_fixtures_table_id", "table_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -144,14 +150,43 @@ class TournamentFixture(Base):
         ForeignKey("matches.id", ondelete="SET NULL"),
         nullable=True,
     )
-    #: A **placement**'s table: a *string ref* naming a ``tournament_tables`` row's id,
-    #: the same string-ref pattern as ``pool_id``. Not a foreign key **yet** — the
-    #: catalogue only became a real table in ADR 20260801, which also makes "the table
-    #: exists" an invariant, so the key (and the ``ON DELETE RESTRICT`` behind its
-    #: named 409) is the step after this one. ``NULL`` = unassigned.
-    #: ``(table_id, scheduled_start) = (NULL, NULL)`` means the fixture is unplaced
-    #: (ADR-0790).
-    table_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    #: A **placement**'s table — a real **foreign key** into ``tournament_tables``
+    #: (ADR 20260801, "a placement names a real table, and only that is an invariant").
+    #: ``NULL`` = unassigned; ``(table_id, scheduled_start) = (NULL, NULL)`` means the
+    #: fixture is unplaced (ADR-0790).
+    #:
+    #: This is the one placement claim that is an **invariant** rather than a flag. The
+    #: other three — the table belongs to the fixture's pool, the start falls inside the
+    #: pool's window, nothing is double-booked — are statements about a *relationship*
+    #: between things that each legitimately move while the other stands, so they stay
+    #: derived on read (ADR-0790, undisturbed). "This id names a table" is not that: it
+    #: is whether the reference resolves at all, and a placement whose table does not
+    #: exist is not a state the director chose but a dangling pointer nothing downstream
+    #: can render. It was soft only because there was no table to point at.
+    #:
+    #: ``ON DELETE RESTRICT``, deliberately, and deliberately unlike ``pool_id``'s
+    #: procedural freeze: ``SET NULL`` would destroy information on an *unrelated* write
+    #: — the fixture would stop being "placed at a table that vanished" and become
+    #: indistinguishable from "nobody ever placed this", as an invisible side effect of
+    #: editing the venue. The database refuses by default and the director says yes on
+    #: purpose, through the tournament-edit verb's named 409 and its unplace-and-remove
+    #: opt-in. (A *pool* that merely reserves a table gets the quiet treatment instead —
+    #: the table drops out of its ``table_ids``.)
+    #:
+    #: **The Python/wire type stays ``str``** while the column is a real ``uuid``
+    #: (``as_uuid=False``): a table id crosses this codebase as its canonical text in
+    #: three places at once — here, in a pool's ``table_ids``, and in the solver's
+    #: ``TableId`` — and they are one representation, moved together, not one at a
+    #: time. The database is what holds the type; ``str(table.id)`` is what everything
+    #: above it compares. A non-``uuid`` string can therefore still be *sent*, and it
+    #: is refused at the placement boundary by the same 422 an unknown id gets, rather
+    #: than splitting one refusal ("this names no table") into two a client must tell
+    #: apart.
+    table_id: Mapped[str | None] = mapped_column(
+        UUID(as_uuid=False),
+        ForeignKey("tournament_tables.id", ondelete="RESTRICT"),
+        nullable=True,
+    )
     #: A **placement**'s predicted start — a ``timestamptz`` **instant**
     #: (``TIMESTAMP WITH TIME ZONE``), the server composes it from the event's Slot
     #: wall-clock components anchored by the event ``timezone`` (see the

--- a/api/app/models/tournament_table.py
+++ b/api/app/models/tournament_table.py
@@ -54,8 +54,21 @@ class VenueTable(Base):
         # Two tables of one tournament never share a place in its order — the same
         # guarantee ``Pool.position`` makes by construction, said here as a constraint
         # because these are rows and a constraint is available.
+        #
+        # DEFERRABLE INITIALLY DEFERRED, because the catalogue's write is an id-keyed
+        # diff and a diff **re-orders**: dragging table B above table A moves B onto a
+        # position A has not vacated yet, and SQLAlchemy has no way to emit two UPDATEs
+        # as one. Checked immediately, that transient collision would refuse a
+        # transaction whose END state is perfectly unique — i.e. the constraint would
+        # forbid reordering, which is one of the two things the diff exists to allow.
+        # Deferring is not a weakening: uniqueness is a claim about the catalogue, and
+        # a catalogue only exists between commits.
         UniqueConstraint(
-            "tournament_id", "position", name="uq_tournament_tables_tournament_position"
+            "tournament_id",
+            "position",
+            name="uq_tournament_tables_tournament_position",
+            deferrable=True,
+            initially="DEFERRED",
         ),
     )
 

--- a/api/app/models/tournament_table.py
+++ b/api/app/models/tournament_table.py
@@ -1,0 +1,99 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.tournament import Tournament
+
+
+class VenueTable(Base):
+    """One physical table in a tournament's venue catalogue — a **row**, not a JSONB
+    value-object (ADR 20260801 "a placement names a real table").
+
+    The catalogue used to be ``tournaments.table_catalogue``: a JSONB list of
+    ``{id, label, court}`` objects whose ``id`` was a **client-supplied string**. That
+    left nothing for a placement or a pool to foreign-key, which is the only reason
+    ADR-0790 could say a ``table_id`` naming no table is stored rather than refused.
+    A table is a row now, so "this id names a table" becomes something the database can
+    answer — and the id is the database's to mint (``gen_random_uuid()``), never the
+    client's to author, exactly as a pool's ``position`` became the server's to assign.
+
+    Named ``VenueTable`` rather than ``TournamentTable`` only because the *schema* of
+    that name — the wire shape in ``app.schemas.tournament`` — already holds it; the
+    same reason ``DrawTypeOption`` is not called ``DrawType``. The table itself follows
+    the ``<singular_parent>_<plural_child>`` rule: ``tournament_tables``.
+    """
+
+    __tablename__ = "tournament_tables"
+    __table_args__ = (
+        # The catalogue's order is the director's order, so it is read (and deleted
+        # against) by this index. It doubles as the index Postgres does NOT create for
+        # a REFERENCING column: ``tournament_id`` is on the tournament-delete cascade
+        # path, and unindexed that check is a sequential scan of every table row on
+        # the platform per tournament deleted.
+        Index(
+            "ix_tournament_tables_tournament_id_position",
+            "tournament_id",
+            "position",
+        ),
+        # Two tables of one tournament never share a place in its order — the same
+        # guarantee ``Pool.position`` makes by construction, said here as a constraint
+        # because these are rows and a constraint is available.
+        UniqueConstraint(
+            "tournament_id", "position", name="uq_tournament_tables_tournament_position"
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    tournament_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tournaments.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    label: Mapped[str] = mapped_column(String(255), nullable=False)
+    court: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Where this table sits in its tournament's catalogue: 0-based, contiguous,
+    # assigned by the server from the index the table arrived at.
+    #
+    # It is not decoration. Under the random UUID primary key above, ordering the
+    # catalogue by ``id`` is *arbitrary* and ordering it by ``created_at`` is worse than
+    # arbitrary — every row of one write shares the transaction timestamp, so the tie
+    # breaks on the random id anyway. The array order the JSONB column used to carry for
+    # free has to be carried by something, and this is it (the same argument, and the
+    # same remedy, as ``PoolPosition`` in ADR 20260801).
+    #
+    # Deliberately NOT on the wire: the read shape is a JSON *array*, whose order is
+    # this column, and the write shape's order is what assigns it. Carrying the number
+    # beside the array it is derived from would be carrying a field and its own
+    # derivation (api/CLAUDE.md).
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    tournament: Mapped["Tournament"] = relationship(back_populates="tables")

--- a/api/app/schedule_preview.py
+++ b/api/app/schedule_preview.py
@@ -265,10 +265,13 @@ def build_preview_snapshot(
     overrides = count_overrides or {}
     now = now if now is not None else datetime.now(UTC)
 
+    # The catalogue is rows now (ADR 20260801), eagerly loaded on the tournament and
+    # already in the director's order. The solver's ``TableId`` stays a string, so a
+    # table's UUID id crosses into it as its text.
     catalogue_tables = [
-        TournamentTable.model_validate(table) for table in tournament.table_catalogue
+        TournamentTable.model_validate(table) for table in tournament.tables
     ]
-    catalogue = tuple(TableId(table.id) for table in catalogue_tables)
+    catalogue = tuple(TableId(str(table.id)) for table in catalogue_tables)
     catalogue_ids = set(catalogue)
 
     # First pass: plan every event's synthetic draw. A global counter mints the

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -69,22 +69,40 @@ against the old field should not land.
 inviolable against *optimization*, never against physics. The snapshot phase
 detects pins physics broke, so they never reach the solver *as pins*:
 
-* **table gone** — the pinned ``table_id`` is no longer in the venue
-  **catalogue**: the fixture enters the snapshot **unpinned** (the solver
-  re-places it), and its id is carried in ``SolveInputs.broken_pin_moves``.
-  Pool membership does **not** break a pin: a director deliberately pinning a
-  fixture to a spare catalogue table outside its pool's ``table_ids`` (the
-  manual PATCH allows off-pool soft placements, ADR-0790) is a legitimate
-  hand, and pins are broken by physics, not preferences. Such a pin enters
-  the snapshot as a pin like any other — the pure module treats pins as
-  constants and never checks a pin's table against the pool (or even the
-  catalogue) — survives every solve byte-identical, and is called by the
-  ordinary call pass when imminent;
 * **entrant withdrew** — an entry of the fixture is ``withdrawn`` (and the
   match isn't already settled): the promised match cannot happen, so the
   fixture is **excluded** from the snapshot and carried in
   ``SolveInputs.broken_pin_voids``;
 * a deleted fixture needs nothing — the pin died with its row.
+
+Pool membership does **not** break a pin: a director deliberately pinning a
+fixture to a spare catalogue table outside its pool's ``table_ids`` (the manual
+PATCH allows off-pool soft placements, ADR-0790) is a legitimate hand, and pins
+are broken by physics, not preferences. Such a pin enters the snapshot as a pin
+like any other — the pure module treats pins as constants and never checks a
+pin's table against the pool (or even the catalogue) — survives every solve
+byte-identical, and is called by the ordinary call pass when imminent.
+
+There **was** a third case here, "the pinned table is no longer in the venue
+catalogue" (``SolveInputs.broken_pin_moves``): the fixture entered the snapshot
+unpinned and was re-pinned + moved-notified at apply. It is gone, because the
+state it repaired stopped being representable when ADR 20260801 landed in full.
+``tournament_fixtures.table_id`` is a foreign key (so the row cannot vanish),
+nothing anywhere re-parents a ``VenueTable`` onto another tournament, the
+placement verb refuses a table outside *this* tournament's catalogue, and the one
+route by which a table can leave a catalogue — the tournament PATCH's diff —
+either refuses the removal (the named 409) or unplaces the fixtures first. Three
+of the four writers of ``table_id`` in ``app/`` write a catalogue table of this
+tournament and the fourth writes ``NULL``. The arm survived only because its
+tests manufactured the state by re-parenting a table row onto a throwaway
+tournament, which no production path performs — a guard whose only reachable
+caller is its own test is not defence in depth, it is a claim that the invariant
+above it is optional. The slide-later repair keeps the whole "moved" machinery
+alive, so what went is the detection, not the correction.
+
+A *planned* (unpinned) fixture needs no case at all and never did: it is
+re-placed by the ordinary placement write, silently, because it was never
+promised.
 
 The *repair* is applied only by phase (c), in the same transaction and under
 the same locks as every other placement write — and only on a successful
@@ -513,14 +531,15 @@ class SolveInputs:
     frame, and the fixture rows themselves (keyed by id) so the apply that
     re-read them under lock writes to exactly the rows it fingerprinted.
 
-    The ``broken_pin_*`` sets are the snapshot phase's broken-pin findings
-    (module docstring): ``broken_pin_moves`` entered the snapshot unpinned and
-    are re-pinned+notified at apply; ``broken_pin_voids`` were excluded from
-    the snapshot and have their placement cleared at apply.
-    ``withdrawn_entry_ids`` lets the cancelled correction pick the *remaining*
-    entrant. Everything these sets derive from is fingerprinted, so a
-    fingerprint match between snapshot and apply guarantees the fresh read's
-    sets are the ones the solve was computed against.
+    ``broken_pin_voids`` is the snapshot phase's broken-pin finding (module
+    docstring): those fixtures were excluded from the snapshot and have their
+    placement cleared at apply. ``withdrawn_entry_ids`` lets the cancelled
+    correction pick the *remaining* entrant. Everything these sets derive from is
+    fingerprinted, so a fingerprint match between snapshot and apply guarantees
+    the fresh read's sets are the ones the solve was computed against. (There was
+    a ``broken_pin_moves`` beside it, for a pin whose table left the venue
+    catalogue; that state stopped being representable under ADR 20260801 and the
+    field went with it — see the module docstring.)
 
     ``pool_resolutions`` (keyed by the solver's namespaced ``PoolId`` string
     ``f"{event.id}:{pool.id}"``) and ``fixture_best_of`` (keyed by
@@ -553,7 +572,6 @@ class SolveInputs:
     #: a named ``past_window`` date on the ledger row — the pure solver stays
     #: minute-only, and naming the wall-clock day is this DB-aware layer's job.
     pool_dates: dict[str, date] = field(default_factory=dict)
-    broken_pin_moves: frozenset[uuid.UUID] = frozenset()
     broken_pin_voids: frozenset[uuid.UUID] = frozenset()
     withdrawn_entry_ids: frozenset[uuid.UUID] = frozenset()
     pool_resolutions: dict[str, _PoolResolution] = field(default_factory=dict)
@@ -843,7 +861,6 @@ async def _load_solver_inputs(
     in_progress: list[InProgressMatch] = []
     previous_plan: list[PreviousPlacement] = []
     rest_shadows: list[RestShadow] = []
-    broken_pin_moves: set[uuid.UUID] = set()
     broken_pin_voids: set[uuid.UUID] = set()
     for event, settings, _pools in parsed_events:
         for fixture in fixtures_by_event[event.id]:
@@ -878,26 +895,23 @@ async def _load_solver_inputs(
                     fixture.entry_a_id in withdrawn_entry_ids
                     or fixture.entry_b_id in withdrawn_entry_ids
                 ):
-                    # Case (b), entrant withdrew: the promised match cannot
-                    # happen. Excluded from the snapshot; voided at apply.
+                    # An entrant withdrew: the promised match cannot happen.
+                    # Excluded from the snapshot; voided at apply.
                     broken_pin_voids.add(fixture.id)
                     continue
-                if not settled and TableId(fixture.table_id) not in catalogue_ids:
-                    # Case (a), table gone from the venue CATALOGUE: enters
-                    # the snapshot UNPINNED so the solver re-places it;
-                    # re-pinned + moved-notified at apply. The pool's
-                    # table_ids are deliberately NOT consulted — an off-pool
-                    # pin on a catalogue table is the director's hand (the
-                    # manual PATCH allows off-pool soft placements, ADR-0790),
-                    # and pins break on physics, not preferences. The pure
-                    # module honors it as-is: pins are constants there, never
-                    # checked against pool residency.
-                    broken_pin_moves.add(fixture.id)
-                else:
-                    pin = Pin(
-                        table_id=TableId(fixture.table_id),
-                        start_min=to_min(fixture.scheduled_start),
-                    )
+                # Otherwise the pin stands, as-is. Its table is deliberately NOT
+                # re-checked against the pool's ``table_ids`` — an off-pool pin
+                # on a catalogue table is the director's hand (the manual PATCH
+                # allows off-pool soft placements, ADR-0790), and pins break on
+                # physics, not preferences. Nor against the catalogue, which the
+                # foreign key and the tournament PATCH's diff have made an
+                # invariant rather than a thing to defend against here (module
+                # docstring). The pure module honors it either way: pins are
+                # constants there, never checked against pool residency.
+                pin = Pin(
+                    table_id=TableId(fixture.table_id),
+                    start_min=to_min(fixture.scheduled_start),
+                )
             fixture_id = FixtureId(str(fixture.id))
             # Only placeable (pooled, both-sides-known) fixtures reach here, and
             # only such a fixture can surface in a WindowTooShortForMatch reason
@@ -1052,7 +1066,6 @@ async def _load_solver_inputs(
         base=base,
         fixtures={fixture.id: fixture for fixture in fixture_rows},
         pool_dates=pool_dates,
-        broken_pin_moves=frozenset(broken_pin_moves),
         broken_pin_voids=frozenset(broken_pin_voids),
         withdrawn_entry_ids=frozenset(withdrawn_entry_ids),
         pool_resolutions=pool_resolutions,
@@ -1336,10 +1349,7 @@ async def _apply_result(
                     fixture = fresh.fixtures[uuid.UUID(placement.fixture_id)]
                     new_table = str(placement.table_id)
                     new_start = fresh.base + timedelta(minutes=placement.start_min)
-                    if (
-                        fixture.pinned_at is not None
-                        and fixture.id not in fresh.broken_pin_moves
-                    ):
+                    if fixture.pinned_at is not None:
                         # A called match holds its table, but its start can be
                         # pushed LATER on a re-solve when a predecessor overruns
                         # (ADR "a called match holds its table and slides
@@ -1371,14 +1381,14 @@ async def _apply_result(
                     fixture.table_id = new_table
                     fixture.scheduled_start = new_start
                     if repaired_pin:
-                        # Broken pin, case (a): physics moved the promise, so
-                        # it is renewed — still a pin, re-dated to the moment
+                        # A pin the solver slid later: physics moved the promise,
+                        # so it is renewed — still a pin, re-dated to the moment
                         # the new placement was made — never demoted back to
                         # an estimate.
                         fixture.pinned_at = apply_now
                         moved_repairs.append(fixture)
                     placed += 1
-                # Broken pins, case (b): an entrant withdrew, so the promised
+                # Broken pins: an entrant withdrew, so the promised
                 # match cannot happen and the fixture stops being schedulable.
                 # Whether the draw layer later voids or deletes the fixture is
                 # its business; here the placement and the pin are cleared.

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -743,15 +743,19 @@ async def _load_solver_inputs(
             match_status[match_id] = status
             match_completed_at[match_id] = completed_at
 
-    # Parse the JSONB value-objects once, at this boundary, with the same
-    # models the write boundary validated them with (parse, don't validate).
+    # Parse the value-objects once, at this boundary, with the same models the write
+    # boundary validated them with (parse, don't validate). The catalogue is rows now
+    # (ADR 20260801), eagerly loaded on the tournament and already in the director's
+    # order; the solver's ``TableId`` stays a string, so a table's UUID id crosses into
+    # it as its text — the same text a pool's ``table_ids`` and a fixture's ``table_id``
+    # hold.
     parsed_tables = [
-        TournamentTable.model_validate(table) for table in tournament.table_catalogue
+        TournamentTable.model_validate(table) for table in tournament.tables
     ]
-    catalogue = tuple(TableId(table.id) for table in parsed_tables)
+    catalogue = tuple(TableId(str(table.id)) for table in parsed_tables)
     # table_id → catalogue label: the DB-aware resolution a placement conflict's
     # shared table is humanized through (mirrors ``load_copy_ingredients``).
-    table_labels = {table.id: table.label for table in parsed_tables}
+    table_labels = {str(table.id): table.label for table in parsed_tables}
     parsed_events: list[tuple[TournamentEvent, EventMatchSettings, list[Pool]]] = [
         (
             event,

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -286,11 +286,11 @@ def _draw_settings_write(
 # ----- value-objects (typed JSONB) -----------------------------------------
 
 ValueObjectId = Annotated[str, Field(min_length=1)]
-"""The **identity** of a JSONB value-object — a pool, a table in the venue catalogue.
+"""The **identity** of a JSONB value-object — today, a pool.
 
-These ids are *string refs*, not foreign keys: pools and tables have no tables of their
-own, so a pool is addressed by a client-supplied string and nothing in the database
-constrains it. That is precisely why the constraint has to be stated *here*: the empty
+These ids are *string refs*, not foreign keys: a pool has no table of its own, so it is
+addressed by a client-supplied string and nothing in the database constrains it. That is
+precisely why the constraint has to be stated *here*: the empty
 string is not an identity, and it was a **representable** one — ``Pool(id="")``
 validated, and an event could be created and patched holding it.
 
@@ -309,7 +309,12 @@ Unlike the pool-id *uniqueness* rule (``_pool_ids_are_unique``, an ``AfterValida
 that contributes nothing to the JSON schema), this **does** change the OpenAPI shape:
 ``minLength: 1`` is a real JSON-schema keyword, so the generated clients learn the rule
 too — which is a feature. A rule the client can express is a rule the organizer meets
-under the field instead of in a 422."""
+under the field instead of in a 422.
+
+It used to cover the venue catalogue's tables as well. It does not any more: a table is
+a row with a server-minted UUID primary key (ADR 20260801), so its identity is neither a
+string nor the client's to author, and there is nothing here left to floor. Pools follow
+when they become rows, and this alias goes with them."""
 
 
 MAX_ADDRESS_COMPONENT = 255
@@ -609,22 +614,49 @@ class Predicate(BaseModel):
         return self
 
 
-class TournamentTable(BaseModel):
-    """A physical table in the venue catalogue, referenced by id from pools.
+class TournamentTableWrite(BaseModel):
+    """A physical table in the venue catalogue, as a client **sends** it: what the
+    table is called and where it stands. Nothing else — in particular, not an ``id``.
 
-    Its ``id`` is a ``ValueObjectId`` for the same reason a pool's is: a pool holds a
-    list of these strings (``table_ids``) and nothing else connects the two, so an id
-    that is the empty string is a table nothing can name — and a ``table_ids`` entry of
-    ``""`` would "resolve" against it. It is the same string-ref pattern with the same
-    hole, and closing it in one place and not the other would leave the boundary
-    half-drawn.
+    A table is a row now (ADR 20260801, "a placement names a real table"), and its id
+    is minted by the database (``gen_random_uuid()``). So the id is simply not a field
+    of this model, and ``extra="forbid"`` turns an attempt to send one into a 422 that
+    names it — the treatment :class:`PoolWrite` gives ``position`` and the event
+    schemas give ``entered``. A server-managed value is kept **off** the write shape
+    rather than accepted and then ignored: a client cannot tell from the schema that the
+    id it sent decided nothing, and a boundary that silently discards half of a payload
+    has to be documented to be understood.
+
+    That is a real change of who owns a table's identity, and it is the point of the
+    ADR. While the catalogue was JSONB, the id was a client-supplied string with nothing
+    to key on, which is the only reason a placement naming no table could be *stored*
+    rather than refused. The **order** of the list is what a client does control: it is
+    the catalogue's order, and the server assigns each table its place from it.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    id: ValueObjectId
     label: str
     court: str
+
+
+class TournamentTable(TournamentTableWrite):
+    """A table in the venue catalogue as it is **read back**: everything a client wrote,
+    plus the ``id`` the server minted for it.
+
+    Deriving it from :class:`TournamentTableWrite` keeps the two shapes one shape plus
+    a field, exactly as :class:`Pool` derives from :class:`PoolWrite`: a column added to
+    the write side is readable without a second edit, and the two can never disagree
+    about what a table *is*.
+
+    ``id`` is a UUID — the ``tournament_tables`` row's primary key. It is what a pool's
+    ``table_ids`` and a fixture's ``table_id`` name, and (from the fixture side) what a
+    foreign key will hold.
+    """
+
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    id: uuid.UUID
 
 
 PoolPosition = Annotated[
@@ -1032,8 +1064,8 @@ class TournamentFixtureRead(BaseModel):
       JSONB, not a foreign key, because pools are value-objects with no table.
     * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means
       **unassigned to a table**. When set, it names a ``TournamentTable`` in the
-      tournament's ``table_catalogue`` — a string ref into JSONB, not a foreign key,
-      the same pattern as ``pool_id``.
+      tournament's ``table_catalogue`` — carried as a string ref, still not a foreign
+      key, though the table it names is a real row now (ADR 20260801).
     * ``scheduled_start`` — the placement's **predicted** start: ``null`` means
       **unscheduled**. When set, a :class:`FixtureTimeRead` (see it) — a venue-local
       label + tz abbrev for display, plus the raw UTC instant for geometry — composed
@@ -1567,18 +1599,30 @@ class TournamentCreate(BaseModel):
     # venue is booked, and a private tournament may withhold its address deliberately;
     # requiring one here made both impossible through every write path (#1206).
     address: SubmittedAddress = None
-    table_catalogue: list[TournamentTable] = Field(default_factory=list)
+    # The venue catalogue, in the order it should be shown. Each entry is a label and a
+    # court and nothing else — a table's id is minted by the server (ADR 20260801), so
+    # sending one is a 422 (``TournamentTableWrite``, ``extra="forbid"``).
+    table_catalogue: list[TournamentTableWrite] = Field(default_factory=list)
     league_id: uuid.UUID | None = None
 
 
 class TournamentUpdate(BaseModel):
     """Partial update. A field that is *absent* is left unchanged; an explicit
-    value replaces the current one. The columns backing ``name`` and
-    ``table_catalogue`` are NOT NULL, so for those an explicit ``null`` is
+    value replaces the current one. ``name`` maps to a NOT NULL column and
+    ``table_catalogue`` to a whole child table, so for those an explicit ``null`` is
     rejected (422) rather than allowed to reach the DB — "omitted" and "cleared"
     are different. ``description``/``start_date``/``end_date`` are nullable
-    columns and may be cleared. ``table_catalogue`` replaces wholesale when
-    present.
+    columns and may be cleared.
+
+    ``table_catalogue``, when present, is the catalogue **in full and in order**, and it
+    is applied by position: the i-th table sent is the i-th table stored, a longer list
+    adds tables, a shorter one removes from the end. Position is the only identity a
+    client has left now that a table's id is the server's (ADR 20260801) — and matching
+    on it, rather than dropping the catalogue and rebuilding it, is what stops an
+    unrelated edit (the client re-sends the catalogue on every PATCH) from re-minting
+    every id and dangling every pool's ``table_ids`` and every fixture's ``table_id``.
+    Removing a table that a fixture is placed at is not yet refused; that refusal, and
+    the id-keyed diff it needs, is the next step of the ADR.
 
     ``address`` is nullable too, as of #1206: **omitted means unchanged; ``null`` — or
     an all-blank object, which :data:`SubmittedAddress` normalizes to ``null`` — means
@@ -1613,7 +1657,12 @@ class TournamentUpdate(BaseModel):
     # "remove" — the disambiguator is ``"address" in updates.model_fields_set``, never
     # the value.
     address: SubmittedAddress = None
-    table_catalogue: list[TournamentTable] | None = None
+    # The venue catalogue in full, in the order it should be shown, or omitted to leave
+    # it alone. Ids are the server's (``TournamentTableWrite``), so the position of an
+    # entry in this list is the only way a client can say "this is the table I already
+    # had": the i-th entry sent updates the i-th table stored, a longer list adds, a
+    # shorter one removes from the end.
+    table_catalogue: list[TournamentTableWrite] | None = None
     league_id: uuid.UUID | None = None
 
     @field_validator("name", "table_catalogue", "league_id", mode="before")
@@ -1932,8 +1981,10 @@ class TournamentFixturePlacementUpdate(BaseModel):
     flag-on-read concern). They save. Conflict detection is a future scheduler slice.
 
     ``table_id`` is a **string ref** into the tournament's ``table_catalogue`` (names a
-    ``TournamentTable.id``) — the same pattern as a fixture's ``pool_id``, not a
-    foreign key — and per the soft rule above an unknown id is stored, not refused.
+    ``TournamentTable.id``) — not yet a foreign key, and per the soft rule above an
+    unknown id is stored, not refused. That last clause is on its way out: ADR 20260801
+    makes "the table exists" an invariant now that a table is a real row, so a bogus
+    ``table_id`` becomes a 422 once the key is in place.
 
     The one thing the *route* refuses is moving a fixture whose linked match is
     ``completed`` or ``voided``: its placement is history (409). A fixture with no match

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -1064,8 +1064,9 @@ class TournamentFixtureRead(BaseModel):
       JSONB, not a foreign key, because pools are value-objects with no table.
     * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means
       **unassigned to a table**. When set, it names a ``TournamentTable`` in the
-      tournament's ``table_catalogue`` — carried as a string ref, still not a foreign
-      key, though the table it names is a real row now (ADR 20260801).
+      tournament's ``table_catalogue``, and it is guaranteed to: the column is a real
+      foreign key, so this is never a dangling ref (ADR 20260801). Carried as the id's
+      text, the same form a pool's ``table_ids`` carry.
     * ``scheduled_start`` — the placement's **predicted** start: ``null`` means
       **unscheduled**. When set, a :class:`FixtureTimeRead` (see it) — a venue-local
       label + tz abbrev for display, plus the raw UTC instant for geometry — composed
@@ -1109,7 +1110,8 @@ class TournamentFixtureRead(BaseModel):
     # Read from the match row on every load (never snapshotted), so it tracks the match
     # as it is played rather than freezing at go-live. See ``match_id`` above.
     match_status: MatchStatus | None
-    # A placement. ``table_id`` string-refs the tournament's table_catalogue; both it
+    # A placement. ``table_id`` is a table of the tournament's catalogue, by id and by
+    # foreign key (never dangling, ADR 20260801); both it
     # and ``scheduled_start`` ``null`` = unassigned. ``scheduled_start`` is the
     # predicted start as a ``FixtureTimeRead`` (venue-local label + tz abbrev + raw
     # UTC instant), composed server-side in the event's timezone.
@@ -1972,19 +1974,29 @@ class TournamentFixturePlacementUpdate(BaseModel):
     The body is the placement in full — both fields are stated together. ``null`` on
     either clears that half, and ``(null, null)`` unassigns the fixture entirely.
 
-    **Soft, deliberately.** ``scheduled_start`` is a *prediction*, not a commitment,
-    and the placement's constraints — the table belongs to the fixture's pool, the time
-    falls inside the pool's window, nothing is double-booked — are **flags derived on
-    read, not invariants** (ADR-0790). So this write does **not** reject an
-    out-of-window time, nor a ``table_id`` that names no table in the tournament's
-    ``table_catalogue`` (a later pool/catalogue edit can dangle the ref; that is a
-    flag-on-read concern). They save. Conflict detection is a future scheduler slice.
+    **Soft, deliberately — with one exception.** ``scheduled_start`` is a *prediction*,
+    not a commitment, and three of the placement's four constraints — the table belongs
+    to the fixture's pool, the time falls inside the pool's window, nothing is
+    double-booked — are **flags derived on read, not invariants** (ADR-0790). So this
+    write does **not** reject an out-of-window time or an off-pool table. They save.
+    Conflict detection is the scheduler's business, not this boundary's.
 
-    ``table_id`` is a **string ref** into the tournament's ``table_catalogue`` (names a
-    ``TournamentTable.id``) — not yet a foreign key, and per the soft rule above an
-    unknown id is stored, not refused. That last clause is on its way out: ADR 20260801
-    makes "the table exists" an invariant now that a table is a real row, so a bogus
-    ``table_id`` becomes a 422 once the key is in place.
+    The exception is the fourth claim: **the table has to exist**. ``table_id`` names a
+    ``TournamentTable.id`` in the tournament's ``table_catalogue``, and since the
+    catalogue became real rows a fixture's ``table_id`` is a real **foreign key** into
+    them, so an id that names no table is a **422 naming this field** rather than
+    something stored and hoped about (ADR 20260801, "a placement names a real table, and
+    only that is an invariant" — which supersedes exactly one clause of ADR-0790 and
+    leaves the rest standing). The three flags are statements about a *relationship*
+    between things that each legitimately move, so they must stay soft; "this id
+    resolves to a table" is not one of those, and a placement whose table does not exist
+    is a dangling pointer nothing downstream can render.
+
+    The field carries the id's canonical **text** rather than a typed UUID, which is
+    also what a pool's ``table_ids`` carry — one representation for a table id, moved in
+    one piece rather than a field at a time. A value that is not a well-formed id is
+    therefore refused by the same 422 as an unknown one: there is one question here
+    ("does this name a table of this tournament?") and it gets one answer.
 
     The one thing the *route* refuses is moving a fixture whose linked match is
     ``completed`` or ``voided``: its placement is history (409). A fixture with no match

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -632,12 +632,61 @@ class TournamentTableWrite(BaseModel):
     to key on, which is the only reason a placement naming no table could be *stored*
     rather than refused. The **order** of the list is what a client does control: it is
     the catalogue's order, and the server assigns each table its place from it.
+
+    This is the shape a **create** takes, and there it is the whole story: a tournament
+    being born has no tables, so there is nothing an ``id`` could name. A *patch* is a
+    diff over tables that already exist, so its entries derive from this one and add an
+    optional ``id`` naming the table they keep (:class:`TournamentTableUpsert`) — which
+    is citing an id, not authoring one, and does not disturb who mints them.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     label: str
     court: str
+
+
+class TournamentTableUpsert(TournamentTableWrite):
+    """One entry of a catalogue a client **edits** (``PATCH /v1/tournaments/{id}``):
+    everything :class:`TournamentTableWrite` carries, plus an **optional** ``id`` naming
+    a table the tournament already has.
+
+    The optional id is what makes the catalogue write a **diff** rather than a
+    positional overwrite, and it exists because the ADR's removal semantics need one.
+    The two cases are exhaustive and mean different things:
+
+    * ``id`` **present** — "this is the table you already have, with these words". The
+      row keeps its id (and therefore every pool ``table_ids`` entry and every fixture
+      ``table_id`` that names it) and takes the new ``label``/``court``, and its place
+      in the list is its new place in the catalogue's order.
+    * ``id`` **omitted** (or ``null``) — "add a table". The server mints its id, exactly
+      as on create.
+    * a stored table **no entry names** — "remove it". Which is the whole reason this
+      field had to arrive: a removal can be *refused*
+      (:class:`~app.tournament_errors.TableInUseError`), and a verb that cannot tell
+      "the table you renamed" from "a different table at the same index" cannot tell a
+      rename from a removal either.
+
+    That last point is why the by-position stopgap this replaces could not stand.
+    Matching the i-th sent against the i-th stored made **reordering swap labels between
+    ids**: send the same two tables in the other order and each row kept its id and took
+    its neighbour's words, so a fixture placed at "Table 1" started rendering as
+    "Table 2". Nothing refused it and nothing could see it — an id is not a position,
+    and only the client knows which of its rows is which.
+
+    An id that names no table of *this* tournament is a 422 on the field, not a silently
+    minted new table: a client that names a table it cannot see has a bug, and quietly
+    handing it a different id than it asked for would hide it (parse-at-boundaries).
+
+    It is deliberately **not** on :class:`TournamentTableWrite`, the create shape: a
+    tournament being born has no tables to name, so an ``id`` there is still a 422 for
+    an unknown field. Nothing about who mints an id has changed — the server still does
+    (ADR 20260801); what changed is that a client may now *cite* one it was given.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: uuid.UUID | None = None
 
 
 class TournamentTable(TournamentTableWrite):
@@ -836,6 +885,60 @@ reads ``pool.id``, not ``pool["id"]``) and it contributes **nothing** to the JSO
 schema, so the OpenAPI shape of ``pools`` is the array it always was. A rule a client
 cannot express in a schema keyword is not a reason to let the server hold a state it
 cannot survive."""
+
+
+def _table_ids_are_unique(
+    tables: list[TournamentTableUpsert],
+) -> list[TournamentTableUpsert]:
+    """Refuse an edited catalogue when two of its entries cite the same table ``id``
+    (422) — the diff's twin of :func:`_pool_ids_are_unique`.
+
+    ``[{id: X, label: "Table 1"}, {id: X, label: "Table 2"}]`` is not a catalogue: it
+    asks one row to be in two places at once and to be called two things. The diff would
+    have to pick a winner, and either pick is a catalogue the director did not send —
+    the row lands at one of the two positions with one of the two labels, and the
+    "other" table it looked like they were keeping is silently *removed* instead, taking
+    its fixtures' placements through the 409 (or, with the opt-in, through an unplacing
+    the director never asked for).
+    A rule about the **list**, so it is a validator on the list type
+    (:data:`EditedTableCatalogue`) rather than on an entry — an entry cannot see its
+    siblings. Entries with no ``id`` are ignored: those are additions, and any number of
+    new tables may be added at once.
+
+    The duplicated **ids** are named rather than the labels, exactly as the pool rule
+    names ids: the id is what is duplicated, two entries citing one id may well carry
+    different labels, and the id is what the client has to fix. A 422, not a 409,
+    because it is a malformed payload whatever state the tournament is in.
+    """
+    counted = Counter(table.id for table in tables if table.id is not None)
+    duplicated = [str(table_id) for table_id, count in counted.items() if count > 1]
+    if duplicated:
+        raise ValueError(
+            f"A table id names one table: {named_list(duplicated)} "
+            f"{'is' if len(duplicated) == 1 else 'are'} cited by more than one "
+            "entry of this catalogue. Cite each table you are keeping exactly once, "
+            "and omit the id of a table you are adding."
+        )
+    return tables
+
+
+EditedTableCatalogue = Annotated[
+    list[TournamentTableUpsert], AfterValidator(_table_ids_are_unique)
+]
+"""A venue catalogue **as a PATCH sends it**: the catalogue in full and in order, each
+entry either citing the table it keeps or omitting an ``id`` to add one
+(:class:`TournamentTableUpsert`), and no two entries citing the same table.
+
+It is the **whole** catalogue every time, not a list of changes: what a client sends is
+the state it wants, and the verb computes the delete/keep/add from it
+(:func:`~app.tournament_tables.apply_table_catalogue`). That is what makes "a table this
+payload does not mention is removed" a statement about the payload rather than about the
+order things happened to be in.
+
+An ``AfterValidator`` on the list, deliberately: it runs on the parsed entries (so it
+reads ``table.id``, not ``table["id"]``) and contributes **nothing** to the JSON schema,
+so the OpenAPI shape of ``table_catalogue`` stays the array it always was — the same
+arrangement :data:`EventPools` uses for the same reason."""
 
 
 def stored_pools(pools: Sequence[PoolWrite]) -> list[dict[str, Any]]:
@@ -1617,14 +1720,11 @@ class TournamentUpdate(BaseModel):
     columns and may be cleared.
 
     ``table_catalogue``, when present, is the catalogue **in full and in order**, and it
-    is applied by position: the i-th table sent is the i-th table stored, a longer list
-    adds tables, a shorter one removes from the end. Position is the only identity a
-    client has left now that a table's id is the server's (ADR 20260801) — and matching
-    on it, rather than dropping the catalogue and rebuilding it, is what stops an
-    unrelated edit (the client re-sends the catalogue on every PATCH) from re-minting
-    every id and dangling every pool's ``table_ids`` and every fixture's ``table_id``.
-    Removing a table that a fixture is placed at is not yet refused; that refusal, and
-    the id-keyed diff it needs, is the next step of the ADR.
+    is applied as an **id-keyed diff** (ADR 20260801): an entry that cites an ``id``
+    keeps that table (with the words and the place this payload gives it), an entry with
+    no ``id`` adds one, and a stored table no entry cites is **removed**. Citing the id
+    is what makes a reorder move *tables* rather than swap labels between ids, and it is
+    what lets a removal be refused — see ``unplace_fixtures_on_removed_tables``.
 
     ``address`` is nullable too, as of #1206: **omitted means unchanged; ``null`` — or
     an all-blank object, which :data:`SubmittedAddress` normalizes to ``null`` — means
@@ -1638,6 +1738,14 @@ class TournamentUpdate(BaseModel):
     ``POST /v1/tournaments/{id}/transitions`` (ADR-0017). A guard on that route
     that left a ``status`` field on this one would have guarded nothing, so
     sending ``status`` here is a 422 via ``extra="forbid"``.
+
+    ``unplace_fixtures_on_removed_tables`` is the **removal opt-in**, not a field of the
+    tournament: it decides what happens when this payload's ``table_catalogue`` drops a
+    table that matches are placed at. Left ``false`` (the default) the whole edit is
+    refused with a ``409`` naming the table, and nothing is written. Set ``true``, the
+    removal goes through and those matches are unplaced — table, predicted start and
+    pin all cleared — which is why it has to be said on purpose (ADR 20260801). A table
+    that only a *pool* reserves needs no opt-in: the pool simply reserves one fewer.
 
     ``league_id`` is updatable, but **only while the tournament is ``draft``**
     (ADR-0783): once it is published, registration is open and eligibility is live,
@@ -1660,12 +1768,22 @@ class TournamentUpdate(BaseModel):
     # the value.
     address: SubmittedAddress = None
     # The venue catalogue in full, in the order it should be shown, or omitted to leave
-    # it alone. Ids are the server's (``TournamentTableWrite``), so the position of an
-    # entry in this list is the only way a client can say "this is the table I already
-    # had": the i-th entry sent updates the i-th table stored, a longer list adds, a
-    # shorter one removes from the end.
-    table_catalogue: list[TournamentTableWrite] | None = None
+    # it alone. An entry citing an ``id`` is a table this tournament already has; an
+    # entry with no ``id`` is a new one; a stored table no entry cites is removed. Send
+    # back the catalogue you read, edited — the ids came from the read.
+    table_catalogue: EditedTableCatalogue | None = None
     league_id: uuid.UUID | None = None
+    # The removal opt-in, and the one field on this model that is not a value the
+    # tournament ends up holding: it is a **confirmation**, and it is inert unless this
+    # payload's ``table_catalogue`` removes a table that matches are placed at. A
+    # removal is refused (409) by default precisely so this cannot happen by accident —
+    # silently unplacing a match as a side effect of editing the venue would make it
+    # indistinguishable from a match nobody ever placed (ADR 20260801).
+    #
+    # It rides on the body rather than on a query string so the MCP ``edit_tournament``
+    # tool — which takes this very model and has no query string — offers the director's
+    # agent the same way out the HTTP caller has, out of one schema that cannot drift.
+    unplace_fixtures_on_removed_tables: bool = False
 
     @field_validator("name", "table_catalogue", "league_id", mode="before")
     @classmethod

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -1741,11 +1741,11 @@ class TournamentUpdate(BaseModel):
 
     ``unplace_fixtures_on_removed_tables`` is the **removal opt-in**, not a field of the
     tournament: it decides what happens when this payload's ``table_catalogue`` drops a
-    table that matches are placed at. Left ``false`` (the default) the whole edit is
-    refused with a ``409`` naming the table, and nothing is written. Set ``true``, the
-    removal goes through and those matches are unplaced — table, predicted start and
-    pin all cleared — which is why it has to be said on purpose (ADR 20260801). A table
-    that only a *pool* reserves needs no opt-in: the pool simply reserves one fewer.
+    table that matches are placed at. **Omitted** — or ``false``, or ``null`` — the
+    whole edit is refused with a ``409`` naming the table, and nothing is written. Set
+    ``true``, the removal goes through and those matches are unplaced — table, predicted
+    start and pin all cleared — which is why it is said on purpose (ADR 20260801). A
+    table that only a *pool* reserves needs no opt-in: the pool reserves one fewer.
 
     ``league_id`` is updatable, but **only while the tournament is ``draft``**
     (ADR-0783): once it is published, registration is open and eligibility is live,
@@ -1783,7 +1783,42 @@ class TournamentUpdate(BaseModel):
     # It rides on the body rather than on a query string so the MCP ``edit_tournament``
     # tool — which takes this very model and has no query string — offers the director's
     # agent the same way out the HTTP caller has, out of one schema that cannot drift.
-    unplace_fixtures_on_removed_tables: bool = False
+    #
+    # ``bool | None``, defaulting to ``None`` rather than ``bool = False``, because on a
+    # PATCH an omitted key must stay omittable — and **the discriminator generated
+    # clients use is the default's nullness, not the field's optionality**. A non-null
+    # default (``False``) is emitted into the JSON schema as ``"default": false``, and
+    # ``openapi-typescript`` promotes any property carrying one to **required**: a PATCH
+    # that renames a tournament — ``{"name": "…"}``, or even ``{}`` — stopped
+    # type-checking, because an opt-in for one destructive action had become mandatory
+    # on every unrelated write. That is wrong for a partial update, where omitting a key
+    # means "unchanged" and this key means "and I am not removing anything". A ``None``
+    # default emits no ``default`` at all and generates as ``field?: boolean | null``,
+    # which is the same trap ``position`` sprang on the pool write shape.
+    #
+    # The three-valued *wire* type does NOT reach the interior: ``None`` and ``False``
+    # are the same answer (nobody opted in) and :attr:`unplacing_is_confirmed` collapses
+    # them into the one ``bool`` the verb takes, so nothing downstream can ask this
+    # question and get three answers (api/CLAUDE.md, "no tri-state booleans").
+    unplace_fixtures_on_removed_tables: bool | None = None
+
+    @property
+    def unplacing_is_confirmed(self) -> bool:
+        """Did this payload opt in to removing a table matches are placed at?
+
+        The **one** reading of :attr:`unplace_fixtures_on_removed_tables`, and the
+        reason that field's three wire values are only ever two states inside: an opt-in
+        is something a caller *says*, so anything that is not ``true`` — ``false``,
+        ``null``, or an absent key — is a caller who did not say it, and the removal is
+        refused (:class:`~app.tournament_errors.TableInUseError`).
+
+        A read-side ``property`` rather than a validator that coerces the field, for the
+        reason :meth:`RoundRobinDrawSettingsWrite.qualifiers_per_pool` is one: the
+        field's declared type is what shapes the wire (and here, what keeps the key
+        omittable), while this is what the interior holds. Callers take this and never
+        the field, so ``unplace_fixtures`` stays a total ``bool``.
+        """
+        return self.unplace_fixtures_on_removed_tables is True
 
     @field_validator("name", "table_catalogue", "league_id", mode="before")
     @classmethod

--- a/api/app/tournament_edit.py
+++ b/api/app/tournament_edit.py
@@ -40,6 +40,7 @@ from app.tournament_errors import (
     TournamentNotFoundError,
 )
 from app.tournament_geocoding import geocode_address
+from app.tournament_realtime import stage_event_entrant_hints
 from app.tournament_tables import apply_table_catalogue
 
 
@@ -205,14 +206,28 @@ async def edit_tournament(
     value, so both branches key on ``"address" in updates.model_fields_set``, never on
     ``updates.address is not None``.
 
-    A submitted ``table_catalogue`` is applied **by position**
+    A submitted ``table_catalogue`` is applied as an **id-keyed diff**
     (:func:`~app.tournament_tables.apply_table_catalogue`) rather than assigned: the
-    catalogue is child rows now (ADR 20260801), and a table's id is the server's, so the
-    i-th table sent updates the i-th table stored, a longer list adds and a shorter one
-    removes from the end. That is what stops the catalogue the web client re-sends on
-    every PATCH from re-minting every id — which would dangle every pool's ``table_ids``
-    and unplace every fixture as a side effect of a rename. (Refusing to remove a table
-    a fixture is placed at is the ADR's next step; today the removal goes through.)
+    catalogue is child rows now (ADR 20260801), so an entry citing an ``id`` keeps that
+    row (with this payload's words and place), an entry with no ``id`` adds one, and a
+    stored table no entry cites is removed. Keying on the id is what keeps the catalogue
+    the web client re-sends on every PATCH from re-minting anybody's id — and what makes
+    a **reorder move tables** instead of swapping labels between ids, which the
+    by-position stopgap it replaces did silently.
+
+    That gives the verb two more refusals, both judged **before anything is written**:
+
+    * **422** — an entry citing an id this tournament's catalogue does not hold raises
+      :class:`~app.tournament_errors.TableNotInCatalogueError`, naming the entry.
+    * **409** — a removal that a fixture's **placement** stands in the way of raises
+      :class:`~app.tournament_errors.TableInUseError`, naming the table by label, unless
+      the payload carries ``unplace_fixtures_on_removed_tables``. With the opt-in the
+      removal goes through and those fixtures are unplaced (table, start and pin all
+      cleared) and their events' entrants are hinted. A table only a **pool** reserves
+      needs no opt-in and produces no refusal: the pool quietly reserves one fewer. The
+      asymmetry is the ADR's point — clearing a placement destroys information on an
+      unrelated write, so the database refuses by default and the director says yes on
+      purpose.
 
     Then it applies the remaining fields (``model_dump(exclude_unset=True)``
     already serialized the nested value-objects to plain dicts/lists, so one
@@ -308,23 +323,45 @@ async def edit_tournament(
         else:
             del fields["address"]
 
-    # The catalogue is child ROWS now (ADR 20260801), so it comes out of the generic
-    # ``setattr`` loop: there is no ``table_catalogue`` column to assign. It is applied
-    # by position (:func:`apply_table_catalogue`), which is what keeps a table's
-    # server-minted id — and therefore every ref that names it — alive across the
-    # catalogue the web client re-sends on every PATCH. The schema rejects an explicit
-    # ``null``, so the key being present means a real list.
+    # Neither of these is a column on ``tournaments``, so both come out of the generic
+    # ``setattr`` loop before it runs. The catalogue is child ROWS (ADR 20260801) — a
+    # diff, not an assignment — and the opt-in is a *confirmation about this request*,
+    # not a value the tournament ends up holding, so there is nothing on the row for
+    # either of them to be set on.
+    fields.pop("unplace_fixtures_on_removed_tables", None)
     catalogue_changed = False
+    unplaced_event_ids: tuple[uuid.UUID, ...] = ()
     submitted_catalogue = updates.table_catalogue
     if submitted_catalogue is not None:
         fields.pop("table_catalogue", None)
-        catalogue_changed = apply_table_catalogue(tournament, submitted_catalogue)
+        # The id-keyed diff, and its two refusals — an entry citing an id this
+        # catalogue does not hold, and a removal a placement stands in the way of. Both
+        # raise before a single row is touched, and the commit is at the bottom of this
+        # function, so a refused catalogue leaves the tournament exactly as it was —
+        # including the ``league_id`` this verb may have set two branches above.
+        applied = await apply_table_catalogue(
+            db,
+            tournament,
+            submitted_catalogue,
+            unplace_fixtures=updates.unplace_fixtures_on_removed_tables,
+        )
+        catalogue_changed = applied.changed
+        unplaced_event_ids = applied.unplaced_event_ids
 
     for key, value in fields.items():
         setattr(tournament, key, value)
 
     if catalogue_changed and await tournament_has_drawn_event(db, tournament_id):
         await request_solve(db, tournament_id, ScheduleSolveTrigger.settings_changed)
+
+    # The opt-in just took a table and a time off somebody's dashboard panel, and — this
+    # being a *venue* edit rather than a placement one — nothing else tells them: an
+    # unplacing fans out no call and sends no correction, exactly as clearing a
+    # placement through ``place_fixture`` does not. Staged on this transaction, so a
+    # rollback hints nobody. An ordinary catalogue edit unplaces nothing and this is
+    # skipped.
+    if unplaced_event_ids:
+        await stage_event_entrant_hints(db, list(unplaced_event_ids))
 
     await db.commit()
     await db.refresh(tournament)

--- a/api/app/tournament_edit.py
+++ b/api/app/tournament_edit.py
@@ -31,7 +31,6 @@ from app.schedule_solves import request_solve, tournament_has_drawn_event
 from app.schemas.tournament import (
     Address,
     AddressInput,
-    TournamentTable,
     TournamentUpdate,
 )
 from app.tournament_errors import (
@@ -41,6 +40,7 @@ from app.tournament_errors import (
     TournamentNotFoundError,
 )
 from app.tournament_geocoding import geocode_address
+from app.tournament_tables import apply_table_catalogue
 
 
 async def _load_tournament_for_update(
@@ -89,18 +89,6 @@ async def _load_owned_tournament_for_update(
     if tournament.created_by_user_id != actor.id:
         raise NotTournamentOwnerError()
     return tournament
-
-
-def _catalogue_ids(tournament: Tournament) -> list[str]:
-    """The table catalogue reduced to its ``id`` list — the only slice of it the
-    solver reads (``_load_solver_inputs`` reduces the catalogue to ``TableId``s;
-    labels and courts are display). Parsed with the same model the write boundary
-    validated it with, so the before/after comparison is over what actually feeds
-    a solve: a rename/address/date edit and a label-only re-word trigger nothing,
-    adding/removing/re-identifying a table triggers a re-solve."""
-    return [
-        TournamentTable.model_validate(table).id for table in tournament.table_catalogue
-    ]
 
 
 #: The six free-text components of a venue address — the fields a client sends
@@ -217,12 +205,23 @@ async def edit_tournament(
     value, so both branches key on ``"address" in updates.model_fields_set``, never on
     ``updates.address is not None``.
 
+    A submitted ``table_catalogue`` is applied **by position**
+    (:func:`~app.tournament_tables.apply_table_catalogue`) rather than assigned: the
+    catalogue is child rows now (ADR 20260801), and a table's id is the server's, so the
+    i-th table sent updates the i-th table stored, a longer list adds and a shorter one
+    removes from the end. That is what stops the catalogue the web client re-sends on
+    every PATCH from re-minting every id — which would dangle every pool's ``table_ids``
+    and unplace every fixture as a side effect of a rename. (Refusing to remove a table
+    a fixture is placed at is the ADR's next step; today the removal goes through.)
+
     Then it applies the remaining fields (``model_dump(exclude_unset=True)``
     already serialized the nested value-objects to plain dicts/lists, so one
     ``setattr`` loop covers the JSONB and scalar columns alike) and, when the
-    table-catalogue ids changed AND at least one event is drawn, requests a
+    table-catalogue gained or lost a table AND at least one event is drawn, requests a
     ``settings_changed`` solve inside this transaction under the row lock (the
-    lock order ``request_solve`` requires). A ``None`` return from
+    lock order ``request_solve`` requires). Adding or removing a table changes the
+    solver's inputs (it reduces the catalogue to its ids); re-wording a label does not.
+    A ``None`` return from
     ``request_solve`` (Redis down) is deliberately ignored: the edit is what the
     owner asked for, and the missing solve is recovered by the pin tick or the
     Run-scheduler button.
@@ -309,14 +308,22 @@ async def edit_tournament(
         else:
             del fields["address"]
 
-    catalogue_ids_before = _catalogue_ids(tournament)
+    # The catalogue is child ROWS now (ADR 20260801), so it comes out of the generic
+    # ``setattr`` loop: there is no ``table_catalogue`` column to assign. It is applied
+    # by position (:func:`apply_table_catalogue`), which is what keeps a table's
+    # server-minted id — and therefore every ref that names it — alive across the
+    # catalogue the web client re-sends on every PATCH. The schema rejects an explicit
+    # ``null``, so the key being present means a real list.
+    catalogue_changed = False
+    submitted_catalogue = updates.table_catalogue
+    if submitted_catalogue is not None:
+        fields.pop("table_catalogue", None)
+        catalogue_changed = apply_table_catalogue(tournament, submitted_catalogue)
+
     for key, value in fields.items():
         setattr(tournament, key, value)
-    catalogue_ids_after = _catalogue_ids(tournament)
 
-    if catalogue_ids_after != catalogue_ids_before and await tournament_has_drawn_event(
-        db, tournament_id
-    ):
+    if catalogue_changed and await tournament_has_drawn_event(db, tournament_id):
         await request_solve(db, tournament_id, ScheduleSolveTrigger.settings_changed)
 
     await db.commit()

--- a/api/app/tournament_edit.py
+++ b/api/app/tournament_edit.py
@@ -343,7 +343,9 @@ async def edit_tournament(
             db,
             tournament,
             submitted_catalogue,
-            unplace_fixtures=updates.unplace_fixtures_on_removed_tables,
+            # The opt-in's one reading (``true``, and nothing else), so what crosses
+            # this seam is a ``bool`` rather than the field's omittable ``bool | None``.
+            unplace_fixtures=updates.unplacing_is_confirmed,
         )
         catalogue_changed = applied.changed
         unplaced_event_ids = applied.unplaced_event_ids

--- a/api/app/tournament_errors.py
+++ b/api/app/tournament_errors.py
@@ -398,6 +398,35 @@ class FixturePlacementFrozenError(Exception):
         self.match_status = match_status
 
 
+class PlacementTableNotFoundError(Exception):
+    """Raised by the place-fixture verb when the placement's ``table_id`` names no
+    table in the tournament's venue catalogue — the ONE thing about a placement that is
+    an **invariant** rather than a flag (ADR 20260801, "a placement names a real table,
+    and only that is an invariant").
+
+    It is deliberately *not* a sibling of :class:`FixturePlacementFrozenError`'s 409.
+    The freeze is about the state of the resource; this is about the **content of the
+    body**: the id sent does not resolve, so the field is wrong, and it will go on being
+    wrong until the client sends a different one. The HTTP adapter therefore names the
+    field the way every other refused field on this route is named — a 422 whose
+    ``detail`` carries ``loc: ["body", "table_id"]``, the same shape the schema's own
+    422s have, so a client needs no second parser for it.
+
+    Everything else about a placement stays soft (ADR-0790, undisturbed): an
+    out-of-window start, a table outside the fixture's pool, and a double-booking all
+    still SAVE and surface as flags derived on read. Only "does this reference resolve
+    at all" is hard, because a placement whose table does not exist is not a state the
+    director chose — it is a dangling pointer nothing downstream can render.
+
+    Carries the offending ``table_id`` verbatim (the string as sent, which need not even
+    be a well-formed UUID) so the adapter can echo it back as the ``input`` of the
+    validation error. Never an ``HTTPException``."""
+
+    def __init__(self, table_id: str) -> None:
+        super().__init__("This tournament's venue catalogue has no table with that id.")
+        self.table_id = table_id
+
+
 class NoDrawnEventsError(Exception):
     """Raised by the request-schedule-solve verb when no event of the addressed
     tournament has a **cut draw** — nothing the solver can place, so a run would

--- a/api/app/tournament_errors.py
+++ b/api/app/tournament_errors.py
@@ -229,6 +229,62 @@ class PoolSetFrozenError(Exception):
         self.added = added
 
 
+class TableNotInCatalogueError(Exception):
+    """Raised by the edit verb when an entry of a submitted ``table_catalogue`` cites an
+    ``id`` that names no table of **this** tournament's catalogue (ADR 20260801).
+
+    The sibling of :class:`PlacementTableNotFoundError`, one verb over, and refused for
+    the same reason: the id does not resolve, so the field is wrong and will go on being
+    wrong until the client sends a different one. Silently minting a fresh table for it
+    would hand the client back a different id than it asked for, and quietly *remove*
+    whatever table it meant to keep — the two failures a diff must never confuse.
+
+    Carries the ``index`` of the offending entry as well as the id, because a catalogue
+    is a list and a refusal a client cannot attribute to a row is a refusal it cannot
+    render: the HTTP adapter names ``loc: ["body", "table_catalogue", index, "id"]``,
+    the same shape the schema's own 422s on this field have. Never an
+    ``HTTPException``."""
+
+    def __init__(self, index: int, table_id: str) -> None:
+        super().__init__("This tournament's venue catalogue has no table with that id.")
+        self.index = index
+        self.table_id = table_id
+
+
+class TableInUseError(Exception):
+    """Raised by the edit verb when a submitted ``table_catalogue`` would **remove a
+    table that matches are placed at**, without the unplace-and-remove opt-in
+    (ADR 20260801, "a placement names a real table, and only that is an invariant").
+
+    This is the loud half of the ADR's deliberate split. A **pool** that merely reserves
+    a removed table is not consulted at all — it quietly reserves one fewer, because a
+    table breaking or freeing up is ordinary venue traffic. A **placement** gets the
+    refusal, because silently clearing one destroys information on an *unrelated* write:
+    the fixture would stop being "placed at a table that vanished" and become
+    indistinguishable from "nobody ever placed this", as an invisible side effect of
+    renaming the venue. The database refuses by default (``ON DELETE RESTRICT``); the
+    director says yes on purpose.
+
+    It is a 409, not a 403 or a 422 (the same reasoning as :class:`PoolSetFrozenError`,
+    whose house style its sentence follows): the caller is the owner and the payload is
+    well-formed — it is the *state of the world* that forbids the edit, and the
+    identical request succeeds the moment the matches are moved off the table, or the
+    moment the caller sends the opt-in.
+
+    Carries the domain-authored sentence the adapters rebuild verbatim with
+    ``str(exc)``, plus the structured ``tables`` (the at-fault tables' **labels**, never
+    their ids — an id tells a director looking at a page of named tables nothing to act
+    on) and ``placements`` (how many matches would be unplaced) for any adapter that
+    wants to reshape rather than echo. **Nothing is written when it is raised**: it is
+    judged before the diff touches a row, so a refused edit leaves the tournament
+    exactly as it was. Never an ``HTTPException``."""
+
+    def __init__(self, message: str, *, tables: list[str], placements: int) -> None:
+        super().__init__(message)
+        self.tables = tables
+        self.placements = placements
+
+
 class DrawTypeFrozenError(Exception):
     """Raised by the update-event verb when a ``draw_type`` payload would change the
     draw type of an event that **has a draw** (ADR-0786). A draw type is the strategy

--- a/api/app/tournament_lifecycle.py
+++ b/api/app/tournament_lifecycle.py
@@ -26,7 +26,7 @@ and its 500.
 import uuid
 from typing import assert_never
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.geocoding import Geocoder
@@ -36,6 +36,7 @@ from app.models import (
     ScheduleSolveTrigger,
     Tournament,
     TournamentEvent,
+    TournamentFixture,
     TournamentStatus,
     User,
 )
@@ -215,9 +216,34 @@ async def delete_tournament(
     pending tournament delete ahead of it anyway. It is spelled out so the ordering
     survives a session with autoflush disabled — and, measured, removing it alone
     leaves the suite green, so nothing here would catch its loss.
+
+    It also **unplaces every fixture first**, and that one IS the mechanism. A
+    fixture's ``table_id`` is a foreign key with ``ON DELETE RESTRICT`` (ADR 20260801),
+    ``Tournament.tables`` is loaded, so SQLAlchemy issues the child ``DELETE`` of
+    ``tournament_tables`` **itself** — as its own statement, ahead of the
+    ``tournaments`` row whose cascade takes the fixtures. RESTRICT is checked
+    immediately and cannot be deferred, so at that moment the fixtures are still
+    there, still pointing at the tables, and the whole delete dies on a foreign-key
+    violation. Dropping the references first is not a policy decision sneaking in:
+    RESTRICT exists so a placement is not destroyed as a side effect of editing the
+    **venue**, and this is not a venue edit — the fixture is being deleted too, one
+    statement later, along with everything else the director asked to be rid of. The
+    refusal that ADR belongs to is the tournament PATCH's, over a table removed out
+    from under a fixture that survives it.
     """
     tournament = await _load_owned_tournament_for_update(db, tournament_id, actor)
     settings_ids = await draw_settings_ids_for_tournament(db, tournament.id)
+    await db.execute(
+        update(TournamentFixture)
+        .where(
+            TournamentFixture.event_id.in_(
+                select(TournamentEvent.id).where(
+                    TournamentEvent.tournament_id == tournament.id
+                )
+            )
+        )
+        .values(table_id=None)
+    )
     await db.delete(tournament)
     await db.flush()
     await reap_draw_settings(db, settings_ids)

--- a/api/app/tournament_lifecycle.py
+++ b/api/app/tournament_lifecycle.py
@@ -57,6 +57,7 @@ from app.tournament_errors import (
 from app.tournament_geocoding import geocode_address
 from app.tournament_materialization import materialize_live_draw
 from app.tournament_realtime import stage_tournament_entrant_hints
+from app.tournament_tables import stored_tables
 
 # The lifecycle runs forward only, and exactly three transitions exist (ADR-0017):
 # ``draft`` → ``published`` (publish), ``published`` → ``live`` (go live), and
@@ -130,8 +131,10 @@ async def create_tournament(
       than attempted-and-forgiven precisely because a blank address composes to ``""``,
       which resolves to zero candidates — an organizer with no venue would otherwise be
       told their nonexistent venue could not be found.
-    * The value-objects (``address``, ``table_catalogue``) persist as plain JSONB;
-      the dicts ``model_dump`` produces don't propagate beyond this write boundary.
+    * The ``address`` value-object persists as plain JSONB; the dict ``model_dump``
+      produces doesn't propagate beyond this write boundary. The ``table_catalogue``
+      does **not**: it becomes ``tournament_tables`` rows (ADR 20260801), each carrying
+      a server-minted UUID id and the ``position`` of its place in the submitted list.
     * **No** ``status`` is set: it isn't on the create schema (ADR-0017), so a
       tournament is born ``draft`` from the column's server default — one source for
       the starting status — and the ``refresh`` below reads it back.
@@ -164,7 +167,10 @@ async def create_tournament(
         start_date=payload.start_date,
         end_date=payload.end_date,
         address=address.model_dump() if address is not None else None,
-        table_catalogue=[t.model_dump() for t in payload.table_catalogue],
+        # The catalogue is child ROWS now (ADR 20260801), not a JSONB column, and the
+        # ids on them are the database's — ``stored_tables`` sets no id, only the
+        # ``position`` each table's index in the submitted list gives it.
+        tables=stored_tables(payload.table_catalogue),
         league_id=league.id,
         created_by_user_id=actor.id,
     )

--- a/api/app/tournament_placement.py
+++ b/api/app/tournament_placement.py
@@ -19,10 +19,13 @@ Per the tournament-verbs ADR (mirroring ``tournament_lifecycle`` /
 ``tournament_events`` / ``tournament_entries`` / ``tournament_edit``), it signals every
 refusal with a **domain exception** from ``app.tournament_errors`` — never an
 ``HTTPException`` — and each adapter maps it back to the exact response it produced
-before. ``apply_manual_placement`` raises no refusal of its own (the placement is soft,
-ADR-0790: an out-of-window time or a dangling ``table_id`` SAVES), so the two coded
-refusals — a missing fixture (:class:`FixtureNotFoundError`) and a played-out fixture
-(:class:`FixturePlacementFrozenError`) — are judged here, before it is called.
+before. ``apply_manual_placement`` raises no refusal of its own (the placement is still
+soft everywhere ADR-0790 made it soft: an out-of-window time, an off-pool table and a
+double-booking all SAVE), so all three coded refusals — a missing fixture
+(:class:`FixtureNotFoundError`), a played-out fixture
+(:class:`FixturePlacementFrozenError`), and a ``table_id`` that names no table in the
+tournament's catalogue (:class:`PlacementTableNotFoundError`, ADR 20260801) — are judged
+here, before it is called.
 """
 
 import uuid
@@ -36,6 +39,7 @@ from app.models import (
     Match,
     MatchStatus,
     ScheduleSolveTrigger,
+    Tournament,
     TournamentEvent,
     TournamentFixture,
     User,
@@ -49,6 +53,7 @@ from app.tournament_edit import _load_owned_tournament_for_update
 from app.tournament_errors import (
     FixtureNotFoundError,
     FixturePlacementFrozenError,
+    PlacementTableNotFoundError,
 )
 from app.tournament_queries import fixtures_by_event
 from app.tournament_realtime import stage_event_entrant_hints
@@ -113,6 +118,37 @@ def _enforce_fixture_placeable(match_status: MatchStatus | None) -> None:
             assert_never(match_status)
 
 
+def _enforce_table_exists(tournament: Tournament, table_id: str | None) -> None:
+    """Raise :class:`PlacementTableNotFoundError` unless ``table_id`` names a table in
+    ``tournament``'s venue catalogue — the one *invariant* of an otherwise-soft
+    placement (ADR 20260801).
+
+    ``None`` is not a miss: it is the placement's "no table", which is exactly how a
+    fixture is unplaced.
+
+    Answered against the catalogue rows the locked owner-load already carries
+    (``Tournament.tables`` is ``lazy="selectin"``), so this costs no extra statement,
+    and it is judged under the same tournament row lock the catalogue is *edited* under
+    — a concurrent PATCH cannot remove the table between this check and the write.
+
+    Scoped to **this tournament**, which is stricter than the column's foreign key can
+    be: the key only knows the row exists somewhere on the platform, while a table
+    belonging to somebody else's tournament is, from here, exactly the dangling pointer
+    the ADR makes unrepresentable — nothing on this page could render it. That is not a
+    fourth constraint sneaking in: it is the same claim ("the placement names a real
+    table") asked of the only catalogue this placement can be read against.
+
+    The comparison is on the id's **text**, so a ``table_id`` that is not even a
+    well-formed UUID lands here rather than at the database as a type error, and one
+    refusal covers both — a client that sent a bad id gets told the id is bad, not two
+    different things depending on how bad.
+    """
+    if table_id is None:
+        return
+    if table_id not in {str(table.id) for table in tournament.tables}:
+        raise PlacementTableNotFoundError(table_id)
+
+
 async def place_fixture(
     db: AsyncSession,
     *,
@@ -141,11 +177,15 @@ async def place_fixture(
       (:func:`_load_fixture_for_placement`); a mismatched pair raises
       :class:`FixtureNotFoundError`, alongside its match's live status and its event's
       timezone.
-    * **409** — the one hard rule, before anything is written: a played-out
-      (``completed``/``voided``) fixture keeps its placement
+    * **409** — the hard rule about the fixture's state, before anything is written: a
+      played-out (``completed``/``voided``) fixture keeps its placement
       (:func:`_enforce_fixture_placeable`, raising
-      :class:`FixturePlacementFrozenError`). Everything else — an odd time, a dangling
-      table ref — saves (the write is soft, ADR-0790).
+      :class:`FixturePlacementFrozenError`).
+    * **422** — the hard rule about the body: the ``table_id`` must name a table in
+      this tournament's catalogue (:func:`_enforce_table_exists`, raising
+      :class:`PlacementTableNotFoundError`, ADR 20260801). Everything else still saves
+      — an out-of-window time, a table outside the fixture's pool and a double-booking
+      are flags derived on read, not refusals (ADR-0790).
 
     Then the whole pin/notify transition runs through
     :func:`app.match_calls.apply_manual_placement` on this open transaction (a
@@ -173,9 +213,16 @@ async def place_fixture(
     fixture, match_status, event_timezone = await _load_fixture_for_placement(
         db, tournament_id, fixture_id
     )
-    # The one hard rule, before anything is written: a played-out fixture keeps its
-    # placement. Everything else — an odd time, a dangling table ref — saves.
+    # The one hard rule about the fixture's STATE, before anything is written: a
+    # played-out fixture keeps its placement.
     _enforce_fixture_placeable(match_status)
+    # ...and the one hard rule about the BODY: the table must exist (ADR 20260801).
+    # Judged second, because the freeze is the fact that will not change — a completed
+    # fixture is never placeable again, whatever id is sent — where a bogus table id is
+    # a request the director can fix and retry. Everything else about the placement
+    # still saves: an out-of-window start, an off-pool table and a double-booking are
+    # flags derived on read, not refusals (ADR-0790).
+    _enforce_table_exists(tournament, placement.table_id)
     # The whole pin/notify transition — columns, ``pinned_at``, in-app rows — on this
     # open transaction (the atomicity contract of ``app.match_calls``: a call and its
     # durable record commit together); the returned push/email fan-out is enqueued

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -100,10 +100,16 @@ def _tournament_fields(
     current_user_id: uuid.UUID,
 ) -> dict[str, Any]:
     # The request-scoped fields (``created_by_username``/``can_edit``) aren't on
-    # the ORM row. The JSONB columns (``address``/``table_catalogue``) are read
-    # straight off the attributes; Pydantic validates them into
-    # Address/TournamentTable when the returned dict is fed to model_validate,
-    # so the raw dicts never leave the serialize boundary.
+    # the ORM row. The ``address`` JSONB is read straight off the attribute and
+    # Pydantic validates it into an ``Address`` when the returned dict is fed to
+    # model_validate, so the raw dict never leaves the serialize boundary.
+    #
+    # ``table_catalogue`` is no longer a column: the wire field is unchanged, but the
+    # value now comes off the ``tables`` relationship (ADR 20260801), already in the
+    # director's order and eagerly loaded (``lazy="selectin"``), so this stays a plain
+    # attribute read and the serializer still fires no query. ``TournamentTable`` is
+    # ``from_attributes``, so the ORM rows validate into the read model at the same one
+    # boundary the JSONB used to.
     return {
         "id": t.id,
         "name": t.name,
@@ -112,7 +118,7 @@ def _tournament_fields(
         "start_date": t.start_date,
         "end_date": t.end_date,
         "address": t.address,
-        "table_catalogue": t.table_catalogue,
+        "table_catalogue": t.tables,
         "league_id": t.league_id,
         "created_by_user_id": t.created_by_user_id,
         "created_by_username": created_by_username,

--- a/api/app/tournament_tables.py
+++ b/api/app/tournament_tables.py
@@ -1,0 +1,80 @@
+"""The one place a tournament's venue catalogue is written.
+
+A table is a row now (ADR 20260801, "a placement names a real table, and only that is
+an invariant"), not an entry in ``tournaments.table_catalogue`` JSONB, and its id is
+minted by the database. So the two write verbs — ``create_tournament`` and
+``edit_tournament`` — no longer assign a column; they compose ``VenueTable`` rows, and
+they do it through this module rather than each spelling it out, for the reason
+``stored_pools`` is shared between the event verbs: the shape a catalogue is stored in
+must not depend on which verb happened to store it.
+
+It imports the model and the write schema and nothing else — no router, no session —
+so it stays callable from a REPL and cycle-free.
+"""
+
+from collections.abc import Sequence
+
+from app.models import Tournament, VenueTable
+from app.schemas.tournament import TournamentTableWrite
+
+__all__ = ["apply_table_catalogue", "stored_tables"]
+
+
+def stored_tables(submitted: Sequence[TournamentTableWrite]) -> list[VenueTable]:
+    """Fresh :class:`VenueTable` rows for a catalogue that has none yet — the create
+    verb's whole job.
+
+    Each row is stamped with the ``position`` of its index in ``submitted`` — the only
+    place a position is ever assigned on the create path, and what makes the stored
+    positions ``range(len(submitted))`` by construction. No ``id`` is set: that is the
+    database's (``gen_random_uuid()``), and the point of the ADR is that it is not the
+    client's to author.
+    """
+    return [
+        VenueTable(label=table.label, court=table.court, position=index)
+        for index, table in enumerate(submitted)
+    ]
+
+
+def apply_table_catalogue(
+    tournament: Tournament, submitted: Sequence[TournamentTableWrite]
+) -> bool:
+    """Make ``tournament``'s catalogue equal ``submitted``, **by position**, and answer
+    whether the set of tables changed (a table was added or removed).
+
+    The i-th table sent is the i-th table stored: its row keeps its id and takes the new
+    ``label``/``court``. A longer list appends rows; a shorter one drops the tail, which
+    ``delete-orphan`` on ``Tournament.tables`` turns into DELETEs.
+
+    **Position is the only identity a client has left**, and matching on it is the whole
+    reason this is not a two-line "delete them all and insert the new list". The
+    catalogue is sent in full on *every* tournament PATCH (the web client re-sends the
+    tournament it loaded), so a rebuild would re-mint every id on a rename — dangling
+    every pool's ``table_ids`` and unplacing every fixture, as an invisible side effect
+    of editing the venue's name. The ADR is explicit that a placement must not be
+    destroyed by an unrelated write.
+
+    It is deliberately **not** the id-keyed diff the ADR ends at. That diff needs the
+    client to be able to name an existing table, and it has to be able to *refuse* —
+    removing a table a fixture is placed at is a named 409 with an unplace-and-remove
+    opt-in. Both belong with the ``ON DELETE RESTRICT`` that makes the refusal
+    enforceable; until then, positional matching is what keeps the ids that already
+    exist pointing at the tables they already named.
+
+    The answer feeds the re-solve trigger, so it is deliberately about the *set* and not
+    the labels: the solver reduces the catalogue to its ids (``_load_solver_inputs``),
+    so adding or removing a table changes its inputs and re-wording a label does not.
+    Under positional identity a length change is exactly an add or a remove.
+    """
+    existing = list(tournament.tables)
+    for row, table in zip(existing, submitted, strict=False):
+        row.label = table.label
+        row.court = table.court
+    if len(submitted) > len(existing):
+        tournament.tables.extend(
+            VenueTable(label=table.label, court=table.court, position=position)
+            for position, table in enumerate(submitted[len(existing) :], len(existing))
+        )
+    elif len(submitted) < len(existing):
+        del tournament.tables[len(submitted) :]
+    return len(submitted) != len(existing)

--- a/api/app/tournament_tables.py
+++ b/api/app/tournament_tables.py
@@ -8,16 +8,35 @@ they do it through this module rather than each spelling it out, for the reason
 ``stored_pools`` is shared between the event verbs: the shape a catalogue is stored in
 must not depend on which verb happened to store it.
 
-It imports the model and the write schema and nothing else — no router, no session —
-so it stays callable from a REPL and cycle-free.
+The edit path is a **diff**, and the ADR is explicit about why it had to become one:
+"``table_catalogue``'s wholesale replace becomes a diff. A PATCH that omits a table is
+now a delete, and a delete can be refused, so the verb has to compute what changed
+rather than assign a list." That refusal — a removal a fixture's placement stands in the
+way of — is this module's other half, and it is what pulls a session in here: the
+question "is anything placed at this table" is a query, and the answer decides whether
+the write happens at all.
+
+It imports the models, the write schemas and the domain-error leaf, and nothing else —
+no router, no FastAPI — so it stays callable from a REPL with a raw session, and
+cycle-free.
 """
 
-from collections.abc import Sequence
+import uuid
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 
-from app.models import Tournament, VenueTable
-from app.schemas.tournament import TournamentTableWrite
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
-__all__ = ["apply_table_catalogue", "stored_tables"]
+from app.models import Tournament, TournamentFixture, VenueTable
+from app.schemas.tournament import (
+    TournamentTableUpsert,
+    TournamentTableWrite,
+    named_list,
+)
+from app.tournament_errors import TableInUseError, TableNotInCatalogueError
+
+__all__ = ["AppliedCatalogue", "apply_table_catalogue", "stored_tables"]
 
 
 def stored_tables(submitted: Sequence[TournamentTableWrite]) -> list[VenueTable]:
@@ -36,45 +55,239 @@ def stored_tables(submitted: Sequence[TournamentTableWrite]) -> list[VenueTable]
     ]
 
 
-def apply_table_catalogue(
-    tournament: Tournament, submitted: Sequence[TournamentTableWrite]
-) -> bool:
-    """Make ``tournament``'s catalogue equal ``submitted``, **by position**, and answer
-    whether the set of tables changed (a table was added or removed).
+@dataclass(frozen=True)
+class AppliedCatalogue:
+    """What :func:`apply_table_catalogue` did, for the caller that has to react to it.
 
-    The i-th table sent is the i-th table stored: its row keeps its id and takes the new
-    ``label``/``court``. A longer list appends rows; a shorter one drops the tail, which
-    ``delete-orphan`` on ``Tournament.tables`` turns into DELETEs.
+    Two facts, and they are wanted by two different consumers, which is why this is a
+    small record rather than a bare ``bool``:
 
-    **Position is the only identity a client has left**, and matching on it is the whole
-    reason this is not a two-line "delete them all and insert the new list". The
-    catalogue is sent in full on *every* tournament PATCH (the web client re-sends the
-    tournament it loaded), so a rebuild would re-mint every id on a rename — dangling
-    every pool's ``table_ids`` and unplacing every fixture, as an invisible side effect
-    of editing the venue's name. The ADR is explicit that a placement must not be
-    destroyed by an unrelated write.
-
-    It is deliberately **not** the id-keyed diff the ADR ends at. That diff needs the
-    client to be able to name an existing table, and it has to be able to *refuse* —
-    removing a table a fixture is placed at is a named 409 with an unplace-and-remove
-    opt-in. Both belong with the ``ON DELETE RESTRICT`` that makes the refusal
-    enforceable; until then, positional matching is what keeps the ids that already
-    exist pointing at the tables they already named.
-
-    The answer feeds the re-solve trigger, so it is deliberately about the *set* and not
-    the labels: the solver reduces the catalogue to its ids (``_load_solver_inputs``),
-    so adding or removing a table changes its inputs and re-wording a label does not.
-    Under positional identity a length change is exactly an add or a remove.
+    * ``changed`` — whether the **set** of tables moved (one was added or removed), the
+      re-solve trigger's question. Deliberately about the set and not the words: the
+      solver reduces the catalogue to its ids (``_load_solver_inputs``), so adding or
+      removing a table changes its inputs while re-wording a label — or re-ordering the
+      list, which is presentation — does not.
+    * ``unplaced_event_ids`` — the events whose fixtures this write unplaced, under the
+      opt-in. Their entrants have just lost a table and a time off their panels, so they
+      are exactly the audience of a ``dashboard.changed`` hint; an ordinary catalogue
+      edit unplaces nobody and this is empty.
     """
-    existing = list(tournament.tables)
-    for row, table in zip(existing, submitted, strict=False):
-        row.label = table.label
-        row.court = table.court
-    if len(submitted) > len(existing):
-        tournament.tables.extend(
-            VenueTable(label=table.label, court=table.court, position=position)
-            for position, table in enumerate(submitted[len(existing) :], len(existing))
+
+    changed: bool
+    unplaced_event_ids: tuple[uuid.UUID, ...]
+
+
+def _tables_in_use_detail(labels: list[str], *, placements: int) -> str:
+    """The 409 sentence for a catalogue edit that would remove a table matches are
+    placed at — composed in the house style of ``_pool_set_frozen_detail``
+    (``app.tournament_events``): **name the things, then name the way out.**
+
+    It names the tables **by label**, never by id, for the reason ``named_list`` exists:
+    the id is what the diff compared, but "table 4f9c-… cannot be removed" tells a
+    director looking at a page of named tables nothing to act on.
+
+    And it names both ways out, because a refusal with only one is a director stuck
+    between an edit they cannot make and a schedule they did not want to lose: send the
+    same edit again with the opt-in and accept the unplacing, or move the matches off
+    the table first and keep them. Which of the two is right is theirs to decide — that
+    is the whole content of the ADR's split between a pool (quiet) and a placement
+    (loud).
+    """
+    one = len(labels) == 1
+    has, it, the_table = ("has", "it", "the table") if one else ("have", "them", "them")
+    matches = "match" if placements == 1 else "matches"
+    return (
+        f"{named_list(labels)} {has} {placements} {matches} placed at {it}, so "
+        f"removing {it} from the catalogue would leave those matches with no table — "
+        "indistinguishable from matches nobody ever placed. To remove "
+        f"{it} anyway, send the same edit again with "
+        "“unplace_fixtures_on_removed_tables”: true, and those matches lose their "
+        "table, their time and their call and go back to the schedule to be placed "
+        f"again. To keep them where they are, leave {the_table} in the catalogue and "
+        f"move the matches off {it} first."
+    )
+
+
+async def _placed_fixtures(
+    db: AsyncSession, table_ids: Iterable[str]
+) -> Sequence[TournamentFixture]:
+    """Every fixture whose placement names one of ``table_ids``.
+
+    Scoped by the ids alone and not by the tournament, which is not a shortcut: these
+    ids came off this tournament's own catalogue rows, and a fixture's ``table_id`` is a
+    foreign key to exactly those rows, so "placed at this table" already means "in this
+    tournament". The ``ix_tournament_fixtures_table_id`` index — the one the ``ON DELETE
+    RESTRICT`` needed anyway — is what makes this a lookup rather than a scan.
+
+    The rows themselves, not a count: the refusal needs to say how many there are, the
+    opt-in needs to clear their placement columns, and the hint needs their events. One
+    query answers all three.
+    """
+    return (
+        (
+            await db.execute(
+                select(TournamentFixture).where(
+                    TournamentFixture.table_id.in_(list(table_ids))
+                )
+            )
         )
-    elif len(submitted) < len(existing):
-        del tournament.tables[len(submitted) :]
-    return len(submitted) != len(existing)
+        .scalars()
+        .all()
+    )
+
+
+async def _unplace_or_refuse(
+    db: AsyncSession, removed: Sequence[VenueTable], *, unplace: bool
+) -> tuple[uuid.UUID, ...]:
+    """Clear the placements standing in the way of removing ``removed`` — or, without
+    the opt-in, raise :class:`TableInUseError` having written nothing.
+
+    This is the ADR's split, in one function. A table that no fixture names is removed
+    with no ceremony whatever any *pool* thinks of it: a pool's ``table_ids`` are a
+    reservation, and the pool simply reserves one fewer. A table a fixture is **placed
+    at** is a different question, and it is asked of the director rather than answered
+    for them.
+
+    Under the opt-in the three placement columns go together — ``table_id``,
+    ``scheduled_start`` and ``pinned_at`` — because two of them are meaningless without
+    the first. A start with no table is a bar on a schedule with nowhere to be, and a
+    ``pinned_at`` is a *promise about a table*: leaving it set would tell every later
+    solve that this fixture is nailed to a table that no longer exists. The same three,
+    together, are what the broken-pin void clears (``app.schedule_solves``), for the
+    same reason.
+
+    The explicit ``flush`` IS the mechanism, not belt-and-braces. The caller removes the
+    ``VenueTable`` rows straight after this returns, by dropping them from
+    ``Tournament.tables`` (``delete-orphan``), and ``tournament_fixtures.table_id`` is
+    ``ON DELETE RESTRICT`` — checked immediately, never deferred. There is no ORM
+    ``relationship`` between the two (the FK is a bare column), so the unit of work has
+    no dependency to order the child UPDATEs ahead of the parent DELETEs; flushing here
+    puts them in the database first, in this transaction, where the RESTRICT check will
+    find them.
+    """
+    placed = await _placed_fixtures(db, [str(table.id) for table in removed])
+    if not placed:
+        return ()
+    if not unplace:
+        blocking = {fixture.table_id for fixture in placed}
+        labels = [table.label for table in removed if str(table.id) in blocking]
+        raise TableInUseError(
+            _tables_in_use_detail(labels, placements=len(placed)),
+            tables=labels,
+            placements=len(placed),
+        )
+    for fixture in placed:
+        fixture.table_id = None
+        fixture.scheduled_start = None
+        fixture.pinned_at = None
+    await db.flush()
+    return tuple(sorted({fixture.event_id for fixture in placed}))
+
+
+async def apply_table_catalogue(
+    db: AsyncSession,
+    tournament: Tournament,
+    submitted: Sequence[TournamentTableUpsert],
+    *,
+    unplace_fixtures: bool,
+) -> AppliedCatalogue:
+    """Make ``tournament``'s catalogue equal ``submitted`` as an **id-keyed diff**, and
+    report what that did (:class:`AppliedCatalogue`).
+
+    Each entry either cites the ``id`` of a table the tournament already has — which
+    keeps that row, with the ``label``/``court`` and the position this payload gives it
+    — or omits one, which adds a row the database mints an id for. A stored table no
+    entry cites is **removed**, by dropping it from ``Tournament.tables``, which
+    ``delete-orphan`` turns into a ``DELETE``.
+
+    **Keying on the id is what makes a reorder move tables.** The by-position stopgap
+    this replaces (chore 2a) matched the i-th sent against the i-th stored, so sending
+    two tables in the other order left each row holding its own id and its neighbour's
+    words — a fixture placed at "Table 1" silently began rendering as "Table 2", with
+    nothing refused and nothing to see. Only the client knows which of its rows is
+    which, and the id is the one way it can say so.
+
+    Three refusals, all judged **before anything is written**, so a refused catalogue
+    leaves the tournament byte-identical:
+
+    * an entry citing an id this tournament's catalogue does not hold →
+      :class:`TableNotInCatalogueError` (a 422 on that entry's ``id``). Never a silently
+      minted new table: that would hand the client an id it did not ask for and remove
+      the table it meant to keep.
+    * a removal a fixture's **placement** stands in the way of, without
+      ``unplace_fixtures`` → :class:`TableInUseError` (the named 409). See
+      :func:`_unplace_or_refuse` for why this one is loud where a pool's reservation is
+      silent.
+    * (two entries citing one id is refused a layer earlier, at the boundary —
+      :data:`~app.schemas.tournament.EditedTableCatalogue`.)
+
+    With ``unplace_fixtures`` the removal goes through and those fixtures are unplaced,
+    and the events they belong to come back on the result so the caller can hint their
+    entrants: a player whose promised table just disappeared is told by nothing else.
+
+    ``changed`` answers the re-solve trigger, and is deliberately about the **set** of
+    tables: the solver reduces the catalogue to its ids, so an add or a remove changes
+    its inputs while re-wording a label — or re-ordering the list — does not.
+    """
+    stored = {table.id: table for table in tournament.tables}
+    # Judged first, over the whole payload, because a catalogue naming a table this
+    # tournament does not have is not a catalogue: every subsequent question (what is
+    # kept, and therefore what is removed) would be answered against a list the client
+    # did not mean. Named by index so the refusal lands on the entry that caused it.
+    for index, entry in enumerate(submitted):
+        if entry.id is not None and entry.id not in stored:
+            raise TableNotInCatalogueError(index=index, table_id=str(entry.id))
+
+    kept = {entry.id for entry in submitted if entry.id is not None}
+    removed = [table for table in tournament.tables if table.id not in kept]
+    unplaced_event_ids: tuple[uuid.UUID, ...] = ()
+    if removed:
+        # The refusal, or the opt-in's unplacing — either way this returns before a
+        # single catalogue row has been touched, which is what makes the 409 a refusal
+        # rather than a report of something that already happened.
+        unplaced_event_ids = await _unplace_or_refuse(
+            db, removed, unplace=unplace_fixtures
+        )
+
+    # Assigning the whole collection is what expresses all three operations at once: the
+    # rows carried over keep their identity (and every ref that names them), the fresh
+    # ``VenueTable``s are inserts, and the stored rows left out are orphans that
+    # ``delete-orphan`` deletes. The list order IS the catalogue order, so the read-back
+    # is in the order the director sent without waiting for a re-select.
+    tournament.tables = [
+        _table_for(stored, entry, position) for position, entry in enumerate(submitted)
+    ]
+    return AppliedCatalogue(
+        changed=bool(removed) or any(entry.id is None for entry in submitted),
+        unplaced_event_ids=unplaced_event_ids,
+    )
+
+
+def _table_for(
+    stored: dict[uuid.UUID, VenueTable], entry: TournamentTableUpsert, position: int
+) -> VenueTable:
+    """The row one catalogue entry resolves to: the cited table, re-worded and
+    re-placed, or a brand-new one.
+
+    ``position`` is the entry's index in the submitted list and is assigned here on both
+    arms, so the stored positions are ``range(len(submitted))`` by construction — the
+    same guarantee :func:`stored_tables` makes on create, and the reason a reorder is
+    expressible at all.
+
+    Re-positioning kept rows is precisely why the catalogue's
+    ``uq_tournament_tables_tournament_position`` is ``DEFERRABLE INITIALLY DEFERRED``:
+    swapping two tables moves one onto a position the other has not vacated yet, and an
+    immediate constraint would refuse the intermediate state of a transaction whose
+    *end* state is perfectly unique.
+
+    ``stored[entry.id]`` cannot miss — every cited id was checked against ``stored``
+    before this runs, so this is an indexing operation rather than a second lookup with
+    a second opinion about what an unknown id means.
+    """
+    if entry.id is None:
+        return VenueTable(label=entry.label, court=entry.court, position=position)
+    row = stored[entry.id]
+    row.label = entry.label
+    row.court = entry.court
+    row.position = position
+    return row

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi.exceptions import RequestValidationError
 from pyrate_limiter import Duration, Rate
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -75,6 +76,7 @@ from app.tournament_errors import (
     NotAllowedToEnterError,
     NotAllowedToWithdrawError,
     NotTournamentOwnerError,
+    PlacementTableNotFoundError,
     PlayerNotFoundError,
     PoolSetFrozenError,
     ScheduleQueueUnavailableError,
@@ -1181,16 +1183,19 @@ async def uncut_event_draw(
 
 # ----- fixture placement (ADR-0790) -----------------------------------------
 #
-# A placement is two nullable columns on a fixture — ``table_id`` (a string ref into
-# the tournament's ``table_catalogue``) and ``scheduled_start`` (a naive, predicted
-# wall-clock time). A human PATCHes them here; the schedule solver writes the same two
+# A placement is two nullable columns on a fixture — ``table_id`` (a foreign key into
+# ``tournament_tables``) and ``scheduled_start`` (a predicted wall-clock time, anchored
+# to an instant). A human PATCHes them here; the schedule solver writes the same two
 # fields. The placement RIDES the tournament-detail BFF on read (2a put the fields
 # on ``TournamentFixtureRead``), so there is deliberately no ``GET …/placement``.
 #
-# The write is **soft**: the placement's constraints (table-in-pool, time-in-window, no
-# double-booking) are flags derived on read, NOT invariants (ADR-0790), so this route
-# stores an out-of-window time and an unknown ``table_id`` without complaint. Its one
-# hard rule is the freeze below.
+# The write is **soft** where ADR-0790 made it soft: the table belongs to the fixture's
+# pool, the time falls inside the pool's window, nothing is double-booked — all three
+# are flags derived on read, NOT invariants, so this route stores an out-of-window time
+# and an off-pool table without complaint. What it does NOT store is a ``table_id`` that
+# names no table: "the placement names a real table" became an invariant when the
+# catalogue became rows (ADR 20260801), so that is a 422 naming the field. Plus the
+# freeze below.
 #
 # But a manual placement is a **pin** (ADR "the schedule is solved; the call is
 # pinned"): the director's hand is a human commitment every later solve schedules
@@ -1199,9 +1204,45 @@ async def uncut_event_draw(
 # transition (``app.match_calls.apply_manual_placement``), the re-solve enqueue and the
 # read-back — now lives on the transport-neutral ``place_fixture`` verb
 # (``app.tournament_placement``), so the HTTP route below and the MCP ``place_fixture``
-# tool run the same transition. The verb raises :class:`FixtureNotFoundError` (404) and
-# :class:`FixturePlacementFrozenError` (409, carrying the freeze sentence), which the
-# adapter maps to the exact responses this route used to produce inline.
+# tool run the same transition. The verb raises :class:`FixtureNotFoundError` (404),
+# :class:`FixturePlacementFrozenError` (409, carrying the freeze sentence) and
+# :class:`PlacementTableNotFoundError` (422, carrying the id that named no table), which
+# the adapter maps to the responses this route produces.
+
+
+def _placement_table_not_found(
+    exc: PlacementTableNotFoundError,
+) -> RequestValidationError:
+    """The 422 for a placement whose ``table_id`` names no table in the tournament's
+    catalogue (ADR 20260801) — as a **validation error on the field**, not a hand-rolled
+    body.
+
+    A ``RequestValidationError`` rather than an ``HTTPException``, because that is
+    precisely what this is: the body's ``table_id`` did not validate. The only reason
+    the schema could not judge it is that the answer lives in the database, and a client
+    should not have to tell "your table_id is malformed" (a schema 422) apart from "your
+    table_id names nothing" (this one) by parsing two different envelopes. Raising the
+    same exception the schema raises puts it through the app's own handler
+    (``app.main.validation_error_handler``), so the body is byte-shape-identical to
+    every other 422 the route can produce — ``{"detail": [{"loc": ["body",
+    "table_id"], …}]}``, already the documented ``HTTPValidationError`` of this
+    operation — and no new response schema reaches the generated clients.
+
+    Contrast ``_no_drawn_events_refusal`` and the geocoding refusal, which are about the
+    *state of the tournament* rather than a field of the body and so carry a coded
+    ``detail`` object of their own. This one names a field, so it is shaped like a field
+    refusal.
+    """
+    return RequestValidationError(
+        [
+            {
+                "type": "value_error",
+                "loc": ("body", "table_id"),
+                "msg": str(exc),
+                "input": exc.table_id,
+            }
+        ]
+    )
 
 
 @router.patch(
@@ -1218,8 +1259,8 @@ async def place_fixture(
     """Set (or clear) a fixture's **placement** — its table and its predicted start
     (ADR-0790) — and answer with the updated fixture.
 
-    The body is the placement in full: `table_id` (a string ref into the tournament's
-    `table_catalogue`) and `scheduled_start` (a **naive** wall-clock time, in the
+    The body is the placement in full: `table_id` (the id of one of the tournament's
+    `table_catalogue` tables) and `scheduled_start` (a **naive** wall-clock time, in the
     venue's local frame — an offset-aware value is a `422`). `null` on either clears
     that half; `(null, null)` unassigns the fixture.
 
@@ -1243,15 +1284,21 @@ async def place_fixture(
     Every successful write also queues a re-solve (`settings_changed`): the director
     just changed the solver's inputs, so the board re-plans around the new pin set.
 
-    **The placement is otherwise soft.** `scheduled_start` is a *prediction* until
-    pinned, and the placement's constraints — the table belongs to the fixture's pool,
-    the time falls inside the pool's window, nothing is double-booked — are flags
-    derived on read, **not** invariants. So an out-of-window time, or a `table_id` that
-    names no table in the catalogue, is **stored, not rejected**; the queued re-solve
-    is what judges the consequences.
+    **The table must exist.** A `table_id` that names no table in this tournament's
+    `table_catalogue` is a `422` naming the field — the one thing about a placement that
+    is an invariant rather than a flag. A placement whose table does not exist is not a
+    state you chose; it is a dangling reference nothing can render.
 
-    **The one hard rule:** a fixture whose linked match is `completed` or `voided` is
-    history, so its placement can no longer be changed — a `409`. A fixture with no
+    **The placement is otherwise soft.** `scheduled_start` is a *prediction* until
+    pinned, and the placement's other constraints — the table belongs to the fixture's
+    pool, the time falls inside the pool's window, nothing is double-booked — are flags
+    derived on read, **not** invariants. So an out-of-window time, or a table outside
+    the fixture's pool, is **stored, not rejected**; the queued re-solve is what judges
+    the consequences.
+
+    **The one hard rule about the fixture:** a fixture whose linked match is `completed`
+    or `voided` is history, so its placement can no longer be changed — a `409`. A
+    fixture with no
     match yet, or a `pending`/`in_progress` one, is freely (re)placeable (a round-robin
     match is born `pending` at go-live and only becomes `in_progress` when called, so
     neither is the freeze trigger).
@@ -1270,6 +1317,7 @@ async def place_fixture(
     #   NotTournamentOwnerError      -> 403 "You can only modify tournaments …"
     #   FixtureNotFoundError         -> 404 "Fixture not found."
     #   FixturePlacementFrozenError  -> 409 "This fixture's match is already {status}…"
+    #   PlacementTableNotFoundError  -> 422 on ``body.table_id`` (ADR 20260801)
     try:
         return await place_fixture_core(
             db,
@@ -1292,6 +1340,9 @@ async def place_fixture(
         # placement — the exact 409 sentence the handler used to compose inline,
         # rebuilt verbatim with ``str``.
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except PlacementTableNotFoundError as exc:
+        # Verb-specific: the placement named no table of this tournament (ADR 20260801).
+        raise _placement_table_not_found(exc) from exc
 
 
 # ----- the schedule solver (ADR "the schedule is solved; the call is pinned") -----

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -80,6 +80,8 @@ from app.tournament_errors import (
     PlayerNotFoundError,
     PoolSetFrozenError,
     ScheduleQueueUnavailableError,
+    TableInUseError,
+    TableNotInCatalogueError,
     TournamentAlreadyInStatusError,
     TournamentNotFoundError,
     TournamentNotPreLiveError,
@@ -458,6 +460,36 @@ async def get_tournament(
     )
 
 
+def _table_not_in_catalogue(exc: TableNotInCatalogueError) -> RequestValidationError:
+    """The 422 for a catalogue entry citing a table ``id`` this tournament does not have
+    (ADR 20260801) — as a **validation error on that entry's field**, not a hand-rolled
+    body.
+
+    The sibling of :func:`_placement_table_not_found`, and the same argument: the body's
+    ``id`` did not validate, the only reason the schema could not judge it is that the
+    answer lives in the database, and a client should not need a second parser to tell
+    "your id is malformed" (a schema 422) from "your id names nothing" (this one).
+    Raising the exception the schema raises puts it through the app's own handler, so
+    the body is byte-shape-identical to every other 422 this route can produce and no
+    new response schema reaches the generated clients.
+
+    The ``loc`` carries the entry's **index** — ``["body", "table_catalogue", i, "id"]``
+    — because a catalogue is a list and a client renders a validation error under the
+    input that caused it. A refusal that named the array alone would leave the director
+    hunting the row across a page of tables.
+    """
+    return RequestValidationError(
+        [
+            {
+                "type": "value_error",
+                "loc": ("body", "table_catalogue", exc.index, "id"),
+                "msg": str(exc),
+                "input": exc.table_id,
+            }
+        ]
+    )
+
+
 @router.patch(
     "/tournaments/{tournament_id}",
     response_model=TournamentRead,
@@ -470,6 +502,34 @@ async def update_tournament(
     current_user: User = Depends(get_current_user),
     geocoder: Geocoder = Depends(get_geocoder),
 ) -> TournamentRead:
+    """Edit a tournament you own. Absent fields are left alone; a supplied field
+    replaces the current value. Owner-only.
+
+    **`table_catalogue` is an id-keyed diff, sent in full and in order.** Each entry
+    either carries the `id` of a table this tournament already has — keeping that table,
+    with the `label`, `court` and position this payload gives it — or omits the `id` to
+    add a new table, whose id the server mints. **A table no entry names is removed.**
+    Send back the catalogue you read, edited: the ids came from the read, and naming an
+    id this tournament does not have is a `422` on that entry.
+
+    **Removing a table that matches are placed at is a `409` naming the table**, and
+    nothing is written. To go through with it, repeat the request with
+    `unplace_fixtures_on_removed_tables: true`: the table is removed and those matches
+    are unplaced — table, predicted start and call all cleared — which is a thing worth
+    saying on purpose rather than a silent side effect of editing the venue. Removing a
+    table that only a *pool* reserves needs no confirmation and produces no refusal; the
+    pool simply reserves one fewer.
+
+    **`address` has three cases and the value alone cannot tell them apart.** Omit it to
+    leave the venue and its coordinates untouched; send a real address to move the venue
+    (re-geocoded only when its text actually changed, a `409` when it cannot be
+    resolved); send `null` — or an object whose six components are all blank — to remove
+    the venue entirely.
+
+    `league_id` may only be changed while the tournament is a `draft`; once it is
+    published the ladder is settled (`409`). `status` is not editable here — the
+    lifecycle moves only across `POST /v1/tournaments/{id}/transitions`.
+    """
     # Thin adapter over the transport-neutral ``edit_tournament`` verb: it owns the
     # load-lock, the owner gate, the league state-rule, the STRICT league lookup, the
     # before-lock geocode of a changed address, the partial apply and the
@@ -482,6 +542,8 @@ async def update_tournament(
     #   LeagueNotEditableError     -> 409 "This tournament is {status}; its league …"
     #   LeagueNotFoundError        -> 404 "League not found."
     #   AddressNotGeocodableError  -> 409 coded ``address_not_geocodable`` refusal
+    #   TableInUseError            -> 409 "…has 2 matches placed at it…" (ADR 20260801)
+    #   TableNotInCatalogueError   -> 422 on ``body.table_catalogue[i].id``
     try:
         tournament = await edit_tournament(
             db,
@@ -490,6 +552,18 @@ async def update_tournament(
             updates=payload,
             geocoder=geocoder,
         )
+    except TableInUseError as exc:
+        # The catalogue's named refusal: removing a table matches are placed at, with no
+        # opt-in. Bare prose, like the pool-set freeze and the league state rule on this
+        # same route — it carries the exact domain-authored sentence, rebuilt verbatim
+        # with ``str``. Nothing was written (the verb raises before the diff touches a
+        # row and long before the commit), so the same request with the opt-in is safe
+        # to send straight back.
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except TableNotInCatalogueError as exc:
+        # A catalogue entry cited an id this tournament does not have: a field refusal,
+        # shaped like every other 422 on this route (see ``_table_not_in_catalogue``).
+        raise _table_not_in_catalogue(exc) from exc
     except _TOURNAMENT_WRITE_ERRORS as exc:
         # Shared arms: the 404 (absent), the 403 (not the owner), and the 409
         # (league not editable) all map identically across the owner-only writes.

--- a/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
+++ b/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
@@ -222,12 +222,14 @@ def upgrade() -> None:
         # way. The single-representation invariant is therefore enforced by the
         # model, not by this schema.
         sa.Column("address", postgresql.JSONB(), nullable=True),
-        sa.Column(
-            "table_catalogue",
-            postgresql.JSONB(),
-            nullable=False,
-            server_default=sa.text("'[]'::jsonb"),
-        ),
+        # There is deliberately NO ``table_catalogue`` column. The venue catalogue was
+        # a NOT NULL JSONB list of ``{id, label, court}`` objects keyed by
+        # client-supplied strings; it is the ``tournament_tables`` table created below
+        # (ADR 20260801 "a placement names a real table, and only that is an
+        # invariant"), so a placement can foreign-key the table it names and the id is
+        # the database's to mint. Edited out of this migration in place, per the
+        # pre-deploy convention in api/CLAUDE.md — revision ids and the
+        # ``down_revision`` chain stay frozen.
         # The rating ladder a tournament's eligibility is judged on (ADR-0783).
         # NOT NULL: every tournament names its league, so no read of an entry
         # decision has to ask "rated against *what*?". Resolved at create — an
@@ -264,6 +266,68 @@ def upgrade() -> None:
         "ix_tournaments_created_by_user_id_created_at",
         "tournaments",
         ["created_by_user_id", sa.text("created_at DESC")],
+    )
+
+    # The venue catalogue, as rows (ADR 20260801 "a placement names a real table").
+    # Created immediately after ``tournaments`` because it FKs it, and before
+    # ``tournament_events`` only for readability — nothing in this migration references
+    # it. Added here in place per the pre-deploy convention, not as a chained ALTER.
+    #
+    # ``id`` is a server-minted UUID with the same ``gen_random_uuid()`` default every
+    # other id in this migration has: a table's identity is the database's to mint. It
+    # used to be a client-supplied string inside ``tournaments.table_catalogue``, which
+    # is exactly why a ``tournament_fixtures.table_id`` naming no table could be stored
+    # rather than refused — there was no key to point at.
+    op.create_table(
+        "tournament_tables",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        # CASCADE: deleting a tournament takes its catalogue with it, in the same
+        # statement, exactly as it takes its events (below).
+        sa.Column(
+            "tournament_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tournaments.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("label", sa.String(length=255), nullable=False),
+        sa.Column("court", sa.String(length=255), nullable=False),
+        # Where the table sits in the director's catalogue order: 0-based, contiguous,
+        # server-assigned from the order the catalogue was sent in. The JSONB array
+        # carried this for free; under random UUID primary keys neither ``id`` nor
+        # ``created_at`` (every row of one write shares the transaction timestamp) can,
+        # so it is a column — the same remedy ``tournament_events.pools`` got in
+        # ADR 20260801 for the same reason.
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # Two tables of one tournament never share a place in its order.
+        sa.UniqueConstraint(
+            "tournament_id", "position", name="uq_tournament_tables_tournament_position"
+        ),
+    )
+    # Postgres indexes the REFERENCED key of a foreign key, never the referencing
+    # column, so this is what keeps the tournament-delete cascade from sequentially
+    # scanning every table row on the platform — and it is the catalogue's read order
+    # besides.
+    op.create_index(
+        "ix_tournament_tables_tournament_id_position",
+        "tournament_tables",
+        ["tournament_id", "position"],
     )
 
     op.create_table(
@@ -378,6 +442,13 @@ def downgrade() -> None:
         table_name="tournament_events",
     )
     op.drop_table("tournament_events")
+
+    # Symmetric with upgrade(): dropped before the tournaments it references.
+    op.drop_index(
+        "ix_tournament_tables_tournament_id_position",
+        table_name="tournament_tables",
+    )
+    op.drop_table("tournament_tables")
 
     op.drop_index(
         "ix_tournaments_created_by_user_id_created_at", table_name="tournaments"

--- a/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
+++ b/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
@@ -316,8 +316,19 @@ def upgrade() -> None:
             nullable=False,
         ),
         # Two tables of one tournament never share a place in its order.
+        #
+        # DEFERRABLE INITIALLY DEFERRED: the catalogue is written as an id-keyed diff
+        # (ADR 20260801), and a diff re-orders — dragging one table above another moves
+        # it onto a position the other has not vacated yet. An immediately-checked
+        # constraint refuses that intermediate state and so forbids reordering outright,
+        # though the transaction's END state is perfectly unique. Deferred here in
+        # place per the pre-deploy convention, not as a chained ALTER.
         sa.UniqueConstraint(
-            "tournament_id", "position", name="uq_tournament_tables_tournament_position"
+            "tournament_id",
+            "position",
+            name="uq_tournament_tables_tournament_position",
+            deferrable=True,
+            initially="DEFERRED",
         ),
     )
     # Postgres indexes the REFERENCED key of a foreign key, never the referencing

--- a/api/migrations/versions/20260712_0000_0012_create_tournament_fixtures_table.py
+++ b/api/migrations/versions/20260712_0000_0012_create_tournament_fixtures_table.py
@@ -84,10 +84,22 @@ def upgrade() -> None:
             sa.ForeignKey("matches.id", ondelete="SET NULL"),
             nullable=True,
         ),
-        # A *placement* (ADR-0790). ``table_id`` is a string ref into the tournament's
-        # ``table_catalogue`` JSONB (a ``TournamentTable.id``), the same pattern as
-        # ``pool_id`` — NOT a foreign key, there is no tables table. NULL = unassigned.
-        sa.Column("table_id", sa.Text(), nullable=True),
+        # A *placement* (ADR-0790). ``table_id`` is a real FOREIGN KEY into
+        # ``tournament_tables`` (created by 0010) — "the placement names a real table"
+        # is the one placement claim that is an invariant rather than a flag-on-read
+        # (ADR 20260801). NULL = unassigned.
+        #
+        # RESTRICT, not SET NULL: removing a table a fixture is placed at destroys
+        # information on an unrelated write — the fixture would become
+        # indistinguishable from one nobody ever placed — so the database refuses and
+        # the director opts in explicitly. A *pool* that merely reserves the table gets
+        # ON DELETE CASCADE on its own side instead; only a placement is loud.
+        sa.Column(
+            "table_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("tournament_tables.id", ondelete="RESTRICT"),
+            nullable=True,
+        ),
         # ``scheduled_start`` is a placement's predicted start — a ``timestamptz``
         # instant (TIMESTAMP WITH TIME ZONE), composed server-side from the event's
         # Slot wall-clock components anchored by the event timezone. The 2026-07-19 ADR
@@ -144,9 +156,16 @@ def upgrade() -> None:
     op.create_index(
         "ix_tournament_fixtures_match_id", "tournament_fixtures", ["match_id"]
     )
+    # The index Postgres does not create for a REFERENCING column. Under RESTRICT every
+    # delete of a ``tournament_tables`` row must prove no fixture references it, which
+    # unindexed is a sequential scan of every fixture on the platform per table removed.
+    op.create_index(
+        "ix_tournament_fixtures_table_id", "tournament_fixtures", ["table_id"]
+    )
 
 
 def downgrade() -> None:
+    op.drop_index("ix_tournament_fixtures_table_id", table_name="tournament_fixtures")
     op.drop_index("ix_tournament_fixtures_match_id", table_name="tournament_fixtures")
     op.drop_index("ix_tournament_fixtures_event_id", table_name="tournament_fixtures")
     op.drop_table("tournament_fixtures")

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -25,9 +25,11 @@ from app.models import (
     RatingHistorySource,
     Role,
     RolePermission,
+    Tournament,
     User,
     UserLeagueRating,
     UserRole,
+    VenueTable,
 )
 from app.notifications.apns import Environment, SendOutcome, SendResult
 from app.notifications.dependencies import get_push_sender
@@ -119,6 +121,75 @@ async def make_user(db_session: AsyncSession, username: str) -> User:
     await db_session.commit()
     await db_session.refresh(user)
     return user
+
+
+def venue_tables(*specs: tuple[str, str]) -> list[VenueTable]:
+    """Catalogue rows — ``(label, court)`` pairs — for a tournament a test seeds
+    straight through the ORM, positioned in the order given.
+
+    The ids are minted **here**, up front, rather than left to the column's
+    ``gen_random_uuid()`` default, for one reason: a pool's ``table_ids`` and a
+    fixture's ``table_id`` name a table by id, so a test that seeds a placement needs
+    the id before the row is flushed. Fresh ``uuid4``s per call, never module
+    constants — the id is a primary key, so two tournaments in one test cannot share
+    one.
+
+    Through the API the ids are the *server's* and there is no ``id`` on the write
+    shape at all (ADR 20260801); this is the direct-to-database seam, which no HTTP
+    caller can reach.
+    """
+    return [
+        VenueTable(id=uuid.uuid4(), label=label, court=court, position=position)
+        for position, (label, court) in enumerate(specs)
+    ]
+
+
+def with_table_aliases(
+    tournament: Tournament, pools: Sequence[Mapping[str, object]]
+) -> list[dict[str, object]]:
+    """Rewrite each pool's ``table_ids`` from the positional aliases a test writes
+    (``"t1"``, ``"t2"``, …) into the real ids of ``tournament``'s catalogue rows.
+
+    A pool reserves a slice of the venue by naming table ids, and those ids are UUIDs
+    the server minted (ADR 20260801) — so a seeded pool cannot spell one as a literal.
+    The alias is 1-based and positional: ``"t1"`` is the tournament's first table, in
+    its own catalogue order. It exists so a test can go on saying which tables a pool
+    holds in the terms the test is about, instead of threading a UUID through every
+    helper it passes a pool to.
+    """
+    by_alias = {
+        f"t{position}": str(table.id)
+        for position, table in enumerate(tournament.tables, start=1)
+    }
+    resolved: list[dict[str, object]] = []
+    for pool in pools:
+        aliases = pool["table_ids"]
+        assert isinstance(aliases, list)
+        resolved.append({**pool, "table_ids": [by_alias[alias] for alias in aliases]})
+    return resolved
+
+
+async def table_ids_of(db_session: AsyncSession, tournament_id: uuid.UUID) -> list[str]:
+    """The tournament's venue-table ids, as strings, in its own catalogue order.
+
+    Read from ``tournament_tables`` rather than off an ORM instance, so it is safe
+    after the commits and ``expire_all``s these suites do between acting and
+    asserting. Tests unpack it (``table_1, table_2 = await table_ids_of(...)``) where
+    they used to write the literal ``"t1"``: the id is a server-minted UUID now
+    (ADR 20260801), so a placement or a pool has to be told which one it means.
+    """
+    return [
+        str(table_id)
+        for table_id in (
+            await db_session.execute(
+                select(VenueTable.id)
+                .where(VenueTable.tournament_id == tournament_id)
+                .order_by(VenueTable.position)
+            )
+        )
+        .scalars()
+        .all()
+    ]
 
 
 async def assert_tournament_address_is_sql_null(

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -46,7 +46,10 @@ from app.models import (
 from app.roles import grant_default_role
 from app.sessions import SESSION_TOKEN_CONTEXT
 from app.tournament_draws import cut_draw
-from tests._helpers import start_session
+from tests._helpers import (
+    start_session,
+    venue_tables,
+)
 
 
 async def _make_ephemeral(db: AsyncSession, username: str) -> User:
@@ -412,7 +415,7 @@ async def test_merge_repoints_tournament_ownership(db_session: AsyncSession):
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[{"id": "t1", "label": "Table 1", "court": "A"}],
+        tables=venue_tables(("Table 1", "A")),
     )
     tournament.events.append(
         TournamentEvent(
@@ -475,7 +478,7 @@ async def _make_event(db: AsyncSession, owner: User) -> TournamentEvent:
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[{"id": "t1", "label": "Table 1", "court": "A"}],
+        tables=venue_tables(("Table 1", "A")),
     )
     event = TournamentEvent(
         name="Open Singles",
@@ -970,7 +973,7 @@ async def _make_rr_event(
                 "latitude": 37.8703,
                 "longitude": -122.2731,
             },
-            table_catalogue=[{"id": "t1", "label": "Table 1", "court": "A"}],
+            tables=venue_tables(("Table 1", "A")),
         )
     slot = {"date": "2026-06-13", "start": "09:00", "end": "18:00"}
     event = TournamentEvent(

--- a/api/tests/test_admin_schedule_solves.py
+++ b/api/tests/test_admin_schedule_solves.py
@@ -56,7 +56,6 @@ async def _make_tournament(db: AsyncSession, owner: User, name: str) -> uuid.UUI
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[],
         league_id=league.id,
         created_by_user_id=owner.id,
     )

--- a/api/tests/test_dashboard_tournaments.py
+++ b/api/tests/test_dashboard_tournaments.py
@@ -725,12 +725,15 @@ async def test_a_withdrawn_entry_that_was_never_entered_is_not_a_uuid_lookup(
 
 # The pin, measured (print the statements below to re-measure): the caller's live
 # entries — joined to their events, those events' tournaments AND, since #1086, those
-# events' draw settings rows — then ONE batched load of every event's active entrants,
-# ONE of every event's fixtures, ONE of the completed matches' game counts, ONE of the
-# handful of focus matches, and that load's own eager options (the match's league,
-# results, sides, settings, side players and those players' users — one batched
-# ``selectin`` each). Eleven, whatever the number of events.
-EXPECTED_DASHBOARD_PANEL_STATEMENTS = 11
+# events' draw settings rows — plus ONE batched load of those tournaments' venue tables
+# (``Tournament.tables``, ``lazy="selectin"`` — the catalogue is rows now,
+# ADR 20260801, and the panel resolves a placement's table LABEL through it), then ONE
+# batched load of every event's active entrants, ONE of every event's fixtures, ONE of
+# the completed matches' game counts, ONE of the handful of focus matches, and that
+# load's own eager options (the match's league, results, sides, settings, side players
+# and those players' users — one batched ``selectin`` each). Twelve, whatever the
+# number of events.
+EXPECTED_DASHBOARD_PANEL_STATEMENTS = 12
 
 
 @pytest.mark.parametrize("event_count", [1, 3])

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -61,11 +61,16 @@ from app.models import (
     TournamentFixture,
     TournamentStatus,
     User,
+    VenueTable,
 )
 from app.schedule_solves import RUN_SCHEDULE_SOLVE_JOB, SUPERSEDED_ERROR, request_solve
 from app.schemas.notification import NotificationJob
 from app.tournament_draws import cut_draw
-from tests._helpers import hijack_solve, make_user
+from tests._helpers import (
+    hijack_solve,
+    make_user,
+    venue_tables,
+)
 
 DATE = "2030-01-01"
 #: The event's venue timezone — the IANA zone that anchors its wall-clock pool
@@ -109,6 +114,7 @@ async def _make_tournament(
     league = await get_default_league(db)
     assert league is not None, "the autouse default_league fixture seeds this"
 
+    catalogue = venue_tables(*((table.upper(), "Main") for table in tables))
     tournament = Tournament(
         name="Called Open",
         status=status,
@@ -122,9 +128,7 @@ async def _make_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": table, "label": table.upper(), "court": "Main"} for table in tables
-        ],
+        tables=catalogue,
         league_id=league.id,
         created_by_user_id=owner.id,
     )
@@ -146,7 +150,7 @@ async def _make_tournament(
                 "id": "pool-a",
                 "name": "Pool A",
                 "slot": {"date": DATE, "start": window[0], "end": window[1]},
-                "table_ids": list(tables),
+                "table_ids": [str(row.id) for row in catalogue],
             }
         ],
     )
@@ -201,6 +205,32 @@ async def _call_notifications(db: AsyncSession) -> Sequence[Notification]:
     )
 
 
+async def _table(db: AsyncSession, event_id: uuid.UUID, alias: str) -> str:
+    """``"t1"`` → the id of the FIRST table in this event's tournament's catalogue.
+
+    A table's id is a server-minted UUID now (ADR 20260801), so a placement cannot
+    spell one as a literal. These tests are about which *table* a fixture sits on, so
+    they keep naming it positionally and resolve here — 1-based, in catalogue order,
+    matching the ``tables=("t1", "t2")`` argument ``_make_tournament`` labels them
+    from."""
+    ids = (
+        (
+            await db.execute(
+                select(VenueTable.id)
+                .join(
+                    TournamentEvent,
+                    TournamentEvent.tournament_id == VenueTable.tournament_id,
+                )
+                .where(TournamentEvent.id == event_id)
+                .order_by(VenueTable.position)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return str(ids[int(alias.removeprefix("t")) - 1])
+
+
 async def _place_fixture(
     db: AsyncSession,
     event_id: uuid.UUID,
@@ -208,8 +238,9 @@ async def _place_fixture(
     table_id: str,
     start: datetime,
 ) -> uuid.UUID:
+    """``table_id`` is a positional alias (``"t1"``), resolved by :func:`_table`."""
     fixture = await _the_fixture(db, event_id)
-    fixture.table_id = table_id
+    fixture.table_id = await _table(db, event_id, table_id)
     fixture.scheduled_start = start
     await db.commit()
     return fixture.id
@@ -264,7 +295,7 @@ class TestApplyCallEvaluation:
         await _request_and_run_solve(db_session, solver_queue, tournament_id)
 
         fixture = await _the_fixture(db_session, event_id)
-        assert fixture.table_id == "t1"
+        assert fixture.table_id == await _table(db_session, event_id, "t1")
         assert fixture.scheduled_start == BASE
         assert fixture.pinned_at == BASE
         assert fixture.call_notified_count == 1
@@ -313,7 +344,7 @@ class TestApplyCallEvaluation:
         await _request_and_run_solve(db_session, solver_queue, tournament_id)
 
         fixture = await _the_fixture(db_session, event_id)
-        assert fixture.table_id == "t1"
+        assert fixture.table_id == await _table(db_session, event_id, "t1")
         assert fixture.scheduled_start == start
         assert fixture.pinned_at == silent_pin_time  # the promise, untouched
         assert fixture.call_notified_count == 1  # …finally delivered
@@ -408,7 +439,7 @@ class TestApplyCallEvaluation:
         await _request_and_run_solve(db_session, solver_queue, tournament_id)
 
         fixture = await _the_fixture(db_session, event_id)
-        assert fixture.table_id == "t1"
+        assert fixture.table_id == await _table(db_session, event_id, "t1")
         assert fixture.scheduled_start == off_grid
         assert fixture.pinned_at == BASE
         assert fixture.call_notified_count == 1
@@ -494,7 +525,7 @@ class TestPinTick:
 
         db_session.expire_all()
         fixture = await _the_fixture(db_session, event_id)
-        assert fixture.table_id == "t1"
+        assert fixture.table_id == await _table(db_session, event_id, "t1")
         assert fixture.scheduled_start == start  # the placement is untouched…
         assert fixture.pinned_at == silent_pin_time  # …and so is the pin
         assert fixture.call_notified_count == 1
@@ -669,7 +700,7 @@ class TestResourceFreedomGate:
             db_session, tournament_id, held, status=MatchStatus.in_progress
         )
         # The successor: same table, imminent, untold → due, but t1 is held.
-        due.table_id = "t1"
+        due.table_id = await _table(db_session, event_id, "t1")
         due.scheduled_start = BASE + timedelta(minutes=5)
         due_id = due.id
         await db_session.commit()
@@ -700,7 +731,7 @@ class TestResourceFreedomGate:
             db_session, tables=("t1", "t2")
         )
         fixture = await _the_fixture(db_session, event_id)
-        fixture.table_id = "t1"
+        fixture.table_id = await _table(db_session, event_id, "t1")
         fixture.scheduled_start = BASE + timedelta(minutes=5)  # imminent, untold
         fixture_id = fixture.id
         await db_session.commit()
@@ -755,7 +786,7 @@ class TestResourceFreedomGate:
             db_session, tournament_id, held, status=MatchStatus.in_progress
         )
         # The free fixture: t2, imminent, untold, players free.
-        free.table_id = "t2"
+        free.table_id = await _table(db_session, event_id, "t2")
         free.scheduled_start = BASE + timedelta(minutes=5)
         free_id = free.id
         free_users = await _users_for_entries(
@@ -795,9 +826,9 @@ class TestResourceFreedomGate:
         later = next(
             f for f in fixtures if len({f.entry_a_id, f.entry_b_id} & shared) == 1
         )
-        earlier.table_id = "t1"
+        earlier.table_id = await _table(db_session, event_id, "t1")
         earlier.scheduled_start = BASE  # the earlier predicted start
-        later.table_id = "t2"
+        later.table_id = await _table(db_session, event_id, "t2")
         later.scheduled_start = BASE + timedelta(minutes=2)
         earlier_id, later_id = earlier.id, later.id
         await db_session.commit()
@@ -849,7 +880,7 @@ class TestResourceFreedomGate:
         for offset, (fixture, table) in enumerate(
             zip(chosen, ("t1", "t2", "t3"), strict=True)
         ):
-            fixture.table_id = table
+            fixture.table_id = await _table(db_session, event_id, table)
             fixture.scheduled_start = BASE + timedelta(minutes=offset)
             chosen_ids.append(fixture.id)
         expected_users = await _users_for_entries(
@@ -1057,9 +1088,16 @@ class TestIdleTournamentWedgeIsGone:
         await _link_match(db_session, tournament_id, r2, status=MatchStatus.pending)
         # Round 1 is due immediately (09:00); round 2 is predicted 20 min out,
         # beyond the 10-min call-ahead window — not yet due at 09:00.
-        r1a.table_id, r1a.scheduled_start = "t1", BASE
-        r1b.table_id, r1b.scheduled_start = "t2", BASE
-        r2.table_id, r2.scheduled_start = "t3", BASE + timedelta(minutes=20)
+        r1a.table_id, r1a.scheduled_start = (
+            await _table(db_session, event_id, "t1"),
+            BASE,
+        )
+        r1b.table_id, r1b.scheduled_start = (
+            await _table(db_session, event_id, "t2"),
+            BASE,
+        )
+        r2.table_id = await _table(db_session, event_id, "t3")
+        r2.scheduled_start = BASE + timedelta(minutes=20)
         r1a_id, r1b_id, r2_id = r1a.id, r1b.id, r2.id
         r1a_winner = r1a.entry_a_id
         assert r1a_winner is not None
@@ -1408,8 +1446,9 @@ async def _pin_directly(
 ) -> None:
     """Stage an already-called (or pre-live silently pinned) fixture directly
     on the row: the two real pin paths are exercised by the classes above;
-    repair tests need exact pre-states."""
-    fixture.table_id = table_id
+    repair tests need exact pre-states. ``table_id`` is a positional alias
+    (``"t1"``), resolved by :func:`_table`."""
+    fixture.table_id = await _table(db, fixture.event_id, table_id)
     fixture.scheduled_start = start
     fixture.pinned_at = pinned_at
     fixture.call_notified_count = notified
@@ -1460,13 +1499,18 @@ async def _remove_table(
 ) -> None:
     """Simulate the director's settings writes that break a placement's table,
     directly on the models: drop it from the tournament's catalogue and/or
-    from every pool's ``table_ids``."""
+    from every pool's ``table_ids``. ``table_id`` is a positional alias
+    (``"t1"``), resolved by :func:`_table`."""
+    table_id = await _table(db, event_id, table_id)
     if from_catalogue:
         tournament = (
             await db.execute(select(Tournament).where(Tournament.id == tournament_id))
         ).scalar_one()
-        tournament.table_catalogue = [
-            table for table in tournament.table_catalogue if table["id"] != table_id
+        # A table is a ROW now (ADR 20260801), so "the director removed it" is a
+        # DELETE — expressed by dropping it out of the collection, which
+        # ``delete-orphan`` on ``Tournament.tables`` turns into one.
+        tournament.tables = [
+            table for table in tournament.tables if str(table.id) != table_id
         ]
     if from_pools:
         event = (
@@ -1569,6 +1613,13 @@ class TestBrokenPinRepair:
             start=control_start,
             pinned_at=original_pin_time,
         )
+        # Captured BEFORE the removal: dropping a table shifts every later
+        # position, so the aliases would name different rows afterwards.
+        survivors = {
+            await _table(db_session, event_id, "t2"),
+            await _table(db_session, event_id, "t3"),
+        }
+        control_table = await _table(db_session, event_id, "t2")
         await _remove_table(db_session, tournament_id, event_id, "t1")
         now = BASE - timedelta(minutes=60)
         _freeze_clocks(monkeypatch, now)
@@ -1577,14 +1628,14 @@ class TestBrokenPinRepair:
 
         await db_session.refresh(target)
         await db_session.refresh(control)
-        assert target.table_id in {"t2", "t3"}  # re-placed on a survivor
+        assert target.table_id in survivors  # re-placed on a survivor
         assert target.scheduled_start is not None
         assert target.scheduled_start >= BASE
         assert target.pinned_at == now  # the promise is renewed, not demoted
         assert target.call_notified_count == 2
 
         # The untouched pin: byte-identical, no re-notification.
-        assert control.table_id == "t2"
+        assert control.table_id == control_table
         assert control.scheduled_start == control_start
         assert control.pinned_at == original_pin_time
         assert control.call_notified_count == 1
@@ -1595,7 +1646,16 @@ class TestBrokenPinRepair:
         rows = await _call_notifications(db_session)
         assert len(rows) == 2  # target's pair and nothing else
         assert {row.user_id for row in rows} == target_users
-        new_label = target.table_id.upper()
+        # The label is the catalogue row's, not the id's — ``_make_tournament``
+        # labels its tables ``T1``/``T2``/``T3`` from the ``tables`` argument, and the
+        # copy renders that label rather than the (now UUID) id.
+        new_label = (
+            await db_session.execute(
+                select(VenueTable.label).where(
+                    VenueTable.id == uuid.UUID(target.table_id)
+                )
+            )
+        ).scalar_one()
         for row in rows:
             assert row.title == f"Your match moved to {new_label}"
             assert new_label in row.body
@@ -1654,7 +1714,8 @@ class TestBrokenPinRepair:
         await _request_and_run_solve(db_session, solver_queue, tournament_id)
 
         await db_session.refresh(fixture)
-        assert fixture.table_id == "t1"  # the off-pool pin, honored
+        assert fixture.table_id == await _table(db_session, event_id, "t1")
+        # ^ the off-pool pin, honored
         assert fixture.scheduled_start == start
         assert fixture.pinned_at == pin_time  # not refreshed: nothing repaired
         assert fixture.call_notified_count == 1  # told once, never re-told
@@ -1705,7 +1766,8 @@ class TestBrokenPinRepair:
         await _request_and_run_solve(db_session, solver_queue, tournament_id)
 
         await db_session.refresh(fixture)
-        assert fixture.table_id == "t2"  # the off-pool pin, honored…
+        assert fixture.table_id == await _table(db_session, event_id, "t2")
+        # ^ the off-pool pin, honored…
         assert fixture.scheduled_start == start
         assert fixture.pinned_at == silent_pin_time  # …and not re-pinned
         assert fixture.call_notified_count == 1  # …but finally delivered
@@ -1749,13 +1811,14 @@ class TestBrokenPinRepair:
             start=BASE + timedelta(minutes=5),
             pinned_at=BASE - timedelta(minutes=5),
         )
+        survivor = await _table(db_session, event_id, "t2")  # before the removal
         await _remove_table(db_session, tournament_id, event_id, "t1", from_pools=False)
         _freeze_clocks(monkeypatch, BASE)
 
         await _request_and_run_solve(db_session, solver_queue, tournament_id)
 
         await db_session.refresh(fixture)
-        assert fixture.table_id == "t2"
+        assert fixture.table_id == survivor
         assert fixture.scheduled_start == BASE  # 09:00 on the survivor
         entrants = await _entrant_user_ids(db_session, event_id)
         usernames = await _usernames(db_session, entrants)
@@ -1844,13 +1907,14 @@ class TestBrokenPinRepair:
         await _place_fixture(
             db_session, event_id, table_id="t2", start=BASE + timedelta(minutes=60)
         )
+        survivor = await _table(db_session, event_id, "t1")  # before the removal
         await _remove_table(db_session, tournament_id, event_id, "t2")
         _freeze_clocks(monkeypatch, BASE - timedelta(minutes=60))
 
         await _request_and_run_solve(db_session, solver_queue, tournament_id)
 
         fixture = await _the_fixture(db_session, event_id)
-        assert fixture.table_id == "t1"
+        assert fixture.table_id == survivor
         assert fixture.scheduled_start == BASE
         assert fixture.pinned_at is None
         assert fixture.call_notified_count == 0
@@ -1879,13 +1943,14 @@ class TestBrokenPinRepair:
             pinned_at=BASE - timedelta(minutes=15),
             notified=0,  # a silent pre-live pin was never announced
         )
+        survivor = await _table(db_session, event_id, "t2")  # before the removal
         await _remove_table(db_session, tournament_id, event_id, "t1")
         _freeze_clocks(monkeypatch, BASE)
 
         await _request_and_run_solve(db_session, solver_queue, tournament_id)
 
         await db_session.refresh(fixture)
-        assert fixture.table_id == "t2"
+        assert fixture.table_id == survivor
         assert fixture.scheduled_start == BASE
         assert fixture.pinned_at == BASE  # repaired and renewed…
         assert fixture.call_notified_count == 0  # …but nobody was told
@@ -2228,6 +2293,7 @@ class TestManualPlacementPin:
         )
         target = fixtures[0]
         target_id = target.id
+        the_table = await _table(db_session, event_id, "t1")
         # Late on the shared table, after the other two pack in: a called
         # match's start is a floor, not a constant (ADR "a called match holds
         # its table and slides later"), so an uncontended pin is the one the
@@ -2237,7 +2303,7 @@ class TestManualPlacementPin:
             db_session,
             tournament,
             target,
-            table_id="t1",
+            table_id=the_table,
             scheduled_start=pin_start,
             event_timezone="America/Chicago",
         )
@@ -2258,7 +2324,7 @@ class TestManualPlacementPin:
             .all()
         )
         pinned_row = next(row for row in rows if row.id == target_id)
-        assert pinned_row.table_id == "t1"
+        assert pinned_row.table_id == the_table
         assert pinned_row.scheduled_start == pin_start
         assert pinned_row.pinned_at == BASE  # the director's pin, untouched
         assert pinned_row.call_notified_count == 0
@@ -2268,7 +2334,7 @@ class TestManualPlacementPin:
         duration = timedelta(minutes=scheduling.match_minutes(3))
         intervals: list[tuple[datetime, datetime]] = []
         for row in rows:
-            assert row.table_id == "t1"
+            assert row.table_id == the_table
             assert row.scheduled_start is not None
             intervals.append((row.scheduled_start, row.scheduled_start + duration))
         intervals.sort()

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -740,7 +740,10 @@ class TestResourceFreedomGate:
         # A second event of the SAME tournament, with an in_progress match on a
         # different table (t2) whose entrant is the same human.
         await _hold_user_in_second_event(
-            db_session, tournament_id, held_user=shared_user, table_id="t2"
+            db_session,
+            tournament_id,
+            held_user=shared_user,
+            table_id=await _table(db_session, event_id, "t2"),
         )
         _freeze_clocks(monkeypatch, BASE)
 
@@ -1497,21 +1500,52 @@ async def _remove_table(
     from_catalogue: bool = True,
     from_pools: bool = True,
 ) -> None:
-    """Simulate the director's settings writes that break a placement's table,
-    directly on the models: drop it from the tournament's catalogue and/or
-    from every pool's ``table_ids``. ``table_id`` is a positional alias
-    (``"t1"``), resolved by :func:`_table`."""
+    """Put a placement's table beyond the tournament's venue catalogue and/or every
+    pool's ``table_ids`` — the pre-state each broken-pin repair below reacts to.
+    ``table_id`` is a positional alias (``"t1"``), resolved by :func:`_table`.
+
+    The **pools** arm is a plain edit, and always was.
+
+    The **catalogue** arm can no longer be the DELETE it used to be. A fixture's
+    ``table_id`` is a foreign key with ``ON DELETE RESTRICT`` since ADR 20260801, so
+    the database now refuses to remove a table a fixture is placed at — which is the
+    ADR's entire point: a placement is not destroyed as a side effect of editing the
+    venue; the director opts into unplacing it, through the named 409 and the
+    unplace-and-remove opt-in that chore 2c puts on the tournament PATCH.
+
+    What the repair branch under test actually keys on is narrower than "the row was
+    deleted": ``_load_solver_inputs`` compares ``fixture.table_id`` against **this
+    tournament's** catalogue ids, so the state it repairs is "the placement's table is
+    not in this tournament's catalogue". That is what this constructs, in the one way
+    the foreign key still allows — the row survives, re-parented onto a throwaway
+    tournament — so these tests keep asserting about the repair rather than about how
+    the venue got edited.
+
+    Worth naming plainly, because it is a live question for 2c: once removal is
+    unplace-and-remove, a fixture placed at a table that left the catalogue may not be
+    reachable through any supported write at all, and the ``broken_pin_moves`` arm of
+    ``_load_solver_inputs`` would then be defending a state nothing can produce.
+    Whether that arm keeps its reason to exist is 2c's call; it is not this chore's to
+    delete.
+    """
     table_id = await _table(db, event_id, table_id)
     if from_catalogue:
         tournament = (
             await db.execute(select(Tournament).where(Tournament.id == tournament_id))
         ).scalar_one()
-        # A table is a ROW now (ADR 20260801), so "the director removed it" is a
-        # DELETE — expressed by dropping it out of the collection, which
-        # ``delete-orphan`` on ``Tournament.tables`` turns into one.
-        tournament.tables = [
-            table for table in tournament.tables if str(table.id) != table_id
-        ]
+        elsewhere = Tournament(
+            name="Storage Closet",
+            status=TournamentStatus.draft,
+            address=None,
+            league_id=tournament.league_id,
+            created_by_user_id=tournament.created_by_user_id,
+        )
+        db.add(elsewhere)
+        await db.flush()
+        removed = next(
+            table for table in tournament.tables if str(table.id) == table_id
+        )
+        removed.tournament_id = elsewhere.id
     if from_pools:
         event = (
             await db.execute(
@@ -2037,7 +2071,7 @@ class TestCallFlipsMatchLive:
             db_session,
             tournament,
             fixture,
-            table_id="t1",
+            table_id=await _table(db_session, event_id, "t1"),
             scheduled_start=BASE + timedelta(minutes=5),
             event_timezone="America/Chicago",
         )
@@ -2109,7 +2143,7 @@ class TestCallFlipsMatchLive:
             db_session,
             tournament,
             fixture,
-            table_id="t1",
+            table_id=await _table(db_session, event_id, "t1"),
             scheduled_start=BASE + timedelta(minutes=20),  # a move
             event_timezone="America/Chicago",
         )

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -1491,74 +1491,37 @@ async def _match_status(db: AsyncSession, match_id: uuid.UUID) -> MatchStatus:
     return match.status
 
 
-async def _remove_table(
+async def _drop_table_from_pools(
     db: AsyncSession,
-    tournament_id: uuid.UUID,
     event_id: uuid.UUID,
     table_id: str,
-    *,
-    from_catalogue: bool = True,
-    from_pools: bool = True,
 ) -> None:
-    """Put a placement's table beyond the tournament's venue catalogue and/or every
-    pool's ``table_ids`` — the pre-state each broken-pin repair below reacts to.
-    ``table_id`` is a positional alias (``"t1"``), resolved by :func:`_table`.
+    """Take a table out of every pool's ``table_ids``, leaving it in the tournament's
+    venue catalogue — the pre-state the "pool membership is a preference, not physics"
+    tests below react to. ``table_id`` is a positional alias (``"t1"``), resolved by
+    :func:`_table`.
 
-    The **pools** arm is a plain edit, and always was.
-
-    The **catalogue** arm can no longer be the DELETE it used to be. A fixture's
-    ``table_id`` is a foreign key with ``ON DELETE RESTRICT`` since ADR 20260801, so
-    the database now refuses to remove a table a fixture is placed at — which is the
-    ADR's entire point: a placement is not destroyed as a side effect of editing the
-    venue; the director opts into unplacing it, through the named 409 and the
-    unplace-and-remove opt-in that chore 2c puts on the tournament PATCH.
-
-    What the repair branch under test actually keys on is narrower than "the row was
-    deleted": ``_load_solver_inputs`` compares ``fixture.table_id`` against **this
-    tournament's** catalogue ids, so the state it repairs is "the placement's table is
-    not in this tournament's catalogue". That is what this constructs, in the one way
-    the foreign key still allows — the row survives, re-parented onto a throwaway
-    tournament — so these tests keep asserting about the repair rather than about how
-    the venue got edited.
-
-    Worth naming plainly, because it is a live question for 2c: once removal is
-    unplace-and-remove, a fixture placed at a table that left the catalogue may not be
-    reachable through any supported write at all, and the ``broken_pin_moves`` arm of
-    ``_load_solver_inputs`` would then be defending a state nothing can produce.
-    Whether that arm keeps its reason to exist is 2c's call; it is not this chore's to
-    delete.
+    There used to be a ``from_catalogue`` arm here too, constructing "the placement's
+    table is not in this tournament's catalogue" by **re-parenting the table row onto a
+    throwaway tournament** — the one way ADR 20260801's ``ON DELETE RESTRICT`` foreign
+    key still allowed the state to be built. It is gone with the ``broken_pin_moves``
+    repair it fed (chore 2c). That repair defended a state no production path could
+    produce: the tournament PATCH's diff either refuses to remove a table matches are
+    placed at (the named 409) or unplaces them first, and nothing in ``app/`` ever moves
+    a ``VenueTable`` between tournaments. A helper whose whole job is to manufacture an
+    unreachable state is not a test fixture, it is a second implementation of a bug.
     """
     table_id = await _table(db, event_id, table_id)
-    if from_catalogue:
-        tournament = (
-            await db.execute(select(Tournament).where(Tournament.id == tournament_id))
-        ).scalar_one()
-        elsewhere = Tournament(
-            name="Storage Closet",
-            status=TournamentStatus.draft,
-            address=None,
-            league_id=tournament.league_id,
-            created_by_user_id=tournament.created_by_user_id,
-        )
-        db.add(elsewhere)
-        await db.flush()
-        removed = next(
-            table for table in tournament.tables if str(table.id) == table_id
-        )
-        removed.tournament_id = elsewhere.id
-    if from_pools:
-        event = (
-            await db.execute(
-                select(TournamentEvent).where(TournamentEvent.id == event_id)
-            )
-        ).scalar_one()
-        event.pools = [
-            {
-                **pool,
-                "table_ids": [t for t in pool["table_ids"] if t != table_id],
-            }
-            for pool in event.pools
-        ]
+    event = (
+        await db.execute(select(TournamentEvent).where(TournamentEvent.id == event_id))
+    ).scalar_one()
+    event.pools = [
+        {
+            **pool,
+            "table_ids": [t for t in pool["table_ids"] if t != table_id],
+        }
+        for pool in event.pools
+    ]
     await db.commit()
 
 
@@ -1591,128 +1554,16 @@ async def _usernames(
 
 class TestBrokenPinRepair:
     """Chore 3c: pins are inviolable against optimization, not against
-    physics. A pinned fixture whose table left the venue CATALOGUE is
-    re-placed by the next solve and STAYS a pin (renewed, moved-notified); a
-    pinned fixture whose entrant withdrew is voided (placement cleared, the
-    remaining entrant cancelled-notified). Pool membership is a preference,
-    not physics: an off-pool pin on a table still in the catalogue is the
-    director's legitimate hand and is honored byte-identical. Planned
-    fixtures re-plan silently; pre-live repairs are silent; untouched pins
-    stay byte-identical."""
+    physics. A pinned fixture whose entrant withdrew is voided (placement
+    cleared, the remaining entrant cancelled-notified). Pool membership is a
+    preference, not physics: an off-pool pin on a table still in the catalogue
+    is the director's legitimate hand and is honored byte-identical.
 
-    async def test_a_removed_catalogue_table_moved_correction_and_untouched_control_pin(
-        self,
-        db_session: AsyncSession,
-        solver_queue: Queue,
-        fake_notifications_queue: Queue,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """The called match's table vanishes from the catalogue (and, as the
-        settings flow does, from the pool) → the next solve re-places the
-        fixture on a surviving table, still pinned with ``pinned_at``
-        refreshed, count 1→2, exactly one moved notification per entrant
-        carrying the NEW table label — while a healthy pinned control fixture
-        in the very same solve does not move a byte and re-notifies nobody."""
-        tournament_id, event_id = await _make_tournament(
-            db_session, entrants=4, tables=("t1", "t2", "t3")
-        )
-        fixtures = await _all_fixtures(db_session, event_id)
-        target = fixtures[0]
-        control = next(
-            f
-            for f in fixtures
-            if not (
-                {f.entry_a_id, f.entry_b_id} & {target.entry_a_id, target.entry_b_id}
-            )
-        )
-        original_pin_time = BASE - timedelta(minutes=15)
-        # The control sits late on t2, after every other fixture packs in, so
-        # it is uncontended and the solver leaves it byte-for-byte. A called
-        # match's start is a floor, not a constant (ADR "a called match holds
-        # its table and slides later") — an EARLY pin sharing a player with the
-        # rest of the round-robin gets legitimately bumped later, which is not
-        # the "untouched" case this control is here to demonstrate.
-        control_start = BASE + timedelta(minutes=300)
-        await _pin_directly(
-            db_session,
-            target,
-            table_id="t1",
-            start=BASE,
-            pinned_at=original_pin_time,
-        )
-        await _pin_directly(
-            db_session,
-            control,
-            table_id="t2",
-            start=control_start,
-            pinned_at=original_pin_time,
-        )
-        # Captured BEFORE the removal: dropping a table shifts every later
-        # position, so the aliases would name different rows afterwards.
-        survivors = {
-            await _table(db_session, event_id, "t2"),
-            await _table(db_session, event_id, "t3"),
-        }
-        control_table = await _table(db_session, event_id, "t2")
-        await _remove_table(db_session, tournament_id, event_id, "t1")
-        now = BASE - timedelta(minutes=60)
-        _freeze_clocks(monkeypatch, now)
-
-        await _request_and_run_solve(db_session, solver_queue, tournament_id)
-
-        await db_session.refresh(target)
-        await db_session.refresh(control)
-        assert target.table_id in survivors  # re-placed on a survivor
-        assert target.scheduled_start is not None
-        assert target.scheduled_start >= BASE
-        assert target.pinned_at == now  # the promise is renewed, not demoted
-        assert target.call_notified_count == 2
-
-        # The untouched pin: byte-identical, no re-notification.
-        assert control.table_id == control_table
-        assert control.scheduled_start == control_start
-        assert control.pinned_at == original_pin_time
-        assert control.call_notified_count == 1
-
-        target_users = await _users_for_entries(
-            db_session, [target.entry_a_id, target.entry_b_id]
-        )
-        rows = await _call_notifications(db_session)
-        assert len(rows) == 2  # target's pair and nothing else
-        assert {row.user_id for row in rows} == target_users
-        # The label is the catalogue row's, not the id's — ``_make_tournament``
-        # labels its tables ``T1``/``T2``/``T3`` from the ``tables`` argument, and the
-        # copy renders that label rather than the (now UUID) id.
-        new_label = (
-            await db_session.execute(
-                select(VenueTable.label).where(
-                    VenueTable.id == uuid.UUID(target.table_id)
-                )
-            )
-        ).scalar_one()
-        for row in rows:
-            assert row.title == f"Your match moved to {new_label}"
-            assert new_label in row.body
-            # The stored instant round-trips as UTC-aware; the copy renders it in
-            # the venue frame, so compare the venue-local wall-clock.
-            assert (
-                target.scheduled_start.astimezone(VENUE_TZ).strftime("%H:%M")
-                in row.body
-            )
-        jobs = _fanout_jobs(fake_notifications_queue)
-        assert {job.user_id for job in jobs} == target_users
-        assert all(job.collapse_id == f"match-call:{target.id}" for job in jobs)
-
-        ledger = (
-            await db_session.execute(
-                select(ScheduleSolve).where(
-                    ScheduleSolve.tournament_id == tournament_id
-                )
-            )
-        ).scalar_one()
-        assert ledger.status is ScheduleSolveStatus.succeeded
-        assert ledger.fixtures_placed == 5  # 4 plans + the repaired pin
-        assert ledger.fixtures_pinned == 1  # the control's verbatim echo
+    The catalogue-departure repair this class also covered is gone (chore 2c):
+    under ADR 20260801 a placement's table cannot leave the catalogue — the
+    tournament PATCH's diff refuses the removal or unplaces the fixtures first
+    — so the only way its tests could reach the state was to re-parent a table
+    row onto a throwaway tournament, which no production path performs."""
 
     async def test_a_table_dropped_from_the_pool_keeps_the_pin(
         self,
@@ -1740,9 +1591,7 @@ class TestBrokenPinRepair:
             start=start,
             pinned_at=pin_time,
         )
-        await _remove_table(
-            db_session, tournament_id, event_id, "t1", from_catalogue=False
-        )
+        await _drop_table_from_pools(db_session, event_id, "t1")
         _freeze_clocks(monkeypatch, BASE)
 
         await _request_and_run_solve(db_session, solver_queue, tournament_id)
@@ -1792,9 +1641,7 @@ class TestBrokenPinRepair:
             pinned_at=silent_pin_time,
             notified=0,  # placed silently while planning; never announced
         )
-        await _remove_table(
-            db_session, tournament_id, event_id, "t2", from_catalogue=False
-        )
+        await _drop_table_from_pools(db_session, event_id, "t2")
         _freeze_clocks(monkeypatch, BASE)
 
         await _request_and_run_solve(db_session, solver_queue, tournament_id)
@@ -1822,49 +1669,6 @@ class TestBrokenPinRepair:
         assert ledger.status is ScheduleSolveStatus.succeeded
         assert ledger.fixtures_placed == 0
         assert ledger.fixtures_pinned == 1  # echoed verbatim
-
-    async def test_the_moved_correction_copy_renders_the_new_table_label_and_time(
-        self,
-        db_session: AsyncSession,
-        solver_queue: Queue,
-        fake_notifications_queue: Queue,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """The moved sentence names the NEW table and HH:MM — asserted whole,
-        per recipient, with the opponent's name. The table is removed from
-        the CATALOGUE only (the pool still names it): catalogue departure
-        alone is the physics that breaks a pin."""
-        tournament_id, event_id = await _make_tournament(
-            db_session, tables=("t1", "t2")
-        )
-        fixture = await _the_fixture(db_session, event_id)
-        await _pin_directly(
-            db_session,
-            fixture,
-            table_id="t1",
-            start=BASE + timedelta(minutes=5),
-            pinned_at=BASE - timedelta(minutes=5),
-        )
-        survivor = await _table(db_session, event_id, "t2")  # before the removal
-        await _remove_table(db_session, tournament_id, event_id, "t1", from_pools=False)
-        _freeze_clocks(monkeypatch, BASE)
-
-        await _request_and_run_solve(db_session, solver_queue, tournament_id)
-
-        await db_session.refresh(fixture)
-        assert fixture.table_id == survivor
-        assert fixture.scheduled_start == BASE  # 09:00 on the survivor
-        entrants = await _entrant_user_ids(db_session, event_id)
-        usernames = await _usernames(db_session, entrants)
-        rows = await _call_notifications(db_session)
-        assert len(rows) == 2
-        for row in rows:
-            (opponent_id,) = entrants - {row.user_id}
-            assert row.title == "Your match moved to T2"
-            assert row.body == (
-                "Your Called Open · Open Singles · Pool A match against "
-                f"{usernames[opponent_id]} now starts around 09:00 on T2."
-            )
 
     async def test_a_withdrawal_sends_cancelled_to_the_remaining_entrant_only(
         self,
@@ -1924,72 +1728,6 @@ class TestBrokenPinRepair:
         assert ledger.status is ScheduleSolveStatus.succeeded
         assert ledger.fixtures_placed == 0
         assert ledger.fixtures_pinned == 0
-
-    async def test_a_planned_fixture_on_a_removed_table_gets_no_moved_or_cancelled(
-        self,
-        db_session: AsyncSession,
-        solver_queue: Queue,
-        fake_notifications_queue: Queue,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Repairs are for promises. A merely *planned* (unpinned) fixture on
-        a removed table is silently re-placed — it was never promised, so
-        nobody is told anything."""
-        tournament_id, event_id = await _make_tournament(
-            db_session, tables=("t1", "t2")
-        )
-        await _place_fixture(
-            db_session, event_id, table_id="t2", start=BASE + timedelta(minutes=60)
-        )
-        survivor = await _table(db_session, event_id, "t1")  # before the removal
-        await _remove_table(db_session, tournament_id, event_id, "t2")
-        _freeze_clocks(monkeypatch, BASE - timedelta(minutes=60))
-
-        await _request_and_run_solve(db_session, solver_queue, tournament_id)
-
-        fixture = await _the_fixture(db_session, event_id)
-        assert fixture.table_id == survivor
-        assert fixture.scheduled_start == BASE
-        assert fixture.pinned_at is None
-        assert fixture.call_notified_count == 0
-        assert await _call_notifications(db_session) == []
-        assert fake_notifications_queue.jobs == []
-
-    async def test_a_pre_live_broken_pin_is_repaired_but_no_moved_correction_is_sent(
-        self,
-        db_session: AsyncSession,
-        solver_queue: Queue,
-        fake_notifications_queue: Queue,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Pre-live pins are silent (free rearranging while planning — ADR),
-        so their repairs are too: the placement is rewritten and the pin
-        renewed, but the count stays untouched and nobody is notified."""
-        tournament_id, event_id = await _make_tournament(
-            db_session, status=TournamentStatus.published, tables=("t1", "t2")
-        )
-        fixture = await _the_fixture(db_session, event_id)
-        await _pin_directly(
-            db_session,
-            fixture,
-            table_id="t1",
-            start=BASE + timedelta(minutes=5),
-            pinned_at=BASE - timedelta(minutes=15),
-            notified=0,  # a silent pre-live pin was never announced
-        )
-        survivor = await _table(db_session, event_id, "t2")  # before the removal
-        await _remove_table(db_session, tournament_id, event_id, "t1")
-        _freeze_clocks(monkeypatch, BASE)
-
-        await _request_and_run_solve(db_session, solver_queue, tournament_id)
-
-        await db_session.refresh(fixture)
-        assert fixture.table_id == survivor
-        assert fixture.scheduled_start == BASE
-        assert fixture.pinned_at == BASE  # repaired and renewed…
-        assert fixture.call_notified_count == 0  # …but nobody was told
-        assert await _call_notifications(db_session) == []
-        assert fake_notifications_queue.jobs == []
 
 
 class TestCallFlipsMatchLive:

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -92,6 +92,7 @@ from tests._helpers import (
     grant_permissions,
     make_user,
     start_session,
+    table_ids_of,
     venue_tables,
     with_table_aliases,
 )
@@ -1810,8 +1811,9 @@ async def test_get_schedule_returns_placed_fixtures_and_latest_solve_verdict(
     # a US-Central dev box, 09:00Z in a UTC CI runner). 9:00 AM America/Chicago
     # (CDT on this August date) = 14:00Z, which the BFF renders back as "9:00 AM CDT".
     scheduled_start = datetime(2026, 8, 1, 9, 0, tzinfo=ZoneInfo("America/Chicago"))
+    (the_table, *_) = await table_ids_of(db_session, uuid.UUID(tournament_id))
     fixture = await _seed_placed_fixture(
-        db_session, event_id, table_id="t1", scheduled_start=scheduled_start
+        db_session, event_id, table_id=the_table, scheduled_start=scheduled_start
     )
     # A finished solve on the ledger, so the projection carries a verdict.
     db_session.add(
@@ -1842,7 +1844,7 @@ async def test_get_schedule_returns_placed_fixtures_and_latest_solve_verdict(
     assert len(group["fixtures"]) == 1
     placed = group["fixtures"][0]
     assert placed["id"] == str(fixture.id)
-    assert placed["table_id"] == "t1"
+    assert placed["table_id"] == the_table
     # ``scheduled_start`` is now a venue-local ``FixtureTimeRead`` (ADR "tournament
     # times are timezone-aware instants"): the 09:00 seed is anchored in the event's
     # America/Chicago zone (= 14:00Z), rendered with its local label + tz abbrev.
@@ -4074,6 +4076,8 @@ async def test_place_fixture_owner_round_trip(
         db_session, owner, default_league
     )
     tournament_id, fixture_id = tournament.id, fixture.id
+    # A placement names a real table (ADR 20260801), and its id is the server's.
+    table_id = str(tournament.tables[0].id)
 
     async with _mcp_client(raw) as client, client:
         result = await client.call_tool_mcp(
@@ -4082,7 +4086,7 @@ async def test_place_fixture_owner_round_trip(
                 "tournament_id": str(tournament_id),
                 "fixture_id": str(fixture_id),
                 "placement": {
-                    "table_id": "t1",
+                    "table_id": table_id,
                     "scheduled_start": "2026-06-13T10:00:00",
                 },
             },
@@ -4090,7 +4094,7 @@ async def test_place_fixture_owner_round_trip(
     assert result.isError is False
     assert result.structuredContent is not None
     assert result.structuredContent["id"] == str(fixture_id)
-    assert result.structuredContent["table_id"] == "t1"
+    assert result.structuredContent["table_id"] == table_id
     assert result.structuredContent["scheduled_start"] is not None
 
     db_session.expire_all()
@@ -4099,7 +4103,7 @@ async def test_place_fixture_owner_round_trip(
             select(TournamentFixture).where(TournamentFixture.id == fixture_id)
         )
     ).scalar_one()
-    assert row.table_id == "t1"
+    assert row.table_id == table_id
     assert row.scheduled_start is not None
     assert row.pinned_at is not None
 
@@ -4117,6 +4121,7 @@ async def test_place_fixture_non_owner_raises_tool_error(
         db_session, owner, default_league
     )
     tournament_id, fixture_id = tournament.id, fixture.id
+    table_id = str(tournament.tables[0].id)
 
     async with _mcp_client(stranger_token) as client, client:
         with pytest.raises(ToolError, match="tournaments you created"):
@@ -4126,7 +4131,7 @@ async def test_place_fixture_non_owner_raises_tool_error(
                     "tournament_id": str(tournament_id),
                     "fixture_id": str(fixture_id),
                     "placement": {
-                        "table_id": "t1",
+                        "table_id": table_id,
                         "scheduled_start": "2026-06-13T10:00:00",
                     },
                 },
@@ -4154,6 +4159,7 @@ async def test_place_fixture_played_out_fixture_raises_tool_error(
         db_session, owner, default_league
     )
     tournament_id, fixture_id = tournament.id, fixture.id
+    table_id = str(tournament.tables[1].id)
     match = Match(
         match_settings=MatchSettings(team_size=1, best_of=5, affects_rating=False),
         league_id=default_league.id,
@@ -4173,7 +4179,7 @@ async def test_place_fixture_played_out_fixture_raises_tool_error(
                     "tournament_id": str(tournament_id),
                     "fixture_id": str(fixture_id),
                     "placement": {
-                        "table_id": "t2",
+                        "table_id": table_id,
                         "scheduled_start": "2026-06-13T14:00:00",
                     },
                 },

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -92,6 +92,8 @@ from tests._helpers import (
     grant_permissions,
     make_user,
     start_session,
+    venue_tables,
+    with_table_aliases,
 )
 
 MCP_URL = "http://testserver/mcp/"
@@ -1401,7 +1403,7 @@ def _tournament_payload() -> dict[str, object]:
             "postal": "94703",
             "country": "USA",
         },
-        "table_catalogue": [{"id": "t1", "label": "Table 1", "court": "A"}],
+        "table_catalogue": [{"label": "Table 1", "court": "A"}],
     }
 
 
@@ -1544,7 +1546,6 @@ async def _seed_owned_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[],
         league_id=league.id,
         created_by_user_id=owner.id,
         status=status,
@@ -2103,10 +2104,7 @@ async def _seed_drawable_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": "t1", "label": "Table 1", "court": "A"},
-            {"id": "t2", "label": "Table 2", "court": "A"},
-        ],
+        tables=venue_tables(("Table 1", "A"), ("Table 2", "A")),
         league_id=league.id,
         created_by_user_id=owner.id,
         status=TournamentStatus.draft,
@@ -2125,7 +2123,7 @@ async def _seed_drawable_tournament(
         slot={"date": "2026-08-01", "start": "09:00", "end": "18:00"},
         match_settings={"rated": True, "length_games": 5},
         predicates=[],
-        pools=[_DRAW_POOL_A, _DRAW_POOL_B],
+        pools=with_table_aliases(tournament, [_DRAW_POOL_A, _DRAW_POOL_B]),
     )
     db_session.add(event)
     await db_session.commit()
@@ -2643,10 +2641,7 @@ async def _seed_previewable_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": "t1", "label": "Table 1", "court": "A"},
-            {"id": "t2", "label": "Table 2", "court": "A"},
-        ],
+        tables=venue_tables(("Table 1", "A"), ("Table 2", "A")),
         league_id=league.id,
         created_by_user_id=owner.id,
         status=status,
@@ -2665,14 +2660,21 @@ async def _seed_previewable_tournament(
         match_settings={"rated": False, "length_games": 3},
         predicates=[],
         timezone="America/Los_Angeles",
-        pools=[
-            {
-                "id": "pool-a",
-                "name": "Pool A",
-                "slot": {"date": "2030-01-01", "start": "09:00", "end": "17:00"},
-                "table_ids": ["t1", "t2"],
-            }
-        ],
+        pools=with_table_aliases(
+            tournament,
+            [
+                {
+                    "id": "pool-a",
+                    "name": "Pool A",
+                    "slot": {
+                        "date": "2030-01-01",
+                        "start": "09:00",
+                        "end": "17:00",
+                    },
+                    "table_ids": ["t1", "t2"],
+                }
+            ],
+        ),
     )
     db_session.add(event)
     await db_session.commit()
@@ -3999,10 +4001,7 @@ async def _seed_placeable_fixture(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": "t1", "label": "Table 1", "court": "A"},
-            {"id": "t2", "label": "Table 2", "court": "A"},
-        ],
+        tables=venue_tables(("Table 1", "A"), ("Table 2", "A")),
         league_id=league.id,
         created_by_user_id=owner.id,
         status=TournamentStatus.draft,
@@ -4021,14 +4020,17 @@ async def _seed_placeable_fixture(
         slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         match_settings={"rated": True, "length_games": 5},
         predicates=[],
-        pools=[
-            {
-                "id": "p-os-1",
-                "name": "Pool A",
-                "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
-                "table_ids": ["t1"],
-            }
-        ],
+        pools=with_table_aliases(
+            tournament,
+            [
+                {
+                    "id": "p-os-1",
+                    "name": "Pool A",
+                    "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+                    "table_ids": ["t1"],
+                }
+            ],
+        ),
     )
     db.add(event)
     await db.commit()

--- a/api/tests/test_realtime_publishing_calls.py
+++ b/api/tests/test_realtime_publishing_calls.py
@@ -79,10 +79,17 @@ class Staged:
     later: tuple[User, User]
     #: The called fixture's two entry rows, in the same order as ``called``.
     called_entry_ids: tuple[uuid.UUID, uuid.UUID]
+    #: The venue catalogue's ids, in its order — server-minted UUIDs (ADR 20260801),
+    #: which a fixture's ``table_id`` foreign-keys, so a test cannot spell one.
+    table_ids: tuple[str, ...]
 
     @property
     def watched(self) -> tuple[uuid.UUID, ...]:
         return tuple(user.id for user in (*self.called, *self.later))
+
+    def table(self, alias: str) -> str:
+        """The id of the ``"t1"``-style positional alias this module talks in."""
+        return self.table_ids[int(alias.removeprefix("t")) - 1]
 
 
 async def _stage(
@@ -113,6 +120,7 @@ async def _stage(
     )
     db.add(tournament)
     await db.flush()
+    table_ids = tuple(str(table.id) for table in tournament.tables)
 
     event = TournamentEvent(
         tournament_id=tournament.id,
@@ -163,7 +171,7 @@ async def _stage(
         position=2,
         entry_a_id=entry_c.id,
         entry_b_id=entry_d.id,
-        table_id="t2",
+        table_id=table_ids[1],
         scheduled_start=LATER,
     )
     db.add_all([called_fixture, later_fixture])
@@ -176,6 +184,7 @@ async def _stage(
         called=(called_a, called_b),
         later=(later_a, later_b),
         called_entry_ids=(entry_a.id, entry_b.id),
+        table_ids=table_ids,
     )
 
 
@@ -231,7 +240,12 @@ async def test_a_player_called_to_a_table_is_hinted_and_one_playing_later_is_not
     signed-in user."""
     staged = await _stage(db_session)
     bystander = await _bystander(db_session)
-    await _place(db_session, staged, table_id="t1", start=BASE + timedelta(minutes=5))
+    await _place(
+        db_session,
+        staged,
+        table_id=staged.table("t1"),
+        start=BASE + timedelta(minutes=5),
+    )
     _freeze(monkeypatch, BASE)
 
     async with watch_hints(realtime_broker, *staged.watched, bystander.id) as watch:
@@ -264,7 +278,7 @@ async def test_a_call_that_fires_for_nobody_hints_nobody(
     from something other than the call's recipient list."""
     staged = await _stage(db_session)
     bystander = await _bystander(db_session)
-    await _place(db_session, staged, table_id="t1", start=LATER)
+    await _place(db_session, staged, table_id=staged.table("t1"), start=LATER)
     _freeze(monkeypatch, BASE)
 
     async with watch_hints(realtime_broker, *staged.watched, bystander.id) as watch:
@@ -294,7 +308,7 @@ async def test_moving_a_called_player_to_another_table_hints_that_pair_only(
     await _place(
         db_session,
         staged,
-        table_id="t1",
+        table_id=staged.table("t1"),
         start=BASE + timedelta(minutes=5),
         pinned_at=BASE - timedelta(minutes=5),
         notified=1,  # already told → a re-place is a *moved* correction
@@ -306,7 +320,7 @@ async def test_moving_a_called_player_to_another_table_hints_that_pair_only(
             db_session,
             await _tournament(db_session, staged),
             await _called_fixture(db_session, staged),
-            table_id="t2",
+            table_id=staged.table("t2"),
             scheduled_start=BASE + timedelta(minutes=20),
             event_timezone=VENUE_TZ_NAME,
         )
@@ -337,7 +351,7 @@ async def test_cancelling_a_call_hints_the_pair_who_were_told_to_go_there(
     await _place(
         db_session,
         staged,
-        table_id="t1",
+        table_id=staged.table("t1"),
         start=BASE + timedelta(minutes=5),
         pinned_at=BASE - timedelta(minutes=5),
         notified=1,
@@ -387,7 +401,7 @@ async def test_a_withdrawal_cancellation_hints_only_the_player_left_standing(
     await _place(
         db_session,
         staged,
-        table_id="t1",
+        table_id=staged.table("t1"),
         start=BASE + timedelta(minutes=5),
         pinned_at=BASE - timedelta(minutes=5),
         notified=1,
@@ -440,7 +454,7 @@ async def test_a_silent_pre_live_placement_hints_nobody(
             db_session,
             await _tournament(db_session, staged),
             await _called_fixture(db_session, staged),
-            table_id="t1",
+            table_id=staged.table("t1"),
             scheduled_start=BASE + timedelta(minutes=5),
             event_timezone=VENUE_TZ_NAME,
         )

--- a/api/tests/test_realtime_publishing_calls.py
+++ b/api/tests/test_realtime_publishing_calls.py
@@ -50,7 +50,10 @@ from app.models import (
     User,
 )
 from app.realtime import EventKind, RealtimeBroker
-from tests._helpers import make_user
+from tests._helpers import (
+    make_user,
+    venue_tables,
+)
 from tests._realtime import watch_hints
 
 DATE = "2030-01-01"
@@ -104,10 +107,7 @@ async def _stage(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": "t1", "label": "T1", "court": "Main"},
-            {"id": "t2", "label": "T2", "court": "Main"},
-        ],
+        tables=venue_tables(("T1", "Main"), ("T2", "Main")),
         league_id=league.id,
         created_by_user_id=owner.id,
     )

--- a/api/tests/test_realtime_publishing_tournaments.py
+++ b/api/tests/test_realtime_publishing_tournaments.py
@@ -63,7 +63,11 @@ from app.tournament_advancement import on_match_completed
 from app.tournament_draws import cut_draw
 from app.tournament_lifecycle import transition_tournament
 from app.tournament_placement import place_fixture
-from tests._helpers import make_user
+from tests._helpers import (
+    make_user,
+    table_ids_of,
+    venue_tables,
+)
 from tests._realtime import watch_hints
 
 #: Far enough out that the solver never has to argue with the wall clock.
@@ -156,6 +160,7 @@ async def _seed_field(
     this is about the create routes. The draw is left un-cut; callers cut it.
     """
     director = await make_user(db, _name("director"))
+    catalogue = venue_tables(*((table.upper(), "Main") for table in tables))
     tournament = Tournament(
         name="Realtime Open",
         status=status,
@@ -169,9 +174,7 @@ async def _seed_field(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": table, "label": table.upper(), "court": "Main"} for table in tables
-        ],
+        tables=catalogue,
         league_id=league.id,
         created_by_user_id=director.id,
     )
@@ -193,7 +196,7 @@ async def _seed_field(
                 "id": "pool-a",
                 "name": "Pool A",
                 "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
-                "table_ids": list(tables),
+                "table_ids": [str(row.id) for row in catalogue],
             }
         ],
     )
@@ -434,6 +437,7 @@ async def test_applying_a_schedule_solve_hints_the_players_whose_times_moved(
     field = await _seed_field(db_session, default_league, entrants=2, tables=("t1",))
     await cut_draw(db_session, field.event)
     await db_session.commit()
+    (the_table,) = await table_ids_of(db_session, field.tournament.id)
     (unplaced,) = await _fixtures_of(db_session, field.event.id)
     assert unplaced.scheduled_start is None and unplaced.table_id is None
 
@@ -461,7 +465,7 @@ async def test_applying_a_schedule_solve_hints_the_players_whose_times_moved(
             )
         )
     ).one()
-    assert table_id == "t1" and scheduled_start is not None, (
+    assert table_id == the_table and scheduled_start is not None, (
         "the solve actually moved something — otherwise the hint proves nothing"
     )
     field.assert_only_entrants_hinted(hints)

--- a/api/tests/test_realtime_publishing_tournaments.py
+++ b/api/tests/test_realtime_publishing_tournaments.py
@@ -488,6 +488,8 @@ async def test_placing_a_fixture_hints_the_events_entrants(
     await cut_draw(db_session, field.event)
     await db_session.commit()
     (fixture,) = await _fixtures_of(db_session, field.event.id)
+    # The catalogue's real id: a placement names a real table now (ADR 20260801).
+    (the_table, *_) = await table_ids_of(db_session, field.tournament.id)
 
     async with watch_hints(realtime_broker, *field.everyone) as watch:
         read = await place_fixture(
@@ -496,12 +498,12 @@ async def test_placing_a_fixture_hints_the_events_entrants(
             fixture_id=fixture.id,
             actor=field.director,
             placement=TournamentFixturePlacementUpdate(
-                table_id="t1", scheduled_start=START
+                table_id=the_table, scheduled_start=START
             ),
         )
         hints = await watch.collect()
 
-    assert read.table_id == "t1"
+    assert read.table_id == the_table
     field.assert_only_entrants_hinted(hints)
 
 
@@ -522,13 +524,14 @@ async def test_unpinning_a_fixture_still_hints_the_events_entrants(
     await db_session.commit()
     (fixture,) = await _fixtures_of(db_session, field.event.id)
     fixture_id = fixture.id
+    (the_table, *_) = await table_ids_of(db_session, field.tournament.id)
     await place_fixture(
         db_session,
         tournament_id=field.tournament.id,
         fixture_id=fixture_id,
         actor=field.director,
         placement=TournamentFixturePlacementUpdate(
-            table_id="t1", scheduled_start=START
+            table_id=the_table, scheduled_start=START
         ),
     )
 

--- a/api/tests/test_rr_then_ko.py
+++ b/api/tests/test_rr_then_ko.py
@@ -84,7 +84,7 @@ def _tournament_payload() -> dict[str, Any]:
             "postal": "94703",
             "country": "USA",
         },
-        "table_catalogue": [{"id": "t1", "label": "Table 1", "court": "A"}],
+        "table_catalogue": [{"label": "Table 1", "court": "A"}],
     }
 
 

--- a/api/tests/test_rr_then_ko.py
+++ b/api/tests/test_rr_then_ko.py
@@ -192,12 +192,16 @@ async def _call(
     flips to ``in_progress`` and becomes scorable (#1073)."""
     tournament = await db.get(Tournament, uuid.UUID(tournament_id))
     assert tournament is not None
+    # The catalogue's first row, by the id the server minted: ``table_id`` is a foreign
+    # key since ADR 20260801, so the ``"t1"`` alias is no longer a table. Every fixture
+    # onto the one table — a double-booking is a flag on read, never a refusal.
+    table_id = str(tournament.tables[0].id)
     for fixture in fixtures:
         await match_calls.apply_manual_placement(
             db,
             tournament,
             fixture,
-            table_id="t1",
+            table_id=table_id,
             scheduled_start=datetime(2026, 6, 1, 10, 0),
             event_timezone="America/Chicago",
         )

--- a/api/tests/test_schedule_preview_route.py
+++ b/api/tests/test_schedule_preview_route.py
@@ -49,12 +49,17 @@ from app.models import (
     User,
 )
 from app.schedule_preview_solve import RUN_SCHEDULE_PREVIEW_JOB
-from tests._helpers import make_client, start_session
+from tests._helpers import (
+    make_client,
+    start_session,
+    venue_tables,
+    with_table_aliases,
+)
 
-TABLE_CATALOGUE: list[dict[str, object]] = [
-    {"id": "t1", "label": "Table 1", "court": "A"},
-    {"id": "t2", "label": "Table 2", "court": "A"},
-]
+# Built per tournament, never as a module constant: a catalogue is
+# ``tournament_tables`` rows now (ADR 20260801). The pool below names them by the
+# positional ``t1``/``t2`` aliases ``with_table_aliases`` resolves.
+TABLE_CATALOGUE = (("Table 1", "A"), ("Table 2", "A"))
 
 
 @pytest.fixture
@@ -118,7 +123,7 @@ async def _make_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=TABLE_CATALOGUE,
+        tables=venue_tables(*TABLE_CATALOGUE),
         league_id=league.id,
         created_by_user_id=owner.id,
     )
@@ -136,14 +141,21 @@ async def _make_tournament(
             slot={"date": "2030-01-01", "start": "09:00", "end": "17:00"},
             match_settings={"rated": False, "length_games": 3},
             timezone="America/Los_Angeles",
-            pools=[
-                {
-                    "id": "pool-a",
-                    "name": "Pool A",
-                    "slot": {"date": "2030-01-01", "start": "09:00", "end": "17:00"},
-                    "table_ids": ["t1", "t2"],
-                }
-            ],
+            pools=with_table_aliases(
+                tournament,
+                [
+                    {
+                        "id": "pool-a",
+                        "name": "Pool A",
+                        "slot": {
+                            "date": "2030-01-01",
+                            "start": "09:00",
+                            "end": "17:00",
+                        },
+                        "table_ids": ["t1", "t2"],
+                    }
+                ],
+            ),
         )
         db.add(event)
         await db.flush()

--- a/api/tests/test_schedule_preview_snapshot.py
+++ b/api/tests/test_schedule_preview_snapshot.py
@@ -41,13 +41,13 @@ from app.models import (
 )
 from app.models.tournament import DrawType, EventFormat
 from app.schedule_preview import DEFAULT_UNCAPPED_FIELD, build_preview_snapshot
-from tests._helpers import make_user
+from tests._helpers import make_user, venue_tables, with_table_aliases
 
-# A venue with two tables, so a pool can be given one or both.
-TABLE_CATALOGUE: list[dict[str, object]] = [
-    {"id": "t1", "label": "Table 1", "court": "A"},
-    {"id": "t2", "label": "Table 2", "court": "A"},
-]
+# A venue with two tables, so a pool can be given one or both. Built per tournament,
+# never as a module constant: a catalogue is ``tournament_tables`` rows now
+# (ADR 20260801), and rows belong to one tournament and one session. The pools below
+# name them by the positional ``t1``/``t2`` aliases ``with_table_aliases`` resolves.
+TABLE_CATALOGUE = (("Table 1", "A"), ("Table 2", "A"))
 
 
 def _one_pool(table_ids: list[str]) -> dict[str, object]:
@@ -76,7 +76,7 @@ async def _make_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=TABLE_CATALOGUE,
+        tables=venue_tables(*TABLE_CATALOGUE),
         league_id=league.id,
         created_by_user_id=owner.id,
         status=TournamentStatus.draft,
@@ -111,7 +111,9 @@ async def _add_event(
         slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         match_settings={"rated": True, "length_games": length_games},
         predicates=[],
-        pools=[_one_pool(["t1"])] if pools is None else pools,
+        pools=with_table_aliases(
+            tournament, [_one_pool(["t1"])] if pools is None else pools
+        ),
         timezone=timezone,
     )
     db.add(event)

--- a/api/tests/test_schedule_preview_solve.py
+++ b/api/tests/test_schedule_preview_solve.py
@@ -69,12 +69,12 @@ from app.tournament_errors import (
     TournamentNotFoundError,
     TournamentNotPreLiveError,
 )
-from tests._helpers import make_user
+from tests._helpers import make_user, venue_tables, with_table_aliases
 
-TABLE_CATALOGUE: list[dict[str, object]] = [
-    {"id": "t1", "label": "Table 1", "court": "A"},
-    {"id": "t2", "label": "Table 2", "court": "A"},
-]
+# Built per tournament, never as a module constant: a catalogue is
+# ``tournament_tables`` rows now (ADR 20260801). The pools name them by the positional
+# ``t1``/``t2`` aliases ``with_table_aliases`` resolves.
+TABLE_CATALOGUE = (("Table 1", "A"), ("Table 2", "A"))
 
 
 def _pool(
@@ -134,7 +134,7 @@ async def _make_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=TABLE_CATALOGUE,
+        tables=venue_tables(*TABLE_CATALOGUE),
         league_id=league.id,
         created_by_user_id=owner.id,
         status=status,
@@ -169,7 +169,9 @@ async def _add_event(
         slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         match_settings={"rated": True, "length_games": length_games},
         predicates=[],
-        pools=[_pool(["t1", "t2"])] if pools is None else pools,
+        pools=with_table_aliases(
+            tournament, [_pool(["t1", "t2"])] if pools is None else pools
+        ),
         timezone=timezone,
     )
     db.add(event)

--- a/api/tests/test_schedule_solve_models.py
+++ b/api/tests/test_schedule_solve_models.py
@@ -38,9 +38,10 @@ from app.models import (
     TournamentEventDrawSettings,
     TournamentFixture,
     TournamentStatus,
+    VenueTable,
 )
 from app.schemas.tournament import ScheduleSolveRead
-from tests._helpers import make_user
+from tests._helpers import make_user, venue_tables
 
 
 async def _make_tournament(db_session: AsyncSession) -> Tournament:
@@ -66,6 +67,9 @@ async def _make_tournament(db_session: AsyncSession) -> Tournament:
         },
         league_id=league.id,
         created_by_user_id=owner.id,
+        # One catalogue row, so a pinned fixture below has a real table to sit at:
+        # ``table_id`` is a foreign key since ADR 20260801.
+        tables=venue_tables(("Table 3", "A")),
     )
     db_session.add(tournament)
     await db_session.commit()
@@ -277,13 +281,24 @@ async def test_a_pinned_fixture_round_trips_its_pin_facts(
     superseding ADR-0790's naive frame), and the notified count comes back
     exact."""
     event = await _make_event(db_session)
+    # The catalogue's one table, by the id the server minted for it — ``table_id`` is a
+    # foreign key now (ADR 20260801), so "table-3" is no longer a table.
+    table_id = str(
+        (
+            await db_session.execute(
+                select(VenueTable.id).where(
+                    VenueTable.tournament_id == event.tournament_id
+                )
+            )
+        ).scalar_one()
+    )
     called_at = datetime(2026, 8, 1, 14, 30, tzinfo=UTC)
     fixture = TournamentFixture(
         event_id=event.id,
         pool_id="pool-a",
         round=1,
         position=1,
-        table_id="table-3",
+        table_id=table_id,
         scheduled_start=datetime(2026, 8, 1, 14, 40, tzinfo=UTC),
         pinned_at=called_at,
         call_notified_count=2,

--- a/api/tests/test_schedule_solve_queries.py
+++ b/api/tests/test_schedule_solve_queries.py
@@ -40,7 +40,6 @@ async def _make_tournament(db: AsyncSession, owner: User, name: str) -> uuid.UUI
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[],
         league_id=league.id,
         created_by_user_id=owner.id,
     )

--- a/api/tests/test_schedule_solve_route.py
+++ b/api/tests/test_schedule_solve_route.py
@@ -53,7 +53,14 @@ from app.models import (
 from app.schedule_solves import RUN_SCHEDULE_SOLVE_JOB
 from app.tournament_draws import cut_draw
 from app.tournaments import NO_DRAWN_EVENTS_CODE, TOURNAMENT_CREATE, TOURNAMENT_VIEW
-from tests._helpers import grant_permissions, make_client, make_user, start_session
+from tests._helpers import (
+    grant_permissions,
+    make_client,
+    make_user,
+    start_session,
+    table_ids_of,
+    venue_tables,
+)
 
 DATE = "2030-01-01"
 #: The event's venue timezone, anchoring its wall-clock windows to real instants
@@ -123,6 +130,7 @@ async def _make_tournament(
     league = await get_default_league(db)
     assert league is not None, "the autouse default_league fixture seeds this"
 
+    catalogue = venue_tables(*((table.upper(), "Main") for table in tables))
     tournament = Tournament(
         name="Scheduled Open",
         status=TournamentStatus.published,
@@ -136,9 +144,7 @@ async def _make_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": table, "label": table.upper(), "court": "Main"} for table in tables
-        ],
+        tables=catalogue,
         league_id=league.id,
         created_by_user_id=owner.id,
     )
@@ -164,7 +170,7 @@ async def _make_tournament(
                 "id": "pool-a",
                 "name": "Pool A",
                 "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
-                "table_ids": list(tables),
+                "table_ids": [str(row.id) for row in catalogue],
             }
         ],
     )
@@ -530,6 +536,7 @@ async def test_after_the_drained_job_the_solve_strip_and_pin_facts_reach_the_pag
     and ``call_notified_count`` 0, nobody told)."""
     client, owner = authed_client
     tournament_id, _ = await _make_tournament(db_session, owner)
+    catalogue = set(await table_ids_of(db_session, tournament_id))
 
     response = await client.post(_solves_url(tournament_id))
     assert response.status_code == 202, response.text
@@ -559,7 +566,7 @@ async def test_after_the_drained_job_the_solve_strip_and_pin_facts_reach_the_pag
     fixtures: list[dict[str, Any]] = event_read["fixtures"]
     assert len(fixtures) == 6
     for fixture in fixtures:
-        assert fixture["table_id"] in ("t1", "t2")
+        assert fixture["table_id"] in catalogue
         start = datetime.fromisoformat(fixture["scheduled_start"]["instant"])
         assert BASE <= start
         assert start + timedelta(minutes=MATCH_MINUTES) <= WINDOW_END

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -102,7 +102,12 @@ from app.schemas.schedule_solve import (
 )
 from app.schemas.tournament import ScheduleSolveRead
 from app.tournament_draws import cut_draw
-from tests._helpers import hijack_solve, make_user
+from tests._helpers import (
+    hijack_solve,
+    make_user,
+    table_ids_of,
+    venue_tables,
+)
 
 DATE = "2030-01-01"
 #: The event's venue timezone — the IANA zone anchoring its wall-clock windows
@@ -151,6 +156,7 @@ async def _make_tournament(
     league = await get_default_league(db)
     assert league is not None, "the autouse default_league fixture seeds this"
 
+    catalogue = venue_tables(*((table.upper(), "Main") for table in tables))
     tournament = Tournament(
         name="Scheduled Open",
         status=status,
@@ -164,9 +170,7 @@ async def _make_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": table, "label": table.upper(), "court": "Main"} for table in tables
-        ],
+        tables=catalogue,
         league_id=league.id,
         created_by_user_id=owner.id,
     )
@@ -188,7 +192,7 @@ async def _make_tournament(
                 "id": "pool-a",
                 "name": "Pool A",
                 "slot": {"date": slot_date, "start": window[0], "end": window[1]},
-                "table_ids": list(tables),
+                "table_ids": [str(row.id) for row in catalogue],
             }
         ],
     )
@@ -913,8 +917,9 @@ class TestSolveJob:
         fixtures = await _fixtures_of(db_session, event_id)
         assert len(fixtures) == 6  # round-robin over 4 entrants
         window_end = BASE + timedelta(hours=8)
+        catalogue = set(await table_ids_of(db_session, tournament_id))
         for fixture in fixtures:
-            assert fixture.table_id in {"t1", "t2"}
+            assert fixture.table_id in catalogue
             assert fixture.scheduled_start is not None
             assert BASE <= fixture.scheduled_start
             assert fixture.scheduled_start + timedelta(minutes=25) <= window_end
@@ -992,7 +997,8 @@ class TestSolveJob:
         assert ledger.fixtures_placed == 1
 
         (fixture,) = await _fixtures_of(db_session, event_id)
-        assert fixture.table_id == "t1"
+        (only_table,) = await table_ids_of(db_session, tournament_id)
+        assert fixture.table_id == only_table
         assert fixture.scheduled_start is not None
         # Placed at/after ``now`` and finishing inside the venue window — the
         # instant axis the whole epic hinges on. Aware/aware comparisons across
@@ -1066,7 +1072,8 @@ class TestSolveJob:
         # this pin is uncontended and the solver leaves it exactly here.
         pinned_start = BASE + timedelta(minutes=302)
         pinned_at = BASE - timedelta(minutes=30)
-        pinned.table_id = "t1"
+        table_1, table_2 = await table_ids_of(db_session, tournament_id)
+        pinned.table_id = table_1
         pinned.scheduled_start = pinned_start
         pinned.pinned_at = pinned_at
         await db_session.commit()
@@ -1082,13 +1089,13 @@ class TestSolveJob:
         db_session.expire_all()
         refreshed = {f.id: f for f in await _fixtures_of(db_session, event_id)}
         survivor = refreshed[pinned_id]
-        assert survivor.table_id == "t1"
+        assert survivor.table_id == table_1
         assert survivor.scheduled_start == pinned_start
         assert survivor.pinned_at == pinned_at
         for fixture in refreshed.values():
             if fixture.id == pinned_id:
                 continue
-            assert fixture.table_id in {"t1", "t2"}
+            assert fixture.table_id in {table_1, table_2}
             assert fixture.scheduled_start is not None
             assert (fixture.scheduled_start - BASE).total_seconds() / 60 % 5 == 0
 
@@ -1110,7 +1117,8 @@ class TestSolveJob:
         pre_placed = fixtures[0]
         pre_placed_id = pre_placed.id
         pre_start = BASE + timedelta(minutes=5)
-        pre_placed.table_id = "t2"
+        _table_1, table_2 = await table_ids_of(db_session, tournament_id)
+        pre_placed.table_id = table_2
         pre_placed.scheduled_start = pre_start
         await db_session.commit()
 
@@ -1124,7 +1132,7 @@ class TestSolveJob:
 
         db_session.expire_all()
         refreshed = {f.id: f for f in await _fixtures_of(db_session, event_id)}
-        assert refreshed[pre_placed_id].table_id == "t2"
+        assert refreshed[pre_placed_id].table_id == table_2
         assert refreshed[pre_placed_id].scheduled_start == pre_start
         for fixture in refreshed.values():
             if fixture.id == pre_placed_id:
@@ -1502,9 +1510,10 @@ class TestSolveJob:
         # Stage both as physically underway on the SAME table at the SAME start
         # (a soft double-book): pinned, live, promised start already arrived.
         colliding = (first_fixture, partner)
+        table_1, _table_2 = await table_ids_of(db_session, tournament_id)
         for fixture in colliding:
             await _link_match(db_session, fixture, status=MatchStatus.in_progress)
-            fixture.table_id = "t1"
+            fixture.table_id = table_1
             fixture.scheduled_start = BASE
             fixture.pinned_at = BASE - timedelta(minutes=5)
         await db_session.commit()
@@ -1732,10 +1741,11 @@ class TestCalledMatchSlides:
         entry_a_id, entry_b_id = fixture.entry_a_id, fixture.entry_b_id
         assert entry_a_id is not None and entry_b_id is not None
         original_pin_time = BASE - timedelta(minutes=15)
+        (table_1,) = await table_ids_of(db_session, tournament_id)
         await _pin_fixture(
             db_session,
             fixture,
-            table_id="t1",
+            table_id=table_1,
             start=BASE,
             pinned_at=original_pin_time,
             notified=1,
@@ -1758,7 +1768,7 @@ class TestCalledMatchSlides:
 
         db_session.expire_all()
         slid = (await _fixtures_of(db_session, event_id))[0]
-        assert slid.table_id == "t1"  # the table is invariant
+        assert slid.table_id == table_1  # the table is invariant
         assert slid.scheduled_start == BASE + timedelta(minutes=20)  # slid later
         assert slid.pinned_at == apply_now  # the promise is renewed, not demoted
         assert slid.call_notified_count == 2  # the call, then the moved correction
@@ -1795,10 +1805,11 @@ class TestCalledMatchSlides:
         fixture_id = fixture.id
         original_pin_time = BASE - timedelta(minutes=15)
         pinned_start = BASE + timedelta(minutes=7)  # off the 5-minute grid
+        (table_1,) = await table_ids_of(db_session, tournament_id)
         await _pin_fixture(
             db_session,
             fixture,
-            table_id="t1",
+            table_id=table_1,
             start=pinned_start,
             pinned_at=original_pin_time,
             notified=1,
@@ -1818,7 +1829,7 @@ class TestCalledMatchSlides:
         db_session.expire_all()
         survivor = (await _fixtures_of(db_session, event_id))[0]
         assert survivor.id == fixture_id
-        assert survivor.table_id == "t1"
+        assert survivor.table_id == table_1
         assert survivor.scheduled_start == pinned_start  # byte-identical
         assert survivor.pinned_at == original_pin_time  # not refreshed
         assert survivor.call_notified_count == 1  # never re-told

--- a/api/tests/test_schedule_triggers.py
+++ b/api/tests/test_schedule_triggers.py
@@ -468,13 +468,24 @@ async def test_a_completion_during_a_running_solve_sets_the_rerun_flag(
 # cut draw to place.
 
 
-def _catalogue(*labels: str) -> list[dict[str, str]]:
-    """A table-catalogue payload in the shape ``_make_tournament`` stores.
+def _catalogue(*labels: str, keeping: Sequence[str] = ()) -> list[dict[str, str]]:
+    """A table-catalogue PATCH payload: one entry per label, the first
+    ``len(keeping)`` of them citing the table ids in ``keeping``.
 
-    Labels only: a table's id is minted by the server (ADR 20260801), so the write
-    shape has no ``id`` and the catalogue is applied **by position** — the i-th entry
-    here is the i-th table the tournament already holds."""
-    return [{"label": label, "court": "Main"} for label in labels]
+    The catalogue is an id-keyed diff (ADR 20260801), so which entries carry an id is
+    the whole content of the payload: a cited table is KEPT (re-worded at most, which is
+    not a solver-input change), and an entry with no id ADDS a table (which is). Passing
+    no ``keeping`` therefore says "remove every table this tournament has and add these
+    instead" — occasionally what a test means, never what "re-send the catalogue you
+    already had" means."""
+    return [
+        (
+            {"label": label, "court": "Main", "id": keeping[index]}
+            if index < len(keeping)
+            else {"label": label, "court": "Main"}
+        )
+        for index, label in enumerate(labels)
+    ]
 
 
 async def _catalogue_ids(db: AsyncSession, tournament_id: uuid.UUID) -> list[str]:
@@ -537,10 +548,11 @@ async def test_a_table_catalogue_edit_on_a_drawn_tournament_requests_a_settings_
     tournament_id, event = await _make_tournament(db_session, owner)
     entrants = [await make_user(db_session, f"cat-{i}") for i in range(3)]
     await _enter_and_cut(db_session, event, entrants)
+    kept = await _catalogue_ids(db_session, tournament_id)
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}",
-        json={"table_catalogue": _catalogue("T1", "T2", "T3")},
+        json={"table_catalogue": _catalogue("T1", "T2", "T3", keeping=kept)},
     )
 
     assert response.status_code == 200, response.text
@@ -558,13 +570,14 @@ async def test_a_rename_only_tournament_patch_requests_no_settings_solve(
     tournament_id, event = await _make_tournament(db_session, owner)
     entrants = [await make_user(db_session, f"rn-{i}") for i in range(3)]
     await _enter_and_cut(db_session, event, entrants)
+    kept = await _catalogue_ids(db_session, tournament_id)
 
     renamed = await client.patch(
         f"/v1/tournaments/{tournament_id}", json={"name": "Renamed Open"}
     )
     resent = await client.patch(
         f"/v1/tournaments/{tournament_id}",
-        json={"table_catalogue": _catalogue("T1", "T2")},
+        json={"table_catalogue": _catalogue("T1", "T2", keeping=kept)},
     )
 
     assert renamed.status_code == 200, renamed.text
@@ -580,10 +593,11 @@ async def test_a_table_catalogue_edit_with_no_drawn_event_requests_no_settings_s
     the ledger free of no-op rows while the venue is still being configured."""
     client, owner = authed_client
     tournament_id, _event = await _make_tournament(db_session, owner)
+    kept = await _catalogue_ids(db_session, tournament_id)
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}",
-        json={"table_catalogue": _catalogue("T1", "T2", "T3")},
+        json={"table_catalogue": _catalogue("T1", "T2", "T3", keeping=kept)},
     )
 
     assert response.status_code == 200, response.text

--- a/api/tests/test_schedule_triggers.py
+++ b/api/tests/test_schedule_triggers.py
@@ -196,7 +196,9 @@ async def _call_fixture(
         db,
         tournament,
         fixture,
-        table_id="t1",
+        # The catalogue's first row, by its server-minted id: ``table_id`` is a
+        # foreign key now (ADR 20260801).
+        table_id=str(tournament.tables[0].id),
         scheduled_start=datetime(2030, 1, 1, 10, 0),
         event_timezone="America/Chicago",
     )
@@ -734,8 +736,9 @@ async def test_a_recut_clears_prior_pins_and_requests_a_settings_solve(
     await _enter_and_cut(db_session, event, entrants)
     old_fixtures = await _fixtures_of(db_session, event.id)
     assert len(old_fixtures) == 3
+    (the_table, *_) = await _catalogue_ids(db_session, tournament_id)
     for fixture in old_fixtures:
-        fixture.table_id = "t1"
+        fixture.table_id = the_table
         fixture.scheduled_start = datetime(2030, 1, 1, 9, 30)
         fixture.pinned_at = datetime(2030, 1, 1, 9, 20)
     await db_session.commit()

--- a/api/tests/test_schedule_triggers.py
+++ b/api/tests/test_schedule_triggers.py
@@ -18,7 +18,7 @@ instead of stacking a new one.
 """
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from datetime import datetime
 from decimal import Decimal
 from typing import Any
@@ -46,6 +46,7 @@ from app.models import (
     TournamentFixture,
     TournamentStatus,
     User,
+    VenueTable,
 )
 from app.tournament_draws import cut_draw
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
@@ -54,6 +55,7 @@ from tests._helpers import (
     make_user,
     opponent_session,
     start_session,
+    venue_tables,
 )
 
 DATE = "2030-01-01"
@@ -85,6 +87,7 @@ async def _make_tournament(
     matches."""
     league = await get_default_league(db)
     assert league is not None, "the autouse default_league fixture seeds this"
+    catalogue = venue_tables(*((table.upper(), "Main") for table in tables))
     tournament = Tournament(
         name="Trigger Open",
         status=TournamentStatus.published,
@@ -98,9 +101,7 @@ async def _make_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": table, "label": table.upper(), "court": "Main"} for table in tables
-        ],
+        tables=catalogue,
         league_id=league.id,
         created_by_user_id=owner.id,
     )
@@ -121,7 +122,7 @@ async def _make_tournament(
                 "id": "pool-a",
                 "name": "Pool A",
                 "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
-                "table_ids": list(tables),
+                "table_ids": [str(row.id) for row in catalogue],
             }
         ],
     )
@@ -465,17 +466,33 @@ async def test_a_completion_during_a_running_solve_sets_the_rerun_flag(
 # cut draw to place.
 
 
-def _catalogue(*table_ids: str) -> list[dict[str, str]]:
-    """A table-catalogue payload in the shape ``_make_tournament`` stores."""
+def _catalogue(*labels: str) -> list[dict[str, str]]:
+    """A table-catalogue payload in the shape ``_make_tournament`` stores.
+
+    Labels only: a table's id is minted by the server (ADR 20260801), so the write
+    shape has no ``id`` and the catalogue is applied **by position** — the i-th entry
+    here is the i-th table the tournament already holds."""
+    return [{"label": label, "court": "Main"} for label in labels]
+
+
+async def _catalogue_ids(db: AsyncSession, tournament_id: uuid.UUID) -> list[str]:
+    """The tournament's venue-table ids, in catalogue order — what a pool's
+    ``table_ids`` must name now that they are server-minted UUIDs."""
     return [
-        {"id": table_id, "label": table_id.upper(), "court": "Main"}
-        for table_id in table_ids
+        str(table_id)
+        for table_id in (
+            await db.execute(
+                select(VenueTable.id)
+                .where(VenueTable.tournament_id == tournament_id)
+                .order_by(VenueTable.position)
+            )
+        )
+        .scalars()
+        .all()
     ]
 
 
-def _pools_payload(
-    *, end: str, table_ids: tuple[str, ...] = ("t1", "t2")
-) -> list[dict[str, Any]]:
+def _pools_payload(*, end: str, table_ids: Sequence[str]) -> list[dict[str, Any]]:
     """The event's one pool, re-sent with the same id (the pool-set freeze
     demands it) and whatever window/tables the test is moving."""
     return [
@@ -521,7 +538,7 @@ async def test_a_table_catalogue_edit_on_a_drawn_tournament_requests_a_settings_
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}",
-        json={"table_catalogue": _catalogue("t1", "t2", "t3")},
+        json={"table_catalogue": _catalogue("T1", "T2", "T3")},
     )
 
     assert response.status_code == 200, response.text
@@ -545,7 +562,7 @@ async def test_a_rename_only_tournament_patch_requests_no_settings_solve(
     )
     resent = await client.patch(
         f"/v1/tournaments/{tournament_id}",
-        json={"table_catalogue": _catalogue("t1", "t2")},
+        json={"table_catalogue": _catalogue("T1", "T2")},
     )
 
     assert renamed.status_code == 200, renamed.text
@@ -564,7 +581,7 @@ async def test_a_table_catalogue_edit_with_no_drawn_event_requests_no_settings_s
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}",
-        json={"table_catalogue": _catalogue("t1", "t2", "t3")},
+        json={"table_catalogue": _catalogue("T1", "T2", "T3")},
     )
 
     assert response.status_code == 200, response.text
@@ -581,10 +598,11 @@ async def test_a_pool_window_edit_requests_a_settings_solve(
     tournament_id, event = await _make_tournament(db_session, owner)
     entrants = [await make_user(db_session, f"win-{i}") for i in range(3)]
     await _enter_and_cut(db_session, event, entrants)
+    table_ids = await _catalogue_ids(db_session, tournament_id)
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event.id}",
-        json={"pools": _pools_payload(end="18:00")},
+        json={"pools": _pools_payload(end="18:00", table_ids=table_ids)},
     )
 
     assert response.status_code == 200, response.text
@@ -601,6 +619,7 @@ async def test_a_name_only_event_patch_requests_no_settings_solve(
     tournament_id, event = await _make_tournament(db_session, owner)
     entrants = [await make_user(db_session, f"nm-{i}") for i in range(3)]
     await _enter_and_cut(db_session, event, entrants)
+    table_ids = await _catalogue_ids(db_session, tournament_id)
 
     renamed = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event.id}",
@@ -608,7 +627,7 @@ async def test_a_name_only_event_patch_requests_no_settings_solve(
     )
     resent = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event.id}",
-        json={"pools": _pools_payload(end="17:00")},
+        json={"pools": _pools_payload(end="17:00", table_ids=table_ids)},
     )
 
     assert renamed.status_code == 200, renamed.text

--- a/api/tests/test_tournament_draw_service.py
+++ b/api/tests/test_tournament_draw_service.py
@@ -38,7 +38,10 @@ from app.tournament_errors import (
     NotTournamentOwnerError,
     TournamentNotFoundError,
 )
-from tests._helpers import make_user
+from tests._helpers import (
+    make_user,
+    venue_tables,
+)
 
 # Two pools, so the snake has somewhere to snake to and a fixture's ``pool_id`` is a
 # ref that resolves against the right one — the same shape ``test_tournaments.py``'s
@@ -76,10 +79,7 @@ async def _make_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": "t1", "label": "Table 1", "court": "A"},
-            {"id": "t2", "label": "Table 2", "court": "A"},
-        ],
+        tables=venue_tables(("Table 1", "A"), ("Table 2", "A")),
         league_id=league.id,
         created_by_user_id=owner.id,
         status=TournamentStatus.draft,

--- a/api/tests/test_tournament_draws.py
+++ b/api/tests/test_tournament_draws.py
@@ -42,7 +42,10 @@ from app.tournament_queries import (
     fixtures_by_event,
     game_counts_by_match,
 )
-from tests._helpers import make_user
+from tests._helpers import (
+    make_user,
+    venue_tables,
+)
 
 POOL_A: dict[str, object] = {
     "id": "p-a",
@@ -68,7 +71,7 @@ async def _make_event(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[{"id": "t1", "label": "Table 1", "court": "A"}],
+        tables=venue_tables(("Table 1", "A")),
         league_id=league.id,
         created_by_user_id=owner.id,
         status=TournamentStatus.live,

--- a/api/tests/test_tournament_edit.py
+++ b/api/tests/test_tournament_edit.py
@@ -40,7 +40,7 @@ from app.models import (
 from app.models.tournament import DrawType, EventFormat
 from app.schemas.tournament import (
     AddressInput,
-    TournamentTableWrite,
+    TournamentTableUpsert,
     TournamentUpdate,
 )
 from app.tournament_edit import edit_tournament
@@ -698,6 +698,7 @@ async def test_adding_a_table_on_a_drawn_tournament_requests_a_solve(
     tournament = await _make_tournament(db_session, owner=owner, league=default_league)
     tournament_id = tournament.id
     await _draw_an_event(db_session, tournament)
+    kept_first, kept_second = await _catalogue_ids(db_session, tournament_id)
 
     assert await _queued_solves(db_session, tournament_id) == []
 
@@ -711,9 +712,10 @@ async def test_adding_a_table_on_a_drawn_tournament_requests_a_solve(
         actor=owner,
         updates=TournamentUpdate(
             table_catalogue=[
-                TournamentTableWrite(label="Table 1", court="A"),
-                TournamentTableWrite(label="Table 2", court="A"),
-                TournamentTableWrite(label="Table 3", court="B"),
+                # The two it already has, cited by id, plus one it does not.
+                TournamentTableUpsert(id=kept_first, label="Table 1", court="A"),
+                TournamentTableUpsert(id=kept_second, label="Table 2", court="A"),
+                TournamentTableUpsert(label="Table 3", court="B"),
             ]
         ),
         geocoder=_GEOCODER,
@@ -733,10 +735,9 @@ async def test_re_wording_a_table_on_a_drawn_tournament_requests_no_solve(
     ``TableId``s). Re-wording a table leaves that set untouched — the same rows, the
     same ids — so a drawn tournament is not re-solved for a piece of signage.
 
-    This is what positional application buys. Rebuild the catalogue on every PATCH and
-    a re-word would mint two fresh ids, which genuinely IS an input change — so the
-    board would be re-solved, and every placement pointing at the old ids would have
-    dangled first."""
+    This is what citing the id buys. Rebuild the catalogue on every PATCH and a re-word
+    would mint two fresh ids, which genuinely IS an input change — so the board would be
+    re-solved, and every placement pointing at the old ids would have dangled first."""
     owner = await make_user(db_session, "owner-reword")
     tournament = await _make_tournament(db_session, owner=owner, league=default_league)
     tournament_id = tournament.id
@@ -750,8 +751,12 @@ async def test_re_wording_a_table_on_a_drawn_tournament_requests_no_solve(
         actor=owner,
         updates=TournamentUpdate(
             table_catalogue=[
-                TournamentTableWrite(label="Centre Table", court="A"),
-                TournamentTableWrite(label="Table 2", court="A"),
+                TournamentTableUpsert(
+                    id=table_ids_before[0], label="Centre Table", court="A"
+                ),
+                TournamentTableUpsert(
+                    id=table_ids_before[1], label="Table 2", court="A"
+                ),
             ]
         ),
         geocoder=_GEOCODER,
@@ -782,7 +787,7 @@ async def test_table_catalogue_change_without_a_draw_requests_no_solve(
         actor=owner,
         updates=TournamentUpdate(
             table_catalogue=[
-                TournamentTableWrite(label="Table 9", court="C"),
+                TournamentTableUpsert(label="Table 9", court="C"),
             ]
         ),
         geocoder=_GEOCODER,
@@ -812,7 +817,9 @@ async def test_a_shorter_catalogue_removes_the_tables_off_the_end(
         tournament_id=tournament_id,
         actor=owner,
         updates=TournamentUpdate(
-            table_catalogue=[TournamentTableWrite(label="Table 1", court="A")]
+            table_catalogue=[
+                TournamentTableUpsert(id=first_id, label="Table 1", court="A")
+            ]
         ),
         geocoder=_GEOCODER,
     )

--- a/api/tests/test_tournament_edit.py
+++ b/api/tests/test_tournament_edit.py
@@ -35,9 +35,14 @@ from app.models import (
     TournamentFixture,
     TournamentStatus,
     User,
+    VenueTable,
 )
 from app.models.tournament import DrawType, EventFormat
-from app.schemas.tournament import AddressInput, TournamentTable, TournamentUpdate
+from app.schemas.tournament import (
+    AddressInput,
+    TournamentTableWrite,
+    TournamentUpdate,
+)
 from app.tournament_edit import edit_tournament
 from app.tournament_errors import (
     LeagueNotEditableError,
@@ -50,6 +55,7 @@ from tests._helpers import (
     assert_tournament_address_is_sql_null,
     blank_addresses,
     make_user,
+    venue_tables,
 )
 
 # The deterministic geocoder the edit verb re-geocodes a changed address with (the
@@ -111,7 +117,7 @@ async def _make_tournament(
     owner: User,
     league: League,
     status: TournamentStatus = TournamentStatus.draft,
-    table_catalogue: list[dict[str, str]] | None = None,
+    catalogue: list[VenueTable] | None = None,
     with_venue: bool = True,
 ) -> Tournament:
     tournament = Tournament(
@@ -120,11 +126,11 @@ async def _make_tournament(
         # ``with_venue=False`` seeds the state #1206 made reachable: a tournament whose
         # address column is SQL NULL because it has no venue at all.
         address=_stored_address() if with_venue else None,
-        table_catalogue=table_catalogue
-        or [
-            {"id": "t1", "label": "Table 1", "court": "A"},
-            {"id": "t2", "label": "Table 2", "court": "A"},
-        ],
+        tables=(
+            catalogue
+            if catalogue is not None
+            else venue_tables(("Table 1", "A"), ("Table 2", "A"))
+        ),
         league_id=league.id,
         created_by_user_id=owner.id,
         status=status,
@@ -163,6 +169,34 @@ async def _persisted_league_id(db: AsyncSession, tournament_id: uuid.UUID) -> uu
         .scalar_one()
         .league_id
     )
+
+
+async def _catalogue_rows(
+    db: AsyncSession, tournament_id: uuid.UUID
+) -> list[VenueTable]:
+    """The tournament's venue tables, straight off ``tournament_tables`` in the
+    director's order — read from the rows and never off an ORM instance the verb under
+    test still holds, so an assertion is about what was persisted."""
+    db.expire_all()
+    return list(
+        (
+            await db.execute(
+                select(VenueTable)
+                .where(VenueTable.tournament_id == tournament_id)
+                .order_by(VenueTable.position)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def _catalogue_ids(db: AsyncSession, tournament_id: uuid.UUID) -> list[uuid.UUID]:
+    return [row.id for row in await _catalogue_rows(db, tournament_id)]
+
+
+async def _catalogue_labels(db: AsyncSession, tournament_id: uuid.UUID) -> list[str]:
+    return [row.label for row in await _catalogue_rows(db, tournament_id)]
 
 
 async def _queued_solves(
@@ -653,13 +687,13 @@ async def test_league_that_names_no_league_raises_not_found(
 # ----- table-catalogue change on a drawn tournament requests a solve --------
 
 
-async def test_table_catalogue_change_on_a_drawn_tournament_requests_a_solve(
+async def test_adding_a_table_on_a_drawn_tournament_requests_a_solve(
     db_session: AsyncSession,
     default_league: League,
 ) -> None:
-    """Re-identifying a table changes the solver's inputs, and the tournament has a
-    cut draw, so the edit queues a ``settings_changed`` solve in the same
-    transaction."""
+    """A table the venue did not have is a new place to put a match — the solver's
+    inputs changed — and the tournament has a cut draw, so the edit queues a
+    ``settings_changed`` solve in the same transaction."""
     owner = await make_user(db_session, "owner-solve")
     tournament = await _make_tournament(db_session, owner=owner, league=default_league)
     tournament_id = tournament.id
@@ -677,8 +711,9 @@ async def test_table_catalogue_change_on_a_drawn_tournament_requests_a_solve(
         actor=owner,
         updates=TournamentUpdate(
             table_catalogue=[
-                TournamentTable(id="t1", label="Table 1", court="A"),
-                TournamentTable(id="t3", label="Table 3", court="B"),
+                TournamentTableWrite(label="Table 1", court="A"),
+                TournamentTableWrite(label="Table 2", court="A"),
+                TournamentTableWrite(label="Table 3", court="B"),
             ]
         ),
         geocoder=_GEOCODER,
@@ -687,6 +722,48 @@ async def test_table_catalogue_change_on_a_drawn_tournament_requests_a_solve(
     (solve,) = await _queued_solves(db_session, tournament_id)
     assert solve.trigger is ScheduleSolveTrigger.settings_changed
     assert solve.status is ScheduleSolveStatus.queued
+
+
+async def test_re_wording_a_table_on_a_drawn_tournament_requests_no_solve(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """The other side of the same rule: a label and a court are DISPLAY, and the
+    catalogue the solver reads is its ids (``_load_solver_inputs`` reduces it to
+    ``TableId``s). Re-wording a table leaves that set untouched — the same rows, the
+    same ids — so a drawn tournament is not re-solved for a piece of signage.
+
+    This is what positional application buys. Rebuild the catalogue on every PATCH and
+    a re-word would mint two fresh ids, which genuinely IS an input change — so the
+    board would be re-solved, and every placement pointing at the old ids would have
+    dangled first."""
+    owner = await make_user(db_session, "owner-reword")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+    await _draw_an_event(db_session, tournament)
+    table_ids_before = await _catalogue_ids(db_session, tournament_id)
+
+    await db_session.refresh(owner)
+    await edit_tournament(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        updates=TournamentUpdate(
+            table_catalogue=[
+                TournamentTableWrite(label="Centre Table", court="A"),
+                TournamentTableWrite(label="Table 2", court="A"),
+            ]
+        ),
+        geocoder=_GEOCODER,
+    )
+
+    assert await _queued_solves(db_session, tournament_id) == []
+    # And the re-word landed on the very rows that were already there.
+    assert await _catalogue_ids(db_session, tournament_id) == table_ids_before
+    assert await _catalogue_labels(db_session, tournament_id) == [
+        "Centre Table",
+        "Table 2",
+    ]
 
 
 async def test_table_catalogue_change_without_a_draw_requests_no_solve(
@@ -705,10 +782,39 @@ async def test_table_catalogue_change_without_a_draw_requests_no_solve(
         actor=owner,
         updates=TournamentUpdate(
             table_catalogue=[
-                TournamentTable(id="t9", label="Table 9", court="C"),
+                TournamentTableWrite(label="Table 9", court="C"),
             ]
         ),
         geocoder=_GEOCODER,
     )
 
     assert await _queued_solves(db_session, tournament_id) == []
+
+
+async def test_a_shorter_catalogue_removes_the_tables_off_the_end(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A table the director stopped sending is gone from the ``tournament_tables``
+    rows, not merely absent from a JSON blob — ``delete-orphan`` on
+    ``Tournament.tables`` is what turns dropping it out of the collection into a
+    DELETE. The table that stayed keeps the id it already had."""
+    owner = await make_user(db_session, "owner-shrink")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+    first_id, _second_id = await _catalogue_ids(db_session, tournament_id)
+
+    # The catalogue read expired ``owner``; a real request holds a freshly-loaded
+    # ``current_user``, so refresh it back before handing it to the verb.
+    await db_session.refresh(owner)
+    await edit_tournament(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        updates=TournamentUpdate(
+            table_catalogue=[TournamentTableWrite(label="Table 1", court="A")]
+        ),
+        geocoder=_GEOCODER,
+    )
+
+    assert await _catalogue_ids(db_session, tournament_id) == [first_id]

--- a/api/tests/test_tournament_event_draw_settings.py
+++ b/api/tests/test_tournament_event_draw_settings.py
@@ -70,7 +70,7 @@ def _tournament_payload() -> dict[str, Any]:
             "postal": "94703",
             "country": "USA",
         },
-        "table_catalogue": [{"id": "t1", "label": "Table 1", "court": "A"}],
+        "table_catalogue": [{"label": "Table 1", "court": "A"}],
     }
 
 

--- a/api/tests/test_tournament_events.py
+++ b/api/tests/test_tournament_events.py
@@ -43,7 +43,10 @@ from app.tournament_errors import (
     TournamentNotFoundError,
 )
 from app.tournament_events import create_event, delete_event, update_event
-from tests._helpers import make_user
+from tests._helpers import (
+    make_user,
+    venue_tables,
+)
 
 
 def _address() -> Address:
@@ -102,10 +105,7 @@ async def _make_tournament(
     tournament = Tournament(
         name="Eventful Cup",
         address=_address().model_dump(),
-        table_catalogue=[
-            {"id": "t1", "label": "Table 1", "court": "A"},
-            {"id": "t2", "label": "Table 2", "court": "A"},
-        ],
+        tables=venue_tables(("Table 1", "A"), ("Table 2", "A")),
         league_id=league.id,
         created_by_user_id=owner.id,
         status=TournamentStatus.draft,

--- a/api/tests/test_tournament_lifecycle.py
+++ b/api/tests/test_tournament_lifecycle.py
@@ -497,6 +497,73 @@ async def test_the_venue_tables_fk_cascades_in_the_database(
     assert await _catalogue_ids(db_session, tournament_id) == []
 
 
+async def test_delete_of_a_tournament_whose_fixture_is_placed_still_removes_it(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A tournament with a fixture PLACED at one of its own tables still deletes — the
+    tables, the fixtures and the tournament all go.
+
+    Without the unplace the delete verb does first, this is a **500**: a fixture's
+    ``table_id`` is ``ON DELETE RESTRICT`` (ADR 20260801) and the ORM deletes the
+    catalogue rows in their own statement, ahead of the ``tournaments`` row whose
+    cascade takes the fixtures — so the immediate, undeferrable RESTRICT check fires
+    while the placements are still pointing at the tables. The refusal that ADR asks
+    for is about removing a table out from under a fixture that SURVIVES; here nothing
+    survives, and the director asked for exactly that.
+    """
+    owner = await make_user(db_session, "lifecycle-delete-placed")
+    tournament = Tournament(
+        name="Placed Cup",
+        address=_stored_address(),
+        league_id=default_league.id,
+        created_by_user_id=owner.id,
+        status=TournamentStatus.draft,
+        tables=venue_tables(("Table 1", "A")),
+    )
+    db_session.add(tournament)
+    await db_session.commit()
+    await db_session.refresh(tournament)
+    tournament_id = tournament.id
+    event = TournamentEvent(
+        tournament_id=tournament_id,
+        name="Open Singles",
+        format=EventFormat.singles,
+        draw_settings=TournamentEventDrawSettings.for_draw_type(DrawType.round_robin),
+        max_players=None,
+        entry_fee=Decimal("0.00"),
+        timezone="America/Chicago",
+        slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
+        match_settings={"rated": False, "length_games": 3},
+        pools=[],
+    )
+    db_session.add(event)
+    await db_session.commit()
+    db_session.add(
+        TournamentFixture(
+            event_id=event.id,
+            round=1,
+            position=1,
+            table_id=str(tournament.tables[0].id),
+        )
+    )
+    await db_session.commit()
+    await db_session.refresh(owner)
+
+    await delete_tournament(db_session, tournament_id=tournament_id, actor=owner)
+
+    db_session.expire_all()
+    assert await _catalogue_ids(db_session, tournament_id) == []
+    assert (
+        await db_session.execute(select(func.count()).select_from(TournamentFixture))
+    ).scalar_one() == 0
+    assert (
+        await db_session.execute(
+            select(Tournament).where(Tournament.id == tournament_id)
+        )
+    ).scalar_one_or_none() is None
+
+
 async def _catalogue_ids(db: AsyncSession, tournament_id: uuid.UUID) -> list[uuid.UUID]:
     return list(
         (

--- a/api/tests/test_tournament_lifecycle.py
+++ b/api/tests/test_tournament_lifecycle.py
@@ -14,7 +14,7 @@ from decimal import Decimal
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.geocoding import FakeGeocoder
@@ -35,8 +35,13 @@ from app.models import (
     TournamentFixture,
     TournamentStatus,
     User,
+    VenueTable,
 )
-from app.schemas.tournament import AddressInput, TournamentCreate, TournamentTable
+from app.schemas.tournament import (
+    AddressInput,
+    TournamentCreate,
+    TournamentTableWrite,
+)
 from app.tournament_draws import cut_draw
 from app.tournament_errors import (
     IllegalTournamentTransitionError,
@@ -57,6 +62,7 @@ from tests._helpers import (
     assert_tournament_address_is_sql_null,
     blank_addresses,
     make_user,
+    venue_tables,
 )
 
 # The deterministic geocoder the create verb resolves the venue address with (the
@@ -108,7 +114,7 @@ def _payload(*, league_id: uuid.UUID | None = None) -> TournamentCreate:
         name="Bay Area Open 2026",
         description="Two-day open.",
         address=_address(),
-        table_catalogue=[TournamentTable(id="t1", label="Table 1", court="A")],
+        table_catalogue=[TournamentTableWrite(label="Table 1", court="A")],
         league_id=league_id,
     )
 
@@ -145,7 +151,21 @@ async def test_create_persists_a_draft_owned_by_the_actor(
         )
     ).scalar_one()
     assert row.created_by_user_id == actor_id
-    assert row.table_catalogue == [{"id": "t1", "label": "Table 1", "court": "A"}]
+    # The catalogue is ROWS now (ADR 20260801), positioned in the order it was sent,
+    # and the id on each is the SERVER's — a v4 UUID the payload could not have named.
+    (table,) = (
+        (
+            await db_session.execute(
+                select(VenueTable)
+                .where(VenueTable.tournament_id == tournament_id)
+                .order_by(VenueTable.position)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert (table.label, table.court, table.position) == ("Table 1", "A", 0)
+    assert table.id.version == 4
 
 
 async def test_create_naming_a_league_runs_on_that_league(
@@ -375,7 +395,6 @@ async def _make_tournament(
     tournament = Tournament(
         name="Deletable Cup",
         address=_stored_address(),
-        table_catalogue=[],
         league_id=league.id,
         created_by_user_id=owner.id,
         status=TournamentStatus.draft,
@@ -402,6 +421,94 @@ async def test_delete_removes_an_owned_tournament(
             select(Tournament).where(Tournament.id == tournament_id)
         )
     ).scalar_one_or_none() is None
+
+
+async def test_delete_takes_the_tournaments_venue_tables_with_it(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """The catalogue is a child table now (ADR 20260801), so deleting a tournament has
+    to take its ``tournament_tables`` rows with it — by ``ON DELETE CASCADE``, the
+    shape ``tournament_events`` already uses, not by the ORM loading and deleting them
+    one at a time.
+
+    Asserted against the rows rather than through the read model, because the read
+    model would answer "no catalogue" for a tournament whose rows were orphaned just as
+    happily as for one whose rows were removed."""
+    owner = await make_user(db_session, "lifecycle-delete-tables")
+    tournament = Tournament(
+        name="Deletable Cup",
+        address=_stored_address(),
+        league_id=default_league.id,
+        created_by_user_id=owner.id,
+        status=TournamentStatus.draft,
+        tables=venue_tables(("Table 1", "A"), ("Table 2", "B")),
+    )
+    db_session.add(tournament)
+    await db_session.commit()
+    tournament_id = tournament.id
+    assert len(await _catalogue_ids(db_session, tournament_id)) == 2
+    await db_session.refresh(owner)
+
+    await delete_tournament(db_session, tournament_id=tournament_id, actor=owner)
+
+    db_session.expire_all()
+    assert await _catalogue_ids(db_session, tournament_id) == []
+    # Asserted over the WHOLE table, not just this tournament's rows, so a stray row
+    # left behind anywhere would show.
+    assert (
+        await db_session.execute(select(func.count()).select_from(VenueTable))
+    ).scalar_one() == 0
+
+
+async def test_the_venue_tables_fk_cascades_in_the_database(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """The FK itself, with the ORM taken out of the picture.
+
+    The verb's delete goes through ``Tournament.tables``, which ``lazy="selectin"``
+    has already loaded, so SQLAlchemy issues the child ``DELETE`` itself — meaning the
+    test above would stay green against ``ON DELETE RESTRICT`` (measured: it does).
+    The cascade is the backstop for every path that does NOT load the collection first
+    — a raw ``DELETE``, a psql session, a future bulk reap — and it is only tested by
+    being one of those paths, so this one deletes the row in SQL.
+    """
+    owner = await make_user(db_session, "lifecycle-cascade-tables")
+    tournament = Tournament(
+        name="Cascade Cup",
+        address=_stored_address(),
+        league_id=default_league.id,
+        created_by_user_id=owner.id,
+        status=TournamentStatus.draft,
+        tables=venue_tables(("Table 1", "A")),
+    )
+    db_session.add(tournament)
+    await db_session.commit()
+    tournament_id = tournament.id
+    assert len(await _catalogue_ids(db_session, tournament_id)) == 1
+
+    await db_session.execute(
+        text("DELETE FROM tournaments WHERE id = :id"), {"id": tournament_id}
+    )
+    await db_session.commit()
+
+    db_session.expire_all()
+    assert await _catalogue_ids(db_session, tournament_id) == []
+
+
+async def _catalogue_ids(db: AsyncSession, tournament_id: uuid.UUID) -> list[uuid.UUID]:
+    return list(
+        (
+            await db.execute(
+                select(VenueTable.id)
+                .where(VenueTable.tournament_id == tournament_id)
+                .order_by(VenueTable.position)
+            )
+        )
+        .scalars()
+        .all()
+    )
 
 
 async def test_delete_of_a_non_owned_tournament_raises_not_owner(
@@ -462,10 +569,7 @@ async def _make_tournament_at(
     tournament = Tournament(
         name="Lifecycle Cup",
         address=_stored_address(),
-        table_catalogue=[
-            {"id": "t1", "label": "Table 1", "court": "A"},
-            {"id": "t2", "label": "Table 2", "court": "A"},
-        ],
+        tables=venue_tables(("Table 1", "A"), ("Table 2", "A")),
         league_id=league.id,
         created_by_user_id=owner.id,
         status=status,

--- a/api/tests/test_tournament_placement.py
+++ b/api/tests/test_tournament_placement.py
@@ -49,7 +49,10 @@ from app.tournament_errors import (
     TournamentNotFoundError,
 )
 from app.tournament_placement import place_fixture
-from tests._helpers import make_user
+from tests._helpers import (
+    make_user,
+    venue_tables,
+)
 
 
 async def _seed_placeable_fixture(
@@ -75,10 +78,7 @@ async def _seed_placeable_fixture(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": "t1", "label": "Table 1", "court": "A"},
-            {"id": "t2", "label": "Table 2", "court": "A"},
-        ],
+        tables=venue_tables(("Table 1", "A"), ("Table 2", "A")),
         league_id=league.id,
         created_by_user_id=owner.id,
         status=status,

--- a/api/tests/test_tournament_placement.py
+++ b/api/tests/test_tournament_placement.py
@@ -12,14 +12,22 @@ The matrix is exactly: an owner places a fixture (the columns take effect and th
 placement silently pins pre-live), a non-owner is refused
 (:class:`NotTournamentOwnerError`), an absent tournament is a not-found
 (:class:`TournamentNotFoundError`), an absent/cross-tournament fixture is a not-found
-(:class:`FixtureNotFoundError`), and a played-out fixture's placement is frozen
-(:class:`FixturePlacementFrozenError`) — the one hard rule of an otherwise-soft
-endpoint (ADR-0790).
+(:class:`FixtureNotFoundError`), a played-out fixture's placement is frozen
+(:class:`FixturePlacementFrozenError`), and a ``table_id`` naming no table of the
+tournament is refused (:class:`PlacementTableNotFoundError`).
+
+Those last two are the endpoint's only hard rules, and they are hard for different
+reasons: the freeze is about the *state* of the fixture (ADR-0790), the table is about
+the *content* of the body (ADR 20260801 — "a placement names a real table, and only that
+is an invariant"). Everything else stays soft, which the out-of-window test at the
+bottom of this file exists to hold in place: it is the one that would red if the FK
+tempted somebody into validating the whole placement.
 """
 
 import uuid
 from datetime import datetime
 from decimal import Decimal
+from zoneinfo import ZoneInfo
 
 import pytest
 from sqlalchemy import select
@@ -46,13 +54,26 @@ from app.tournament_errors import (
     FixtureNotFoundError,
     FixturePlacementFrozenError,
     NotTournamentOwnerError,
+    PlacementTableNotFoundError,
     TournamentNotFoundError,
 )
 from app.tournament_placement import place_fixture
 from tests._helpers import (
     make_user,
     venue_tables,
+    with_table_aliases,
 )
+
+
+def _table(tournament: Tournament, position: int) -> str:
+    """The id of ``tournament``'s ``position``-th catalogue table (1-based), as the
+    text a placement carries.
+
+    Table ids are the server's UUIDs since ADR 20260801, so a test cannot spell one as
+    a literal — and now that ``table_id`` is a foreign key it cannot invent one either.
+    Positional, in the tournament's own catalogue order, exactly like the ``"t1"``
+    aliases the pool seeds use."""
+    return str(tournament.tables[position - 1].id)
 
 
 async def _seed_placeable_fixture(
@@ -64,8 +85,10 @@ async def _seed_placeable_fixture(
 ) -> tuple[Tournament, TournamentEvent, TournamentFixture]:
     """A tournament owned by ``owner`` with one singles event and one fixture seating
     two active entrants — written straight to the database, the state the place verb's
-    load path expects. The ``table_catalogue`` carries ``t1``/``t2`` so a placement can
-    name a real table, and the event's pool ``p-os-1`` anchors the fixture."""
+    load path expects. The catalogue carries two real ``tournament_tables`` rows so a
+    placement can name a real table (it must, since ADR 20260801 made ``table_id`` a
+    foreign key), and the event's pool ``p-os-1`` — which reserves the first of them and
+    runs 09:00–12:30 — anchors the fixture."""
     tournament = Tournament(
         name="Placement Cup",
         address={
@@ -97,14 +120,17 @@ async def _seed_placeable_fixture(
         slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         match_settings={"rated": True, "length_games": 5},
         predicates=[],
-        pools=[
-            {
-                "id": "p-os-1",
-                "name": "Pool A",
-                "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
-                "table_ids": ["t1"],
-            }
-        ],
+        pools=with_table_aliases(
+            tournament,
+            [
+                {
+                    "id": "p-os-1",
+                    "name": "Pool A",
+                    "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+                    "table_ids": ["t1"],
+                }
+            ],
+        ),
     )
     db.add(event)
     await db.commit()
@@ -148,26 +174,31 @@ async def test_owner_places_a_fixture_and_the_columns_take_effect(
     db_session: AsyncSession,
     default_league: League,
 ) -> None:
-    """The owner sets a full placement (table + naive wall-clock start): the returned
-    read carries both, and the persisted fixture row records them — and, because a full
-    placement of a known-entrant fixture is a pin, ``pinned_at`` is set (silently, since
-    the tournament is a pre-live draft)."""
+    """The owner sets a full placement (a REAL table + a naive wall-clock start): the
+    returned read carries both, and the persisted fixture row records them — and,
+    because a full placement of a known-entrant fixture is a pin, ``pinned_at`` is set
+    (silently, since the tournament is a pre-live draft).
+
+    The other half of ADR 20260801's invariant, and the reason it is worth asserting
+    that this still works: making a bogus ``table_id`` a refusal must not make a real
+    one one."""
     owner = await make_user(db_session, "place-owner")
     tournament, event, fixture = await _seed_placeable_fixture(
         db_session, owner, default_league
     )
     fixture_id = fixture.id
+    table_id = _table(tournament, 1)
 
     read = await place_fixture(
         db_session,
         tournament_id=tournament.id,
         fixture_id=fixture_id,
         actor=owner,
-        placement=_placement("t1", datetime(2026, 6, 13, 10, 0)),
+        placement=_placement(table_id, datetime(2026, 6, 13, 10, 0)),
     )
 
     assert read.id == fixture_id
-    assert read.table_id == "t1"
+    assert read.table_id == table_id
     assert read.scheduled_start is not None
 
     # The columns are durable, and the full placement pinned the fixture.
@@ -177,7 +208,7 @@ async def test_owner_places_a_fixture_and_the_columns_take_effect(
             select(TournamentFixture).where(TournamentFixture.id == fixture_id)
         )
     ).scalar_one()
-    assert row.table_id == "t1"
+    assert row.table_id == table_id
     assert row.scheduled_start is not None
     assert row.pinned_at is not None
 
@@ -202,7 +233,7 @@ async def test_non_owner_cannot_place_a_fixture(
             tournament_id=tournament.id,
             fixture_id=fixture_id,
             actor=stranger,
-            placement=_placement("t1", datetime(2026, 6, 13, 10, 0)),
+            placement=_placement(_table(tournament, 1), datetime(2026, 6, 13, 10, 0)),
         )
 
     db_session.expire_all()
@@ -307,7 +338,7 @@ async def test_a_played_out_fixture_refuses_the_placement(
             tournament_id=tournament.id,
             fixture_id=fixture_id,
             actor=owner,
-            placement=_placement("t1", datetime(2026, 6, 13, 10, 0)),
+            placement=_placement(_table(tournament, 1), datetime(2026, 6, 13, 10, 0)),
         )
     assert exc_info.value.match_status == frozen_status.value
 
@@ -321,3 +352,138 @@ async def test_a_played_out_fixture_refuses_the_placement(
     assert row.table_id is None
     assert row.scheduled_start is None
     assert row.pinned_at is None
+
+
+@pytest.mark.parametrize(
+    ("bogus", "why"),
+    [
+        (str(uuid.uuid4()), "a well-formed id that names no row"),
+        ("t1", "not even a well-formed id"),
+    ],
+)
+async def test_a_table_id_naming_no_table_is_refused(
+    db_session: AsyncSession,
+    default_league: League,
+    bogus: str,
+    why: str,
+) -> None:
+    """A placement whose ``table_id`` names no table of this tournament raises
+    :class:`PlacementTableNotFoundError` — where it used to be **stored, and answered
+    200** (ADR-0790's fourth, weakest clause, superseded by ADR 20260801).
+
+    Both flavours of "no table" get the one refusal, carrying the offending id: a
+    well-formed UUID matching no row, and a string that is not a UUID at all (the
+    ``"t1"`` a client of the JSONB catalogue would have sent). One question, one answer
+    — the caller is not asked to tell a malformed id from an unknown one.
+
+    Nothing is written: the fixture is left unplaced, which is the point. A refusal that
+    half-applied would be worse than the storing it replaces."""
+    owner = await make_user(db_session, f"place-bogus-{uuid.uuid4().hex[:8]}")
+    tournament, _event, fixture = await _seed_placeable_fixture(
+        db_session, owner, default_league
+    )
+    fixture_id = fixture.id
+
+    with pytest.raises(PlacementTableNotFoundError) as exc_info:
+        await place_fixture(
+            db_session,
+            tournament_id=tournament.id,
+            fixture_id=fixture_id,
+            actor=owner,
+            placement=_placement(bogus, datetime(2026, 6, 13, 10, 0)),
+        )
+    assert exc_info.value.table_id == bogus, why
+
+    db_session.expire_all()
+    row = (
+        await db_session.execute(
+            select(TournamentFixture).where(TournamentFixture.id == fixture_id)
+        )
+    ).scalar_one()
+    assert row.table_id is None
+    assert row.scheduled_start is None
+    assert row.pinned_at is None
+
+
+async def test_another_tournaments_table_is_refused(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A real ``tournament_tables`` row — of somebody *else's* tournament — is refused
+    too, which the foreign key alone could not do: the key only knows the row exists
+    somewhere.
+
+    From this fixture's page that id resolves to nothing renderable, so it is the same
+    dangling pointer the ADR makes unrepresentable, and it gets the same refusal. Not a
+    fourth constraint: the invariant is "names a real table", asked of the only
+    catalogue this placement can be read against."""
+    owner = await make_user(db_session, "place-foreign-table-owner")
+    tournament, _event, fixture = await _seed_placeable_fixture(
+        db_session, owner, default_league
+    )
+    other, _other_event, _other_fixture = await _seed_placeable_fixture(
+        db_session, owner, default_league
+    )
+    foreign_table_id = _table(other, 1)
+    fixture_id = fixture.id
+
+    with pytest.raises(PlacementTableNotFoundError) as exc_info:
+        await place_fixture(
+            db_session,
+            tournament_id=tournament.id,
+            fixture_id=fixture_id,
+            actor=owner,
+            placement=_placement(foreign_table_id, datetime(2026, 6, 13, 10, 0)),
+        )
+    assert exc_info.value.table_id == foreign_table_id
+
+
+async def test_an_out_of_window_start_still_saves_as_a_flag(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """The placement is still SOFT everywhere ADR-0790 made it soft. A start hours
+    outside the fixture's pool window (09:00–12:30) on a table outside the pool's
+    ``table_ids`` saves — and pins — exactly as an in-window one does: no refusal, no
+    ``None`` columns, the time the director asked for.
+
+    This is the test that would red if the foreign key were read as licence to validate
+    the whole placement rather than the one claim ADR 20260801 hardened. A pool's
+    tables and window stay editable under a standing draw precisely because the venue
+    changes under a running tournament, so a placement a later edit outranges is a flag
+    derived on read, never a refusal."""
+    owner = await make_user(db_session, "place-out-of-window-owner")
+    tournament, _event, fixture = await _seed_placeable_fixture(
+        db_session, owner, default_league
+    )
+    fixture_id = fixture.id
+    # Table 2 is in the catalogue but NOT in pool ``p-os-1``'s ``table_ids``, and
+    # 23:30 is long past the pool's 12:30 end — two flags in one placement.
+    off_pool_table = _table(tournament, 2)
+    out_of_window = datetime(2026, 6, 13, 23, 30)
+
+    read = await place_fixture(
+        db_session,
+        tournament_id=tournament.id,
+        fixture_id=fixture_id,
+        actor=owner,
+        placement=_placement(off_pool_table, out_of_window),
+    )
+
+    assert read.table_id == off_pool_table
+    assert read.scheduled_start is not None
+
+    db_session.expire_all()
+    row = (
+        await db_session.execute(
+            select(TournamentFixture).where(TournamentFixture.id == fixture_id)
+        )
+    ).scalar_one()
+    assert row.table_id == off_pool_table
+    assert row.scheduled_start is not None
+    # The venue-anchored instant of 23:30 America/Chicago, stored as it was asked for.
+    assert (
+        row.scheduled_start.astimezone(ZoneInfo("America/Chicago")).replace(tzinfo=None)
+        == out_of_window
+    )
+    assert row.pinned_at is not None

--- a/api/tests/test_tournament_solve_service.py
+++ b/api/tests/test_tournament_solve_service.py
@@ -45,7 +45,10 @@ from app.tournament_errors import (
     TournamentNotFoundError,
 )
 from app.tournament_solve_service import request_schedule_solve
-from tests._helpers import make_user
+from tests._helpers import (
+    make_user,
+    venue_tables,
+)
 
 DATE = "2030-01-01"
 
@@ -75,6 +78,7 @@ async def _make_tournament(
     league = await get_default_league(db)
     assert league is not None, "the autouse default_league fixture seeds this"
 
+    catalogue = venue_tables(*((table.upper(), "Main") for table in tables))
     tournament = Tournament(
         name="Scheduled Open",
         status=TournamentStatus.published,
@@ -88,9 +92,7 @@ async def _make_tournament(
             "latitude": 37.8703,
             "longitude": -122.2731,
         },
-        table_catalogue=[
-            {"id": table, "label": table.upper(), "court": "Main"} for table in tables
-        ],
+        tables=catalogue,
         league_id=league.id,
         created_by_user_id=owner.id,
     )
@@ -116,7 +118,7 @@ async def _make_tournament(
                 "id": "pool-a",
                 "name": "Pool A",
                 "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
-                "table_ids": list(tables),
+                "table_ids": [str(row.id) for row in catalogue],
             }
         ],
     )

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -6599,9 +6599,14 @@ async def test_a_pools_patch_that_empties_a_pool_id_or_name_is_refused(
 #
 # A table used to be a JSONB value-object whose ``id`` was a client-supplied string —
 # which is exactly why a placement naming no table could be stored rather than refused:
-# there was no key to point at. It is a ``tournament_tables`` row now (ADR 20260801),
-# its id is minted by ``gen_random_uuid()``, and the write shape has no ``id`` field at
-# all, so a client that tries to author one is told so rather than quietly ignored.
+# there was no key to point at. It is a ``tournament_tables`` row now (ADR 20260801) and
+# its id is minted by ``gen_random_uuid()``.
+#
+# Minting and CITING are different things, and the diff needs the second. A **create**
+# has no tables to cite, so its write shape has no ``id`` field at all and sending one
+# is a 422. A **patch** is a diff, so each entry may carry the id of a table it is
+# keeping — but only one this tournament actually has: an id is something a client was
+# *given*, never something it authors.
 
 
 async def test_a_created_table_carries_a_server_minted_uuid_the_client_never_chose(
@@ -6666,12 +6671,19 @@ async def test_creating_a_tournament_that_sends_a_table_id_is_refused(
     assert ["body", "table_catalogue", 0, "id"] in _error_locs(response), response.text
 
 
-async def test_patching_a_table_catalogue_that_sends_a_table_id_is_refused(
+async def test_patching_a_table_catalogue_that_authors_a_table_id_is_refused(
     authed_client: tuple[AsyncClient, User],
 ) -> None:
-    """The catalogue's patch verb, for the reason every catalogue rule is stated on both
-    verbs: a tournament that could not be created holding a client-authored id and could
-    be edited into one is a tournament that holds a client-authored id."""
+    """A patch entry's ``id`` is one the server **gave** the client, so a string of the
+    client's own devising — ``"t9"``, the id shape the JSONB catalogue used to accept —
+    is a 422 on that entry rather than a table born holding it.
+
+    The patch verb states the rule for the same reason the create verb does: a
+    tournament that could not be *created* holding a client-authored id and could be
+    *edited* into one is a tournament that holds one. What the patch adds is the
+    second half — an id that is a well-formed UUID but names no table of this
+    tournament is refused too (see the citing-an-unknown-id test below), so "the id is
+    the server's" survives both the shape and the lookup."""
     client, _ = authed_client
     created = (await client.post("/v1/tournaments", json=_create_payload())).json()
     minted = [table["id"] for table in created["table_catalogue"]]
@@ -6688,18 +6700,18 @@ async def test_patching_a_table_catalogue_that_sends_a_table_id_is_refused(
     assert [table["id"] for table in reread["table_catalogue"]] == minted
 
 
-async def test_a_patched_catalogue_keeps_the_ids_of_the_tables_it_kept(
+async def test_a_patched_catalogue_keeps_the_ids_of_the_tables_it_cited(
     authed_client: tuple[AsyncClient, User],
 ) -> None:
-    """The catalogue is applied BY POSITION, so a PATCH that re-sends it — which the web
-    client does on every tournament edit — does not re-mint anybody's id.
+    """The catalogue is an ID-KEYED DIFF: an entry citing an ``id`` keeps that table
+    (re-worded), an entry with no ``id`` adds one, and nobody's id is re-minted.
 
     This is what makes a placement survive an unrelated edit. Rebuild the catalogue on
     each PATCH and every fixture's ``table_id`` and every pool's ``table_ids`` would
     dangle as an invisible side effect of renaming the venue."""
     client, _ = authed_client
     created = (await client.post("/v1/tournaments", json=_create_payload())).json()
-    minted = [table["id"] for table in created["table_catalogue"]]
+    first, second = [table["id"] for table in created["table_catalogue"]]
 
     # Re-send the catalogue with the second table re-worded, and a third appended.
     patched = (
@@ -6707,8 +6719,8 @@ async def test_a_patched_catalogue_keeps_the_ids_of_the_tables_it_kept(
             f"/v1/tournaments/{created['id']}",
             json={
                 "table_catalogue": [
-                    {"label": "Table 1", "court": "A"},
-                    {"label": "Centre Table", "court": "B"},
+                    {"id": first, "label": "Table 1", "court": "A"},
+                    {"id": second, "label": "Centre Table", "court": "B"},
                     {"label": "Table 3", "court": "C"},
                 ]
             },
@@ -6716,13 +6728,311 @@ async def test_a_patched_catalogue_keeps_the_ids_of_the_tables_it_kept(
     ).json()
 
     catalogue = patched["table_catalogue"]
-    assert [table["id"] for table in catalogue[:2]] == minted
+    assert [table["id"] for table in catalogue[:2]] == [first, second]
     assert [(t["label"], t["court"]) for t in catalogue] == [
         ("Table 1", "A"),
         ("Centre Table", "B"),
         ("Table 3", "C"),
     ]
-    assert catalogue[2]["id"] not in minted
+    assert catalogue[2]["id"] not in {first, second}
+
+
+async def test_reordering_a_catalogue_moves_the_tables_not_their_labels(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """Send the same two tables in the other order and the **ids move with their
+    words** — the regression this chore's diff exists to make unreachable.
+
+    The by-position stopgap it replaces matched the i-th sent against the i-th stored,
+    so this exact request left each row holding its own id and its neighbour's label
+    (measured end-to-end on 2a: ``[{"Table 2", id_1}, {"Table 1", id_2}]``). Nothing
+    refused it, nothing logged it, and the bill landed somewhere else entirely: a
+    fixture placed at ``id_1`` — untouched, still pointing where the director put it —
+    started rendering as "Table 2". A silently-wrong catalogue is worse than a dangling
+    one, because the page still looks right.
+
+    Asserted as the id→label PAIRING rather than as the order alone, because order
+    alone cannot tell the two implementations apart: both answer "Table 2" first."""
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    first, second = [table["id"] for table in created["table_catalogue"]]
+    assert [t["label"] for t in created["table_catalogue"]] == ["Table 1", "Table 2"]
+
+    patched = (
+        await client.patch(
+            f"/v1/tournaments/{created['id']}",
+            json={
+                "table_catalogue": [
+                    {"id": second, "label": "Table 2", "court": "A"},
+                    {"id": first, "label": "Table 1", "court": "A"},
+                ]
+            },
+        )
+    ).json()
+
+    swapped = [(t["id"], t["label"]) for t in patched["table_catalogue"]]
+    assert swapped == [(second, "Table 2"), (first, "Table 1")]
+    # And on the page a client actually loads, not only in the PATCH echo.
+    reread = (await client.get(f"/v1/tournaments/{created['id']}")).json()
+    assert [(t["id"], t["label"]) for t in reread["table_catalogue"]] == swapped
+
+
+async def test_a_catalogue_entry_citing_an_unknown_table_id_is_422_on_that_entry(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """An ``id`` this tournament's catalogue does not hold is refused **on the entry
+    that carried it**, never quietly minted as a new table.
+
+    Minting one would be the worst available answer: the client would be handed back a
+    different id than it asked for, AND the table it meant to keep — cited by nothing
+    else — would be removed, taking its placements through the 409 or (with the opt-in)
+    through an unplacing nobody asked for. Two failures out of one typo."""
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    minted = [table["id"] for table in created["table_catalogue"]]
+    stranger = str(uuid.uuid4())
+
+    response = await client.patch(
+        f"/v1/tournaments/{created['id']}",
+        json={
+            "table_catalogue": [
+                {"id": minted[0], "label": "Table 1", "court": "A"},
+                {"id": stranger, "label": "Table 2", "court": "A"},
+            ]
+        },
+    )
+
+    assert response.status_code == 422, response.text
+    assert ["body", "table_catalogue", 1, "id"] in _error_locs(response), response.text
+    reread = (await client.get(f"/v1/tournaments/{created['id']}")).json()
+    assert [table["id"] for table in reread["table_catalogue"]] == minted
+
+
+async def test_two_catalogue_entries_citing_one_table_id_are_refused(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """One row cannot be in two places at once, or be called two things.
+
+    The diff would have to pick a winner — and whichever it picked, the *other* table
+    the director looked like they were keeping is cited by nothing and therefore
+    removed. Refused at the boundary, like the duplicate pool id, and for the same
+    reason: a payload that is nonsense in every state the tournament could be in."""
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    minted = [table["id"] for table in created["table_catalogue"]]
+
+    response = await client.patch(
+        f"/v1/tournaments/{created['id']}",
+        json={
+            "table_catalogue": [
+                {"id": minted[0], "label": "Table 1", "court": "A"},
+                {"id": minted[0], "label": "Table 2", "court": "A"},
+            ]
+        },
+    )
+
+    assert response.status_code == 422, response.text
+    assert ["body", "table_catalogue"] in _error_locs(response), response.text
+    reread = (await client.get(f"/v1/tournaments/{created['id']}")).json()
+    assert [table["id"] for table in reread["table_catalogue"]] == minted
+
+
+# ----- removing a table: the 409, and the opt-in that gets past it ------------
+#
+# The ADR's split, and it is deliberately asymmetric. A **pool** that merely reserves a
+# removed table is not consulted — a table breaking or freeing up is ordinary venue
+# traffic, and the pool simply reserves one fewer. A **placement** refuses, because
+# silently clearing one destroys information on an unrelated write: the fixture stops
+# being "placed at a table that vanished" and becomes indistinguishable from "nobody
+# ever placed this". The database refuses by default; the director says yes on purpose.
+
+
+async def _tables_of(client: AsyncClient, tournament_id: str) -> list[dict[str, Any]]:
+    body = (await client.get(f"/v1/tournaments/{tournament_id}")).json()
+    tables: list[dict[str, Any]] = body["table_catalogue"]
+    return tables
+
+
+async def _tournament_with_a_placed_fixture(
+    client: AsyncClient, db_session: AsyncSession, *, prefix: str
+) -> tuple[str, str, TournamentFixture, str, str]:
+    """A drawn round-robin whose pool reserves **both** of the tournament's real tables,
+    with its first fixture placed on the first of them.
+
+    The pool reserving the real ids is the whole point of the third case below: an event
+    payload's ``table_ids`` are written before the tournament's tables have ids a test
+    can know, so the default fixtures reserve the string ``"t1"`` — which names no table
+    and would make "a table only a pool reserves" untestable. Here the event is created
+    *after* the tournament, off its minted ids."""
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    tournament_id = created["id"]
+    table_1, table_2 = [table["id"] for table in created["table_catalogue"]]
+    event = (
+        await client.post(
+            f"/v1/tournaments/{tournament_id}/events",
+            json=_rr_payload({**POOL_A, "table_ids": [table_1, table_2]}),
+        )
+    ).json()
+    await _seed_field(db_session, event["id"], 3, prefix=prefix)
+    await _cut_the_draw(client, tournament_id, event["id"])
+    fixture, *_ = await _fixture_rows(db_session, event["id"])
+    placed = await client.patch(
+        _placement_url(tournament_id, str(fixture.id)),
+        json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"},
+    )
+    assert placed.status_code == 200, placed.text
+    return tournament_id, event["id"], fixture, table_1, table_2
+
+
+async def test_removing_a_catalogue_table_a_fixture_is_placed_at_is_a_409_naming_it(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """Omit a table a match is placed at and the whole edit is refused, with a
+    sentence that names the table **by label** and names the way out — and **nothing
+    is written**.
+
+    That last clause is the load-bearing one, and it is why this PATCH also renames the
+    tournament. A guard that refused *after* writing would satisfy every assertion about
+    the 409 and still have moved the venue underneath the director; the ``name`` is the
+    tripwire that catches it, because it is the one field on this payload the verb would
+    otherwise have ``setattr``'d before the catalogue branch ran."""
+    client, _ = authed_client
+    (
+        tournament_id,
+        _event_id,
+        fixture,
+        table_1,
+        table_2,
+    ) = await _tournament_with_a_placed_fixture(client, db_session, prefix="tr1")
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}",
+        json={
+            "name": "Renamed While Removing",
+            "table_catalogue": [{"id": table_2, "label": "Table 2", "court": "A"}],
+        },
+    )
+
+    assert response.status_code == 409, response.text
+    detail = response.json()["detail"]
+    # Named by LABEL, never by id: an id tells a director looking at a page of named
+    # tables nothing to act on.
+    assert "“Table 1”" in detail, detail
+    assert table_1 not in detail, detail
+    assert "1 match" in detail, detail
+    # …and the way out, so the refusal is actionable rather than merely correct.
+    assert "unplace_fixtures_on_removed_tables" in detail, detail
+
+    # Nothing was written. Not the catalogue…
+    reread = (await client.get(f"/v1/tournaments/{tournament_id}")).json()
+    assert [table["id"] for table in reread["table_catalogue"]] == [table_1, table_2]
+    # …not the name that rode along on the same refused request…
+    assert reread["name"] == "Bay Area Open 2026"
+    # …and not the placement the refusal was protecting.
+    db_session.expire_all()
+    await db_session.refresh(fixture)
+    assert fixture.table_id == table_1
+    assert fixture.scheduled_start is not None
+    assert fixture.pinned_at is not None
+
+
+async def test_the_opt_in_removes_the_catalogue_table_and_leaves_its_fixtures_unplaced(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The identical request, plus ``unplace_fixtures_on_removed_tables``, goes through:
+    the table is gone and the matches that were on it are unplaced.
+
+    All three placement columns go, not just ``table_id``. A predicted start with no
+    table is a bar on a schedule with nowhere to be, and a ``pinned_at`` is a *promise
+    about a table* — leaving it would tell every later solve the fixture is nailed to a
+    table that no longer exists. Unplaced means unplaced, which is exactly why it takes
+    a confirmation to ask for."""
+    client, _ = authed_client
+    (
+        tournament_id,
+        _event_id,
+        fixture,
+        table_1,
+        table_2,
+    ) = await _tournament_with_a_placed_fixture(client, db_session, prefix="tr2")
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}",
+        json={
+            "name": "Renamed While Removing",
+            "table_catalogue": [{"id": table_2, "label": "Table 2", "court": "A"}],
+            "unplace_fixtures_on_removed_tables": True,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert [table["id"] for table in response.json()["table_catalogue"]] == [table_2]
+    assert response.json()["name"] == "Renamed While Removing"
+    # The row itself is gone, not merely absent from the projection.
+    remaining = (
+        (
+            await db_session.execute(
+                select(VenueTable.id).where(
+                    VenueTable.tournament_id == uuid.UUID(tournament_id)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [str(row) for row in remaining] == [table_2]
+
+    db_session.expire_all()
+    await db_session.refresh(fixture)
+    assert fixture.table_id is None
+    assert fixture.scheduled_start is None
+    assert fixture.pinned_at is None
+
+
+async def test_removing_a_catalogue_table_only_a_pool_reserves_succeeds_silently(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A table a pool merely **reserves**, with no match placed at it, is removed with
+    no refusal and no opt-in — the quiet half of the ADR's split.
+
+    A pool's ``table_ids`` are a reservation, not a placement: "a table breaks, a table
+    frees up" is ordinary venue traffic and is exactly why a pool's tables stay editable
+    mid-event. The pool simply reserves one fewer, which today is derived on read (the
+    solver intersects ``table_ids`` with the catalogue, ``_load_solver_inputs``) — the
+    stored JSONB still lists the dead id, and cleaning that up is Slice 3's
+    ``tournament_event_pool_tables`` CASCADE, not this verb's. Asserted, so that when
+    the join table lands the change is a decision rather than a surprise."""
+    client, _ = authed_client
+    (
+        tournament_id,
+        event_id,
+        fixture,
+        table_1,
+        table_2,
+    ) = await _tournament_with_a_placed_fixture(client, db_session, prefix="tr3")
+    # The pool reserves BOTH tables; only ``table_1`` has a match on it.
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}",
+        json={"table_catalogue": [{"id": table_1, "label": "Table 1", "court": "A"}]},
+    )
+
+    assert response.status_code == 200, response.text
+    assert [table["id"] for table in await _tables_of(client, tournament_id)] == [
+        table_1
+    ]
+    # The placement on the surviving table is untouched — this removal unplaced nobody.
+    db_session.expire_all()
+    await db_session.refresh(fixture)
+    assert fixture.table_id == table_1
+    assert fixture.scheduled_start is not None
+
+    (event,) = await _events_of(client, tournament_id)
+    (pool,) = event["pools"]
+    assert pool["table_ids"] == [table_1, table_2]  # Slice 3's to prune
 
 
 # ----- the draw-type freeze (409) -------------------------------------------

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -56,6 +56,7 @@ from app.models import (
     TournamentStatus,
     User,
     UserLeagueRating,
+    VenueTable,
 )
 from app.models.tournament import DrawType, EventFormat
 from app.schemas.notification import NotificationJob
@@ -144,9 +145,12 @@ def _create_payload(**overrides: Any) -> dict[str, Any]:
         "start_date": "2026-06-13",
         "end_date": "2026-06-14",
         "address": _address(),
+        # No ``id`` on a submitted table: a table is a row whose id the server mints
+        # (ADR 20260801), so sending one is a 422 (see the two tests at
+        # "the catalogue's ids are the server's").
         "table_catalogue": [
-            {"id": "t1", "label": "Table 1", "court": "A"},
-            {"id": "t2", "label": "Table 2", "court": "A"},
+            {"label": "Table 1", "court": "A"},
+            {"label": "Table 2", "court": "A"},
         ],
     }
     payload.update(overrides)
@@ -196,10 +200,13 @@ async def test_create_tournament_returns_201(
     # The venue address is geocoded on write: the read carries the six text fields the
     # client sent PLUS the server-resolved coordinates (NOT NULL).
     assert body["address"] == await _geocoded_address(_address())
-    assert body["table_catalogue"] == [
-        {"id": "t1", "label": "Table 1", "court": "A"},
-        {"id": "t2", "label": "Table 2", "court": "A"},
+    # The catalogue comes back in the order it was sent, each table carrying the id the
+    # SERVER minted for it — a real UUID the client never chose (ADR 20260801).
+    assert [(table["label"], table["court"]) for table in body["table_catalogue"]] == [
+        ("Table 1", "A"),
+        ("Table 2", "A"),
     ]
+    assert [uuid.UUID(table["id"]) for table in body["table_catalogue"]]
     assert body["can_edit"] is True
     assert body["created_by_username"] == user.username
     assert body["created_by_user_id"] == str(user.id)
@@ -1797,12 +1804,15 @@ async def test_patch_event_answers_with_its_existing_entrants(
 
 
 # The pin, measured (print the statements below to re-measure): the tournaments +
-# usernames join, the events, ONE batched load of every event's active entrants, ONE
-# batched load of every event's fixtures — its draw (ADR-0786) — and ONE batched load of
-# the caller's rating on every league those tournaments run on (which each event's
-# ``entry_state`` is judged against, ADR-0783). Five, whatever the number of tournaments
-# and events.
-EXPECTED_TOURNAMENT_LIST_STATEMENTS = 5
+# usernames join, ONE batched load of every one of those tournaments' venue tables
+# (``Tournament.tables``, ``lazy="selectin"`` — the catalogue is rows now,
+# ADR 20260801, and selectin batches it across the whole page rather than one query
+# per card), the events, ONE batched load of every event's active entrants, ONE
+# batched load of every event's fixtures — its draw (ADR-0786) — and ONE batched load
+# of the caller's rating on every league those tournaments run on (which each event's
+# ``entry_state`` is judged against, ADR-0783). Six, whatever the number of
+# tournaments, tables and events.
+EXPECTED_TOURNAMENT_LIST_STATEMENTS = 6
 
 
 @pytest.mark.parametrize("event_count", [1, 4])
@@ -1933,7 +1943,6 @@ async def _seed_located_tournament(
         name=name,
         status=status,
         address={**_address(), "latitude": latitude, "longitude": longitude},
-        table_catalogue=[],
         league_id=league.id,
         created_by_user_id=owner.id,
     )
@@ -2038,7 +2047,6 @@ async def test_a_tournament_with_no_venue_never_matches_a_proximity_search(
         name="Unbooked Open",
         status=TournamentStatus.published,
         address=None,
-        table_catalogue=[],
         league_id=default_league.id,
         created_by_user_id=user.id,
     )
@@ -4329,22 +4337,24 @@ async def test_the_tournaments_list_does_not_carry_the_draw_type_catalogue(
     assert await _catalogue_of(client, tournament_id)
 
 
-# The pin, measured: the tournament + username join, its events, ONE batched load of
+# The pin, measured: the tournament + username join, ONE load of its venue tables
+# (``Tournament.tables``, ``lazy="selectin"`` — the catalogue is rows now,
+# ADR 20260801), its events, ONE batched load of
 # those events' active entrants (their ratings on the tournament's ladder ride along on
 # that same statement — see ``active_entrants_by_event``), ONE batched load of those
 # events' fixtures — their draws (ADR-0786) — ONE read of the caller's rating on the
 # tournament's league, ONE read of the newest solve-ledger row (the Schedule tab's
 # solve strip, ADR "the schedule is solved, the call is pinned"), and ONE read of the
 # ``draw_types`` catalogue the event form's picker renders (ADR "a draw type is a
-# seeded row, and the enum holds only what runs"). Seven, whatever the number of
+# seeded row, and the enum holds only what runs"). Eight, whatever the number of
 # events, whatever the number of entrants in them, whatever the size of their draws,
-# and whatever the length of the day's solve ledger.
+# whatever the size of the venue, and whatever the length of the day's solve ledger.
 #
-# It was six until the catalogue landed, and the seventh is deliberate: the catalogue
-# is global reference data with nothing to key off the page, so it is one flat read
-# that does not grow with anything — which is exactly what the parametrized cases
-# below check by measuring the same number at one event and at four.
-EXPECTED_TOURNAMENT_DETAIL_STATEMENTS = 7
+# Two of the eight are deliberate flat reads that grow with nothing: the draw-type
+# catalogue is global reference data with nothing to key off the page, and the venue
+# tables are one batched read per *page*, not per card — which is exactly what the
+# parametrized cases below check by measuring the same number at one event and at four.
+EXPECTED_TOURNAMENT_DETAIL_STATEMENTS = 8
 
 
 @pytest.mark.parametrize("event_count", [1, 4])
@@ -6582,23 +6592,70 @@ async def test_a_pools_patch_that_empties_a_pool_id_or_name_is_refused(
     assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
 
 
-async def test_creating_a_tournament_with_an_empty_table_id_is_refused(
+# ----- the catalogue's ids are the server's ---------------------------------
+#
+# A table used to be a JSONB value-object whose ``id`` was a client-supplied string —
+# which is exactly why a placement naming no table could be stored rather than refused:
+# there was no key to point at. It is a ``tournament_tables`` row now (ADR 20260801),
+# its id is minted by ``gen_random_uuid()``, and the write shape has no ``id`` field at
+# all, so a client that tries to author one is told so rather than quietly ignored.
+
+
+async def test_a_created_table_carries_a_server_minted_uuid_the_client_never_chose(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The whole claim, end to end: the catalogue round-trips through its own rows, and
+    the id on each one is a UUID the server minted.
+
+    It is asserted against the ``tournament_tables`` rows and not only the response
+    body, because a response body alone cannot tell "stored as rows" from "stored as
+    JSONB and echoed back" — which is the thing that changed."""
+    client, _ = authed_client
+
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+
+    rows = (
+        (
+            await db_session.execute(
+                select(VenueTable)
+                .where(VenueTable.tournament_id == uuid.UUID(created["id"]))
+                .order_by(VenueTable.position)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [(row.label, row.court, row.position) for row in rows] == [
+        ("Table 1", "A", 0),
+        ("Table 2", "A", 1),
+    ]
+    # Real, distinct, version-4 UUIDs — not a client string, and not one id reused.
+    assert {row.id.version for row in rows} == {4}
+    assert len({row.id for row in rows}) == 2
+    # And the read path serves exactly those row ids, in the director's order.
+    assert [table["id"] for table in created["table_catalogue"]] == [
+        str(row.id) for row in rows
+    ]
+
+
+async def test_creating_a_tournament_that_sends_a_table_id_is_refused(
     authed_client: tuple[AsyncClient, User],
 ) -> None:
-    """A table in the venue catalogue is the same string-ref pattern as a pool: a pool
-    holds a list of these ids (``table_ids``) and nothing else connects the two — no
-    table, no foreign key, no index. An id of ``""`` is a table nothing can name, and a
-    ``table_ids`` entry of ``""`` would "resolve" against it.
+    """A table's identity is the server's to mint (ADR 20260801), so ``id`` is simply
+    not a field of the write shape and ``extra="forbid"`` turns sending one into a 422
+    that names it.
 
-    Closing the hole on pools and leaving it open on the thing pools point AT would be a
-    boundary drawn half way.
-    """
+    Refused rather than ignored, for the reason ``PoolWrite`` refuses a ``position``: a
+    client cannot tell from the schema that the id it sent decided nothing, and a
+    boundary that silently discards half a payload has to be documented to be
+    understood."""
     client, _ = authed_client
 
     response = await client.post(
         "/v1/tournaments",
         json=_create_payload(
-            table_catalogue=[{"id": "", "label": "Table 1", "court": "A"}]
+            table_catalogue=[{"id": "t1", "label": "Table 1", "court": "A"}]
         ),
     )
 
@@ -6606,25 +6663,63 @@ async def test_creating_a_tournament_with_an_empty_table_id_is_refused(
     assert ["body", "table_catalogue", 0, "id"] in _error_locs(response), response.text
 
 
-async def test_patching_a_table_catalogue_with_an_empty_table_id_is_refused(
+async def test_patching_a_table_catalogue_that_sends_a_table_id_is_refused(
     authed_client: tuple[AsyncClient, User],
 ) -> None:
-    """The table catalogue's patch verb, for the reason every pools rule is stated
-    on both verbs: a tournament that could not be created with an id-less table and
-    could be edited into one is a tournament that holds an id-less table."""
+    """The catalogue's patch verb, for the reason every catalogue rule is stated on both
+    verbs: a tournament that could not be created holding a client-authored id and could
+    be edited into one is a tournament that holds a client-authored id."""
     client, _ = authed_client
     created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    minted = [table["id"] for table in created["table_catalogue"]]
 
     response = await client.patch(
         f"/v1/tournaments/{created['id']}",
-        json={"table_catalogue": [{"id": "", "label": "Table 9", "court": "B"}]},
+        json={"table_catalogue": [{"id": "t9", "label": "Table 9", "court": "B"}]},
     )
 
     assert response.status_code == 422, response.text
     assert ["body", "table_catalogue", 0, "id"] in _error_locs(response), response.text
     # And the catalogue it was born with is the catalogue it still has.
     reread = (await client.get(f"/v1/tournaments/{created['id']}")).json()
-    assert [table["id"] for table in reread["table_catalogue"]] == ["t1", "t2"]
+    assert [table["id"] for table in reread["table_catalogue"]] == minted
+
+
+async def test_a_patched_catalogue_keeps_the_ids_of_the_tables_it_kept(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """The catalogue is applied BY POSITION, so a PATCH that re-sends it — which the web
+    client does on every tournament edit — does not re-mint anybody's id.
+
+    This is what makes a placement survive an unrelated edit. Rebuild the catalogue on
+    each PATCH and every fixture's ``table_id`` and every pool's ``table_ids`` would
+    dangle as an invisible side effect of renaming the venue."""
+    client, _ = authed_client
+    created = (await client.post("/v1/tournaments", json=_create_payload())).json()
+    minted = [table["id"] for table in created["table_catalogue"]]
+
+    # Re-send the catalogue with the second table re-worded, and a third appended.
+    patched = (
+        await client.patch(
+            f"/v1/tournaments/{created['id']}",
+            json={
+                "table_catalogue": [
+                    {"label": "Table 1", "court": "A"},
+                    {"label": "Centre Table", "court": "B"},
+                    {"label": "Table 3", "court": "C"},
+                ]
+            },
+        )
+    ).json()
+
+    catalogue = patched["table_catalogue"]
+    assert [table["id"] for table in catalogue[:2]] == minted
+    assert [(t["label"], t["court"]) for t in catalogue] == [
+        ("Table 1", "A"),
+        ("Centre Table", "B"),
+        ("Table 3", "C"),
+    ]
+    assert catalogue[2]["id"] not in minted
 
 
 # ----- the draw-type freeze (409) -------------------------------------------
@@ -8478,6 +8573,16 @@ async def _entrant_user_ids_of(
     )
 
 
+async def _catalogue_table_ids(client: AsyncClient, tournament_id: str) -> list[str]:
+    """The tournament's venue-table ids, read back off its detail payload.
+
+    A table's id is minted by the server now (ADR 20260801), so a test that wants a
+    placement to RESOLVE to a label — rather than merely to save, which an unknown ref
+    still does — has to ask which ids exist rather than assert one."""
+    body = (await client.get(f"/v1/tournaments/{tournament_id}")).json()
+    return [table["id"] for table in body["table_catalogue"]]
+
+
 def _match_call_jobs(queue: Queue) -> list[NotificationJob]:
     jobs = [NotificationJob.model_validate_json(job.args[0]) for job in queue.jobs]
     return [job for job in jobs if job.category == "match_calls"]
@@ -8496,12 +8601,13 @@ async def test_a_live_placement_pins_and_calls_both_entrants(
     client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
     entrants = await _entrant_user_ids_of(db_session, fixture)
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
     await _go_live_directly(db_session, tournament_id)
     await _clear_solve_ledger(db_session)
 
     response = await client.patch(
         _placement_url(tournament_id, str(fixture.id)),
-        json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"},
+        json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"},
     )
 
     assert response.status_code == 200, response.text
@@ -8569,6 +8675,7 @@ async def test_a_replacement_of_a_called_fixture_sends_the_moved_correction(
     client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
     entrants = await _entrant_user_ids_of(db_session, fixture)
+    table_1, table_2 = await _catalogue_table_ids(client, tournament_id)
     await _go_live_directly(db_session, tournament_id)
     url = _placement_url(tournament_id, str(fixture.id))
 
@@ -8576,7 +8683,7 @@ async def test_a_replacement_of_a_called_fixture_sends_the_moved_correction(
         match_calls, "_wall_now", lambda: datetime(2026, 6, 13, 9, 40, tzinfo=UTC)
     )
     first = await client.patch(
-        url, json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"}
+        url, json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"}
     )
     assert datetime.fromisoformat(first.json()["pinned_at"]["instant"]) == datetime(
         2026, 6, 13, 9, 40, tzinfo=UTC
@@ -8586,7 +8693,7 @@ async def test_a_replacement_of_a_called_fixture_sends_the_moved_correction(
         match_calls, "_wall_now", lambda: datetime(2026, 6, 13, 9, 50, tzinfo=UTC)
     )
     response = await client.patch(
-        url, json={"table_id": "t2", "scheduled_start": "2026-06-13T10:30:00"}
+        url, json={"table_id": table_2, "scheduled_start": "2026-06-13T10:30:00"}
     )
 
     assert response.status_code == 200, response.text

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -6991,6 +6991,65 @@ async def test_the_opt_in_removes_the_catalogue_table_and_leaves_its_fixtures_un
     assert fixture.pinned_at is None
 
 
+@pytest.mark.parametrize(
+    ("spelling", "opt_in"),
+    [
+        ("omitted", {}),
+        ("false", {"unplace_fixtures_on_removed_tables": False}),
+        ("null", {"unplace_fixtures_on_removed_tables": None}),
+    ],
+)
+async def test_only_an_explicit_true_opts_in_to_unplacing(
+    spelling: str,
+    opt_in: dict[str, Any],
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The opt-in has **one** affirmative spelling and three ways of not saying it —
+    omitted, ``false`` and ``null`` — and all three are refused identically.
+
+    The field is ``bool | None`` on the wire rather than ``bool = False`` for a reason
+    that pytest cannot see: a non-null default is emitted as ``"default": false`` into
+    the JSON schema, and ``openapi-typescript`` promotes any property carrying one to
+    **required** — which made an opt-in for one destructive action mandatory on every
+    unrelated PATCH, down to ``{"name": "…"}``. Omitting a key on a partial update means
+    "unchanged", and it has to stay sayable.
+
+    What that costs is a third wire value, and this test is what keeps it from becoming
+    a third *state*: ``None`` and ``False`` are one answer — nobody opted in — collapsed
+    at ``TournamentUpdate.unplacing_is_confirmed`` before the verb ever sees them. The
+    parametrization is over spellings of the same request, so a future coercion that got
+    ``null`` wrong (or a client that sends it explicitly) cannot quietly start unplacing
+    somebody's schedule."""
+    client, _ = authed_client
+    (
+        tournament_id,
+        _event_id,
+        fixture,
+        table_1,
+        table_2,
+    ) = await _tournament_with_a_placed_fixture(
+        client, db_session, prefix=f"opt{spelling[:2]}"
+    )
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}",
+        json={
+            "table_catalogue": [{"id": table_2, "label": "Table 2", "court": "A"}],
+            **opt_in,
+        },
+    )
+
+    assert response.status_code == 409, response.text
+    assert "“Table 1”" in response.json()["detail"], response.text
+    # Nothing written: the table stands and the placement it was protecting stands.
+    reread = (await client.get(f"/v1/tournaments/{tournament_id}")).json()
+    assert [table["id"] for table in reread["table_catalogue"]] == [table_1, table_2]
+    db_session.expire_all()
+    await db_session.refresh(fixture)
+    assert fixture.table_id == table_1
+
+
 async def test_removing_a_catalogue_table_only_a_pool_reserves_succeeds_silently(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -773,11 +773,12 @@ async def test_a_timezone_change_preserves_a_placement_wall_clock(
     shifts into the new zone."""
     client, _ = authed_client
     tournament_id, event_id, fixture = await _drawn_fixture(client, db_session)
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
 
     # Place it at 18:00 local; the default event zone is America/Chicago.
     place = await client.patch(
         _placement_url(tournament_id, str(fixture.id)),
-        json={"table_id": "t1", "scheduled_start": "2026-06-13T18:00:00"},
+        json={"table_id": table_1, "scheduled_start": "2026-06-13T18:00:00"},
     )
     assert place.status_code == 200, place.text
     before = await _fixture_in_detail(client, tournament_id, str(fixture.id))
@@ -5806,8 +5807,10 @@ async def test_place_fixture_blocks_on_a_concurrent_uncut_then_404s_the_gone_fix
             actor = (
                 await session.execute(select(User).where(User.id == owner_id))
             ).scalar_one()
+            # The placement's CONTENT is beside the point here — this test is about the
+            # lock — so it is the empty one, which no table has to exist for.
             payload = TournamentFixturePlacementUpdate(
-                table_id="t1", scheduled_start=None
+                table_id=None, scheduled_start=None
             )
             try:
                 await place_fixture(
@@ -7411,6 +7414,11 @@ async def _call_fixtures(
     follows a call, so the tests go through one rather than forcing the status."""
     tournament = await db.get(Tournament, uuid.UUID(tournament_id))
     assert tournament is not None
+    # Real catalogue rows, cycled: ``table_id`` is a foreign key now (ADR 20260801), so
+    # the ``f"t{i + 1}"`` this used to send is no longer a table a fixture can sit at.
+    # Cycling past the end of a two-table catalogue double-books, which is fine and
+    # deliberate — a double-booking is a flag derived on read, never a refusal.
+    tables = [str(table.id) for table in tournament.tables]
     # The director enters ``scheduled_start`` as venue wall-clock; the write path
     # anchors it to the event timezone into the ``timestamptz`` column (ADR
     # "tournament times are timezone-aware instants").
@@ -7419,7 +7427,7 @@ async def _call_fixtures(
             db,
             tournament,
             fixture,
-            table_id=f"t{i + 1}",
+            table_id=tables[i % len(tables)],
             scheduled_start=datetime(2026, 6, 1, 10, 0),
             event_timezone="America/Chicago",
         )
@@ -8241,20 +8249,21 @@ async def test_owner_sets_a_fixture_placement_and_the_detail_reflects_it(
     rides the detail BFF, so this is where a client sees it)."""
     client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
 
     response = await client.patch(
         _placement_url(tournament_id, str(fixture.id)),
-        json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"},
+        json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"},
     )
 
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["id"] == str(fixture.id)
-    assert body["table_id"] == "t1"
+    assert body["table_id"] == table_1
     assert _is_venue_instant(body["scheduled_start"], "2026-06-13T10:00:00")
 
     placed = await _fixture_in_detail(client, tournament_id, str(fixture.id))
-    assert placed["table_id"] == "t1"
+    assert placed["table_id"] == table_1
     assert _is_venue_instant(placed["scheduled_start"], "2026-06-13T10:00:00")
 
 
@@ -8275,10 +8284,11 @@ async def test_a_pinned_fixture_time_carries_a_venue_local_label_and_a_utc_insta
     """
     client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
 
     response = await client.patch(
         _placement_url(tournament_id, str(fixture.id)),
-        json={"table_id": "t1", "scheduled_start": "2026-06-13T18:00:00"},
+        json={"table_id": table_1, "scheduled_start": "2026-06-13T18:00:00"},
     )
     assert response.status_code == 200, response.text
 
@@ -8311,9 +8321,10 @@ async def test_owner_clears_a_fixture_placement_back_to_null(
     both halves; the detail shows an unplaced fixture again."""
     client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
     url = _placement_url(tournament_id, str(fixture.id))
     await client.patch(
-        url, json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"}
+        url, json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"}
     )
 
     response = await client.patch(url, json={"table_id": None, "scheduled_start": None})
@@ -8337,13 +8348,14 @@ async def test_a_non_owner_cannot_place_a_fixture(
     fixture is left unplaced."""
     owner_client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(owner_client, db_session)
+    table_1, _table_2 = await _catalogue_table_ids(owner_client, tournament_id)
 
     async with make_client() as stranger:
         user = await start_session(stranger, db_session)
         await _grant_tournament_perms(db_session, user)
         response = await stranger.patch(
             _placement_url(tournament_id, str(fixture.id)),
-            json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"},
+            json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"},
         )
         assert response.status_code == 403
 
@@ -8352,35 +8364,101 @@ async def test_a_non_owner_cannot_place_a_fixture(
     assert placed["scheduled_start"] is None
 
 
+async def test_an_out_of_window_or_off_pool_placement_still_saves(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The placement is still **soft** everywhere ADR-0790 made it soft:
+    ``scheduled_start`` is a prediction, and three of its four constraints (table-in-
+    pool, time-in-window, no double-booking) are flags on read, not invariants — so the
+    write does not reject them. Pool A reserves the first table for 09:00–12:30; the
+    SECOND table (in the catalogue, off the pool) at 23:00 **saves** rather than 4xx.
+    Conflict detection is the scheduler's job, not this boundary's.
+
+    This test used to carry a second parameter — a ``table_id`` naming nothing in the
+    catalogue at all — asserting that *that* saved too. It no longer does: ADR 20260801
+    supersedes exactly that clause of ADR-0790 and makes it the 422 in the test below.
+    The two are kept adjacent on purpose, because the whole content of the decision is
+    where the line falls between them."""
+    client, _ = authed_client
+    tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    _table_1, table_2 = await _catalogue_table_ids(client, tournament_id)
+
+    response = await client.patch(
+        _placement_url(tournament_id, str(fixture.id)),
+        json={"table_id": table_2, "scheduled_start": "2026-06-13T23:00:00"},
+    )
+
+    assert 200 <= response.status_code < 300, response.text
+    body = response.json()
+    assert body["table_id"] == table_2
+    assert _is_venue_instant(body["scheduled_start"], "2026-06-13T23:00:00")
+
+
 @pytest.mark.parametrize(
     "table_id",
     [
-        pytest.param("t2", id="off-pool"),  # in the catalogue, but not in Pool A
-        pytest.param("ghost-table", id="not-in-catalogue"),  # names no table at all
+        # A well-formed id that names no row, and a string that is not an id at all —
+        # the ``"t1"`` a client of the old JSONB catalogue would still be sending.
+        pytest.param(str(uuid.uuid4()), id="unknown-id"),
+        pytest.param("ghost-table", id="not-even-an-id"),
     ],
 )
-async def test_an_out_of_window_or_off_pool_placement_still_saves(
+async def test_a_placement_naming_no_table_is_a_422_on_the_field(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
     table_id: str,
 ) -> None:
-    """The placement is **soft** (ADR-0790): ``scheduled_start`` is a prediction, and
-    the constraints (table-in-pool, time-in-window, no double-booking) are flags on
-    read, not invariants — so the write does not reject them. Pool A reserves ``t1`` for
-    09:00–12:30; a table off the pool (or naming nothing in the catalogue at all) and a
-    23:00 start both **save** rather than 4xx. Conflict detection is a later slice."""
+    """A ``table_id`` that names no table of this tournament is refused with a **422
+    naming the field** — where it was previously stored and answered 200 (ADR 20260801,
+    superseding ADR-0790's fourth clause now that a table is a real row to point at).
+
+    The refusal is attributed to ``body.table_id``, not to the request at large: this is
+    the same ``loc`` a schema 422 on this field would carry, so a client renders it
+    under the input that caused it and needs no second parser for the database-answered
+    half of the same question.
+
+    And it writes nothing — the fixture is left unplaced, not half-placed."""
     client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
 
     response = await client.patch(
         _placement_url(tournament_id, str(fixture.id)),
-        json={"table_id": table_id, "scheduled_start": "2026-06-13T23:00:00"},
+        json={"table_id": table_id, "scheduled_start": "2026-06-13T10:00:00"},
     )
 
-    assert 200 <= response.status_code < 300, response.text
-    body = response.json()
-    assert body["table_id"] == table_id
-    assert _is_venue_instant(body["scheduled_start"], "2026-06-13T23:00:00")
+    assert response.status_code == 422, response.text
+    assert ["body", "table_id"] in _error_locs(response), response.text
+
+    placed = await _fixture_in_detail(client, tournament_id, str(fixture.id))
+    assert placed["table_id"] is None
+    assert placed["scheduled_start"] is None
+
+
+async def test_another_tournaments_table_cannot_be_placed_at(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A real table id — belonging to a **different** tournament — is refused the same
+    way, which the foreign key alone cannot do (it only knows the row exists somewhere).
+
+    From this tournament's page that id renders as nothing, so it is the same dangling
+    pointer the ADR makes unrepresentable, and it earns the same 422 on the same field.
+    """
+    client, _ = authed_client
+    tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    other_id, _other_event, _other_fixture = await _drawn_fixture(
+        client, db_session, prefix="ot", name="Other Open"
+    )
+    (foreign_table, *_) = await _catalogue_table_ids(client, other_id)
+
+    response = await client.patch(
+        _placement_url(tournament_id, str(fixture.id)),
+        json={"table_id": foreign_table, "scheduled_start": "2026-06-13T10:00:00"},
+    )
+
+    assert response.status_code == 422, response.text
+    assert ["body", "table_id"] in _error_locs(response), response.text
 
 
 @pytest.mark.parametrize("frozen_status", [MatchStatus.completed, MatchStatus.voided])
@@ -8399,9 +8477,10 @@ async def test_a_played_out_fixture_refuses_a_placement_move(
     both the 409 and that the historical placement survives the refusal."""
     client, owner = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    table_1, table_2 = await _catalogue_table_ids(client, tournament_id)
     url = _placement_url(tournament_id, str(fixture.id))
     await client.patch(
-        url, json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"}
+        url, json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"}
     )
 
     match = await _make_match(db_session, owner, default_league)
@@ -8410,7 +8489,7 @@ async def test_a_played_out_fixture_refuses_a_placement_move(
     await db_session.commit()
 
     response = await client.patch(
-        url, json={"table_id": "t2", "scheduled_start": "2026-06-13T14:00:00"}
+        url, json={"table_id": table_2, "scheduled_start": "2026-06-13T14:00:00"}
     )
 
     assert response.status_code == 409, response.text
@@ -8418,7 +8497,7 @@ async def test_a_played_out_fixture_refuses_a_placement_move(
     # The move changed nothing: the placement recorded before the match went to history
     # is the placement the fixture still carries.
     placed = await _fixture_in_detail(client, tournament_id, str(fixture.id))
-    assert placed["table_id"] == "t1"
+    assert placed["table_id"] == table_1
     assert _is_venue_instant(placed["scheduled_start"], "2026-06-13T10:00:00")
 
 
@@ -8432,6 +8511,7 @@ async def test_an_in_progress_fixture_is_freely_placeable(
     live-match fixture still (re)places."""
     client, owner = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
     match = await _make_match(db_session, owner, default_league)
     match.status = MatchStatus.in_progress
     fixture.match_id = match.id
@@ -8439,11 +8519,11 @@ async def test_an_in_progress_fixture_is_freely_placeable(
 
     response = await client.patch(
         _placement_url(tournament_id, str(fixture.id)),
-        json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"},
+        json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"},
     )
 
     assert response.status_code == 200, response.text
-    assert response.json()["table_id"] == "t1"
+    assert response.json()["table_id"] == table_1
 
 
 async def test_an_offset_aware_start_is_a_422(
@@ -8456,10 +8536,11 @@ async def test_an_offset_aware_start_is_a_422(
     500-ing in the driver — the same discipline the fee/player-limit bounds keep."""
     client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
 
     response = await client.patch(
         _placement_url(tournament_id, str(fixture.id)),
-        json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00Z"},
+        json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00Z"},
     )
 
     assert response.status_code == 422, response.text
@@ -8724,10 +8805,11 @@ async def test_a_pre_live_placement_is_a_silent_pin(
     first drag — but nobody is paged and the count stays 0."""
     client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
 
     response = await client.patch(
         _placement_url(tournament_id, str(fixture.id)),
-        json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"},
+        json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"},
     )
 
     assert response.status_code == 200, response.text
@@ -8751,13 +8833,14 @@ async def test_clearing_a_called_placement_cancels_the_call(
     client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
     entrants = await _entrant_user_ids_of(db_session, fixture)
+    table_1, table_2 = await _catalogue_table_ids(client, tournament_id)
     await _go_live_directly(db_session, tournament_id)
     url = _placement_url(tournament_id, str(fixture.id))
     await client.patch(
-        url, json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"}
+        url, json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"}
     )
     await client.patch(
-        url, json={"table_id": "t2", "scheduled_start": "2026-06-13T10:30:00"}
+        url, json={"table_id": table_2, "scheduled_start": "2026-06-13T10:30:00"}
     )
 
     response = await client.patch(url, json={"table_id": None, "scheduled_start": None})
@@ -8786,9 +8869,10 @@ async def test_clearing_a_pre_live_placement_is_silent(
     nobody hears about a promise that was never made."""
     client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
     url = _placement_url(tournament_id, str(fixture.id))
     await client.patch(
-        url, json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"}
+        url, json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"}
     )
 
     response = await client.patch(url, json={"table_id": None, "scheduled_start": None})
@@ -8811,9 +8895,10 @@ async def test_clearing_a_never_notified_placement_is_silent_even_live(
     nothing (a cancellation corrects a promise; this fixture never carried one)."""
     client, _ = authed_client
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
     url = _placement_url(tournament_id, str(fixture.id))
     await client.patch(
-        url, json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"}
+        url, json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"}
     )
     await _go_live_directly(db_session, tournament_id)
 
@@ -8840,17 +8925,18 @@ async def test_a_tbd_side_fixture_placement_saves_without_pinning(
     tournament_id, _event_id, fixture = await _drawn_fixture(client, db_session)
     fixture.entry_b_id = None  # a TBD side — representable by design (ADR-0786)
     await db_session.commit()
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
     await _go_live_directly(db_session, tournament_id)
     await _clear_solve_ledger(db_session)
 
     response = await client.patch(
         _placement_url(tournament_id, str(fixture.id)),
-        json={"table_id": "t1", "scheduled_start": "2026-06-13T10:00:00"},
+        json={"table_id": table_1, "scheduled_start": "2026-06-13T10:00:00"},
     )
 
     assert response.status_code == 200, response.text
     body = response.json()
-    assert body["table_id"] == "t1"
+    assert body["table_id"] == table_1
     assert _is_venue_instant(body["scheduled_start"], "2026-06-13T10:00:00")
     assert body["pinned_at"] is None
     assert body["call_notified_count"] == 0

--- a/e2e/page-objects/tournament-detail-page/tables-tab.page.ts
+++ b/e2e/page-objects/tournament-detail-page/tables-tab.page.ts
@@ -1,0 +1,76 @@
+import { Locator, Page } from '@playwright/test'
+
+/**
+ * The tournament detail page's **Tables tab** — the venue catalogue (ADR 20260801,
+ * "a placement names a real table, and only that is an invariant"), and the one
+ * refusal editing it can meet.
+ *
+ * Composed by `TournamentDetailPage.openTables()`, the child-composition variant
+ * `dashboard.page.ts` established. Raw selectors stay here; specs read intent-named
+ * locators.
+ *
+ * The vocabulary deliberately mirrors the web-client suite's own tables-tab page
+ * objects (`tables-tab.page.tsx`, and the Tables section of
+ * `web-client/e2e/page-objects/tournaments/tournament-detail.page.ts`) — same nouns for
+ * the same controls, so a reader moving between the three suites is reading one surface
+ * described three times rather than three parallel vocabularies.
+ */
+export class TablesTabPage {
+  constructor(private readonly page: Page) {}
+
+  /** The tab's root. A spec awaits it before asserting on cards: every "the catalogue
+   * shows X" assertion passes vacuously against a tab that has not rendered. */
+  get root(): Locator {
+    return this.page.getByTestId('tables-tab')
+  }
+
+  /** One table's card, by the label the director reads.
+   *
+   * Filtered by an **exact** text match on the label rather than `hasText`'s substring
+   * match: a card also carries its court line and any using-event badges, and "Table 1"
+   * is a substring of "Table 10" — so a substring filter can resolve two cards and quietly
+   * turn a "the table is gone" assertion into an assertion about its neighbour. */
+  tableCard(label: string): Locator {
+    return this.root
+      .locator('[data-slot=card]')
+      .filter({ has: this.page.getByText(label, { exact: true }) })
+  }
+
+  /** One table's Remove button, by label. Owner-only — a viewer is offered none. */
+  removeTableButton(label: string): Locator {
+    return this.page.getByRole('button', { name: `Remove ${label}` })
+  }
+
+  // ----- the in-use refusal, asked back as a question -------------------------
+
+  /** The confirm an in-use removal's **409** opens. Not scoped to `root`: Radix portals
+   * an `AlertDialog` to the body, so a tab-scoped query finds nothing whether it opened
+   * or not. */
+  get removeTableConfirm(): Locator {
+    return this.page.getByTestId('confirm-remove-table')
+  }
+
+  /** The confirm's body — the **server's own sentence**, verbatim. The whole reason the
+   * dialog exists: it names the tables by label, counts the matches placed at them and
+   * states both ways out, none of which a client can reconstruct. */
+  get removeTableConfirmDetail(): Locator {
+    return this.page.getByTestId('confirm-remove-table-detail')
+  }
+
+  /** "Remove and unplace" — re-sends the identical edit plus the opt-in. */
+  get removeTableConfirmButton(): Locator {
+    return this.page.getByTestId('confirm-remove-table-confirm')
+  }
+
+  /** "Keep the table" — cancelling sends nothing at all. */
+  get removeTableCancelButton(): Locator {
+    return this.page.getByTestId('confirm-remove-table-cancel')
+  }
+
+  /** The tab's inline failure banner — every failure that is NOT the in-use refusal, in
+   * the client's own words. Asserted *absent* by a spec whose refusal must have been
+   * classified as a question rather than reported as an error. */
+  get tablesError(): Locator {
+    return this.page.getByTestId('tables-error')
+  }
+}

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -2,6 +2,7 @@ import { Locator, Page } from '@playwright/test'
 
 import { EventEditorPage } from './tournament-detail-page/event-editor.page'
 import { ScheduleTabPage } from './tournament-detail-page/schedule-tab.page'
+import { TablesTabPage } from './tournament-detail-page/tables-tab.page'
 
 /**
  * The tournament detail page (`/tournaments/$tournamentId`) — scoped to the
@@ -41,6 +42,17 @@ export class TournamentDetailPage {
   async openSchedule(): Promise<ScheduleTabPage> {
     await this.page.getByRole('tab', { name: 'Schedule' }).click()
     return new ScheduleTabPage(this.page)
+  }
+
+  /** Switch to the **Tables** tab (the venue catalogue) and return its page object.
+   *
+   * Matched by a `^Tables` regex, not by an exact name: the trigger carries a count
+   * badge, so its accessible name is "Tables 2", and the number is the very thing a
+   * removal changes — an exact-name locator would stop resolving the tab the moment the
+   * spec succeeded at what it came to do. */
+  async openTables(): Promise<TablesTabPage> {
+    await this.page.getByRole('tab', { name: /^Tables/ }).click()
+    return new TablesTabPage(this.page)
   }
 
   // ----- the hero (header) --------------------------------------------------

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -24,9 +24,12 @@ import { findUserId, mintGuest, type Guest } from './match-api'
 const API = '/api/v1'
 const CSRF_HEADER = 'x-csrf-token'
 
-/** The id of the one table seeded into the tournament's catalogue, referenced by
- * the event's single pool. A round-robin pool wants at least one table. */
-const TABLE_ID = 't1'
+/** The **label** of the one table seeded into the tournament's catalogue, reserved by
+ * the event's single pool. A round-robin pool wants at least one table.
+ *
+ * A label, not an id, because the id is no longer the seed's to choose (see
+ * `TableSpec`). */
+const TABLE_LABEL = 'Table 1'
 /** The id of the event's single pool — a round-robin needs ≥1 pool, and two
  * entrants in one pool is exactly one fixture: the minimal playable draw. */
 const POOL_ID = 'pool-a'
@@ -62,8 +65,34 @@ function tomorrowUtc(): string {
   return new Date(Date.now() + DAY_MS).toISOString().slice(0, 10)
 }
 
-/** One table of the tournament's catalogue (`TournamentTable` on the wire). */
+/** One table of the tournament's catalogue, as a client **sends** it
+ * (`TournamentTableWrite` on the wire): what it is called and where it stands, and
+ * deliberately **no id**.
+ *
+ * A table is a row now, and its id is minted by the database (ADR 20260801, "a
+ * placement names a real table, and only that is an invariant"). The write shape has no
+ * `id` field at all and is `extra="forbid"`, so a seed that supplies its own `t1` is a
+ * **422 naming the field**, not a stack that agrees to call the table `t1` — which is
+ * exactly how this helper broke when the catalogue became a real table.
+ *
+ * So nothing here names a table by id. A pool cites the tables it reserves by
+ * **label** (`PoolSpec.tableLabels`), and anything that needs the real id reads it back
+ * off the create response (`StoredTable`, returned by `createTournament` and
+ * `seedTournament`). The label is also the vocabulary the server's own in-use refusal
+ * speaks, so a spec asserting on that sentence and a spec seeding the catalogue name
+ * the same table the same way. */
 export interface TableSpec {
+  readonly label: string
+  readonly court: string
+}
+
+/** One table as the API **reads it back** (`TournamentTable` on the wire): what was
+ * sent, plus the uuid the server minted for it.
+ *
+ * The only place a spec can learn a table id — and the id everything downstream is
+ * keyed by: a fixture's `table_id`, the schedule board's table sections, a pool's
+ * `table_ids`. */
+export interface StoredTable {
   readonly id: string
   readonly label: string
   readonly court: string
@@ -79,14 +108,21 @@ export interface TableSpec {
  * order — and the thing `tournament-pool-order.spec.ts` seeds deliberately at odds with
  * the ids' lexicographic order.
  *
- * `tableIds` is optional because the single-pool default reserves the whole catalogue; a
- * multi-pool seed usually wants a table each, so ten pools raise no double-booking
- * warning over one shared table. */
+ * `tableLabels` is optional because the single-pool default reserves the whole catalogue;
+ * a multi-pool seed usually wants a table each, so ten pools raise no double-booking
+ * warning over one shared table.
+ *
+ * Tables are cited by **label**, not by id: the ids are minted by the server (see
+ * `TableSpec`), so at the moment a caller writes down its pools there is no id to name.
+ * `seedTournament` resolves each label against the catalogue it just created, and throws
+ * on one that names no seeded table rather than sending a reservation the solver would
+ * quietly intersect away to nothing. */
 export interface PoolSpec {
   readonly id: string
   readonly name: string
-  /** The catalogue tables this pool reserves. Omitted = **every** seeded table. */
-  readonly tableIds?: ReadonlyArray<string>
+  /** The catalogue tables this pool reserves, **by label**. Omitted = **every** seeded
+   * table. */
+  readonly tableLabels?: ReadonlyArray<string>
 }
 
 /** A venue's six free-text address components (`AddressInput` on the wire). The
@@ -168,9 +204,16 @@ export interface SeedTournamentOptions {
   readonly address?: AddressInput | null
 }
 
-/** A seeded tournament and the ids a spec needs to address it and its event. */
-export interface SeededTournament {
+/** A created tournament and the catalogue the server minted for it. */
+export interface CreatedTournament {
   readonly tournamentId: string
+  /** The seeded tables **as stored**, in the order they were sent — each now carrying
+   * the uuid the server minted. The only handle a caller has on a table id. */
+  readonly tables: ReadonlyArray<StoredTable>
+}
+
+/** A seeded tournament and the ids a spec needs to address it and its event. */
+export interface SeededTournament extends CreatedTournament {
   readonly eventId: string
   /** The event's **first** pool id — its only one under the default seed — so a spec
    * can scope its standings assertions. */
@@ -198,8 +241,8 @@ export async function createTournament(
   director: Guest,
   name: string,
   options: SeedTournamentOptions = {},
-): Promise<string> {
-  const tables = options.tables ?? [{ id: TABLE_ID, label: 'Table 1', court: 'A' }]
+): Promise<CreatedTournament> {
+  const tables = options.tables ?? [{ label: TABLE_LABEL, court: 'A' }]
   // `??` would be wrong here: `null` is a MEANINGFUL value for this option ("no
   // venue"), and `null ?? default` would silently give it a venue. Only an
   // *omitted* option falls back to the default address.
@@ -225,14 +268,26 @@ export async function createTournament(
       // two routes distinct is deliberate: the browser's explicit `null` is
       // covered through the UI in `tournament-no-venue.spec.ts`.
       ...(address === null ? {} : { address }),
-      // A pool references these tables by id, so the catalogue must carry them.
-      table_catalogue: tables,
+      // A pool references these tables by id, so the catalogue must carry them —
+      // sent WITHOUT ids (see `TableSpec`), and read back below with the ones the
+      // server minted.
+      table_catalogue: tables.map((table) => ({
+        label: table.label,
+        court: table.court,
+      })),
     },
   })
   if (res.status() !== 201) {
     throw new Error(`create tournament failed: ${res.status()} ${await res.text()}`)
   }
-  return ((await res.json()) as { id: string }).id
+  // `TournamentRead` carries the stored catalogue, in the order it was sent — so the
+  // minted ids come back on the create itself and no second read is needed to learn
+  // them.
+  const created = (await res.json()) as {
+    id: string
+    table_catalogue: ReadonlyArray<StoredTable>
+  }
+  return { tournamentId: created.id, tables: created.table_catalogue }
 }
 
 /**
@@ -261,15 +316,18 @@ export async function seedTournament(
     start: '09:00',
     end: '17:00',
   }
-  const tables = options.tables ?? [{ id: TABLE_ID, label: 'Table 1', court: 'A' }]
+  const tables = options.tables ?? [{ label: TABLE_LABEL, court: 'A' }]
   const pools = options.pools ?? [{ id: POOL_ID, name: 'Pool A' }]
   // Resolve the catalogue HERE and pass it down, rather than letting
-  // `createTournament` default it again: the pool below references these tables
-  // by id, so the two must be the same list by construction.
-  const tournamentId = await createTournament(director, name, {
-    ...options,
-    tables,
-  })
+  // `createTournament` default it again: the pools below reserve tables out of the
+  // catalogue it creates, so the two must be the same list by construction. What comes
+  // back (`storedTables`) is that same list carrying the ids the server minted — the
+  // only form in which a pool can name a table on the wire.
+  const { tournamentId, tables: storedTables } = await createTournament(
+    director,
+    name,
+    { ...options, tables },
+  )
 
   const eventRes = await director.ctx.post(
     `${API}/tournaments/${tournamentId}/events`,
@@ -303,7 +361,11 @@ export async function seedTournament(
           id: pool.id,
           name: pool.name,
           slot,
-          table_ids: [...(pool.tableIds ?? tables.map((table) => table.id))],
+          // Labels resolved to the ids the server just minted — a pool's `table_ids`
+          // are catalogue ids on the wire, and a stale one is silently intersected
+          // away by the solver ("a stale ref is a table the pool cannot use"), so a
+          // typo would surface as an inexplicably infeasible day rather than an error.
+          table_ids: tableIdsFor(storedTables, pool.tableLabels),
         })),
       },
     },
@@ -317,10 +379,35 @@ export async function seedTournament(
 
   return {
     tournamentId,
+    tables: storedTables,
     eventId,
     poolId: pools[0].id,
     poolIds: pools.map((pool) => pool.id),
   }
+}
+
+/** Resolve a pool's reserved-table **labels** to the catalogue ids the wire wants;
+ * omitted labels reserve the whole catalogue (the single-pool default).
+ *
+ * Throws on a label the catalogue does not hold. That is not defensiveness for its own
+ * sake: an unresolvable label sent as-is would be a table the pool "reserves" and the
+ * solver cannot see, so the seed would look fine and the day would come back
+ * infeasible three screens away. */
+function tableIdsFor(
+  tables: ReadonlyArray<StoredTable>,
+  labels: ReadonlyArray<string> | undefined,
+): string[] {
+  if (labels === undefined) return tables.map((table) => table.id)
+  return labels.map((label) => {
+    const table = tables.find((candidate) => candidate.label === label)
+    if (!table) {
+      const known = tables.map((t) => t.label).join(', ') || '(none)'
+      throw new Error(
+        `pool reserves "${label}", which the seeded catalogue does not hold — has: ${known}`,
+      )
+    }
+    return table.id
+  })
 }
 
 /**
@@ -668,19 +755,25 @@ function naiveNow(): string {
  * `scheduled_start` defaults to NOW as a naive wall-clock; the placement is *soft*
  * (an out-of-window time is a flag on read, not a rejection), so a near-now time
  * against a far-future pool window still calls the match.
+ *
+ * `tableId` is a **required argument with no default**, and that is the shape of the
+ * ADR rather than a style choice: `tournament_fixtures.table_id` is a real foreign key
+ * now, so a placement names a table of this tournament's catalogue or it is a 422. This
+ * helper has no id it could invent — take one off the seed's `tables`.
  */
 export async function callFixture(
   director: Guest,
   tournamentId: string,
   fixtureId: string,
-  options: { readonly tableId?: string; readonly scheduledStart?: string } = {},
+  tableId: string,
+  options: { readonly scheduledStart?: string } = {},
 ): Promise<void> {
   const res = await director.ctx.patch(
     `${API}/tournaments/${tournamentId}/fixtures/${fixtureId}/placement`,
     {
       headers: { [CSRF_HEADER]: director.csrf },
       data: {
-        table_id: options.tableId ?? TABLE_ID,
+        table_id: tableId,
         scheduled_start: options.scheduledStart ?? naiveNow(),
       },
     },
@@ -688,6 +781,27 @@ export async function callFixture(
   if (res.status() !== 200) {
     throw new Error(`call fixture failed: ${res.status()} ${await res.text()}`)
   }
+}
+
+/**
+ * Read a tournament's table catalogue back **as stored** (`GET /v1/tournaments/{id}`),
+ * in the catalogue's own order.
+ *
+ * The seam a removal is judged at: `createTournament` says what the catalogue was at
+ * birth, and this says what it is now — which is how "the refusal wrote nothing" and
+ * "the confirm removed exactly that one table" become facts read off the server rather
+ * than inferred from a card that left the screen.
+ */
+export async function getTableCatalogue(
+  viewer: Guest,
+  tournamentId: string,
+): Promise<ReadonlyArray<StoredTable>> {
+  const res = await viewer.ctx.get(`${API}/tournaments/${tournamentId}`)
+  if (!res.ok()) {
+    throw new Error(`load tournament failed: ${res.status()} ${await res.text()}`)
+  }
+  return ((await res.json()) as { table_catalogue: ReadonlyArray<StoredTable> })
+    .table_catalogue
 }
 
 /**

--- a/e2e/tests/schedule-preview.spec.ts
+++ b/e2e/tests/schedule-preview.spec.ts
@@ -18,8 +18,8 @@ const EXPECTED_MATCHES = 6
 /** A two-table venue so the round-robin's rounds run in parallel and the day
  * fits comfortably. */
 const TABLES = [
-  { id: 't1', label: 'Table 1', court: 'A' },
-  { id: 't2', label: 'Table 2', court: 'A' },
+  { label: 'Table 1', court: 'A' },
+  { label: 'Table 2', court: 'A' },
 ]
 
 /**

--- a/e2e/tests/tournament-lifecycle.spec.ts
+++ b/e2e/tests/tournament-lifecycle.spec.ts
@@ -71,7 +71,10 @@ test.describe('Tournament — round-robin lifecycle', () => {
     // The inert scaffolding, over the API, as the director (so it comes back
     // `can_edit: true` and the browser sees the owner controls).
     const name = `RR ${faker.string.alphanumeric(8)}`
-    const { tournamentId, eventId, poolId } = await seedTournament(director, name)
+    const { tournamentId, eventId, poolId, tables } = await seedTournament(
+      director,
+      name,
+    )
 
     // The second entrant — a wholly separate guest, searchable as an opponent.
     const opponent = await mintGuest(baseURL!)
@@ -119,7 +122,7 @@ test.describe('Tournament — round-robin lifecycle', () => {
     // `pending → in_progress` and makes it scorable (#1073). We need the fixture
     // id, not just the match id, to address its placement.
     const fixture = await firstFixture(director, tournamentId, eventId)
-    await callFixture(director, tournamentId, fixture.id)
+    await callFixture(director, tournamentId, fixture.id, tables[0].id)
     await detail.reload(tournamentId)
     // Now the fixture reads live, and its deep-link is still there to follow.
     await expect(detail.fixtureMatchStatus(eventId)).toHaveText('In progress')

--- a/e2e/tests/tournament-pool-order.spec.ts
+++ b/e2e/tests/tournament-pool-order.spec.ts
@@ -39,7 +39,7 @@ const ID_SUFFIX = 'mkq1x'
  * warns about, and this spec's subject is the order, not the warning. */
 const TABLES: ReadonlyArray<TableSpec> = Array.from(
   { length: POOL_COUNT },
-  (_, i) => ({ id: `t${i + 1}`, label: `Table ${i + 1}`, court: 'A' }),
+  (_, i) => ({ label: `Table ${i + 1}`, court: 'A' }),
 )
 
 /**
@@ -57,7 +57,7 @@ const POOLS: ReadonlyArray<PoolSpec> = Array.from(
   (_, i) => ({
     id: `p-${i + 1}-${ID_SUFFIX}`,
     name: `Pool ${i + 1}`,
-    tableIds: [`t${i + 1}`],
+    tableLabels: [`Table ${i + 1}`],
   }),
 )
 

--- a/e2e/tests/tournament-rr-then-ko.spec.ts
+++ b/e2e/tests/tournament-rr-then-ko.spec.ts
@@ -44,9 +44,9 @@ const ROUND_ONE_FIXTURES = 2
 /** Three tables, one per pool, so the seeded catalogue can furnish the pools the
  * director adds in the editor. */
 const TABLES: ReadonlyArray<TableSpec> = [
-  { id: 't1', label: 'Table 1', court: 'A' },
-  { id: 't2', label: 'Table 2', court: 'B' },
-  { id: 't3', label: 'Table 3', court: 'C' },
+  { label: 'Table 1', court: 'A' },
+  { label: 'Table 2', court: 'B' },
+  { label: 'Table 3', court: 'C' },
 ]
 
 /**
@@ -115,7 +115,9 @@ test.describe('Tournament — rr-then-ko draw', () => {
 
     // ----- the shell, over the API: a tournament and its tables, no events ----
     const name = `RRKO ${faker.string.alphanumeric(8)}`
-    const tournamentId = await createTournament(director, name, { tables: TABLES })
+    const { tournamentId } = await createTournament(director, name, {
+      tables: TABLES,
+    })
 
     const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
     // `toContainText`, not `toHaveText`: the hero sets its own full stop after the name.

--- a/e2e/tests/tournament-solver-schedule.spec.ts
+++ b/e2e/tests/tournament-solver-schedule.spec.ts
@@ -23,10 +23,11 @@ import {
 const EVENT_NAME = 'Open Singles'
 
 /** The two-table venue this spec seeds; labels are what the call notification
- * names, ids are what the board's table sections are keyed by. */
+ * names, and the ids the board's table sections are keyed by are minted by the server
+ * (ADR 20260801) — read back off the seed as `tables`, never written down here. */
 const TABLES = [
-  { id: 't1', label: 'Table 1', court: 'A' },
-  { id: 't2', label: 'Table 2', court: 'A' },
+  { label: 'Table 1', court: 'A' },
+  { label: 'Table 2', court: 'A' },
 ]
 
 /** The `HH:MM` of a naive wire timestamp (`YYYY-MM-DDTHH:MM:SS`) — the same
@@ -101,7 +102,7 @@ test.describe('Tournament — solver schedule', () => {
       end: '23:55',
     }
     const name = `Solve ${faker.string.alphanumeric(8)}`
-    const { tournamentId, eventId } = await seedTournament(director, name, {
+    const { tournamentId, eventId, tables } = await seedTournament(director, name, {
       slot,
       tables: TABLES,
     })
@@ -190,7 +191,7 @@ test.describe('Tournament — solver schedule', () => {
     expect(tracked.table_id).not.toBeNull()
     expect(tracked.scheduled_start).not.toBeNull()
     expect(tracked.call_notified_count).toBeGreaterThan(0)
-    const trackedTable = TABLES.find((t) => t.id === tracked.table_id)!
+    const trackedTable = tables.find((t) => t.id === tracked.table_id)!
     const trackedTime = tracked.scheduled_start!.local_label
 
     // Record the called fixture's placement on the Gantt board: its bar exists

--- a/e2e/tests/tournament-table-removal.spec.ts
+++ b/e2e/tests/tournament-table-removal.spec.ts
@@ -1,0 +1,261 @@
+import { test, expect, type Page, type Response } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+
+import { TournamentDetailPage } from '../page-objects/tournament-detail.page'
+import { guestFromContext } from '../support/match-api'
+import { grantBetaTester } from '../support/rbac-grant'
+import {
+  callFixture,
+  cutDraw,
+  firstFixture,
+  getTableCatalogue,
+  seedEntrants,
+  seedTournament,
+  transitionTournament,
+  type PoolSpec,
+  type TableSpec,
+} from '../support/tournament-api'
+
+/** The table the director tries to remove — the one a match is placed at. */
+const DOOMED = 'Table 1'
+/** A second table, in the catalogue but reserved by no pool. It is the witness that the
+ * confirmed removal removed **that** table and not the catalogue: a one-table venue
+ * could not tell "the diff removed the table I cited" from "the write replaced the
+ * catalogue wholesale". */
+const SPARE = 'Table 2'
+
+/** A two-table venue, sent with **no ids** — the server mints them (ADR 20260801). */
+const TABLES: ReadonlyArray<TableSpec> = [
+  { label: DOOMED, court: 'A' },
+  { label: SPARE, court: 'B' },
+]
+
+/**
+ * One pool, reserving **only the doomed table**.
+ *
+ * That is not scene-setting, it is what makes the last assertion of this spec a fact
+ * rather than a race. A catalogue edit that changes the *set* of tables on a tournament
+ * with a cut draw enqueues a `settings_changed` schedule solve (`tournament_edit`), and
+ * this stack runs a real solver on a real worker — so between the confirmed removal and
+ * the read that checks the fixture came back unplaced, a solve could otherwise land and
+ * re-place it, and the spec would flake on correct behaviour.
+ *
+ * A pool's `table_ids` are intersected with the catalogue when the solver's inputs are
+ * loaded ("a stale ref is a table the pool cannot use"), so once `Table 1` is gone this
+ * pool has **zero** usable tables and its one fixture has nowhere to go: the solve is
+ * honestly infeasible and applies nothing. `Table 2` stays in the catalogue as a table
+ * no pool reserves — a spare, which is a perfectly ordinary thing for a venue to have.
+ */
+const POOLS: ReadonlyArray<PoolSpec> = [
+  { id: 'pool-a', name: 'Pool A', tableLabels: [DOOMED] },
+]
+
+/** A uuid — what a table id is now that the catalogue is a real table with a
+ * `gen_random_uuid()` primary key. Asserted on the seed so that "the label is not the
+ * id" is established before the spec starts leaning on the difference. */
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * **Removing a table that a match is placed at is refused — and the match keeps its
+ * placement** (#1226, ADR 20260801 "a placement names a real table, and only that is an
+ * invariant").
+ *
+ * A director opens the Tables tab of a tournament whose one fixture is placed at
+ * `Table 1`, and clicks Remove on it. The server answers a **409** whose sentence names
+ * the table by label and states both ways out; the tab renders that sentence verbatim in
+ * a confirm; and — the half worth having end to end — **the fixture is still placed**.
+ * Confirming re-sends the same edit with the opt-in, the removal goes through, and the
+ * fixture comes back with no table, no time and no pin.
+ *
+ * ## Why this claim needs the composed stack
+ *
+ * The api tests prove the refusal in isolation and the web-client's own e2e suite proves
+ * the dialog against a `page.route` stub that *implements* the 409. Neither can say the
+ * two halves meet: the sentence in the dialog is composed by
+ * `_tables_in_use_detail` on the server and shown verbatim by the client, so a stub that
+ * words it differently — or a client that reworded it, or a `saveFailure`
+ * classification that stopped landing in the `refused` arm — is invisible to both. Here
+ * the dialog's text is compared against **the body of the very response that opened
+ * it**, read off the wire. Nothing in this spec writes that sentence down; if the two
+ * ever diverge, this is the only suite that can notice.
+ *
+ * The same goes for "nothing was written". A stub can be made to answer 409 and mutate
+ * nothing by construction. Only a real API can be *wrong* about it — the refusal is
+ * raised after the diff has been computed and before the catalogue collection is
+ * reassigned — so the placement is read back over the API on **both** sides of the
+ * refusal, from the same rows the browser is looking at.
+ *
+ * ## Seed vs UI split
+ *
+ * Over the API (`support/tournament-api.ts`): the tournament and its two-table
+ * catalogue, the event, the publish, two director-entered entrants, the draw, and the
+ * placement — a placement drag has no simple UI surface to drive, and none of it is the
+ * subject. In the browser: the Tables tab, the Remove click, the confirm, and the cards
+ * on either side.
+ *
+ * The tournament is left **published**, never live. Going live would materialize the
+ * fixture into a real match and auto-enqueue a solve that places every fixture for us,
+ * which buys no part of this claim and costs the determinism the pool above was shaped
+ * to get. What the server counts and calls "matches placed at" a table is the fixture's
+ * placement, which is exactly what is seeded here.
+ *
+ * ## RBAC
+ *
+ * As in `tournament-lifecycle.spec.ts`: a minted user holds only the permissionless
+ * default role, so `grantBetaTester` hands the director the tournament bundle over the
+ * stack's own `postgres` container before any tournament write. Skipped against an
+ * external `E2E_BASE_URL` stack, where the caller owns provisioning.
+ */
+test.describe('Tournament — removing a table that is in use', () => {
+  test('is refused with the server’s sentence and keeps the placement, until the director confirms', async ({
+    page,
+    baseURL,
+  }) => {
+    // Two minted guests, a real draw cut and two round-trips through the browser —
+    // comfortably past the 30s default, and every wait below is bounded.
+    test.setTimeout(180_000)
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    // The director IS the browser's own session (`page.request` shares its cookie jar),
+    // so the page sees the owner-only Remove buttons.
+    const director = await guestFromContext(page.request)
+    grantBetaTester(director.username)
+
+    // ----- seed: a two-table venue, one pool over the doomed table ------------
+    const name = `Tables ${faker.string.alphanumeric(8)}`
+    const { tournamentId, eventId, tables } = await seedTournament(director, name, {
+      tables: TABLES,
+      pools: POOLS,
+    })
+    const doomed = tables.find((table) => table.label === DOOMED)!
+    const spare = tables.find((table) => table.label === SPARE)!
+    // The ids are the SERVER's — the seed sent none. Everything below distinguishes the
+    // label (what the refusal speaks) from the id (what the diff keys on), so establish
+    // here that they are genuinely different things.
+    expect(doomed.id).toMatch(UUID)
+    expect(spare.id).toMatch(UUID)
+
+    // ----- a field, a draw, and a fixture placed at the doomed table ----------
+    await transitionTournament(director, tournamentId, 'published')
+    const entrants = await seedEntrants(director, baseURL!, tournamentId, eventId, 2)
+    await cutDraw(director, tournamentId, eventId)
+    const fixture = await firstFixture(director, tournamentId, eventId)
+    await callFixture(director, tournamentId, fixture.id, doomed.id)
+
+    const placed = await firstFixture(director, tournamentId, eventId)
+    expect(placed.table_id, 'the seeded fixture must be placed at the doomed table').toBe(
+      doomed.id,
+    )
+    expect(placed.scheduled_start).not.toBeNull()
+
+    // ----- the browser: the Tables tab, with both tables on it ----------------
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    // `toContainText`, not `toHaveText`: the hero sets its own full stop after the name.
+    // The long timeout is for the FIRST navigation only, and it is about the stack rather
+    // than the app — the composed web-client is a Vite **dev** server, so the first
+    // request for a route pays for transforming it on demand.
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+    const tablesTab = await detail.openTables()
+    await expect(tablesTab.root).toBeVisible()
+    await expect(tablesTab.tableCard(DOOMED)).toBeVisible()
+    await expect(tablesTab.tableCard(SPARE)).toBeVisible()
+
+    // ----- Remove the doomed table: the server refuses -----------------------
+    const refusalSent = catalogueWrite(page, tournamentId)
+    await tablesTab.removeTableButton(DOOMED).click()
+    const refusal = await refusalSent
+    // Asserted on the RESPONSE, before anything about the dialog. A red here reads
+    // "Expected: 409, Received: 200" and names the reason outright; the same broken
+    // guard seen only through the dialog would red as an undiscriminated "waiting for
+    // locator" timeout that cannot tell a permitted removal from a dialog that never
+    // rendered.
+    expect(
+      refusal.status(),
+      'removing a table with a match placed at it must be refused',
+    ).toBe(409)
+    const sentence = ((await refusal.json()) as { detail: string }).detail
+
+    // The refused write did NOT volunteer the opt-in — so the 409 is the server's
+    // judgement on a plain removal, not an answer to a request that asked to be refused.
+    expect(refusal.request().postDataJSON()).not.toHaveProperty(
+      'unplace_fixtures_on_removed_tables',
+    )
+
+    // ----- the dialog carries the server's own sentence, verbatim ------------
+    await expect(tablesTab.removeTableConfirm).toBeVisible()
+    await expect(tablesTab.removeTableConfirmDetail).toHaveText(sentence)
+    // Named by LABEL and never by id: the id is what the diff compared, but "table
+    // 4f9c-… cannot be removed" tells a director looking at a page of named tables
+    // nothing to act on.
+    expect(sentence).toContain(DOOMED)
+    expect(sentence).not.toContain(doomed.id)
+    // The refusal is a question, not an error — it must not also land in the inline
+    // failure banner the client words itself.
+    await expect(tablesTab.tablesError).toHaveCount(0)
+
+    // ----- …and NOTHING was written -----------------------------------------
+    // The load-bearing half. "A dialog appeared" is satisfied by a server that refused
+    // *after* unplacing; these two reads are what say the tournament is byte-identical.
+    expect(
+      (await getTableCatalogue(director, tournamentId)).map((t) => t.id),
+      'a refused catalogue edit must leave the catalogue untouched',
+    ).toEqual([doomed.id, spare.id])
+    const kept = await firstFixture(director, tournamentId, eventId)
+    expect(kept.table_id, 'the refused removal must leave the match placed').toBe(
+      doomed.id,
+    )
+    expect(kept.scheduled_start?.instant).toBe(placed.scheduled_start?.instant)
+    expect(kept.pinned_at?.instant).toBe(placed.pinned_at?.instant)
+
+    // ----- confirm: the same edit, plus the opt-in ---------------------------
+    const confirmSent = catalogueWrite(page, tournamentId)
+    await tablesTab.removeTableConfirmButton.click()
+    const confirmed = await confirmSent
+    expect(
+      confirmed.status(),
+      `the confirmed removal was refused: ${await confirmed.text()}`,
+    ).toBe(200)
+    expect(
+      confirmed.request().postDataJSON().unplace_fixtures_on_removed_tables,
+      'only an explicit true opts in to unplacing',
+    ).toBe(true)
+
+    // The card goes, the spare stays, and no failure is reported.
+    await expect(tablesTab.removeTableConfirm).toHaveCount(0)
+    await expect(tablesTab.tableCard(DOOMED)).toHaveCount(0)
+    await expect(tablesTab.tableCard(SPARE)).toBeVisible()
+    await expect(tablesTab.tablesError).toHaveCount(0)
+
+    // ----- and the fixture comes back unplaced ------------------------------
+    expect(
+      (await getTableCatalogue(director, tournamentId)).map((t) => t.id),
+      'the confirmed removal must take the cited table and only it',
+    ).toEqual([spare.id])
+    const unplaced = await firstFixture(director, tournamentId, eventId)
+    // All three placement columns go together: a start with no table is a bar on a
+    // schedule with nowhere to be, and a `pinned_at` is a promise about a table.
+    expect(unplaced.table_id).toBeNull()
+    expect(unplaced.scheduled_start).toBeNull()
+    expect(unplaced.pinned_at).toBeNull()
+
+    await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
+  })
+})
+
+/**
+ * The next **catalogue write** the page makes — the `PATCH /v1/tournaments/{id}` the
+ * Tables tab sends, awaited from before the click that causes it.
+ *
+ * Taken off the wire rather than inferred from the screen because the two things this
+ * spec most needs are only there: the 409's status (a discriminating red, where a dialog
+ * that never opened is only a timeout) and its `detail`, which is the sentence the
+ * dialog must be showing verbatim.
+ */
+function catalogueWrite(page: Page, tournamentId: string): Promise<Response> {
+  return page.waitForResponse(
+    (response) =>
+      response.request().method() === 'PATCH' &&
+      response.url().endsWith(`/tournaments/${tournamentId}`),
+  )
+}

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -582,6 +582,34 @@ internal protocol APIProtocol: Sendable {
     func getTournamentV1TournamentsTournamentIdGet(_ input: Operations.GetTournamentV1TournamentsTournamentIdGet.Input) async throws -> Operations.GetTournamentV1TournamentsTournamentIdGet.Output
     /// Update Tournament
     ///
+    /// Edit a tournament you own. Absent fields are left alone; a supplied field
+    /// replaces the current value. Owner-only.
+    ///
+    /// **`table_catalogue` is an id-keyed diff, sent in full and in order.** Each entry
+    /// either carries the `id` of a table this tournament already has — keeping that table,
+    /// with the `label`, `court` and position this payload gives it — or omits the `id` to
+    /// add a new table, whose id the server mints. **A table no entry names is removed.**
+    /// Send back the catalogue you read, edited: the ids came from the read, and naming an
+    /// id this tournament does not have is a `422` on that entry.
+    ///
+    /// **Removing a table that matches are placed at is a `409` naming the table**, and
+    /// nothing is written. To go through with it, repeat the request with
+    /// `unplace_fixtures_on_removed_tables: true`: the table is removed and those matches
+    /// are unplaced — table, predicted start and call all cleared — which is a thing worth
+    /// saying on purpose rather than a silent side effect of editing the venue. Removing a
+    /// table that only a *pool* reserves needs no confirmation and produces no refusal; the
+    /// pool simply reserves one fewer.
+    ///
+    /// **`address` has three cases and the value alone cannot tell them apart.** Omit it to
+    /// leave the venue and its coordinates untouched; send a real address to move the venue
+    /// (re-geocoded only when its text actually changed, a `409` when it cannot be
+    /// resolved); send `null` — or an object whose six components are all blank — to remove
+    /// the venue entirely.
+    ///
+    /// `league_id` may only be changed while the tournament is a `draft`; once it is
+    /// published the ladder is settled (`409`). `status` is not editable here — the
+    /// lifecycle moves only across `POST /v1/tournaments/{id}/transitions`.
+    ///
     /// - Remark: HTTP `PATCH /v1/tournaments/{tournament_id}`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/patch(update_tournament_v1_tournaments__tournament_id__patch)`.
     func updateTournamentV1TournamentsTournamentIdPatch(_ input: Operations.UpdateTournamentV1TournamentsTournamentIdPatch.Input) async throws -> Operations.UpdateTournamentV1TournamentsTournamentIdPatch.Output
@@ -801,8 +829,8 @@ internal protocol APIProtocol: Sendable {
     /// Set (or clear) a fixture's **placement** — its table and its predicted start
     /// (ADR-0790) — and answer with the updated fixture.
     ///
-    /// The body is the placement in full: `table_id` (a string ref into the tournament's
-    /// `table_catalogue`) and `scheduled_start` (a **naive** wall-clock time, in the
+    /// The body is the placement in full: `table_id` (the id of one of the tournament's
+    /// `table_catalogue` tables) and `scheduled_start` (a **naive** wall-clock time, in the
     /// venue's local frame — an offset-aware value is a `422`). `null` on either clears
     /// that half; `(null, null)` unassigns the fixture.
     ///
@@ -826,15 +854,21 @@ internal protocol APIProtocol: Sendable {
     /// Every successful write also queues a re-solve (`settings_changed`): the director
     /// just changed the solver's inputs, so the board re-plans around the new pin set.
     ///
-    /// **The placement is otherwise soft.** `scheduled_start` is a *prediction* until
-    /// pinned, and the placement's constraints — the table belongs to the fixture's pool,
-    /// the time falls inside the pool's window, nothing is double-booked — are flags
-    /// derived on read, **not** invariants. So an out-of-window time, or a `table_id` that
-    /// names no table in the catalogue, is **stored, not rejected**; the queued re-solve
-    /// is what judges the consequences.
+    /// **The table must exist.** A `table_id` that names no table in this tournament's
+    /// `table_catalogue` is a `422` naming the field — the one thing about a placement that
+    /// is an invariant rather than a flag. A placement whose table does not exist is not a
+    /// state you chose; it is a dangling reference nothing can render.
     ///
-    /// **The one hard rule:** a fixture whose linked match is `completed` or `voided` is
-    /// history, so its placement can no longer be changed — a `409`. A fixture with no
+    /// **The placement is otherwise soft.** `scheduled_start` is a *prediction* until
+    /// pinned, and the placement's other constraints — the table belongs to the fixture's
+    /// pool, the time falls inside the pool's window, nothing is double-booked — are flags
+    /// derived on read, **not** invariants. So an out-of-window time, or a table outside
+    /// the fixture's pool, is **stored, not rejected**; the queued re-solve is what judges
+    /// the consequences.
+    ///
+    /// **The one hard rule about the fixture:** a fixture whose linked match is `completed`
+    /// or `voided` is history, so its placement can no longer be changed — a `409`. A
+    /// fixture with no
     /// match yet, or a `pending`/`in_progress` one, is freely (re)placeable (a round-robin
     /// match is born `pending` at go-live and only becomes `in_progress` when called, so
     /// neither is the freeze trigger).
@@ -1956,6 +1990,34 @@ extension APIProtocol {
     }
     /// Update Tournament
     ///
+    /// Edit a tournament you own. Absent fields are left alone; a supplied field
+    /// replaces the current value. Owner-only.
+    ///
+    /// **`table_catalogue` is an id-keyed diff, sent in full and in order.** Each entry
+    /// either carries the `id` of a table this tournament already has — keeping that table,
+    /// with the `label`, `court` and position this payload gives it — or omits the `id` to
+    /// add a new table, whose id the server mints. **A table no entry names is removed.**
+    /// Send back the catalogue you read, edited: the ids came from the read, and naming an
+    /// id this tournament does not have is a `422` on that entry.
+    ///
+    /// **Removing a table that matches are placed at is a `409` naming the table**, and
+    /// nothing is written. To go through with it, repeat the request with
+    /// `unplace_fixtures_on_removed_tables: true`: the table is removed and those matches
+    /// are unplaced — table, predicted start and call all cleared — which is a thing worth
+    /// saying on purpose rather than a silent side effect of editing the venue. Removing a
+    /// table that only a *pool* reserves needs no confirmation and produces no refusal; the
+    /// pool simply reserves one fewer.
+    ///
+    /// **`address` has three cases and the value alone cannot tell them apart.** Omit it to
+    /// leave the venue and its coordinates untouched; send a real address to move the venue
+    /// (re-geocoded only when its text actually changed, a `409` when it cannot be
+    /// resolved); send `null` — or an object whose six components are all blank — to remove
+    /// the venue entirely.
+    ///
+    /// `league_id` may only be changed while the tournament is a `draft`; once it is
+    /// published the ladder is settled (`409`). `status` is not editable here — the
+    /// lifecycle moves only across `POST /v1/tournaments/{id}/transitions`.
+    ///
     /// - Remark: HTTP `PATCH /v1/tournaments/{tournament_id}`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/patch(update_tournament_v1_tournaments__tournament_id__patch)`.
     internal func updateTournamentV1TournamentsTournamentIdPatch(
@@ -2265,8 +2327,8 @@ extension APIProtocol {
     /// Set (or clear) a fixture's **placement** — its table and its predicted start
     /// (ADR-0790) — and answer with the updated fixture.
     ///
-    /// The body is the placement in full: `table_id` (a string ref into the tournament's
-    /// `table_catalogue`) and `scheduled_start` (a **naive** wall-clock time, in the
+    /// The body is the placement in full: `table_id` (the id of one of the tournament's
+    /// `table_catalogue` tables) and `scheduled_start` (a **naive** wall-clock time, in the
     /// venue's local frame — an offset-aware value is a `422`). `null` on either clears
     /// that half; `(null, null)` unassigns the fixture.
     ///
@@ -2290,15 +2352,21 @@ extension APIProtocol {
     /// Every successful write also queues a re-solve (`settings_changed`): the director
     /// just changed the solver's inputs, so the board re-plans around the new pin set.
     ///
-    /// **The placement is otherwise soft.** `scheduled_start` is a *prediction* until
-    /// pinned, and the placement's constraints — the table belongs to the fixture's pool,
-    /// the time falls inside the pool's window, nothing is double-booked — are flags
-    /// derived on read, **not** invariants. So an out-of-window time, or a `table_id` that
-    /// names no table in the catalogue, is **stored, not rejected**; the queued re-solve
-    /// is what judges the consequences.
+    /// **The table must exist.** A `table_id` that names no table in this tournament's
+    /// `table_catalogue` is a `422` naming the field — the one thing about a placement that
+    /// is an invariant rather than a flag. A placement whose table does not exist is not a
+    /// state you chose; it is a dangling reference nothing can render.
     ///
-    /// **The one hard rule:** a fixture whose linked match is `completed` or `voided` is
-    /// history, so its placement can no longer be changed — a `409`. A fixture with no
+    /// **The placement is otherwise soft.** `scheduled_start` is a *prediction* until
+    /// pinned, and the placement's other constraints — the table belongs to the fixture's
+    /// pool, the time falls inside the pool's window, nothing is double-booked — are flags
+    /// derived on read, **not** invariants. So an out-of-window time, or a table outside
+    /// the fixture's pool, is **stored, not rejected**; the queued re-solve is what judges
+    /// the consequences.
+    ///
+    /// **The one hard rule about the fixture:** a fixture whose linked match is `completed`
+    /// or `voided` is history, so its placement can no longer be changed — a `409`. A
+    /// fixture with no
     /// match yet, or a `pending`/`in_progress` one, is freely (re)placeable (a round-robin
     /// match is born `pending` at go-live and only becomes `in_progress` when called, so
     /// neither is the freeze trigger).
@@ -9904,7 +9972,7 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/TournamentCreate/address`.
             internal var address: Components.Schemas.TournamentCreate.AddressPayload?
             /// - Remark: Generated from `#/components/schemas/TournamentCreate/table_catalogue`.
-            internal var tableCatalogue: [Components.Schemas.TournamentTable]?
+            internal var tableCatalogue: [Components.Schemas.TournamentTableWrite]?
             /// - Remark: Generated from `#/components/schemas/TournamentCreate/league_id`.
             internal var leagueId: Swift.String?
             /// Creates a new `TournamentCreate`.
@@ -9923,7 +9991,7 @@ internal enum Components {
                 startDate: Swift.String? = nil,
                 endDate: Swift.String? = nil,
                 address: Components.Schemas.TournamentCreate.AddressPayload? = nil,
-                tableCatalogue: [Components.Schemas.TournamentTable]? = nil,
+                tableCatalogue: [Components.Schemas.TournamentTableWrite]? = nil,
                 leagueId: Swift.String? = nil
             ) {
                 self.name = name
@@ -9966,7 +10034,7 @@ internal enum Components {
                     forKey: .address
                 )
                 self.tableCatalogue = try container.decodeIfPresent(
-                    [Components.Schemas.TournamentTable].self,
+                    [Components.Schemas.TournamentTableWrite].self,
                     forKey: .tableCatalogue
                 )
                 self.leagueId = try container.decodeIfPresent(
@@ -10844,17 +10912,29 @@ internal enum Components {
         /// The body is the placement in full — both fields are stated together. ``null`` on
         /// either clears that half, and ``(null, null)`` unassigns the fixture entirely.
         ///
-        /// **Soft, deliberately.** ``scheduled_start`` is a *prediction*, not a commitment,
-        /// and the placement's constraints — the table belongs to the fixture's pool, the time
-        /// falls inside the pool's window, nothing is double-booked — are **flags derived on
-        /// read, not invariants** (ADR-0790). So this write does **not** reject an
-        /// out-of-window time, nor a ``table_id`` that names no table in the tournament's
-        /// ``table_catalogue`` (a later pool/catalogue edit can dangle the ref; that is a
-        /// flag-on-read concern). They save. Conflict detection is a future scheduler slice.
+        /// **Soft, deliberately — with one exception.** ``scheduled_start`` is a *prediction*,
+        /// not a commitment, and three of the placement's four constraints — the table belongs
+        /// to the fixture's pool, the time falls inside the pool's window, nothing is
+        /// double-booked — are **flags derived on read, not invariants** (ADR-0790). So this
+        /// write does **not** reject an out-of-window time or an off-pool table. They save.
+        /// Conflict detection is the scheduler's business, not this boundary's.
         ///
-        /// ``table_id`` is a **string ref** into the tournament's ``table_catalogue`` (names a
-        /// ``TournamentTable.id``) — the same pattern as a fixture's ``pool_id``, not a
-        /// foreign key — and per the soft rule above an unknown id is stored, not refused.
+        /// The exception is the fourth claim: **the table has to exist**. ``table_id`` names a
+        /// ``TournamentTable.id`` in the tournament's ``table_catalogue``, and since the
+        /// catalogue became real rows a fixture's ``table_id`` is a real **foreign key** into
+        /// them, so an id that names no table is a **422 naming this field** rather than
+        /// something stored and hoped about (ADR 20260801, "a placement names a real table, and
+        /// only that is an invariant" — which supersedes exactly one clause of ADR-0790 and
+        /// leaves the rest standing). The three flags are statements about a *relationship*
+        /// between things that each legitimately move, so they must stay soft; "this id
+        /// resolves to a table" is not one of those, and a placement whose table does not exist
+        /// is a dangling pointer nothing downstream can render.
+        ///
+        /// The field carries the id's canonical **text** rather than a typed UUID, which is
+        /// also what a pool's ``table_ids`` carry — one representation for a table id, moved in
+        /// one piece rather than a field at a time. A value that is not a well-formed id is
+        /// therefore refused by the same 422 as an unknown one: there is one question here
+        /// ("does this name a table of this tournament?") and it gets one answer.
         ///
         /// The one thing the *route* refuses is moving a fixture whose linked match is
         /// ``completed`` or ``voided``: its placement is history (409). A fixture with no match
@@ -10934,8 +11014,9 @@ internal enum Components {
         ///   JSONB, not a foreign key, because pools are value-objects with no table.
         /// * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means
         ///   **unassigned to a table**. When set, it names a ``TournamentTable`` in the
-        ///   tournament's ``table_catalogue`` — a string ref into JSONB, not a foreign key,
-        ///   the same pattern as ``pool_id``.
+        ///   tournament's ``table_catalogue``, and it is guaranteed to: the column is a real
+        ///   foreign key, so this is never a dangling ref (ADR 20260801). Carried as the id's
+        ///   text, the same form a pool's ``table_ids`` carry.
         /// * ``scheduled_start`` — the placement's **predicted** start: ``null`` means
         ///   **unscheduled**. When set, a :class:`FixtureTimeRead` (see it) — a venue-local
         ///   label + tz abbrev for display, plus the raw UTC instant for geometry — composed
@@ -11251,49 +11332,200 @@ internal enum Components {
             case live = "live"
             case archived = "archived"
         }
-        /// A physical table in the venue catalogue, referenced by id from pools.
+        /// A table in the venue catalogue as it is **read back**: everything a client wrote,
+        /// plus the ``id`` the server minted for it.
         ///
-        /// Its ``id`` is a ``ValueObjectId`` for the same reason a pool's is: a pool holds a
-        /// list of these strings (``table_ids``) and nothing else connects the two, so an id
-        /// that is the empty string is a table nothing can name — and a ``table_ids`` entry of
-        /// ``""`` would "resolve" against it. It is the same string-ref pattern with the same
-        /// hole, and closing it in one place and not the other would leave the boundary
-        /// half-drawn.
+        /// Deriving it from :class:`TournamentTableWrite` keeps the two shapes one shape plus
+        /// a field, exactly as :class:`Pool` derives from :class:`PoolWrite`: a column added to
+        /// the write side is readable without a second edit, and the two can never disagree
+        /// about what a table *is*.
+        ///
+        /// ``id`` is a UUID — the ``tournament_tables`` row's primary key. It is what a pool's
+        /// ``table_ids`` and a fixture's ``table_id`` name, and (from the fixture side) what a
+        /// foreign key will hold.
         ///
         /// - Remark: Generated from `#/components/schemas/TournamentTable`.
         internal struct TournamentTable: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/TournamentTable/id`.
-            internal var id: Swift.String
             /// - Remark: Generated from `#/components/schemas/TournamentTable/label`.
             internal var label: Swift.String
             /// - Remark: Generated from `#/components/schemas/TournamentTable/court`.
             internal var court: Swift.String
+            /// - Remark: Generated from `#/components/schemas/TournamentTable/id`.
+            internal var id: Swift.String
             /// Creates a new `TournamentTable`.
             ///
             /// - Parameters:
+            ///   - label:
+            ///   - court:
             ///   - id:
+            internal init(
+                label: Swift.String,
+                court: Swift.String,
+                id: Swift.String
+            ) {
+                self.label = label
+                self.court = court
+                self.id = id
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case label
+                case court
+                case id
+            }
+            internal init(from decoder: any Swift.Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.label = try container.decode(
+                    Swift.String.self,
+                    forKey: .label
+                )
+                self.court = try container.decode(
+                    Swift.String.self,
+                    forKey: .court
+                )
+                self.id = try container.decode(
+                    Swift.String.self,
+                    forKey: .id
+                )
+                try decoder.ensureNoAdditionalProperties(knownKeys: [
+                    "label",
+                    "court",
+                    "id"
+                ])
+            }
+        }
+        /// One entry of a catalogue a client **edits** (``PATCH /v1/tournaments/{id}``):
+        /// everything :class:`TournamentTableWrite` carries, plus an **optional** ``id`` naming
+        /// a table the tournament already has.
+        ///
+        /// The optional id is what makes the catalogue write a **diff** rather than a
+        /// positional overwrite, and it exists because the ADR's removal semantics need one.
+        /// The two cases are exhaustive and mean different things:
+        ///
+        /// * ``id`` **present** — "this is the table you already have, with these words". The
+        ///   row keeps its id (and therefore every pool ``table_ids`` entry and every fixture
+        ///   ``table_id`` that names it) and takes the new ``label``/``court``, and its place
+        ///   in the list is its new place in the catalogue's order.
+        /// * ``id`` **omitted** (or ``null``) — "add a table". The server mints its id, exactly
+        ///   as on create.
+        /// * a stored table **no entry names** — "remove it". Which is the whole reason this
+        ///   field had to arrive: a removal can be *refused*
+        ///   (:class:`~app.tournament_errors.TableInUseError`), and a verb that cannot tell
+        ///   "the table you renamed" from "a different table at the same index" cannot tell a
+        ///   rename from a removal either.
+        ///
+        /// That last point is why the by-position stopgap this replaces could not stand.
+        /// Matching the i-th sent against the i-th stored made **reordering swap labels between
+        /// ids**: send the same two tables in the other order and each row kept its id and took
+        /// its neighbour's words, so a fixture placed at "Table 1" started rendering as
+        /// "Table 2". Nothing refused it and nothing could see it — an id is not a position,
+        /// and only the client knows which of its rows is which.
+        ///
+        /// An id that names no table of *this* tournament is a 422 on the field, not a silently
+        /// minted new table: a client that names a table it cannot see has a bug, and quietly
+        /// handing it a different id than it asked for would hide it (parse-at-boundaries).
+        ///
+        /// It is deliberately **not** on :class:`TournamentTableWrite`, the create shape: a
+        /// tournament being born has no tables to name, so an ``id`` there is still a 422 for
+        /// an unknown field. Nothing about who mints an id has changed — the server still does
+        /// (ADR 20260801); what changed is that a client may now *cite* one it was given.
+        ///
+        /// - Remark: Generated from `#/components/schemas/TournamentTableUpsert`.
+        internal struct TournamentTableUpsert: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/TournamentTableUpsert/label`.
+            internal var label: Swift.String
+            /// - Remark: Generated from `#/components/schemas/TournamentTableUpsert/court`.
+            internal var court: Swift.String
+            /// - Remark: Generated from `#/components/schemas/TournamentTableUpsert/id`.
+            internal var id: Swift.String?
+            /// Creates a new `TournamentTableUpsert`.
+            ///
+            /// - Parameters:
+            ///   - label:
+            ///   - court:
+            ///   - id:
+            internal init(
+                label: Swift.String,
+                court: Swift.String,
+                id: Swift.String? = nil
+            ) {
+                self.label = label
+                self.court = court
+                self.id = id
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case label
+                case court
+                case id
+            }
+            internal init(from decoder: any Swift.Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.label = try container.decode(
+                    Swift.String.self,
+                    forKey: .label
+                )
+                self.court = try container.decode(
+                    Swift.String.self,
+                    forKey: .court
+                )
+                self.id = try container.decodeIfPresent(
+                    Swift.String.self,
+                    forKey: .id
+                )
+                try decoder.ensureNoAdditionalProperties(knownKeys: [
+                    "label",
+                    "court",
+                    "id"
+                ])
+            }
+        }
+        /// A physical table in the venue catalogue, as a client **sends** it: what the
+        /// table is called and where it stands. Nothing else — in particular, not an ``id``.
+        ///
+        /// A table is a row now (ADR 20260801, "a placement names a real table"), and its id
+        /// is minted by the database (``gen_random_uuid()``). So the id is simply not a field
+        /// of this model, and ``extra="forbid"`` turns an attempt to send one into a 422 that
+        /// names it — the treatment :class:`PoolWrite` gives ``position`` and the event
+        /// schemas give ``entered``. A server-managed value is kept **off** the write shape
+        /// rather than accepted and then ignored: a client cannot tell from the schema that the
+        /// id it sent decided nothing, and a boundary that silently discards half of a payload
+        /// has to be documented to be understood.
+        ///
+        /// That is a real change of who owns a table's identity, and it is the point of the
+        /// ADR. While the catalogue was JSONB, the id was a client-supplied string with nothing
+        /// to key on, which is the only reason a placement naming no table could be *stored*
+        /// rather than refused. The **order** of the list is what a client does control: it is
+        /// the catalogue's order, and the server assigns each table its place from it.
+        ///
+        /// This is the shape a **create** takes, and there it is the whole story: a tournament
+        /// being born has no tables, so there is nothing an ``id`` could name. A *patch* is a
+        /// diff over tables that already exist, so its entries derive from this one and add an
+        /// optional ``id`` naming the table they keep (:class:`TournamentTableUpsert`) — which
+        /// is citing an id, not authoring one, and does not disturb who mints them.
+        ///
+        /// - Remark: Generated from `#/components/schemas/TournamentTableWrite`.
+        internal struct TournamentTableWrite: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/TournamentTableWrite/label`.
+            internal var label: Swift.String
+            /// - Remark: Generated from `#/components/schemas/TournamentTableWrite/court`.
+            internal var court: Swift.String
+            /// Creates a new `TournamentTableWrite`.
+            ///
+            /// - Parameters:
             ///   - label:
             ///   - court:
             internal init(
-                id: Swift.String,
                 label: Swift.String,
                 court: Swift.String
             ) {
-                self.id = id
                 self.label = label
                 self.court = court
             }
             internal enum CodingKeys: String, CodingKey {
-                case id
                 case label
                 case court
             }
             internal init(from decoder: any Swift.Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
-                self.id = try container.decode(
-                    Swift.String.self,
-                    forKey: .id
-                )
                 self.label = try container.decode(
                     Swift.String.self,
                     forKey: .label
@@ -11303,7 +11535,6 @@ internal enum Components {
                     forKey: .court
                 )
                 try decoder.ensureNoAdditionalProperties(knownKeys: [
-                    "id",
                     "label",
                     "court"
                 ])
@@ -11342,12 +11573,18 @@ internal enum Components {
             }
         }
         /// Partial update. A field that is *absent* is left unchanged; an explicit
-        /// value replaces the current one. The columns backing ``name`` and
-        /// ``table_catalogue`` are NOT NULL, so for those an explicit ``null`` is
+        /// value replaces the current one. ``name`` maps to a NOT NULL column and
+        /// ``table_catalogue`` to a whole child table, so for those an explicit ``null`` is
         /// rejected (422) rather than allowed to reach the DB — "omitted" and "cleared"
         /// are different. ``description``/``start_date``/``end_date`` are nullable
-        /// columns and may be cleared. ``table_catalogue`` replaces wholesale when
-        /// present.
+        /// columns and may be cleared.
+        ///
+        /// ``table_catalogue``, when present, is the catalogue **in full and in order**, and it
+        /// is applied as an **id-keyed diff** (ADR 20260801): an entry that cites an ``id``
+        /// keeps that table (with the words and the place this payload gives it), an entry with
+        /// no ``id`` adds one, and a stored table no entry cites is **removed**. Citing the id
+        /// is what makes a reorder move *tables* rather than swap labels between ids, and it is
+        /// what lets a removal be refused — see ``unplace_fixtures_on_removed_tables``.
         ///
         /// ``address`` is nullable too, as of #1206: **omitted means unchanged; ``null`` — or
         /// an all-blank object, which :data:`SubmittedAddress` normalizes to ``null`` — means
@@ -11361,6 +11598,14 @@ internal enum Components {
         /// ``POST /v1/tournaments/{id}/transitions`` (ADR-0017). A guard on that route
         /// that left a ``status`` field on this one would have guarded nothing, so
         /// sending ``status`` here is a 422 via ``extra="forbid"``.
+        ///
+        /// ``unplace_fixtures_on_removed_tables`` is the **removal opt-in**, not a field of the
+        /// tournament: it decides what happens when this payload's ``table_catalogue`` drops a
+        /// table that matches are placed at. **Omitted** — or ``false``, or ``null`` — the
+        /// whole edit is refused with a ``409`` naming the table, and nothing is written. Set
+        /// ``true``, the removal goes through and those matches are unplaced — table, predicted
+        /// start and pin all cleared — which is why it is said on purpose (ADR 20260801). A
+        /// table that only a *pool* reserves needs no opt-in: the pool reserves one fewer.
         ///
         /// ``league_id`` is updatable, but **only while the tournament is ``draft``**
         /// (ADR-0783): once it is published, registration is open and eligibility is live,
@@ -11400,9 +11645,11 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/TournamentUpdate/address`.
             internal var address: Components.Schemas.TournamentUpdate.AddressPayload?
             /// - Remark: Generated from `#/components/schemas/TournamentUpdate/table_catalogue`.
-            internal var tableCatalogue: [Components.Schemas.TournamentTable]?
+            internal var tableCatalogue: [Components.Schemas.TournamentTableUpsert]?
             /// - Remark: Generated from `#/components/schemas/TournamentUpdate/league_id`.
             internal var leagueId: Swift.String?
+            /// - Remark: Generated from `#/components/schemas/TournamentUpdate/unplace_fixtures_on_removed_tables`.
+            internal var unplaceFixturesOnRemovedTables: Swift.Bool?
             /// Creates a new `TournamentUpdate`.
             ///
             /// - Parameters:
@@ -11413,14 +11660,16 @@ internal enum Components {
             ///   - address:
             ///   - tableCatalogue:
             ///   - leagueId:
+            ///   - unplaceFixturesOnRemovedTables:
             internal init(
                 name: Swift.String? = nil,
                 description: Swift.String? = nil,
                 startDate: Swift.String? = nil,
                 endDate: Swift.String? = nil,
                 address: Components.Schemas.TournamentUpdate.AddressPayload? = nil,
-                tableCatalogue: [Components.Schemas.TournamentTable]? = nil,
-                leagueId: Swift.String? = nil
+                tableCatalogue: [Components.Schemas.TournamentTableUpsert]? = nil,
+                leagueId: Swift.String? = nil,
+                unplaceFixturesOnRemovedTables: Swift.Bool? = nil
             ) {
                 self.name = name
                 self.description = description
@@ -11429,6 +11678,7 @@ internal enum Components {
                 self.address = address
                 self.tableCatalogue = tableCatalogue
                 self.leagueId = leagueId
+                self.unplaceFixturesOnRemovedTables = unplaceFixturesOnRemovedTables
             }
             internal enum CodingKeys: String, CodingKey {
                 case name
@@ -11438,6 +11688,7 @@ internal enum Components {
                 case address
                 case tableCatalogue = "table_catalogue"
                 case leagueId = "league_id"
+                case unplaceFixturesOnRemovedTables = "unplace_fixtures_on_removed_tables"
             }
             internal init(from decoder: any Swift.Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -11462,12 +11713,16 @@ internal enum Components {
                     forKey: .address
                 )
                 self.tableCatalogue = try container.decodeIfPresent(
-                    [Components.Schemas.TournamentTable].self,
+                    [Components.Schemas.TournamentTableUpsert].self,
                     forKey: .tableCatalogue
                 )
                 self.leagueId = try container.decodeIfPresent(
                     Swift.String.self,
                     forKey: .leagueId
+                )
+                self.unplaceFixturesOnRemovedTables = try container.decodeIfPresent(
+                    Swift.Bool.self,
+                    forKey: .unplaceFixturesOnRemovedTables
                 )
                 try decoder.ensureNoAdditionalProperties(knownKeys: [
                     "name",
@@ -11476,7 +11731,8 @@ internal enum Components {
                     "end_date",
                     "address",
                     "table_catalogue",
-                    "league_id"
+                    "league_id",
+                    "unplace_fixtures_on_removed_tables"
                 ])
             }
         }
@@ -22302,6 +22558,34 @@ internal enum Operations {
     }
     /// Update Tournament
     ///
+    /// Edit a tournament you own. Absent fields are left alone; a supplied field
+    /// replaces the current value. Owner-only.
+    ///
+    /// **`table_catalogue` is an id-keyed diff, sent in full and in order.** Each entry
+    /// either carries the `id` of a table this tournament already has — keeping that table,
+    /// with the `label`, `court` and position this payload gives it — or omits the `id` to
+    /// add a new table, whose id the server mints. **A table no entry names is removed.**
+    /// Send back the catalogue you read, edited: the ids came from the read, and naming an
+    /// id this tournament does not have is a `422` on that entry.
+    ///
+    /// **Removing a table that matches are placed at is a `409` naming the table**, and
+    /// nothing is written. To go through with it, repeat the request with
+    /// `unplace_fixtures_on_removed_tables: true`: the table is removed and those matches
+    /// are unplaced — table, predicted start and call all cleared — which is a thing worth
+    /// saying on purpose rather than a silent side effect of editing the venue. Removing a
+    /// table that only a *pool* reserves needs no confirmation and produces no refusal; the
+    /// pool simply reserves one fewer.
+    ///
+    /// **`address` has three cases and the value alone cannot tell them apart.** Omit it to
+    /// leave the venue and its coordinates untouched; send a real address to move the venue
+    /// (re-geocoded only when its text actually changed, a `409` when it cannot be
+    /// resolved); send `null` — or an object whose six components are all blank — to remove
+    /// the venue entirely.
+    ///
+    /// `league_id` may only be changed while the tournament is a `draft`; once it is
+    /// published the ladder is settled (`409`). `status` is not editable here — the
+    /// lifecycle moves only across `POST /v1/tournaments/{id}/transitions`.
+    ///
     /// - Remark: HTTP `PATCH /v1/tournaments/{tournament_id}`.
     /// - Remark: Generated from `#/paths//v1/tournaments/{tournament_id}/patch(update_tournament_v1_tournaments__tournament_id__patch)`.
     internal enum UpdateTournamentV1TournamentsTournamentIdPatch {
@@ -24358,8 +24642,8 @@ internal enum Operations {
     /// Set (or clear) a fixture's **placement** — its table and its predicted start
     /// (ADR-0790) — and answer with the updated fixture.
     ///
-    /// The body is the placement in full: `table_id` (a string ref into the tournament's
-    /// `table_catalogue`) and `scheduled_start` (a **naive** wall-clock time, in the
+    /// The body is the placement in full: `table_id` (the id of one of the tournament's
+    /// `table_catalogue` tables) and `scheduled_start` (a **naive** wall-clock time, in the
     /// venue's local frame — an offset-aware value is a `422`). `null` on either clears
     /// that half; `(null, null)` unassigns the fixture.
     ///
@@ -24383,15 +24667,21 @@ internal enum Operations {
     /// Every successful write also queues a re-solve (`settings_changed`): the director
     /// just changed the solver's inputs, so the board re-plans around the new pin set.
     ///
-    /// **The placement is otherwise soft.** `scheduled_start` is a *prediction* until
-    /// pinned, and the placement's constraints — the table belongs to the fixture's pool,
-    /// the time falls inside the pool's window, nothing is double-booked — are flags
-    /// derived on read, **not** invariants. So an out-of-window time, or a `table_id` that
-    /// names no table in the catalogue, is **stored, not rejected**; the queued re-solve
-    /// is what judges the consequences.
+    /// **The table must exist.** A `table_id` that names no table in this tournament's
+    /// `table_catalogue` is a `422` naming the field — the one thing about a placement that
+    /// is an invariant rather than a flag. A placement whose table does not exist is not a
+    /// state you chose; it is a dangling reference nothing can render.
     ///
-    /// **The one hard rule:** a fixture whose linked match is `completed` or `voided` is
-    /// history, so its placement can no longer be changed — a `409`. A fixture with no
+    /// **The placement is otherwise soft.** `scheduled_start` is a *prediction* until
+    /// pinned, and the placement's other constraints — the table belongs to the fixture's
+    /// pool, the time falls inside the pool's window, nothing is double-booked — are flags
+    /// derived on read, **not** invariants. So an out-of-window time, or a table outside
+    /// the fixture's pool, is **stored, not rejected**; the queued re-solve is what judges
+    /// the consequences.
+    ///
+    /// **The one hard rule about the fixture:** a fixture whose linked match is `completed`
+    /// or `voided` is history, so its placement can no longer be changed — a `409`. A
+    /// fixture with no
     /// match yet, or a `pending`/`in_progress` one, is freely (re)placeable (a round-robin
     /// match is born `pending` at go-live and only becomes `in_progress` when called, so
     /// neither is the freeze trigger).

--- a/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
+++ b/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
@@ -687,6 +687,62 @@ export class TournamentDetailPage {
     return this.eventCard(eventName).getByTestId('capacity-remaining')
   }
 
+  // ----- the Tables tab (the venue catalogue, ADR 20260801) -----------------
+
+  /** Open the Tables tab and wait for it to really be on screen — every "the
+   * catalogue shows X" assertion passes vacuously against a tab that has not
+   * rendered. */
+  async openTablesTab() {
+    await this.page.getByRole('tab', { name: /^Tables/ }).click()
+    await expect(this.page.getByTestId('tables-tab')).toBeVisible()
+  }
+
+  /** One table's card, by the label the director reads. */
+  tableCard(label: string): Locator {
+    return this.page.locator('[data-slot=card]').filter({ hasText: label })
+  }
+
+  /** One table's Remove button. Owner-only — a viewer is offered none. */
+  removeTableButton(label: string): Locator {
+    return this.page.getByRole('button', { name: `Remove ${label}` })
+  }
+
+  get tableLabelInput(): Locator {
+    return this.page.getByLabel('Table label')
+  }
+
+  get tableCourtInput(): Locator {
+    return this.page.getByLabel('Court')
+  }
+
+  get addTableButton(): Locator {
+    return this.page.getByRole('button', { name: 'Add table' })
+  }
+
+  /** The in-use refusal's confirm — the 409 asked back as a question. Its body is
+   * the SERVER's sentence, verbatim. */
+  get removeTableConfirm(): Locator {
+    return this.page.getByTestId('confirm-remove-table')
+  }
+
+  get removeTableConfirmDetail(): Locator {
+    return this.page.getByTestId('confirm-remove-table-detail')
+  }
+
+  get removeTableConfirmButton(): Locator {
+    return this.page.getByTestId('confirm-remove-table-confirm')
+  }
+
+  get removeTableCancelButton(): Locator {
+    return this.page.getByTestId('confirm-remove-table-cancel')
+  }
+
+  /** The tab's inline failure — everything that is NOT the in-use refusal, in the
+   * client's own words. */
+  get tablesError(): Locator {
+    return this.page.getByTestId('tables-error')
+  }
+
   // ----- the Schedule tab & its solve strip (ADR "the schedule is solved") ---
 
   /** Open the Schedule tab and wait for its strip to really be on screen — every

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -25,11 +25,15 @@ import {
   UNBREAKABLE_VENUE_NAME,
   type DrawPlan,
 } from '../../../src/mocks/factories/tournaments/tournament.factory'
+import { mockUuid } from '../../../src/mocks/mock-uuid'
 import { sessionResponse } from '../../../src/test/factories'
 import { fulfillParkedStream, STREAM_PATH } from '../../support/realtime'
 
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
 type TournamentCreate = components['schemas']['TournamentCreate']
+type TournamentUpdate = components['schemas']['TournamentUpdate']
+type TournamentTable = components['schemas']['TournamentTable']
+type TournamentTableUpsert = components['schemas']['TournamentTableUpsert']
 type TournamentEventRead = components['schemas']['TournamentEventRead']
 type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
 type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
@@ -773,6 +777,14 @@ export interface TournamentsStoreOptions {
    * mocks use, so a contract change reds this file. Defaults to `null` — no solve
    * ever requested, the state every tournament is born in. */
   latestSolve?: ScheduleSolveRead
+  /** Place an event's **first fixture** at the catalogue's first table before the page
+   * loads — the state that makes removing that table a **409** (ADR 20260801).
+   *
+   * Seeded rather than driven through the Schedule tab because the claim under test is
+   * the Tables tab's, not the scheduler's: a spec that had to place a match through the
+   * UI first would red for a scheduling regression and read as a tables bug. Only
+   * meaningful with `drawn` — a fixture has to exist to be placed. */
+  placed?: string
 }
 
 /** The options for a tournament that can actually be **started**: every event drawable,
@@ -859,6 +871,35 @@ function namedList(names: string[]): string {
   const quoted = names.map((name) => `“${name}”`)
   if (quoted.length === 1) return quoted[0]
   return `${quoted.slice(0, -1).join(', ')} and ${quoted[quoted.length - 1]}`
+}
+
+/**
+ * The server's sentence for a catalogue edit that would remove a table matches are
+ * placed at (`_tables_in_use_detail`, `api/app/tournament_tables.py`) — **verbatim**,
+ * because the confirm dialog renders it verbatim.
+ *
+ * Written out here rather than imported from the app: a stub that read its refusal out
+ * of the client's own copy could never disagree with it, so a spec built on one would
+ * prove the app consistent with itself instead of consistent with the server. It names
+ * the tables by LABEL, never by id, and it names both ways out — send the same edit
+ * again with the opt-in, or move the matches off the table first.
+ */
+export function tablesInUseDetail(labels: string[], placements: number): string {
+  const one = labels.length === 1
+  const has = one ? 'has' : 'have'
+  const it = one ? 'it' : 'them'
+  const theTable = one ? 'the table' : 'them'
+  const matches = placements === 1 ? 'match' : 'matches'
+  return (
+    `${namedList(labels)} ${has} ${placements} ${matches} placed at ${it}, so ` +
+    `removing ${it} from the catalogue would leave those matches with no table — ` +
+    'indistinguishable from matches nobody ever placed. To remove ' +
+    `${it} anyway, send the same edit again with ` +
+    '“unplace_fixtures_on_removed_tables”: true, and those matches lose their ' +
+    'table, their time and their call and go back to the schedule to be placed ' +
+    `again. To keep them where they are, leave ${theTable} in the catalogue and ` +
+    `move the matches off ${it} first.`
+  )
 }
 
 /** The server's sentence for a tournament with nothing to run. */
@@ -1040,6 +1081,7 @@ interface RecordedRequest {
 export class TournamentsStore {
   private detail: TournamentDetailRead
   private entryCounter = 0
+  private tableCounter = 0
   private gate: Promise<void> | null = null
   private refusingWrites = false
   private refusingTournamentCreate = false
@@ -1059,6 +1101,14 @@ export class TournamentsStore {
    * send `address: null` (CONTEXT.md, "Venue"), and the only way to see that six
    * empty strings did not go instead is to read the serialized body. */
   readonly createBodies: TournamentCreate[] = []
+  /** Every `PATCH /v1/tournaments/{id}` body, in order — what the Tables tab actually
+   * PUT ON THE WIRE.
+   *
+   * It exists for the id: a new table must be sent with **no `id` at all** (the server
+   * mints them, ADR 20260801), and a component test can only see the callback's
+   * argument. Only the serialized body can show that a client-minted id did not go —
+   * and only here, with MSW off, does the real `openapi-fetch` do the serializing. */
+  readonly patchBodies: TournamentUpdate[] = []
 
   constructor(private readonly options: TournamentsStoreOptions = {}) {
     this.detail = seed(options)
@@ -1107,6 +1157,28 @@ export class TournamentsStore {
           ? CUP_RESULTS
           : CUP_RESULTS_MID_FLIGHT
       this.mutateEvent(event.id, (e) => ({ ...e, results }))
+    }
+    // A fixture standing on a table — what makes removing that table a 409 rather
+    // than the quiet removal a merely pool-reserved table gets.
+    if (options.placed) {
+      const event = this.eventNamed(options.placed)
+      const fixture = event.fixtures[0]
+      if (!fixture) {
+        throw new Error(`cannot place a fixture for ${options.placed}: no draw`)
+      }
+      const table = this.detail.table_catalogue[0]
+      this.mutateEvent(event.id, (e) => ({
+        ...e,
+        fixtures: e.fixtures.map((f) =>
+          f.id === fixture.id
+            ? {
+                ...f,
+                table_id: table.id,
+                scheduled_start: simFixtureTime('2026-06-13T09:00:00'),
+              }
+            : f,
+        ),
+      }))
     }
     // The seeded solve ledger row, if any — a terminal strip state the spec starts on.
     if (options.latestSolve) {
@@ -1424,6 +1496,11 @@ export class TournamentsStore {
     // The list page's one write: `POST /v1/tournaments`, the "New tournament" dialog.
     if (method === 'POST' && path === '/v1/tournaments') {
       return this.createTournament(route, request.postDataJSON())
+    }
+
+    // The tournament-level PATCH — the Tables tab's write (ADR 20260801).
+    if (method === 'PATCH' && path === `/v1/tournaments/${TOURNAMENT_ID}`) {
+      return this.updateTournament(route, request.postDataJSON())
     }
 
     if (method === 'POST' && path === `/v1/tournaments/${TOURNAMENT_ID}/transitions`) {
@@ -1798,6 +1875,121 @@ export class TournamentsStore {
     const fields = body as { name?: string }
     this.detail = { ...this.detail, name: fields.name ?? this.detail.name }
     return json(route, 201, this.readDetail())
+  }
+
+  /**
+   * `PATCH /v1/tournaments/{id}` — the tournament's own fields, and the one this
+   * suite exists for: the **table catalogue as an id-keyed diff** (ADR 20260801).
+   *
+   * The three cases are exhaustive and mean different things, so the stub implements
+   * all three rather than the one the happy path needs:
+   *
+   * - an entry **citing an id** keeps that table, with this payload's words and place;
+   * - an entry with **no id** is an insert, and the id is **minted here** — the client
+   *   has none to give, and one it invented would name no table of this tournament;
+   * - a stored table **no entry cites** is REMOVED.
+   *
+   * And the removal's refusal, judged **before anything is written**: a table matches
+   * are *placed at* cannot go without `unplace_fixtures_on_removed_tables: true`, and
+   * without it the answer is a 409 carrying the server's own sentence — verbatim,
+   * because the confirm dialog renders it verbatim. (A table only a *pool* reserves
+   * needs no opt-in: a reservation is not a placement.)
+   *
+   * The 422 arm matters as much as the 409: it is what makes a client-minted id a
+   * loud failure here, exactly as it is on the server. A stub that quietly minted an
+   * id for an entry citing an unknown one would let the very regression this chore
+   * fixed sail through green.
+   */
+  private async updateTournament(route: Route, body: unknown) {
+    this.patchBodies.push(body as TournamentUpdate)
+    if (this.faultingWrites) return serverFault(route)
+    if (!this.detail.can_edit) {
+      return json(route, 403, {
+        detail: 'Only the creator can edit this tournament.',
+      })
+    }
+
+    const patch = body as TournamentUpdate
+    const submitted = patch.table_catalogue
+    if (submitted === undefined || submitted === null) {
+      this.detail = { ...this.detail, name: patch.name ?? this.detail.name }
+      return json(route, 200, this.readDetail())
+    }
+
+    const stored = this.detail.table_catalogue
+    const byId = new Map(stored.map((t) => [t.id, t]))
+    for (const [index, entry] of submitted.entries()) {
+      if (entry.id != null && !byId.has(entry.id)) {
+        return json(route, 422, {
+          detail: [
+            {
+              type: 'value_error',
+              loc: ['body', 'table_catalogue', index, 'id'],
+              msg: "This tournament's venue catalogue has no table with that id.",
+              input: entry.id,
+            },
+          ],
+        })
+      }
+    }
+
+    const kept = new Set(
+      submitted.map((e) => e.id).filter((id): id is string => id != null),
+    )
+    const removed = stored.filter((t) => !kept.has(t.id))
+    const removedIds = new Set(removed.map((t) => t.id))
+    const placed = this.detail.events
+      .flatMap((e) => e.fixtures)
+      .filter((f) => f.table_id !== null && removedIds.has(f.table_id))
+
+    // The opt-in has ONE affirmative spelling; omitted, `false` and `null` are three
+    // ways of not saying it, and all three refuse.
+    if (placed.length > 0 && patch.unplace_fixtures_on_removed_tables !== true) {
+      const blocking = new Set(placed.map((f) => f.table_id))
+      const labels = removed.filter((t) => blocking.has(t.id)).map((t) => t.label)
+      return json(route, 409, {
+        detail: tablesInUseDetail(labels, placed.length),
+      })
+    }
+
+    const unplaced = new Set(placed.map((f) => f.id))
+    this.detail = {
+      ...this.detail,
+      name: patch.name ?? this.detail.name,
+      // The list's ORDER is the catalogue's order; a cited row keeps its id while
+      // taking this payload's words and place.
+      table_catalogue: submitted.map((entry) => this.upsertTable(entry)),
+      events: this.detail.events.map((event) => ({
+        ...event,
+        fixtures: event.fixtures.map((f) =>
+          unplaced.has(f.id)
+            ? { ...f, table_id: null, scheduled_start: null, pinned_at: null }
+            : f,
+        ),
+      })),
+    }
+    return json(route, 200, this.readDetail())
+  }
+
+  /** One catalogue entry after the diff: the cited row, re-worded — or a brand-new
+   * one whose **uuid the server mints** (`gen_random_uuid()`; `TournamentTable.id` is
+   * `format: uuid` on the wire, so the stub must not hand back a slug). */
+  private upsertTable(entry: TournamentTableUpsert): TournamentTable {
+    if (entry.id != null) {
+      return { id: entry.id, label: entry.label, court: entry.court }
+    }
+    this.tableCounter += 1
+    return {
+      id: mockUuid(`e2e-tournament-table-${this.tableCounter}`),
+      label: entry.label,
+      court: entry.court,
+    }
+  }
+
+  /** The catalogue as the SERVER now holds it — so a spec asserts what was stored
+   * (and which id it was stored under), not what the DOM happens to show. */
+  get tables(): TournamentTable[] {
+    return this.detail.table_catalogue
   }
 
   /**

--- a/web-client/e2e/tournaments/tournament-tables.spec.ts
+++ b/web-client/e2e/tournaments/tournament-tables.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * The **Tables tab** — the venue catalogue as an id-keyed diff (ADR 20260801).
+ *
+ * Two claims, and neither can be made in vitest:
+ *
+ * 1. **A new table goes on the wire with no `id` at all.** The server mints table ids
+ *    (`TournamentTableWrite` is `extra="forbid"`), so a client-minted one is a 422
+ *    naming the row. A component test can only see what the tab handed its callback;
+ *    only here — MSW off, the real `openapi-fetch` doing the serializing — can a spec
+ *    read the **body that was actually sent**.
+ * 2. **Removing a table matches are placed at is refused, and the refusal is a
+ *    question.** The server answers a 409 whose sentence names the tables, counts the
+ *    matches and states both ways out; the tab renders it verbatim in a confirm, and
+ *    confirming re-sends **the identical body plus the opt-in** — safe precisely
+ *    because the refusal wrote nothing.
+ *
+ * The stub in `tournaments-store.ts` implements the whole diff (cite / insert /
+ * remove) and both of its refusals, so these specs cannot pass against a stub more
+ * permissive than the API.
+ */
+import { expect, test } from '@playwright/test'
+
+import { TournamentDetailPage } from '../page-objects/tournaments/tournament-detail.page'
+import {
+  EVENT,
+  tablesInUseDetail,
+  type TournamentsStoreOptions,
+} from '../page-objects/tournaments/tournaments-store'
+
+/** A tournament whose JOURNEY event has a cut draw, so there are fixtures to place. */
+const DRAWN: TournamentsStoreOptions = { drawable: true, drawn: [EVENT.JOURNEY] }
+
+test.describe('the Tables tab · adding a table', () => {
+  test('sends NO id and renders the one the server minted', async ({ page }) => {
+    const { pom, store } = await TournamentDetailPage.navigateTo(page, DRAWN)
+    await pom.openTablesTab()
+    const before = store.tables.length
+
+    await pom.tableLabelInput.fill('T9')
+    await pom.tableCourtInput.fill('D')
+    await pom.addTableButton.click()
+
+    // The card on screen came back from the server through the refetch.
+    await expect(pom.tableCard('T9')).toBeVisible()
+    await expect(pom.tablesError).toHaveCount(0)
+
+    // What actually went on the wire: every stored table CITED by id (dropping one
+    // would have removed it), and the new row with no `id` key whatsoever.
+    expect(store.patchBodies).toHaveLength(1)
+    const sent = store.patchBodies[0].table_catalogue!
+    expect(sent).toHaveLength(before + 1)
+    expect(sent.slice(0, before).map((t) => t.id)).toEqual(
+      store.tables.slice(0, before).map((t) => t.id),
+    )
+    expect(sent[before]).toEqual({ label: 'T9', court: 'D' })
+    expect('id' in sent[before]).toBe(false)
+    // The opt-in is never volunteered — an add removes nothing.
+    expect(
+      'unplace_fixtures_on_removed_tables' in store.patchBodies[0],
+    ).toBe(false)
+
+    // And the id the catalogue now holds for it is the SERVER's uuid.
+    const minted = store.tables[before]
+    expect(minted.label).toBe('T9')
+    expect(minted.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    )
+    expect(store.unhandled).toEqual([])
+  })
+})
+
+test.describe('the Tables tab · removing a table matches are placed at', () => {
+  test('refuses with the server’s sentence, and confirming completes it', async ({
+    page,
+  }) => {
+    const { pom, store } = await TournamentDetailPage.navigateTo(page, {
+      ...DRAWN,
+      placed: EVENT.JOURNEY,
+    })
+    await pom.openTablesTab()
+    const doomed = store.tables[0]
+
+    await pom.removeTableButton(doomed.label).click()
+
+    // The confirm carries the API's own words — it names the table by LABEL, counts
+    // the matches, and states both ways out. None of that is reconstructible client
+    // side, which is why it is shown verbatim.
+    await expect(pom.removeTableConfirmDetail).toHaveText(
+      tablesInUseDetail([doomed.label], 1),
+    )
+    await expect(pom.removeTableConfirmDetail).not.toContainText(doomed.id)
+    // Nothing was written: the refusal is a refusal, not a report.
+    expect(store.tables.map((t) => t.id)).toContain(doomed.id)
+    expect(store.fixturesOf(EVENT.JOURNEY)[0].table_id).toBe(doomed.id)
+
+    await pom.removeTableConfirmButton.click()
+
+    await expect(pom.removeTableConfirm).toHaveCount(0)
+    await expect(pom.tableCard(doomed.label)).toHaveCount(0)
+    expect(store.tables.map((t) => t.id)).not.toContain(doomed.id)
+    // The matches lost table, time AND pin together — a start with no table is a bar
+    // on a schedule with nowhere to be.
+    const fixture = store.fixturesOf(EVENT.JOURNEY)[0]
+    expect(fixture.table_id).toBeNull()
+    expect(fixture.scheduled_start).toBeNull()
+    expect(fixture.pinned_at).toBeNull()
+
+    // The confirm re-sent the SAME diff, plus the opt-in — the answer is to the
+    // question that was asked, not to a catalogue recomputed in between.
+    expect(store.patchBodies).toHaveLength(2)
+    const [refused, confirmed] = store.patchBodies
+    expect(confirmed.table_catalogue).toEqual(refused.table_catalogue)
+    expect(refused.unplace_fixtures_on_removed_tables).toBeUndefined()
+    expect(confirmed.unplace_fixtures_on_removed_tables).toBe(true)
+    expect(store.unhandled).toEqual([])
+  })
+
+  test('keeping the table sends nothing', async ({ page }) => {
+    const { pom, store } = await TournamentDetailPage.navigateTo(page, {
+      ...DRAWN,
+      placed: EVENT.JOURNEY,
+    })
+    await pom.openTablesTab()
+    const doomed = store.tables[0]
+
+    await pom.removeTableButton(doomed.label).click()
+    await expect(pom.removeTableConfirmDetail).toBeVisible()
+    await pom.removeTableCancelButton.click()
+
+    await expect(pom.removeTableConfirm).toHaveCount(0)
+    await expect(pom.tableCard(doomed.label)).toBeVisible()
+    expect(store.tables.map((t) => t.id)).toContain(doomed.id)
+    expect(store.fixturesOf(EVENT.JOURNEY)[0].table_id).toBe(doomed.id)
+    // One PATCH — the refused one. Cancelling is the absence of a request.
+    expect(store.patchBodies).toHaveLength(1)
+  })
+
+  // The quiet half of the ADR's split: a pool's `table_ids` are a RESERVATION, not a
+  // placement, so removing a table nothing stands on needs no ceremony at all.
+  test('a table nothing is placed at goes without a confirm', async ({ page }) => {
+    const { pom, store } = await TournamentDetailPage.navigateTo(page, {
+      ...DRAWN,
+      placed: EVENT.JOURNEY,
+    })
+    await pom.openTablesTab()
+    // The LAST table — the placement above is on the first.
+    const spare = store.tables[store.tables.length - 1]
+
+    await pom.removeTableButton(spare.label).click()
+
+    await expect(pom.tableCard(spare.label)).toHaveCount(0)
+    expect(store.tables.map((t) => t.id)).not.toContain(spare.id)
+    await expect(pom.removeTableConfirm).toHaveCount(0)
+    await expect(pom.tablesError).toHaveCount(0)
+    // The placed fixture on the OTHER table was not touched.
+    expect(store.fixturesOf(EVENT.JOURNEY)[0].table_id).toBe(store.tables[0].id)
+  })
+})

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1061,7 +1061,36 @@ export interface paths {
         delete: operations["delete_tournament_v1_tournaments__tournament_id__delete"];
         options?: never;
         head?: never;
-        /** Update Tournament */
+        /**
+         * Update Tournament
+         * @description Edit a tournament you own. Absent fields are left alone; a supplied field
+         *     replaces the current value. Owner-only.
+         *
+         *     **`table_catalogue` is an id-keyed diff, sent in full and in order.** Each entry
+         *     either carries the `id` of a table this tournament already has — keeping that table,
+         *     with the `label`, `court` and position this payload gives it — or omits the `id` to
+         *     add a new table, whose id the server mints. **A table no entry names is removed.**
+         *     Send back the catalogue you read, edited: the ids came from the read, and naming an
+         *     id this tournament does not have is a `422` on that entry.
+         *
+         *     **Removing a table that matches are placed at is a `409` naming the table**, and
+         *     nothing is written. To go through with it, repeat the request with
+         *     `unplace_fixtures_on_removed_tables: true`: the table is removed and those matches
+         *     are unplaced — table, predicted start and call all cleared — which is a thing worth
+         *     saying on purpose rather than a silent side effect of editing the venue. Removing a
+         *     table that only a *pool* reserves needs no confirmation and produces no refusal; the
+         *     pool simply reserves one fewer.
+         *
+         *     **`address` has three cases and the value alone cannot tell them apart.** Omit it to
+         *     leave the venue and its coordinates untouched; send a real address to move the venue
+         *     (re-geocoded only when its text actually changed, a `409` when it cannot be
+         *     resolved); send `null` — or an object whose six components are all blank — to remove
+         *     the venue entirely.
+         *
+         *     `league_id` may only be changed while the tournament is a `draft`; once it is
+         *     published the ladder is settled (`409`). `status` is not editable here — the
+         *     lifecycle moves only across `POST /v1/tournaments/{id}/transitions`.
+         */
         patch: operations["update_tournament_v1_tournaments__tournament_id__patch"];
         trace?: never;
     };
@@ -1359,8 +1388,8 @@ export interface paths {
          * @description Set (or clear) a fixture's **placement** — its table and its predicted start
          *     (ADR-0790) — and answer with the updated fixture.
          *
-         *     The body is the placement in full: `table_id` (a string ref into the tournament's
-         *     `table_catalogue`) and `scheduled_start` (a **naive** wall-clock time, in the
+         *     The body is the placement in full: `table_id` (the id of one of the tournament's
+         *     `table_catalogue` tables) and `scheduled_start` (a **naive** wall-clock time, in the
          *     venue's local frame — an offset-aware value is a `422`). `null` on either clears
          *     that half; `(null, null)` unassigns the fixture.
          *
@@ -1384,15 +1413,21 @@ export interface paths {
          *     Every successful write also queues a re-solve (`settings_changed`): the director
          *     just changed the solver's inputs, so the board re-plans around the new pin set.
          *
-         *     **The placement is otherwise soft.** `scheduled_start` is a *prediction* until
-         *     pinned, and the placement's constraints — the table belongs to the fixture's pool,
-         *     the time falls inside the pool's window, nothing is double-booked — are flags
-         *     derived on read, **not** invariants. So an out-of-window time, or a `table_id` that
-         *     names no table in the catalogue, is **stored, not rejected**; the queued re-solve
-         *     is what judges the consequences.
+         *     **The table must exist.** A `table_id` that names no table in this tournament's
+         *     `table_catalogue` is a `422` naming the field — the one thing about a placement that
+         *     is an invariant rather than a flag. A placement whose table does not exist is not a
+         *     state you chose; it is a dangling reference nothing can render.
          *
-         *     **The one hard rule:** a fixture whose linked match is `completed` or `voided` is
-         *     history, so its placement can no longer be changed — a `409`. A fixture with no
+         *     **The placement is otherwise soft.** `scheduled_start` is a *prediction* until
+         *     pinned, and the placement's other constraints — the table belongs to the fixture's
+         *     pool, the time falls inside the pool's window, nothing is double-booked — are flags
+         *     derived on read, **not** invariants. So an out-of-window time, or a table outside
+         *     the fixture's pool, is **stored, not rejected**; the queued re-solve is what judges
+         *     the consequences.
+         *
+         *     **The one hard rule about the fixture:** a fixture whose linked match is `completed`
+         *     or `voided` is history, so its placement can no longer be changed — a `409`. A
+         *     fixture with no
          *     match yet, or a `pending`/`in_progress` one, is freely (re)placeable (a round-robin
          *     match is born `pending` at go-live and only becomes `in_progress` when called, so
          *     neither is the freeze trigger).
@@ -4581,7 +4616,7 @@ export interface components {
             end_date?: string | null;
             address?: components["schemas"]["AddressInput"] | null;
             /** Table Catalogue */
-            table_catalogue?: components["schemas"]["TournamentTable"][];
+            table_catalogue?: components["schemas"]["TournamentTableWrite"][];
             /** League Id */
             league_id?: string | null;
         };
@@ -4839,17 +4874,29 @@ export interface components {
          *     The body is the placement in full — both fields are stated together. ``null`` on
          *     either clears that half, and ``(null, null)`` unassigns the fixture entirely.
          *
-         *     **Soft, deliberately.** ``scheduled_start`` is a *prediction*, not a commitment,
-         *     and the placement's constraints — the table belongs to the fixture's pool, the time
-         *     falls inside the pool's window, nothing is double-booked — are **flags derived on
-         *     read, not invariants** (ADR-0790). So this write does **not** reject an
-         *     out-of-window time, nor a ``table_id`` that names no table in the tournament's
-         *     ``table_catalogue`` (a later pool/catalogue edit can dangle the ref; that is a
-         *     flag-on-read concern). They save. Conflict detection is a future scheduler slice.
+         *     **Soft, deliberately — with one exception.** ``scheduled_start`` is a *prediction*,
+         *     not a commitment, and three of the placement's four constraints — the table belongs
+         *     to the fixture's pool, the time falls inside the pool's window, nothing is
+         *     double-booked — are **flags derived on read, not invariants** (ADR-0790). So this
+         *     write does **not** reject an out-of-window time or an off-pool table. They save.
+         *     Conflict detection is the scheduler's business, not this boundary's.
          *
-         *     ``table_id`` is a **string ref** into the tournament's ``table_catalogue`` (names a
-         *     ``TournamentTable.id``) — the same pattern as a fixture's ``pool_id``, not a
-         *     foreign key — and per the soft rule above an unknown id is stored, not refused.
+         *     The exception is the fourth claim: **the table has to exist**. ``table_id`` names a
+         *     ``TournamentTable.id`` in the tournament's ``table_catalogue``, and since the
+         *     catalogue became real rows a fixture's ``table_id`` is a real **foreign key** into
+         *     them, so an id that names no table is a **422 naming this field** rather than
+         *     something stored and hoped about (ADR 20260801, "a placement names a real table, and
+         *     only that is an invariant" — which supersedes exactly one clause of ADR-0790 and
+         *     leaves the rest standing). The three flags are statements about a *relationship*
+         *     between things that each legitimately move, so they must stay soft; "this id
+         *     resolves to a table" is not one of those, and a placement whose table does not exist
+         *     is a dangling pointer nothing downstream can render.
+         *
+         *     The field carries the id's canonical **text** rather than a typed UUID, which is
+         *     also what a pool's ``table_ids`` carry — one representation for a table id, moved in
+         *     one piece rather than a field at a time. A value that is not a well-formed id is
+         *     therefore refused by the same 422 as an unknown one: there is one question here
+         *     ("does this name a table of this tournament?") and it gets one answer.
          *
          *     The one thing the *route* refuses is moving a fixture whose linked match is
          *     ``completed`` or ``voided``: its placement is history (409). A fixture with no match
@@ -4899,8 +4946,9 @@ export interface components {
          *       JSONB, not a foreign key, because pools are value-objects with no table.
          *     * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means
          *       **unassigned to a table**. When set, it names a ``TournamentTable`` in the
-         *       tournament's ``table_catalogue`` — a string ref into JSONB, not a foreign key,
-         *       the same pattern as ``pool_id``.
+         *       tournament's ``table_catalogue``, and it is guaranteed to: the column is a real
+         *       foreign key, so this is never a dangling ref (ADR 20260801). Carried as the id's
+         *       text, the same form a pool's ``table_ids`` carry.
          *     * ``scheduled_start`` — the placement's **predicted** start: ``null`` means
          *       **unscheduled**. When set, a :class:`FixtureTimeRead` (see it) — a venue-local
          *       label + tz abbrev for display, plus the raw UTC instant for geometry — composed
@@ -5009,18 +5057,102 @@ export interface components {
         TournamentStatus: "draft" | "published" | "live" | "archived";
         /**
          * TournamentTable
-         * @description A physical table in the venue catalogue, referenced by id from pools.
+         * @description A table in the venue catalogue as it is **read back**: everything a client wrote,
+         *     plus the ``id`` the server minted for it.
          *
-         *     Its ``id`` is a ``ValueObjectId`` for the same reason a pool's is: a pool holds a
-         *     list of these strings (``table_ids``) and nothing else connects the two, so an id
-         *     that is the empty string is a table nothing can name — and a ``table_ids`` entry of
-         *     ``""`` would "resolve" against it. It is the same string-ref pattern with the same
-         *     hole, and closing it in one place and not the other would leave the boundary
-         *     half-drawn.
+         *     Deriving it from :class:`TournamentTableWrite` keeps the two shapes one shape plus
+         *     a field, exactly as :class:`Pool` derives from :class:`PoolWrite`: a column added to
+         *     the write side is readable without a second edit, and the two can never disagree
+         *     about what a table *is*.
+         *
+         *     ``id`` is a UUID — the ``tournament_tables`` row's primary key. It is what a pool's
+         *     ``table_ids`` and a fixture's ``table_id`` name, and (from the fixture side) what a
+         *     foreign key will hold.
          */
         TournamentTable: {
-            /** Id */
+            /** Label */
+            label: string;
+            /** Court */
+            court: string;
+            /**
+             * Id
+             * Format: uuid
+             */
             id: string;
+        };
+        /**
+         * TournamentTableUpsert
+         * @description One entry of a catalogue a client **edits** (``PATCH /v1/tournaments/{id}``):
+         *     everything :class:`TournamentTableWrite` carries, plus an **optional** ``id`` naming
+         *     a table the tournament already has.
+         *
+         *     The optional id is what makes the catalogue write a **diff** rather than a
+         *     positional overwrite, and it exists because the ADR's removal semantics need one.
+         *     The two cases are exhaustive and mean different things:
+         *
+         *     * ``id`` **present** — "this is the table you already have, with these words". The
+         *       row keeps its id (and therefore every pool ``table_ids`` entry and every fixture
+         *       ``table_id`` that names it) and takes the new ``label``/``court``, and its place
+         *       in the list is its new place in the catalogue's order.
+         *     * ``id`` **omitted** (or ``null``) — "add a table". The server mints its id, exactly
+         *       as on create.
+         *     * a stored table **no entry names** — "remove it". Which is the whole reason this
+         *       field had to arrive: a removal can be *refused*
+         *       (:class:`~app.tournament_errors.TableInUseError`), and a verb that cannot tell
+         *       "the table you renamed" from "a different table at the same index" cannot tell a
+         *       rename from a removal either.
+         *
+         *     That last point is why the by-position stopgap this replaces could not stand.
+         *     Matching the i-th sent against the i-th stored made **reordering swap labels between
+         *     ids**: send the same two tables in the other order and each row kept its id and took
+         *     its neighbour's words, so a fixture placed at "Table 1" started rendering as
+         *     "Table 2". Nothing refused it and nothing could see it — an id is not a position,
+         *     and only the client knows which of its rows is which.
+         *
+         *     An id that names no table of *this* tournament is a 422 on the field, not a silently
+         *     minted new table: a client that names a table it cannot see has a bug, and quietly
+         *     handing it a different id than it asked for would hide it (parse-at-boundaries).
+         *
+         *     It is deliberately **not** on :class:`TournamentTableWrite`, the create shape: a
+         *     tournament being born has no tables to name, so an ``id`` there is still a 422 for
+         *     an unknown field. Nothing about who mints an id has changed — the server still does
+         *     (ADR 20260801); what changed is that a client may now *cite* one it was given.
+         */
+        TournamentTableUpsert: {
+            /** Label */
+            label: string;
+            /** Court */
+            court: string;
+            /** Id */
+            id?: string | null;
+        };
+        /**
+         * TournamentTableWrite
+         * @description A physical table in the venue catalogue, as a client **sends** it: what the
+         *     table is called and where it stands. Nothing else — in particular, not an ``id``.
+         *
+         *     A table is a row now (ADR 20260801, "a placement names a real table"), and its id
+         *     is minted by the database (``gen_random_uuid()``). So the id is simply not a field
+         *     of this model, and ``extra="forbid"`` turns an attempt to send one into a 422 that
+         *     names it — the treatment :class:`PoolWrite` gives ``position`` and the event
+         *     schemas give ``entered``. A server-managed value is kept **off** the write shape
+         *     rather than accepted and then ignored: a client cannot tell from the schema that the
+         *     id it sent decided nothing, and a boundary that silently discards half of a payload
+         *     has to be documented to be understood.
+         *
+         *     That is a real change of who owns a table's identity, and it is the point of the
+         *     ADR. While the catalogue was JSONB, the id was a client-supplied string with nothing
+         *     to key on, which is the only reason a placement naming no table could be *stored*
+         *     rather than refused. The **order** of the list is what a client does control: it is
+         *     the catalogue's order, and the server assigns each table its place from it.
+         *
+         *     This is the shape a **create** takes, and there it is the whole story: a tournament
+         *     being born has no tables, so there is nothing an ``id`` could name. A *patch* is a
+         *     diff over tables that already exist, so its entries derive from this one and add an
+         *     optional ``id`` naming the table they keep (:class:`TournamentTableUpsert`) — which
+         *     is citing an id, not authoring one, and does not disturb who mints them.
+         */
+        TournamentTableWrite: {
             /** Label */
             label: string;
             /** Court */
@@ -5041,12 +5173,18 @@ export interface components {
         /**
          * TournamentUpdate
          * @description Partial update. A field that is *absent* is left unchanged; an explicit
-         *     value replaces the current one. The columns backing ``name`` and
-         *     ``table_catalogue`` are NOT NULL, so for those an explicit ``null`` is
+         *     value replaces the current one. ``name`` maps to a NOT NULL column and
+         *     ``table_catalogue`` to a whole child table, so for those an explicit ``null`` is
          *     rejected (422) rather than allowed to reach the DB — "omitted" and "cleared"
          *     are different. ``description``/``start_date``/``end_date`` are nullable
-         *     columns and may be cleared. ``table_catalogue`` replaces wholesale when
-         *     present.
+         *     columns and may be cleared.
+         *
+         *     ``table_catalogue``, when present, is the catalogue **in full and in order**, and it
+         *     is applied as an **id-keyed diff** (ADR 20260801): an entry that cites an ``id``
+         *     keeps that table (with the words and the place this payload gives it), an entry with
+         *     no ``id`` adds one, and a stored table no entry cites is **removed**. Citing the id
+         *     is what makes a reorder move *tables* rather than swap labels between ids, and it is
+         *     what lets a removal be refused — see ``unplace_fixtures_on_removed_tables``.
          *
          *     ``address`` is nullable too, as of #1206: **omitted means unchanged; ``null`` — or
          *     an all-blank object, which :data:`SubmittedAddress` normalizes to ``null`` — means
@@ -5060,6 +5198,14 @@ export interface components {
          *     ``POST /v1/tournaments/{id}/transitions`` (ADR-0017). A guard on that route
          *     that left a ``status`` field on this one would have guarded nothing, so
          *     sending ``status`` here is a 422 via ``extra="forbid"``.
+         *
+         *     ``unplace_fixtures_on_removed_tables`` is the **removal opt-in**, not a field of the
+         *     tournament: it decides what happens when this payload's ``table_catalogue`` drops a
+         *     table that matches are placed at. **Omitted** — or ``false``, or ``null`` — the
+         *     whole edit is refused with a ``409`` naming the table, and nothing is written. Set
+         *     ``true``, the removal goes through and those matches are unplaced — table, predicted
+         *     start and pin all cleared — which is why it is said on purpose (ADR 20260801). A
+         *     table that only a *pool* reserves needs no opt-in: the pool reserves one fewer.
          *
          *     ``league_id`` is updatable, but **only while the tournament is ``draft``**
          *     (ADR-0783): once it is published, registration is open and eligibility is live,
@@ -5079,9 +5225,11 @@ export interface components {
             end_date?: string | null;
             address?: components["schemas"]["AddressInput"] | null;
             /** Table Catalogue */
-            table_catalogue?: components["schemas"]["TournamentTable"][] | null;
+            table_catalogue?: components["schemas"]["TournamentTableUpsert"][] | null;
             /** League Id */
             league_id?: string | null;
+            /** Unplace Fixtures On Removed Tables */
+            unplace_fixtures_on_removed_tables?: boolean | null;
         };
         /**
          * UnreadCountResponse

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -13,12 +13,14 @@ import {
   apiToEntryState,
   apiToEvent,
   apiToTournament,
+  catalogueToUpdateBody,
   draftToCreateBody,
   eventToCreateBody,
   eventToUpdateBody,
   tournamentToUpdateBody,
 } from './api'
 import { blankAddress } from './helpers'
+import { addTable, keepTables } from './table-catalogue'
 import type { Tournament, TournamentEvent } from './types'
 
 type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
@@ -723,7 +725,10 @@ describe('tournamentToUpdateBody', () => {
     expect('status' in body).toBe(false)
   })
 
-  it('sends the catalogue verbatim (it IS the editable table set)', () => {
+  // A no-op diff, not a replace. Under the server's id-keyed diff (ADR 20260801) an
+  // uncited stored table is a REMOVAL, so a Details-tab save that dropped the ids —
+  // or the catalogue — would read as "remove every table you have".
+  it('cites every stored table’s id, so a field edit removes nothing', () => {
     const tournament: Tournament = {
       ...draft,
       id: 't-1',
@@ -736,6 +741,72 @@ describe('tournamentToUpdateBody', () => {
     const body = tournamentToUpdateBody(tournament, catalogue)
 
     expect(body.table_catalogue).toEqual(catalogue)
+  })
+})
+
+describe('catalogueToUpdateBody', () => {
+  const stored = [
+    { id: 't1', label: 'T1', court: 'A' },
+    { id: 't2', label: 'T2', court: 'B' },
+  ]
+
+  it('cites kept tables by id and sends an added one with NO id key', () => {
+    const body = catalogueToUpdateBody(
+      [...keepTables(stored), addTable('T3', 'C')],
+      { unplaceFixturesOnRemovedTables: false },
+    )
+
+    expect(body.table_catalogue).toEqual([
+      { id: 't1', label: 'T1', court: 'A' },
+      { id: 't2', label: 'T2', court: 'B' },
+      { label: 'T3', court: 'C' },
+    ])
+    // Not `id: null` — the key is absent, so a reader can see at a glance that this
+    // row cites nothing and is therefore an insert.
+    expect('id' in body.table_catalogue![2]).toBe(false)
+  })
+
+  // A removal IS an omission: the diff is keyed by id, so leaving a stored table out
+  // is the only way to ask for it to go.
+  it('removes a table by leaving it out', () => {
+    const body = catalogueToUpdateBody(keepTables([stored[1]]), {
+      unplaceFixturesOnRemovedTables: false,
+    })
+
+    expect(body.table_catalogue).toEqual([{ id: 't2', label: 'T2', court: 'B' }])
+  })
+
+  // A PATCH leaves an absent field unchanged. Re-sending the name/dates/address a
+  // table edit never touched would make every add a chance to clobber a rename
+  // another tab made in between.
+  it('sends the catalogue and NOTHING else', () => {
+    const body = catalogueToUpdateBody(keepTables(stored), {
+      unplaceFixturesOnRemovedTables: false,
+    })
+
+    expect(Object.keys(body)).toEqual(['table_catalogue'])
+  })
+
+  // The opt-in has one affirmative spelling and is *said on purpose* — by a director
+  // who has read the 409. A body that always carried the key would make that answer
+  // look like a default; omitted and `false` mean the same thing to the server.
+  it('omits the opt-in unless it is being given', () => {
+    const body = catalogueToUpdateBody(keepTables(stored), {
+      unplaceFixturesOnRemovedTables: false,
+    })
+
+    expect('unplace_fixtures_on_removed_tables' in body).toBe(false)
+  })
+
+  it('sends the opt-in as true when the organizer confirmed', () => {
+    const body = catalogueToUpdateBody(keepTables(stored), {
+      unplaceFixturesOnRemovedTables: true,
+    })
+
+    expect(body.unplace_fixtures_on_removed_tables).toBe(true)
+    // The rest of the body is byte-identical to the refused one — the confirm
+    // re-sends the same edit, it does not recompute it.
+    expect(body.table_catalogue).toEqual(stored)
   })
 })
 

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -22,6 +22,7 @@ import type { components } from '@/api/schema'
 import { parseDrawTypeCatalogue } from './draw-types'
 import { entryRefusalNotice } from './entry-refusal'
 import { hasVenue } from './helpers'
+import { keepTables } from './table-catalogue'
 import { parseFixtures } from './fixtures'
 import { parseResults } from './results'
 import {
@@ -42,6 +43,7 @@ import type {
   Tournament,
   TournamentEvent,
   TournamentTable,
+  TournamentTableEntry,
 } from './types'
 
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
@@ -296,11 +298,37 @@ export function draftToCreateBody(
   }
 }
 
+/**
+ * One catalogue entry as the wire takes it (`TournamentTableUpsert`) — the domain's
+ * tagged union flattened onto the shape the server's **id-keyed diff** reads
+ * (ADR 20260801).
+ *
+ * The `added` arm omits the `id` **key**, rather than sending `null`. Both are
+ * accepted by `TournamentTableUpsert` (`id?: string | null`), so this is not a
+ * correctness fix on today's schema — it is the same discipline `drawSettingsToApi`
+ * applies below: send the field only when there is a table to name. A payload a
+ * reader can eyeball and see "this row cites nothing, so it is an insert" is the
+ * whole readability of a diff.
+ */
+function tableEntryToApi(
+  entry: TournamentTableEntry,
+): components['schemas']['TournamentTableUpsert'] {
+  return entry.kind === 'kept'
+    ? { id: entry.table.id, label: entry.table.label, court: entry.table.court }
+    : { label: entry.label, court: entry.court }
+}
+
 /** Build the tournament-level `TournamentUpdate` body from an edited prototype
  * `Tournament` and the full table catalogue. Events are NOT included — they
- * have their own endpoints. The catalogue is sent as-is (the Tables tab edits
- * it directly: assign IS catalogue here, since the API has no separate global
- * table list), so a Tables-tab edit round-trips the label/court, not just ids.
+ * have their own endpoints.
+ *
+ * The catalogue this takes is the tournament's **stored** tables, and every one of
+ * them is sent CITING ITS ID — a no-op diff (ADR 20260801). That is what keeps a
+ * Details-tab save (a renamed tournament, a new venue) from reading, to the server,
+ * as "remove every table you have": under an id-keyed diff, an uncited stored table
+ * is a removal. The Tables tab does not come through here — an *edit* of the
+ * catalogue is `catalogueToUpdateBody` below, which is the only builder that can
+ * express an add or a removal.
  *
  * **No `status`.** An edit carries no status, so editing a tournament's name or
  * dates can never move its lifecycle (ADR-0017). Moving it is
@@ -315,7 +343,33 @@ export function tournamentToUpdateBody(
     start_date: t.startDate,
     end_date: t.endDate,
     address: toAddressInput(t.address),
-    table_catalogue: catalogue,
+    table_catalogue: keepTables(catalogue).map(tableEntryToApi),
+  }
+}
+
+/**
+ * Build the **catalogue-only** `TournamentUpdate` body — the Tables tab's write.
+ *
+ * `table_catalogue` and nothing else. A PATCH leaves an absent field unchanged, so
+ * this edit says exactly what it means and no more: re-sending the name, dates and
+ * address a Tables-tab save never touched would make every table edit a chance to
+ * clobber a rename another tab made in between.
+ *
+ * `unplace_fixtures_on_removed_tables` is the **removal opt-in**, and it is sent only
+ * when it is `true`. Omitted, `false` and `null` are one answer to the server ("not
+ * opted in"), so there is nothing to gain by spelling it — and the field's whole point
+ * is that it is *said on purpose*, by a director who has read the 409 and answered it.
+ * A body that always carried the key would make that answer look like a default.
+ */
+export function catalogueToUpdateBody(
+  entries: readonly TournamentTableEntry[],
+  options: { unplaceFixturesOnRemovedTables: boolean },
+): TournamentUpdate {
+  return {
+    table_catalogue: entries.map(tableEntryToApi),
+    ...(options.unplaceFixturesOnRemovedTables
+      ? { unplace_fixtures_on_removed_tables: true }
+      : {}),
   }
 }
 
@@ -672,6 +726,46 @@ export function useUpdateTournament() {
       ),
     onSuccess: (_data, input) => invalidateTournament(qc, input.id),
     onError: notifyError('update the tournament'),
+  })
+}
+
+/**
+ * Write the **table catalogue** — the Tables tab's add and remove — as the id-keyed
+ * diff the server applies (ADR 20260801): `PATCH /v1/tournaments/{id}` carrying
+ * `table_catalogue` alone (`catalogueToUpdateBody`).
+ *
+ * Separate from `useUpdateTournament`, which patches the tournament's *fields*, for
+ * two reasons that are really the same reason — this write has a refusal the caller
+ * has to answer:
+ *
+ * - **No global `onError` toast.** The refusal it can meet is the 409 naming the
+ *   tables matches are placed at, and the Tables tab answers it with a confirm
+ *   carrying the server's own sentence. A toast on top of that would tell the
+ *   director the same thing twice and then take the sentence away after four seconds
+ *   (`web-client/CLAUDE.md`, ## Forms). The tab therefore awaits `mutateAsync` and
+ *   surfaces *every* failure itself.
+ * - **Reconciles `onSuccess` only**, unlike the draw/entry/lifecycle mutations. Their
+ *   interesting failure is the one that says "this screen is stale"; this one's is
+ *   not — a refused catalogue edit wrote **nothing** (the server judges the diff
+ *   before it moves a row), so there is no server state to re-read and, more to the
+ *   point, the confirm is about to re-send this exact body. A refetch underneath an
+ *   open dialog would swap the catalogue the pending edit was computed from.
+ */
+export function useUpdateTableCatalogue(tournamentId: string) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: {
+      entries: readonly TournamentTableEntry[]
+      unplaceFixturesOnRemovedTables: boolean
+    }): Promise<TournamentRead> =>
+      unwrap(
+        'update the tables',
+        await api.PATCH('/v1/tournaments/{tournament_id}', {
+          params: { path: { tournament_id: tournamentId } },
+          body: catalogueToUpdateBody(input.entries, input),
+        }),
+      ),
+    onSuccess: () => invalidateTournament(qc, tournamentId),
   })
 }
 

--- a/web-client/src/components/tournaments/data/table-catalogue.test.ts
+++ b/web-client/src/components/tournaments/data/table-catalogue.test.ts
@@ -1,0 +1,92 @@
+import { ApiError } from '@/api/client'
+
+import { addTable, keepTable, keepTables, tableInUseRefusal } from './table-catalogue'
+import { buildTable, buildTables } from './seed.factory'
+
+describe('keepTable / keepTables', () => {
+  it('cites a table the server sent back', () => {
+    const table = buildTable({ id: 't1', label: 'T1', court: 'A' })
+
+    expect(keepTable(table)).toEqual({ kind: 'kept', table })
+  })
+
+  it('cites every stored table — the change-nothing catalogue', () => {
+    const tables = buildTables(3)
+
+    expect(keepTables(tables)).toEqual(tables.map((table) => ({ kind: 'kept', table })))
+  })
+})
+
+describe('addTable', () => {
+  // The whole point of the tagged union: a new entry has no `id` FIELD, so there is
+  // no way to put a client-minted one on the wire (ADR 20260801 — the server mints
+  // table ids, and `TournamentTableWrite` is `extra="forbid"`).
+  it('carries the words and NO id', () => {
+    const entry = addTable('T9', 'A')
+
+    expect(entry).toEqual({ kind: 'added', label: 'T9', court: 'A' })
+    expect('id' in entry).toBe(false)
+  })
+})
+
+/** A refusal as `unwrap` builds it: the status, the extracted human `detail`, and
+ * the raw body it came from. */
+const refusal = (status: number, detail: unknown) =>
+  new ApiError(
+    status,
+    typeof detail === 'string' ? detail : null,
+    'update the tables',
+    { detail },
+  )
+
+const IN_USE =
+  '“T1” has 1 match placed at it, so removing it from the catalogue would leave ' +
+  'those matches with no table — indistinguishable from matches nobody ever placed. ' +
+  'To remove it anyway, send the same edit again with ' +
+  '“unplace_fixtures_on_removed_tables”: true, and those matches lose their table, ' +
+  'their time and their call and go back to the schedule to be placed again. To keep ' +
+  'them where they are, leave the table in the catalogue and move the matches off it ' +
+  'first.'
+
+describe('tableInUseRefusal', () => {
+  // Rendered VERBATIM — the ADR-0968 fallback. It names the tables by label and
+  // counts the matches, neither of which the client can reconstruct.
+  it('returns the 409’s sentence, untouched', () => {
+    expect(tableInUseRefusal(refusal(409, IN_USE))).toBe(IN_USE)
+  })
+
+  // The narrowing that matters most. `saveFailure`'s `refused` arm is broader than
+  // this refusal: a 403 lands in it too, and answering THAT with a confirm would ask
+  // the director to authorise their own lockout — and re-send a destructive opt-in
+  // against a request that will refuse identically.
+  it('declines a 403, however sentence-shaped its detail', () => {
+    expect(
+      tableInUseRefusal(
+        refusal(403, 'You can only modify tournaments you created.'),
+      ),
+    ).toBeNull()
+  })
+
+  // A 422 is Pydantic's array — machine prose, never shown (see `save-failure.ts`).
+  it('declines a 422', () => {
+    expect(
+      tableInUseRefusal(
+        refusal(422, [
+          { type: 'value_error', loc: ['body', 'table_catalogue', 0, 'id'], msg: 'nope' },
+        ]),
+      ),
+    ).toBeNull()
+  })
+
+  // The whole content of the confirm IS the server's prose. With nothing readable
+  // there is no question to ask, so it takes the ordinary failure path instead of
+  // opening an empty dialog.
+  it('declines a 409 with no readable detail', () => {
+    expect(tableInUseRefusal(refusal(409, null))).toBeNull()
+  })
+
+  it('declines anything that is not an ApiError', () => {
+    expect(tableInUseRefusal(new TypeError('Failed to fetch'))).toBeNull()
+    expect(tableInUseRefusal(undefined)).toBeNull()
+  })
+})

--- a/web-client/src/components/tournaments/data/table-catalogue.ts
+++ b/web-client/src/components/tournaments/data/table-catalogue.ts
@@ -1,0 +1,70 @@
+// The table catalogue as an **id-keyed diff** (ADR 20260801), on the client side of the
+// wire: how a Tables-tab edit is expressed, and how the one refusal it can meet is
+// recognised.
+//
+// Two facts drive everything here, and both are the server's:
+//
+// 1. **The server mints table ids.** `TournamentTableWrite` is `extra="forbid"` and has
+//    no `id` field, so a client-minted one is a 422 naming the row. A new entry
+//    therefore carries no id at all — which is what `TournamentTableEntry`'s `added`
+//    arm makes structurally true rather than a rule to remember (`./types`).
+// 2. **An uncited stored table is removed** — and a removal that would strand matches
+//    already placed at that table is **refused with a 409**, unless the write says
+//    `unplace_fixtures_on_removed_tables: true`. The refusal is the server's own
+//    sentence, written for a director to act on, and it is the reason this module has
+//    a classifier at all.
+
+import { ApiError } from '@/api/client'
+
+import { saveFailure } from './save-failure'
+import type { TournamentTable, TournamentTableEntry } from './types'
+
+/** "Keep this table" — an entry citing a row the server actually sent back. Takes the
+ * whole `TournamentTable` rather than an id, so there is no way to cite an id that
+ * came from anywhere but a read. */
+export const keepTable = (table: TournamentTable): TournamentTableEntry => ({
+  kind: 'kept',
+  table,
+})
+
+/** Every stored table, cited — the "change nothing" catalogue. What a surface that is
+ * editing something *else* about the tournament sends, and the base a Tables-tab edit
+ * is built by filtering or appending. */
+export const keepTables = (
+  tables: readonly TournamentTable[],
+): TournamentTableEntry[] => tables.map(keepTable)
+
+/** "Add this table" — no id, because the client has none to give (ADR 20260801). */
+export const addTable = (label: string, court: string): TournamentTableEntry => ({
+  kind: 'added',
+  label,
+  court,
+})
+
+/**
+ * The server's sentence when a catalogue edit was refused because it would remove a
+ * table **matches are placed at** — or `null` when the failure is anything else.
+ *
+ * This is the one refusal a client may answer with a *question* instead of an error,
+ * because the server's 409 explicitly names the way through: send the same edit again
+ * with the opt-in. So the classification has to be narrow, and it is narrow in two
+ * ways at once:
+ *
+ * - **the status must be 409.** `saveFailure`'s `refused` arm is broader than this
+ *   refusal — a 403 ("you can only modify tournaments you created") lands in it too,
+ *   and re-sending *that* with an opt-in flag would refuse identically while looking,
+ *   to the director, like the app had asked them to authorise their own lockout.
+ * - **the body must carry a sentence.** A 409 with no readable `detail` is not
+ *   something to put in a dialog: the whole content of the confirm IS the server's
+ *   prose (it names the tables, the match count, and both ways out), so with nothing
+ *   to show there is no question to ask, and the failure takes the ordinary path.
+ *
+ * The sentence is rendered **verbatim** — the ADR-0968 fallback, the case where the
+ * API wrote for a human rather than for a validator. Nothing here rewords it: it names
+ * the tables by label and the number of matches, which no client can reconstruct.
+ */
+export function tableInUseRefusal(error: unknown): string | null {
+  if (!(error instanceof ApiError) || error.status !== 409) return null
+  const failure = saveFailure(error)
+  return failure.kind === 'refused' ? failure.message : null
+}

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -510,12 +510,41 @@ export interface TournamentEvent {
 }
 
 /** A physical table in the venue catalogue, referenced by id from a
- * tournament's `tableIds` and a pool's `tableIds`. */
+ * tournament's `tableIds` and a pool's `tableIds`.
+ *
+ * The `id` is the SERVER's — a uuid it minted for the `tournament_tables` row
+ * (ADR 20260801). A client never authors one: this shape is what comes *back*, and
+ * the shape that goes *out* is `TournamentTableEntry` below. */
 export interface TournamentTable {
   id: string
   label: string
   court: string
 }
+
+/**
+ * One entry of an **edited** table catalogue — what the Tables tab emits and
+ * `catalogueToUpdateBody` (`./api`) puts on the wire as a `TournamentTableUpsert`.
+ *
+ * A catalogue write is an **id-keyed diff**, not a replace (ADR 20260801), and the
+ * two things an entry can mean are opposite:
+ *
+ * - **`kept`** — "this is the table you already have, with these words." It carries
+ *   a whole `TournamentTable`, so it cannot be constructed without a row the server
+ *   actually sent back.
+ * - **`added`** — "mint me one." It has no `id` **field at all**, so a client-minted
+ *   id is not a value this type can hold — which is the point: `TournamentTableWrite`
+ *   is `extra="forbid"`, so an `id` on a new entry is a 422, and an entry citing an
+ *   id the tournament does not have is a 422 on that row.
+ *
+ * (And a stored table **no entry names** is a *removal* — which is why this is a
+ * tagged union rather than the obvious `id?: string`. With one optional field, a
+ * draft row that had somehow acquired an id and a saved row that had lost one are
+ * both representable, and each is a silent data-loss bug: the first mints a
+ * duplicate table, the second deletes the row it meant to rename.)
+ */
+export type TournamentTableEntry =
+  | { kind: 'kept'; table: TournamentTable }
+  | { kind: 'added'; label: string; court: string }
 
 export interface Tournament {
   id: string

--- a/web-client/src/components/tournaments/tournament-detail-page.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.factory.tsx
@@ -10,7 +10,7 @@ export function buildTournamentDetailPageProps(
     tournament: buildTournament(),
     allTables: buildTables(12),
     onUpdate: () => {},
-    onChangeCatalogue: () => {},
+    onChangeCatalogue: async () => {},
     onCreateEvent: async () => {},
     onUpdateEvent: async () => {},
     onDeleteEvent: () => {},

--- a/web-client/src/components/tournaments/tournament-detail-page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.tsx
@@ -19,6 +19,7 @@ import type {
   Tournament,
   TournamentEvent,
   TournamentTable,
+  TournamentTableEntry,
 } from './data/types'
 import { PageHeading } from './page-heading'
 import { StatusBadge } from './status-badge'
@@ -35,8 +36,14 @@ export interface TournamentDetailPageProps {
   /** This tournament's table catalogue (for the Tables tab and pool editor). */
   allTables: TournamentTable[]
   onUpdate: (tournament: Tournament) => void
-  /** Persist an edited table catalogue (add/remove from the Tables tab). */
-  onChangeCatalogue: (catalogue: TournamentTable[]) => void
+  /** Persist an edited table catalogue (add/remove from the Tables tab) as the
+   * server's id-keyed diff (ADR 20260801). **The returned promise is load-bearing**:
+   * `TablesTab` awaits it and turns the 409 on removing an in-use table into a
+   * confirm, so a rejection must reach it rather than being swallowed by a toast. */
+  onChangeCatalogue: (
+    entries: TournamentTableEntry[],
+    options: { unplaceFixturesOnRemovedTables: boolean },
+  ) => Promise<void>
   /** Persist a new event. **The returned promise is load-bearing**: the `EventEditor`
    * awaits it, closes itself only when it RESOLVES, and stays open over a rejection —
    * so a refused create is reported instead of quietly binning everything the

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.factory.tsx
@@ -10,7 +10,7 @@ export function buildTablesTabProps(
     tournament: buildTournament({ tableIds: catalogue.map((t) => t.id) }),
     catalogue,
     canEdit: true,
-    onChangeCatalogue: () => {},
+    onChangeCatalogue: async () => {},
     ...overrides,
   }
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.page.tsx
@@ -26,6 +26,30 @@ const scoped = (container: Container) => ({
   getAddButton() {
     return container.getByRole('button', { name: 'Add table' })
   },
+  /** The in-use refusal's confirm — the 409 asked back as a question (ADR 20260801).
+   * Queried off `screen`, never the tab's container: an `AlertDialog` is PORTALED to
+   * the body, so a container-scoped query finds nothing whether it opened or not. */
+  queryConfirmDialog() {
+    return screen.queryByTestId('confirm-remove-table')
+  },
+  /** The confirm's body — the SERVER's sentence, verbatim. The assertion the whole
+   * dialog exists for: it names the tables and the match count, which the client
+   * cannot reconstruct. */
+  getConfirmDetail() {
+    return screen.getByTestId('confirm-remove-table-detail')
+  },
+  getConfirmRemoveButton() {
+    return screen.getByTestId('confirm-remove-table-confirm')
+  },
+  getConfirmCancelButton() {
+    return screen.getByTestId('confirm-remove-table-cancel')
+  },
+  /** The inline failure banner — every failure that is NOT the in-use refusal, in
+   * the client's own words (`saveFailureMessage`). Absent when the last write
+   * landed. */
+  queryError() {
+    return container.queryByTestId('tables-error')
+  },
   /** The add-table submit button — absent for a non-creator (`canEdit: false`),
    * along with the rest of the add-table form. */
   queryAddButton() {

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
@@ -1,38 +1,99 @@
 import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
 
+import { server } from '@/mocks/server'
+import {
+  findTournament,
+  placeFixture,
+  resetTournamentsStore,
+} from '@/mocks/tournaments-store'
+import { render, screen, waitFor } from '@/test/utilities'
+
+import {
+  useTables,
+  useTournament,
+  useUpdateTableCatalogue,
+} from '../data/api'
 import { buildTable, buildTables } from '../data/seed.factory'
+import type { TournamentTableEntry } from '../data/types'
+import { TablesTab } from './tables-tab'
 import { tablesTabPage } from './tables-tab.page'
 
+/** The recorded calls of a fake `onChangeCatalogue`, plus the answer it gives.
+ * Resolves by default — the tab clears the add form only on the success path. */
+function spyCatalogue(answer: () => Promise<void> = () => Promise.resolve()) {
+  const calls: {
+    entries: TournamentTableEntry[]
+    options: { unplaceFixturesOnRemovedTables: boolean }
+  }[] = []
+  return {
+    calls,
+    onChangeCatalogue: async (
+      entries: TournamentTableEntry[],
+      options: { unplaceFixturesOnRemovedTables: boolean },
+    ) => {
+      calls.push({ entries, options })
+      await answer()
+    },
+  }
+}
+
 describe('TablesTab', () => {
-  it('adds a new table to the catalogue', async () => {
-    const onChangeCatalogue = vi.fn()
-    tablesTabPage.render({
-      catalogue: buildTables(2),
-      onChangeCatalogue,
-    })
+  // ----- the diff a catalogue edit really is (ADR 20260801) ------------------
+  //
+  // A catalogue write is an **id-keyed diff**, not a replace: an entry citing an id
+  // means "this existing table", an entry with no id means "create this one", and a
+  // stored table no entry cites is REMOVED. So what this tab emits is not a list of
+  // tables — it is a list of *intents*, and these are the assertions that it says the
+  // one it means.
+
+  it('adds a table with NO id — the server mints it', async () => {
+    const spy = spyCatalogue()
+    tablesTabPage.render({ catalogue: buildTables(2), ...spy })
 
     await userEvent.type(tablesTabPage.getLabelInput(), 'T9')
     await userEvent.type(tablesTabPage.getCourtInput(), '9')
     await userEvent.click(tablesTabPage.getAddButton())
 
-    expect(onChangeCatalogue).toHaveBeenCalledTimes(1)
-    const next = onChangeCatalogue.mock.calls[0][0]
-    expect(next).toHaveLength(3)
-    expect(next[2]).toEqual(
-      expect.objectContaining({ label: 'T9', court: '9' }),
-    )
+    await waitFor(() => expect(spy.calls).toHaveLength(1))
+    const { entries } = spy.calls[0]
+    // The two stored tables are CITED — they are kept, not re-created. Under an
+    // id-keyed diff, dropping them from the payload would delete them.
+    expect(entries.slice(0, 2)).toEqual([
+      { kind: 'kept', table: buildTable({ id: 't1', label: 'T1', court: '1' }) },
+      { kind: 'kept', table: buildTable({ id: 't2', label: 'T2', court: '2' }) },
+    ])
+    // And the new one carries no id at ALL — not a minted one, not a null one.
+    // `TournamentTableWrite` is `extra="forbid"`, so an id here is a 422 (and, against
+    // the patch shape, an id naming no table of this tournament is a 422 too).
+    expect(entries[2]).toEqual({ kind: 'added', label: 'T9', court: '9' })
+    expect('id' in entries[2]).toBe(false)
+    // The destructive opt-in is never volunteered — an add removes nothing.
+    expect(spy.calls[0].options).toEqual({ unplaceFixturesOnRemovedTables: false })
   })
 
-  // The Court field is already labeled "Court" (its aria-label), and the card
-  // renders "Court {court}" — so the value stored is a BARE identifier. The
-  // placeholder must hint that bare value, never "Court", or a user who follows
-  // it types "Court A" and the card reads "Court Court A".
+  it('removes a table by leaving it OUT of the cited catalogue', async () => {
+    const spy = spyCatalogue()
+    tablesTabPage.render({ catalogue: buildTables(3), ...spy })
+
+    await userEvent.click(tablesTabPage.getRemoveButton('T1'))
+
+    await waitFor(() => expect(spy.calls).toHaveLength(1))
+    expect(spy.calls[0].entries).toEqual([
+      { kind: 'kept', table: buildTable({ id: 't2', label: 'T2', court: '2' }) },
+      { kind: 'kept', table: buildTable({ id: 't3', label: 'T3', court: '3' }) },
+    ])
+    // The first attempt NEVER opts in: the whole point of the flag is that a director
+    // says it on purpose, having read the refusal.
+    expect(spy.calls[0].options).toEqual({ unplaceFixturesOnRemovedTables: false })
+  })
+
+  // The card renders "Court {court}", so the value stored is a BARE identifier. The
+  // placeholder must hint that bare value, never "Court", or a user who follows it
+  // types "Court A" and the card reads "Court Court A".
   it('hints a bare Court value, not "Court", so "Court Court A" is impossible', async () => {
-    const onChangeCatalogue = vi.fn()
-    tablesTabPage.render({
-      catalogue: buildTables(2),
-      onChangeCatalogue,
-    })
+    const spy = spyCatalogue()
+    tablesTabPage.render({ catalogue: buildTables(2), ...spy })
 
     const placeholder = tablesTabPage.getCourtPlaceholder()
     expect(placeholder).not.toBe('Court')
@@ -43,9 +104,13 @@ describe('TablesTab', () => {
     await userEvent.type(tablesTabPage.getCourtInput(), 'A')
     await userEvent.click(tablesTabPage.getAddButton())
 
-    const next = onChangeCatalogue.mock.calls[0][0]
+    await waitFor(() => expect(spy.calls).toHaveLength(1))
     // Stored raw as "A" (not "Court A") → the card's "Court " prefix reads "Court A".
-    expect(next[2]).toEqual(expect.objectContaining({ label: 'T9', court: 'A' }))
+    expect(spy.calls[0].entries[2]).toEqual({
+      kind: 'added',
+      label: 'T9',
+      court: 'A',
+    })
   })
 
   // The card prepends "Court " to the raw value, so a bare "A" reads "Court A"
@@ -67,19 +132,20 @@ describe('TablesTab', () => {
     expect(tablesTabPage.getAddButton()).toBeEnabled()
   })
 
-  it('removes a table from the catalogue', async () => {
-    const onChangeCatalogue = vi.fn()
-    tablesTabPage.render({
-      catalogue: buildTables(3),
-      onChangeCatalogue,
-    })
+  // A modal/form that clears itself over a rejected write has silently thrown the
+  // organizer's work away (#614, #933). The add form is the same contract: it empties
+  // only on the success path.
+  it('keeps the typed label and court when the add is refused', async () => {
+    const spy = spyCatalogue(() => Promise.reject(new Error('nope')))
+    tablesTabPage.render({ catalogue: buildTables(2), ...spy })
 
-    await userEvent.click(tablesTabPage.getRemoveButton('T1'))
+    await userEvent.type(tablesTabPage.getLabelInput(), 'T9')
+    await userEvent.type(tablesTabPage.getCourtInput(), '9')
+    await userEvent.click(tablesTabPage.getAddButton())
 
-    expect(onChangeCatalogue).toHaveBeenCalledWith([
-      expect.objectContaining({ id: 't2' }),
-      expect.objectContaining({ id: 't3' }),
-    ])
+    await waitFor(() => expect(tablesTabPage.queryError()).not.toBeNull())
+    expect(tablesTabPage.getLabelInput()).toHaveValue('T9')
+    expect(tablesTabPage.getCourtInput()).toHaveValue('9')
   })
 
   it('hides the add-table form and per-row removes for a non-creator', () => {
@@ -127,5 +193,191 @@ describe('TablesTab', () => {
       'The physical tables available at this venue.',
     )
     expect(document.body).not.toHaveTextContent('Add them to pools')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The tab against the API — MSW + the tournaments store, which enforces the real
+// contract (id-keyed diff, minted ids, the in-use 409). The fakes above prove what
+// the tab *emits*; these prove the loop, which is a different claim: a
+// client-minted id is not merely unwanted, it is a **422** naming the row, and the
+// removal refusal is not a string this file invented but the sentence the server
+// composes (`_tables_in_use_detail`, `api/app/tournament_tables.py`).
+//
+// The harness is the detail route's wiring, minus the route: the same query, the
+// same mutation, the same `mutateAsync` whose rejection reaches the tab.
+// ---------------------------------------------------------------------------
+
+/** The seeded, owned `draft` tournament — a catalogue of `t1`… tables and one drawn
+ * event whose fixtures start UNPLACED. Its size is read from the store rather than
+ * written down here: what these tests assert is the DELTA an edit makes. */
+const SLAM = 'summer-slam-2026'
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+const catalogueOf = (id: string) => findTournament(id)!.table_catalogue
+const fixturesOf = (id: string) =>
+  findTournament(id)!.events.flatMap((e) => e.fixtures)
+
+function TablesTabHarness({ tournamentId }: { tournamentId: string }) {
+  const { data: tournament } = useTournament(tournamentId)
+  const catalogue = useTables(tournamentId)
+  const save = useUpdateTableCatalogue(tournamentId)
+  if (!tournament) return <p>Loading…</p>
+  return (
+    <TablesTab
+      tournament={tournament}
+      catalogue={catalogue}
+      canEdit
+      onChangeCatalogue={async (entries, options) => {
+        await save.mutateAsync({ entries, ...options })
+      }}
+    />
+  )
+}
+
+/** Place the drawn event's first fixture on `T1` — a full placement, so it pins.
+ * The pin is what makes "all three placement columns go together" a real assertion
+ * once the removal goes through. */
+function placeAMatchOnT1(): { fixtureId: string; tableId: string } {
+  const tableId = catalogueOf(SLAM)[0].id
+  const fixtureId = fixturesOf(SLAM)[0].id
+  const placed = placeFixture(SLAM, fixtureId, {
+    table_id: tableId,
+    scheduled_start: '2026-06-13T09:00:00',
+  })
+  if (!placed.ok) throw new Error('setup failed: could not place the fixture')
+  return { fixtureId, tableId }
+}
+
+describe('TablesTab against the API', () => {
+  beforeEach(() => resetTournamentsStore())
+
+  it('adds a table with no id and renders the one the SERVER minted', async () => {
+    const before = catalogueOf(SLAM)
+    render(<TablesTabHarness tournamentId={SLAM} />)
+    await screen.findByLabelText('Remove T1')
+
+    await userEvent.type(tablesTabPage.getLabelInput(), 'T13')
+    await userEvent.type(tablesTabPage.getCourtInput(), 'D')
+    await userEvent.click(tablesTabPage.getAddButton())
+
+    // The row on screen is the SERVER's, arriving through the refetch — not an
+    // optimistic local echo.
+    await screen.findByLabelText('Remove T13')
+    expect(tablesTabPage.queryError()).toBeNull()
+
+    const stored = catalogueOf(SLAM)
+    expect(stored).toHaveLength(before.length + 1)
+    expect(stored[before.length]).toEqual({
+      id: expect.stringMatching(UUID),
+      label: 'T13',
+      court: 'D',
+    })
+    // The stored rows are untouched — an add is an insert, not a re-mint of the
+    // catalogue (which is what a positional overwrite would have been).
+    expect(stored.slice(0, before.length)).toEqual(before)
+    // The falsification this test really carries: a client-minted id would name no
+    // table of this tournament, so the store would 422 and nothing would be added.
+  })
+
+  it('asks before removing a table matches are placed at, in the SERVER’s words', async () => {
+    const { tableId } = placeAMatchOnT1()
+    const before = catalogueOf(SLAM)
+    render(<TablesTabHarness tournamentId={SLAM} />)
+    await screen.findByLabelText('Remove T1')
+
+    await userEvent.click(tablesTabPage.getRemoveButton('T1'))
+
+    // Verbatim: it names the table by LABEL, counts the matches, and states both ways
+    // out — none of which this client could reconstruct.
+    const detail = await screen.findByTestId('confirm-remove-table-detail')
+    expect(detail).toHaveTextContent(
+      '“T1” has 1 match placed at it, so removing it from the catalogue would leave ' +
+        'those matches with no table — indistinguishable from matches nobody ever ' +
+        'placed. To remove it anyway, send the same edit again with ' +
+        '“unplace_fixtures_on_removed_tables”: true, and those matches lose their ' +
+        'table, their time and their call and go back to the schedule to be placed ' +
+        'again. To keep them where they are, leave the table in the catalogue and ' +
+        'move the matches off it first.',
+    )
+    // Never the id — a uuid tells a director looking at a page of named tables
+    // nothing to act on.
+    expect(detail.textContent).not.toContain(tableId)
+    // And NOTHING was written: the refusal is a refusal, not a report.
+    expect(catalogueOf(SLAM)).toEqual(before)
+    expect(fixturesOf(SLAM)[0].table_id).toBe(tableId)
+  })
+
+  it('completes the removal when the organizer confirms, unplacing those matches', async () => {
+    const { fixtureId, tableId } = placeAMatchOnT1()
+    const before = catalogueOf(SLAM)
+    render(<TablesTabHarness tournamentId={SLAM} />)
+    await screen.findByLabelText('Remove T1')
+
+    await userEvent.click(tablesTabPage.getRemoveButton('T1'))
+    await screen.findByTestId('confirm-remove-table-detail')
+
+    await userEvent.click(tablesTabPage.getConfirmRemoveButton())
+
+    // The STORE first, deliberately: it names what it holds, so a red here reads
+    // "the table is still in the catalogue" rather than the undiscriminated
+    // "timed out" a DOM-absence wait would give (see the timeout note in
+    // `web-client/CLAUDE.md`).
+    await waitFor(() =>
+      expect(catalogueOf(SLAM).map((t) => t.id)).not.toContain(tableId),
+    )
+    expect(catalogueOf(SLAM)).toHaveLength(before.length - 1)
+    // …and the row leaves the screen through the refetch.
+    await waitFor(() => expect(screen.queryByLabelText('Remove T1')).toBeNull())
+    // …the dialog closed itself, and no failure was reported…
+    await waitFor(() => expect(tablesTabPage.queryConfirmDialog()).toBeNull())
+    expect(tablesTabPage.queryError()).toBeNull()
+    // …and all THREE placement columns went together: a start with no table is a bar
+    // on a schedule with nowhere to be, and a pin is a promise about a table.
+    const fixture = fixturesOf(SLAM).find((f) => f.id === fixtureId)!
+    expect(fixture.table_id).toBeNull()
+    expect(fixture.scheduled_start).toBeNull()
+    expect(fixture.pinned_at).toBeNull()
+  })
+
+  it('sends nothing when the organizer keeps the table', async () => {
+    const { tableId } = placeAMatchOnT1()
+    render(<TablesTabHarness tournamentId={SLAM} />)
+    await screen.findByLabelText('Remove T1')
+
+    await userEvent.click(tablesTabPage.getRemoveButton('T1'))
+    await screen.findByTestId('confirm-remove-table-detail')
+    await userEvent.click(tablesTabPage.getConfirmCancelButton())
+
+    await waitFor(() => expect(tablesTabPage.queryConfirmDialog()).toBeNull())
+    expect(catalogueOf(SLAM).map((t) => t.id)).toContain(tableId)
+    expect(fixturesOf(SLAM)[0].table_id).toBe(tableId)
+    expect(screen.getByLabelText('Remove T1')).toBeInTheDocument()
+  })
+
+  // The confirm is for ONE refusal. A 403 is also a 4xx the server explains in a
+  // sentence — and re-sending it with the destructive opt-in would refuse
+  // identically, while asking the director to authorise their own lockout.
+  it('reports a non-409 refusal inline — never as a confirm', async () => {
+    server.use(
+      http.patch('*/v1/tournaments/:tournamentId', () =>
+        HttpResponse.json(
+          { detail: 'Only the creator can edit this tournament.' },
+          { status: 403 },
+        ),
+      ),
+    )
+    render(<TablesTabHarness tournamentId={SLAM} />)
+    await screen.findByLabelText('Remove T1')
+
+    await userEvent.click(tablesTabPage.getRemoveButton('T1'))
+
+    await waitFor(() =>
+      expect(tablesTabPage.queryError()).toHaveTextContent(
+        'Only the creator can edit this tournament.',
+      ),
+    )
+    expect(tablesTabPage.queryConfirmDialog()).toBeNull()
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.tsx
@@ -1,27 +1,69 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Plus, Trash2 } from 'lucide-react'
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 
-import { genId } from '../data/helpers'
-import type { Tournament, TournamentTable } from '../data/types'
+import {
+  saveFailure,
+  saveFailureMessage,
+  TOURNAMENT_SAVE_TARGET,
+} from '../data/save-failure'
+import { addTable, keepTables, tableInUseRefusal } from '../data/table-catalogue'
+import type {
+  Tournament,
+  TournamentTable,
+  TournamentTableEntry,
+} from '../data/types'
 import { SectionHeader } from './section-header'
+
+/** The edit a 409 refused, held so the confirm can re-send it **byte for byte** plus
+ * the opt-in — which is safe precisely because the refusal wrote nothing (the server
+ * judges the whole diff before it moves a row), so there is no partial state to
+ * reconcile against first. The `message` is the server's sentence, kept beside the
+ * entries because a confirm with no explanation is not a question. */
+interface RefusedEdit {
+  entries: TournamentTableEntry[]
+  message: string
+}
 
 export interface TablesTabProps {
   tournament: Tournament
-  /** This tournament's table catalogue (the venue tables it owns). */
+  /** This tournament's table catalogue (the venue tables it owns), as the server
+   * sent it — every row carrying the id the server minted for it. */
   catalogue: TournamentTable[]
   /** When false (a non-creator), the add-table form and per-row Remove buttons
    * are hidden, the organizer-voiced half of the subtitle is dropped, and the
    * tab is a read-only list of tables. */
   canEdit: boolean
-  /** Emit the next catalogue. The catalogue IS the assigned set — the API has
-   * no separate global table list, so removing a table drops it outright and
-   * the "Add" affordance creates a brand-new table. */
-  onChangeCatalogue: (catalogue: TournamentTable[]) => void
+  /**
+   * Persist the next catalogue as the server's **id-keyed diff** (ADR 20260801): a
+   * `kept` entry cites a table the tournament already has, an `added` entry has no id
+   * for the server to mint one, and a stored table no entry names is **removed**.
+   *
+   * **The rejection is load-bearing** — this tab awaits it and classifies it. Do not
+   * swallow the failure (or attach a global error toast to the mutation behind it):
+   * the one refusal that matters here, the 409 on removing a table matches are placed
+   * at, is not an error to report but a question to ask, and this component is what
+   * asks it.
+   */
+  onChangeCatalogue: (
+    entries: TournamentTableEntry[],
+    options: { unplaceFixturesOnRemovedTables: boolean },
+  ) => Promise<void>
 }
 
 /** The Tables tab: the venue tables in this tournament's catalogue, each with
@@ -34,6 +76,15 @@ export const TablesTab = ({
 }: TablesTabProps) => {
   const [label, setLabel] = useState('')
   const [court, setCourt] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [refused, setRefused] = useState<RefusedEdit | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  // Radix reports the ACTION click's close through the same `onOpenChange(false)` as
+  // Escape and the overlay — remember a confirm so its close is not read as a cancel.
+  // Written in the click handler and consumed at the next close, so it re-arms itself
+  // (unlike a cleanup-only mounted ref, which StrictMode latches — see
+  // `web-client/CLAUDE.md`).
+  const confirmed = useRef(false)
 
   const usage = catalogue.map((table) => {
     const usingEvents = tournament.events
@@ -42,18 +93,61 @@ export const TablesTab = ({
     return { table, usingEvents }
   })
 
+  /**
+   * Send a catalogue edit and answer whatever comes back. Resolves `true` when the
+   * write landed.
+   *
+   * The 409 branch is deliberately gated on `!unplaceFixturesOnRemovedTables`: a
+   * refusal that survives the opt-in is not a question worth re-asking, so it falls
+   * through to the inline failure rather than re-opening the dialog the director just
+   * answered.
+   */
+  const save = async (
+    entries: TournamentTableEntry[],
+    unplaceFixturesOnRemovedTables: boolean,
+  ): Promise<boolean> => {
+    setError(null)
+    setSaving(true)
+    try {
+      await onChangeCatalogue(entries, { unplaceFixturesOnRemovedTables })
+      setRefused(null)
+      return true
+    } catch (failure) {
+      const message = tableInUseRefusal(failure)
+      if (message !== null && !unplaceFixturesOnRemovedTables) {
+        setRefused({ entries, message })
+        return false
+      }
+      setRefused(null)
+      // Everything else is reported in OUR words, from the classification — never the
+      // raw `detail` (a 422's message is Pydantic's). The one server sentence this tab
+      // shows verbatim is the 409 above, which `saveFailure` also routes through its
+      // `refused` arm.
+      setError(saveFailureMessage(saveFailure(failure), TOURNAMENT_SAVE_TARGET))
+      return false
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  /** Remove one table: every OTHER stored table, cited. The removed one is simply
+   * absent — an uncited stored table is what a removal *is* on the wire. */
   const removeTable = (id: string) =>
-    onChangeCatalogue(catalogue.filter((t) => t.id !== id))
+    void save(keepTables(catalogue.filter((t) => t.id !== id)), false)
 
   const trimmedLabel = label.trim()
   const canAdd = trimmedLabel.length > 0
 
-  const addTable = () => {
+  /** Add one table: the whole stored catalogue, cited, plus one entry carrying **no
+   * id** — the server mints it (ADR 20260801). The form clears only when the write
+   * landed, so a refused add leaves the words the organizer typed on screen. */
+  const submitTable = async () => {
     if (!canAdd) return
-    onChangeCatalogue([
-      ...catalogue,
-      { id: genId('table'), label: trimmedLabel, court: court.trim() },
-    ])
+    const saved = await save(
+      [...keepTables(catalogue), addTable(trimmedLabel, court.trim())],
+      false,
+    )
+    if (!saved) return
     setLabel('')
     setCourt('')
   }
@@ -93,6 +187,7 @@ export const TablesTab = ({
                   type="button"
                   aria-label={`Remove ${table.label}`}
                   onClick={() => removeTable(table.id)}
+                  disabled={saving}
                   className="grid size-7 place-items-center rounded-md text-[color:var(--fg-3)] hover:bg-[color:var(--bg-hover)] hover:text-[color:var(--loss)]"
                 >
                   <Trash2 size={14} />
@@ -120,6 +215,16 @@ export const TablesTab = ({
         ))}
       </div>
 
+      {error !== null && (
+        <Alert
+          variant="destructive"
+          data-testid="tables-error"
+          className="mt-4 max-w-2xl"
+        >
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
       {canEdit && (
         <div className="mt-6">
           <div className="mb-2 text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase">
@@ -129,7 +234,7 @@ export const TablesTab = ({
             className="flex flex-wrap items-center gap-2"
             onSubmit={(e) => {
               e.preventDefault()
-              addTable()
+              void submitTable()
             }}
           >
             <Input
@@ -151,13 +256,58 @@ export const TablesTab = ({
               onChange={(e) => setCourt(e.target.value)}
               className="w-28"
             />
-            <Button type="submit" disabled={!canAdd}>
+            <Button type="submit" disabled={!canAdd || saving}>
               <Plus size={14} />
               Add table
             </Button>
           </form>
         </div>
       )}
+
+      {/* The removal's one refusal, asked back as a question (ADR 20260801). The body
+          is the SERVER's sentence, verbatim: it names the tables by label, counts the
+          matches placed at them, and states both ways out — none of which this client
+          can reconstruct, and all of which the director needs to choose between
+          unplacing and moving the matches first. */}
+      <AlertDialog
+        open={refused !== null}
+        onOpenChange={(next) => {
+          if (next) return
+          if (!confirmed.current) setRefused(null)
+          confirmed.current = false
+        }}
+      >
+        <AlertDialogContent data-testid="confirm-remove-table">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove the table anyway?</AlertDialogTitle>
+            <AlertDialogDescription data-testid="confirm-remove-table-detail">
+              {refused?.message}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            {/* No onClick of its own: the cancel is reported once, through
+                onOpenChange, the same channel Escape and the overlay use — and
+                cancelling sends nothing, so the table stays. */}
+            <AlertDialogCancel data-testid="confirm-remove-table-cancel">
+              Keep the table
+            </AlertDialogCancel>
+            <AlertDialogAction
+              data-testid="confirm-remove-table-confirm"
+              variant="destructive"
+              disabled={saving}
+              onClick={() => {
+                if (!refused) return
+                confirmed.current = true
+                // The SAME entries, plus the opt-in. Not recomputed from
+                // `catalogue`: the answer must be to the question that was asked.
+                void save(refused.entries, true)
+              }}
+            >
+              Remove and unplace
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -2187,6 +2187,29 @@ export const handlers = [
       | undefined
     const result = updateTournament(String(params.tournamentId), body ?? {})
     if (!result.ok) {
+      // The catalogue's named refusal (ADR 20260801): this edit would remove a table
+      // matches are placed at, and nobody opted in. Bare prose, carrying the domain's
+      // own sentence — the client shows it verbatim — and nothing was written.
+      if (result.status === 409) return detail(result.detail, 409)
+      // An entry citing an id this tournament's catalogue does not hold. Shaped as a
+      // **field** refusal — FastAPI's per-field array, `loc` naming the entry's index —
+      // because that is what the route really sends and what `validationFields`
+      // (`src/api/client.ts`) reads to blame the Tables row.
+      if (result.status === 422) {
+        return HttpResponse.json(
+          {
+            detail: [
+              {
+                type: 'value_error',
+                loc: ['body', 'table_catalogue', result.index, 'id'],
+                msg: result.detail,
+                input: result.tableId,
+              },
+            ],
+          },
+          { status: 422 },
+        )
+      }
       return detail(
         result.status === 403
           ? 'Only the creator can edit this tournament.'

--- a/web-client/src/mocks/tournaments-handlers.test.ts
+++ b/web-client/src/mocks/tournaments-handlers.test.ts
@@ -352,3 +352,169 @@ describe('the event write boundary — the draw configuration (ADR 20260727)', (
     expect((body as TournamentEventRead).qualifiers_per_pool).toBeNull()
   })
 })
+
+// ----- the tournament write boundary — the venue catalogue (ADR 20260801) --------
+//
+// The catalogue moved from a JSONB blob a client authored ids into, to child ROWS whose
+// ids the SERVER mints, written as an id-keyed DIFF. Two of its consequences are wire
+// facts a component can only meet through a handler, so they are asserted here rather
+// than against the store: a create's response carries ids the client never sent, and a
+// removal the state of the world forbids comes back as a **409 carrying the server's own
+// sentence** (which the client shows verbatim) — not as a quietly-applied edit.
+//
+// A mock that answered that removal with a 200 would be more permissive than the API it
+// stands in for: the Tables tab would look perfect in `npm run dev` and in vitest, and
+// 409 in front of a director on the morning of their tournament.
+describe('the tournament write boundary — the venue catalogue (ADR 20260801)', () => {
+  /** Summer Slam: draft, owned, catalogue `T1`–`T8`, one drawn round-robin. */
+  const SLAM = SUMMER_SLAM
+
+  async function getTournament(id: string) {
+    const res = await fetch(`http://localhost/v1/tournaments/${id}`)
+    return { status: res.status, body: (await res.json()) as TournamentDetailRead }
+  }
+
+  async function patchTournament(
+    id: string,
+    patch: components['schemas']['TournamentUpdate'],
+  ) {
+    const res = await fetch(`http://localhost/v1/tournaments/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(patch),
+    })
+    return { status: res.status, body: await res.json() }
+  }
+
+  /** The tournament's catalogue as a PATCH body carries it: every table cited by id, so
+   * this alone is a no-op diff and dropping an entry from it is a removal. */
+  const upsertsOf = (t: TournamentDetailRead) =>
+    t.table_catalogue.map((tbl) => ({
+      id: tbl.id,
+      label: tbl.label,
+      court: tbl.court,
+    }))
+
+  /** Place Summer Slam's first pool fixture on its first table, over the wire. */
+  async function placeAFixture(): Promise<{ fixtureId: string; tableId: string }> {
+    const { body } = await getTournament(SLAM)
+    const tableId = body.table_catalogue[0].id
+    const fixtureId = body.events.flatMap((e) => e.fixtures)[0].id
+    const res = await fetch(
+      `http://localhost/v1/tournaments/${SLAM}/fixtures/${fixtureId}/placement`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          table_id: tableId,
+          scheduled_start: '2026-08-22T09:00:00',
+        }),
+      },
+    )
+    expect(res.status).toBe(200)
+    return { fixtureId, tableId }
+  }
+
+  it('mints an id for every table on a CREATE — the body carries none', async () => {
+    const res = await fetch('http://localhost/v1/tournaments', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Minted Over The Wire',
+        description: null,
+        start_date: null,
+        end_date: null,
+        address: null,
+        // `TournamentTableWrite` — no `id` is even sendable.
+        table_catalogue: [{ label: 'T1', court: 'A' }],
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    const created = (await res.json()) as components['schemas']['TournamentRead']
+    const [table] = created.table_catalogue
+    expect(table).toMatchObject({ label: 'T1', court: 'A' })
+    expect(table.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    )
+  })
+
+  it('409s a removal a placement stands in the way of, and writes nothing', async () => {
+    const { tableId } = await placeAFixture()
+    const before = (await getTournament(SLAM)).body
+
+    const { status, body } = await patchTournament(SLAM, {
+      // The rename rides along, so a guard that refused *after* writing is caught.
+      name: 'Renamed While Removing',
+      table_catalogue: upsertsOf(before).filter((t) => t.id !== tableId),
+    })
+
+    expect(status).toBe(409)
+    // A bare `detail` STRING — the shape `extractDetail` reads and the editor's banner
+    // shows verbatim, because the sentence is the domain's, not a validator's.
+    const { detail } = body as { detail: string }
+    expect(detail).toContain('“T1”')
+    expect(detail).toContain('1 match')
+    expect(detail).toContain('unplace_fixtures_on_removed_tables')
+    // …and named by LABEL, never by the id the diff actually compared.
+    expect(detail).not.toContain(tableId)
+
+    const after = (await getTournament(SLAM)).body
+    expect(after.table_catalogue).toEqual(before.table_catalogue)
+    expect(after.name).toBe(before.name)
+    expect(after.events.flatMap((e) => e.fixtures)[0].table_id).toBe(tableId)
+  })
+
+  it('accepts the same removal with the opt-in, leaving those fixtures unplaced', async () => {
+    const { fixtureId, tableId } = await placeAFixture()
+    const before = (await getTournament(SLAM)).body
+
+    const { status } = await patchTournament(SLAM, {
+      name: 'Renamed While Removing',
+      table_catalogue: upsertsOf(before).filter((t) => t.id !== tableId),
+      unplace_fixtures_on_removed_tables: true,
+    })
+
+    expect(status).toBe(200)
+    const after = (await getTournament(SLAM)).body
+    expect(after.table_catalogue.map((t) => t.id)).not.toContain(tableId)
+    expect(after.name).toBe('Renamed While Removing')
+    const fixture = after.events
+      .flatMap((e) => e.fixtures)
+      .find((f) => f.id === fixtureId)!
+    expect(fixture.table_id).toBeNull()
+    expect(fixture.scheduled_start).toBeNull()
+    expect(fixture.pinned_at).toBeNull()
+  })
+
+  it('422s an entry citing an id this catalogue does not hold, naming the entry', async () => {
+    const before = (await getTournament(SLAM)).body
+
+    const { status, body } = await patchTournament(SLAM, {
+      table_catalogue: [
+        ...upsertsOf(before),
+        { id: 'not-a-table-of-this-tournament', label: 'T9', court: '9' },
+      ],
+    })
+
+    expect(status).toBe(422)
+    // FastAPI's per-field array, so `validationFields` (`src/api/client.ts`) can blame
+    // the Tables row rather than falling through to the generic sentence.
+    const { detail } = body as {
+      detail: { loc: (string | number)[]; msg: string }[]
+    }
+    expect(detail[0].loc).toEqual([
+      'body',
+      'table_catalogue',
+      before.table_catalogue.length,
+      'id',
+    ])
+    expect(detail[0].msg).toBe(
+      "This tournament's venue catalogue has no table with that id.",
+    )
+    // Nothing minted, nothing removed.
+    expect((await getTournament(SLAM)).body.table_catalogue).toEqual(
+      before.table_catalogue,
+    )
+  })
+})

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -17,6 +17,7 @@ import {
   findTournament,
   listTournaments,
   markFixturePlayed,
+  placeFixture,
   placeInStatus,
   requestScheduleSolve,
   resetTournamentsStore,
@@ -26,12 +27,15 @@ import {
   updateTournament,
   withdrawEntry,
   type EnterResult,
+  type StoreResult,
   type TransitionResult,
   type WithdrawResult,
 } from './tournaments-store'
 import type { components } from '@/api/schema'
 
 type TournamentStatus = components['schemas']['TournamentStatus']
+type TournamentTable = components['schemas']['TournamentTable']
+type TournamentTableUpsert = components['schemas']['TournamentTableUpsert']
 
 const TOURNAMENT = 'bay-area-open-2026' // seeded `published`, owned
 const DRAFT_TOURNAMENT = 'summer-slam-2026' // seeded `draft`, owned, one drawn event
@@ -2281,5 +2285,313 @@ describe('the seeded two-stage (rr-then-ko) events', () => {
     // The finishes hold only what the bracket has actually settled: the two beaten
     // semifinalists, tied 3rd. No 1st, no 2nd — those do not exist yet.
     expect(midFlight.finishes.map((f) => f.position)).toEqual([3, 3])
+  })
+})
+
+// ----- the venue catalogue on a write (ADR 20260801) --------------------------
+//
+// A table is a ROW now, and two things about it moved at once:
+//
+//   1. its **id is the server's to mint** — the create shape has no `id` at all, and the
+//      patch shape's optional one *cites* a table rather than authoring one;
+//   2. the catalogue write is a **diff**, not a replace — a stored table no entry names
+//      is removed, and a removal can be REFUSED.
+//
+// Both are mirrored here, and the refusal is the reason it matters. A mock that
+// wholesale-replaced the catalogue would let a component that drops a table look
+// perfectly healthy in `npm run dev` and in vitest, and 409 in front of a director on
+// the morning of their tournament — with the matches they had already placed silently
+// homeless in the mock world in the meantime.
+//
+// The asymmetry is the ADR's point and is asserted on both sides: a table only a POOL
+// reserves goes quietly (a table breaking or freeing up is ordinary venue traffic), a
+// table a fixture is PLACED at is refused (clearing a placement destroys information on
+// an unrelated write).
+describe('the venue catalogue on a write (ADR 20260801)', () => {
+  beforeEach(() => resetTournamentsStore())
+  afterEach(() => resetTournamentsStore())
+
+  /** Summer Slam: draft, owned, catalogue `T1`–`T8`, one drawn round-robin whose two
+   * pools reserve `T1`–`T4`. Everything below edits ITS catalogue. */
+  const SLAM = DRAFT_TOURNAMENT
+
+  const catalogueOf = (id: string): TournamentTable[] =>
+    findTournament(id)!.table_catalogue
+
+  const fixturesOf = (id: string) =>
+    findTournament(id)!.events.flatMap((e) => e.fixtures)
+
+  /** The tournament's own catalogue as a PATCH body carries it — the round trip the
+   * client really makes: read the tables, send them back edited. Every entry cites its
+   * id, so this alone is a no-op diff. */
+  const asUpserts = (id: string): TournamentTableUpsert[] =>
+    catalogueOf(id).map((t) => ({ id: t.id, label: t.label, court: t.court }))
+
+  /** Assert the named refusal and hand back its payload, narrowed — one per status, so
+   * a test reading `.index` off a 409 is a type error rather than an `undefined`. */
+  function refusal409(result: StoreResult) {
+    if (result.ok || result.status !== 409) {
+      throw new Error(`expected a 409, got ${JSON.stringify(result)}`)
+    }
+    return result
+  }
+
+  function refusal422(result: StoreResult) {
+    if (result.ok || result.status !== 422) {
+      throw new Error(`expected a 422, got ${JSON.stringify(result)}`)
+    }
+    return result
+  }
+
+  /** Place Summer Slam's first pool fixture on `T1` — a FULL placement of a fixture
+   * whose two sides are known, so it pins (`manualPlacementPin`, every status). That
+   * pin is what makes the opt-in's "all three columns go" a real assertion. */
+  function placeAFixtureOnT1(): { fixtureId: string; tableId: string } {
+    const tableId = catalogueOf(SLAM)[0].id
+    const fixtureId = fixturesOf(SLAM)[0].id
+    const placed = placeFixture(SLAM, fixtureId, {
+      table_id: tableId,
+      scheduled_start: '2026-08-22T09:00:00',
+    })
+    if (!placed.ok) throw new Error('setup failed: could not place the fixture')
+    expect(placed.fixture.pinned_at).not.toBeNull()
+    return { fixtureId, tableId }
+  }
+
+  const fixtureIn = (tournamentId: string, fixtureId: string) =>
+    fixturesOf(tournamentId).find((f) => f.id === fixtureId)!
+
+  // ----- who mints an id ------------------------------------------------------
+
+  it('MINTS an id for every table on a create — the client sends none', () => {
+    const created = createTournament({
+      name: 'Minted On Create',
+      description: null,
+      start_date: null,
+      end_date: null,
+      address: null,
+      // `TournamentTableWrite`: label and court, and no `id` to send.
+      table_catalogue: [
+        { label: 'T1', court: 'A' },
+        { label: 'T2', court: 'B' },
+      ],
+    })
+
+    const [first, second] = created.table_catalogue
+    expect(first).toMatchObject({ label: 'T1', court: 'A' })
+    expect(second).toMatchObject({ label: 'T2', court: 'B' })
+    // Real, distinct uuids — the wire says `format: uuid`, and two rows sharing an id
+    // is the one thing an id-keyed diff cannot survive.
+    expect(first.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    )
+    expect(second.id).not.toBe(first.id)
+  })
+
+  it('MINTS an id for a table added by a PATCH, and leaves the cited ones alone', () => {
+    const before = catalogueOf(SLAM)
+
+    const result = updateTournament(SLAM, {
+      // The whole catalogue, cited by id, plus one entry with NO id: "add this one".
+      table_catalogue: [...asUpserts(SLAM), { label: 'T9', court: '9' }],
+    })
+
+    expect(result.ok).toBe(true)
+    const after = catalogueOf(SLAM)
+    expect(after).toHaveLength(before.length + 1)
+    // Every table that was already there kept its id — every pool `table_ids` and
+    // fixture `table_id` that names one still names it.
+    expect(after.slice(0, before.length).map((t) => t.id)).toEqual(
+      before.map((t) => t.id),
+    )
+    const added = after[after.length - 1]
+    expect(added).toMatchObject({ label: 'T9', court: '9' })
+    expect(before.map((t) => t.id)).not.toContain(added.id)
+  })
+
+  // ----- the diff is keyed on the id, not the position ------------------------
+
+  it('re-words a CITED table in place — the id is what the entry names', () => {
+    const [first, ...rest] = catalogueOf(SLAM)
+
+    updateTournament(SLAM, {
+      table_catalogue: [
+        { id: first.id, label: 'Centre Court', court: 'Z' },
+        ...rest.map((t) => ({ id: t.id, label: t.label, court: t.court })),
+      ],
+    })
+
+    expect(catalogueOf(SLAM)[0]).toEqual({
+      id: first.id,
+      label: 'Centre Court',
+      court: 'Z',
+    })
+  })
+
+  // The by-position stopgap this replaces matched the i-th sent against the i-th stored,
+  // so sending two tables in the other order left each row holding its own id and its
+  // NEIGHBOUR's words: a fixture placed at "T1" silently began rendering as "T2", with
+  // nothing refused and nothing to see. Only the client knows which of its rows is which.
+  it('MOVES tables on a reorder — it does not swap labels between ids', () => {
+    const [first, second, ...rest] = catalogueOf(SLAM)
+
+    updateTournament(SLAM, {
+      table_catalogue: [second, first, ...rest].map((t) => ({
+        id: t.id,
+        label: t.label,
+        court: t.court,
+      })),
+    })
+
+    const after = catalogueOf(SLAM)
+    expect(after[0]).toEqual(second)
+    expect(after[1]).toEqual(first)
+  })
+
+  it('refuses an entry citing an id this catalogue does not hold, naming the entry', () => {
+    const before = catalogueOf(SLAM)
+
+    const result = updateTournament(SLAM, {
+      name: 'Renamed While Citing A Ghost',
+      table_catalogue: [
+        ...asUpserts(SLAM),
+        { id: 'not-a-table-of-this-tournament', label: 'T9', court: '9' },
+      ],
+    })
+
+    const refused = refusal422(result)
+    // The INDEX, because a catalogue is a list and a refusal a client cannot attribute
+    // to a row is a refusal it cannot render.
+    expect(refused.index).toBe(before.length)
+    expect(refused.tableId).toBe('not-a-table-of-this-tournament')
+    expect(refused.detail).toBe(
+      "This tournament's venue catalogue has no table with that id.",
+    )
+    // Never a silently minted table — and never the name that rode along either.
+    expect(catalogueOf(SLAM)).toEqual(before)
+    expect(findTournament(SLAM)!.name).toBe('Summer Slam 2026')
+  })
+
+  // ----- removal: the quiet half, and the loud one ----------------------------
+
+  it('REMOVES a table no entry names', () => {
+    const before = catalogueOf(SLAM)
+
+    updateTournament(SLAM, {
+      table_catalogue: asUpserts(SLAM).filter((t) => t.id !== before[7].id),
+    })
+
+    expect(catalogueOf(SLAM).map((t) => t.id)).toEqual(
+      before.slice(0, 7).map((t) => t.id),
+    )
+  })
+
+  // The QUIET half of the ADR's split. A pool's `table_ids` are a reservation, not a
+  // placement — "a table breaks, a table frees up" is ordinary venue traffic — so the
+  // pool simply reserves one fewer and nothing is refused. (The stored `table_ids` still
+  // list the dead id; pruning them is a later slice on the server too.)
+  it('removes a table only a POOL reserves — no refusal, no opt-in', () => {
+    // `T2` is reserved by Pool A and has nothing placed on it.
+    const [t1, t2, ...rest] = catalogueOf(SLAM)
+    const pool = findTournament(SLAM)!.events[0].pools[0]
+    expect(pool.table_ids).toContain(t2.id)
+
+    const result = updateTournament(SLAM, {
+      table_catalogue: [t1, ...rest].map((t) => ({
+        id: t.id,
+        label: t.label,
+        court: t.court,
+      })),
+    })
+
+    expect(result.ok).toBe(true)
+    expect(catalogueOf(SLAM).map((t) => t.id)).not.toContain(t2.id)
+  })
+
+  // The LOUD half. Silently clearing a placement destroys information on an UNRELATED
+  // write: the fixture stops being "placed at a table that vanished" and becomes
+  // indistinguishable from "nobody ever placed this".
+  it('REFUSES removing a table matches are placed at, in the server’s words', () => {
+    const { fixtureId, tableId } = placeAFixtureOnT1()
+    const before = catalogueOf(SLAM)
+
+    const result = updateTournament(SLAM, {
+      // The rename is the tripwire: a guard that refused AFTER writing would satisfy
+      // every assertion about the 409 and still have moved the venue underneath the
+      // director.
+      name: 'Renamed While Removing',
+      table_catalogue: asUpserts(SLAM).filter((t) => t.id !== tableId),
+    })
+
+    const { detail } = refusal409(result)
+    // Named by LABEL, never by id: an id tells a director looking at a page of named
+    // tables nothing to act on.
+    expect(detail).toBe(
+      '“T1” has 1 match placed at it, so removing it from the catalogue would leave ' +
+        'those matches with no table — indistinguishable from matches nobody ever ' +
+        'placed. To remove it anyway, send the same edit again with ' +
+        '“unplace_fixtures_on_removed_tables”: true, and those matches lose their ' +
+        'table, their time and their call and go back to the schedule to be placed ' +
+        'again. To keep them where they are, leave the table in the catalogue and ' +
+        'move the matches off it first.',
+    )
+    expect(detail).not.toContain(tableId)
+
+    // NOTHING was written. Not the catalogue…
+    expect(catalogueOf(SLAM)).toEqual(before)
+    // …not the name that rode along on the same refused request…
+    expect(findTournament(SLAM)!.name).toBe('Summer Slam 2026')
+    // …and not the placement the refusal was protecting.
+    const fixture = fixtureIn(SLAM, fixtureId)
+    expect(fixture.table_id).toBe(tableId)
+    expect(fixture.scheduled_start).not.toBeNull()
+    expect(fixture.pinned_at).not.toBeNull()
+  })
+
+  it('the OPT-IN removes the table and leaves those fixtures unplaced', () => {
+    const { fixtureId, tableId } = placeAFixtureOnT1()
+
+    const result = updateTournament(SLAM, {
+      name: 'Renamed While Removing',
+      table_catalogue: asUpserts(SLAM).filter((t) => t.id !== tableId),
+      unplace_fixtures_on_removed_tables: true,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(catalogueOf(SLAM).map((t) => t.id)).not.toContain(tableId)
+    // The rest of the same edit landed too.
+    expect(findTournament(SLAM)!.name).toBe('Renamed While Removing')
+    // All THREE placement columns go together: a start with no table is a bar on a
+    // schedule with nowhere to be, and a pin is a *promise about a table*.
+    const fixture = fixtureIn(SLAM, fixtureId)
+    expect(fixture.table_id).toBeNull()
+    expect(fixture.scheduled_start).toBeNull()
+    expect(fixture.pinned_at).toBeNull()
+    // And only the fixtures that were on the removed table: nobody else was touched.
+    expect(
+      fixturesOf(SLAM).filter((f) => f.id !== fixtureId && f.table_id !== null),
+    ).toHaveLength(0)
+  })
+
+  // The opt-in has ONE affirmative spelling and three ways of not saying it. The field is
+  // `bool | None` on the wire rather than `bool = False` because a non-null default is
+  // emitted as `"default": false` and `openapi-typescript` promotes any property carrying
+  // one to REQUIRED — which would make an opt-in for one destructive action mandatory on
+  // every unrelated PATCH. That third wire value must not become a third state.
+  it.each([
+    ['omitted', {}],
+    ['false', { unplace_fixtures_on_removed_tables: false }],
+    ['null', { unplace_fixtures_on_removed_tables: null }],
+  ] as const)('refuses identically when the opt-in is %s', (_spelling, optIn) => {
+    const { fixtureId, tableId } = placeAFixtureOnT1()
+
+    const result = updateTournament(SLAM, {
+      table_catalogue: asUpserts(SLAM).filter((t) => t.id !== tableId),
+      ...optIn,
+    })
+
+    expect(refusal409(result).detail).toContain('“T1”')
+    expect(catalogueOf(SLAM).map((t) => t.id)).toContain(tableId)
+    expect(fixtureIn(SLAM, fixtureId).table_id).toBe(tableId)
   })
 })

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -52,7 +52,16 @@ type AddressInput = components['schemas']['AddressInput']
 type TournamentEventCreate = components['schemas']['TournamentEventCreate']
 type TournamentEventUpdate = components['schemas']['TournamentEventUpdate']
 type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
+/** A table as it is **read back**: what the client wrote, plus the id the server
+ * minted for it. `id` is required here — clients no longer author one (ADR 20260801). */
 type TournamentTable = components['schemas']['TournamentTable']
+/** A table as a **create** body carries it: `label` and `court`, and deliberately no
+ * `id` — a tournament being born has no tables an id could name. */
+type TournamentTableWrite = components['schemas']['TournamentTableWrite']
+/** A table as an **edit** body carries it: the write shape plus an *optional* `id`
+ * naming a table the tournament already has. Omitted means "add this one"; supplied
+ * means "this existing one". A stored table no entry names is removed. */
+type TournamentTableUpsert = components['schemas']['TournamentTableUpsert']
 type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
 /** The **read** pool — it carries `position`. Its write twin below deliberately does
  * not; see `positionPools`. */
@@ -1453,6 +1462,167 @@ function submittedAddress(
   return geocodeAddress(input)
 }
 
+// ----- the venue catalogue: server-minted ids, and an id-keyed diff -------------
+//
+// A table is a ROW now (ADR 20260801, `api/app/tournament_tables.py`), and its id is
+// **the server's to mint** — `TournamentTableWrite` (create) has no `id` at all, and
+// `TournamentTableUpsert` (patch) has an optional one that *cites* a table rather than
+// authoring it. So this store mints too: a catalogue entry that arrives without an id
+// is a new table and gets one here, exactly as `gen_random_uuid()` gives it one there.
+//
+// And the patch is a **diff**, not an assignment: an entry citing an id keeps that
+// table (re-worded, re-positioned), an entry with no id adds one, and a stored table no
+// entry cites is REMOVED. Keying on the id is what makes a reorder move tables instead
+// of swapping labels between ids — the by-position read this replaces did the latter
+// silently. The removal is where the two refusals live; see `applyTableCatalogue`.
+
+let tableCounter = 0
+
+/** A brand-new catalogue row for an entry that carries no `id` — the mock's
+ * `gen_random_uuid()`.
+ *
+ * UUID-shaped (`mockUuid`) because the wire says so (`TournamentTable.id` is
+ * `format: uuid`), and counter-derived rather than label-derived because two tables may
+ * legitimately share a label across tournaments — and two rows sharing an id is the one
+ * thing an id-keyed diff cannot survive. The counter deliberately does NOT reset with
+ * the store: a fresh seed re-creates the seeded rows, and an id minted for a *previous*
+ * test's table must never be handed out again. */
+function mintTable(entry: TournamentTableWrite): TournamentTable {
+  tableCounter += 1
+  return {
+    id: mockUuid(`tournament-table-${tableCounter}`),
+    label: entry.label,
+    court: entry.court,
+  }
+}
+
+/** The server's sentence for a catalogue edit that would remove a table matches are
+ * placed at (`_tables_in_use_detail`, `api/app/tournament_tables.py`) — **verbatim**,
+ * because the client shows it verbatim.
+ *
+ * Names the tables by **label**, never by id (an id tells a director looking at a page
+ * of named tables nothing to act on), and names both ways out: send the same edit again
+ * with the opt-in and accept the unplacing, or move the matches off the table first. */
+function tablesInUseDetail(labels: string[], placements: number): string {
+  const one = labels.length === 1
+  const has = one ? 'has' : 'have'
+  const it = one ? 'it' : 'them'
+  const theTable = one ? 'the table' : 'them'
+  const matches = placements === 1 ? 'match' : 'matches'
+  return (
+    `${namedList(labels)} ${has} ${placements} ${matches} placed at ${it}, so ` +
+    `removing ${it} from the catalogue would leave those matches with no table — ` +
+    'indistinguishable from matches nobody ever placed. To remove ' +
+    `${it} anyway, send the same edit again with ` +
+    '“unplace_fixtures_on_removed_tables”: true, and those matches lose their ' +
+    'table, their time and their call and go back to the schedule to be placed ' +
+    `again. To keep them where they are, leave ${theTable} in the catalogue and ` +
+    `move the matches off ${it} first.`
+  )
+}
+
+/** The server's message for an entry citing an id this tournament's catalogue does not
+ * hold (`TableNotInCatalogueError`, `api/app/tournament_errors.py`) — a **422 on that
+ * entry's `id`**, never a silently minted table: quietly handing the client a different
+ * id than it asked for would *also* remove the table it meant to keep, which are the two
+ * failures a diff must never confuse. */
+const TABLE_NOT_IN_CATALOGUE =
+  "This tournament's venue catalogue has no table with that id."
+
+/** What the diff did — the new catalogue and the (possibly unplaced) events — or the
+ * refusal that stopped it before a single row moved. */
+type CatalogueResult =
+  | { ok: true; tables: TournamentTable[]; events: StoredEvent[] }
+  | { ok: false; status: 409; detail: string }
+  | { ok: false; status: 422; index: number; tableId: string; detail: string }
+
+/** Apply a submitted catalogue to `stored` as an id-keyed diff
+ * (`apply_table_catalogue`, `api/app/tournament_tables.py`), judging both refusals
+ * **before** anything changes so a refused edit leaves the tournament byte-identical.
+ *
+ * The asymmetry between a pool and a placement is the ADR's whole point, and it is
+ * mirrored here rather than smoothed over. A table a **pool** merely reserves is removed
+ * with no ceremony — a pool's `table_ids` are a reservation, and the pool simply
+ * reserves one fewer (the stored ids still list the dead one; pruning them is a later
+ * slice, on the server too). A table a fixture is **placed at** is refused, because
+ * clearing a placement destroys information on an unrelated write: the fixture stops
+ * being "placed at a table that vanished" and becomes indistinguishable from "nobody
+ * ever placed this".
+ *
+ * With `unplace` the removal goes through and all THREE placement columns go together —
+ * `table_id`, `scheduled_start` and `pinned_at`. A start with no table is a bar on a
+ * schedule with nowhere to be, and a pin is a *promise about a table*: leaving either
+ * would tell every later solve the fixture is nailed to a table that no longer exists. */
+function applyTableCatalogue(
+  stored: StoredTournament,
+  submitted: TournamentTableUpsert[],
+  unplace: boolean,
+): CatalogueResult {
+  const byId = new Map(stored.table_catalogue.map((t) => [t.id, t]))
+  // Judged first, over the whole payload: a catalogue naming a table this tournament
+  // does not have is not a catalogue, and every subsequent question (what is kept, and
+  // therefore what is removed) would be answered against a list the client did not mean.
+  for (const [index, entry] of submitted.entries()) {
+    if (entry.id != null && !byId.has(entry.id)) {
+      return {
+        ok: false,
+        status: 422,
+        index,
+        tableId: entry.id,
+        detail: TABLE_NOT_IN_CATALOGUE,
+      }
+    }
+  }
+
+  const kept = new Set(
+    submitted.map((entry) => entry.id).filter((id): id is string => id != null),
+  )
+  const removedIds = new Set(
+    stored.table_catalogue.filter((t) => !kept.has(t.id)).map((t) => t.id),
+  )
+  const placed = stored.events
+    .flatMap((event) => event.fixtures)
+    .filter((f) => f.table_id !== null && removedIds.has(f.table_id))
+
+  if (placed.length > 0 && !unplace) {
+    const blocking = new Set(placed.map((f) => f.table_id))
+    const labels = stored.table_catalogue
+      .filter((t) => removedIds.has(t.id) && blocking.has(t.id))
+      .map((t) => t.label)
+    return {
+      ok: false,
+      status: 409,
+      detail: tablesInUseDetail(labels, placed.length),
+    }
+  }
+
+  const unplacedIds = new Set(placed.map((f) => f.id))
+  const events =
+    unplacedIds.size === 0
+      ? stored.events
+      : stored.events.map((event) => ({
+          ...event,
+          fixtures: event.fixtures.map((f) =>
+            unplacedIds.has(f.id)
+              ? { ...f, table_id: null, scheduled_start: null, pinned_at: null }
+              : f,
+          ),
+        }))
+
+  return {
+    ok: true,
+    // The list's ORDER is the catalogue's order — a cited row keeps its id (and every
+    // pool `table_ids` and fixture `table_id` that names it) while taking this
+    // payload's words and place; an entry with no id is an insert.
+    tables: submitted.map((entry) =>
+      entry.id == null
+        ? mintTable(entry)
+        : { id: entry.id, label: entry.label, court: entry.court },
+    ),
+    events,
+  }
+}
+
 export function createTournament(body: TournamentCreate): TournamentRead {
   const now = new Date().toISOString()
   const id = slugId(body.name)
@@ -1472,7 +1642,9 @@ export function createTournament(body: TournamentCreate): TournamentRead {
     // with NO VENUE (CONTEXT.md, "Venue"), which is a state the server allows at
     // every status and this store must be able to hold.
     address: submittedAddress(body.address),
-    table_catalogue: body.table_catalogue ?? [],
+    // Every table on a create body is a NEW table — `TournamentTableWrite` has no `id`
+    // at all — so the store mints one for each, in the order the payload sent them.
+    table_catalogue: (body.table_catalogue ?? []).map(mintTable),
     created_by_user_id: DEV_USER_ID,
     created_by_username: DEV_USERNAME,
     can_edit: true,
@@ -1485,9 +1657,19 @@ export function createTournament(body: TournamentCreate): TournamentRead {
   return readOf(created)
 }
 
+/** A tournament PATCH fails four ways, mirroring the API: 404 (no such tournament),
+ * 403 (not the creator), and — both from the table catalogue's id-keyed diff
+ * (ADR 20260801) — a **409** when the edit would remove a table matches are placed at
+ * without the opt-in, and a **422** naming the entry that cited an id this tournament's
+ * catalogue does not hold. The 422 carries the offending entry's `index` so the handler
+ * can build the `loc` (`["body", "table_catalogue", i, "id"]`) the real route sends:
+ * a catalogue is a list, and a refusal a client cannot attribute to a row is a refusal
+ * it cannot render. */
 export type StoreResult =
   | { ok: true; tournament: TournamentRead }
   | { ok: false; status: 403 | 404 }
+  | { ok: false; status: 409; detail: string }
+  | { ok: false; status: 422; index: number; tableId: string; detail: string }
 
 /** An event write fails four ways: 404 (no such tournament/event), 403 (not the
  * creator), and — on a PATCH that would move the pools out from under a cut draw — a
@@ -1585,7 +1767,13 @@ function requireOwned(id: string): OwnedResult {
  * return 403; a missing id returns 404 — mirroring the real API's gating.
  *
  * `status` is untouched by design: `TournamentUpdate` has no such field
- * (ADR-0017), so an edit cannot move the lifecycle — only a transition can. */
+ * (ADR-0017), so an edit cannot move the lifecycle — only a transition can.
+ *
+ * A submitted `table_catalogue` is an **id-keyed diff**, with the two refusals
+ * `applyTableCatalogue` judges — and both are judged BEFORE anything is written, which
+ * is what makes them refusals rather than reports. The refused PATCH's *other* fields
+ * (the `name` that rode along on the same request) are not written either: the whole
+ * edit is atomic, exactly as it is on the server. */
 export function updateTournament(
   id: string,
   patch: TournamentUpdate,
@@ -1593,6 +1781,24 @@ export function updateTournament(
   const owned = requireOwned(id)
   if (!owned.ok) return owned
   const existing = owned.tournament
+  // The catalogue diff first, and nothing assigned until it answers: a refusal here
+  // must leave the tournament byte-identical, `name` included.
+  let catalogue = existing.table_catalogue
+  let events = existing.events
+  if (patch.table_catalogue !== undefined && patch.table_catalogue !== null) {
+    const applied = applyTableCatalogue(
+      existing,
+      patch.table_catalogue,
+      // The opt-in's ONE affirmative spelling. Omitted, `false` and `null` are three
+      // ways of not saying it and all three mean "not opted in" — the field is
+      // `bool | None` on the wire (a non-null default would make it *required* on
+      // every PATCH through `openapi-typescript`), so the collapse happens here.
+      patch.unplace_fixtures_on_removed_tables === true,
+    )
+    if (!applied.ok) return applied
+    catalogue = applied.tables
+    events = applied.events
+  }
   const next: StoredTournament = {
     ...existing,
     name: patch.name ?? existing.name,
@@ -1611,10 +1817,10 @@ export function updateTournament(
       patch.address === undefined
         ? existing.address
         : submittedAddress(patch.address),
-    table_catalogue:
-      patch.table_catalogue === undefined || patch.table_catalogue === null
-        ? existing.table_catalogue
-        : patch.table_catalogue,
+    // OMITTED (or `null`) means unchanged; anything else is the diff computed above —
+    // which may have unplaced fixtures, hence `events` moving in the same breath.
+    table_catalogue: catalogue,
+    events,
     updated_at: new Date().toISOString(),
   }
   replace(next)

--- a/web-client/src/routes/_app/tournaments.$tournamentId.tsx
+++ b/web-client/src/routes/_app/tournaments.$tournamentId.tsx
@@ -13,6 +13,7 @@ import {
   useTables,
   useTournament,
   useUpdateEvent,
+  useUpdateTableCatalogue,
   useUpdateTournament,
 } from '@/components/tournaments/data/api'
 import { pageTitle } from '@/lib/page-title'
@@ -62,6 +63,7 @@ function TournamentDetailRoute() {
   const { data: tournament, isPending } = useTournament(tournamentId)
   const allTables = useTables(tournamentId)
   const updateTournament = useUpdateTournament()
+  const updateCatalogue = useUpdateTableCatalogue(tournamentId)
   const createEvent = useCreateEvent(tournamentId)
   const updateEvent = useUpdateEvent(tournamentId)
   const deleteEvent = useDeleteEvent(tournamentId)
@@ -92,12 +94,15 @@ function TournamentDetailRoute() {
           patch: tournamentToUpdateBody(next, allTables),
         })
       }
-      onChangeCatalogue={(catalogue) =>
-        updateTournament.mutate({
-          id: tournament.id,
-          patch: tournamentToUpdateBody(tournament, catalogue),
-        })
-      }
+      // `mutateAsync`, and the rejection is deliberately NOT caught here: the
+      // `TablesTab` awaits it, turns the in-use 409 into a confirm carrying the
+      // server's sentence, and re-sends the identical diff with the opt-in when the
+      // organizer answers. Catching it here — or letting the mutation toast — would
+      // turn the one refusal the director can act on into a message that leaves after
+      // four seconds.
+      onChangeCatalogue={async (entries, options) => {
+        await updateCatalogue.mutateAsync({ entries, ...options })
+      }}
       // `mutateAsync`, not `mutate`: the event editor AWAITS these, closes only
       // when they resolve, and renders the failure inline when they don't (the
       // `NewTournamentModal` contract — a modal that closes over a rejected write


### PR DESCRIPTION
Slice 2 of #1226. **Stacked on #1238** — review that first; this PR's diff is only the 9 commits above it.

## What this changes

A tournament's table catalogue was a JSONB blob, and a fixture's `table_id` was a free string that happened to look like one of its keys. Nothing enforced the relationship, so a placement could name a table that had never existed or had been edited away, and the only thing standing between the two was application code remembering to check.

The catalogue is now a real `tournament_tables` table, and `tournament_fixtures.table_id` is a real foreign key with `ON DELETE RESTRICT`. Per [ADR: a placement names a real table, and only that is an invariant](docs/adr/20260801-a-placement-names-a-real-table-and-only-that-is-an-invariant.md), that referential claim is the *only* one promoted to a database constraint — table/window/double-booking remain soft flags derived on read, as ADR-0790 has it.

That forced three follow-on decisions:

**Ids are minted by the server.** Clients used to invent them (`t1`, `genId('table')`). Now a write with no `id` means "create this", and one citing an `id` means "this existing row".

**The catalogue write became a diff, not a replace.** An uncited stored table is removed — which makes removal a real operation with a real failure mode, where before it was a silent side effect of sending a shorter array.

**Removing a table in use is refused, not cascaded.** A 409 names the tables by label. `unplace_fixtures_on_removed_tables: true` is the opt-in that lets it through, leaving those fixtures unplaced. A table only a *pool* reserves is removed silently — a reservation is a preference, a placement is a commitment.

## Commits

| | |
| --- | --- |
| `2a` | `tournament_tables` replaces the JSONB catalogue |
| `2b` | a fixture's placement table becomes a real FK |
| `2c` | the catalogue write becomes an id-keyed diff that refuses removing a table in use |
| `2c2` | the removal opt-in becomes optional on the wire |
| `2d` | regen `schema.d.ts` |
| — | regen `Types.swift` (operator-run; needs a Swift toolchain) |
| `2f` | the mock layer mirrors server-minted ids and the refusal |
| `2e` | the tables tab stops minting ids and surfaces the refusal as a confirm |
| `2g` | the refusal proven end to end against the real API |

## Three bugs found along the way that the plan hadn't anticipated

**A rename would have wiped the venue.** `tournamentToUpdateBody` sent the catalogue with no ids. Harmless against a replace; against the new diff it reads as *"remove every table you have"*. Caught by 2e.

**The root `e2e` suite could not seed a tournament at all.** `tournament-api.ts` still minted client-side table ids, and since `TournamentTableWrite` is `extra="forbid"`, every `createTournament` was a 422 — 6 of 15 spec files dead. No chore covered it; 2g fixed it as a prerequisite. The lesson worth carrying: a change to a shared write shape has consumers beyond `web-client`, and they aren't in any single layer's scope.

**`bool = False` on a write schema generates as *required* in TypeScript.** The second occurrence in two slices. `2c2` fixes the field; #1254 writes the rule down.

## A dead code path this makes unreachable

`schedule_solves.py`'s `broken_pin_moves` catalogue arm — "the table left the catalogue" — no longer has a producer. Only three sites write `fixture.table_id` and all write a table of this tournament's catalogue or `None`; nothing mutates `VenueTable.tournament_id`; and the route by which a table could leave a catalogue now dies on the FK. `TestBrokenPinRepair` passes only because its helper re-parents a table row onto a throwaway tournament, which has no production analogue. **Left in place deliberately** — deleting it is a separate call, and this PR is already the largest of the three slices.

## Verification

- `pytest` — 2111 passed
- `npm run test:run` — 3391 passed / 319 files
- `tsc -b` — clean
- root `e2e` — 24 collected / 24 ran / 24 passed on a self-managed stack

Falsifications run on every guard, and each red named its reason. The one worth citing: a server that unplaces the fixture and *then* raises the 409 passes every assertion about the dialog, and reds only on the placement — `Expected "13c4aeb1-…", received null`. That is why 2g asserts state on both sides of the refusal rather than just that the dialog appeared.

**Not yet run:** `/simplify`, `/code-review`, `/security-review` and `/qa-review` — those are `land-the-plane`'s gates and this is a draft.

## Migration note

Pre-deploy, so `0027` was edited in place rather than superseded. Per `api/CLAUDE.md`, `pytest` builds the schema with `create_all` and never invokes Alembic, so the suite passing is *not* evidence the migration works — it was run against a fresh Postgres separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCCG5jQq19dG8SDPFcmTwh)_