### PR TITLE
Say what the solver is doing while it solves

### DIFF
--- a/web-client/e2e/tournaments/tournament-schedule-solve.spec.ts
+++ b/web-client/e2e/tournaments/tournament-schedule-solve.spec.ts
@@ -124,7 +124,7 @@ test.describe('Tournaments · schedule solve strip', () => {
     // The 202 answered a queued row; the reconcile read shows the run in flight…
     await expect(pom.solveStripState('solving')).toBeVisible()
     await expect(pom.solveStripState('solving')).toContainText(
-      'Solving the schedule…',
+      'Placing matches on tables…',
     )
     // …and the button is withheld while it is (the server would absorb a second
     // click anyway — one solve in flight per tournament).

--- a/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
@@ -51,7 +51,7 @@ describe('SolveStrip', () => {
         }),
       })
       const text = solveStripPage.getStateText('solving')
-      expect(text).toContain('Solving the schedule…')
+      expect(text).toContain('Placing matches on tables…')
       expect(text).toContain('Run by hand')
       // The raw enum never reaches the UI.
       expect(text).not.toContain('manual')

--- a/web-client/src/components/tournaments/tournament-detail-page/solve-strip.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/solve-strip.tsx
@@ -96,7 +96,9 @@ const SolveState = ({ solve, canEdit }: { solve: ScheduleSolve | null; canEdit: 
           <Line
             icon={<Loader2 size={18} className="animate-spin" />}
             tint="text-[color:var(--ball-500)]"
-            title="Solving the schedule…"
+            // Says what the solver is actually doing, in the same words the
+            // `none` state used to promise it ("place every match on a table").
+            title="Placing matches on tables…"
           >
             {TRIGGER_LABEL[state.trigger]}.
           </Line>


### PR DESCRIPTION
Closes #1107.

## What

The schedule strip's in-flight state said **"Solving the schedule…"** — a restatement of the button that was just pressed, which tells the director nothing about what is happening on their behalf.

It now says **"Placing matches on tables…"**, borrowing the words the `none` state already uses to promise the run ("Run the scheduler to place every match on a table"), so the two states read as one sentence across the click. Tone matches the sibling states in the same component ("No schedule plan yet", "Schedule solved").

The subtitle is unchanged — it still names the trigger in our copy (`TRIGGER_LABEL`).

## Files

- `web-client/src/components/tournaments/tournament-detail-page/solve-strip.tsx` — the `'solving'` case's `title`
- `solve-strip.test.tsx` — the matching assertion (2 cases: `queued` + `running`)
- `web-client/e2e/tournaments/tournament-schedule-solve.spec.ts` — the `toContainText` on the polling-loop spec

## Verification

- `vitest solve-strip.test.tsx` — 21/21 pass. **Falsified**: with the title deliberately broken the 2 copy assertions red for the stated reason (`expected 'XXbrokenXX…' to contain 'Placing matches on tables…'`), so they are real assertions, not weakened ones.
- `tsc --noEmit` clean; `npm run lint` clean (the one warning is pre-existing, in `public/mockServiceWorker.js`).
- `playwright test e2e/tournaments/tournament-schedule-solve.spec.ts` — **9 collected, 9 ran, 9 passed**, including the spec that asserts this string. (The session image ships chromium-1194 against a Playwright wanting 1234, so the run used a throwaway config pointing `executablePath` at the preinstalled binary; that file was deleted and is not in the diff.)

No API/schema change, so no OpenAPI or type regen.

---
_Generated by [Claude Code](https://claude.ai/code/session_015yrgwGEysPD5Vj7Eq1rv8i)_