### PR TITLE
Slice 1: name the over-subscribed player behind an infeasible solve (#1129)

### DIFF
--- a/api/app/schedule_preview.py
+++ b/api/app/schedule_preview.py
@@ -101,6 +101,25 @@ from app.venue_time import anchor_wallclock
 DEFAULT_UNCAPPED_FIELD = 16
 
 
+#: The prefix every synthetic entrant's ``PlayerId`` carries — ``placeholder-{k}``
+#: for the global ordinal ``k``. Minted by :func:`_schedule_fixture` and read back
+#: by :func:`placeholder_label`, so the spelling lives in one place.
+PLACEHOLDER_PREFIX = "placeholder-"
+
+
+def placeholder_label(player_id: str) -> str:
+    """``placeholder-7`` → ``Placeholder 7`` — the *display* name of a synthetic
+    entrant, the way the preview surface already shows one to the director (ADR
+    "the synthetic ids are shown as ``Placeholder N``").
+
+    A preview's players are stand-ins, not humans, so there is nothing to look up:
+    the label is derived from the id itself, with no DB read. This is how a
+    DB-blind preview resolves the one infeasibility reason that names a *player*
+    (:class:`~app.scheduling.PlayerOverSubscribed`) into the same resolved read
+    form a real solve records."""
+    return f"Placeholder {player_id.removeprefix(PLACEHOLDER_PREFIX)}"
+
+
 def preview_pool_key(event_id: uuid.UUID, pool_id: str) -> str:
     """The one namespaced ``event:pool`` spelling every preview site keys a pool by
     — the ``SchedulePool`` id, a fixture's ``pool_id`` ref, and the enqueue verb's
@@ -438,6 +457,6 @@ def _schedule_fixture(
         id=FixtureId(f"{pool_ref}:{fixture.round}:{fixture.position}"),
         event_id=event_id,
         pool_id=PoolId(pool_ref),
-        player_a_id=PlayerId(f"placeholder-{fixture.entry_a_id.int}"),
-        player_b_id=PlayerId(f"placeholder-{fixture.entry_b_id.int}"),
+        player_a_id=PlayerId(f"{PLACEHOLDER_PREFIX}{fixture.entry_a_id.int}"),
+        player_b_id=PlayerId(f"{PLACEHOLDER_PREFIX}{fixture.entry_b_id.int}"),
     )

--- a/api/app/schedule_preview_solve.py
+++ b/api/app/schedule_preview_solve.py
@@ -60,7 +60,11 @@ from app import scheduling
 from app.config import get_settings
 from app.match_calls import _wall_now
 from app.models import Tournament, TournamentStatus, User
-from app.schedule_preview import build_preview_snapshot, preview_pool_key
+from app.schedule_preview import (
+    build_preview_snapshot,
+    placeholder_label,
+    preview_pool_key,
+)
 from app.schedule_solves import _solve_num_workers
 from app.scheduling import (
     InfeasibilityReason,
@@ -68,6 +72,7 @@ from app.scheduling import (
     NoSingleCause,
     PastWindow,
     PlacedFixture,
+    PlayerOverSubscribed,
     PoolHasNoTables,
     PoolOverCapacity,
     ScheduleSnapshot,
@@ -88,6 +93,7 @@ from app.schemas.schedule_preview import (
 from app.schemas.schedule_solve import (
     NoSingleCauseRead,
     PastWindowReasonRead,
+    PlayerOverSubscribedRead,
     PoolHasNoTablesRead,
     PoolOverCapacityRead,
     ResolvedReason,
@@ -543,8 +549,10 @@ def _resolve_reasons(
     — reusing the resolved-reason machinery rather than forking it. The pool name +
     ``HH:MM`` come from ``inputs.pool_resolutions``; ``best_of`` from a
     fixture-id → ``length_games`` map derived from the snapshot's events (a preview
-    has no DB to read it from). Exhaustive ``match`` with an ``assert_never`` floor,
-    like ``app.schedule_solves._resolve_reason``."""
+    has no DB to read it from); a blamed *player* from their own synthetic id
+    (``placeholder-7`` → ``Placeholder 7``), since a preview's entrants are
+    stand-ins with no name to look up. Exhaustive ``match`` with an
+    ``assert_never`` floor, like ``app.schedule_solves._resolve_reason``."""
     best_of = _fixture_best_of(inputs.snapshot)
     return [
         _resolve_reason(reason, inputs.pool_resolutions, best_of) for reason in reasons
@@ -595,6 +603,22 @@ def _resolve_reason(
                 required_min=reason.required_min,
                 capacity_min=reason.capacity_min,
                 table_count=reason.table_count,
+            )
+        case PlayerOverSubscribed():
+            # The one arm that names a *player* — and a preview's entrants are
+            # synthetic stand-ins, not humans, so there is no name to look up:
+            # ``placeholder-7`` resolves to the same ``Placeholder 7`` label the
+            # preview surface already shows the director, derived from the id with
+            # no DB read (:func:`app.schedule_preview.placeholder_label`).
+            pool = pool_resolutions[reason.pool_id]
+            return PlayerOverSubscribedRead(
+                player_name=placeholder_label(reason.player_id),
+                pool_name=pool.name,
+                window_start=pool.window_start,
+                window_end=pool.window_end,
+                match_count=reason.match_count,
+                required_min=reason.required_min,
+                window_span_min=reason.window_span_min,
             )
         case NoSingleCause():
             return NoSingleCauseRead(

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -171,6 +171,7 @@ from app.scheduling import (
     PlacementConflict,
     PlayerConflict,
     PlayerId,
+    PlayerOverSubscribed,
     PoolHasNoTables,
     PoolId,
     PoolOverCapacity,
@@ -192,6 +193,7 @@ from app.schemas.schedule_solve import (
     NoSingleCauseRead,
     PastWindowReasonRead,
     PlayerConflictRead,
+    PlayerOverSubscribedRead,
     PoolHasNoTablesRead,
     PoolOverCapacityRead,
     ResolvedConflict,
@@ -534,7 +536,11 @@ class SolveInputs:
     usernames) are the sibling lookups the apply humanizes a solve's
     *placement conflicts* through (ADR "overlapping in-progress matches are
     tolerated and reported"). Same fingerprinted provenance, so the fresh read's
-    maps resolve exactly the ids a conflict carries."""
+    maps resolve exactly the ids a conflict carries. ``player_names`` does
+    double duty: it is also how the one *reason* that names a human
+    (:class:`~app.scheduling.PlayerOverSubscribed`) is resolved — it is built
+    from every drawn event's entrants, not just the in-progress ones, so it
+    covers any player a pre-check can blame."""
 
     snapshot: ScheduleSnapshot
     fingerprint: str
@@ -1061,7 +1067,8 @@ def _resolve_reason(reason: InfeasibilityReason, inputs: SolveInputs) -> Resolve
     """Humanize one pure, id-and-minute reason into its resolved read form
     (ADR "structured data, not prose"): the pool's display name and ``HH:MM``
     window come from ``inputs.pool_resolutions``, ``best_of`` from
-    ``inputs.fixture_best_of``; the integer minutes pass through untouched for
+    ``inputs.fixture_best_of``, the blamed human's display name from
+    ``inputs.player_names``; the integer minutes pass through untouched for
     the client to format. Direct id lookups are safe here — the apply resolves
     only after the drift guard proved this read's inputs fingerprint-identical
     to the ones the reasons were computed against, so every pool/fixture id a
@@ -1095,6 +1102,21 @@ def _resolve_reason(reason: InfeasibilityReason, inputs: SolveInputs) -> Resolve
                 required_min=reason.required_min,
                 capacity_min=reason.capacity_min,
                 table_count=reason.table_count,
+            )
+        case PlayerOverSubscribed():
+            # The one arm that names a *human*: resolved through the same
+            # ``player_names`` map the PlayerConflict humanization already uses
+            # (solver PlayerId — a user-id string — → display username), built in
+            # the same fingerprinted read, so no second lookup is needed.
+            pool = inputs.pool_resolutions[reason.pool_id]
+            return PlayerOverSubscribedRead(
+                player_name=inputs.player_names[reason.player_id],
+                pool_name=pool.name,
+                window_start=pool.window_start,
+                window_end=pool.window_end,
+                match_count=reason.match_count,
+                required_min=reason.required_min,
+                window_span_min=reason.window_span_min,
             )
         case NoSingleCause():
             return NoSingleCauseRead(

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -1027,8 +1027,13 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
         required_min = sum(duration_of(f) for f in pool_unpinned)
         table_count = len(pool.table_ids)
         # Effective end: pre-live this is the planned window; live it is softened
-        # so an overrunning live day is never falsely flagged over-capacity.
-        capacity_min = (effective_end(pool) - pool.window.start_min) * table_count
+        # so an overrunning live day is never falsely flagged over-capacity. Bound
+        # once, here, because BOTH certain arms below measure against it — a pool's
+        # capacity and one human's own day are different proofs about the same
+        # window, and computing the span twice would let them drift into reporting
+        # contradictory numbers for the same pool.
+        window_span = effective_end(pool) - pool.window.start_min
+        capacity_min = window_span * table_count
         if required_min > capacity_min:
             reasons.append(
                 PoolOverCapacity(
@@ -1039,52 +1044,47 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
                 )
             )
 
-    # Per (pool, human): a pigeonhole over ONE person, run in the same cheap
-    # pre-check pass (ADR "the conflict core is a second, max-placed solve" —
-    # certain per-player over-subscription is a pre-check, not a residual). A
-    # player plays one match at a time and their unpinned fixtures in a pool must
-    # all run inside that pool's window, so
-    #     Σ durations + (N − 1) × REST_MIN > window span
-    # proves the day cannot fit no matter how many tables the pool owns.
-    #
-    # The (N − 1) is load-bearing: the model pads EVERY player interval by
-    # REST_MIN (correct for AddNoOverlap, which needs the gap in either
-    # direction), but the last match of the day owes no trailing rest inside the
-    # window — charging N × REST_MIN would overcount and could falsely accuse a
-    # player, which is unacceptable for an arm whose whole claim is certainty.
-    #
-    # Reported ALONGSIDE PoolOverCapacity rather than dominated by it: they are
-    # proofs about different subjects with different remedies (add tables vs. this
-    # human is in too many matches), so both are actionable and both are certain.
-    # The pool-level *unplaceable* causes above do dominate — a past-window,
-    # no-tables or too-short-window pool is already unrunnable, so piling a
-    # per-player claim on top of it would just be noise.
-    for pool in snapshot.pools:
-        pool_unpinned = unpinned_by_pool.get(pool.id)
-        if not pool_unpinned:
-            continue
-        if pool.id in pools_past_window or pool.id in pools_short_window:
-            continue
-        if not pool.table_ids:
-            continue  # PoolHasNoTables already names this pool
-        fixtures_by_player: defaultdict[PlayerId, list[ScheduleFixture]] = defaultdict(
-            list
-        )
+        # Per (pool, human): a pigeonhole over ONE person, run in the same cheap
+        # pre-check pass (ADR "the conflict core is a second, max-placed solve" —
+        # certain per-player over-subscription is a pre-check, not a residual). A
+        # player plays one match at a time and their unpinned fixtures in a pool
+        # must all run inside that pool's window, so
+        #     Σ durations + (N − 1) × REST_MIN > window span
+        # proves the day cannot fit no matter how many tables the pool owns.
+        #
+        # The (N − 1) is load-bearing: the model pads EVERY player interval by
+        # REST_MIN (correct for AddNoOverlap, which needs the gap in either
+        # direction), but the last match of the day owes no trailing rest inside
+        # the window — charging N × REST_MIN would overcount and could falsely
+        # accuse a player, unacceptable for an arm whose whole claim is certainty.
+        #
+        # Reported ALONGSIDE PoolOverCapacity rather than dominated by it: they
+        # are proofs about different subjects with different remedies (add tables
+        # vs. this human is in too many matches), so both are actionable and both
+        # are certain. It shares this loop's guards rather than re-deriving them,
+        # so the "a pool already proven unplaceable dominates every finer claim
+        # about it" rule is stated once — a sixth arm cannot drop a clause and
+        # start piling per-player noise onto a pool that cannot run at all.
+        #
+        # Only each match's LENGTH is accumulated, never the fixture: the bound
+        # reads a count and a sum, and nothing else about the match matters to it.
+        minutes_by_player: defaultdict[PlayerId, list[int]] = defaultdict(list)
         for fixture in pool_unpinned:
+            minutes = duration_of(fixture)
             for player in (fixture.player_a_id, fixture.player_b_id):
-                fixtures_by_player[player].append(fixture)
-        # Effective end: pre-live the planned window; live it is softened, so an
-        # overrunning live day is never falsely flagged over-subscribed (the same
-        # span PoolOverCapacity measures itself against).
-        window_span = effective_end(pool) - pool.window.start_min
-        for player_id, player_fixtures in sorted(fixtures_by_player.items()):
-            match_count = len(player_fixtures)
+                minutes_by_player[player].append(minutes)
+        # Sorted by player id (the keys alone — sorting `.items()` would make the
+        # report's order depend on ScheduleFixture being orderable, which it is
+        # neither meant nor guaranteed to be).
+        for player_id in sorted(minutes_by_player):
+            # NOT `match_minutes` — that is this module's own function, and a
+            # local of that name shadows it for the whole of `_build_model`,
+            # breaking the `duration_of` closure that calls it.
+            player_minutes = minutes_by_player[player_id]
+            match_count = len(player_minutes)
             if match_count < 2:
                 continue  # one match is a window question, not over-subscription
-            required = (
-                sum(duration_of(f) for f in player_fixtures)
-                + (match_count - 1) * REST_MIN
-            )
+            required = sum(player_minutes) + (match_count - 1) * REST_MIN
             if required > window_span:
                 reasons.append(
                     PlayerOverSubscribed(

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -435,6 +435,46 @@ class PoolOverCapacity:
 
 
 @dataclass(frozen=True, slots=True)
+class PlayerOverSubscribed:
+    """One human with more *unpinned* match-time in a pool than that pool's
+    window can hold, however the tables are arranged: a pigeonhole over a single
+    person. A player plays one match at a time and their fixtures in a pool must
+    all run inside that pool's window, so
+
+        ``Σ durations + (match_count − 1) × REST_MIN > window_span_min``
+
+    is a **necessary** condition for infeasibility — provable by arithmetic on
+    the snapshot with no solver at all, which is why it joins the cheap pre-check
+    pass rather than waiting on CP-SAT (ADR "the conflict core is a second,
+    max-placed solve"). ``required_min`` is that left-hand side: the player's own
+    serial demand, table count irrelevant (extra tables let *other* people play in
+    parallel, never this one).
+
+    **The rest term is ``(N − 1)``, not ``N``.** :func:`_build_model` pads *every*
+    player interval by :data:`REST_MIN`, which is right for ``AddNoOverlap`` (it
+    enforces a gap in either direction) and wrong as a pigeonhole bound: the last
+    match of the day owes no trailing rest *inside* the window. Charging ``N ×
+    REST_MIN`` would overcount demand and could **falsely accuse a player** — fatal
+    for an arm whose whole claim is certainty. Like every certain arm here it is
+    deliberately conservative: it may miss a real infeasibility, it may never
+    invent one. Same conservatism drives the other two scopings — only *unpinned*
+    fixtures count (a pin is bound to neither this pool's tables nor its window,
+    ADR-0790), and only a player with ≥2 of them can be *over*-subscribed (a lone
+    fixture that cannot fit is :class:`WindowTooShortForMatch`'s finding, not
+    this one's).
+
+    Id-only, like every value this pure module emits: naming the human is the
+    DB-aware caller's job."""
+
+    pool_id: PoolId
+    player_id: PlayerId
+    match_count: int
+    required_min: int
+    window_span_min: int
+    kind: Literal["player_over_subscribed"] = "player_over_subscribed"
+
+
+@dataclass(frozen=True, slots=True)
 class NoSingleCause:
     """The honest residual: CP-SAT *proved* the day infeasible, yet no certain
     structural cause (arms above) explains it — the infeasibility lives in the
@@ -476,10 +516,12 @@ class PastWindow:
 
 
 #: The closed set of reasons an infeasible solve can carry. A discriminated
-#: union over ``kind``: the first three arms are *certain* structural causes a
+#: union over ``kind``: the first four arms are *certain* structural causes a
 #: guard proves without the solver (and are collected exhaustively — every one
-#: that holds, not just the first), ``PastWindow`` is the equally-certain
-#: pre-live "the day is dated in the past" cause (ADR "a past day is named, not
+#: that holds, not just the first) — three about a *pool* and
+#: ``PlayerOverSubscribed`` about a single *human* (ADR "the conflict core is a
+#: second, max-placed solve") — ``PastWindow`` is the equally-certain pre-live
+#: "the day is dated in the past" cause (ADR "a past day is named, not
 #: disguised", #1101), and ``NoSingleCause`` is the best-effort residual when
 #: CP-SAT refuses but no structure does. Frozen dataclasses + a ``kind``
 #: discriminator so a downstream humanizer can ``match`` exhaustively with no
@@ -489,6 +531,7 @@ InfeasibilityReason = (
     PoolHasNoTables
     | WindowTooShortForMatch
     | PoolOverCapacity
+    | PlayerOverSubscribed
     | NoSingleCause
     | PastWindow
 )
@@ -878,8 +921,8 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
 
     # Structural feasibility first — but gathered *exhaustively*, not first-fail.
     # A day that cannot possibly be placed should explain every certain cause at
-    # once (the director fixes them together), not just the first one hit. Four
-    # certain, per-structure causes need no solver to prove:
+    # once (the director fixes them together), not just the first one hit. Five
+    # certain causes need no solver to prove — four about a pool's structure:
     #   * PastWindow — a pool whose ENTIRE planned window is already past (pre-
     #     live only): unschedulable because of *when* it is, not how much fits,
     #     fixed by "move the date" (ADR "a past day is named, not disguised",
@@ -887,7 +930,10 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
     #     window / over-capacity arms for the same pool.
     #   * PoolHasNoTables — a pool with unpinned fixtures but no tables to use,
     #   * WindowTooShortForMatch — a single fixture whose window can't hold it,
-    #   * PoolOverCapacity — a pool's unpinned demand exceeds window × tables.
+    #   * PoolOverCapacity — a pool's unpinned demand exceeds window × tables,
+    # and one about a single human:
+    #   * PlayerOverSubscribed — one player's own serial demand (their matches
+    #     plus the rest between them) exceeds the pool's window span.
     # We dedupe to the *most specific* cause per pool: a past-window, no-tables,
     # or window-too-short pool is already unplaceable, so we don't also pile on
     # over-capacity for it. Bucket bounds for the pools that *do* fit are recorded
@@ -992,6 +1038,63 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
                     table_count=table_count,
                 )
             )
+
+    # Per (pool, human): a pigeonhole over ONE person, run in the same cheap
+    # pre-check pass (ADR "the conflict core is a second, max-placed solve" —
+    # certain per-player over-subscription is a pre-check, not a residual). A
+    # player plays one match at a time and their unpinned fixtures in a pool must
+    # all run inside that pool's window, so
+    #     Σ durations + (N − 1) × REST_MIN > window span
+    # proves the day cannot fit no matter how many tables the pool owns.
+    #
+    # The (N − 1) is load-bearing: the model pads EVERY player interval by
+    # REST_MIN (correct for AddNoOverlap, which needs the gap in either
+    # direction), but the last match of the day owes no trailing rest inside the
+    # window — charging N × REST_MIN would overcount and could falsely accuse a
+    # player, which is unacceptable for an arm whose whole claim is certainty.
+    #
+    # Reported ALONGSIDE PoolOverCapacity rather than dominated by it: they are
+    # proofs about different subjects with different remedies (add tables vs. this
+    # human is in too many matches), so both are actionable and both are certain.
+    # The pool-level *unplaceable* causes above do dominate — a past-window,
+    # no-tables or too-short-window pool is already unrunnable, so piling a
+    # per-player claim on top of it would just be noise.
+    for pool in snapshot.pools:
+        pool_unpinned = unpinned_by_pool.get(pool.id)
+        if not pool_unpinned:
+            continue
+        if pool.id in pools_past_window or pool.id in pools_short_window:
+            continue
+        if not pool.table_ids:
+            continue  # PoolHasNoTables already names this pool
+        fixtures_by_player: defaultdict[PlayerId, list[ScheduleFixture]] = defaultdict(
+            list
+        )
+        for fixture in pool_unpinned:
+            for player in (fixture.player_a_id, fixture.player_b_id):
+                fixtures_by_player[player].append(fixture)
+        # Effective end: pre-live the planned window; live it is softened, so an
+        # overrunning live day is never falsely flagged over-subscribed (the same
+        # span PoolOverCapacity measures itself against).
+        window_span = effective_end(pool) - pool.window.start_min
+        for player_id, player_fixtures in sorted(fixtures_by_player.items()):
+            match_count = len(player_fixtures)
+            if match_count < 2:
+                continue  # one match is a window question, not over-subscription
+            required = (
+                sum(duration_of(f) for f in player_fixtures)
+                + (match_count - 1) * REST_MIN
+            )
+            if required > window_span:
+                reasons.append(
+                    PlayerOverSubscribed(
+                        pool_id=pool.id,
+                        player_id=player_id,
+                        match_count=match_count,
+                        required_min=required,
+                        window_span_min=window_span,
+                    )
+                )
 
     if reasons:
         # A certain structural infeasibility: refuse without building or running

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -441,7 +441,7 @@ class PlayerOverSubscribed:
     person. A player plays one match at a time and their fixtures in a pool must
     all run inside that pool's window, so
 
-        ``Σ durations + (match_count − 1) × REST_MIN > window_span_min``
+        ``Σ durations + (match_count − 1) × REST_MIN > playable span``
 
     is a **necessary** condition for infeasibility — provable by arithmetic on
     the snapshot with no solver at all, which is why it joins the cheap pre-check
@@ -449,6 +449,16 @@ class PlayerOverSubscribed:
     max-placed solve"). ``required_min`` is that left-hand side: the player's own
     serial demand, table count irrelevant (extra tables let *other* people play in
     parallel, never this one).
+
+    ``window_span_min`` is the pool's **planned** span (``end − start``), the
+    same span :class:`WindowTooShortForMatch` reports — it is the window the
+    director sees on screen beside this number. The span the bound is *tested*
+    against is the live-softened one, which while live is wider; testing against
+    the planned span would falsely accuse a player on an overrunning live day
+    that genuinely schedules. Reporting the tested span instead would print a
+    span that contradicts the window clock rendered next to it. Both numbers are
+    honest because ``planned span ≤ tested span < required_min``, so the
+    inequality the reader is shown holds too.
 
     **The rest term is ``(N − 1)``, not ``N``.** :func:`_build_model` pads *every*
     player interval by :data:`REST_MIN`, which is right for ``AddNoOverlap`` (it
@@ -1028,10 +1038,11 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
         table_count = len(pool.table_ids)
         # Effective end: pre-live this is the planned window; live it is softened
         # so an overrunning live day is never falsely flagged over-capacity. Bound
-        # once, here, because BOTH certain arms below measure against it — a pool's
+        # once, here, because BOTH certain arms below TEST against it — a pool's
         # capacity and one human's own day are different proofs about the same
-        # window, and computing the span twice would let them drift into reporting
-        # contradictory numbers for the same pool.
+        # window, and deriving the compared span twice would let the two proofs
+        # drift apart for the same pool. (What each arm *reports* is a separate
+        # question — see PlayerOverSubscribed's `window_span_min` below.)
         window_span = effective_end(pool) - pool.window.start_min
         capacity_min = window_span * table_count
         if required_min > capacity_min:
@@ -1083,7 +1094,15 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
             player_minutes = minutes_by_player[player_id]
             match_count = len(player_minutes)
             if match_count < 2:
-                continue  # one match is a window question, not over-subscription
+                # Provably dead, kept as a cheap explicit statement of the
+                # arm's precondition. Every fixture in a pool that reached here
+                # cleared the window-too-short guard above (`lo <= hi`), which
+                # means some grid start `g` satisfies `g >= window.start` and
+                # `g + duration <= effective_end` — so `window_span >= duration`
+                # and a lone match can never exceed the span it is compared
+                # against. A single fixture that genuinely cannot fit is
+                # WindowTooShortForMatch's finding, and it already fired.
+                continue
             required = sum(player_minutes) + (match_count - 1) * REST_MIN
             if required > window_span:
                 reasons.append(
@@ -1092,7 +1111,26 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
                         player_id=player_id,
                         match_count=match_count,
                         required_min=required,
-                        window_span_min=window_span,
+                        # The compared span and the REPORTED span deliberately
+                        # differ while live — do not "fix" this back to
+                        # `window_span`. We compare against the softened
+                        # effective span (above) because that is the
+                        # conservative direction: while live the window end is
+                        # advisory and the remainder overruns, so comparing
+                        # against the smaller *planned* span would falsely
+                        # accuse a player on an overrunning day that genuinely
+                        # schedules. But the director's screen prints this
+                        # number beside the pool's *planned* window clock
+                        # (window_start/window_end, never softened), so
+                        # reporting the effective span would render a
+                        # self-contradictory sentence — a "09:30–10:30 window"
+                        # described in the same breath as "only 2.5h long".
+                        # Report the planned span —
+                        # as WindowTooShortForMatch already does, for the same
+                        # reason. The sentence stays true either way:
+                        # planned_span <= effective_span < required, so
+                        # `required > planned_span` too.
+                        window_span_min=pool.window.end_min - pool.window.start_min,
                     )
                 )
 

--- a/api/app/schemas/schedule_solve.py
+++ b/api/app/schemas/schedule_solve.py
@@ -62,6 +62,25 @@ class PoolOverCapacityRead(BaseModel):
     table_count: int
 
 
+class PlayerOverSubscribedRead(BaseModel):
+    """One human with more match-time in a pool than its window can hold: their
+    ``match_count`` matches plus the rest between them need ``required_min``
+    minutes of *their* time, against a window spanning only ``window_span_min``.
+    A pigeonhole over one person, so adding tables cannot fix it — the remedy is
+    fewer matches for them in this pool, or a longer window. Resolved: the
+    human's display ``player_name`` and the pool's ``name`` + ``HH:MM`` bounds;
+    the minutes stay integers for the client to format."""
+
+    kind: Literal["player_over_subscribed"] = "player_over_subscribed"
+    player_name: str
+    pool_name: str
+    window_start: str
+    window_end: str
+    match_count: int
+    required_min: int
+    window_span_min: int
+
+
 class NoSingleCauseRead(BaseModel):
     """CP-SAT proved the day infeasible yet no structural arm explains it — the
     whole-day residual. No pool: it carries only the day aggregate,
@@ -95,6 +114,7 @@ ResolvedReason = Annotated[
     PoolHasNoTablesRead
     | WindowTooShortForMatchRead
     | PoolOverCapacityRead
+    | PlayerOverSubscribedRead
     | NoSingleCauseRead
     | PastWindowReasonRead,
     Field(discriminator="kind"),

--- a/api/tests/test_schedule_preview_solve.py
+++ b/api/tests/test_schedule_preview_solve.py
@@ -61,6 +61,7 @@ from app.schemas.schedule_preview import (
 )
 from app.schemas.schedule_solve import (
     PastWindowReasonRead,
+    PlayerOverSubscribedRead,
     WindowTooShortForMatchRead,
 )
 from app.tournament_errors import (
@@ -567,6 +568,55 @@ async def test_preview_solve_infeasible_resolves_its_reasons(
     assert reason.pool_name == "Pool A"
     assert reason.window_start == "09:00"
     assert reason.best_of == 5
+
+
+async def test_preview_over_subscribed_placeholder_resolves_to_its_label(
+    db_session: AsyncSession,
+    default_league: League,
+    preview_queue: Queue,
+) -> None:
+    """The one reason arm that names a *player*, on the DB-blind preview path: a
+    preview's entrants are synthetic stand-ins, not humans, so the arm resolves
+    straight off the id — ``placeholder-3`` → ``Placeholder 3``, the same label
+    the preview surface already shows the director — with no DB read.
+
+    Four entrants in a round-robin means every one of them plays three
+    35-minute matches: 105 minutes plus two 10-minute rests is 125 minutes of one
+    person's time against a 120-minute window, so all four are certainly
+    over-subscribed. Two tables keep the *pool* under capacity (210 needed
+    against 120 × 2 = 240), so this arm is the only one that can fire."""
+    owner = await make_user(db_session, "prev-oversubscribed")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    await _add_event(
+        db_session,
+        tournament,
+        max_players=4,
+        length_games=5,
+        pools=[_pool(["t1", "t2"], start="09:00", end="11:00")],
+    )
+
+    await request_schedule_preview(db_session, tournament_id=tournament.id, actor=owner)
+    (job,) = preview_queue.jobs
+    (inputs,) = job.args
+    result = PreviewResult.model_validate(run_schedule_preview(inputs))
+
+    assert result.verdict is PreviewVerdict.infeasible
+    reasons = result.infeasibility_reasons
+    assert [r.kind for r in reasons] == ["player_over_subscribed"] * 4
+    assert all(isinstance(r, PlayerOverSubscribedRead) for r in reasons)
+    over_subscribed = [r for r in reasons if isinstance(r, PlayerOverSubscribedRead)]
+    # The synthetic ids are shown the way the preview surface shows them — never
+    # the raw ``placeholder-3`` spelling.
+    assert {r.player_name for r in over_subscribed} == {
+        f"Placeholder {k}" for k in (1, 2, 3, 4)
+    }
+    first = over_subscribed[0]
+    assert first.pool_name == "Pool A"
+    assert first.window_start == "09:00"
+    assert first.window_end == "11:00"
+    assert first.match_count == 3
+    assert first.required_min == 125  # 3 * 35 + 2 * REST_MIN
+    assert first.window_span_min == 120
 
 
 async def test_preview_solve_past_dated_window_resolves_past_window(

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -79,6 +79,8 @@ from app.schedule_solves import (
 from app.scheduling import (
     REST_MIN,
     PlacedFixture,
+    PlayerId,
+    PlayerOverSubscribed,
     PoolHasNoTables,
     PoolId,
     PoolOverCapacity,
@@ -91,6 +93,7 @@ from app.schemas.notification import NotificationJob
 from app.schemas.schedule_solve import (
     PastWindowReasonRead,
     PlayerConflictRead,
+    PlayerOverSubscribedRead,
     PoolHasNoTablesRead,
     PoolOverCapacityRead,
     TableConflictRead,
@@ -1347,6 +1350,73 @@ class TestSolveJob:
         assert over_capacity.required_min == 600
         assert over_capacity.capacity_min == 480
         assert over_capacity.table_count == 2
+
+    async def test_over_subscribed_player_resolves_to_their_display_name(
+        self,
+        db_session: AsyncSession,
+        solver_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The one reason arm that names a *human* is humanized at apply through
+        the same ``player_names`` map the player-conflict arm already uses — the
+        persisted reason carries the entrant's display username (never the raw
+        user-id string the solver speaks), alongside the pool's name and clock."""
+        tournament_id, event_id = await _make_tournament(
+            db_session, window=("09:00", "17:00")
+        )
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+        assert row is not None
+        row_id = row.id
+        await db_session.commit()
+
+        # Any entrant of the drawn event: ``player_names`` is built from all of
+        # them, so a pre-check can blame any one.
+        user_id, username = (
+            await db_session.execute(
+                select(User.id, User.username)
+                .join(TournamentEntry, TournamentEntry.user_id == User.id)
+                .where(TournamentEntry.event_id == event_id)
+                .order_by(User.username)
+                .limit(1)
+            )
+        ).one()
+
+        def infeasible(
+            snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+        ) -> SolveResult:
+            return SolveResult(
+                verdict=Verdict.infeasible,
+                placements=(),
+                stats=SolveStats(wall_time_ms=42, objective=None),
+                reasons=(
+                    PlayerOverSubscribed(
+                        pool_id=PoolId(f"{event_id}:pool-a"),
+                        player_id=PlayerId(str(user_id)),
+                        match_count=3,
+                        required_min=95,
+                        window_span_min=60,
+                    ),
+                ),
+            )
+
+        monkeypatch.setattr(schedule_solves, "_solve", infeasible)
+        _run_recorded_job(solver_queue, row_id)
+
+        db_session.expire_all()
+        (ledger,) = await _solve_rows(db_session, tournament_id)
+        assert ledger.status is ScheduleSolveStatus.infeasible
+
+        (reason,) = parse_infeasibility_reasons(ledger.infeasibility_reasons)
+        assert isinstance(reason, PlayerOverSubscribedRead)
+        assert reason.player_name == username
+        assert reason.pool_name == "Pool A"
+        assert reason.window_start == "09:00"
+        assert reason.window_end == "17:00"
+        assert reason.match_count == 3
+        assert reason.required_min == 95
+        assert reason.window_span_min == 60
 
     async def test_succeeded_apply_leaves_infeasibility_reasons_null(
         self, db_session: AsyncSession, solver_queue: Queue

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -30,6 +30,7 @@ from app.scheduling import (
     PlacedFixture,
     PlayerConflict,
     PlayerId,
+    PlayerOverSubscribed,
     PoolHasNoTables,
     PoolId,
     PoolOverCapacity,
@@ -641,22 +642,39 @@ class TestInfeasibility:
         assert "pool_over_capacity" not in by_kind
         assert result.reasons == ()
 
-    def test_tight_shared_window_is_no_single_cause(self) -> None:
-        """Every certain guard passes — each match fits its window, two tables
-        give room to spare, the pool is well under aggregate capacity — yet the
-        two matches share a player and cannot both fit with the rest floor in the
-        tight window, so CP-SAT proves it infeasible. No single structural cause
-        explains that, so the residual :class:`NoSingleCause` is attached, with
+    def test_a_player_shared_across_pools_is_no_single_cause(self) -> None:
+        """Every certain guard passes — each match fits its own pool's window,
+        each pool has a table to itself and is well under aggregate capacity, and
+        no *single pool* over-subscribes anyone (one match each) — yet the two
+        matches share a player across the two pools and cannot both fit with the
+        rest floor in their tight, overlapping windows, so CP-SAT proves it
+        infeasible.
+
+        This is the shape of infeasibility the per-(pool, player) pre-check
+        deliberately does NOT claim: it is scoped to one pool, so a human split
+        across pools is beyond what it can prove. No single structural cause
+        explains it, so the residual :class:`NoSingleCause` is attached, with
         aggregate room to spare (``required_min <= available_min``)."""
         p1, p2, p3 = _players(3)
-        fixtures = (_fixture(1, p1, p2), _fixture(2, p1, p3))  # share P1
-        # 55-minute window, 2 tables. Each 25-min match starts by 30 (fits), and
-        # 2*25=50 <= 55*2=110 (under capacity) — but P1's chain needs 25+10+25=60.
-        snapshot = _one_pool_snapshot(fixtures, tables=2, window=(0, 55))
+        table_ids = _tables(2)
+        snapshot = ScheduleSnapshot(
+            table_ids=table_ids,
+            pools=(
+                SchedulePool(PoolId("A"), (TableId("T1"),), Window(0, 30)),
+                SchedulePool(PoolId("B"), (TableId("T2"),), Window(0, 30)),
+            ),
+            events=(EventSettings(EventId("E1"), 3),),
+            # P1 plays once in each pool: one match per (pool, player), so the
+            # per-player pigeonhole never fires — but P1's two 25-min matches plus
+            # the 10-min rest need 60 minutes of P1's time, and both windows end
+            # at 30.
+            fixtures=(_fixture(1, p1, p2, pool="A"), _fixture(2, p1, p3, pool="B")),
+            now_min=0,
+        )
         result = solve(snapshot, time_cap_s=CAP)
         assert result.verdict is Verdict.infeasible
         assert result.placements == ()
-        assert result.reasons == (NoSingleCause(required_min=50, available_min=110),)
+        assert result.reasons == (NoSingleCause(required_min=50, available_min=60),)
         (only,) = result.reasons
         assert isinstance(only, NoSingleCause)
         assert only.required_min <= only.available_min
@@ -693,7 +711,7 @@ class TestInfeasibility:
         """Two independently-broken pools: one has no tables, the other is over
         capacity. Both causes are reported in a single solve (not first-fail),
         each blaming its own pool."""
-        p1, p2, p3, p4 = _players(4)
+        p1, p2, p3, p4, p5, p6 = _players(6)
         table_ids = _tables(1)  # the single table belongs to pool B only
         snapshot = ScheduleSnapshot(
             table_ids=table_ids,
@@ -704,8 +722,10 @@ class TestInfeasibility:
             events=(EventSettings(EventId("E1"), 3),),
             fixtures=(
                 _fixture(1, p1, p2, pool="A"),
+                # Pool B's two fixtures share no player (each of P3..P6 plays
+                # once), so its only cause is the pool-level capacity one.
                 _fixture(2, p3, p4, pool="B"),
-                _fixture(3, p1, p3, pool="B"),  # 2 * 25 = 50 > 40 * 1
+                _fixture(3, p5, p6, pool="B"),  # 2 * 25 = 50 > 40 * 1
             ),
             now_min=0,
         )
@@ -736,6 +756,177 @@ class TestInfeasibility:
         result = solve(_one_pool_snapshot(()), time_cap_s=CAP)
         assert result.verdict is Verdict.optimal
         assert result.reasons == ()
+
+
+class TestPlayerOverSubscribed:
+    """The per-(pool, player) pigeonhole (ADR "the conflict core is a second,
+    max-placed solve", decision 1): one human's own serial demand — their
+    matches plus the rest between them — measured against the pool window. A
+    *certain* cause, proved by arithmetic in the pre-check pass with no CP-SAT
+    run, so like every certain arm it must never accuse anyone falsely."""
+
+    def test_an_over_subscribed_player_is_reported_without_the_solver(self) -> None:
+        """P1 plays three 25-minute matches in a 60-minute window. However many
+        tables the pool owns, P1 can only play one at a time: 75 minutes of
+        matches plus two 10-minute rests is 95 minutes of P1's day against a
+        60-minute window, so the day cannot fit — blamed on the human by id, with
+        the raw minute arithmetic, and no solver run.
+
+        Note the pool itself is nowhere near over capacity (75 needed against
+        60 × 3 tables = 180), which is exactly why the pool-level arms cannot see
+        this and a per-player one is needed."""
+        p1, p2, p3, p4 = _players(4)
+        fixtures = (
+            _fixture(1, p1, p2),
+            _fixture(2, p1, p3),
+            _fixture(3, p1, p4),
+        )
+        snapshot = _one_pool_snapshot(fixtures, tables=3, window=(0, 60))
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict is Verdict.infeasible
+        assert result.placements == ()
+        assert result.reasons == (
+            PlayerOverSubscribed(
+                pool_id=PoolId("A"),
+                player_id=p1,
+                match_count=3,
+                required_min=95,  # 3 * 25 + 2 * REST_MIN
+                window_span_min=60,
+            ),
+        )
+
+    def test_the_rest_charged_is_one_gap_short_of_the_match_count(self) -> None:
+        """THE falsification for this arm's bound. Two 25-minute matches for P1
+        in a 60-minute window need 25 + 10 + 25 = 60 — exactly the window — and
+        the day genuinely fits (P1 plays [0, 25) and [35, 60)). So no reason may
+        be reported and the solve must succeed.
+
+        With the rest term charged as ``N × REST_MIN`` instead of ``(N − 1)``,
+        demand would read 70 > 60 and this feasible day would be refused with a
+        *certain* reason naming an innocent player — the failure mode the ADR
+        calls unacceptable. Flip the bound in :func:`_build_model` and this test
+        reds on both assertions."""
+        p1, p2, p3 = _players(3)
+        assert 2 * match_minutes(3) + (2 - 1) * REST_MIN == 60
+        fixtures = (_fixture(1, p1, p2), _fixture(2, p1, p3))
+        snapshot = _one_pool_snapshot(fixtures, tables=2, window=(0, 60))
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.reasons == ()
+        assert result.verdict in SOLVED
+        _assert_hard_constraints(snapshot, result)
+        assert sorted(p.start_min for p in result.placements) == [0, 35]
+
+    def test_every_over_subscribed_player_is_reported(self) -> None:
+        """Collected exhaustively, like every other certain cause: two humans are
+        each in three matches of a 60-minute window, and both are named in one
+        solve so the director fixes them together rather than re-running into the
+        next. Reported in player-id order for determinism."""
+        p1, p2, p3, p4, p5, p6, p7, p8 = _players(8)
+        fixtures = (
+            _fixture(1, p1, p3),
+            _fixture(2, p1, p4),
+            _fixture(3, p1, p5),
+            _fixture(4, p2, p6),
+            _fixture(5, p2, p7),
+            _fixture(6, p2, p8),
+        )
+        # 4 tables: pool demand is 6 * 25 = 150 against 60 * 4 = 240, so the pool
+        # is under capacity and only the per-player arm can fire.
+        snapshot = _one_pool_snapshot(fixtures, tables=4, window=(0, 60))
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict is Verdict.infeasible
+        assert result.reasons == (
+            PlayerOverSubscribed(
+                pool_id=PoolId("A"),
+                player_id=p1,
+                match_count=3,
+                required_min=95,
+                window_span_min=60,
+            ),
+            PlayerOverSubscribed(
+                pool_id=PoolId("A"),
+                player_id=p2,
+                match_count=3,
+                required_min=95,
+                window_span_min=60,
+            ),
+        )
+
+    def test_an_over_capacity_pool_also_names_its_over_subscribed_player(
+        self,
+    ) -> None:
+        """The two certain arms coexist: they are proofs about different subjects
+        with different remedies — "this pool needs more table-time" and "this
+        human is in too many matches" — so a pool that is both reports both,
+        rather than one silently dominating the other. One table, a 60-minute
+        window, three matches all involving P1: the pool needs 75 table-minutes
+        against 60, and P1 needs 95 minutes of their own day."""
+        p1, p2, p3, p4 = _players(4)
+        fixtures = (
+            _fixture(1, p1, p2),
+            _fixture(2, p1, p3),
+            _fixture(3, p1, p4),
+        )
+        snapshot = _one_pool_snapshot(fixtures, tables=1, window=(0, 60))
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict is Verdict.infeasible
+        by_kind = _reasons_by_kind(result)
+        assert by_kind["pool_over_capacity"] == [
+            PoolOverCapacity(
+                pool_id=PoolId("A"),
+                required_min=75,
+                capacity_min=60,
+                table_count=1,
+            )
+        ]
+        assert by_kind["player_over_subscribed"] == [
+            PlayerOverSubscribed(
+                pool_id=PoolId("A"),
+                player_id=p1,
+                match_count=3,
+                required_min=95,
+                window_span_min=60,
+            )
+        ]
+
+    def test_pinned_matches_do_not_count_toward_a_players_load(self) -> None:
+        """Scoped to *unpinned* demand, like every other certain arm: a pin is
+        bound to neither the pool's tables nor its window (ADR-0790), so counting
+        it could invent a false accusation. P1 has one unpinned match in the pool
+        plus two called ones — three in total, which summed naively (95) would
+        overflow the 60-minute window — but only the unpinned one is P1's
+        provable in-window load, and the day solves."""
+        p1, p2, p3, p4 = _players(4)
+        fixtures = (
+            _fixture(1, p1, p2),  # unpinned, in-window
+            _fixture(2, p1, p3, pin=Pin(TableId("T1"), 0)),  # called: [0, 25)
+            _fixture(3, p1, p4, pin=Pin(TableId("T2"), 300)),  # called, past the window
+        )
+        snapshot = _one_pool_snapshot(fixtures, tables=2, window=(0, 60))
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict in SOLVED
+        assert result.reasons == ()
+        _assert_hard_constraints(snapshot, result)
+
+    def test_a_no_tables_pool_reports_only_that(self) -> None:
+        """The pool-level *unplaceable* causes dominate: a pool with no tables is
+        already unrunnable, so piling a per-player claim on top of it would be
+        noise. P1 is in three matches of a 60-minute no-tables pool and only
+        :class:`PoolHasNoTables` is reported."""
+        p1, p2, p3, p4 = _players(4)
+        snapshot = ScheduleSnapshot(
+            table_ids=(),
+            pools=(SchedulePool(PoolId("A"), (), Window(0, 60)),),
+            events=(EventSettings(EventId("E1"), 3),),
+            fixtures=(
+                _fixture(1, p1, p2),
+                _fixture(2, p1, p3),
+                _fixture(3, p1, p4),
+            ),
+            now_min=0,
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.reasons == (PoolHasNoTables(pool_id=PoolId("A")),)
 
     def test_entirely_past_window_pre_live_names_past_window_reason(self) -> None:
         """A pre-live pool whose ENTIRE window is already behind ``now`` is

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -757,6 +757,34 @@ class TestInfeasibility:
         assert result.verdict is Verdict.optimal
         assert result.reasons == ()
 
+    def test_entirely_past_window_pre_live_names_past_window_reason(self) -> None:
+        """A pre-live pool whose ENTIRE window is already behind ``now`` is
+        infeasible with a specific, machine-readable ``past_window`` reason that
+        identifies the offending pool — the most specific pre-live cause, distinct
+        from a too-tight current window (ADR "a past day is named, not disguised",
+        #1101). The pure module is minute-only, so the reason carries only the
+        pool id; the DB-aware layer resolves it to a date."""
+        p1, p2 = _players(2)
+        # Window [0, 60) is wholly before now (minute 120): no grid start >= now
+        # can ever land inside it — a dated-in-the-past day, not too-tight.
+        snapshot = _one_pool_snapshot(
+            (_fixture(1, p1, p2),),
+            window=(0, 60),
+            now_min=120,
+        )
+        assert snapshot.is_live is False
+        result = solve(snapshot, time_cap_s=CAP)
+
+        assert result.verdict is Verdict.infeasible
+        assert result.placements == ()
+        assert result.overrunning is False
+        # Past window dominates: it is the only reason (the tight-window arm is
+        # suppressed for the same pool), and it names the offending pool.
+        assert result.reasons == (PastWindow(pool_id=PoolId("A")),)
+        (reason,) = result.reasons
+        assert isinstance(reason, PastWindow)
+        assert reason.kind == "past_window"
+
 
 class TestPlayerOverSubscribed:
     """The per-(pool, player) pigeonhole (ADR "the conflict core is a second,
@@ -816,19 +844,102 @@ class TestPlayerOverSubscribed:
         _assert_hard_constraints(snapshot, result)
         assert sorted(p.start_min for p in result.placements) == [0, 35]
 
+    def test_a_live_overrunning_day_does_not_accuse_its_busiest_player(self) -> None:
+        """THE falsification for this arm's *span*. Once the day is live the pool
+        window's end is advisory — the unplayed remainder overruns instead of
+        wedging (ADR "the solver stops wedging", #1067) — so the span this bound
+        is tested against must be the live-softened one, not the planned one.
+
+        P1 is in three 25-minute matches (95 minutes of P1's own day) in a pool
+        whose *planned* window is only 60 minutes long, and it is already minute
+        50 of a live day. Measured against the planned span this reads
+        95 > 60 — a *certain* reason naming an innocent human — yet the day
+        genuinely schedules, P1 playing back-to-back-with-rest into the overrun.
+        So no reason may be reported and every fixture must be placed.
+
+        Swap ``effective_end(pool)`` for ``pool.window.end_min`` in the span
+        :func:`_build_model` compares against and this test reds: infeasible,
+        placements gone, PlayerOverSubscribed(P1, required_min=95) reported."""
+        p1, p2, p3, p4 = _players(4)
+        fixtures = (
+            _fixture(1, p1, p2),
+            _fixture(2, p1, p3),
+            _fixture(3, p1, p4),
+        )
+        snapshot = dataclasses.replace(
+            _one_pool_snapshot(fixtures, tables=3, window=(0, 60), now_min=50),
+            is_live=True,
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+
+        assert result.reasons == ()
+        assert result.verdict is Verdict.optimal
+        # P1 plays all three, serialized with the rest floor between them, from
+        # the first grid start at/after now: [50, 75), [85, 110), [120, 145).
+        assert sorted(p.start_min for p in result.placements) == [50, 85, 120]
+        # It overruns the planned end, which is precisely the case the softened
+        # span exists to keep schedulable rather than blame someone for.
+        assert result.overrunning is True
+
+    def test_the_reported_span_is_the_planned_one_not_the_softened_one(self) -> None:
+        """The span reported and the span compared against deliberately differ
+        while live. The director's screen prints ``window_span_min`` beside the
+        pool's *planned* window clock, which is never softened, so reporting the
+        (wider) live-softened span would render a self-contradictory sentence:
+        "they need 1.6h, but the window is only 1.4h long" next to a 09:30–10:40
+        window. The planned span is reported — as WindowTooShortForMatch already
+        does — while the *bound* still uses the softened span, which is the
+        conservative direction (see the test above).
+
+        A live day at minute 0 whose pool window is [20, 100): planned span 80,
+        softened span 85 (now + the 105-minute overrun allowance clips the end to
+        105). P1's 95 minutes beat both, so the arm fires — and the sentence the
+        director reads stays true because planned <= softened < required."""
+        p1, p2, p3, p4 = _players(4)
+        fixtures = (
+            _fixture(1, p1, p2),
+            _fixture(2, p1, p3),
+            _fixture(3, p1, p4),
+        )
+        snapshot = dataclasses.replace(
+            _one_pool_snapshot(fixtures, tables=3, window=(20, 100), now_min=0),
+            is_live=True,
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+
+        assert result.verdict is Verdict.infeasible
+        assert result.reasons == (
+            PlayerOverSubscribed(
+                pool_id=PoolId("A"),
+                player_id=p1,
+                match_count=3,
+                required_min=95,
+                window_span_min=80,  # 100 - 20, the PLANNED span (not 85)
+            ),
+        )
+        # The inequality the director is shown holds as printed.
+        (reason,) = result.reasons
+        assert isinstance(reason, PlayerOverSubscribed)
+        assert reason.required_min > reason.window_span_min
+
     def test_every_over_subscribed_player_is_reported(self) -> None:
         """Collected exhaustively, like every other certain cause: two humans are
         each in three matches of a 60-minute window, and both are named in one
         solve so the director fixes them together rather than re-running into the
-        next. Reported in player-id order for determinism."""
+        next. Reported in player-id order for determinism.
+
+        P2's fixtures are listed FIRST on purpose: snapshot order therefore
+        disagrees with player-id order, so the expected (P1, P2) tuple can only
+        hold if the arm really sorts. Listing P1 first would make insertion order
+        and sorted order identical, and dropping the ``sorted(...)`` would pass."""
         p1, p2, p3, p4, p5, p6, p7, p8 = _players(8)
         fixtures = (
-            _fixture(1, p1, p3),
-            _fixture(2, p1, p4),
-            _fixture(3, p1, p5),
-            _fixture(4, p2, p6),
-            _fixture(5, p2, p7),
-            _fixture(6, p2, p8),
+            _fixture(1, p2, p6),
+            _fixture(2, p2, p7),
+            _fixture(3, p2, p8),
+            _fixture(4, p1, p3),
+            _fixture(5, p1, p4),
+            _fixture(6, p1, p5),
         )
         # 4 tables: pool demand is 6 * 25 = 150 against 60 * 4 = 240, so the pool
         # is under capacity and only the per-player arm can fire.
@@ -928,33 +1039,56 @@ class TestPlayerOverSubscribed:
         result = solve(snapshot, time_cap_s=CAP)
         assert result.reasons == (PoolHasNoTables(pool_id=PoolId("A")),)
 
-    def test_entirely_past_window_pre_live_names_past_window_reason(self) -> None:
-        """A pre-live pool whose ENTIRE window is already behind ``now`` is
-        infeasible with a specific, machine-readable ``past_window`` reason that
-        identifies the offending pool — the most specific pre-live cause, distinct
-        from a too-tight current window (ADR "a past day is named, not disguised",
-        #1101). The pure module is minute-only, so the reason carries only the
-        pool id; the DB-aware layer resolves it to a date."""
-        p1, p2 = _players(2)
-        # Window [0, 60) is wholly before now (minute 120): no grid start >= now
-        # can ever land inside it — a dated-in-the-past day, not too-tight.
-        snapshot = _one_pool_snapshot(
-            (_fixture(1, p1, p2),),
-            window=(0, 60),
-            now_min=120,
+    def test_a_past_window_pool_reports_only_that(self) -> None:
+        """The second of the three domination guards this arm shares with the
+        pool-level pass (the no-tables one is above, the short-window one below):
+        a pre-live pool whose ENTIRE window is behind ``now`` is unschedulable
+        because of *when* it is, fixed by moving the date, so naming a human on
+        top of it is noise. P1 is in three matches of a 60-minute window that
+        ended an hour ago and only :class:`PastWindow` is reported.
+
+        Drop the ``pools_past_window`` ``continue`` from the per-pool loop and
+        this test reds with a PlayerOverSubscribed(P1) piled on."""
+        p1, p2, p3, p4 = _players(4)
+        fixtures = (
+            _fixture(1, p1, p2),
+            _fixture(2, p1, p3),
+            _fixture(3, p1, p4),
         )
+        # 3 tables, so the pool is nowhere near over capacity (75 vs 60 * 3) and
+        # the per-player arm is the only one the dropped guard could let through.
+        snapshot = _one_pool_snapshot(fixtures, tables=3, window=(0, 60), now_min=120)
         assert snapshot.is_live is False
         result = solve(snapshot, time_cap_s=CAP)
-
-        assert result.verdict is Verdict.infeasible
-        assert result.placements == ()
-        assert result.overrunning is False
-        # Past window dominates: it is the only reason (the tight-window arm is
-        # suppressed for the same pool), and it names the offending pool.
         assert result.reasons == (PastWindow(pool_id=PoolId("A")),)
-        (reason,) = result.reasons
-        assert isinstance(reason, PastWindow)
-        assert reason.kind == "past_window"
+
+    def test_a_short_window_pool_reports_only_its_unfittable_matches(self) -> None:
+        """The third domination guard: a pool whose window cannot hold even one
+        match is already proven unplaceable per fixture, so the pool- and
+        player-level claims about it are suppressed. A 20-minute window against
+        25-minute matches, all three involving P1 — only the three
+        :class:`WindowTooShortForMatch` findings are reported.
+
+        Drop the ``pools_short_window`` ``continue`` and this test reds twice
+        over: a PoolOverCapacity (75 > 20 * 3) and a PlayerOverSubscribed(P1,
+        95 > 20) get piled onto a pool that already explained itself."""
+        p1, p2, p3, p4 = _players(4)
+        fixtures = (
+            _fixture(1, p1, p2),
+            _fixture(2, p1, p3),
+            _fixture(3, p1, p4),
+        )
+        snapshot = _one_pool_snapshot(fixtures, tables=3, window=(0, 20))
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.reasons == tuple(
+            WindowTooShortForMatch(
+                pool_id=PoolId("A"),
+                fixture_id=FixtureId(f"F{n}"),
+                needed_min=25,
+                window_span_min=20,
+            )
+            for n in (1, 2, 3)
+        )
 
 
 class TestSoftWindowOnceLive:

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -2906,6 +2906,8 @@ internal enum Components {
                 case noSingleCause(Components.Schemas.NoSingleCauseRead)
                 /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload/PastWindowReasonRead`.
                 case pastWindow(Components.Schemas.PastWindowReasonRead)
+                /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload/PlayerOverSubscribedRead`.
+                case playerOverSubscribed(Components.Schemas.PlayerOverSubscribedRead)
                 /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload/PoolHasNoTablesRead`.
                 case poolHasNoTables(Components.Schemas.PoolHasNoTablesRead)
                 /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload/PoolOverCapacityRead`.
@@ -2926,6 +2928,8 @@ internal enum Components {
                         self = .noSingleCause(try .init(from: decoder))
                     case "past_window":
                         self = .pastWindow(try .init(from: decoder))
+                    case "player_over_subscribed":
+                        self = .playerOverSubscribed(try .init(from: decoder))
                     case "pool_has_no_tables":
                         self = .poolHasNoTables(try .init(from: decoder))
                     case "pool_over_capacity":
@@ -2945,6 +2949,8 @@ internal enum Components {
                     case let .noSingleCause(value):
                         try value.encode(to: encoder)
                     case let .pastWindow(value):
+                        try value.encode(to: encoder)
+                    case let .playerOverSubscribed(value):
                         try value.encode(to: encoder)
                     case let .poolHasNoTables(value):
                         try value.encode(to: encoder)
@@ -7383,6 +7389,77 @@ internal enum Components {
                 case ratingChange = "rating_change"
             }
         }
+        /// One human with more match-time in a pool than its window can hold: their
+        /// ``match_count`` matches plus the rest between them need ``required_min``
+        /// minutes of *their* time, against a window spanning only ``window_span_min``.
+        /// A pigeonhole over one person, so adding tables cannot fix it — the remedy is
+        /// fewer matches for them in this pool, or a longer window. Resolved: the
+        /// human's display ``player_name`` and the pool's ``name`` + ``HH:MM`` bounds;
+        /// the minutes stay integers for the client to format.
+        ///
+        /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead`.
+        internal struct PlayerOverSubscribedRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/kind`.
+            internal enum KindPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case playerOverSubscribed = "player_over_subscribed"
+            }
+            /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/kind`.
+            internal var kind: Components.Schemas.PlayerOverSubscribedRead.KindPayload?
+            /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/player_name`.
+            internal var playerName: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/pool_name`.
+            internal var poolName: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/window_start`.
+            internal var windowStart: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/window_end`.
+            internal var windowEnd: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/match_count`.
+            internal var matchCount: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/required_min`.
+            internal var requiredMin: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/window_span_min`.
+            internal var windowSpanMin: Swift.Int
+            /// Creates a new `PlayerOverSubscribedRead`.
+            ///
+            /// - Parameters:
+            ///   - kind:
+            ///   - playerName:
+            ///   - poolName:
+            ///   - windowStart:
+            ///   - windowEnd:
+            ///   - matchCount:
+            ///   - requiredMin:
+            ///   - windowSpanMin:
+            internal init(
+                kind: Components.Schemas.PlayerOverSubscribedRead.KindPayload? = nil,
+                playerName: Swift.String,
+                poolName: Swift.String,
+                windowStart: Swift.String,
+                windowEnd: Swift.String,
+                matchCount: Swift.Int,
+                requiredMin: Swift.Int,
+                windowSpanMin: Swift.Int
+            ) {
+                self.kind = kind
+                self.playerName = playerName
+                self.poolName = poolName
+                self.windowStart = windowStart
+                self.windowEnd = windowEnd
+                self.matchCount = matchCount
+                self.requiredMin = requiredMin
+                self.windowSpanMin = windowSpanMin
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case kind
+                case playerName = "player_name"
+                case poolName = "pool_name"
+                case windowStart = "window_start"
+                case windowEnd = "window_end"
+                case matchCount = "match_count"
+                case requiredMin = "required_min"
+                case windowSpanMin = "window_span_min"
+            }
+        }
         /// A user the current player can pick as a match opponent.
         ///
         /// Used by the typeahead/opponent picker. ``rating`` is the player's current
@@ -8200,6 +8277,8 @@ internal enum Components {
                 case noSingleCause(Components.Schemas.NoSingleCauseRead)
                 /// - Remark: Generated from `#/components/schemas/PreviewResult/InfeasibilityReasonsPayload/PastWindowReasonRead`.
                 case pastWindow(Components.Schemas.PastWindowReasonRead)
+                /// - Remark: Generated from `#/components/schemas/PreviewResult/InfeasibilityReasonsPayload/PlayerOverSubscribedRead`.
+                case playerOverSubscribed(Components.Schemas.PlayerOverSubscribedRead)
                 /// - Remark: Generated from `#/components/schemas/PreviewResult/InfeasibilityReasonsPayload/PoolHasNoTablesRead`.
                 case poolHasNoTables(Components.Schemas.PoolHasNoTablesRead)
                 /// - Remark: Generated from `#/components/schemas/PreviewResult/InfeasibilityReasonsPayload/PoolOverCapacityRead`.
@@ -8220,6 +8299,8 @@ internal enum Components {
                         self = .noSingleCause(try .init(from: decoder))
                     case "past_window":
                         self = .pastWindow(try .init(from: decoder))
+                    case "player_over_subscribed":
+                        self = .playerOverSubscribed(try .init(from: decoder))
                     case "pool_has_no_tables":
                         self = .poolHasNoTables(try .init(from: decoder))
                     case "pool_over_capacity":
@@ -8239,6 +8320,8 @@ internal enum Components {
                     case let .noSingleCause(value):
                         try value.encode(to: encoder)
                     case let .pastWindow(value):
+                        try value.encode(to: encoder)
+                    case let .playerOverSubscribed(value):
                         try value.encode(to: encoder)
                     case let .poolHasNoTables(value):
                         try value.encode(to: encoder)
@@ -9002,6 +9085,8 @@ internal enum Components {
                 case noSingleCause(Components.Schemas.NoSingleCauseRead)
                 /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload/PastWindowReasonRead`.
                 case pastWindow(Components.Schemas.PastWindowReasonRead)
+                /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload/PlayerOverSubscribedRead`.
+                case playerOverSubscribed(Components.Schemas.PlayerOverSubscribedRead)
                 /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload/PoolHasNoTablesRead`.
                 case poolHasNoTables(Components.Schemas.PoolHasNoTablesRead)
                 /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload/PoolOverCapacityRead`.
@@ -9022,6 +9107,8 @@ internal enum Components {
                         self = .noSingleCause(try .init(from: decoder))
                     case "past_window":
                         self = .pastWindow(try .init(from: decoder))
+                    case "player_over_subscribed":
+                        self = .playerOverSubscribed(try .init(from: decoder))
                     case "pool_has_no_tables":
                         self = .poolHasNoTables(try .init(from: decoder))
                     case "pool_over_capacity":
@@ -9041,6 +9128,8 @@ internal enum Components {
                     case let .noSingleCause(value):
                         try value.encode(to: encoder)
                     case let .pastWindow(value):
+                        try value.encode(to: encoder)
+                    case let .playerOverSubscribed(value):
                         try value.encode(to: encoder)
                     case let .poolHasNoTables(value):
                         try value.encode(to: encoder)

--- a/web-client/e2e/tournaments/tournament-schedule-solve.spec.ts
+++ b/web-client/e2e/tournaments/tournament-schedule-solve.spec.ts
@@ -243,6 +243,61 @@ test.describe('Tournaments · schedule solve strip', () => {
     await expectAxeClean(page, 'schedule tab — past-window infeasible solve on the strip')
   })
 
+  test('names an over-subscribed PLAYER — the `player_over_subscribed` fact crosses the real wire, and the remedy never says "add tables"', async ({
+    page,
+  }) => {
+    // A `player_over_subscribed` arm of `infeasibility_reasons` crosses the real
+    // wire (MSW off, this stub IS the API) with all seven of its fields; the
+    // client Zod-parses it in the queryFn and the strip renders the human-named
+    // sentence (ADR "the conflict core is a second, max-placed solve", decision 1).
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      ...DRAWN_SEED,
+      latestSolve: buildScheduleSolveRead({
+        status: 'infeasible',
+        verdict: 'infeasible',
+        trigger: 'manual',
+        fixtures_placed: null,
+        fixtures_pinned: null,
+        infeasibility_reasons: [
+          {
+            kind: 'player_over_subscribed',
+            player_name: 'spiked-frigatebird',
+            pool_name: 'Pool A',
+            window_start: '09:00',
+            window_end: '10:30',
+            match_count: 4,
+            required_min: 150,
+            window_span_min: 90,
+          },
+        ],
+      }),
+    })
+    await pom.openScheduleTab()
+
+    const state = pom.solveStripState('infeasible')
+    await expect(state).toBeVisible()
+    // WHO, in HOW MANY matches, in WHICH window — the ticket's headline.
+    await expect(state).toContainText('spiked-frigatebird is in 4 matches')
+    await expect(state).toContainText("Pool A's 09:00–10:30 window")
+    await expect(state).toContainText('they need about 2.5h')
+    // The remedies that work for one human — and NOT the add-tables trap: extra
+    // tables let somebody ELSE play in parallel, never this person twice at once.
+    await expect(state).toContainText('fewer matches in Pool A')
+    await expect(state).toContainText("adding tables won't help one player")
+    await expect(state).not.toContainText('Add a table to Pool A')
+    await expect(state).not.toContainText('Add tables, widen a pool window')
+    // Still a designed state, not an error, and the raw wire code stays off screen.
+    await expect(pom.runSchedulerNotice).not.toBeVisible()
+    await expect(pom.toasts).toHaveCount(0)
+    await expect(state).not.toContainText('player_over_subscribed')
+    await expect(pom.runScheduler).toBeEnabled()
+
+    await expectAxeClean(
+      page,
+      'schedule tab — over-subscribed-player infeasible solve on the strip',
+    )
+  })
+
   test('answers the coded 422 with the designed "cut a draw first" message, inline on the strip', async ({
     page,
   }) => {

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1794,7 +1794,7 @@ export interface components {
             /** Error */
             error: string | null;
             /** Infeasibility Reasons */
-            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
+            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["PlayerOverSubscribedRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
             /** Placement Conflicts */
             placement_conflicts: (components["schemas"]["TableConflictRead"] | components["schemas"]["PlayerConflictRead"])[];
             /** Input Fingerprint */
@@ -3519,6 +3519,37 @@ export interface components {
             rating_change?: components["schemas"]["RatingChange"] | null;
         };
         /**
+         * PlayerOverSubscribedRead
+         * @description One human with more match-time in a pool than its window can hold: their
+         *     ``match_count`` matches plus the rest between them need ``required_min``
+         *     minutes of *their* time, against a window spanning only ``window_span_min``.
+         *     A pigeonhole over one person, so adding tables cannot fix it — the remedy is
+         *     fewer matches for them in this pool, or a longer window. Resolved: the
+         *     human's display ``player_name`` and the pool's ``name`` + ``HH:MM`` bounds;
+         *     the minutes stay integers for the client to format.
+         */
+        PlayerOverSubscribedRead: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "player_over_subscribed";
+            /** Player Name */
+            player_name: string;
+            /** Pool Name */
+            pool_name: string;
+            /** Window Start */
+            window_start: string;
+            /** Window End */
+            window_end: string;
+            /** Match Count */
+            match_count: number;
+            /** Required Min */
+            required_min: number;
+            /** Window Span Min */
+            window_span_min: number;
+        };
+        /**
          * PlayerRead
          * @description A user the current player can pick as a match opponent.
          *
@@ -3882,7 +3913,7 @@ export interface components {
             /** Events */
             events: components["schemas"]["PreviewEventBreakdown"][];
             /** Infeasibility Reasons */
-            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
+            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["PlayerOverSubscribedRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
             /** Notes */
             notes: string[];
             /**
@@ -4240,7 +4271,7 @@ export interface components {
             /** Error */
             error: string | null;
             /** Infeasibility Reasons */
-            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
+            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["PlayerOverSubscribedRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
             /** Placement Conflicts */
             placement_conflicts: (components["schemas"]["TableConflictRead"] | components["schemas"]["PlayerConflictRead"])[];
         };

--- a/web-client/src/components/scheduling/solve-ledger-page.factory.ts
+++ b/web-client/src/components/scheduling/solve-ledger-page.factory.ts
@@ -64,9 +64,10 @@ export function buildLedgerVariety(): AdminScheduleSolveRead[] {
       fixtures_pinned: null,
       tournament_id: 'summer-slam-2026',
       tournament_name: 'Summer Slam 2026',
-      // The resolved causes the day doesn't fit — two arms, so the expansion
+      // The resolved causes the day doesn't fit — three arms, so the expansion
       // proves it renders each reason's sentence + remedy (the same list the
-      // Schedule-tab strip shows).
+      // Schedule-tab strip shows), including the one that names a *human*
+      // (`player_over_subscribed`) rather than a pool or a fixture.
       infeasibility_reasons: [
         {
           kind: 'window_too_short_for_match',
@@ -76,6 +77,16 @@ export function buildLedgerVariety(): AdminScheduleSolveRead[] {
           best_of: 5,
           needed_min: 75,
           window_span_min: 60,
+        },
+        {
+          kind: 'player_over_subscribed',
+          player_name: 'spiked-frigatebird',
+          pool_name: 'Pool A',
+          window_start: '09:00',
+          window_end: '10:30',
+          match_count: 4,
+          required_min: 150,
+          window_span_min: 90,
         },
         {
           kind: 'no_single_cause',

--- a/web-client/src/components/scheduling/solve-ledger-page.test.tsx
+++ b/web-client/src/components/scheduling/solve-ledger-page.test.tsx
@@ -24,6 +24,16 @@ const windowReasonCopy = infeasibilityReasonCopy({
   neededMin: 75,
   windowSpanMin: 60,
 })
+const overSubscribedCopy = infeasibilityReasonCopy({
+  kind: 'player_over_subscribed',
+  playerName: 'spiked-frigatebird',
+  poolName: 'Pool A',
+  windowStart: '09:00',
+  windowEnd: '10:30',
+  matchCount: 4,
+  requiredMin: 150,
+  windowSpanMin: 90,
+})
 const noSingleCauseCopy = infeasibilityReasonCopy({
   kind: 'no_single_cause',
   requiredMin: 420,
@@ -126,11 +136,17 @@ describe('SolveLedgerPage', () => {
     expect(detail).toHaveTextContent("The day doesn't fit")
     expect(detail).toHaveTextContent('Input fingerprint')
 
-    // Both resolved reasons render their sentence AND remedy — the SAME copy the
+    // Every resolved reason renders its sentence AND remedy — the SAME copy the
     // Schedule-tab strip shows (reused from `infeasibilityReasonCopy`, so the two
     // surfaces cannot drift).
     expect(detail).toHaveTextContent(windowReasonCopy.sentence)
     expect(detail).toHaveTextContent(windowReasonCopy.remedy)
+    // The arm that names a HUMAN: who, in how many matches, in which window —
+    // and a remedy that never suggests tables (one person plays one at a time).
+    expect(detail).toHaveTextContent('spiked-frigatebird is in 4 matches')
+    expect(detail).toHaveTextContent(overSubscribedCopy.sentence)
+    expect(detail).toHaveTextContent(overSubscribedCopy.remedy)
+    expect(overSubscribedCopy.remedy).not.toMatch(/add (a |another |more )?tables?/i)
     expect(detail).toHaveTextContent(noSingleCauseCopy.sentence)
     expect(detail).toHaveTextContent(noSingleCauseCopy.remedy)
     // An infeasible run carries no failed `error` sentence.

--- a/web-client/src/components/tournaments/data/solve.test.ts
+++ b/web-client/src/components/tournaments/data/solve.test.ts
@@ -133,6 +133,30 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
     })
   })
 
+  it('parses player_over_subscribed — the one arm that names a human', () => {
+    expect(
+      infeasibilityReasonSchema.parse({
+        kind: 'player_over_subscribed',
+        player_name: 'spiked-frigatebird',
+        pool_name: 'Pool A',
+        window_start: '09:00',
+        window_end: '10:30',
+        match_count: 4,
+        required_min: 150,
+        window_span_min: 90,
+      }),
+    ).toEqual({
+      kind: 'player_over_subscribed',
+      playerName: 'spiked-frigatebird',
+      poolName: 'Pool A',
+      windowStart: '09:00',
+      windowEnd: '10:30',
+      matchCount: 4,
+      requiredMin: 150,
+      windowSpanMin: 90,
+    })
+  })
+
   it('parses no_single_cause (the residual, no pool)', () => {
     expect(
       infeasibilityReasonSchema.parse({
@@ -369,6 +393,49 @@ describe('infeasibilityReasonCopy', () => {
     ).toContain('on 1 table only')
   })
 
+  it('words player_over_subscribed by naming the human, the pool, its window and the match count', () => {
+    expect(
+      infeasibilityReasonCopy({
+        kind: 'player_over_subscribed',
+        playerName: 'spiked-frigatebird',
+        poolName: 'Pool A',
+        windowStart: '09:00',
+        windowEnd: '10:30',
+        matchCount: 4,
+        requiredMin: 150,
+        windowSpanMin: 90,
+      }),
+    ).toEqual({
+      sentence:
+        "spiked-frigatebird is in 4 matches inside Pool A's 09:00–10:30 window — playing one at a time, with a rest between, they need about 2.5h, but the window is only 1.5h long.",
+      remedy:
+        "Give spiked-frigatebird fewer matches in Pool A — a smaller pool, or a shorter match format — or widen its window; adding tables won't help one player.",
+    })
+  })
+
+  it('never offers "add a table" as the remedy for an over-subscribed player — a table is parallelism, and one human plays one match at a time', () => {
+    // THE regression this arm exists to avoid: extra tables let *other* people
+    // play at once, and do nothing for one over-subscribed human. The remedies are
+    // fewer matches for them in that pool, or a longer window.
+    const copy = infeasibilityReasonCopy({
+      kind: 'player_over_subscribed',
+      playerName: 'spiked-frigatebird',
+      poolName: 'Pool A',
+      windowStart: '09:00',
+      windowEnd: '10:30',
+      matchCount: 4,
+      requiredMin: 150,
+      windowSpanMin: 90,
+    })
+    // Not the `pool_over_capacity` remedy's advice, in any casing…
+    expect(copy.remedy).not.toMatch(/add (a |another |more )?tables?/i)
+    // …and the trap is called out explicitly, so a director cannot infer it.
+    expect(copy.remedy).toContain("adding tables won't help one player")
+    // The remedies that DO work.
+    expect(copy.remedy).toContain('fewer matches in Pool A')
+    expect(copy.remedy).toContain('widen its window')
+  })
+
   it('words no_single_cause as a timing conflict that steers away from adding tables', () => {
     const copy = infeasibilityReasonCopy({
       kind: 'no_single_cause',
@@ -418,6 +485,16 @@ describe('infeasibilityReasonCopy', () => {
         requiredMin: 480,
         capacityMin: 450,
         tableCount: 5,
+      },
+      {
+        kind: 'player_over_subscribed',
+        playerName: 'spiked-frigatebird',
+        poolName: 'Pool A',
+        windowStart: '09:00',
+        windowEnd: '10:30',
+        matchCount: 4,
+        requiredMin: 150,
+        windowSpanMin: 90,
       },
       { kind: 'no_single_cause', requiredMin: 360, availableMin: 480 },
       { kind: 'past_window', date: '2026-07-18' },

--- a/web-client/src/components/tournaments/data/solve.ts
+++ b/web-client/src/components/tournaments/data/solve.ts
@@ -89,6 +89,8 @@ type WindowTooShortForMatchWire =
   components['schemas']['WindowTooShortForMatchRead']
 type PoolOverCapacityWire =
   components['schemas']['PoolOverCapacityRead']
+type PlayerOverSubscribedWire =
+  components['schemas']['PlayerOverSubscribedRead']
 type NoSingleCauseWire =
   components['schemas']['NoSingleCauseRead']
 type PastWindowReasonWire =
@@ -107,7 +109,13 @@ type PastWindowReasonWire =
  *   contiguously, whatever the table count.
  * - **`pool_over_capacity`** — a pool's aggregate match-time exceeds what its
  *   window × tables can hold (a *certain* pre-check, not a CP-SAT guess).
- * - **`no_single_cause`** — CP-SAT proved infeasible but arms 1–3 all passed: a
+ * - **`player_over_subscribed`** — ONE human is in more matches inside a pool's
+ *   window than that window can hold, counting the rest owed between them: a
+ *   pigeonhole over a single person (CONTEXT.md, "Over-subscribed"), so it is the
+ *   one structural cause that names a *person* rather than a pool or fixture —
+ *   and the one where adding tables is provably useless (extra tables let *other*
+ *   people play in parallel, never this one).
+ * - **`no_single_cause`** — CP-SAT proved infeasible but arms 1–4 all passed: a
  *   *timing* conflict, never a raw-capacity shortfall (so: don't add tables).
  * - **`past_window`** — a pool's ENTIRE planned window is already a day behind
  *   now (ADR "a past day is named, not disguised"), fixed by moving the date, not
@@ -134,6 +142,16 @@ export type InfeasibilityReason =
       requiredMin: number
       capacityMin: number
       tableCount: number
+    }
+  | {
+      kind: 'player_over_subscribed'
+      playerName: string
+      poolName: string
+      windowStart: string
+      windowEnd: string
+      matchCount: number
+      requiredMin: number
+      windowSpanMin: number
     }
   | { kind: 'no_single_cause'; requiredMin: number; availableMin: number }
   | { kind: 'past_window'; date: string }
@@ -167,6 +185,17 @@ const poolOverCapacityWireSchema = z.object({
   table_count: z.number().int(),
 }) satisfies z.ZodType<PoolOverCapacityWire>
 
+const playerOverSubscribedWireSchema = z.object({
+  kind: z.literal('player_over_subscribed'),
+  player_name: z.string(),
+  pool_name: z.string(),
+  window_start: z.string(),
+  window_end: z.string(),
+  match_count: z.number().int(),
+  required_min: z.number().int(),
+  window_span_min: z.number().int(),
+}) satisfies z.ZodType<PlayerOverSubscribedWire>
+
 const noSingleCauseWireSchema = z.object({
   kind: z.literal('no_single_cause'),
   required_min: z.number().int(),
@@ -178,13 +207,14 @@ const pastWindowReasonWireSchema = z.object({
   date: z.string(),
 }) satisfies z.ZodType<PastWindowReasonWire>
 
-/** The five arms as one `z.discriminatedUnion('kind', …)` — an unknown `kind`
+/** The six arms as one `z.discriminatedUnion('kind', …)` — an unknown `kind`
  * has no arm and throws, which is exactly the boundary rule: a reason this
  * client cannot render must fail the parse, not blank the row. */
 export const infeasibilityReasonWireSchema = z.discriminatedUnion('kind', [
   poolHasNoTablesWireSchema,
   windowTooShortForMatchWireSchema,
   poolOverCapacityWireSchema,
+  playerOverSubscribedWireSchema,
   noSingleCauseWireSchema,
   pastWindowReasonWireSchema,
 ])
@@ -192,7 +222,7 @@ export const infeasibilityReasonWireSchema = z.discriminatedUnion('kind', [
 /** One wire arm → one domain `InfeasibilityReason`. Annotated `: InfeasibilityReason`
  * so the union above and the wire arms are one thing — drop or rename a field on
  * either and this is a compile error. Exhaustive over `kind` (a `never` default),
- * so a fifth arm added to the API cannot slip through unmapped. */
+ * so a further arm added to the API cannot slip through unmapped. */
 export function infeasibilityReasonFromWire(
   r: z.infer<typeof infeasibilityReasonWireSchema>,
 ): InfeasibilityReason {
@@ -218,6 +248,17 @@ export function infeasibilityReasonFromWire(
         requiredMin: r.required_min,
         capacityMin: r.capacity_min,
         tableCount: r.table_count,
+      }
+    case 'player_over_subscribed':
+      return {
+        kind: r.kind,
+        playerName: r.player_name,
+        poolName: r.pool_name,
+        windowStart: r.window_start,
+        windowEnd: r.window_end,
+        matchCount: r.match_count,
+        requiredMin: r.required_min,
+        windowSpanMin: r.window_span_min,
       }
     case 'no_single_cause':
       return {
@@ -629,12 +670,19 @@ export interface InfeasibilityReasonCopy {
 
 /**
  * Map one resolved reason to its designed copy. Exhaustive over `kind` — a `never`
- * default makes a fifth arm added to the API a compile error here until it is
+ * default makes a further arm added to the API a compile error here until it is
  * given words, so a reason can never reach the UI as a blank line.
  *
- * The residual (`no_single_cause`) is deliberately worded to steer the director
- * *away* from adding tables: by construction there is a table-time surplus, so the
- * problem is timing, not capacity (the ADR's "don't add tables here").
+ * Two arms are deliberately worded to steer the director *away* from adding
+ * tables, for two different reasons:
+ *
+ * - the residual (`no_single_cause`), because by construction there is a
+ *   table-time surplus — the problem is timing, not capacity;
+ * - `player_over_subscribed`, because a table is parallelism and this is a
+ *   pigeonhole over ONE human — a second table lets somebody *else* play, never
+ *   this person twice at once. Its remedies are fewer matches for them in that
+ *   pool, or a longer window (ADR "the conflict core is a second, max-placed
+ *   solve", decision 1).
  */
 export function infeasibilityReasonCopy(
   reason: InfeasibilityReason,
@@ -654,6 +702,20 @@ export function infeasibilityReasonCopy(
       return {
         sentence: `${reason.poolName} can't fit all its matches: they need about ${fmtTableTime(reason.requiredMin)} of table-time, but its ${reason.windowStart}–${reason.windowEnd} window on ${fmtTables(reason.tableCount)} only holds about ${fmtTableTime(reason.capacityMin)}.`,
         remedy: `Add a table to ${reason.poolName}, widen its window, or trim the field.`,
+      }
+    case 'player_over_subscribed':
+      // The ticket's headline example, in the director's words: "player X is in 4
+      // matches inside a 90-minute window". Both figures go through the shared
+      // `fmtTableTime`, which owns the hour/minute rounding and leaves "about" to
+      // this sentence. `matchCount` is always ≥2 — a lone fixture that cannot fit
+      // is `window_too_short_for_match`'s finding, so the API never emits this arm
+      // with one match and the plural is safe.
+      return {
+        sentence: `${reason.playerName} is in ${reason.matchCount} matches inside ${reason.poolName}'s ${reason.windowStart}–${reason.windowEnd} window — playing one at a time, with a rest between, they need about ${fmtTableTime(reason.requiredMin)}, but the window is only ${fmtTableTime(reason.windowSpanMin)} long.`,
+        // NOT "add tables": a table is parallelism, and one human cannot play two
+        // matches at once, so a second table would relieve nothing here (the same
+        // trap `no_single_cause`'s remedy avoids, for a different reason).
+        remedy: `Give ${reason.playerName} fewer matches in ${reason.poolName} — a smaller pool, or a shorter match format — or widen its window; adding tables won't help one player.`,
       }
     case 'no_single_cause':
       return {

--- a/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
@@ -189,6 +189,46 @@ describe('SolveStrip', () => {
     expect(text).not.toContain('past_window')
   })
 
+  it('names an over-subscribed PLAYER — the human, the pool, its window and the match count — and never tells the director to add tables', () => {
+    solveStripPage.render({
+      solve: buildScheduleSolve({
+        status: 'infeasible',
+        verdict: 'infeasible',
+        fixturesPlaced: null,
+        fixturesPinned: null,
+        infeasibilityReasons: [
+          {
+            kind: 'player_over_subscribed',
+            playerName: 'spiked-frigatebird',
+            poolName: 'Pool A',
+            windowStart: '09:00',
+            windowEnd: '10:30',
+            matchCount: 4,
+            requiredMin: 150,
+            windowSpanMin: 90,
+          },
+        ],
+      }),
+    })
+    const text = solveStripPage.getStateText('infeasible')
+    expect(text).toContain("The day doesn't fit")
+    // The ticket's headline sentence: WHO, in HOW MANY matches, in WHICH window.
+    expect(text).toContain('spiked-frigatebird is in 4 matches')
+    expect(text).toContain("Pool A's 09:00–10:30 window")
+    expect(text).toContain('they need about 2.5h')
+    expect(text).toContain('the window is only 1.5h long')
+    // The remedies that work for ONE human — and NOT the add-tables trap, which
+    // would only let somebody else play in parallel.
+    expect(text).toContain('fewer matches in Pool A')
+    expect(text).toContain('widen its window')
+    expect(text).toContain("adding tables won't help one player")
+    expect(text).not.toContain('Add a table to Pool A')
+    // The generic body (which DOES say "Add tables") is replaced, not appended.
+    expect(text).not.toContain('Add tables, widen a pool window')
+    // The raw wire code never reaches the UI.
+    expect(text).not.toContain('player_over_subscribed')
+  })
+
   it('falls back to the generic sentence if an infeasible row carries no reasons — the strip never renders bodyless', () => {
     solveStripPage.render({
       solve: buildScheduleSolve({


### PR DESCRIPTION
Draft — slice 1 of 2 for #1129. **Stacked on #1262** (the design/ADR), which is its base; merge that first.

> A director whose player is booked into more matches than a pool's window can hold is told **which player**, and **which pool**.

## What this adds

`PlayerOverSubscribed(pool_id, player_id, match_count, required_min, window_span_min)` — a fifth **certain** arm of the `InfeasibilityReason` union, computed in the cheap pre-check pass **before CP-SAT is built**.

A player plays one match at a time and their fixtures in a pool must all run inside that pool's window, so

```
Σ durations + (match_count − 1) × REST_MIN  >  window_span
```

is a *necessary* condition for infeasibility — a pigeonhole over one human, provable by arithmetic with no solver at all. That is why it is a pre-check and not part of the post-`INFEASIBLE` diagnostic: a certain claim should never cost a solve. This satisfies acceptance criterion 2 of the issue on its own, with **no CP-SAT model change** — slice 2 carries the remodel.

## The load-bearing detail

**The rest term is `(N−1)`, not `N`.** `_build_model` pads *every* player interval by `REST_MIN`, which is correct for `AddNoOverlap` (it enforces a gap in either direction) but overcounts as a pigeonhole — the last match of the day owes no trailing rest *inside* the window. Charging `N` would **falsely accuse a player**, which is fatal for an arm whose entire claim is certainty.

That is pinned by a falsification test, not just asserted: switching the bound to `N × REST_MIN` reds a feasible 2-match / 60-minute day as `infeasible` with `required_min=70` against a `window_span_min=60`.

## Scoping, and two calls the ADR left open

Conservative like its siblings — **unpinned fixtures only** (a pin is bound to neither the pool's tables nor its window), measured against the same softened-while-live span `PoolOverCapacity` uses, so a live overrunning day is never falsely flagged. Collected exhaustively, not first-fail.

- **`PoolOverCapacity` and `PlayerOverSubscribed` coexist** rather than one suppressing the other. They are proofs about different subjects with different remedies — "this pool needs more table-time" vs "this human is in too many matches" — and neither refines the other. The pool-level *unplaceable* causes (no tables, window too short, past window) do still dominate; piling a per-player claim onto a pool that cannot run at all is noise.
- **`match_count ≥ 2` to fire.** A single fixture that cannot fit its window is already `WindowTooShortForMatch`'s finding.

## The copy will not say "add tables"

Extra tables let *other* people play in parallel; they do nothing for one over-subscribed human. The remedy points at fewer matches for that player in the pool, or a longer window. A test pins it — swapping in the over-capacity remedy reds four tests across the data, strip and ledger layers.

No component changed: the solve strip, the admin ledger and the schedule-preview modal all iterate the union generically through the shared copy module, so the arm reached all three the moment it had words. The copy switch's `never` floor kept the build red until it did.

## Commits

- `1a [api]` — the arm, the pre-check, and resolution on **both** wire paths (the union's `assert_never` floors make arm and resolution atomic). Reuses the player-name map already built for the player-conflict arm; the DB-blind preview labels synthetic entrants `Placeholder N` via a helper colocated with the id minting so the two cannot drift.
- `1b [main]` — OpenAPI regen (`schema.d.ts` + `Types.swift`), generated only.
- `1c [web-client]` — the Zod arm, the mapping, and the copy.

No migration: the reasons column is JSONB and takes new arms as-is.

## Verification

`ruff` / `ruff format` clean · `mypy` clean (165 files) · `pytest` 2082 passed · web-client `build` clean · `test:run` 3349 passed. Falsification runs done on both the `(N−1)` bound and the no-add-tables remedy.

Independently re-run in the main session before this PR was opened, rather than taken from the implementing agents' reports.

⚠️ `npm run test:e2e` shows **5 failures that reproduce identically on a clean tree** (an admin empty-state `page.goto` timeout, a design-system screenshot, an opponent-picker skeleton race, and two schedule-board specs whose `AxeBuilder.analyze()` crashes in this container). Pre-existing and environmental, not from this change — but flagging rather than burying them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVaEuNi4R9Lozdfp5x1XZx)_