### PR TITLE
Pools are rows: server-minted, order-carrying, and unable to borrow another tournament's table

### DIFF
--- a/api/app/dashboard_tournaments.py
+++ b/api/app/dashboard_tournaments.py
@@ -62,13 +62,13 @@ from app.schemas.dashboard import (
 from app.schemas.tournament import (
     Address,
     MatchSettings,
-    Pool,
     StandingsResultsRead,
     StandingsThenFinishesResultsRead,
     TournamentEntrantRead,
     TournamentFixtureRead,
     TournamentTable,
 )
+from app.tournament_draws import event_pools
 from app.tournament_queries import (
     active_entrants_by_event,
     completed_match_ids,
@@ -279,9 +279,7 @@ def _build_event(
     game_counts: dict[uuid.UUID, tuple[int, int]],
 ) -> DashboardTournamentEvent:
     username_by_entry = {entrant.id: entrant.username for entrant in entrants}
-    pools = {
-        pool.id: pool for pool in (Pool.model_validate(raw) for raw in event.pools)
-    }
+    pools = {pool.id: pool for pool in event_pools(event)}
     settings = MatchSettings.model_validate(event.match_settings)
     # The draw type off the event's ``draw_settings`` row — its one home (ADR "an
     # event's draw configuration is a row, not a column"). Read once here and passed

--- a/api/app/dashboard_tournaments.py
+++ b/api/app/dashboard_tournaments.py
@@ -587,7 +587,9 @@ def _fixture_state(status: MatchStatus | None) -> TournamentFixtureState:
             assert_never(status)
 
 
-def _round_label(draw_type: DrawType, pool_id: str | None, round_number: int) -> str:
+def _round_label(
+    draw_type: DrawType, pool_id: uuid.UUID | None, round_number: int
+) -> str:
     """A round number in its draw type's own vocabulary, composed here so no client
     maps an integer to a word.
 

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -51,9 +51,12 @@ from app.pool_finishing_order import EntryTally, MatchOutcome, finishing_order
 EntryId = NewType("EntryId", uuid.UUID)
 FixtureId = NewType("FixtureId", uuid.UUID)
 MatchId = NewType("MatchId", uuid.UUID)
-#: A pool is a JSONB value-object on the event, not a row — its id is a *string ref*
-#: into ``TournamentEvent.pools``, which is why this is a ``str`` and not a UUID FK.
-PoolId = NewType("PoolId", str)
+#: A pool is a row (``tournament_event_pools``, ADR 20260801) with a server-minted uuid
+#: primary key, and a fixture's ``pool_id`` is a real composite foreign key onto it — so
+#: this is a ``uuid.UUID``, exactly like the ids above. It was a ``str``, a dangling ref
+#: into ``TournamentEvent.pools`` JSONB, for as long as there was no pools table to
+#: point at and no server to mint one.
+PoolId = NewType("PoolId", uuid.UUID)
 
 
 class DrawError(Exception):
@@ -252,18 +255,13 @@ class DrawConfig:
     order** — ascending ``Pool.position``, which is what the caller
     (:func:`app.tournament_draws.draw_config`) sorts them by, and which this tuple then
     carries *as* its sequence. That order is what the snake seeds against, so nothing
-    downstream may re-sort it: an ``sorted(config.pool_ids)`` anywhere below here would
-    seed the draw against the ids' lexicographic order, which is not the director's
-    (``p-10-`` sorts between ``p-1-`` and ``p-2-``) and, once pools are rows with random
-    UUID ids, is not anybody's.
+    downstream may re-sort it: a ``sorted(config.pool_ids)`` anywhere below here would
+    seed the draw against the ids' own order, which under a random uuid is nobody's.
 
     Empty for an un-pooled draw type (single-elim), where every fixture's ``pool_id``
-    is ``NULL``. The pool *id set* freezes while a draw exists, which is what lets a
-    fixture's string ref stay valid without a foreign key. No id among them is ever the
-    empty string — ``Pool.id`` is a ``ValueObjectId`` (``min_length=1``) at the write
-    boundary, which is what keeps ``ready_fixtures``' "pooled?" test (``pool_id is
-    None``) and its id tie-break (``pool_id or ""``) answering the same question the
-    same way.
+    is ``NULL``. The pool *id set* freezes while a draw exists
+    (``app.tournament_events`` refuses a payload that moves it), and underneath that a
+    composite foreign key holds the reference itself.
     """
 
     pool_ids: tuple[PoolId, ...] = ()
@@ -970,28 +968,16 @@ def ready_fixtures(fixtures: Sequence[FixtureState]) -> tuple[FixtureId, ...]:
     twice. Ordered by ``(pool, round, position)`` so the plan itself is deterministic.
 
     **"Pool" is the pool's** :attr:`~FixtureState.pool_position` — its place in the
-    event's own pool order — **not its id.** The ids are client-minted strings
-    (``p-1-…``, ``p-2-…``, ``p-10-…``) whose lexicographic order is not the director's:
-    ``p-10-`` sorts between ``p-1-`` and ``p-2-``, so a ten-pool draw's plan ran pool 1,
-    pool 10, pool 2. For a pool that **has** a position it is the same key the read
-    path's ``fixtures_by_event`` sorts on and the same one :attr:`DrawConfig.pool_ids`
-    is ordered by, so the sequence a director sees, the sequence the snake dealt
-    against, and the sequence matches are created in are one order rather than three
-    that agree by luck.
-
-    **The exception is a pool written before positions existed**, and it is worth
-    stating because the two fallbacks are not the same one. ``pools`` is JSONB and no
-    migration backfilled it, so rows predating this field survive in any long-lived
-    database (UAT's ``fortymm-uat_postgres-data`` volume, a standing QA stack). For
-    those, the read path's SQL reads a missing key as ``NULL``, every pool ties, and it
-    falls through to ``pool_id`` — **id order**; while this sort and
-    :attr:`DrawConfig.pool_ids` parse through :class:`~app.schemas.tournament.Pool`,
-    where ``position`` defaults to ``0``, so every pool ties there too and a stable sort
-    leaves them in **array order**. Two different fallbacks for the same absent field.
-    It bites only an event with ten or more pre-field pools, and it changes the order
-    matches are *created* in rather than which fixtures exist or who plays whom — but
-    it is a real disagreement, not a documented equivalence. It stops existing when
-    pools become rows with a ``NOT NULL`` position, where the column cannot be absent.
+    event's own pool order — **not its id.** It was the id once, back when ids were
+    client-minted strings (``p-1-…``, ``p-2-…``, ``p-10-…``) whose lexicographic order
+    was not the director's: ``p-10-`` sorts between ``p-1-`` and ``p-2-``, so a ten-pool
+    draw's plan ran pool 1, pool 10, pool 2. A minted uuid is worse still — its order is
+    nobody's at all — which is exactly why the explicit ``position`` column had to land
+    (ADR 20260801) before the ids could move. It is the same key the read path's
+    ``fixtures_by_event`` sorts on and the same one :attr:`DrawConfig.pool_ids` is
+    ordered by, so the sequence a director sees, the sequence the snake dealt against,
+    and the sequence matches are created in are one order rather than three that agree
+    by luck.
 
     The sort key asks three questions, in this order:
 
@@ -999,22 +985,18 @@ def ready_fixtures(fixtures: Sequence[FixtureState]) -> tuple[FixtureId, ...]:
        an rr-then-ko draw's KO stage) LAST, behind the pools that feed them.
     2. "Where in the event's order is its pool?" — ``pool_position``, with a ``None``
        (an unresolved pool order; see the field) sorting after every pool that has one.
-    3. "Which pool?" — ``pool_id or ""``, the tie-break that keeps the order **total**
-       when the positions cannot decide it, and which is exactly the order this had
-       before positions existed.
+    3. "Which pool?" — the id as text, the tie-break that keeps the order **total** when
+       the positions cannot decide it. A ``uuid`` is not comparable with the ``""`` the
+       un-pooled group collapses to, so this is spelled as a ``str`` rather than left to
+       ``or``; both halves are unobservable anyway, because the first key element has
+       already partitioned the un-pooled off. The ``or 0`` beside it is unobservable for
+       the same reason and by the same argument.
 
-    (1) and (3) agree only because an id is never ``""``. It was: ``Pool.id`` was a bare
-    ``str``, and a fixture drawn into an empty-id pool answered *pooled* to the first
-    question while colliding with the un-pooled group's ``""`` in the third. The floor
-    that closes it is at the write boundary (``ValueObjectId``, ``min_length=1``), not
-    here — an ``if not pool_id`` in this sort would be a runtime check standing in for a
-    state that should not exist. Which is why the ``""`` fallback is *unobservable*:
-    it is reached only by the ``None`` group, which the first key element has already
-    partitioned off, so its value cannot change an order. (Mutation testing agrees —
-    replacing it with any other string survives, and after this it is *supposed* to.)
-    The ``or 0`` beside it is unobservable for the same reason and by the same argument:
-    the element before it has already partitioned the ``None`` positions off, so what
-    the ``None`` group collapses to cannot change an order.
+    (1) and (3) can no longer disagree. They could: ``Pool.id`` was a bare ``str``, and
+    a fixture drawn into an *empty-id* pool answered "pooled" to the first question
+    while colliding with the un-pooled group's ``""`` in the third — one fixture, pooled
+    by one rule and un-pooled by the other. A ``min_length=1`` at the write boundary
+    held that off; a ``uuid`` cannot express it at all, which is the better kind of fix.
     """
     ready = [
         f
@@ -1026,7 +1008,7 @@ def ready_fixtures(fixtures: Sequence[FixtureState]) -> tuple[FixtureId, ...]:
             f.pool_id is None,
             f.pool_position is None,
             f.pool_position or 0,
-            f.pool_id or "",
+            "" if f.pool_id is None else str(f.pool_id),
             f.round,
             f.position,
         )

--- a/api/app/match_calls.py
+++ b/api/app/match_calls.py
@@ -982,9 +982,10 @@ class CopyIngredients:
     users: dict[uuid.UUID, User]
     events: dict[uuid.UUID, TournamentEvent]
     table_labels: dict[str, str]
-    #: Per event, its pools' id → display name (``pool_id`` is a string ref
-    #: into the event's own ``pools`` JSONB).
-    pool_names: dict[uuid.UUID, dict[str, str]]
+    #: Per event, its pools' id → display name. Both keys are uuids: the outer one is
+    #: the event's, the inner one the pool's own ``tournament_event_pools`` primary key
+    #: (ADR 20260801), which is exactly what a fixture's ``pool_id`` holds.
+    pool_names: dict[uuid.UUID, dict[uuid.UUID, str]]
 
     def user_for_entry(self, entry_id: uuid.UUID | None) -> User | None:
         if entry_id is None:
@@ -993,7 +994,10 @@ class CopyIngredients:
         return self.users.get(user_id) if user_id is not None else None
 
     def context_for(
-        self, tournament: Tournament, event: TournamentEvent, pool_id: str | None
+        self,
+        tournament: Tournament,
+        event: TournamentEvent,
+        pool_id: uuid.UUID | None,
     ) -> MatchCallContext:
         """The fixture's whereabouts in the player's terms."""
         pool_name: str | None = None

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -166,6 +166,7 @@ from app.tournament_errors import (
     NotTournamentOwnerError,
     PlacementTableNotFoundError,
     PlayerNotFoundError,
+    PoolNotInEventError,
     PoolSetFrozenError,
     ScheduleQueueUnavailableError,
     TableInUseError,
@@ -1382,7 +1383,11 @@ async def update_event(
     validates, so the MCP and HTTP surfaces can never drift on what a valid edit is.
 
     ``updates`` is a PARTIAL patch: an OMITTED field is left unchanged; ``predicates``
-    and ``pools`` replace wholesale when sent. Editing an event is OWNER-GATED — only
+    replaces wholesale when sent. ``pools`` is an ID-KEYED DIFF sent in full and in
+    order: an entry carrying an ``id`` keeps that pool (re-worded, re-timed, re-tabled,
+    re-positioned), an entry omitting one adds a pool the server mints an id for, and a
+    pool no entry names is removed — so send back the pools you read, edited. An ``id``
+    this event does not have is refused. Editing an event is OWNER-GATED — only
     the tournament's creator may (there is no permission on this route). **Once the
     event's draw is cut, two things freeze** (ADR-0786): a ``pools`` payload that
     changes *which pools* the event has is refused, and so is a ``draw_type`` change —
@@ -1423,6 +1428,13 @@ async def update_event(
             # the ``ToolError`` prose verbatim, so the agent is told how to get unstuck
             # (remove the draw, edit, cut again).
             raise ToolError(str(exc)) from exc
+        except PoolNotInEventError as exc:
+            # The HTTP surface answers this on the field; an agent reads prose, so the
+            # offending id rides in the sentence rather than in a ``loc`` — the same
+            # treatment the catalogue's ``TableNotInCatalogueError`` gets above.
+            raise ToolError(
+                f"{exc} (pools entry {exc.index} names “{exc.pool_id}”)."
+            ) from exc
         # The verb returns the tournament's ``league_id`` (the ladder the caller's
         # ``entry_state`` is judged on, ADR-0783) already loaded under the owner lock,
         # so the shared shaping helper needs no re-query — the same helper the HTTP

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -37,6 +37,7 @@ from app.models.tournament import (
 from app.models.tournament_entry import TournamentEntry, TournamentEntryStatus
 from app.models.tournament_event_draw_settings import TournamentEventDrawSettings
 from app.models.tournament_event_pool import TournamentEventPool
+from app.models.tournament_event_pool_table import TournamentEventPoolTable
 from app.models.tournament_fixture import TournamentFixture
 from app.models.tournament_table import VenueTable
 from app.models.user import User
@@ -81,6 +82,7 @@ __all__ = [
     "TournamentEvent",
     "TournamentEventDrawSettings",
     "TournamentEventPool",
+    "TournamentEventPoolTable",
     "TournamentFixture",
     "TournamentStatus",
     "User",

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -36,6 +36,7 @@ from app.models.tournament import (
 )
 from app.models.tournament_entry import TournamentEntry, TournamentEntryStatus
 from app.models.tournament_event_draw_settings import TournamentEventDrawSettings
+from app.models.tournament_event_pool import TournamentEventPool
 from app.models.tournament_fixture import TournamentFixture
 from app.models.tournament_table import VenueTable
 from app.models.user import User
@@ -79,6 +80,7 @@ __all__ = [
     "TournamentEntryStatus",
     "TournamentEvent",
     "TournamentEventDrawSettings",
+    "TournamentEventPool",
     "TournamentFixture",
     "TournamentStatus",
     "User",

--- a/api/app/models/tournament.py
+++ b/api/app/models/tournament.py
@@ -25,6 +25,7 @@ from app.db import Base
 if TYPE_CHECKING:
     from app.models.tournament_entry import TournamentEntry
     from app.models.tournament_event_draw_settings import TournamentEventDrawSettings
+    from app.models.tournament_event_pool import TournamentEventPool
     from app.models.tournament_fixture import TournamentFixture
     from app.models.tournament_table import VenueTable
 
@@ -196,8 +197,9 @@ class Tournament(Base):
 class TournamentEvent(Base):
     """An event (a draw) within a tournament — its own format, draw type, entry
     rules, schedule slot, and pool layout. The value-objects (``slot``,
-    ``match_settings``, ``predicates``, ``pools``) are typed JSONB decoded to
-    Pydantic models at the API boundary."""
+    ``match_settings``, ``predicates``) are typed JSONB decoded to Pydantic models at
+    the API boundary; the pool layout is **not** — it is ``pools``, a real child table
+    (ADR 20260801 "a pool belongs to its event")."""
 
     __tablename__ = "tournament_events"
     __table_args__ = (
@@ -282,9 +284,11 @@ class TournamentEvent(Base):
     predicates: Mapped[list[dict[str, Any]]] = mapped_column(
         JSONB, nullable=False, server_default=text("'[]'::jsonb")
     )
-    pools: Mapped[list[dict[str, Any]]] = mapped_column(
-        JSONB, nullable=False, server_default=text("'[]'::jsonb")
-    )
+    # There is deliberately no ``pools`` JSONB column. An event's pools were a NOT NULL
+    # JSONB list of ``{id, name, slot, table_ids}`` value-objects keyed by
+    # client-supplied strings; they are the ``pools`` relationship below now, so a
+    # fixture can foreign-key the pool it names — and name one of its OWN event's pools
+    # (ADR 20260801 "a pool belongs to its event").
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -340,6 +344,32 @@ class TournamentEvent(Base):
         order_by="TournamentEntry.created_at",
     )
 
+    # The event's pools, as rows (ADR 20260801), in the director's own order — which is
+    # what ``TournamentEventPool.position`` carries, and what the snake seeds against.
+    #
+    # ``lazy="selectin"``, and declared here rather than as an option at each call site,
+    # for the reason ``Tournament.tables`` and ``draw_settings`` are eager: async
+    # SQLAlchemy raises instead of emitting a lazy load, so each of the ~8 readers of an
+    # event's pools (``event_pools`` and everything through it — the serializer, the
+    # draw config, the solver's input load, the preview, the call copy, the dashboard)
+    # would have to remember one. ``selectin`` and not ``joined`` because this is a
+    # one-to-many: a joined load would multiply the event rows, which the tournament
+    # list's LIMIT/OFFSET could not survive. It batches over the whole result set, so a
+    # page of events costs ONE extra statement however many events it holds.
+    #
+    # ``delete-orphan`` is what the pools *write* leans on — a pool dropped from the
+    # submitted list is removed by taking it out of this collection — and
+    # ``passive_deletes`` + the FK's ``ON DELETE CASCADE`` is the delete path for
+    # everything that does not load the collection first (the tournament delete's single
+    # cascading statement, a raw DELETE, psql).
+    pools: Mapped[list["TournamentEventPool"]] = relationship(
+        back_populates="event",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        lazy="selectin",
+        order_by="TournamentEventPool.position",
+    )
+
     # The event's draw: every fixture the cut produced (ADR-0786). Empty until the
     # draw is cut; a re-cut replaces the set wholesale, which is what
     # ``delete-orphan`` buys.
@@ -360,13 +390,12 @@ class TournamentEvent(Base):
     #
     # It orders the pools by ``pool_id``, where ``fixtures_by_event`` orders them by the
     # pool's ``position`` in the event's own pool order (ADR 20260801) — a relationship
-    # ``order_by`` is an expression over *this* table, and the position lives in the
-    # event's ``pools`` JSONB, so saying it here would take a correlated subquery in a
-    # string. The two agree wherever the ids sort as the director ordered them and part
-    # company where they do not (``p-10-`` sorts between ``p-1-`` and ``p-2-``). Nothing
-    # in the app reads this relationship's order today — every draw a client sees comes
-    # through the loader — and when pools become rows the ``position`` is joinable and
-    # this becomes sayable.
+    # ``order_by`` is an expression over *this* table, so saying it here would still
+    # take a correlated subquery in a string, even now that the position is a column on
+    # ``tournament_event_pools`` and joinable. The two agree wherever the ids sort as
+    # the director ordered them and part company where they do not (``p-10-`` sorts
+    # between ``p-1-`` and ``p-2-``). Nothing in the app reads this relationship's order
+    # today — every draw a client sees comes through the loader.
     fixtures: Mapped[list["TournamentFixture"]] = relationship(
         back_populates="event",
         cascade="all, delete-orphan",

--- a/api/app/models/tournament.py
+++ b/api/app/models/tournament.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    UniqueConstraint,
     func,
     text,
 )
@@ -217,6 +218,16 @@ class TournamentEvent(Base):
         ),
         CheckConstraint(
             "entry_fee >= 0", name="ck_tournament_events_entry_fee_non_negative"
+        ),
+        # Redundant against the primary key, and there for exactly one purpose: it is
+        # the target ``tournament_event_pool_tables`` foreign-keys
+        # ``(tournament_id, event_id)`` against, which is the leg that forces a
+        # reservation's denormalized ``tournament_id`` to be the tournament its pool's
+        # event actually belongs to (ADR 20260801). Without it the other two legs of
+        # that row are satisfiable by a cross-tournament reservation — see
+        # ``TournamentEventPoolTable``.
+        UniqueConstraint(
+            "tournament_id", "id", name="uq_tournament_events_tournament_id_id"
         ),
     )
 

--- a/api/app/models/tournament_event_pool.py
+++ b/api/app/models/tournament_event_pool.py
@@ -1,0 +1,158 @@
+import uuid
+from datetime import date, datetime, time
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    PrimaryKeyConstraint,
+    Text,
+    Time,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.tournament import TournamentEvent
+
+
+class TournamentEventPool(Base):
+    """One pool of an event — a slice of the venue reserved for a window of time, as a
+    **row** (ADR 20260801 "a pool belongs to its event, not to the event's draw
+    settings").
+
+    It used to be an element of ``tournament_events.pools``: a JSONB array of
+    ``{id, name, slot, table_ids}`` value-objects. That is why a fixture's ``pool_id``
+    could name a pool that did not exist — there was no key to point at — and why the
+    integrity of that reference had to be procedural (``_enforce_pool_set_frozen``,
+    ADR-0786). It is a row now, so the reference is a foreign key, and specifically the
+    **composite** one on :class:`~app.models.tournament_fixture.TournamentFixture`:
+    ``(event_id, pool_id) → (event_id, id)``, which says the thing a plain FK to ``id``
+    cannot — that a fixture's pool belongs to *that fixture's own event*.
+
+    **The parent is the event, not the event's draw settings row.** The 2026-07-26 ADR
+    sketched ``draw_settings_id`` here; the composite FK above is what makes that
+    impossible, because ``tournament_event_draw_settings`` deliberately carries no
+    ``event_id`` and so shares no column with a fixture. The ADR named at the top is
+    that correction, and it also holds the rest of the reasoning: a pool is a 1:N
+    collection of entities with their own identity, not a scalar of a configuration.
+
+    **The slot is ``date``/``time``, not ``timestamptz``, and that is deliberate** — the
+    one place in this schema where api/CLAUDE.md's "datetimes are timezone-aware,
+    always" does not apply, because these three columns are not datetimes. A pool's
+    window is *wall-clock*: the director types "the 13th, 09:00 to 12:30" and means it
+    in the venue's own frame, which is carried once by ``tournament_events.timezone``
+    and anchored into real instants at the seam that needs instants
+    (``app.schedule_solves``). Storing an instant here would bake that anchoring into
+    the column, so correcting the event's timezone would have to rewrite every pool
+    window rather than re-read the same wall-clock in the new zone (ADR "tournament
+    times are timezone-aware instants" — "wall-clock is preserved across a timezone
+    edit"). The wire shape is unchanged: the ``Slot`` value-object's ``YYYY-MM-DD`` /
+    ``HH:MM`` strings compose from and to these columns at the boundary
+    (``app.tournament_pools``).
+
+    ``id`` is still the **client's** string, not a server-minted uuid, and only until
+    the chore that mints them (#1226 slice 3d) — which is also the chore that flips this
+    column, ``tournament_fixtures.pool_id`` and ``PoolId`` onto ``uuid`` together,
+    because they are one representation and a half-moved one is not a state worth
+    having."""
+
+    __tablename__ = "tournament_event_pools"
+    __table_args__ = (
+        # Declared explicitly, rather than by two ``primary_key=True`` columns, so the
+        # **order** of the pair is stated: ``event_id`` leads, which is what makes the
+        # key's own index answer "the pools of this event" (every read there is) and
+        # the event-delete cascade's lookup. Keyed on the pair because a pool id is
+        # per-event; see the ``id`` column below.
+        PrimaryKeyConstraint("event_id", "id", name="pk_tournament_event_pools"),
+        # Two pools of one event never share a place in its order — the guarantee
+        # ``stored_pools`` made by construction (it stamps ``range(len(pools))``) said
+        # here as a constraint, now that pools are rows and a constraint is available.
+        #
+        # DEFERRABLE INITIALLY DEFERRED, for the reason
+        # ``uq_tournament_tables_tournament_position`` is: the pools of an event are
+        # written as an id-keyed diff, and a diff **re-orders** — patching pools C, A, B
+        # back as B, C, A moves each row onto a position its neighbour has not vacated
+        # yet, and SQLAlchemy cannot emit three UPDATEs as one statement. Checked
+        # immediately, the constraint would refuse a transaction whose END state is
+        # perfectly unique, i.e. it would forbid reordering — which is the one gesture
+        # the payload's order exists to express.
+        UniqueConstraint(
+            "event_id",
+            "position",
+            name="uq_tournament_event_pools_event_id_position",
+            deferrable=True,
+            initially="DEFERRED",
+        ),
+    )
+
+    #: The pool's identity, and what a fixture's ``pool_id`` holds. A client-supplied
+    #: string today (``p-1-…``); see the class docstring on when it becomes a uuid.
+    #:
+    #: **The primary key is ``(event_id, id)``, not ``id``** — the pair, in that order,
+    #: is also the target of the fixture's composite foreign key, so the ADR's separate
+    #: ``UNIQUE (event_id, id)`` is not needed: the primary key already *is* it, and a
+    #: second index over the same two columns would buy nothing. (It also gives the
+    #: REFERENCING ``event_id`` the index Postgres does not create for one, which the
+    #: event-delete cascade path wants.)
+    #:
+    #: Composite because a pool id is **per-event**, exactly as it was as a JSONB
+    #: value-object: two events of one tournament may each hold a “pool-a”, which
+    #: ``app.schedule_solves`` relies on when it namespaces the solver's ``PoolId`` by
+    #: event id, and which two of ``tests/test_tournament_fixtures.py``'s cases assert
+    #: directly. A bare ``id`` primary key would have made a client-minted string
+    #: globally unique across the platform — a rule nothing in the domain asks for, that
+    #: nothing above the database enforces, and that would fail at the second event.
+    #: When the ids become server-minted uuids the key can shrink to ``id`` alone, with
+    #: the pair kept as the ADR's ``UNIQUE (event_id, id)``; that is the same DDL either
+    #: way and it is why the fixture's FK does not have to change then.
+    id: Mapped[str] = mapped_column(Text, nullable=False)
+    event_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tournament_events.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    #: ``Text``, not ``String(255)``: the write boundary floors a pool name at one
+    #: character and puts no ceiling on it, so a column with one would 500 on a payload
+    #: the schema accepted.
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    #: Where this pool sits in its event's pool order: 0-based, contiguous, assigned by
+    #: the server from the pool's index in the list it was sent in.
+    #:
+    #: Load-bearing, not decoration (ADR 20260801, "Pools carry an explicit
+    #: ``position``"): pool order was carried by the JSONB array's order and by the
+    #: lexicographic sort of client-minted ids, and both of those disappear here. The
+    #: snake seeds against this order, so under random ids an id-sort would deal a draw
+    #: that still cuts but seeds differently — invisible to the type checker.
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    #: The venue-local calendar day of this pool's window. See the class docstring for
+    #: why these three are wall-clock columns rather than instants.
+    slot_date: Mapped[date] = mapped_column(Date, nullable=False)
+    slot_start: Mapped[time] = mapped_column(Time, nullable=False)
+    slot_end: Mapped[time] = mapped_column(Time, nullable=False)
+    #: The tables this pool reserves, still as a JSONB array of table-id text. It
+    #: becomes ``tournament_event_pool_tables`` — rows with composite FKs to both sides,
+    #: so a pool cannot reserve another tournament's table — in the next chore of this
+    #: slice; the ADR's "the tournament-scoping stops at the join table" is about that
+    #: table, not this column.
+    table_ids: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    event: Mapped["TournamentEvent"] = relationship(back_populates="pools")

--- a/api/app/models/tournament_event_pool.py
+++ b/api/app/models/tournament_event_pool.py
@@ -12,15 +12,15 @@ from sqlalchemy import (
     Time,
     UniqueConstraint,
     func,
-    text,
 )
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db import Base
 
 if TYPE_CHECKING:
     from app.models.tournament import TournamentEvent
+    from app.models.tournament_event_pool_table import TournamentEventPoolTable
 
 
 class TournamentEventPool(Base):
@@ -137,14 +137,13 @@ class TournamentEventPool(Base):
     slot_date: Mapped[date] = mapped_column(Date, nullable=False)
     slot_start: Mapped[time] = mapped_column(Time, nullable=False)
     slot_end: Mapped[time] = mapped_column(Time, nullable=False)
-    #: The tables this pool reserves, still as a JSONB array of table-id text. It
-    #: becomes ``tournament_event_pool_tables`` — rows with composite FKs to both sides,
-    #: so a pool cannot reserve another tournament's table — in the next chore of this
-    #: slice; the ADR's "the tournament-scoping stops at the join table" is about that
-    #: table, not this column.
-    table_ids: Mapped[list[str]] = mapped_column(
-        JSONB, nullable=False, server_default=text("'[]'::jsonb")
-    )
+    # There is deliberately no ``table_ids`` column. The tables a pool reserves were a
+    # NOT NULL JSONB array of table-id strings, which could name a table of another
+    # tournament (or of none); they are the ``tables`` relationship below now — rows
+    # with composite foreign keys to both sides, so a cross-tournament reservation is
+    # not constructible (ADR 20260801, "the tournament-scoping stops at the join
+    # table"). The wire shape is unchanged: ``Pool.table_ids`` is composed from those
+    # rows, in ``position`` order, by ``app.tournament_pools``.
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -156,3 +155,30 @@ class TournamentEventPool(Base):
     )
 
     event: Mapped["TournamentEvent"] = relationship(back_populates="pools")
+
+    # The tables this pool reserves (ADR 20260801), in the order the director sent them
+    # — which is what ``TournamentEventPoolTable.position`` carries and what
+    # ``Pool.table_ids`` is composed from.
+    #
+    # ``lazy="selectin"`` for the reason ``TournamentEvent.pools`` itself is eager:
+    # async SQLAlchemy raises rather than emitting a lazy load, so every reader that
+    # reaches a pool's tables — the serializer, the solver's input load, the preview,
+    # the re-solve trigger's before/after comparison — would need to remember an option.
+    # SQLAlchemy chains it onto the pools' own selectin load, so a page of events pays
+    # ONE extra statement however many pools it holds (the
+    # ``EXPECTED_TOURNAMENT_*_STATEMENTS`` pins moved by exactly one).
+    #
+    # ``delete-orphan`` is what the reservation *write* leans on — a table dropped from
+    # the submitted list is removed by taking it out of this collection — and
+    # ``passive_deletes`` + the FK's ``ON DELETE CASCADE`` is the delete path for
+    # everything that does not load the collection first (the event- and
+    # tournament-delete cascades, a raw DELETE, psql). Removing the TABLE is the third
+    # path, and the ORM is never involved in it at all: that cascade comes off
+    # ``tournament_tables``, which has no relationship pointing here.
+    tables: Mapped[list["TournamentEventPoolTable"]] = relationship(
+        back_populates="pool",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        lazy="selectin",
+        order_by="TournamentEventPoolTable.position",
+    )

--- a/api/app/models/tournament_event_pool.py
+++ b/api/app/models/tournament_event_pool.py
@@ -7,11 +7,11 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Integer,
-    PrimaryKeyConstraint,
     Text,
     Time,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -58,20 +58,29 @@ class TournamentEventPool(Base):
     ``HH:MM`` strings compose from and to these columns at the boundary
     (``app.tournament_pools``).
 
-    ``id`` is still the **client's** string, not a server-minted uuid, and only until
-    the chore that mints them (#1226 slice 3d) — which is also the chore that flips this
-    column, ``tournament_fixtures.pool_id`` and ``PoolId`` onto ``uuid`` together,
+    ``id`` is a **server-minted uuid** — ``gen_random_uuid()``, the same default a venue
+    table's id has. It was a client-supplied string (``p-1-…``) for as long as a pool
+    was a JSONB value-object with nothing to mint it; the column,
+    ``tournament_fixtures.pool_id`` and ``PoolId`` moved onto ``uuid`` in one step,
     because they are one representation and a half-moved one is not a state worth
     having."""
 
     __tablename__ = "tournament_event_pools"
     __table_args__ = (
-        # Declared explicitly, rather than by two ``primary_key=True`` columns, so the
-        # **order** of the pair is stated: ``event_id`` leads, which is what makes the
-        # key's own index answer "the pools of this event" (every read there is) and
-        # the event-delete cascade's lookup. Keyed on the pair because a pool id is
-        # per-event; see the ``id`` column below.
-        PrimaryKeyConstraint("event_id", "id", name="pk_tournament_event_pools"),
+        # The target of the fixture's — and the reservation's — composite foreign key:
+        # SQL can only reference a unique set of columns, and the *pair* is what carries
+        # "my pool is my own event's pool". Redundant against the primary key as a
+        # uniqueness claim (a uuid id is unique on its own), and that is exactly what
+        # the ADR says it is for: "``UNIQUE (event_id, id)`` is redundant against the
+        # primary key and exists purely as the target that composite FK needs."
+        #
+        # It earns its index twice over anyway: ``event_id`` leads, so it answers "the
+        # pools of this event" (every read there is), the event-delete cascade's lookup,
+        # and the referential check of both composite foreign keys — none of which the
+        # single-column primary key's index can serve.
+        UniqueConstraint(
+            "event_id", "id", name="uq_tournament_event_pools_event_id_id"
+        ),
         # Two pools of one event never share a place in its order — the guarantee
         # ``stored_pools`` made by construction (it stamps ``range(len(pools))``) said
         # here as a constraint, now that pools are rows and a constraint is available.
@@ -93,27 +102,22 @@ class TournamentEventPool(Base):
         ),
     )
 
-    #: The pool's identity, and what a fixture's ``pool_id`` holds. A client-supplied
-    #: string today (``p-1-…``); see the class docstring on when it becomes a uuid.
+    #: The pool's identity, and what a fixture's ``pool_id`` holds — a uuid the
+    #: **database** mints (ADR 20260801's DDL: ``id uuid PRIMARY KEY``).
     #:
-    #: **The primary key is ``(event_id, id)``, not ``id``** — the pair, in that order,
-    #: is also the target of the fixture's composite foreign key, so the ADR's separate
-    #: ``UNIQUE (event_id, id)`` is not needed: the primary key already *is* it, and a
-    #: second index over the same two columns would buy nothing. (It also gives the
-    #: REFERENCING ``event_id`` the index Postgres does not create for one, which the
-    #: event-delete cascade path wants.)
-    #:
-    #: Composite because a pool id is **per-event**, exactly as it was as a JSONB
-    #: value-object: two events of one tournament may each hold a “pool-a”, which
-    #: ``app.schedule_solves`` relies on when it namespaces the solver's ``PoolId`` by
-    #: event id, and which two of ``tests/test_tournament_fixtures.py``'s cases assert
-    #: directly. A bare ``id`` primary key would have made a client-minted string
-    #: globally unique across the platform — a rule nothing in the domain asks for, that
-    #: nothing above the database enforces, and that would fail at the second event.
-    #: When the ids become server-minted uuids the key can shrink to ``id`` alone, with
-    #: the pair kept as the ADR's ``UNIQUE (event_id, id)``; that is the same DDL either
-    #: way and it is why the fixture's FK does not have to change then.
-    id: Mapped[str] = mapped_column(Text, nullable=False)
+    #: **The primary key is ``id`` alone**, where it was ``(event_id, id)``. The pair
+    #: was never about the fixture's foreign key (that references the ``UNIQUE
+    #: (event_id, id)`` above, which stands either way) — it was there because a
+    #: *client-minted* string is only unique per event: two events of one tournament
+    #: could each hold a “pool-a”, and a bare ``id`` key would have imposed
+    #: platform-wide uniqueness on a string nothing above the database controlled. A
+    #: minted uuid is globally unique by construction, so the reason is gone and the
+    #: narrower key is the honest one: a pool id names one pool, anywhere.
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
     event_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("tournament_events.id", ondelete="CASCADE"),

--- a/api/app/models/tournament_event_pool_table.py
+++ b/api/app/models/tournament_event_pool_table.py
@@ -1,0 +1,178 @@
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    PrimaryKeyConstraint,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import Base
+
+if TYPE_CHECKING:
+    from app.models.tournament_event_pool import TournamentEventPool
+
+
+class TournamentEventPoolTable(Base):
+    """One table a pool **reserves** — a row, where it used to be an entry in the pool's
+    ``table_ids`` JSONB array (ADR 20260801, "the tournament-scoping stops at the join
+    table").
+
+    A reservation is the slice of the venue catalogue a pool draws on: the solver may
+    place that pool's matches on these tables and no others. It is a *preference*, not a
+    commitment — which is the whole reason this row exists as a row. As a string in a
+    JSONB array it could name anything at all, including a table belonging to **another
+    tournament**, and nothing above the database would have said otherwise.
+
+    **The three foreign keys, and why it takes three.** A pool belongs to an event, an
+    event belongs to a tournament, and a table belongs to a tournament — so "this pool's
+    table is its own tournament's table" is a claim about a path this row is the only
+    place to walk. It is spelled by carrying ``tournament_id`` here, denormalized, and
+    pinning every leg of the path to it:
+
+    ==========================  =========================================
+    ``(event_id, pool_id)``     → ``tournament_event_pools (event_id, id)``
+    ``(tournament_id, table_id)``  → ``tournament_tables (tournament_id, id)``
+    ``(tournament_id, event_id)``  → ``tournament_events (tournament_id, id)``
+    ==========================  =========================================
+
+    The third one is the one that looks redundant and is not. With only the first two,
+    a row may say ``tournament_id = X`` while its pool's event belongs to tournament
+    ``Y``: both constraints are satisfied — the pool exists, and ``X`` really does own
+    that table — and the row is *exactly* the reservation the ADR forbids, across two
+    tournaments.
+    The third leg is what forces the ``tournament_id`` this row claims to be the
+    tournament its pool actually lives under, and only then does the second leg mean "my
+    own tournament's table". (Each is composite for the same reason the fixture's
+    ``(event_id, pool_id)`` is: a plain ``REFERENCES tournament_tables (id)`` says the
+    table *exists*, which was never the question.)
+
+    Each referenced pair is a UNIQUE key that exists for no other purpose —
+    ``tournament_events`` and ``tournament_tables`` both gained a
+    ``UNIQUE (tournament_id, id)`` beside their primary key, because SQL can only
+    reference a unique set of columns and the *pair* is what carries the claim. Pools
+    needed nothing: ``(event_id, id)`` is already their primary key.
+
+    **All three delete rules are CASCADE, and one of them is the ADR's asymmetry.**
+    Removing a table that a fixture is *placed at* is refused (``ON DELETE RESTRICT`` on
+    ``tournament_fixtures.table_id``) and the director says yes on purpose; removing a
+    table that a pool merely *reserves* is silent, and this CASCADE is what makes it
+    true rather than merely tolerated — the reservation disappears with the table
+    instead of lingering as a string naming nothing (ADR 20260801, "a placement names a
+    real table"). A pool's reservations likewise go with the pool, and an event's with
+    the event, so no delete path has to learn about this table.
+    """
+
+    __tablename__ = "tournament_event_pool_tables"
+    __table_args__ = (
+        # A pool reserves a table at most once. ``event_id`` leads for the reason it
+        # leads on ``tournament_event_pools``: every read is "the reservations of this
+        # pool", and its own index answers the (event_id, pool_id) foreign key's
+        # referential check as well as the event-delete cascade's lookup.
+        PrimaryKeyConstraint(
+            "event_id",
+            "pool_id",
+            "table_id",
+            name="pk_tournament_event_pool_tables",
+        ),
+        ForeignKeyConstraint(
+            ["event_id", "pool_id"],
+            ["tournament_event_pools.event_id", "tournament_event_pools.id"],
+            name="fk_tournament_event_pool_tables_event_id_pool_id",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["tournament_id", "table_id"],
+            ["tournament_tables.tournament_id", "tournament_tables.id"],
+            name="fk_tournament_event_pool_tables_tournament_id_table_id",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["tournament_id", "event_id"],
+            ["tournament_events.tournament_id", "tournament_events.id"],
+            name="fk_tournament_event_pool_tables_tournament_id_event_id",
+            ondelete="CASCADE",
+        ),
+        # Two reservations of one pool never share a place in its order — the guarantee
+        # ``app.tournament_pools`` makes by construction (it stamps ``range(len(...))``)
+        # said here as a constraint.
+        #
+        # DEFERRABLE INITIALLY DEFERRED for the reason both sibling ``position``
+        # constraints are: the reservations of a pool are written as a diff keyed on the
+        # table id, and a diff **re-orders** — a payload that moves a table up the list
+        # puts it on a position its neighbour has not vacated yet, and SQLAlchemy cannot
+        # emit those UPDATEs as one statement. Checked immediately, the constraint would
+        # refuse a transaction whose END state is perfectly unique.
+        UniqueConstraint(
+            "event_id",
+            "pool_id",
+            "position",
+            name="uq_tournament_event_pool_tables_event_id_pool_id_position",
+            deferrable=True,
+            initially="DEFERRED",
+        ),
+        # The index Postgres does NOT create for a REFERENCING pair, on the leg that
+        # needs it most: removing a venue table cascades through this FK, and unindexed
+        # that check is a sequential scan of every reservation on the platform per table
+        # removed. The primary key covers the other two legs (both lead with
+        # ``event_id``); this pair leads with ``tournament_id``, which no other index
+        # here does.
+        Index(
+            "ix_tournament_event_pool_tables_tournament_id_table_id",
+            "tournament_id",
+            "table_id",
+        ),
+    )
+
+    #: The tournament this reservation is inside — **denormalized on purpose**, and the
+    #: only reason the cross-tournament claim is expressible at all. A pool has no
+    #: ``tournament_id`` (it hangs off its event) and a table has no ``event_id``, so
+    #: the two sides share no column until this row supplies one for them to agree on.
+    tournament_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    #: Half of the reserving pool's composite key, and half of the "this event is that
+    #: tournament's" leg. Both foreign keys read this one column, which is what ties the
+    #: pool and the table into the same tournament.
+    event_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    #: The other half of the pool's key. ``Text``, like ``TournamentEventPool.id``,
+    #: while pool ids are still the client's strings; it moves to ``uuid`` with them
+    #: (#1226 slice 3d), which is the same DDL on both sides and no change to any of the
+    #: constraints above.
+    pool_id: Mapped[str] = mapped_column(Text, nullable=False)
+    #: The reserved table. ``UUID(as_uuid=False)`` — a real ``uuid`` column typed as
+    #: ``str`` in Python, exactly as ``TournamentFixture.table_id`` is, because a table
+    #: id crosses this codebase as its canonical text: here, on a placement, and as the
+    #: solver's ``TableId``. The database holds the type; everything above it compares
+    #: the text.
+    table_id: Mapped[str] = mapped_column(UUID(as_uuid=False), nullable=False)
+    #: Where this table sits in the pool's reservation list: 0-based, contiguous,
+    #: assigned by the server from the order the reservation arrived in.
+    #:
+    #: The JSONB array carried that order for free and the wire shape is still an
+    #: array, so something has to carry it now that the array is rows — the same
+    #: argument, and the same remedy, as ``TournamentEventPool.position`` and
+    #: ``VenueTable.position``. Ordering by ``table_id`` instead would be *arbitrary*
+    #: (random UUIDs), so a director's list would come back shuffled on every read.
+    #:
+    #: Deliberately not on the wire: the read shape is the array whose order this is,
+    #: and carrying the number beside it would be carrying a field and its own
+    #: derivation (api/CLAUDE.md).
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    pool: Mapped["TournamentEventPool"] = relationship(back_populates="tables")

--- a/api/app/models/tournament_event_pool_table.py
+++ b/api/app/models/tournament_event_pool_table.py
@@ -8,7 +8,6 @@ from sqlalchemy import (
     Index,
     Integer,
     PrimaryKeyConstraint,
-    Text,
     UniqueConstraint,
     func,
 )
@@ -141,11 +140,11 @@ class TournamentEventPoolTable(Base):
     #: tournament's" leg. Both foreign keys read this one column, which is what ties the
     #: pool and the table into the same tournament.
     event_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
-    #: The other half of the pool's key. ``Text``, like ``TournamentEventPool.id``,
-    #: while pool ids are still the client's strings; it moves to ``uuid`` with them
-    #: (#1226 slice 3d), which is the same DDL on both sides and no change to any of the
-    #: constraints above.
-    pool_id: Mapped[str] = mapped_column(Text, nullable=False)
+    #: The other half of the pool's key — a ``uuid``, exactly as
+    #: :attr:`~app.models.tournament_event_pool.TournamentEventPool.id` is now that the
+    #: server mints it. The two moved off ``Text`` in one step, which is the same DDL on
+    #: both sides and changed none of the constraints above.
+    pool_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     #: The reserved table. ``UUID(as_uuid=False)`` — a real ``uuid`` column typed as
     #: ``str`` in Python, exactly as ``TournamentFixture.table_id`` is, because a table
     #: id crosses this codebase as its canonical text: here, on a placement, and as the

--- a/api/app/models/tournament_fixture.py
+++ b/api/app/models/tournament_fixture.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import (
     DateTime,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
     Integer,
     Text,
@@ -40,11 +41,18 @@ class TournamentFixture(Base):
     things, and the "is this side unknown, or is it a bye?" question would have to be
     answered by reading a second column.
 
-    ``pool_id`` is a **string ref, not a foreign key**: pools are JSONB value-objects
-    on the event (``{id, name, slot, table_ids}`` — a slice of the venue), so there is
-    no table to point at. Integrity is procedural: the event's pool *id set* freezes
-    while a draw exists. ``NULL`` means the draw is un-pooled — single-elim today, and
-    the knockout stage of a pools-then-knockout draw type once #787 adds one.
+    ``pool_id`` is a **foreign key**, and a *composite* one: ``(event_id, pool_id) →
+    tournament_event_pools (event_id, id)``. Pools are rows now (ADR 20260801 "a pool
+    belongs to its event, not to the event's draw settings"), and the composite form is
+    what makes the reference say the thing that actually matters — not merely "this pool
+    exists" but "this pool is **my own event's**". A plain FK to
+    ``tournament_event_pools.id`` would happily seat one event's fixture in another
+    event's pool, and that is the illegal state the ADR is about; it is unrepresentable
+    here because the two tables share ``event_id`` and the constraint requires it to
+    agree. ``NULL`` means the draw is un-pooled — single-elim, and the knockout stage of
+    an rr-then-ko draw. (A composite FK with one NULL member is satisfied vacuously
+    under the SQL default MATCH SIMPLE, which is exactly right: an un-pooled fixture
+    names no pool to check.)
 
     The ``UNIQUE (event_id, pool_id, round, position)`` below is the identity a re-cut
     reconciles on, and it is declared **NULLS NOT DISTINCT** (Postgres 15+). Under the
@@ -57,6 +65,32 @@ class TournamentFixture(Base):
 
     __tablename__ = "tournament_fixtures"
     __table_args__ = (
+        # "My pool is my own event's pool", as one line of DDL (ADR 20260801). The
+        # referenced ``(event_id, id)`` is a unique constraint on
+        # ``tournament_event_pools`` that exists for no other purpose — SQL can only
+        # reference a unique set of columns, and the *pair* is what carries the claim.
+        #
+        # DEFERRABLE INITIALLY DEFERRED with the default (NO ACTION) delete rule, rather
+        # than ``RESTRICT``, because of the **event-delete** path — the same hazard the
+        # entry FKs below name. Deleting an event removes its pools through the ORM (the
+        # collection is eagerly loaded, so the unit of work issues that DELETE itself)
+        # and its fixtures through Postgres' ``ON DELETE CASCADE``, in that order and in
+        # two separate statements. An immediately-checked constraint fires between them,
+        # on fixtures that are about to be deleted one statement later, and kills the
+        # whole delete. Deferring is not a weakening: the pair is checked, in full,
+        # before the transaction can commit — a fixture pointing at another event's pool
+        # is refused either way, just at COMMIT rather than at the INSERT.
+        #
+        # Removing a pool a fixture is drawn into is refused before it ever reaches this
+        # constraint, by ``_enforce_pool_set_frozen``'s 409 (ADR-0786) — which is now
+        # the *second* line of defence rather than the only one.
+        ForeignKeyConstraint(
+            ["event_id", "pool_id"],
+            ["tournament_event_pools.event_id", "tournament_event_pools.id"],
+            name="fk_tournament_fixtures_event_id_pool_id",
+            deferrable=True,
+            initially="DEFERRED",
+        ),
         # The identity of a fixture within its draw. NULLS NOT DISTINCT so the guard
         # also covers un-pooled draws, where ``pool_id`` is NULL for every row — see
         # the class docstring.
@@ -92,8 +126,8 @@ class TournamentFixture(Base):
         ForeignKey("tournament_events.id", ondelete="CASCADE"),
         nullable=False,
     )
-    #: Names a ``Pool`` value-object in the event's own ``pools`` JSONB — deliberately
-    #: not a FK (there is no pools table). ``NULL`` = the draw is un-pooled.
+    #: Names a pool of **this fixture's own event** — half of the composite foreign key
+    #: declared above. ``NULL`` = the draw is un-pooled.
     pool_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     #: 1-based.
     round: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/api/app/models/tournament_fixture.py
+++ b/api/app/models/tournament_fixture.py
@@ -8,7 +8,6 @@ from sqlalchemy import (
     ForeignKeyConstraint,
     Index,
     Integer,
-    Text,
     UniqueConstraint,
     func,
     text,
@@ -128,7 +127,11 @@ class TournamentFixture(Base):
     )
     #: Names a pool of **this fixture's own event** — half of the composite foreign key
     #: declared above. ``NULL`` = the draw is un-pooled.
-    pool_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    #:
+    #: A ``uuid``, moved off ``Text`` in the same step as
+    #: :attr:`~app.models.tournament_event_pool.TournamentEventPool.id` — the column it
+    #: references, and therefore the column whose type it *is*.
+    pool_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     #: 1-based.
     round: Mapped[int] = mapped_column(Integer, nullable=False)
     #: 1-based within its round (and pool, when pooled).

--- a/api/app/models/tournament_table.py
+++ b/api/app/models/tournament_table.py
@@ -70,6 +70,16 @@ class VenueTable(Base):
             deferrable=True,
             initially="DEFERRED",
         ),
+        # Redundant against the primary key, and there for exactly one purpose: SQL can
+        # only reference a UNIQUE set of columns, so this is the target that lets
+        # ``tournament_event_pool_tables`` foreign-key ``(tournament_id, table_id)`` and
+        # thereby say "the table this pool reserves is my own tournament's" (ADR
+        # 20260801). The same trick, one level down, as ``tournament_event_pools``'
+        # ``(event_id, id)`` primary key — which is that table's key rather than an
+        # extra constraint only because a pool id is per-event and a table id is not.
+        UniqueConstraint(
+            "tournament_id", "id", name="uq_tournament_tables_tournament_id_id"
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/api/app/schedule_preview.py
+++ b/api/app/schedule_preview.py
@@ -120,11 +120,23 @@ def placeholder_label(player_id: str) -> str:
     return f"Placeholder {player_id.removeprefix(PLACEHOLDER_PREFIX)}"
 
 
-def preview_pool_key(event_id: uuid.UUID, pool_id: str) -> str:
+def preview_pool_key(event_id: uuid.UUID, pool_id: uuid.UUID) -> str:
     """The one namespaced ``event:pool`` spelling every preview site keys a pool by
     — the ``SchedulePool`` id, a fixture's ``pool_id`` ref, and the enqueue verb's
     infeasibility-resolution map all pass through here, so the string contract lives
-    in exactly one place and cannot drift between them."""
+    in exactly one place and cannot drift between them.
+
+    **The namespace is no longer needed for uniqueness, and is kept anyway.** It was
+    minted because a pool id was a per-event string and two events of one tournament
+    could each hold a "pool-a"; a pool id is a globally unique uuid now (ADR 20260801),
+    so the ``event:`` prefix disambiguates nothing. It stays because the *key* is a wire
+    value, not an implementation detail: it is what
+    :class:`~app.schemas.schedule_preview.SchedulePreviewFixtureRead.pool_id` carries,
+    what a stored solve's plan is keyed by, and what an infeasibility reason names — so
+    dropping it would be a wire change with client follow-ups, and it would leave every
+    solve row already in a database keyed in a space nothing computes any more. It also
+    still earns its keep as a *label*: a solver pool id that says which event it belongs
+    to is one a human reading a plan or a reason can place."""
     return f"{event_id}:{pool_id}"
 
 

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -1014,7 +1014,10 @@ async def _load_solver_inputs(
                 "length_games": settings.length_games,
                 "pools": [
                     {
-                        "id": pool.id,
+                        # ``str``, because the fingerprint is canonical JSON and a
+                        # ``uuid.UUID`` is not JSON-serializable — the id became one
+                        # when the server started minting them (ADR 20260801).
+                        "id": str(pool.id),
                         "date": pool.slot.date,
                         "start": pool.slot.start,
                         "end": pool.slot.end,
@@ -1035,7 +1038,7 @@ async def _load_solver_inputs(
             {
                 "id": str(fixture.id),
                 "event_id": str(fixture.event_id),
-                "pool_id": fixture.pool_id,
+                "pool_id": _opt(fixture.pool_id),
                 "entry_a": _opt(fixture.entry_a_id),
                 "entry_b": _opt(fixture.entry_b_id),
                 "winner": _opt(fixture.winner_entry_id),

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -284,40 +284,16 @@ def _draw_settings_write(
 
 # ----- value-objects (typed JSONB) -----------------------------------------
 
-ValueObjectId = Annotated[str, Field(min_length=1)]
-"""The **identity** a client authors for a pool.
-
-It is no longer the identity of a *value-object*: a pool is a row in
-``tournament_event_pools`` (ADR 20260801) and a fixture's ``pool_id`` is a real
-composite foreign key to it. What survives from the JSONB era is the id's **authorship**
-— the string is still the client's to mint, until the chore that moves pools onto
-server-minted uuids (#1226 slice 3d) deletes this alias the way the venue catalogue's
-move already deleted its own use of it. Until then the floor still has to be stated
-here: the empty string is not an identity, and it was a **representable** one —
-``Pool(id="")`` validated, and an event could be created and patched holding it.
-
-It is not a theoretical illegal state. A fixture names its pool by this string
-(ADR-0786) and the rest of the system asks two questions of that ref, which an empty id
-answers *inconsistently*: "is this fixture pooled?" is ``pool_id is not None`` — and
-``""`` is not ``None``, so **yes** — while the sort that orders a draw's fixtures reads
-``pool_id or ""`` (``app.draws.ready_fixtures``), where ``""`` is indistinguishable from
-the un-pooled group it deliberately sorts apart. One fixture, pooled by one rule and
-un-pooled by the other, and a draw whose order depends on which one you ask. A ``str``
-with no floor admits that state; a ``min_length=1`` makes it unsayable — at the
-boundary, in the type, rather than as a runtime check downstream (api/CLAUDE.md, "make
-illegal states unrepresentable").
-
-Unlike the pool-id *uniqueness* rule (``_pool_ids_are_unique``, an ``AfterValidator``
-that contributes nothing to the JSON schema), this **does** change the OpenAPI shape:
-``minLength: 1`` is a real JSON-schema keyword, so the generated clients learn the rule
-too — which is a feature. A rule the client can express is a rule the organizer meets
-under the field instead of in a 422.
-
-It used to cover the venue catalogue's tables as well. It does not any more: a table is
-a row with a server-minted UUID primary key (ADR 20260801), so its identity is neither a
-string nor the client's to author, and there is nothing here left to floor. A pool is a
-row now too, but its id is still authored by the client — the *minting* moves in a chore
-of its own, and this alias goes with it."""
+# ``ValueObjectId`` — the ``Annotated[str, Field(min_length=1)]`` a pool's id used to be
+# — is gone, and its deletion is the point of the chore that minted them. It existed
+# only because "pools and tables have no tables of their own, so a pool is addressed by
+# a client-supplied string and nothing in the database constrains it" (ADR 20260726,
+# which scoped its removal). Both halves of that are now false: a pool is a row, its id
+# is a ``uuid`` the database mints, and the illegal state the floor was holding off —
+# the empty-string id, which answered "is this fixture pooled?" and the draw-order tie-
+# break inconsistently — is not expressible in a ``uuid`` at all. A type that cannot
+# hold the bad value beats a validator that refuses it (api/CLAUDE.md, "make illegal
+# states unrepresentable").
 
 
 MAX_ADDRESS_COMPONENT = 255
@@ -793,22 +769,23 @@ actually hold. See :func:`_slot_is_storable`."""
 
 class PoolWrite(BaseModel):
     """A slice of tables reserved for a window of time within an event, as a client
-    **sends** it.
+    **creates** it.
 
-    Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
-    by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
-    these ids. Which is only a coherent thing to say if an id names one pool — see
-    ``EventPools``, the type the event's list of them actually has — and if an id is a
-    thing at all, which is what ``ValueObjectId`` says: the empty string is not one, and
-    a fixture drawn into it is pooled by one rule and un-pooled by another.
+    It has **no** ``id``, and that absence is the whole content of the chore that minted
+    them: a pool's id is a uuid the database mints (ADR 20260801's ``id uuid PRIMARY
+    KEY``), so it is not the client's to author and there is nothing here for it to
+    author. Sending one is a 422 for an unknown field — the same treatment
+    :class:`TournamentTableWrite` gives a venue table's id, and for the same reason. A
+    client that *cites* an id it was given is patching, not creating, and the shape for
+    that is :class:`PoolUpsert`.
 
-    Its ``name`` has the same floor for the plainer reason: a pool is *called*
-    something — it is what the director clicks, what the conflict warnings quote, and
-    what a player reads off a wall. ``""`` is not a name, and an event whose pools list
-    is three blank rows is not a thing anyone could act on.
+    Its ``name`` has a floor for the plainer reason: a pool is *called* something — it
+    is what the director clicks, what the conflict warnings quote, and what a player
+    reads off a wall. ``""`` is not a name, and an event whose pools list is three blank
+    rows is not a thing anyone could act on.
 
-    What is **absent** is as deliberate as what is here: ``position`` is the server's to
-    assign (:data:`PoolPosition`), so it is simply not a field of this model, and
+    ``position`` is absent for the same reason the id is: it is the server's to assign
+    (:data:`PoolPosition`), so it is simply not a field of this model, and
     ``extra="forbid"`` turns an attempt to send one into a 422 that names it. This is
     the treatment ``entered`` already gets on the event schemas — a server-managed value
     is kept **off** the write shape rather than accepted and then ignored. Accepting it
@@ -820,30 +797,65 @@ class PoolWrite(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    id: ValueObjectId
     name: str = Field(min_length=1)
     slot: PoolSlot
     table_ids: list[str]
 
 
+class PoolUpsert(PoolWrite):
+    """One pool of an event a client **edits** (``PATCH …/events/{id}``): everything
+    :class:`PoolWrite` carries, plus an **optional** ``id`` naming a pool the event
+    already has.
+
+    The exact twin of :class:`TournamentTableUpsert`, one resource over, and the two
+    cases are exhaustive:
+
+    * ``id`` **present** — "this is the pool you already have, with these words". The
+      row keeps its id, and therefore every fixture drawn into it and every table it
+      reserves, and takes the new ``name``/``slot``/``table_ids``; its place in the list
+      is its new place in the event's pool order.
+    * ``id`` **omitted** (or ``null``) — "add a pool". The server mints its id, exactly
+      as on create.
+    * a stored pool **no entry names** — "remove it".
+
+    ``X | None = None`` and never a non-null default: an optional field on a *write*
+    schema whose default is not ``None`` generates as **required** in the TypeScript
+    client, which would make "omit the id to add a pool" unsayable there.
+
+    An id that names no pool of *this* event is a 422 on the field
+    (:class:`~app.tournament_errors.PoolNotInEventError`), not a quietly minted new
+    pool. Until this chore that arm was an *addition*, because the id was the client's
+    and an id the server had never seen still named the pool the client meant. It is the
+    server's now, so an id it did not mint names nothing — and minting a fresh one would
+    hand the client back a different id than it asked for while *removing* the pool it
+    meant to keep, which is the pair of failures a diff must never confuse."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: uuid.UUID | None = None
+
+
 class Pool(PoolWrite):
-    """A pool as it is **read back**: everything a client wrote, plus the ``position``
-    the server stamped on it.
+    """A pool as it is **read back**: everything a client wrote, plus the ``id`` the
+    server minted for it and the ``position`` it stamped on it.
 
     It is also the model every interior read of an event's pools arrives through —
     ``_ordered_pools``, ``draw_config``, ``event_pools``, the schedule snapshots — which
     is why moving pools from a JSONB array into ``tournament_event_pools`` rows changed
     nothing above ``app.tournament_pools.pool_read``: the projection composes this same
     model out of typed columns where it used to validate it out of untyped dicts.
-    Deriving it from :class:`PoolWrite` is what keeps the two shapes one shape plus a
-    field: a column added to the write side is readable without a second edit, and the
-    two can never disagree about what a pool *is*.
+    Deriving it from :class:`PoolWrite` is what keeps the two shapes one shape plus two
+    fields, exactly as :class:`TournamentTable` derives from
+    :class:`TournamentTableWrite`: a column added to the write side is readable without
+    a second edit, and the two can never disagree about what a pool *is*.
 
     ``position`` keeps its ``0`` default even though the column is NOT NULL and every
     row carries a real one: the default is what lets a **literal** ``Pool`` be built in
     a test or a REPL without spelling an order out, and a read boundary that
-    hard-required it would gain nothing — the projection always supplies it."""
+    hard-required it would gain nothing — the projection always supplies it. ``id`` has
+    no default, because there is no id a literal pool could sensibly default to."""
 
+    id: uuid.UUID
     position: PoolPosition = 0
 
 
@@ -870,8 +882,9 @@ def named_list(names: list[str]) -> str:
     return f"{', '.join(quoted[:-1])} and {quoted[-1]}"
 
 
-def _pool_ids_are_unique(pools: list[PoolWrite]) -> list[PoolWrite]:
-    """Refuse an event's pools when two of them claim the same ``id`` (422).
+def _pool_ids_are_unique(pools: list[PoolUpsert]) -> list[PoolUpsert]:
+    """Refuse an edited pool list when two of its entries cite the same pool ``id``
+    (422).
 
     A pool id is an **identity**, and everything downstream is built on the assumption
     that it identifies one pool. Nothing enforced it: pools were JSONB with
@@ -885,59 +898,76 @@ def _pool_ids_are_unique(pools: list[PoolWrite]) -> list[PoolWrite]:
     validator existed). A boundary that admits what the interior cannot hold is not a
     boundary.
 
-    Pools are rows now (ADR 20260801), so ``id`` is a primary key and a duplicate is
-    also a thing the database would refuse — but this validator is still the enforcement
-    worth having, and not only because a 422 naming the ids beats an ``IntegrityError``:
-    the write is an id-keyed diff (``app.tournament_pools``), and ``[A, A]`` would
-    resolve *both* entries onto the one stored row, so the payload would be accepted as
-    a single-pool event rather than refused as the two-pool one it claims to be.
+    Pools are rows with a uuid primary key now (ADR 20260801), so a duplicate is also a
+    thing the database would refuse — but this validator is still the enforcement worth
+    having, and not only because a 422 naming the ids beats an ``IntegrityError``: the
+    write is an id-keyed diff (``app.tournament_pools``), and ``[A, A]`` would resolve
+    *both* entries onto the one stored row, so the payload would be accepted as a
+    single-pool event rather than refused as the two-pool one it claims to be.
 
-    It is a rule about the **list**, not about a ``PoolWrite``, so it is a validator on
-    the list type — and it is stated **once**, on the alias both write schemas share,
-    for the reason the numeric bounds are shared (see ``EventMaxPlayers``): "the patch
-    path is the hole" is the same bug wearing a different verb. Guarding only ``create``
-    would leave the event to be born clean and then edited into the 500 — and the patch
-    path is the *worse* of the two, because the pool-set freeze that protects a cut draw
-    compares **sets**: ``[A, A, B]`` against a cut event holding ``{A, B}`` is the same
-    set, so the freeze waved it through (measured: **200**) and the next cut died. The
-    guard that exists to protect the draw was admitting the payload that poisons it.
+    **Entries with no ``id`` are ignored**: those are additions, and any number of new
+    pools may be added at once — exactly as :func:`_table_ids_are_unique` treats them.
+
+    It is a rule about the **list**, so it is a validator on the list type
+    (:data:`EditedEventPools`) rather than on an entry — an entry cannot see its
+    siblings. It has no create-path twin any more, and does not need one: the create
+    shape (:class:`PoolWrite`) has no ``id`` at all, so "the patch path is the hole" —
+    the bug that made this a shared rule when both verbs took ids — is not a hole a
+    ``create`` can have. This *is* the patch path, and it was always the worse of the
+    two: the pool-set freeze that protects a cut draw compares **sets**, so ``[A, A,
+    B]`` against a cut event holding ``{A, B}`` is the same set, the freeze waved it
+    through (measured: **200**) and the next cut died.
 
     The duplicated **ids** are named, not the pools' names: an id is what is duplicated,
     two pools sharing one id may well have different names, and the id is what the
     director must edit. The refusal is a 422 rather than a 409 because this is a
     malformed payload in any state the event could possibly be in — an event with no
-    draw at all still cannot have two pools called ``p-a``.
+    draw at all still cannot cite one pool twice.
     """
-    counted = Counter(pool.id for pool in pools)
-    duplicated = [pool_id for pool_id, count in counted.items() if count > 1]
+    counted = Counter(pool.id for pool in pools if pool.id is not None)
+    duplicated = [str(pool_id) for pool_id, count in counted.items() if count > 1]
     if duplicated:
         raise ValueError(
             f"A pool id identifies one pool: {named_list(duplicated)} "
-            f"{'is' if len(duplicated) == 1 else 'are'} used by more than one pool of "
-            "this event. Give each pool an id of its own."
+            f"{'is' if len(duplicated) == 1 else 'are'} cited by more than one entry "
+            "of this event's pools. Cite each pool you are keeping exactly once, and "
+            "omit the id of a pool you are adding."
         )
     return pools
 
 
-EventPools = Annotated[list[PoolWrite], AfterValidator(_pool_ids_are_unique)]
-"""An event's pools **as a client sends them**: any number of them, no two sharing an
-``id``, none of them carrying a ``position`` (:class:`PoolWrite`).
+EventPools = list[PoolWrite]
+"""An event's pools **as a client creates them** (``POST …/events``): any number of
+them, none carrying an ``id`` or a ``position`` (:class:`PoolWrite`).
 
-Shared verbatim by ``TournamentEventCreate`` and ``TournamentEventUpdate``, so the
-uniqueness rule cannot drift between the two verbs — sharing the alias is what makes
-them impossible to drift apart, exactly as it is for ``EventMaxPlayers``. It is also
-what makes the *shape* impossible to drift: create and patch take the same pool, so
-there is no verb through which a ``position`` could be smuggled in.
+A bare list with no validator, where the patch shape has one: an event being born has no
+pools to cite, so there are no ids in this payload for two entries to share. The
+asymmetry is the same one :class:`TournamentTableWrite` and :data:`EditedTableCatalogue`
+already have, and it comes from the same fact — the server mints the ids.
 
-The list's **order** is the payload's one statement about pool order, and it is honoured
-on both verbs: ``app.tournament_pools`` turns it into the stored positions, so a patch
-re-orders an event's pools by simply sending them re-ordered.
+The list's **order** is the payload's one statement about pool order:
+``app.tournament_pools`` turns it into the stored positions."""
 
-An ``AfterValidator``, deliberately: it runs on the parsed ``list[PoolWrite]`` (so it
-reads ``pool.id``, not ``pool["id"]``) and it contributes **nothing** to the JSON
-schema, so the OpenAPI shape of ``pools`` is the array it always was. A rule a client
-cannot express in a schema keyword is not a reason to let the server hold a state it
-cannot survive."""
+
+EditedEventPools = Annotated[list[PoolUpsert], AfterValidator(_pool_ids_are_unique)]
+"""An event's pools **as a PATCH sends them**: the pool list in full and in order, each
+entry either citing the pool it keeps or omitting an ``id`` to add one
+(:class:`PoolUpsert`), and no two entries citing the same pool.
+
+It is the **whole** list every time, not a list of changes: what a client sends is the
+state it wants, and the verb computes the remove/keep/add from it
+(:func:`~app.tournament_pools.apply_event_pools`). That is what makes "a pool this
+payload does not mention is removed" a statement about the payload rather than about the
+order things happened to be in — and it is what the pool-set freeze judges, before
+anything is written, when the event's draw is already cut.
+
+Re-ordering the entries re-orders the event's pools, on this verb alone: the create verb
+has only one order to state, and this one can restate it.
+
+An ``AfterValidator``, deliberately: it runs on the parsed entries (so it reads
+``pool.id``, not ``pool["id"]``) and it contributes **nothing** to the JSON schema, so
+the OpenAPI shape of ``pools`` is the array it always was — the same arrangement
+:data:`EditedTableCatalogue` uses for the same reason."""
 
 
 def _table_ids_are_unique(
@@ -1226,7 +1256,7 @@ class TournamentFixtureRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
-    pool_id: str | None
+    pool_id: uuid.UUID | None
     round: int
     position: int
     entry_a_id: uuid.UUID | None
@@ -1384,7 +1414,7 @@ class PoolStandingsRead(BaseModel):
     ``pool_id`` names a pool of this same event — the id a fixture also carries — so a
     client titles the table from the pool it already holds."""
 
-    pool_id: str
+    pool_id: uuid.UUID
     rows: list[StandingRowRead]
     complete: bool
 
@@ -1950,11 +1980,12 @@ class TournamentEventCreate(BaseModel):
     slot: Slot
     match_settings: MatchSettings
     predicates: list[Predicate] = Field(default_factory=list)
-    # ``EventPools``, not ``list[PoolWrite]``: no two of an event's pools may share an
-    # ``id`` (a fixture names its pool by that string, and a duplicate id 500'd the
-    # cut). The same alias the patch schema carries, so the rule — and the write
-    # *shape*, which has no ``position`` on it — holds on both verbs. The list's ORDER
-    # is what the server reads the pool order off (``stored_pools``).
+    # ``EventPools`` — the CREATE shape (``PoolWrite``), which carries neither an ``id``
+    # nor a ``position``: both are the server's to assign, so an editor that echoes one
+    # back gets a 422 naming the field rather than a value that quietly decided nothing.
+    # The list's ORDER is what the server reads the pool order off (``stored_pools``).
+    # The patch schema takes ``EditedEventPools`` instead, whose entries may *cite* an
+    # id — the one thing a create has nothing to do.
     pools: EventPools = Field(default_factory=list)
 
     #: The arm :meth:`_parse_draw_settings` parsed, kept rather than re-derived. Set by
@@ -2033,14 +2064,15 @@ class TournamentEventUpdate(BaseModel):
     slot: Slot | None = None
     match_settings: MatchSettings | None = None
     predicates: list[Predicate] | None = None
-    # The create schema's pools, exactly: a payload that could smuggle a duplicate id in
-    # by PATCH would defeat create's boundary entirely — and it is the patch path the
-    # pool-set freeze cannot cover, since it compares SETS and ``[A, A, B]`` is the same
-    # set as ``{A, B}``. See ``_pool_ids_are_unique``. A pool's ``position`` is not on
-    # this shape either (``PoolWrite``), so an editor that echoes one back gets a 422
-    # naming the field rather than a value that quietly decided nothing; the order it
-    # sends the list in is what re-orders the pools.
-    pools: EventPools | None = None
+    # ``EditedEventPools``, not the create shape: this is the verb that can *cite* a
+    # pool, and citing is what makes the write a diff rather than a replace — a stored
+    # pool an entry names keeps its row, and therefore every fixture drawn into it.
+    # Hence the uniqueness rule lives here (``_pool_ids_are_unique``): it is the patch
+    # path the pool-set freeze cannot cover, since the freeze compares SETS and
+    # ``[A, A, B]`` is the same set as ``{A, B}``. A pool's ``position`` is not on this
+    # shape either, so an editor that echoes one back gets a 422 naming the field; the
+    # order it sends the list in is what re-orders the pools.
+    pools: EditedEventPools | None = None
 
     @field_validator(
         "name",

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -1,7 +1,6 @@
 import uuid
 from collections import Counter
-from collections.abc import Sequence
-from datetime import date, datetime
+from datetime import date, datetime, time
 from decimal import ROUND_DOWN, Decimal
 from typing import Annotated, Any, Literal
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -286,13 +285,16 @@ def _draw_settings_write(
 # ----- value-objects (typed JSONB) -----------------------------------------
 
 ValueObjectId = Annotated[str, Field(min_length=1)]
-"""The **identity** of a JSONB value-object — today, a pool.
+"""The **identity** a client authors for a pool.
 
-These ids are *string refs*, not foreign keys: a pool has no table of its own, so it is
-addressed by a client-supplied string and nothing in the database constrains it. That is
-precisely why the constraint has to be stated *here*: the empty
-string is not an identity, and it was a **representable** one — ``Pool(id="")``
-validated, and an event could be created and patched holding it.
+It is no longer the identity of a *value-object*: a pool is a row in
+``tournament_event_pools`` (ADR 20260801) and a fixture's ``pool_id`` is a real
+composite foreign key to it. What survives from the JSONB era is the id's **authorship**
+— the string is still the client's to mint, until the chore that moves pools onto
+server-minted uuids (#1226 slice 3d) deletes this alias the way the venue catalogue's
+move already deleted its own use of it. Until then the floor still has to be stated
+here: the empty string is not an identity, and it was a **representable** one —
+``Pool(id="")`` validated, and an event could be created and patched holding it.
 
 It is not a theoretical illegal state. A fixture names its pool by this string
 (ADR-0786) and the rest of the system asks two questions of that ref, which an empty id
@@ -313,8 +315,9 @@ under the field instead of in a 422.
 
 It used to cover the venue catalogue's tables as well. It does not any more: a table is
 a row with a server-minted UUID primary key (ADR 20260801), so its identity is neither a
-string nor the client's to author, and there is nothing here left to floor. Pools follow
-when they become rows, and this alias goes with them."""
+string nor the client's to author, and there is nothing here left to floor. A pool is a
+row now too, but its id is still authored by the client — the *minting* moves in a chore
+of its own, and this alias goes with it."""
 
 
 MAX_ADDRESS_COMPONENT = 255
@@ -725,22 +728,67 @@ PoolPosition = Annotated[
 """A pool's place in its event's pool order — 0-based, server-assigned, read-only.
 
 Pool order is a **fact about the event**, and until this field existed it was carried by
-two things that are both about to disappear (ADR 20260801, "Pools carry an explicit
-``position``"): the JSONB array's order, and the lexicographic sort of the client-minted
-``p-1-…``/``p-2-…`` ids. Under the random UUID primary keys the pools table will have,
-sorting by id is *arbitrary* — pools would render in a random order and the snake would
-seed against a random order, producing a draw that still cuts but seeds differently.
-Invisible to the type checker; findable only by QA. An explicit ordering column is the
-only thing that survives the id change, so it is written now, while the array order is
-still there to derive it from.
+two things that have now both gone (ADR 20260801, "Pools carry an explicit
+``position``"): the JSONB array's order, which ended when pools became rows, and the
+lexicographic sort of the client-minted ``p-1-…``/``p-2-…`` ids, which ends when those
+ids become uuids. Under a random uuid primary key, sorting by id is *arbitrary* — pools
+would render in a random order and the snake would seed against a random order,
+producing a draw that still cuts but seeds differently. Invisible to the type checker;
+findable only by QA. An explicit ordering column is the only thing that survives the id
+change, which is why it was written first, while the array order was still there to
+derive it from.
 
 It lives on :class:`Pool`, the shape a client **reads**, and deliberately not on
-:class:`PoolWrite`, the shape it **sends**. The server stamps it in :func:`stored_pools`
-— the one seam between the two — from the pool's index in the list it was sent, so an
-event's positions are ``range(len(pools))`` by construction. That is what makes "two
-pools of one event share a position" unrepresentable through the API, and it is why
-"server-assigned" is a property of the schema here rather than a claim in prose: the
-field a client cannot send is a field it cannot decide."""
+:class:`PoolWrite`, the shape it **sends**. The server stamps it in
+``app.tournament_pools`` — the one seam between the two — from the pool's index in the
+list it was sent, so an event's positions are ``range(len(pools))`` by construction.
+That is what makes "two pools of one event share a position" unrepresentable through the
+API, and it is why "server-assigned" is a property of the schema here rather than a
+claim in prose: the field a client cannot send is a field it cannot decide."""
+
+
+def _slot_is_storable(slot: Slot) -> Slot:
+    """Refuse a pool window whose strings are not the ``YYYY-MM-DD`` / ``HH:MM`` this
+    shape has always claimed to be (422).
+
+    A pool's window is three real columns now — ``slot_date DATE``, ``slot_start TIME``,
+    ``slot_end TIME`` (ADR 20260801) — where it used to be three strings inside a JSONB
+    blob that accepted literally anything. ``"next Tuesday"`` was a storable pool window
+    until this line existed; past it, it is a driver error at the INSERT, i.e. a 500 for
+    a payload the boundary waved through. A boundary that admits what the interior
+    cannot hold is not a boundary (:data:`EventMaxPlayers` is the same lesson in a
+    different key).
+
+    Seconds are refused rather than truncated. The stored value must compose back into
+    the ``HH:MM`` the wire shape promises, and a window silently read back one minute
+    from where the director set it is worse than a refusal that says what to send.
+
+    An ``AfterValidator`` on the *pool's* slot only, not on :class:`Slot` itself: the
+    event's own ``slot`` is still an untyped JSONB value-object with no columns behind
+    it, and tightening it here would be a rule about a field this chore does not move.
+    It contributes nothing to the JSON schema, so the OpenAPI shape of a pool's ``slot``
+    is the ``Slot`` it always was.
+    """
+    try:
+        date.fromisoformat(slot.date)
+        start = time.fromisoformat(slot.start)
+        end = time.fromisoformat(slot.end)
+    except ValueError as exc:
+        raise ValueError(
+            "A pool's window is a date and two times: “date” must be YYYY-MM-DD and "
+            f"“start”/“end” must be HH:MM ({exc})."
+        ) from exc
+    if any(t.second or t.microsecond for t in (start, end)):
+        raise ValueError(
+            "A pool's window is stated to the minute: “start” and “end” must be HH:MM, "
+            "with no seconds."
+        )
+    return slot
+
+
+PoolSlot = Annotated[Slot, AfterValidator(_slot_is_storable)]
+"""A pool's window — a :class:`Slot` that the pool's own ``date``/``time`` columns can
+actually hold. See :func:`_slot_is_storable`."""
 
 
 class PoolWrite(BaseModel):
@@ -774,7 +822,7 @@ class PoolWrite(BaseModel):
 
     id: ValueObjectId
     name: str = Field(min_length=1)
-    slot: Slot
+    slot: PoolSlot
     table_ids: list[str]
 
 
@@ -782,21 +830,19 @@ class Pool(PoolWrite):
     """A pool as it is **read back**: everything a client wrote, plus the ``position``
     the server stamped on it.
 
-    It is also the model every interior read of an event's ``pools`` JSONB parses
-    through — ``_ordered_pools``, ``draw_config``, ``event_pools``, the schedule
-    snapshots — so the column becomes typed values at the read boundary rather than
-    stringly-keyed dict lookups (api/CLAUDE.md — "parse, don't validate"). Deriving it
-    from :class:`PoolWrite` is what keeps the two shapes one shape plus a field: a
-    column added to the write side is readable without a second edit, and the two can
-    never disagree about what a pool *is*.
+    It is also the model every interior read of an event's pools arrives through —
+    ``_ordered_pools``, ``draw_config``, ``event_pools``, the schedule snapshots — which
+    is why moving pools from a JSONB array into ``tournament_event_pools`` rows changed
+    nothing above ``app.tournament_pools.pool_read``: the projection composes this same
+    model out of typed columns where it used to validate it out of untyped dicts.
+    Deriving it from :class:`PoolWrite` is what keeps the two shapes one shape plus a
+    field: a column added to the write side is readable without a second edit, and the
+    two can never disagree about what a pool *is*.
 
-    ``position`` defaults to ``0`` so that pools stored before the field existed stay
-    *readable* — a read boundary must not turn a history it cannot change into a
-    ``ValidationError`` (the same asymmetry :data:`AddressComponent` is about). Every
-    pool written since goes through :func:`stored_pools` and carries a real one. The
-    default is a **read** concession only; it is not a way to write one, because there
-    is no way to write one.
-    """
+    ``position`` keeps its ``0`` default even though the column is NOT NULL and every
+    row carries a real one: the default is what lets a **literal** ``Pool`` be built in
+    a test or a REPL without spelling an order out, and a read boundary that
+    hard-required it would gain nothing — the projection always supplies it."""
 
     position: PoolPosition = 0
 
@@ -827,10 +873,10 @@ def named_list(names: list[str]) -> str:
 def _pool_ids_are_unique(pools: list[PoolWrite]) -> list[PoolWrite]:
     """Refuse an event's pools when two of them claim the same ``id`` (422).
 
-    A pool id is an **identity**, and everything downstream of these value-objects is
-    built on the assumption that it identifies one pool. Nothing enforced it: pools are
-    JSONB with client-supplied string ids, there is no pools table and so no unique
-    index, and ``[A, A]`` was stored verbatim (measured: **201**). The bill arrived at
+    A pool id is an **identity**, and everything downstream is built on the assumption
+    that it identifies one pool. Nothing enforced it: pools were JSONB with
+    client-supplied string ids, there was no pools table and so no unique index, and
+    ``[A, A]`` was stored verbatim (measured: **201**). The bill arrived at
     the cut, which deals the field across the event's pool ids and writes a fixture per
     pairing — two pools with one id deal onto the same ``(event_id, pool_id, round,
     position)``, the fixture table's unique constraint fires, and the director gets a
@@ -838,6 +884,13 @@ def _pool_ids_are_unique(pools: list[PoolWrite]) -> list[PoolWrite]:
     (``uq_tournament_fixtures_event_id_pool_id_round_position``, reproduced before this
     validator existed). A boundary that admits what the interior cannot hold is not a
     boundary.
+
+    Pools are rows now (ADR 20260801), so ``id`` is a primary key and a duplicate is
+    also a thing the database would refuse — but this validator is still the enforcement
+    worth having, and not only because a 422 naming the ids beats an ``IntegrityError``:
+    the write is an id-keyed diff (``app.tournament_pools``), and ``[A, A]`` would
+    resolve *both* entries onto the one stored row, so the payload would be accepted as
+    a single-pool event rather than refused as the two-pool one it claims to be.
 
     It is a rule about the **list**, not about a ``PoolWrite``, so it is a validator on
     the list type — and it is stated **once**, on the alias both write schemas share,
@@ -877,7 +930,7 @@ what makes the *shape* impossible to drift: create and patch take the same pool,
 there is no verb through which a ``position`` could be smuggled in.
 
 The list's **order** is the payload's one statement about pool order, and it is honoured
-on both verbs: :func:`stored_pools` turns it into the stored positions, so a patch
+on both verbs: ``app.tournament_pools`` turns it into the stored positions, so a patch
 re-orders an event's pools by simply sending them re-ordered.
 
 An ``AfterValidator``, deliberately: it runs on the parsed ``list[PoolWrite]`` (so it
@@ -941,40 +994,10 @@ so the OpenAPI shape of ``table_catalogue`` stays the array it always was — th
 arrangement :data:`EventPools` uses for the same reason."""
 
 
-def stored_pools(pools: Sequence[PoolWrite]) -> list[dict[str, Any]]:
-    """The rows an event's ``pools`` JSONB column holds, composed from the pools a
-    client sent — each stamped with the ``position`` of its index in that list.
-
-    This is the seam between the two pool shapes, and **the only place a ``position`` is
-    ever assigned**. The pool order an event has is the order its pools arrived in —
-    that is what the director dragged into place, and it is what every ordered read has
-    always meant — so here is where that fact stops being the array's order and becomes
-    a stored value (ADR 20260801, "Pools carry an explicit ``position``"), before the
-    array order and the lexicographic sort of client-minted ids both stop existing.
-
-    Stamping *from the index* is what makes two pools of one event unable to share a
-    position: what is written is ``range(len(pools))``, by construction. There is no
-    pools table yet and so no ``UNIQUE (event_id, position)`` underneath to catch a
-    duplicate — that constraint arrives with the table — which is exactly why the value
-    must not be assembled from anything a caller could repeat, or send.
-
-    Called by **both** write verbs (``create_event`` and ``update_event``), for the
-    reason ``_pool_ids_are_unique`` lives on the shared alias: "the patch path is the
-    hole" is the same bug wearing a different verb, and an event born with positions and
-    then patched without them would be an event whose order silently reverted to
-    whatever its ids sorted as. That is why this is a function over the *list* rather
-    than a per-pool conversion — an index only exists relative to the whole list, and a
-    caller holding one pool has nothing to stamp it with.
-
-    Returns plain ``dict``s because the column is plain JSONB, but composes them through
-    :class:`Pool` rather than by hand: what is written is by construction something the
-    read boundary (``Pool.model_validate``, in ``event_pools`` / ``draw_config`` /
-    ``_ordered_pools``) can parse back.
-    """
-    return [
-        Pool(**pool.model_dump(), position=index).model_dump()
-        for index, pool in enumerate(pools)
-    ]
+# The composition of the pools an event stores lives in ``app.tournament_pools`` now,
+# not here. It used to be ``stored_pools``, a list of JSONB dicts, because the column
+# was JSONB; a pool is a row (ADR 20260801), so what a write verb composes is
+# ``TournamentEventPool`` rows — a model, which a schema module must not import.
 
 
 # ----- read models ----------------------------------------------------------
@@ -1163,8 +1186,9 @@ class TournamentFixtureRead(BaseModel):
       live, not a copy frozen at go-live.
     * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
       un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
-      set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
-      JSONB, not a foreign key, because pools are value-objects with no table.
+      set, it names a pool of **this same event**, and it is guaranteed to: the column
+      is half of a composite foreign key onto ``tournament_event_pools (event_id, id)``,
+      so it is neither a dangling ref nor another event's pool (ADR 20260801).
     * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means
       **unassigned to a table**. When set, it names a ``TournamentTable`` in the
       tournament's ``table_catalogue``, and it is guaranteed to: the column is a real
@@ -1357,9 +1381,8 @@ class PoolStandingsRead(BaseModel):
     """One pool's standings: its rows in finishing order, and whether every one of its
     fixtures has been decided.
 
-    ``pool_id`` names a ``Pool`` in this same event's ``pools`` — the string ref a
-    fixture also carries — so a client titles the table from the pool it already
-    holds."""
+    ``pool_id`` names a pool of this same event — the id a fixture also carries — so a
+    client titles the table from the pool it already holds."""
 
     pool_id: str
     rows: list[StandingRowRead]

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -56,6 +56,7 @@ from app.models import (
     TournamentFixture,
 )
 from app.schemas.tournament import Pool
+from app.tournament_pools import pool_read
 
 
 async def active_draw_entrants(db: AsyncSession, event_id: uuid.UUID) -> list[Entrant]:
@@ -96,9 +97,9 @@ def pool_order(event: TournamentEvent) -> dict[PoolId, int]:
     """Each of this event's pool ids mapped to its **0-based place in the event's pool
     order** — the lookup :func:`fixture_state` resolves a fixture's ``pool_id`` through.
 
-    Computed once per event rather than per fixture: a fixture carries a string ref into
-    the event's ``pools`` JSONB, not an index, so somebody has to do the join and a
-    200-fixture round-robin should not re-parse the pools 200 times.
+    Computed once per event rather than per fixture: a fixture carries its pool's *id*,
+    not its index, so somebody has to do the join and a 200-fixture round-robin should
+    not project the pools 200 times.
 
     The rank is the pool's index *after* sorting on ``Pool.position`` (ADR 20260801),
     not the stored ``position`` read straight off: it is then the same sequence
@@ -110,21 +111,20 @@ def pool_order(event: TournamentEvent) -> dict[PoolId, int]:
 
 
 def _ordered_pools(event: TournamentEvent) -> list[Pool]:
-    """This event's pools, parsed, in the director's order — ascending ``position``.
+    """This event's pools, projected, in the director's order — ascending ``position``.
 
     One definition of "the event's pool order", shared by :func:`draw_config` (which
     seeds the snake against it) and :func:`pool_order` (which the read of a persisted
     fixture resolves through), so a draw is cut in the same order it is advanced in.
 
-    Parsed through :class:`Pool` rather than indexed as ``p["position"]`` on an untyped
-    JSONB dict (api/CLAUDE.md — "parse, don't validate"), which is also where a pool
-    stored before ``position`` existed picks up its ``0`` default. ``sorted`` is stable,
-    so a whole event of those keeps the array order it has always had.
+    The ``sorted`` is belt-and-braces rather than the mechanism: the ``pools``
+    relationship carries ``order_by=TournamentEventPool.position``, so the rows arrive
+    in this order already, and ``UNIQUE (event_id, position)`` makes it a total one. It
+    is kept because this function is *the* statement of what "the event's pool order"
+    means, and a caller who builds a ``TournamentEvent`` in memory (a test, a REPL)
+    never went through that ``ORDER BY``.
     """
-    return sorted(
-        (Pool.model_validate(pool) for pool in event.pools),
-        key=lambda pool: pool.position,
-    )
+    return sorted(event_pools(event), key=lambda pool: pool.position)
 
 
 def fixture_state(
@@ -234,11 +234,10 @@ def draw_config(event: TournamentEvent) -> DrawConfig:
     a second place to learn a fact it had already acted on — one that no strategy read,
     and that a future one could read and be lied to by. See :class:`DrawConfig`.
 
-    The pools are *parsed*, not indexed: ``TournamentEvent.pools`` is JSONB, and
-    ``p["id"]`` on an untyped dict is a ``KeyError`` waiting for the one malformed row
-    (api/CLAUDE.md — "parse, don't validate"). ``Pool`` is the same model the write
-    boundary validated them with, so a pool that could be *stored* can be read here —
-    and its ``min_length=1`` id is why a ``PoolId`` reaching the domain is never ``""``.
+    The pools arrive as typed :class:`Pool` values, never as raw rows or dicts
+    (:func:`app.tournament_pools.pool_read`) — the same model the write boundary
+    validated them with, whose ``min_length=1`` id is why a ``PoolId`` reaching the
+    domain is never ``""``.
 
     Every configured pool is passed, whatever the draw type. An un-pooled strategy
     (single-elim, #785) ignores them and writes ``NULL`` pool refs; a pooled one deals
@@ -281,12 +280,12 @@ def strategy_for_event(event: TournamentEvent) -> DrawStrategy:
 async def event_has_draw(db: AsyncSession, event_id: uuid.UUID) -> bool:
     """Whether this event has a draw at all — whether the cut has happened.
 
-    The question the **pool-set freeze** turns on (ADR-0786). A fixture's ``pool_id`` is
-    a string ref into the event's own ``pools`` JSONB and *not* a foreign key — there is
-    no pools table for it to point at — so nothing in the database stops a ``PATCH``
-    from replacing the pools out from under a cut draw and leaving every fixture in the
-    event referring to a pool that no longer exists. "Integrity is procedural, not
-    schematic": this is the read that procedure is built on.
+    The question the **pool-set freeze** turns on (ADR-0786). Nothing in the database
+    stops a ``PATCH`` from *adding* a pool to an event whose draw was dealt across the
+    pools it had at the cut — the removal half is a foreign-key violation now
+    (ADR 20260801), but an empty new pool breaks no constraint, and the removal's
+    violation is a deferred 500 rather than something a director can act on. This is the
+    read both halves of that refusal are built on.
 
     Deliberately **not** ``draw_has_play``. Play is the gate on *destroying* a draw
     (re-cutting, un-cutting); the mere *existence* of one is the gate on moving the
@@ -310,13 +309,13 @@ async def event_has_draw(db: AsyncSession, event_id: uuid.UUID) -> bool:
 
 
 def event_pools(event: TournamentEvent) -> list[Pool]:
-    """The pools this event *currently* has, parsed — the ones the freeze protects.
+    """The pools this event *currently* has, projected — the ones the freeze protects.
 
-    Parsed through :class:`Pool`, exactly as ``draw_config`` parses them, rather than
-    indexed as ``p["id"]`` on an untyped JSONB dict (api/CLAUDE.md — "parse, don't
-    validate"). It is the same model the write boundary validated these rows with, so
-    a pool that could be *stored* can be read back here; a malformed one fails loudly
-    at the boundary instead of raising a ``KeyError`` somewhere downstream.
+    Every reader of an event's pools comes through here (or through
+    :func:`_ordered_pools`, which is this plus the order), which is why moving pools out
+    of a JSONB column and into ``tournament_event_pools`` rows was invisible above this
+    line: :func:`app.tournament_pools.pool_read` composes the same :class:`Pool` out of
+    typed columns that this used to validate out of untyped dicts.
 
     Returns the **pools**, not just their ids, though identity is all the freeze
     compares: a refusal has to *name* the pools it is about (``named_list``), and a
@@ -329,7 +328,7 @@ def event_pools(event: TournamentEvent) -> list[Pool]:
     the ORDER of the list (read only at the cut, where it seeds the snake) — is free to
     change under a standing draw.
     """
-    return [Pool.model_validate(pool) for pool in event.pools]
+    return [pool_read(pool) for pool in event.pools]
 
 
 async def draw_has_play(db: AsyncSession, event_id: uuid.UUID) -> bool:

--- a/api/app/tournament_errors.py
+++ b/api/app/tournament_errors.py
@@ -229,6 +229,35 @@ class PoolSetFrozenError(Exception):
         self.added = added
 
 
+class PoolNotInEventError(Exception):
+    """Raised by the update-event verb when an entry of a submitted ``pools`` list cites
+    an ``id`` that names no pool of **this** event (ADR 20260801).
+
+    The exact twin of :class:`TableNotInCatalogueError`, one resource over. It could not
+    exist while a pool id was the client's to author — an id the server had never seen
+    still named the pool the client meant, so a new id was an *addition*. The id is a
+    server-minted uuid now, so one the server did not mint names nothing, and minting a
+    fresh pool for it would hand the client back a different id than it asked for while
+    quietly *removing* the pool it meant to keep: the two failures a diff must never
+    confuse.
+
+    It is judged **after** the pool-set freeze, so an event whose draw is cut answers
+    the 409 that names its pools rather than this 422 — the freeze is the refusal a
+    director
+    can act on, and a cited-but-unknown id is an addition as far as a standing draw is
+    concerned.
+
+    Carries the ``index`` of the offending entry as well as the id, because the pools
+    are a list and a refusal a client cannot attribute to a row is a refusal it cannot
+    render: the HTTP adapter names ``loc: ["body", "pools", index, "id"]``, the same
+    shape the schema's own 422s on this field have. Never an ``HTTPException``."""
+
+    def __init__(self, index: int, pool_id: str) -> None:
+        super().__init__("This event has no pool with that id.")
+        self.index = index
+        self.pool_id = pool_id
+
+
 class TableNotInCatalogueError(Exception):
     """Raised by the edit verb when an entry of a submitted ``table_catalogue`` cites an
     ``id`` that names no table of **this** tournament's catalogue (ADR 20260801).

--- a/api/app/tournament_events.py
+++ b/api/app/tournament_events.py
@@ -140,7 +140,7 @@ async def create_event(
         # relationship. ``stored_pools`` composes them — turning the WRITE shape, which
         # carries no ``position``, into rows that do, from each pool's index in the list
         # this payload sent.
-        pools=stored_pools(payload.pools),
+        pools=stored_pools(tournament, payload.pools),
     )
     db.add(event)
     await db.commit()
@@ -586,7 +586,7 @@ async def update_event(
     for key, value in changes.items():
         setattr(event, key, value)
     if updates.pools is not None:
-        apply_event_pools(event, updates.pools)
+        apply_event_pools(tournament, event, updates.pools)
     if draw_settings is not None:
         # The one place an event's draw configuration moves after create (the freeze
         # above has already refused this on a cut draw). Assigned through the settings

--- a/api/app/tournament_events.py
+++ b/api/app/tournament_events.py
@@ -192,14 +192,17 @@ def _pool_set_frozen_detail(removed: list[str], added: list[str]) -> str:
     has — composed exactly as the router's ``_pool_set_refusal`` used to compose it
     inline, so :class:`PoolSetFrozenError` carries the byte-identical body.
 
-    Both halves are named, because a re-**id**'d pool is exactly one removal plus one
-    addition and the director has to be told which of their pools went missing: a
-    **removed** pool leaves its fixtures pointing at a pool that no longer exists (the
-    dangling ref no foreign key is there to catch, ADR-0786), and an **added** pool
+    Both halves are named, because a payload can move both at once and the director has
+    to be told which of their pools went missing: a **removed** pool leaves its fixtures
+    pointing at a pool that no longer exists (which the composite foreign key would
+    refuse too, but only at COMMIT and only as a driver error), and an **added** pool
     arrives with **no fixtures**, because the draw was dealt across the pools the event
     had at the cut. The sentence ends with the way out (remove the draw, change the
     pools, cut again) and with what is still allowed, so a director who has to move a
     broken table is never left with nowhere to go.
+
+    It no longer offers "re-identify" as a third thing to do: a pool id is minted by the
+    server (ADR 20260801), so re-identifying one is not a payload a client can send.
     """
     clauses = []
     if removed:
@@ -216,8 +219,7 @@ def _pool_set_frozen_detail(removed: list[str], added: list[str]) -> str:
         "This event's draw is already cut, so its set of pools is frozen: "
         + "; and ".join(clauses)
         + ". A pool's tables, its time and its name can all still be changed. "
-        "To add, remove or re-identify a pool, remove the draw first, then cut it "
-        "again."
+        "To add or remove a pool, remove the draw first, then cut it again."
     )
 
 
@@ -276,19 +278,27 @@ async def _enforce_pool_set_frozen(
     """Raise :class:`PoolSetFrozenError` once a ``pools`` payload would change *which
     pools* an event with a cut draw has (ADR-0786).
 
-    Remove a pool (or change its ``id``, which is a removal with an addition standing
-    where it was) and every fixture drawn into it refers to nothing; add one and it
+    Remove a pool and every fixture drawn into it refers to nothing; add one and it
     arrives with no fixtures, because the draw was dealt across the pools that existed
     at the cut.
 
-    Pools are rows now and a fixture's ``pool_id`` is a real (composite) foreign key
-    onto them, so the *dangling* half of that is no longer a state the database will
-    hold — but this guard is not thereby redundant, in either direction. The database
-    refuses the removal with a deferred constraint violation at COMMIT: a 500 the
-    director cannot act on, where this is a 409 naming the pools and the way out. And
-    the **addition** half breaks no constraint at all: a pool arriving into a cut draw
-    with no fixtures in it is perfectly legal SQL and still an incoherent draw. So the
-    two lines of defence answer two different questions, and this one is asked first.
+    **What this guard is left saying, now that the ids are minted.** Three categories
+    used to reach it; only two still can, and neither is one a foreign key could answer.
+
+    * **Re-identifying** a pool — the case that used to be a removal and an addition at
+      once, and the loudest reason this guard was written — is **no longer
+      expressible**.
+      A pool id is a server-minted uuid, so a client cannot author one; it either cites
+      an id the event has (which keeps that row) or omits one (which adds a pool). That
+      whole category left with the minting, not with this function.
+    * **Removing** a pool: the composite foreign key does refuse it, but *deferred*, at
+      COMMIT, as an ``IntegrityError`` — a 500 the director cannot act on, where this is
+      a 409 naming the pools and the way out. So the ordering matters and is deliberate:
+      this runs before anything is written, and the constraint underneath is the
+      backstop for every path that does not come through this verb.
+    * **Adding** a pool: no constraint says anything at all. A pool arriving into a cut
+      draw with no fixtures in it is perfectly legal SQL and still an incoherent draw,
+      so this is the only thing standing between a director and one.
 
     What is frozen is the **id set**, and only the id set. A pool's ``table_ids``, its
     ``slot`` and its ``name`` stay editable with a draw standing, on purpose — this is
@@ -296,8 +306,10 @@ async def _enforce_pool_set_frozen(
 
     Asked **before** anything is written (and, like every judge-then-write guard, under
     the tournament's row lock the verb holds), so a refusal leaves both the pools and
-    the fixtures exactly as they were — never written, not merely rolled back. With
-    **no draw cut** this is a no-op and ``pools`` replaces wholesale, as it always has.
+    the fixtures exactly as they were — never written, not merely rolled back. It is
+    also asked before :func:`~app.tournament_pools.apply_event_pools`'s own 422 for an
+    id this event does not have, so a cut event answers the 409 that names its pools.
+    With **no draw cut** this is a no-op and the diff applies as it always has.
     """
     # An absent ``pools`` key is the only way this is ``None`` — an explicit ``null`` is
     # a 422 at the schema (the column is NOT NULL) — so "not sent" is the whole meaning
@@ -309,19 +321,28 @@ async def _enforce_pool_set_frozen(
     # orphanable as a played one.
     if not await event_has_draw(db, event.id):
         return
-    # Parsed ONCE, and kept: the id set decides *whether* to refuse, and the pools
-    # themselves say *which* — a refusal names them (``named_list``), and re-parsing the
-    # JSONB to recover the names would be the same validation run twice per pool.
+    # Projected ONCE, and kept: the id set decides *whether* to refuse, and the pools
+    # themselves say *which* — a refusal names them (``named_list``), and re-projecting
+    # the rows to recover the names would be the same work run twice per pool.
     current = event_pools(event)
     existing = {PoolId(pool.id) for pool in current}
-    incoming = {PoolId(pool.id) for pool in updates.pools}
-    if existing == incoming:
+    # An entry with no ``id`` is an addition and contributes nothing to the incoming
+    # SET — which is what makes ``existing == incoming`` "you cited exactly the pools
+    # you have" rather than "you sent the same number of them".
+    incoming = {PoolId(pool.id) for pool in updates.pools if pool.id is not None}
+    if existing == incoming and len(updates.pools) == len(incoming):
         return
     # Named by their names, from whichever side of the change still knows them: a pool
     # being removed is only described by the row we hold, and one being added only by
-    # the payload.
+    # the payload. An entry citing an id this event does not have counts as an addition
+    # here — it is one in effect, and past this guard it is the 422
+    # ``apply_event_pools`` raises.
     removed = [pool.name for pool in current if PoolId(pool.id) not in incoming]
-    added = [pool.name for pool in updates.pools if pool.id not in existing]
+    added = [
+        pool.name
+        for pool in updates.pools
+        if pool.id is None or PoolId(pool.id) not in existing
+    ]
     raise PoolSetFrozenError(
         _pool_set_frozen_detail(removed, added), removed=removed, added=added
     )
@@ -392,7 +413,7 @@ async def _enforce_draw_settings_frozen(
 
 def _event_scheduling_facts(
     event: TournamentEvent,
-) -> tuple[tuple[tuple[str, Slot, tuple[str, ...]], ...], int, str]:
+) -> tuple[tuple[tuple[uuid.UUID, Slot, tuple[str, ...]], ...], int, str]:
     """The slice of an event the schedule solver actually reads (ADR "the schedule is
     solved; the call is pinned"), in a comparable shape — what the update verb compares
     before/after its write to decide whether a re-solve is owed.
@@ -607,6 +628,14 @@ async def update_event(
         await _reanchor_placements_for_timezone_change(
             db, event.id, old_timezone=old_timezone, new_timezone=event.timezone
         )
+    # Flushed before the facts are re-read, because one of them is a pool's ``id`` and a
+    # pool this payload ADDED does not have one until the INSERT runs: the id is the
+    # database's (``gen_random_uuid()``), not the client's, so an unflushed row would
+    # project as ``id=None`` and the read boundary (``Pool``) would refuse it. Flushing
+    # is safe here for the same reason the diff is: both position constraints and the
+    # fixture's composite foreign key are DEFERRABLE INITIALLY DEFERRED, so an
+    # intermediate state is nobody's business until COMMIT.
+    await db.flush()
     if facts_before != _event_scheduling_facts(event) and await event_has_draw(
         db, event.id
     ):

--- a/api/app/tournament_events.py
+++ b/api/app/tournament_events.py
@@ -42,7 +42,6 @@ from app.schemas.tournament import (
     TournamentEventCreate,
     TournamentEventUpdate,
     named_list,
-    stored_pools,
 )
 from app.tournament_draws import event_has_draw, event_pools
 from app.tournament_edit import _load_owned_tournament_for_update
@@ -51,6 +50,7 @@ from app.tournament_errors import (
     EventNotFoundError,
     PoolSetFrozenError,
 )
+from app.tournament_pools import apply_event_pools, stored_pools
 
 
 async def _load_event(
@@ -99,8 +99,9 @@ async def create_event(
 
     Then it writes the event exactly as the HTTP handler did inline — the nested
     value-objects (``slot``, ``match_settings``, ``predicates``) persist as plain JSONB
-    via ``model_dump``, and ``pools`` through :func:`stored_pools`, which is the same
-    dump plus the server-assigned ``position`` the write shape has no field for. Commits
+    via ``model_dump``, and the ``pools`` as child **rows** through
+    :func:`app.tournament_pools.stored_pools`, which composes them and stamps the
+    server-assigned ``position`` the write shape has no field for. Commits
     and refreshes before returning. Never raises ``HTTPException`` — the caller adapts
     each domain exception to its transport and shapes the read (a just-created event has
     no entrants, draw or results, so those are all empty without a query).
@@ -134,11 +135,11 @@ async def create_event(
         slot=payload.slot.model_dump(),
         match_settings=payload.match_settings.model_dump(),
         predicates=[p.model_dump() for p in payload.predicates],
-        # The one nested value-object that is not a straight ``model_dump``: what the
-        # client sent is the WRITE shape, which carries no ``position``, and the column
-        # holds the stored shape, which does. ``stored_pools`` is that conversion, and
-        # the only place a position is assigned — from each pool's index in the list
-        # this payload sent (ADR 20260801, "Pools carry an explicit ``position``").
+        # The one thing here that is not a column at all: the event's pools are ROWS
+        # (ADR 20260801), created with the event and flushed after it by the
+        # relationship. ``stored_pools`` composes them — turning the WRITE shape, which
+        # carries no ``position``, into rows that do, from each pool's index in the list
+        # this payload sent.
         pools=stored_pools(payload.pools),
     )
     db.add(event)
@@ -275,13 +276,19 @@ async def _enforce_pool_set_frozen(
     """Raise :class:`PoolSetFrozenError` once a ``pools`` payload would change *which
     pools* an event with a cut draw has (ADR-0786).
 
-    A fixture names its pool by a **string ref** into this same event's ``pools`` JSONB,
-    and there is no pools table for it to foreign-key. So the database cannot refuse the
-    edit that orphans it, and the integrity of that reference is procedural — it is this
-    function, and nothing else. Remove a pool (or change its ``id``, which is a removal
-    with an addition standing where it was) and every fixture drawn into it refers to
-    nothing; add one and it arrives with no fixtures, because the draw was dealt across
-    the pools that existed at the cut.
+    Remove a pool (or change its ``id``, which is a removal with an addition standing
+    where it was) and every fixture drawn into it refers to nothing; add one and it
+    arrives with no fixtures, because the draw was dealt across the pools that existed
+    at the cut.
+
+    Pools are rows now and a fixture's ``pool_id`` is a real (composite) foreign key
+    onto them, so the *dangling* half of that is no longer a state the database will
+    hold — but this guard is not thereby redundant, in either direction. The database
+    refuses the removal with a deferred constraint violation at COMMIT: a 500 the
+    director cannot act on, where this is a 409 naming the pools and the way out. And
+    the **addition** half breaks no constraint at all: a pool arriving into a cut draw
+    with no fixtures in it is perfectly legal SQL and still an incoherent draw. So the
+    two lines of defence answer two different questions, and this one is asked first.
 
     What is frozen is the **id set**, and only the id set. A pool's ``table_ids``, its
     ``slot`` and its ``name`` stay editable with a draw standing, on purpose — this is
@@ -503,9 +510,10 @@ async def update_event(
 
     Then the partial apply (``model_dump(exclude_unset=True)`` serializes the nested
     value-objects to plain dicts/lists, so one ``setattr`` loop covers the JSONB and
-    scalar columns alike — with ``pools`` recomposed through :func:`stored_pools` first,
-    since the write shape carries no ``position`` and the column does), with three side
-    effects — the first new, the other two preserved exactly from the router:
+    scalar columns alike — with ``pools`` taken out of it and applied as an id-keyed
+    diff over the event's pool **rows**,
+    :func:`app.tournament_pools.apply_event_pools`), with three side effects — the first
+    new, the other two preserved exactly from the router:
 
     * a **draw-configuration** edit (the draw type and, for ``rr-then-ko``, its
       qualifier count) is applied to the event's ``draw_settings`` row, the only place
@@ -557,24 +565,28 @@ async def update_event(
     # them leaves the loop below touching mapped columns only.
     changes.pop("draw_type", None)
     changes.pop("qualifiers_per_pool", None)
-    if updates.pools is not None:
-        # Recomposed rather than dumped, and on this verb as much as on create: the
-        # dump above is of the WRITE shape, which has no ``position``, so leaving it
-        # alone would store a pool set with no order at all — an event born positioned
-        # and then patched flat, which is the "the patch path is the hole" bug this
-        # repo keeps rediscovering. ``stored_pools`` stamps the order the patch sent,
-        # which is also how a director re-orders pools: send them re-ordered.
-        #
-        # ``is not None`` is exactly "the key was sent": an explicit ``null`` is already
-        # a 422 (``TournamentEventUpdate._reject_explicit_null``), so this cannot be
-        # mistaking a clear for an absence.
-        changes["pools"] = stored_pools(updates.pools)
+    # Pools are rows, so they are taken OUT of the generic setattr loop entirely and
+    # applied as a diff (:func:`app.tournament_pools.apply_event_pools`) — assigning the
+    # dumped payload would put dicts where the relationship expects
+    # ``TournamentEventPool``s, and a wholesale replace would delete and recreate the
+    # very rows this event's fixtures foreign-key. The diff also stamps the order the
+    # patch sent, on this verb as much as on create: an event born positioned and then
+    # patched flat is the "the patch path is the hole" bug this repo keeps
+    # rediscovering.
+    #
+    # ``is not None`` is exactly "the key was sent": an explicit ``null`` is already a
+    # 422 (``TournamentEventUpdate._reject_explicit_null``), so this cannot be mistaking
+    # a clear for an absence. The applying happens after the loop below, with the other
+    # writes, so a payload that touches nothing else still reaches it.
+    changes.pop("pools", None)
     # The parsed union arm, not the loose keys: it is ``None`` exactly when the patch
     # does not touch the draw configuration, and when it is not, the pair it carries is
     # one the settings table's ``CHECK`` accepts (ADR 20260727).
     draw_settings = updates.draw_settings
     for key, value in changes.items():
         setattr(event, key, value)
+    if updates.pools is not None:
+        apply_event_pools(event, updates.pools)
     if draw_settings is not None:
         # The one place an event's draw configuration moves after create (the freeze
         # above has already refused this on a cut draw). Assigned through the settings

--- a/api/app/tournament_pools.py
+++ b/api/app/tournament_pools.py
@@ -1,0 +1,176 @@
+"""The one place an event's pools are written, and the seam their wire shape crosses.
+
+A pool is a row now (ADR 20260801, "a pool belongs to its event, not to the event's draw
+settings"), not an element of ``tournament_events.pools`` JSONB. So the two event write
+verbs — ``create_event`` and ``update_event`` — no longer assign a column; they compose
+:class:`~app.models.tournament_event_pool.TournamentEventPool` rows, and they do it
+through this module rather than each spelling it out, for the reason
+``app.tournament_tables`` exists for the venue catalogue: the shape a pool is stored in
+must not depend on which verb happened to store it.
+
+Two things live here and nowhere else.
+
+**The position.** :func:`stored_pools` and :func:`apply_event_pools` stamp each pool
+with its index in the list the client sent — the only place a ``position`` is ever
+assigned, which is what makes an event's stored positions ``range(len(pools))`` by
+construction (and what the ``UNIQUE (event_id, position)`` underneath now also insists
+on).
+
+**The Slot⇄columns conversion.** A pool's window is three wall-clock columns
+(``slot_date``, ``slot_start``, ``slot_end``) and one wire value-object
+(:class:`~app.schemas.tournament.Slot`, ``YYYY-MM-DD`` + ``HH:MM``). The strings are
+parsed on the way in and composed on the way out, here, so no reader of a pool holds an
+unparsed date and no writer invents a second spelling of one.
+
+The edit path is an **id-keyed diff** and not a wholesale replace, which is a change of
+mechanism and not of meaning: the pool set an event may end up with is exactly what it
+was (the freeze in ``app.tournament_events`` decides that), but a JSONB column could be
+reassigned and rows cannot — re-sending a pool the event already has must UPDATE that
+row, or the write would try to insert a duplicate primary key and, worse, would delete
+and recreate the row every fixture in the event points at.
+
+It imports the models, the schemas and nothing else — no session, no router, no FastAPI
+— so it stays callable from a REPL and cycle-free."""
+
+from collections.abc import Sequence
+from datetime import date, time
+
+from app.models import TournamentEvent, TournamentEventPool
+from app.schemas.tournament import Pool, PoolWrite, Slot
+
+__all__ = ["apply_event_pools", "pool_read", "stored_pools"]
+
+
+def _slot_columns(slot: Slot) -> tuple[date, time, time]:
+    """The three stored columns one wire :class:`Slot` becomes.
+
+    ``fromisoformat`` and not a hand-rolled ``strptime``: it is the parser the rest of
+    this codebase already reads dates with (``app.schedule_preview_solve``), and the
+    boundary has already refused anything it would choke on
+    (:data:`~app.schemas.tournament.PoolSlot`) — so this is a total function of what can
+    reach it, not a parse that needs a failure branch.
+    """
+    return (
+        date.fromisoformat(slot.date),
+        time.fromisoformat(slot.start),
+        time.fromisoformat(slot.end),
+    )
+
+
+def _slot_read(pool: TournamentEventPool) -> Slot:
+    """The wire :class:`Slot` a stored pool's three columns compose back into.
+
+    ``%H:%M`` exactly, with no seconds, because that is the shape the boundary accepts
+    and therefore the only shape a stored value can have had (:data:`PoolSlot` refuses a
+    time carrying seconds rather than storing one it would later have to truncate). The
+    round trip is lossless: what a client sends is what it reads back, character for
+    character.
+    """
+    return Slot(
+        date=pool.slot_date.isoformat(),
+        start=pool.slot_start.strftime("%H:%M"),
+        end=pool.slot_end.strftime("%H:%M"),
+    )
+
+
+def pool_read(pool: TournamentEventPool) -> Pool:
+    """One stored pool as the shape everything above the database reads
+    (:class:`~app.schemas.tournament.Pool`).
+
+    The read boundary, and the reason the row/JSONB change is invisible above it: every
+    consumer — the serializer, ``draw_config``, the solver's input load, the schedule
+    preview, the call copy, the dashboard panel — went through ``Pool``, and still does.
+    They used to get there by validating an untyped JSONB dict; they get there by
+    projecting typed columns now, which is the same "parse, don't validate" contract
+    with the parsing already done by Postgres.
+    """
+    return Pool(
+        id=pool.id,
+        name=pool.name,
+        slot=_slot_read(pool),
+        table_ids=list(pool.table_ids),
+        position=pool.position,
+    )
+
+
+def stored_pools(submitted: Sequence[PoolWrite]) -> list[TournamentEventPool]:
+    """Fresh :class:`TournamentEventPool` rows for an event that has none yet — the
+    create verb's whole job.
+
+    Each row is stamped with the ``position`` of its index in ``submitted``: the only
+    place a position is assigned on the create path, and what makes the stored positions
+    ``range(len(submitted))`` by construction rather than by a caller's care.
+
+    The ``id`` is the client's, for now — the pool-set freeze and the fixtures both name
+    a pool by that string — unlike a venue table's, which the database mints. The chore
+    that moves pools onto server-minted uuids (#1226 slice 3d) is the one that changes
+    it, together with the column type and ``PoolId``.
+    """
+    return [_new_pool(pool, position) for position, pool in enumerate(submitted)]
+
+
+def _new_pool(submitted: PoolWrite, position: int) -> TournamentEventPool:
+    """One brand-new pool row, at ``position``, from the pool a client sent."""
+    slot_date, slot_start, slot_end = _slot_columns(submitted.slot)
+    return TournamentEventPool(
+        id=submitted.id,
+        name=submitted.name,
+        position=position,
+        slot_date=slot_date,
+        slot_start=slot_start,
+        slot_end=slot_end,
+        table_ids=list(submitted.table_ids),
+    )
+
+
+def apply_event_pools(event: TournamentEvent, submitted: Sequence[PoolWrite]) -> None:
+    """Make ``event``'s pools equal ``submitted``, as an **id-keyed diff**.
+
+    A pool whose ``id`` the event already has keeps its row — re-named, re-timed,
+    re-tabled and re-positioned as this payload says — and one whose id is new is added.
+    A stored pool no entry names is **removed**, by leaving it out of the reassigned
+    collection, which ``delete-orphan`` turns into a ``DELETE``.
+
+    **Keying on the id is not an optimization, it is the only correct mechanism.** A
+    fixture holds its pool's id (and, since ADR 20260801, holds it as a foreign key), so
+    a delete-and-recreate of the row a standing draw points at would take the draw with
+    it or be refused outright. The JSONB column this replaces could be reassigned
+    wholesale precisely because nothing pointed into it.
+
+    What may change is decided **before** this runs, not here:
+    ``_enforce_pool_set_frozen`` (``app.tournament_events``) refuses a payload that
+    would add or remove a pool of an event whose draw is cut. With no draw, any diff is
+    legal — which is why this function has no refusal of its own, and why a new id is an
+    addition rather than the 422 the venue catalogue's diff answers an unknown table id
+    with (a table id is the server's to mint, so an id it did not mint names nothing; a
+    pool id is still the client's).
+
+    Reassigning the whole collection is what expresses all three operations at once, in
+    the payload's order — the same gesture ``apply_table_catalogue`` makes, and the
+    reason both tables carry a DEFERRABLE ``UNIQUE (…, position)``: a reorder moves a
+    row onto a position its neighbour has not vacated yet.
+    """
+    stored = {pool.id: pool for pool in event.pools}
+    event.pools = [
+        _pool_for(stored, entry, position) for position, entry in enumerate(submitted)
+    ]
+
+
+def _pool_for(
+    stored: dict[str, TournamentEventPool], entry: PoolWrite, position: int
+) -> TournamentEventPool:
+    """The row one submitted pool resolves to: the event's own pool of that id, updated
+    in place, or a brand-new one.
+
+    ``position`` is the entry's index in the submitted list and is assigned on both
+    arms, so a patch that re-orders the pools re-orders them (and one that re-sends them
+    unchanged writes the positions they already had).
+    """
+    row = stored.get(entry.id)
+    if row is None:
+        return _new_pool(entry, position)
+    row.name = entry.name
+    row.position = position
+    row.slot_date, row.slot_start, row.slot_end = _slot_columns(entry.slot)
+    row.table_ids = list(entry.table_ids)
+    return row

--- a/api/app/tournament_pools.py
+++ b/api/app/tournament_pools.py
@@ -22,6 +22,16 @@ on).
 parsed on the way in and composed on the way out, here, so no reader of a pool holds an
 unparsed date and no writer invents a second spelling of one.
 
+**The reservations.** A pool's ``table_ids`` are rows too now
+(:class:`~app.models.tournament_event_pool_table.TournamentEventPoolTable`, ADR 20260801
+"the tournament-scoping stops at the join table"), and the wire array is composed from
+them in ``position`` order — so the row/JSONB change is invisible above this module on
+that side as well. :func:`_reservations` is where the array becomes rows, and it is the
+one place a reservation's ``tournament_id`` is written, which is why both write verbs
+now take the parent tournament: the denormalized column is what the composite foreign
+keys underneath compare, and a reservation composed without it is not a row Postgres
+will accept.
+
 The edit path is an **id-keyed diff** and not a wholesale replace, which is a change of
 mechanism and not of meaning: the pool set an event may end up with is exactly what it
 was (the freeze in ``app.tournament_events`` decides that), but a JSONB column could be
@@ -35,7 +45,12 @@ It imports the models, the schemas and nothing else — no session, no router, n
 from collections.abc import Sequence
 from datetime import date, time
 
-from app.models import TournamentEvent, TournamentEventPool
+from app.models import (
+    Tournament,
+    TournamentEvent,
+    TournamentEventPool,
+    TournamentEventPoolTable,
+)
 from app.schemas.tournament import Pool, PoolWrite, Slot
 
 __all__ = ["apply_event_pools", "pool_read", "stored_pools"]
@@ -88,12 +103,61 @@ def pool_read(pool: TournamentEventPool) -> Pool:
         id=pool.id,
         name=pool.name,
         slot=_slot_read(pool),
-        table_ids=list(pool.table_ids),
+        table_ids=[reservation.table_id for reservation in pool.tables],
         position=pool.position,
     )
 
 
-def stored_pools(submitted: Sequence[PoolWrite]) -> list[TournamentEventPool]:
+def _reservations(
+    tournament: Tournament,
+    submitted: Sequence[str],
+    stored: Sequence[TournamentEventPoolTable] = (),
+) -> list[TournamentEventPoolTable]:
+    """The reservation rows one pool's submitted ``table_ids`` resolve to, keyed on the
+    table id against whatever ``stored`` rows the pool already has.
+
+    Keyed rather than replaced wholesale for a mechanical reason as well as a tidy one:
+    a reservation's identity IS ``(event, pool, table)``, so re-sending a table the pool
+    already reserves and letting the collection be rebuilt would ask the unit of work to
+    INSERT a primary key it is about to DELETE — and it emits the inserts first. Keeping
+    the row and moving its ``position`` is the same end state with no such window.
+
+    **A table the tournament's catalogue does not hold is dropped, silently**, which is
+    this module's one judgement call and is the ADR's "quiet" half said at write time.
+    A reservation is a *preference* — the loud refusal is reserved for a placement — and
+    a preference naming a table that does not exist is not a preference the schema can
+    hold at all now that it is a foreign key. Nothing observable moves: every reader
+    already intersected ``table_ids`` with the catalogue (the solver's
+    ``_load_solver_inputs``, the preview's snapshot), because a JSONB string could name
+    anything; this puts that intersection at the boundary where it belongs instead of
+    repeating it at each read. The same rule covers the cross-tournament id the
+    composite foreign keys exist to refuse — the app cannot construct the row, and the
+    database would not accept it if it did.
+
+    Duplicates collapse (``dict.fromkeys``, order-preserving) for the same reason: the
+    primary key says a pool reserves a table at most once, and a payload that names one
+    twice means what it says once.
+    """
+    catalogue = {str(table.id) for table in tournament.tables}
+    kept = {reservation.table_id: reservation for reservation in stored}
+    rows: list[TournamentEventPoolTable] = []
+    for table_id in dict.fromkeys(submitted):
+        if table_id not in catalogue:
+            continue
+        row = kept.get(table_id)
+        if row is None:
+            row = TournamentEventPoolTable(
+                tournament_id=tournament.id, table_id=table_id, position=len(rows)
+            )
+        else:
+            row.position = len(rows)
+        rows.append(row)
+    return rows
+
+
+def stored_pools(
+    tournament: Tournament, submitted: Sequence[PoolWrite]
+) -> list[TournamentEventPool]:
     """Fresh :class:`TournamentEventPool` rows for an event that has none yet — the
     create verb's whole job.
 
@@ -101,15 +165,23 @@ def stored_pools(submitted: Sequence[PoolWrite]) -> list[TournamentEventPool]:
     place a position is assigned on the create path, and what makes the stored positions
     ``range(len(submitted))`` by construction rather than by a caller's care.
 
-    The ``id`` is the client's, for now — the pool-set freeze and the fixtures both name
-    a pool by that string — unlike a venue table's, which the database mints. The chore
-    that moves pools onto server-minted uuids (#1226 slice 3d) is the one that changes
-    it, together with the column type and ``PoolId``.
+    ``tournament`` is here for the reservations, not for the pools: it supplies both the
+    catalogue each ``table_ids`` entry is resolved against and the ``tournament_id``
+    every reservation row carries (:func:`_reservations`).
+
+    The pool's ``id`` is the client's, for now — the pool-set freeze and the fixtures
+    both name a pool by that string — unlike a venue table's, which the database mints.
+    The chore that moves pools onto server-minted uuids (#1226 slice 3d) is the one that
+    changes it, together with the column type and ``PoolId``.
     """
-    return [_new_pool(pool, position) for position, pool in enumerate(submitted)]
+    return [
+        _new_pool(tournament, pool, position) for position, pool in enumerate(submitted)
+    ]
 
 
-def _new_pool(submitted: PoolWrite, position: int) -> TournamentEventPool:
+def _new_pool(
+    tournament: Tournament, submitted: PoolWrite, position: int
+) -> TournamentEventPool:
     """One brand-new pool row, at ``position``, from the pool a client sent."""
     slot_date, slot_start, slot_end = _slot_columns(submitted.slot)
     return TournamentEventPool(
@@ -119,12 +191,18 @@ def _new_pool(submitted: PoolWrite, position: int) -> TournamentEventPool:
         slot_date=slot_date,
         slot_start=slot_start,
         slot_end=slot_end,
-        table_ids=list(submitted.table_ids),
+        tables=_reservations(tournament, submitted.table_ids),
     )
 
 
-def apply_event_pools(event: TournamentEvent, submitted: Sequence[PoolWrite]) -> None:
+def apply_event_pools(
+    tournament: Tournament, event: TournamentEvent, submitted: Sequence[PoolWrite]
+) -> None:
     """Make ``event``'s pools equal ``submitted``, as an **id-keyed diff**.
+
+    ``tournament`` is the event's own parent, and it is here for the reservations: it
+    supplies the catalogue each pool's ``table_ids`` are resolved against and the
+    ``tournament_id`` their rows carry (:func:`_reservations`).
 
     A pool whose ``id`` the event already has keeps its row — re-named, re-timed,
     re-tabled and re-positioned as this payload says — and one whose id is new is added.
@@ -152,12 +230,16 @@ def apply_event_pools(event: TournamentEvent, submitted: Sequence[PoolWrite]) ->
     """
     stored = {pool.id: pool for pool in event.pools}
     event.pools = [
-        _pool_for(stored, entry, position) for position, entry in enumerate(submitted)
+        _pool_for(tournament, stored, entry, position)
+        for position, entry in enumerate(submitted)
     ]
 
 
 def _pool_for(
-    stored: dict[str, TournamentEventPool], entry: PoolWrite, position: int
+    tournament: Tournament,
+    stored: dict[str, TournamentEventPool],
+    entry: PoolWrite,
+    position: int,
 ) -> TournamentEventPool:
     """The row one submitted pool resolves to: the event's own pool of that id, updated
     in place, or a brand-new one.
@@ -168,9 +250,14 @@ def _pool_for(
     """
     row = stored.get(entry.id)
     if row is None:
-        return _new_pool(entry, position)
+        return _new_pool(tournament, entry, position)
     row.name = entry.name
     row.position = position
     row.slot_date, row.slot_start, row.slot_end = _slot_columns(entry.slot)
-    row.table_ids = list(entry.table_ids)
+    # The reservations are a diff of their own, one level down: a table this pool
+    # already reserves keeps its row (re-positioned), a new one is added, and a stored
+    # one this payload leaves out becomes an orphan the relationship's ``delete-orphan``
+    # deletes. Assigning fresh rows for the whole list instead would delete and
+    # re-insert the same primary keys in one flush.
+    row.tables = _reservations(tournament, entry.table_ids, row.tables)
     return row

--- a/api/app/tournament_pools.py
+++ b/api/app/tournament_pools.py
@@ -32,6 +32,12 @@ now take the parent tournament: the denormalized column is what the composite fo
 keys underneath compare, and a reservation composed without it is not a row Postgres
 will accept.
 
+**The id.** A pool's id is a uuid the **database** mints (ADR 20260801's ``id uuid
+PRIMARY KEY``), so nothing here assigns one on the create path and the create shape has
+no field for one. On the edit path a client *cites* an id it was given, and citing one
+this event does not have is refused rather than silently minted — the same split, and
+the same 422, ``app.tournament_tables`` already makes for the venue catalogue.
+
 The edit path is an **id-keyed diff** and not a wholesale replace, which is a change of
 mechanism and not of meaning: the pool set an event may end up with is exactly what it
 was (the freeze in ``app.tournament_events`` decides that), but a JSONB column could be
@@ -39,9 +45,10 @@ reassigned and rows cannot — re-sending a pool the event already has must UPDA
 row, or the write would try to insert a duplicate primary key and, worse, would delete
 and recreate the row every fixture in the event points at.
 
-It imports the models, the schemas and nothing else — no session, no router, no FastAPI
-— so it stays callable from a REPL and cycle-free."""
+It imports the models, the schemas and the domain-error leaf, and nothing else — no
+session, no router, no FastAPI — so it stays callable from a REPL and cycle-free."""
 
+import uuid
 from collections.abc import Sequence
 from datetime import date, time
 
@@ -51,7 +58,8 @@ from app.models import (
     TournamentEventPool,
     TournamentEventPoolTable,
 )
-from app.schemas.tournament import Pool, PoolWrite, Slot
+from app.schemas.tournament import Pool, PoolUpsert, PoolWrite, Slot
+from app.tournament_errors import PoolNotInEventError
 
 __all__ = ["apply_event_pools", "pool_read", "stored_pools"]
 
@@ -169,10 +177,10 @@ def stored_pools(
     catalogue each ``table_ids`` entry is resolved against and the ``tournament_id``
     every reservation row carries (:func:`_reservations`).
 
-    The pool's ``id`` is the client's, for now — the pool-set freeze and the fixtures
-    both name a pool by that string — unlike a venue table's, which the database mints.
-    The chore that moves pools onto server-minted uuids (#1226 slice 3d) is the one that
-    changes it, together with the column type and ``PoolId``.
+    No ``id`` is set: that is the database's (``gen_random_uuid()``), exactly as a venue
+    table's is (:func:`app.tournament_tables.stored_tables`), and the point of the ADR
+    is that it is not the client's to author — the create shape (:class:`PoolWrite`) has
+    no field for one.
     """
     return [
         _new_pool(tournament, pool, position) for position, pool in enumerate(submitted)
@@ -182,10 +190,10 @@ def stored_pools(
 def _new_pool(
     tournament: Tournament, submitted: PoolWrite, position: int
 ) -> TournamentEventPool:
-    """One brand-new pool row, at ``position``, from the pool a client sent."""
+    """One brand-new pool row, at ``position``, from the pool a client sent — with no
+    ``id``, which the database mints."""
     slot_date, slot_start, slot_end = _slot_columns(submitted.slot)
     return TournamentEventPool(
-        id=submitted.id,
         name=submitted.name,
         position=position,
         slot_date=slot_date,
@@ -196,7 +204,7 @@ def _new_pool(
 
 
 def apply_event_pools(
-    tournament: Tournament, event: TournamentEvent, submitted: Sequence[PoolWrite]
+    tournament: Tournament, event: TournamentEvent, submitted: Sequence[PoolUpsert]
 ) -> None:
     """Make ``event``'s pools equal ``submitted``, as an **id-keyed diff**.
 
@@ -204,10 +212,11 @@ def apply_event_pools(
     supplies the catalogue each pool's ``table_ids`` are resolved against and the
     ``tournament_id`` their rows carry (:func:`_reservations`).
 
-    A pool whose ``id`` the event already has keeps its row — re-named, re-timed,
-    re-tabled and re-positioned as this payload says — and one whose id is new is added.
-    A stored pool no entry names is **removed**, by leaving it out of the reassigned
-    collection, which ``delete-orphan`` turns into a ``DELETE``.
+    Each entry either cites the ``id`` of a pool the event already has — which keeps
+    that row, re-named, re-timed, re-tabled and re-positioned as this payload says — or
+    omits one, which adds a row the database mints an id for. A stored pool no entry
+    cites is **removed**, by leaving it out of the reassigned collection, which
+    ``delete-orphan`` turns into a ``DELETE``.
 
     **Keying on the id is not an optimization, it is the only correct mechanism.** A
     fixture holds its pool's id (and, since ADR 20260801, holds it as a foreign key), so
@@ -215,13 +224,21 @@ def apply_event_pools(
     it or be refused outright. The JSONB column this replaces could be reassigned
     wholesale precisely because nothing pointed into it.
 
-    What may change is decided **before** this runs, not here:
-    ``_enforce_pool_set_frozen`` (``app.tournament_events``) refuses a payload that
-    would add or remove a pool of an event whose draw is cut. With no draw, any diff is
-    legal — which is why this function has no refusal of its own, and why a new id is an
-    addition rather than the 422 the venue catalogue's diff answers an unknown table id
-    with (a table id is the server's to mint, so an id it did not mint names nothing; a
-    pool id is still the client's).
+    Two refusals, and they are asked in two different places:
+
+    * an entry citing an id this **event** does not have →
+      :class:`~app.tournament_errors.PoolNotInEventError` (a 422 on that entry's
+      ``id``), judged here and before anything is written. Until the ids were minted
+      this arm was an *addition*: the id was the client's, so one the server had never
+      seen still named the pool the client meant. It is the server's now, so an id it
+      did not mint names nothing — and quietly minting a fresh one would hand the client
+      back a different id than it asked for while *removing* the pool it meant to keep.
+      It is the same 422 :func:`~app.tournament_tables.apply_table_catalogue` answers an
+      unknown table id with, for the same reason and now with the same justification.
+    * a payload that would add or remove a pool of an event whose draw is **cut** →
+      ``_enforce_pool_set_frozen`` (``app.tournament_events``), which runs *before* this
+      function, so the 409 wins over the 422 whenever both apply. With no draw, any diff
+      is legal.
 
     Reassigning the whole collection is what expresses all three operations at once, in
     the payload's order — the same gesture ``apply_table_catalogue`` makes, and the
@@ -229,6 +246,14 @@ def apply_event_pools(
     row onto a position its neighbour has not vacated yet.
     """
     stored = {pool.id: pool for pool in event.pools}
+    # Judged first, over the whole payload, for the reason the catalogue's twin is: a
+    # pool list naming a pool this event does not have is not a pool list, and every
+    # subsequent question (what is kept, and therefore what is removed) would be
+    # answered against a list the client did not mean. Named by index so the refusal
+    # lands on the entry that caused it.
+    for index, entry in enumerate(submitted):
+        if entry.id is not None and entry.id not in stored:
+            raise PoolNotInEventError(index=index, pool_id=str(entry.id))
     event.pools = [
         _pool_for(tournament, stored, entry, position)
         for position, entry in enumerate(submitted)
@@ -237,20 +262,24 @@ def apply_event_pools(
 
 def _pool_for(
     tournament: Tournament,
-    stored: dict[str, TournamentEventPool],
-    entry: PoolWrite,
+    stored: dict[uuid.UUID, TournamentEventPool],
+    entry: PoolUpsert,
     position: int,
 ) -> TournamentEventPool:
-    """The row one submitted pool resolves to: the event's own pool of that id, updated
-    in place, or a brand-new one.
+    """The row one submitted pool resolves to: the cited pool, updated in place, or a
+    brand-new one.
 
     ``position`` is the entry's index in the submitted list and is assigned on both
     arms, so a patch that re-orders the pools re-orders them (and one that re-sends them
     unchanged writes the positions they already had).
+
+    ``stored[entry.id]`` cannot miss — every cited id was checked against ``stored``
+    before this runs, so this is an indexing operation rather than a second lookup with
+    a second opinion about what an unknown id means.
     """
-    row = stored.get(entry.id)
-    if row is None:
+    if entry.id is None:
         return _new_pool(tournament, entry, position)
+    row = stored[entry.id]
     row.name = entry.name
     row.position = position
     row.slot_date, row.slot_start, row.slot_end = _slot_columns(entry.slot)

--- a/api/app/tournament_queries.py
+++ b/api/app/tournament_queries.py
@@ -298,8 +298,8 @@ async def fixtures_by_event(
     NULL there, so round and position decide it alone).
 
     "Pool" here means the pool's **position in the event's own pool order**
-    (:func:`_pool_position`), not its id. The id is a client-minted string —
-    ``p-1-…``, ``p-2-…``, ``p-10-…`` — and *lexicographically* ``p-10-`` falls between
+    (:func:`_pool_position`), not its id. The id used to be a client-minted string —
+    ``p-1-…``, ``p-2-…``, ``p-10-…`` — and *lexicographically* ``p-10-`` fell between
     ``p-1-`` and ``p-2-``, so a ten-pool event rendered its draw as pool 1, pool 10,
     pool 2. Sorting on the stored ``position`` (ADR 20260801, "Pools carry an explicit
     ``position``") is also the only key that survives pools becoming rows with random

--- a/api/app/tournament_queries.py
+++ b/api/app/tournament_queries.py
@@ -15,8 +15,7 @@ import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime
 
-from sqlalchemy import ColumnElement, and_, column, func, or_, select
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import ColumnElement, and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.expression import ScalarSelect
 
@@ -30,6 +29,7 @@ from app.models import (
     TournamentEntry,
     TournamentEntryStatus,
     TournamentEvent,
+    TournamentEventPool,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -237,29 +237,33 @@ def _pool_position() -> ScalarSelect[int | None]:
     """The ``position`` of a fixture's pool within its own event — the correlated
     subquery the draw order below sorts on.
 
-    A fixture holds a **string ref** into its event's ``pools`` JSONB, not an FK, so
-    "where does this fixture's pool sit in the director's order?" is a lookup into that
-    array: find the element whose ``id`` matches ``tournament_fixtures.pool_id``, and
-    read its ``position`` (:data:`app.schemas.tournament.PoolPosition` — 0-based,
-    stamped by the server from the order the pools were sent in).
-    ``jsonb_array_elements`` unnests the array; the pool ids of one event are unique
-    (``_pool_ids_are_unique`` at the write boundary), so the subquery is scalar by
-    construction rather than by a ``LIMIT`` papering over duplicates.
+    A fixture holds its pool's **id**, not its index, so "where does this fixture's pool
+    sit in the director's order?" is a join: find the ``tournament_event_pools`` row
+    this fixture's ``(event_id, pool_id)`` names — the same pair the composite foreign
+    key matches on (ADR 20260801) — and read its ``position``
+    (:data:`app.schemas.tournament.PoolPosition` — 0-based, stamped by the server from
+    the order the pools were sent in). Scalar by construction, since ``(event_id, id)``
+    is unique, rather than by a ``LIMIT`` papering over duplicates.
 
-    It is ``NULL`` in exactly two cases, and both want to sort at the end of the pooled
-    group: an **un-pooled** fixture (``pool_id IS NULL`` — single-elim, or the KO stage
-    of an rr-then-ko draw) matches no element, and a pool stored **before** ``position``
-    existed carries no such key. The second is why the id remains a secondary sort key
-    below: a whole event of position-less pools degrades to exactly the id order this
-    used to have, rather than to no order at all.
+    It is ``NULL`` in exactly one case now, and that case wants to sort at the end of
+    the pooled group: an **un-pooled** fixture (``pool_id IS NULL`` — single-elim, or
+    the KO stage of an rr-then-ko draw) matches no row. It used to have a second — a
+    pool stored before ``position`` existed — which the ``NOT NULL`` column has closed;
+    the id stays on as a secondary sort key below because the *order* still has to be
+    total when this is NULL for every row of an un-pooled draw.
+
+    Correlated on ``TournamentFixture`` alone. The ``event_id`` comes off the fixture
+    rather than off the joined ``TournamentEvent`` — the same column either way, and
+    taking it from the fixture keeps the subquery independent of which of the two tables
+    the enclosing statement happens to have in scope.
     """
-    pool = func.jsonb_array_elements(TournamentEvent.pools).table_valued(
-        column("value", JSONB)
-    )
     return (
-        select(pool.c.value["position"].as_integer())
-        .where(pool.c.value["id"].as_string() == TournamentFixture.pool_id)
-        .correlate(TournamentEvent, TournamentFixture)
+        select(TournamentEventPool.position)
+        .where(
+            TournamentEventPool.event_id == TournamentFixture.event_id,
+            TournamentEventPool.id == TournamentFixture.pool_id,
+        )
+        .correlate(TournamentFixture)
         .scalar_subquery()
     )
 
@@ -301,16 +305,15 @@ async def fixtures_by_event(
     ``position``") is also the only key that survives pools becoming rows with random
     UUID primary keys, under which an id sort is not merely wrong but *arbitrary*.
     The id stays on as a secondary key so the order is still total when the positions
-    cannot decide it — an event whose pools predate the field carries no ``position``
-    at all, and degrades to precisely the id order this used to have.
+    cannot decide it — every fixture of an un-pooled draw resolves a ``NULL`` position.
 
     Sorted in Postgres rather than in Python because a NULL is not comparable to an
     ``int`` (nor, before it, to a string): ``sorted(key=lambda f: (f.pool_position,
     ...))`` is a ``TypeError`` the moment an un-pooled fixture meets a pooled one, and
     the defensive coalesce that usually follows (``f.pool_position or 0``) would
     quietly sort the KO stage FIRST — in front of the pools that feed it. The position
-    is also not a column on the fixture at all: it lives in the event's ``pools``
-    JSONB, so resolving it in Python would mean parsing every event's pools per read.
+    is also not a column on the fixture at all: it lives on the fixture's *pool* row, so
+    resolving it in Python would mean loading every event's pools per read.
 
     A materialized fixture carries its match's **live status** (``match_status``), read
     by LEFT-joining ``matches`` on ``fixture.match_id`` (#788) — still ONE statement,

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -65,6 +65,7 @@ from app.tournament_eligibility import (
     evaluate_rating_eligibility,
     event_is_full,
 )
+from app.tournament_pools import pool_read
 from app.tournament_queries import (
     active_entrants_by_event,
     completed_match_ids,
@@ -475,7 +476,11 @@ def serialize_event(
             "slot": e.slot,
             "match_settings": e.match_settings,
             "predicates": e.predicates,
-            "pools": e.pools,
+            # Projected from the event's pool ROWS (ADR 20260801), not handed over as a
+            # JSONB column. They ride on the event's own eager ``selectin`` load, so
+            # this costs the page no statement of its own — the same arrangement the
+            # venue catalogue has.
+            "pools": [pool_read(pool) for pool in e.pools],
             "created_at": e.created_at,
             "updated_at": e.updated_at,
             "entrants": entrants,

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -270,7 +270,7 @@ def _pool_inputs(
     fixtures: list[TournamentFixtureRead],
     game_counts: dict[uuid.UUID, tuple[int, int]],
 ) -> list[PoolInput]:
-    by_pool: dict[str, list[TournamentFixtureRead]] = defaultdict(list)
+    by_pool: dict[uuid.UUID, list[TournamentFixtureRead]] = defaultdict(list)
     for f in fixtures:
         # A round-robin fixture is always pooled; a NULL pool would be a different draw
         # type's fixture and has no pool table to stand in. Skip it rather than key a

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -78,6 +78,7 @@ from app.tournament_errors import (
     NotTournamentOwnerError,
     PlacementTableNotFoundError,
     PlayerNotFoundError,
+    PoolNotInEventError,
     PoolSetFrozenError,
     ScheduleQueueUnavailableError,
     TableInUseError,
@@ -735,6 +736,35 @@ async def create_event(
     )
 
 
+def _pool_not_in_event(exc: PoolNotInEventError) -> RequestValidationError:
+    """The 422 for a ``pools`` entry citing an id this event does not have
+    (ADR 20260801) — as a **validation error on that entry's field**, not a hand-rolled
+    body.
+
+    The exact sibling of :func:`_table_not_in_catalogue`, one resource over, and the
+    same argument: the body's ``id`` did not validate, the only reason the schema could
+    not judge it is that the answer lives in the database, and a client should not need
+    a second parser to tell "your id is malformed" (a schema 422) from "your id names
+    nothing" (this one). Raising the exception the schema raises puts it through the
+    app's own handler, so the body is byte-shape-identical to every other 422 this route
+    can produce and no new response schema reaches the generated clients.
+
+    The ``loc`` carries the entry's **index** — ``["body", "pools", i, "id"]`` — because
+    the pools are a list and a client renders a validation error under the input that
+    caused it.
+    """
+    return RequestValidationError(
+        [
+            {
+                "type": "value_error",
+                "loc": ("body", "pools", exc.index, "id"),
+                "msg": str(exc),
+                "input": exc.pool_id,
+            }
+        ]
+    )
+
+
 @router.patch(
     "/tournaments/{tournament_id}/events/{event_id}",
     response_model=TournamentEventRead,
@@ -746,18 +776,26 @@ async def update_event(
     db: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
 ) -> TournamentEventRead:
-    """Edit an event. Absent fields are left alone; `predicates` and `pools` replace
-    wholesale when sent. No two pools may share an `id`, in any state (`422`) — a pool
-    id identifies one pool, and the fixtures of a draw name their pool by it.
+    """Edit an event. Absent fields are left alone; `predicates` replaces wholesale when
+    sent.
+
+    **`pools` is an id-keyed diff, sent in full and in order.** Each entry either
+    carries the `id` of a pool this event already has — keeping that pool, with the
+    `name`, `slot`, `table_ids` and position this payload gives it — or omits the `id`
+    to add a new pool, whose id the server mints. **A pool no entry names is removed.**
+    Send back the pools you read, edited: the ids came from the read, and naming an id
+    this event does not have is a `422` on that entry. Citing the same pool twice is a
+    `422` too — a pool id identifies one pool, and the fixtures of a draw name their
+    pool by it.
 
     **Once the event's draw is cut, two things freeze** (ADR-0786) — the facts its
     fixtures were derived from:
 
-    * **its set of pools.** A `pools` payload must carry exactly the pool `id`s the
-      event already has, or it is refused with a `409`: a removed (or re-`id`'d) pool
-      would leave the fixtures drawn into it pointing at nothing, and an added one would
-      arrive with no fixtures, since the draw was dealt across the pools that existed at
-      the cut.
+    * **its set of pools.** A `pools` payload must cite exactly the pools the event
+      already has, or it is refused with a `409`: a removed pool would leave the
+      fixtures drawn into it pointing at nothing, and an added one would arrive with no
+      fixtures, since the draw was dealt across the pools that existed at the cut.
+      Re-ordering them, and editing each one, are still allowed.
     * **its `draw_type`.** The draw type chose the strategy that dealt those fixtures,
       so changing it under a standing draw is a `409` too: the event would claim a shape
       its draw does not have. Re-sending the draw type the event already has is not a
@@ -796,6 +834,10 @@ async def update_event(
         # Both freezes carry the exact 409 sentence the handler used to compose inline —
         # rebuilt verbatim with ``str(exc)``.
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except PoolNotInEventError as exc:
+        # A pools entry cited an id this event does not have: a field refusal, shaped
+        # like every other 422 on this route (see ``_pool_not_in_event``).
+        raise _pool_not_in_event(exc) from exc
     except _TOURNAMENT_WRITE_ERRORS as exc:
         raise _map_tournament_write_error(exc) from exc
     # The verb returns the tournament's ``league_id`` — the ladder the caller's

--- a/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
+++ b/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
@@ -399,12 +399,14 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("'[]'::jsonb"),
         ),
-        sa.Column(
-            "pools",
-            postgresql.JSONB(),
-            nullable=False,
-            server_default=sa.text("'[]'::jsonb"),
-        ),
+        # There is deliberately NO ``pools`` column. An event's pools were a NOT NULL
+        # JSONB list of ``{id, name, slot, table_ids}`` objects keyed by client-supplied
+        # strings; they are the ``tournament_event_pools`` table created below (ADR
+        # 20260801 "a pool belongs to its event, not to the event's draw settings"), so
+        # a fixture can foreign-key the pool it names — and specifically one of its OWN
+        # event's pools. Edited out of this migration in place, per the pre-deploy
+        # convention in api/CLAUDE.md — revision ids and the ``down_revision`` chain
+        # stay frozen.
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -442,8 +444,102 @@ def upgrade() -> None:
         ["draw_settings_id"],
     )
 
+    # An event's pools, as rows (ADR 20260801 "a pool belongs to its event, not to the
+    # event's draw settings"). Created after ``tournament_events`` because it FKs it, and
+    # before ``tournament_fixtures`` (0012), which carries the composite foreign key onto
+    # the ``(event_id, id)`` unique constraint below. Added here in place per the
+    # pre-deploy convention, not as a chained ALTER.
+    #
+    # ``id`` is still a client-supplied string — unlike ``tournament_tables.id``, whose
+    # move to a server-minted uuid landed with its own chore. It becomes a uuid in the
+    # chore that mints them, together with ``tournament_fixtures.pool_id``: the two are
+    # one representation and must move in one step.
+    #
+    # The window is ``date``/``time``, NOT ``timestamptz``, and that is the ADR's call
+    # rather than an oversight (api/CLAUDE.md's "datetimes are timezone-aware, always"
+    # governs datetimes, and these are not datetimes). A pool's window is wall-clock in
+    # the venue's own frame, which ``tournament_events.timezone`` carries and the solver
+    # anchors; storing an instant would bake that anchoring into the column, so a
+    # timezone correction would have to rewrite every pool window instead of re-reading
+    # the same wall-clock in the new zone.
+    op.create_table(
+        "tournament_event_pools",
+        sa.Column("id", sa.Text(), nullable=False),
+        # CASCADE: deleting an event takes its pools with it, exactly as it takes its
+        # entries and fixtures.
+        sa.Column(
+            "event_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tournament_events.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        # Where the pool sits in the event's own pool order: 0-based, contiguous,
+        # server-assigned from the order the pools were sent in. The JSONB array carried
+        # this for free and the client-minted ids sorted into it by accident; neither
+        # survives, and the snake seeds against this order (ADR 20260801, "Pools carry an
+        # explicit ``position``").
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("slot_date", sa.Date(), nullable=False),
+        sa.Column("slot_start", sa.Time(), nullable=False),
+        sa.Column("slot_end", sa.Time(), nullable=False),
+        # The tables this pool reserves, still as JSONB text ids. It becomes
+        # ``tournament_event_pool_tables`` — rows with composite FKs to both sides — in
+        # the next chore of this slice.
+        sa.Column(
+            "table_ids",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # The key is the PAIR, ``event_id`` first — which is also what a fixture's
+        # composite foreign key references, so the ADR's separate
+        # ``UNIQUE (event_id, id)`` is unnecessary: this key already is it, and it gives
+        # the REFERENCING ``event_id`` the index Postgres does not create for one (the
+        # event-delete cascade path, and every read of "this event's pools").
+        #
+        # Composite because a pool id is per-event, exactly as it was as a JSONB
+        # value-object: two events of one tournament may each hold a "pool-a". A bare
+        # ``id`` key would make a client-minted string globally unique across the
+        # platform — a rule the domain does not have. When the ids become server-minted
+        # uuids the key can shrink to ``id`` with the pair kept as a UNIQUE constraint;
+        # the fixture's FK is unchanged either way.
+        sa.PrimaryKeyConstraint("event_id", "id", name="pk_tournament_event_pools"),
+        # Two pools of one event never share a place in its order.
+        #
+        # DEFERRABLE INITIALLY DEFERRED, exactly as ``tournament_tables``' position
+        # constraint is: the pools are written as an id-keyed diff, and a diff re-orders
+        # — sending C, A, B back as B, C, A moves each row onto a position its neighbour
+        # has not vacated yet. An immediately-checked constraint would refuse that
+        # intermediate state and so forbid reordering, though the transaction's END state
+        # is perfectly unique.
+        sa.UniqueConstraint(
+            "event_id",
+            "position",
+            name="uq_tournament_event_pools_event_id_position",
+            deferrable=True,
+            initially="DEFERRED",
+        ),
+    )
+
 
 def downgrade() -> None:
+    # Dropped before the events it references (and before the fixtures of 0012 reference
+    # it — that migration is torn down first by the chain).
+    op.drop_table("tournament_event_pools")
+
     op.drop_index(
         "ix_tournament_events_draw_settings_id",
         table_name="tournament_events",

--- a/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
+++ b/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
@@ -330,6 +330,14 @@ def upgrade() -> None:
             deferrable=True,
             initially="DEFERRED",
         ),
+        # Redundant against the primary key, and here for exactly one purpose: SQL can
+        # only reference a UNIQUE set of columns, so this is the target
+        # ``tournament_event_pool_tables`` foreign-keys ``(tournament_id, table_id)``
+        # against — the leg that says the table a pool reserves is its OWN tournament's
+        # (ADR 20260801). Added in place per the pre-deploy convention.
+        sa.UniqueConstraint(
+            "tournament_id", "id", name="uq_tournament_tables_tournament_id_id"
+        ),
     )
     # Postgres indexes the REFERENCED key of a foreign key, never the referencing
     # column, so this is what keeps the tournament-delete cascade from sequentially
@@ -385,6 +393,15 @@ def upgrade() -> None:
         ),
         sa.CheckConstraint(
             "entry_fee >= 0", name="ck_tournament_events_entry_fee_non_negative"
+        ),
+        # Redundant against the primary key, and here for exactly one purpose: it is the
+        # target ``tournament_event_pool_tables`` foreign-keys ``(tournament_id,
+        # event_id)`` against, which is what forces a reservation's denormalized
+        # ``tournament_id`` to be the tournament its pool's event really belongs to. The
+        # other two legs of that row are satisfiable by a cross-tournament reservation
+        # without it (ADR 20260801). Added in place per the pre-deploy convention.
+        sa.UniqueConstraint(
+            "tournament_id", "id", name="uq_tournament_events_tournament_id_id"
         ),
         # No ``entered`` column: an event's entry count is DERIVED from a live
         # count of its active ``tournament_entries`` rows (ADR-0016). A stored
@@ -483,15 +500,12 @@ def upgrade() -> None:
         sa.Column("slot_date", sa.Date(), nullable=False),
         sa.Column("slot_start", sa.Time(), nullable=False),
         sa.Column("slot_end", sa.Time(), nullable=False),
-        # The tables this pool reserves, still as JSONB text ids. It becomes
-        # ``tournament_event_pool_tables`` — rows with composite FKs to both sides — in
-        # the next chore of this slice.
-        sa.Column(
-            "table_ids",
-            postgresql.JSONB(),
-            nullable=False,
-            server_default=sa.text("'[]'::jsonb"),
-        ),
+        # There is deliberately NO ``table_ids`` column. The tables a pool reserves were
+        # a NOT NULL JSONB array of table-id strings — which could name another
+        # tournament's table, or no table at all — and they are the
+        # ``tournament_event_pool_tables`` rows created below (ADR 20260801, "the
+        # tournament-scoping stops at the join table"). Edited out of this migration in
+        # place, per the pre-deploy convention in api/CLAUDE.md.
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -534,8 +548,106 @@ def upgrade() -> None:
         ),
     )
 
+    # The tables a pool reserves, as rows (ADR 20260801, "the tournament-scoping stops
+    # at the join table"). Created last in this migration because it references three of
+    # the tables above. Added here in place per the pre-deploy convention, not as a
+    # chained ALTER.
+    #
+    # ``tournament_id`` is DENORMALIZED, and it is the whole mechanism: a pool hangs off
+    # its event and a table hangs off its tournament, so the two sides share no column
+    # until this row supplies one for them to agree on. Three composite foreign keys
+    # then pin every leg of the path — the pool is a real pool, the table is a real
+    # table of tournament X, and the pool's event really does belong to tournament X.
+    # Drop that third one and the first two are satisfied by exactly the row this table
+    # exists to forbid: ``tournament_id`` naming a tournament whose table the pool
+    # borrows while the pool itself lives under another.
+    #
+    # All three are ON DELETE CASCADE. The one that carries a decision is the table leg:
+    # removing a venue table a fixture is PLACED at is refused (``ON DELETE RESTRICT``
+    # on ``tournament_fixtures.table_id``) and the director opts in on purpose, while
+    # removing one a pool merely RESERVES is silent — a reservation is a preference, a
+    # placement is a commitment (ADR 20260801, "a placement names a real table").
+    op.create_table(
+        "tournament_event_pool_tables",
+        sa.Column("tournament_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("event_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("pool_id", sa.Text(), nullable=False),
+        sa.Column("table_id", postgresql.UUID(as_uuid=True), nullable=False),
+        # Where the table sits in the pool's reservation list: 0-based, contiguous,
+        # server-assigned from the order the ids were sent in. The JSONB array carried
+        # this for free and the wire shape is still an array; ordering by the random
+        # ``table_id`` instead would shuffle a director's list on every read. Same
+        # argument as the two sibling ``position`` columns above.
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # A pool reserves a table at most once. ``event_id`` leads so the key's own
+        # index answers the pool leg's referential check and the event-delete cascade.
+        sa.PrimaryKeyConstraint(
+            "event_id", "pool_id", "table_id", name="pk_tournament_event_pool_tables"
+        ),
+        sa.ForeignKeyConstraint(
+            ["event_id", "pool_id"],
+            ["tournament_event_pools.event_id", "tournament_event_pools.id"],
+            name="fk_tournament_event_pool_tables_event_id_pool_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tournament_id", "table_id"],
+            ["tournament_tables.tournament_id", "tournament_tables.id"],
+            name="fk_tournament_event_pool_tables_tournament_id_table_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["tournament_id", "event_id"],
+            ["tournament_events.tournament_id", "tournament_events.id"],
+            name="fk_tournament_event_pool_tables_tournament_id_event_id",
+            ondelete="CASCADE",
+        ),
+        # Two reservations of one pool never share a place in its order. DEFERRABLE
+        # INITIALLY DEFERRED for the reason both sibling position constraints are: the
+        # reservations are written as a diff keyed on the table id, and a diff re-orders
+        # — moving a table up the list puts it on a position its neighbour has not
+        # vacated yet, though the transaction's END state is perfectly unique.
+        sa.UniqueConstraint(
+            "event_id",
+            "pool_id",
+            "position",
+            name="uq_tournament_event_pool_tables_event_id_pool_id_position",
+            deferrable=True,
+            initially="DEFERRED",
+        ),
+    )
+    # Postgres indexes the REFERENCED key of a foreign key, never the referencing
+    # columns. The primary key covers the two legs that lead with ``event_id``; this is
+    # the third, and it is the one on a routine DELETE path — every venue table removed
+    # cascades through it, which unindexed is a sequential scan of every reservation on
+    # the platform per table removed.
+    op.create_index(
+        "ix_tournament_event_pool_tables_tournament_id_table_id",
+        "tournament_event_pool_tables",
+        ["tournament_id", "table_id"],
+    )
+
 
 def downgrade() -> None:
+    # Dropped before all three of the tables it references.
+    op.drop_index(
+        "ix_tournament_event_pool_tables_tournament_id_table_id",
+        table_name="tournament_event_pool_tables",
+    )
+    op.drop_table("tournament_event_pool_tables")
+
     # Dropped before the events it references (and before the fixtures of 0012 reference
     # it — that migration is torn down first by the chain).
     op.drop_table("tournament_event_pools")

--- a/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
+++ b/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
@@ -467,10 +467,12 @@ def upgrade() -> None:
     # the ``(event_id, id)`` unique constraint below. Added here in place per the
     # pre-deploy convention, not as a chained ALTER.
     #
-    # ``id`` is still a client-supplied string — unlike ``tournament_tables.id``, whose
-    # move to a server-minted uuid landed with its own chore. It becomes a uuid in the
-    # chore that mints them, together with ``tournament_fixtures.pool_id``: the two are
-    # one representation and must move in one step.
+    # ``id`` is a server-minted uuid — ``gen_random_uuid()``, exactly as
+    # ``tournament_tables.id`` is. It was a client-supplied string for as long as a pool
+    # was a JSONB value-object with nothing to mint it; this column,
+    # ``tournament_event_pool_tables.pool_id`` and ``tournament_fixtures.pool_id`` moved
+    # onto uuid in one step, because they are one representation and a half-moved one is
+    # not a state worth having.
     #
     # The window is ``date``/``time``, NOT ``timestamptz``, and that is the ADR's call
     # rather than an oversight (api/CLAUDE.md's "datetimes are timezone-aware, always"
@@ -481,7 +483,12 @@ def upgrade() -> None:
     # the same wall-clock in the new zone.
     op.create_table(
         "tournament_event_pools",
-        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
         # CASCADE: deleting an event takes its pools with it, exactly as it takes its
         # entries and fixtures.
         sa.Column(
@@ -518,19 +525,25 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
-        # The key is the PAIR, ``event_id`` first — which is also what a fixture's
-        # composite foreign key references, so the ADR's separate
-        # ``UNIQUE (event_id, id)`` is unnecessary: this key already is it, and it gives
-        # the REFERENCING ``event_id`` the index Postgres does not create for one (the
-        # event-delete cascade path, and every read of "this event's pools").
+        # The key is ``id`` ALONE. It was the pair ``(event_id, id)`` for as long as the
+        # id was a client-minted string, which is only unique per event — two events of
+        # one tournament could each hold a "pool-a", and a bare ``id`` key would have
+        # imposed platform-wide uniqueness on a string nothing above the database
+        # controlled. A minted uuid is globally unique by construction, so the narrower
+        # key is the honest one.
+        sa.PrimaryKeyConstraint("id", name="pk_tournament_event_pools"),
+        # ``UNIQUE (event_id, id)`` — the ADR's own DDL, and it is here for exactly the
+        # reason the ADR gives: "redundant against the primary key and exists purely as
+        # the target that composite FK needs". SQL can only reference a unique set of
+        # columns, and the *pair* is what carries "my pool is my own event's pool" — for
+        # ``tournament_fixtures`` (0012) and for ``tournament_event_pool_tables`` below.
         #
-        # Composite because a pool id is per-event, exactly as it was as a JSONB
-        # value-object: two events of one tournament may each hold a "pool-a". A bare
-        # ``id`` key would make a client-minted string globally unique across the
-        # platform — a rule the domain does not have. When the ids become server-minted
-        # uuids the key can shrink to ``id`` with the pair kept as a UNIQUE constraint;
-        # the fixture's FK is unchanged either way.
-        sa.PrimaryKeyConstraint("event_id", "id", name="pk_tournament_event_pools"),
+        # Its index earns its keep besides: ``event_id`` leads, so it answers every read
+        # of "this event's pools", the event-delete cascade's lookup, and both foreign
+        # keys' referential checks — none of which the single-column primary key serves.
+        sa.UniqueConstraint(
+            "event_id", "id", name="uq_tournament_event_pools_event_id_id"
+        ),
         # Two pools of one event never share a place in its order.
         #
         # DEFERRABLE INITIALLY DEFERRED, exactly as ``tournament_tables``' position
@@ -571,7 +584,7 @@ def upgrade() -> None:
         "tournament_event_pool_tables",
         sa.Column("tournament_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("event_id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("pool_id", sa.Text(), nullable=False),
+        sa.Column("pool_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("table_id", postgresql.UUID(as_uuid=True), nullable=False),
         # Where the table sits in the pool's reservation list: 0-based, contiguous,
         # server-assigned from the order the ids were sent in. The JSONB array carried

--- a/api/migrations/versions/20260712_0000_0012_create_tournament_fixtures_table.py
+++ b/api/migrations/versions/20260712_0000_0012_create_tournament_fixtures_table.py
@@ -36,11 +36,11 @@ def upgrade() -> None:
             sa.ForeignKey("tournament_events.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        # A *string ref* into the event's ``pools`` JSONB value-objects, deliberately
-        # NOT a foreign key — pools are value-objects on the event, not rows, so there
-        # is nothing to point at (ADR-0786). Integrity is procedural: the event's pool
-        # id set freezes while a draw exists. NULL = the draw is un-pooled
-        # (single-elim), or this is the KO stage of an rr-then-ko event.
+        # Half of the composite foreign key declared at the bottom of this table: a
+        # fixture's pool is one of its OWN event's pools (ADR 20260801). NULL = the draw
+        # is un-pooled (single-elim), or this is the KO stage of an rr-then-ko event —
+        # and a composite FK with a NULL member is satisfied vacuously under MATCH
+        # SIMPLE, which is exactly what an un-pooled fixture wants.
         sa.Column("pool_id", sa.Text(), nullable=True),
         sa.Column("round", sa.Integer(), nullable=False),
         sa.Column("position", sa.Integer(), nullable=False),
@@ -145,6 +145,26 @@ def upgrade() -> None:
             "position",
             name="uq_tournament_fixtures_event_id_pool_id_round_position",
             postgresql_nulls_not_distinct=True,
+        ),
+        # "A fixture's pool belongs to that fixture's own event", as one line of DDL
+        # (ADR 20260801). It references ``tournament_event_pools (event_id, id)`` — a
+        # unique constraint that exists purely to be this FK's target, since a plain FK
+        # to the pool's ``id`` alone could not say the event part, which is the whole
+        # claim. Added here in place per the pre-deploy convention; the pools table is
+        # created by 0010, so it exists by the time this runs.
+        #
+        # DEFERRABLE INITIALLY DEFERRED, with the default NO ACTION delete rule rather
+        # than RESTRICT: deleting an event removes its pools through the ORM and its
+        # fixtures through ``ON DELETE CASCADE``, in two separate statements, so an
+        # immediately-checked constraint would fire between them on fixtures that are
+        # about to be deleted anyway. Deferring checks the same pair, in full, before
+        # COMMIT.
+        sa.ForeignKeyConstraint(
+            ["event_id", "pool_id"],
+            ["tournament_event_pools.event_id", "tournament_event_pools.id"],
+            name="fk_tournament_fixtures_event_id_pool_id",
+            deferrable=True,
+            initially="DEFERRED",
         ),
     )
     # Every read of a draw is "the fixtures of this event".

--- a/api/migrations/versions/20260712_0000_0012_create_tournament_fixtures_table.py
+++ b/api/migrations/versions/20260712_0000_0012_create_tournament_fixtures_table.py
@@ -41,7 +41,7 @@ def upgrade() -> None:
         # is un-pooled (single-elim), or this is the KO stage of an rr-then-ko event —
         # and a composite FK with a NULL member is satisfied vacuously under MATCH
         # SIMPLE, which is exactly what an un-pooled fixture wants.
-        sa.Column("pool_id", sa.Text(), nullable=True),
+        sa.Column("pool_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("round", sa.Integer(), nullable=False),
         sa.Column("position", sa.Integer(), nullable=False),
         # NULL means exactly one thing: TBD — ``advance()`` fills it when the feeding

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -163,6 +163,16 @@ def event_pools(
     as the write boundary parses them, so a seeded pool and a POSTed one are the same
     row.
 
+    The ``id`` is a ``uuid.UUID`` and is **optional**: pass one when the test needs to
+    name the pool from somewhere else (a fixture's ``pool_id``, an assertion), and leave
+    it out when it does not care. A minted ``uuid4`` per call, never a module constant —
+    the id is a primary key, so two events in one test cannot share one. Minted *here*,
+    up front, rather than left to the column's ``gen_random_uuid()`` default, for the
+    reason :func:`venue_tables` mints table ids: a seed that names the pool needs the id
+    before the row is flushed. Through the API the ids are the *server's* and there is
+    no ``id`` on the create shape at all (ADR 20260801); this is the direct-to-database
+    seam, which no HTTP caller can reach.
+
     A pool's ``table_ids`` become ``TournamentEventPoolTable`` **rows** (ADR 20260801),
     so naming any table needs the ``tournament`` — twice over. It supplies the alias
     map, rewriting the positional aliases a test writes (``"t1"``, ``"t2"``, …) into the
@@ -189,17 +199,18 @@ def event_pools(
     for position, pool in enumerate(pools):
         slot = pool.get("slot") or {}
         table_ids = [str(table_id) for table_id in pool.get("table_ids", [])]
+        name = pool.get("name", f"Pool {position + 1}")
         if table_ids and tournament is None:
             raise ValueError(
-                f"pool {pool['id']!r} reserves {table_ids} but no tournament was "
+                f"pool {name!r} reserves {table_ids} but no tournament was "
                 "given: a reservation is a row carrying the tournament's id, so the "
                 "seed has to say which tournament's tables these are — pass "
                 "tournament=… (or with_table_aliases(tournament, pools))"
             )
         rows.append(
             TournamentEventPool(
-                id=pool["id"],
-                name=pool.get("name", pool["id"]),
+                id=pool.get("id") or uuid.uuid4(),
+                name=name,
                 position=pool.get("position", position),
                 slot_date=date.fromisoformat(slot.get("date", "2026-06-13")),
                 slot_start=time.fromisoformat(slot.get("start", "09:00")),

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -29,6 +29,7 @@ from app.models import (
     RolePermission,
     Tournament,
     TournamentEventPool,
+    TournamentEventPoolTable,
     User,
     UserLeagueRating,
     UserRole,
@@ -162,10 +163,19 @@ def event_pools(
     as the write boundary parses them, so a seeded pool and a POSTed one are the same
     row.
 
-    With a ``tournament``, each pool's ``table_ids`` are also rewritten from the
-    positional aliases a test writes (``"t1"``, ``"t2"``, …) into the real ids of that
-    tournament's catalogue rows — 1-based and in catalogue order — because a table id is
-    a server-minted UUID a seed cannot spell as a literal.
+    A pool's ``table_ids`` become ``TournamentEventPoolTable`` **rows** (ADR 20260801),
+    so naming any table needs the ``tournament`` — twice over. It supplies the alias
+    map, rewriting the positional aliases a test writes (``"t1"``, ``"t2"``, …) into the
+    real ids of that tournament's catalogue rows (1-based, in catalogue order), because
+    a table id is a server-minted UUID a seed cannot spell as a literal. And it supplies
+    the ``tournament_id`` every reservation row carries — the denormalized column the
+    composite foreign keys compare, without which the row is not one Postgres accepts.
+    It must already be flushed, since that id is the database's to mint.
+
+    Naming a table with no ``tournament`` is a ``ValueError`` rather than a silently
+    empty reservation list: a seed that means "this pool runs on two tables" and gets a
+    pool running on none would go on passing while testing something else. (A pool with
+    no ``table_ids`` at all needs no tournament, which is most of the suite.)
     """
     by_alias = (
         {
@@ -179,6 +189,13 @@ def event_pools(
     for position, pool in enumerate(pools):
         slot = pool.get("slot") or {}
         table_ids = [str(table_id) for table_id in pool.get("table_ids", [])]
+        if table_ids and tournament is None:
+            raise ValueError(
+                f"pool {pool['id']!r} reserves {table_ids} but no tournament was "
+                "given: a reservation is a row carrying the tournament's id, so the "
+                "seed has to say which tournament's tables these are — pass "
+                "tournament=… (or with_table_aliases(tournament, pools))"
+            )
         rows.append(
             TournamentEventPool(
                 id=pool["id"],
@@ -187,10 +204,34 @@ def event_pools(
                 slot_date=date.fromisoformat(slot.get("date", "2026-06-13")),
                 slot_start=time.fromisoformat(slot.get("start", "09:00")),
                 slot_end=time.fromisoformat(slot.get("end", "18:00")),
-                table_ids=[by_alias.get(table_id, table_id) for table_id in table_ids],
+                tables=_reservations(tournament, table_ids, by_alias),
             )
         )
     return rows
+
+
+def _reservations(
+    tournament: Tournament | None, table_ids: Sequence[str], by_alias: Mapping[str, str]
+) -> list[TournamentEventPoolTable]:
+    """The reservation rows one seeded pool's ``table_ids`` become, aliases resolved and
+    positioned in the order given.
+
+    Unlike the write path (``app.tournament_pools._reservations``), an id that no
+    catalogue row holds is **not** dropped — it is passed through to the database, which
+    refuses it. This is the direct-to-database seam, and a seed that names a table this
+    tournament does not have is a mistake in the seed; swallowing it here would hide the
+    very foreign keys these rows exist to have.
+    """
+    if tournament is None:
+        return []
+    return [
+        TournamentEventPoolTable(
+            tournament_id=tournament.id,
+            table_id=by_alias.get(table_id, table_id),
+            position=position,
+        )
+        for position, table_id in enumerate(table_ids)
+    ]
 
 
 def with_table_aliases(

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -8,6 +8,8 @@ import uuid
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import date, time
+from typing import Any
 
 import pytest
 from httpx import ASGITransport, AsyncClient, Request
@@ -26,6 +28,7 @@ from app.models import (
     Role,
     RolePermission,
     Tournament,
+    TournamentEventPool,
     User,
     UserLeagueRating,
     UserRole,
@@ -144,29 +147,63 @@ def venue_tables(*specs: tuple[str, str]) -> list[VenueTable]:
     ]
 
 
-def with_table_aliases(
-    tournament: Tournament, pools: Sequence[Mapping[str, object]]
-) -> list[dict[str, object]]:
-    """Rewrite each pool's ``table_ids`` from the positional aliases a test writes
-    (``"t1"``, ``"t2"``, …) into the real ids of ``tournament``'s catalogue rows.
+def event_pools(
+    pools: Sequence[Mapping[str, Any]], *, tournament: Tournament | None = None
+) -> list[TournamentEventPool]:
+    """``TournamentEventPool`` rows for an event a test seeds straight through the ORM,
+    written from the ``{id, name, slot, table_ids}`` dict shape the pools JSONB used to
+    hold and positioned in the order given.
 
-    A pool reserves a slice of the venue by naming table ids, and those ids are UUIDs
-    the server minted (ADR 20260801) — so a seeded pool cannot spell one as a literal.
-    The alias is 1-based and positional: ``"t1"`` is the tournament's first table, in
-    its own catalogue order. It exists so a test can go on saying which tables a pool
-    holds in the terms the test is about, instead of threading a UUID through every
-    helper it passes a pool to.
+    Pools are rows now (ADR 20260801), so ``TournamentEvent(pools=[{...}])`` is a
+    ``TypeError`` waiting to happen; this is the one translation from the shape the
+    tests already say a pool in, so a seed reads as the pool it is about rather than as
+    five keyword arguments. The ``slot``'s ``YYYY-MM-DD`` / ``HH:MM`` strings are
+    parsed into the row's ``slot_date`` / ``slot_start`` / ``slot_end`` columns exactly
+    as the write boundary parses them, so a seeded pool and a POSTed one are the same
+    row.
+
+    With a ``tournament``, each pool's ``table_ids`` are also rewritten from the
+    positional aliases a test writes (``"t1"``, ``"t2"``, …) into the real ids of that
+    tournament's catalogue rows — 1-based and in catalogue order — because a table id is
+    a server-minted UUID a seed cannot spell as a literal.
     """
-    by_alias = {
-        f"t{position}": str(table.id)
-        for position, table in enumerate(tournament.tables, start=1)
-    }
-    resolved: list[dict[str, object]] = []
-    for pool in pools:
-        aliases = pool["table_ids"]
-        assert isinstance(aliases, list)
-        resolved.append({**pool, "table_ids": [by_alias[alias] for alias in aliases]})
-    return resolved
+    by_alias = (
+        {
+            f"t{position}": str(table.id)
+            for position, table in enumerate(tournament.tables, start=1)
+        }
+        if tournament is not None
+        else {}
+    )
+    rows: list[TournamentEventPool] = []
+    for position, pool in enumerate(pools):
+        slot = pool.get("slot") or {}
+        table_ids = [str(table_id) for table_id in pool.get("table_ids", [])]
+        rows.append(
+            TournamentEventPool(
+                id=pool["id"],
+                name=pool.get("name", pool["id"]),
+                position=pool.get("position", position),
+                slot_date=date.fromisoformat(slot.get("date", "2026-06-13")),
+                slot_start=time.fromisoformat(slot.get("start", "09:00")),
+                slot_end=time.fromisoformat(slot.get("end", "18:00")),
+                table_ids=[by_alias.get(table_id, table_id) for table_id in table_ids],
+            )
+        )
+    return rows
+
+
+def with_table_aliases(
+    tournament: Tournament, pools: Sequence[Mapping[str, Any]]
+) -> list[TournamentEventPool]:
+    """:func:`event_pools` with the tournament bound — the spelling the seeds that name
+    tables already use.
+
+    Kept as its own name because it is what the call sites are *about*: "these pools
+    reserve this tournament's first two tables", said without threading a UUID through
+    every helper the pools are passed to.
+    """
+    return event_pools(pools, tournament=tournament)
 
 
 async def table_ids_of(db_session: AsyncSession, tournament_id: uuid.UUID) -> list[str]:

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -997,7 +997,7 @@ async def _make_rr_event(
         match_settings={"rated": True, "length_games": 5},
         predicates=[],
         pools=event_pools(
-            [{"id": "pool-a", "name": "Pool A", "slot": slot, "table_ids": ["t1"]}],
+            [{"name": "Pool A", "slot": slot, "table_ids": ["t1"]}],
             tournament=tournament,
         ),
     )

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -47,6 +47,7 @@ from app.roles import grant_default_role
 from app.sessions import SESSION_TOKEN_CONTEXT
 from app.tournament_draws import cut_draw
 from tests._helpers import (
+    event_pools,
     start_session,
     venue_tables,
 )
@@ -986,7 +987,9 @@ async def _make_rr_event(
         slot=slot,
         match_settings={"rated": True, "length_games": 5},
         predicates=[],
-        pools=[{"id": "pool-a", "name": "Pool A", "slot": slot, "table_ids": ["t1"]}],
+        pools=event_pools(
+            [{"id": "pool-a", "name": "Pool A", "slot": slot, "table_ids": ["t1"]}]
+        ),
     )
     tournament.events.append(event)
     db.add(tournament)

--- a/api/tests/test_account_merge.py
+++ b/api/tests/test_account_merge.py
@@ -485,6 +485,7 @@ async def _make_event(db: AsyncSession, owner: User) -> TournamentEvent:
         name="Open Singles",
         format=EventFormat.singles,
         draw_settings=TournamentEventDrawSettings.for_draw_type(DrawType.single_elim),
+        tournament=tournament,
         max_players=32,
         entry_fee=40,
         timezone="America/Chicago",
@@ -493,8 +494,7 @@ async def _make_event(db: AsyncSession, owner: User) -> TournamentEvent:
         predicates=[],
         pools=[],
     )
-    tournament.events.append(event)
-    db.add(tournament)
+    db.add(event)
     await db.commit()
     await db.refresh(event)
     return event
@@ -976,8 +976,17 @@ async def _make_rr_event(
             },
             tables=venue_tables(("Table 1", "A")),
         )
+    db.add(tournament)
+    # Flushed before the event is composed, because the pool below reserves a table and
+    # a reservation row carries the tournament's id — which is the database's to mint
+    # (ADR 20260801).
+    await db.flush()
     slot = {"date": "2026-06-13", "start": "09:00", "end": "18:00"}
     event = TournamentEvent(
+        # By id rather than by ``tournament.events.append``: the tournament is flushed
+        # above (its pool reservations need its id), and appending to a *persistent*
+        # tournament's un-loaded ``events`` collection is a lazy load in sync context.
+        tournament_id=tournament.id,
         name=name,
         format=EventFormat.singles,
         draw_settings=TournamentEventDrawSettings.for_draw_type(DrawType.round_robin),
@@ -988,11 +997,11 @@ async def _make_rr_event(
         match_settings={"rated": True, "length_games": 5},
         predicates=[],
         pools=event_pools(
-            [{"id": "pool-a", "name": "Pool A", "slot": slot, "table_ids": ["t1"]}]
+            [{"id": "pool-a", "name": "Pool A", "slot": slot, "table_ids": ["t1"]}],
+            tournament=tournament,
         ),
     )
-    tournament.events.append(event)
-    db.add(tournament)
+    db.add(event)
     await db.commit()
     await db.refresh(event)
     return event

--- a/api/tests/test_dashboard_tournaments.py
+++ b/api/tests/test_dashboard_tournaments.py
@@ -727,13 +727,15 @@ async def test_a_withdrawn_entry_that_was_never_entered_is_not_a_uuid_lookup(
 # entries — joined to their events, those events' tournaments AND, since #1086, those
 # events' draw settings rows — plus ONE batched load of those tournaments' venue tables
 # (``Tournament.tables``, ``lazy="selectin"`` — the catalogue is rows now,
-# ADR 20260801, and the panel resolves a placement's table LABEL through it), then ONE
-# batched load of every event's active entrants, ONE of every event's fixtures, ONE of
-# the completed matches' game counts, ONE of the handful of focus matches, and that
-# load's own eager options (the match's league, results, sides, settings, side players
-# and those players' users — one batched ``selectin`` each). Twelve, whatever the
-# number of events.
-EXPECTED_DASHBOARD_PANEL_STATEMENTS = 12
+# ADR 20260801, and the panel resolves a placement's table LABEL through it) and ONE of
+# every event's pools (``TournamentEvent.pools``, ``lazy="selectin"`` — pools are rows
+# now too, ADR 20260801, and the panel resolves a fixture's pool NAME through them),
+# then ONE batched load of every event's active entrants, ONE of every event's fixtures,
+# ONE of the completed matches' game counts, ONE of the handful of focus matches, and
+# that load's own eager options (the match's league, results, sides, settings, side
+# players and those players' users — one batched ``selectin`` each). Thirteen, whatever
+# the number of events.
+EXPECTED_DASHBOARD_PANEL_STATEMENTS = 13
 
 
 @pytest.mark.parametrize("event_count", [1, 3])

--- a/api/tests/test_dashboard_tournaments.py
+++ b/api/tests/test_dashboard_tournaments.py
@@ -729,13 +729,16 @@ async def test_a_withdrawn_entry_that_was_never_entered_is_not_a_uuid_lookup(
 # (``Tournament.tables``, ``lazy="selectin"`` — the catalogue is rows now,
 # ADR 20260801, and the panel resolves a placement's table LABEL through it) and ONE of
 # every event's pools (``TournamentEvent.pools``, ``lazy="selectin"`` — pools are rows
-# now too, ADR 20260801, and the panel resolves a fixture's pool NAME through them),
+# now too, ADR 20260801, and the panel resolves a fixture's pool NAME through them) and
+# ONE of every one of THOSE pools' table reservations
+# (``TournamentEventPool.tables``, ``lazy="selectin"`` — chained onto the pools' own
+# batched load, so it is one statement per panel build and not one per pool),
 # then ONE batched load of every event's active entrants, ONE of every event's fixtures,
 # ONE of the completed matches' game counts, ONE of the handful of focus matches, and
 # that load's own eager options (the match's league, results, sides, settings, side
-# players and those players' users — one batched ``selectin`` each). Thirteen, whatever
+# players and those players' users — one batched ``selectin`` each). Fourteen, whatever
 # the number of events.
-EXPECTED_DASHBOARD_PANEL_STATEMENTS = 13
+EXPECTED_DASHBOARD_PANEL_STATEMENTS = 14
 
 
 @pytest.mark.parametrize("event_count", [1, 3])

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -72,9 +72,32 @@ def _seed_of(entry_id: EntryId | None) -> int:
     return entry_id.int
 
 
+#: The base a test pool id is minted from. A pool id is a ``uuid`` (ADR 20260801) — the
+#: ``tournament_event_pools`` primary key the server mints — so the ``"A"``/``"B"`` the
+#: snake matrix below is written in are **labels**, not ids, and :func:`_pool` is the
+#: one place they become the ids the domain actually carries. Derived from the letter
+#: rather than random so the same matrix entry names the same pool on every run and a
+#: failure is readable.
+_POOL_ID_BASE = 0xB00_10000
+
+
+def _pool(letter: str) -> PoolId:
+    """The pool id the matrix's ``letter`` stands for."""
+    return PoolId(uuid.UUID(int=_POOL_ID_BASE + (ord(letter) - ord("A"))))
+
+
 def _pool_ids(count: int) -> tuple[PoolId, ...]:
-    """``('A', 'B', …)`` — pool ids are string refs into the event's JSONB pools."""
-    return tuple(PoolId(chr(ord("A") + i)) for i in range(count))
+    """The first ``count`` pools' ids, in the event's own pool order."""
+    return tuple(_pool(chr(ord("A") + i)) for i in range(count))
+
+
+def _ordered_pool_id(rank: int) -> PoolId:
+    """A pool id whose place in the ids' OWN sort order is ``rank`` (1 sorts first).
+
+    The sort tie-break in ``ready_fixtures`` compares ids, and a random uuid's order is
+    not something a test can state — so the handful of tests that are about that
+    tie-break mint ids whose order is known, and say so."""
+    return PoolId(uuid.UUID(int=_POOL_ID_BASE + 0x1000 + rank))
 
 
 def _config(pool_count: int) -> DrawConfig:
@@ -338,7 +361,12 @@ class TestRoundRobinCut:
         fixtures = RoundRobinStrategy().plan_initial(_config(pools), _ordered(entrants))
 
         members = _members_by_pool(fixtures)
-        assert {str(k): sorted(v) for k, v in members.items()} == expected
+        # Keyed back onto the matrix's letters: the pool ids are uuids
+        # (ADR 20260801), and ``_pool`` is the one place a letter becomes one.
+        assert {
+            letter: sorted(members[_pool(letter)]) for letter in expected
+        } == expected
+        assert set(members) == {_pool(letter) for letter in expected}
 
     @pytest.mark.parametrize(
         ("entrants", "pools", "expected"), SNAKE_MATRIX, ids=MATRIX_IDS
@@ -362,10 +390,10 @@ class TestRoundRobinCut:
         fixtures = RoundRobinStrategy().plan_initial(_config(pools), _ordered(entrants))
 
         pairs_by_pool = _pairs_by_pool(fixtures)
-        assert set(pairs_by_pool) == {PoolId(p) for p in expected}
+        assert set(pairs_by_pool) == {_pool(p) for p in expected}
 
         for pool_id, seeds in expected.items():
-            pairs = pairs_by_pool[PoolId(pool_id)]
+            pairs = pairs_by_pool[_pool(pool_id)]
             n = len(seeds)
             # All-play-all: exactly n(n-1)/2 fixtures...
             assert len(pairs) == n * (n - 1) // 2
@@ -405,7 +433,7 @@ class TestRoundRobinCut:
         fixtures = RoundRobinStrategy().plan_initial(_config(pools), _ordered(entrants))
 
         for pool_id, seeds in expected.items():
-            pool_fixtures = [f for f in fixtures if f.pool_id == PoolId(pool_id)]
+            pool_fixtures = [f for f in fixtures if f.pool_id == _pool(pool_id)]
             n = len(seeds)
             # An even pool plays n-1 rounds; an odd one needs n (each entrant sits out
             # exactly once), which is the whole reason a bye exists.
@@ -441,7 +469,7 @@ class TestRoundRobinCut:
             # An odd pool sits one entrant out per round: (n-1)/2 fixtures, not n/2
             # rounded up, and certainly not a phantom row.
             per_round = Counter(
-                f.round for f in fixtures if f.pool_id == PoolId(pool_id)
+                f.round for f in fixtures if f.pool_id == _pool(pool_id)
             )
             assert set(per_round.values()) == {(n - 1) // 2}
 
@@ -467,7 +495,7 @@ class TestRoundRobinCut:
 
         assert fixtures == [
             PlannedFixture(
-                pool_id=PoolId("A"),
+                pool_id=_pool("A"),
                 round=1,
                 position=1,
                 entry_a_id=_entry_id(1),
@@ -548,16 +576,15 @@ class TestRoundRobinCut:
         assert str(excinfo.value) == "A round-robin draw needs at least one pool."
 
     def test_pools_are_named_by_the_events_own_pool_ids(self) -> None:
-        # A pool id is a string ref into the event's JSONB pools, not an index we mint.
-        config = DrawConfig(
-            pool_ids=(PoolId("pool-morning"), PoolId("pool-evening")),
-        )
+        # A pool id is the event's own pool row's uuid, not an index we mint.
+        morning, evening = PoolId(uuid.uuid4()), PoolId(uuid.uuid4())
+        config = DrawConfig(pool_ids=(morning, evening))
 
         fixtures = RoundRobinStrategy().plan_initial(config, _ordered(6))
 
         assert {f.pool_id for f in fixtures} == {
-            PoolId("pool-morning"),
-            PoolId("pool-evening"),
+            morning,
+            evening,
         }
 
 
@@ -632,7 +659,7 @@ class TestRoundRobinAdvance:
         # It must not rise from the dead and be played a second time.
         decided = FixtureState(
             fixture_id=FixtureId(uuid.UUID(int=1)),
-            pool_id=PoolId("A"),
+            pool_id=_pool("A"),
             round=1,
             position=1,
             entry_a_id=_entry_id(1),
@@ -694,16 +721,19 @@ class TestReadyFixtures:
         (``pool_position``, ADR 20260801) — the same order the read path renders and the
         same one the snake dealt against.
 
-        The ids are handed in *deliberately mismatched* to the positions: pool 1 is
-        ``p-10-…`` and pool 10 is ``p-1-…``. So the two rules do not merely differ,
-        they are opposites — an implementation that fell back to the id could not
-        accidentally agree with this assertion on any prefix of it.
+        The ids are handed in *deliberately mismatched* to the positions: the pool at
+        position 0 carries the id that sorts LAST and the pool at position 9 the id that
+        sorts first. So the two rules do not merely differ, they are opposites — an
+        implementation that fell back to the id could not accidentally agree with this
+        assertion on any prefix of it. (Under the old client-minted ids this was spelled
+        ``p-10-…``/``p-1-…``; a pool id is a uuid now, so the mismatch is constructed
+        from ids whose numeric order is known.)
         """
-        pools = [(f"p-{10 - index}-x", index) for index in range(10)]
+        pools = [(_ordered_pool_id(10 - index), index) for index in range(10)]
         states = [
             self._state(
                 index + 1,
-                pool_id=PoolId(pool_id),
+                pool_id=pool_id,
                 round=1,
                 position=1,
                 pool_position=position,
@@ -736,10 +766,10 @@ class TestReadyFixtures:
         (no id sorts before ``""``), landing in front of the pools that feed it.
         """
         placed = self._state(
-            1, pool_id=PoolId("z"), round=1, position=1, pool_position=0
+            1, pool_id=_ordered_pool_id(9), round=1, position=1, pool_position=0
         )
-        unplaced_b = self._state(2, pool_id=PoolId("b"), round=1, position=1)
-        unplaced_a = self._state(3, pool_id=PoolId("a"), round=1, position=1)
+        unplaced_b = self._state(2, pool_id=_ordered_pool_id(2), round=1, position=1)
+        unplaced_a = self._state(3, pool_id=_ordered_pool_id(1), round=1, position=1)
         ko = self._state(4, pool_id=None, round=1, position=1)
 
         ready = ready_fixtures([ko, unplaced_b, unplaced_a, placed])
@@ -758,10 +788,10 @@ class TestReadyFixtures:
         # un-pooled sit rather than fall over — and where they sit has to be a fact, not
         # whatever order the rows came back in.
         ko = self._state(1, pool_id=None, round=1, position=1)
-        b1 = self._state(2, pool_id=PoolId("B"), round=1, position=1)
-        a2 = self._state(3, pool_id=PoolId("A"), round=1, position=2)
-        a1 = self._state(4, pool_id=PoolId("A"), round=1, position=1)
-        a_round2 = self._state(5, pool_id=PoolId("A"), round=2, position=1)
+        b1 = self._state(2, pool_id=_pool("B"), round=1, position=1)
+        a2 = self._state(3, pool_id=_pool("A"), round=1, position=2)
+        a1 = self._state(4, pool_id=_pool("A"), round=1, position=1)
+        a_round2 = self._state(5, pool_id=_pool("A"), round=2, position=1)
 
         # Fed in scrambled — and it is the *stated* order that is asserted, not merely
         # that the output is self-consistently sorted (which a reversed rule would also
@@ -779,10 +809,10 @@ class TestReadyFixtures:
     def test_readiness_ignores_the_draw_type_that_planned_the_fixture(self) -> None:
         # Same three states, asked of the shared helper and of the strategy: a fixture
         # that is ready is ready, and a strategy cannot make it less so.
-        ready = self._state(1, pool_id=PoolId("A"), round=1, position=1)
+        ready = self._state(1, pool_id=_pool("A"), round=1, position=1)
         materialized = FixtureState(
             fixture_id=FixtureId(uuid.UUID(int=2)),
-            pool_id=PoolId("A"),
+            pool_id=_pool("A"),
             round=1,
             position=2,
             entry_a_id=_entry_id(3),
@@ -1593,7 +1623,7 @@ class TestRrThenKoCut:
         # the format working as intended, not a refusal.
         cut = _rr_then_ko(2).plan_initial(_config(1), _ordered(5))
 
-        assert {f.pool_id for f in _pooled(cut)} == {PoolId("A")}
+        assert {f.pool_id for f in _pooled(cut)} == {_pool("A")}
         assert len(_knockout(cut)) == 1  # a two-qualifier final
 
     def test_rr_then_ko_refuses_to_take_more_qualifiers_than_the_smallest_pool_holds(

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -154,7 +154,8 @@ async def _make_tournament(
                     "slot": {"date": DATE, "start": window[0], "end": window[1]},
                     "table_ids": [str(row.id) for row in catalogue],
                 }
-            ]
+            ],
+            tournament=tournament,
         ),
     )
     db.add(event)
@@ -943,7 +944,8 @@ async def _hold_user_in_second_event(
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": [table_id],
                 }
-            ]
+            ],
+            tournament=tournament,
         ),
     )
     db.add(event)
@@ -1520,12 +1522,17 @@ async def _drop_table_from_pools(
     event = (
         await db.execute(select(TournamentEvent).where(TournamentEvent.id == event_id))
     ).scalar_one()
-    # Mutated in place on the pool ROWS (ADR 20260801) rather than by reassigning a
-    # JSONB list: dropping a table from a pool's reservation is an edit to the rows
-    # the event already has, and rebuilding the collection would delete and re-insert
-    # the very pools its fixtures foreign-key.
+    # Dropping the reservation ROW (ADR 20260801) rather than filtering a JSONB list:
+    # a pool's reserved tables are their own rows now, and taking one out of the
+    # collection is what ``delete-orphan`` turns into the DELETE. The pool rows
+    # themselves are untouched — rebuilding them would delete and re-insert the very
+    # pools this event's fixtures foreign-key.
     for pool in event.pools:
-        pool.table_ids = [t for t in pool.table_ids if t != table_id]
+        pool.tables = [
+            reservation
+            for reservation in pool.tables
+            if reservation.table_id != table_id
+        ]
     await db.commit()
 
 

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -67,6 +67,7 @@ from app.schedule_solves import RUN_SCHEDULE_SOLVE_JOB, SUPERSEDED_ERROR, reques
 from app.schemas.notification import NotificationJob
 from app.tournament_draws import cut_draw
 from tests._helpers import (
+    event_pools,
     hijack_solve,
     make_user,
     venue_tables,
@@ -145,14 +146,16 @@ async def _make_tournament(
         timezone="America/Chicago",
         slot={"date": DATE, "start": window[0], "end": window[1]},
         match_settings={"rated": False, "length_games": 3},
-        pools=[
-            {
-                "id": "pool-a",
-                "name": "Pool A",
-                "slot": {"date": DATE, "start": window[0], "end": window[1]},
-                "table_ids": [str(row.id) for row in catalogue],
-            }
-        ],
+        pools=event_pools(
+            [
+                {
+                    "id": "pool-a",
+                    "name": "Pool A",
+                    "slot": {"date": DATE, "start": window[0], "end": window[1]},
+                    "table_ids": [str(row.id) for row in catalogue],
+                }
+            ]
+        ),
     )
     db.add(event)
     await db.flush()
@@ -932,14 +935,16 @@ async def _hold_user_in_second_event(
         timezone="America/Chicago",
         slot={"date": DATE, "start": "09:00", "end": "17:00"},
         match_settings={"rated": False, "length_games": 3},
-        pools=[
-            {
-                "id": "pool-b",
-                "name": "Pool B",
-                "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
-                "table_ids": [table_id],
-            }
-        ],
+        pools=event_pools(
+            [
+                {
+                    "id": "pool-b",
+                    "name": "Pool B",
+                    "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
+                    "table_ids": [table_id],
+                }
+            ]
+        ),
     )
     db.add(event)
     await db.flush()
@@ -1515,13 +1520,12 @@ async def _drop_table_from_pools(
     event = (
         await db.execute(select(TournamentEvent).where(TournamentEvent.id == event_id))
     ).scalar_one()
-    event.pools = [
-        {
-            **pool,
-            "table_ids": [t for t in pool["table_ids"] if t != table_id],
-        }
-        for pool in event.pools
-    ]
+    # Mutated in place on the pool ROWS (ADR 20260801) rather than by reassigning a
+    # JSONB list: dropping a table from a pool's reservation is an edit to the rows
+    # the event already has, and rebuilding the collection would delete and re-insert
+    # the very pools its fixtures foreign-key.
+    for pool in event.pools:
+        pool.table_ids = [t for t in pool.table_ids if t != table_id]
     await db.commit()
 
 

--- a/api/tests/test_match_calls.py
+++ b/api/tests/test_match_calls.py
@@ -149,7 +149,6 @@ async def _make_tournament(
         pools=event_pools(
             [
                 {
-                    "id": "pool-a",
                     "name": "Pool A",
                     "slot": {"date": DATE, "start": window[0], "end": window[1]},
                     "table_ids": [str(row.id) for row in catalogue],
@@ -939,7 +938,6 @@ async def _hold_user_in_second_event(
         pools=event_pools(
             [
                 {
-                    "id": "pool-b",
                     "name": "Pool B",
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": [table_id],

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -78,6 +78,7 @@ from app.models import (
     TournamentEntryStatus,
     TournamentEvent,
     TournamentEventDrawSettings,
+    TournamentEventPool,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -1424,7 +1425,6 @@ def _event_payload() -> dict[str, object]:
         "predicates": [{"id": "pr-1", "field": "rating", "op": "<", "value": 1500}],
         "pools": [
             {
-                "id": "p-os-1",
                 "name": "Pool A",
                 "slot": {"date": "2026-08-01", "start": "09:00", "end": "12:30"},
                 "table_ids": ["t1"],
@@ -1755,6 +1755,18 @@ async def _first_event_id(db_session: AsyncSession, tournament_id: str) -> uuid.
     ).scalar_one()
 
 
+async def _only_pool_id(db_session: AsyncSession, event_id: uuid.UUID) -> uuid.UUID:
+    """The id of the event's one pool — server-minted (ADR 20260801), so a seed that
+    puts a fixture in it has to look it up rather than spell it."""
+    return (
+        await db_session.execute(
+            select(TournamentEventPool.id).where(
+                TournamentEventPool.event_id == event_id
+            )
+        )
+    ).scalar_one()
+
+
 async def _seed_placed_fixture(
     db_session: AsyncSession,
     event_id: uuid.UUID,
@@ -1780,7 +1792,7 @@ async def _seed_placed_fixture(
     await db_session.commit()
     fixture = TournamentFixture(
         event_id=event_id,
-        pool_id="p-os-1",
+        pool_id=await _only_pool_id(db_session, event_id),
         round=1,
         position=1,
         entry_a_id=entry_a.id,
@@ -1854,7 +1866,7 @@ async def test_get_schedule_returns_placed_fixtures_and_latest_solve_verdict(
         "local_label": "9:00 AM",
         "tz_abbrev": "CDT",
     }
-    assert placed["pool_id"] == "p-os-1"
+    assert placed["pool_id"] == str(fixture.pool_id)
     assert placed["round"] == 1
     assert placed["position"] == 1
     assert body["latest_schedule_solve"]["status"] == "succeeded"
@@ -2068,13 +2080,11 @@ async def test_edit_tournament_league_change_after_publish_raises_tool_error(
 # Two pools, so the round-robin snake deals a clean draw a fixture's ``pool_id``
 # refs against — the same shape ``test_tournament_draw_service.py`` cuts across.
 _DRAW_POOL_A: dict[str, object] = {
-    "id": "p-a",
     "name": "Pool A",
     "slot": {"date": "2026-08-01", "start": "09:00", "end": "12:30"},
     "table_ids": ["t1"],
 }
 _DRAW_POOL_B: dict[str, object] = {
-    "id": "p-b",
     "name": "Pool B",
     "slot": {"date": "2026-08-01", "start": "09:00", "end": "12:30"},
     "table_ids": ["t2"],
@@ -2180,7 +2190,19 @@ async def test_build_cut_returns_fixtures_visible_via_schedule_then_uncut_remove
         assert cut.structuredContent is not None
         fixtures = cut.structuredContent["result"]
         assert len(fixtures) == 2
-        assert all(f["pool_id"] in {"p-a", "p-b"} for f in fixtures)
+        pool_ids = {
+            str(pool_id)
+            for pool_id in (
+                await db_session.execute(
+                    select(TournamentEventPool.id).where(
+                        TournamentEventPool.event_id == event.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        }
+        assert all(f["pool_id"] in pool_ids for f in fixtures)
 
         # The cut draw is visible through the schedule projection.
         schedule = await client.call_tool_mcp(
@@ -2667,7 +2689,6 @@ async def _seed_previewable_tournament(
             tournament,
             [
                 {
-                    "id": "pool-a",
                     "name": "Pool A",
                     "slot": {
                         "date": "2030-01-01",
@@ -3517,7 +3538,6 @@ async def _seed_cut_event(db: AsyncSession, tournament: Tournament) -> Tournamen
         pools=event_pools(
             [
                 {
-                    "id": "p-1",
                     "name": "Pool A",
                     "slot": {"date": "2026-08-01", "start": "09:00", "end": "12:30"},
                     # No tables: this tournament is seeded without a catalogue, and a
@@ -3534,7 +3554,7 @@ async def _seed_cut_event(db: AsyncSession, tournament: Tournament) -> Tournamen
     await db.refresh(event)
     fixture = TournamentFixture(
         event_id=event.id,
-        pool_id="p-1",
+        pool_id=event.pools[0].id,
         round=1,
         position=1,
     )
@@ -4033,7 +4053,6 @@ async def _seed_placeable_fixture(
             tournament,
             [
                 {
-                    "id": "p-os-1",
                     "name": "Pool A",
                     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
                     "table_ids": ["t1"],
@@ -4058,7 +4077,7 @@ async def _seed_placeable_fixture(
     await db.commit()
     fixture = TournamentFixture(
         event_id=event.id,
-        pool_id="p-os-1",
+        pool_id=event.pools[0].id,
         round=1,
         position=1,
         entry_a_id=entry_a.id,

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -89,6 +89,7 @@ from app.tournament_draws import cut_draw
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_ENTER, TOURNAMENT_VIEW
 from tests._helpers import (
     enqueued_notification_jobs,
+    event_pools,
     grant_permissions,
     make_user,
     start_session,
@@ -3513,14 +3514,16 @@ async def _seed_cut_event(db: AsyncSession, tournament: Tournament) -> Tournamen
         slot={"date": "2026-08-01", "start": "09:00", "end": "17:00"},
         match_settings={"rated": False, "length_games": 3},
         predicates=[],
-        pools=[
-            {
-                "id": "p-1",
-                "name": "Pool A",
-                "slot": {"date": "2026-08-01", "start": "09:00", "end": "12:30"},
-                "table_ids": ["t1"],
-            }
-        ],
+        pools=event_pools(
+            [
+                {
+                    "id": "p-1",
+                    "name": "Pool A",
+                    "slot": {"date": "2026-08-01", "start": "09:00", "end": "12:30"},
+                    "table_ids": ["t1"],
+                }
+            ]
+        ),
     )
     db.add(event)
     await db.commit()

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -3520,9 +3520,13 @@ async def _seed_cut_event(db: AsyncSession, tournament: Tournament) -> Tournamen
                     "id": "p-1",
                     "name": "Pool A",
                     "slot": {"date": "2026-08-01", "start": "09:00", "end": "12:30"},
-                    "table_ids": ["t1"],
+                    # No tables: this tournament is seeded without a catalogue, and a
+                    # reservation is a row foreign-keyed to a real one (ADR 20260801).
+                    # Nothing here is about the venue — the target is the draw-type
+                    # freeze.
+                    "table_ids": [],
                 }
-            ]
+            ],
         ),
     )
     db.add(event)

--- a/api/tests/test_pool_finishing_order.py
+++ b/api/tests/test_pool_finishing_order.py
@@ -174,7 +174,7 @@ def test_the_standings_table_is_this_order() -> None:
     entrants = [w, x, y, z]
     outcomes = [_outcome(x, w, 3, 0), _outcome(y, z, 3, 1), _outcome(w, y, 3, 2)]
     pool = PoolInput(
-        pool_id=PoolId("pool-a"),
+        pool_id=PoolId(uuid.uuid4()),
         entrants=tuple(entrants),
         fixture_count=6,
         outcomes=tuple(outcomes),

--- a/api/tests/test_realtime_publishing_calls.py
+++ b/api/tests/test_realtime_publishing_calls.py
@@ -136,7 +136,6 @@ async def _stage(
         pools=event_pools(
             [
                 {
-                    "id": "pool-a",
                     "name": "Pool A",
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": ["t1", "t2"],
@@ -162,7 +161,7 @@ async def _stage(
 
     called_fixture = TournamentFixture(
         event_id=event.id,
-        pool_id="pool-a",
+        pool_id=event.pools[0].id,
         round=1,
         position=1,
         entry_a_id=entry_a.id,
@@ -170,7 +169,7 @@ async def _stage(
     )
     later_fixture = TournamentFixture(
         event_id=event.id,
-        pool_id="pool-a",
+        pool_id=event.pools[0].id,
         round=1,
         position=2,
         entry_a_id=entry_c.id,

--- a/api/tests/test_realtime_publishing_calls.py
+++ b/api/tests/test_realtime_publishing_calls.py
@@ -51,6 +51,7 @@ from app.models import (
 )
 from app.realtime import EventKind, RealtimeBroker
 from tests._helpers import (
+    event_pools,
     make_user,
     venue_tables,
 )
@@ -132,14 +133,16 @@ async def _stage(
         timezone=VENUE_TZ_NAME,
         slot={"date": DATE, "start": "09:00", "end": "17:00"},
         match_settings={"rated": False, "length_games": 3},
-        pools=[
-            {
-                "id": "pool-a",
-                "name": "Pool A",
-                "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
-                "table_ids": ["t1", "t2"],
-            }
-        ],
+        pools=event_pools(
+            [
+                {
+                    "id": "pool-a",
+                    "name": "Pool A",
+                    "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
+                    "table_ids": ["t1", "t2"],
+                }
+            ]
+        ),
     )
     db.add(event)
     await db.flush()

--- a/api/tests/test_realtime_publishing_calls.py
+++ b/api/tests/test_realtime_publishing_calls.py
@@ -141,7 +141,8 @@ async def _stage(
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": ["t1", "t2"],
                 }
-            ]
+            ],
+            tournament=tournament,
         ),
     )
     db.add(event)

--- a/api/tests/test_realtime_publishing_tournaments.py
+++ b/api/tests/test_realtime_publishing_tournaments.py
@@ -200,7 +200,8 @@ async def _seed_field(
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": [str(row.id) for row in catalogue],
                 }
-            ]
+            ],
+            tournament=tournament,
         ),
     )
     db.add(event)

--- a/api/tests/test_realtime_publishing_tournaments.py
+++ b/api/tests/test_realtime_publishing_tournaments.py
@@ -64,6 +64,7 @@ from app.tournament_draws import cut_draw
 from app.tournament_lifecycle import transition_tournament
 from app.tournament_placement import place_fixture
 from tests._helpers import (
+    event_pools,
     make_user,
     table_ids_of,
     venue_tables,
@@ -191,14 +192,16 @@ async def _seed_field(
         timezone="America/Chicago",
         slot={"date": DATE, "start": "09:00", "end": "17:00"},
         match_settings={"rated": False, "length_games": 3},
-        pools=[
-            {
-                "id": "pool-a",
-                "name": "Pool A",
-                "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
-                "table_ids": [str(row.id) for row in catalogue],
-            }
-        ],
+        pools=event_pools(
+            [
+                {
+                    "id": "pool-a",
+                    "name": "Pool A",
+                    "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
+                    "table_ids": [str(row.id) for row in catalogue],
+                }
+            ]
+        ),
     )
     db.add(event)
     await db.flush()

--- a/api/tests/test_realtime_publishing_tournaments.py
+++ b/api/tests/test_realtime_publishing_tournaments.py
@@ -195,7 +195,6 @@ async def _seed_field(
         pools=event_pools(
             [
                 {
-                    "id": "pool-a",
                     "name": "Pool A",
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": [str(row.id) for row in catalogue],

--- a/api/tests/test_results.py
+++ b/api/tests/test_results.py
@@ -30,6 +30,18 @@ def _eid(n: int) -> EntryId:
     return EntryId(uuid.UUID(int=n))
 
 
+def _pid(n: int) -> PoolId:
+    """A stable pool id. A pool id is a ``uuid`` (ADR 20260801) — the
+    ``tournament_event_pools`` primary key the server mints — so these stand in for it,
+    minted from a fixed integer so a failure names the same pool every run."""
+    return PoolId(uuid.UUID(int=0xB0000 + n))
+
+
+#: The pools these tests deal in, by the letters their comments call them.
+_POOL_A, _POOL_B = _pid(1), _pid(2)
+_POOL_P_ID, _POOL_Q_ID = _pid(3), _pid(4)
+
+
 A, B, C, D, E, F = (_eid(n) for n in range(1, 7))
 
 
@@ -53,7 +65,7 @@ def _single_pool(
     outcomes: list[MatchOutcome],
 ) -> PoolInput:
     return PoolInput(
-        pool_id=PoolId("p-a"),
+        pool_id=_POOL_A,
         entrants=entrants,
         fixture_count=fixture_count,
         outcomes=tuple(outcomes),
@@ -229,13 +241,13 @@ def test_a_complete_multi_pool_event_crowns_no_single_champion() -> None:
     has no single champion (that needs a knockout stage to join the pool winners), so
     ``champion`` is ``None`` while each pool still has its own leader."""
     pool_a = PoolInput(
-        pool_id=PoolId("p-a"),
+        pool_id=_POOL_A,
         entrants=(A, B),
         fixture_count=1,
         outcomes=(_outcome(A, B, 2, 0),),
     )
     pool_b = PoolInput(
-        pool_id=PoolId("p-b"),
+        pool_id=_POOL_B,
         entrants=(C, D),
         fixture_count=1,
         outcomes=(_outcome(C, D, 2, 0),),
@@ -426,7 +438,7 @@ def test_a_corrected_final_re_crowns_the_champion() -> None:
 # (or nobody, since a multi-pool round-robin crowns none), never B.
 
 _POOL_P = PoolInput(
-    pool_id=PoolId("p-p"),
+    pool_id=_POOL_P_ID,
     entrants=(A, B, C),
     fixture_count=3,
     outcomes=(
@@ -436,7 +448,7 @@ _POOL_P = PoolInput(
     ),
 )
 _POOL_Q = PoolInput(
-    pool_id=PoolId("p-q"),
+    pool_id=_POOL_Q_ID,
     entrants=(D, E, F),
     fixture_count=3,
     outcomes=(
@@ -476,7 +488,7 @@ def test_rr_then_ko_reads_out_both_stages_in_one_tabulation() -> None:
     about the event's field."""
     results = RrThenKoResults().tabulate([_POOL_P, _POOL_Q], _FULL_BRACKET)
 
-    assert [pool.pool_id for pool in results.pools] == [PoolId("p-p"), PoolId("p-q")]
+    assert [pool.pool_id for pool in results.pools] == [_POOL_P_ID, _POOL_Q_ID]
     assert [[row.entry_id for row in pool.rows] for pool in results.pools] == [
         [A, B, C],
         [D, E, F],

--- a/api/tests/test_rr_then_ko.py
+++ b/api/tests/test_rr_then_ko.py
@@ -38,6 +38,7 @@ from app.models import (
     TournamentEntry,
     TournamentEntryStatus,
     TournamentEvent,
+    TournamentEventPool,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -53,9 +54,11 @@ from tests._helpers import (
 
 RR_THEN_KO = DrawType.rr_then_ko.value
 
+#: Three pools, sent with **no ``id``** — a pool id is a server-minted uuid
+#: (ADR 20260801) and the create shape has no field for one. The tests that need to name
+#: a pool look its id up by name (:func:`_pool_id`).
 POOLS: list[dict[str, Any]] = [
     {
-        "id": f"p-{letter}",
         "name": f"Pool {letter.upper()}",
         "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
         "table_ids": ["t1"],
@@ -110,6 +113,35 @@ def _event_payload(**overrides: Any) -> dict[str, Any]:
     }
     payload.update(overrides)
     return payload
+
+
+async def _pool_id(db_session: AsyncSession, event_id: str, name: str) -> uuid.UUID:
+    """The id of the event's pool **named** ``name`` — the lookup every assertion about
+    a fixture's ``pool_id`` goes through, since the id is the server's
+    (ADR 20260801)."""
+    return (
+        await db_session.execute(
+            select(TournamentEventPool.id).where(
+                TournamentEventPool.event_id == uuid.UUID(event_id),
+                TournamentEventPool.name == name,
+            )
+        )
+    ).scalar_one()
+
+
+async def _pool_ids(db_session: AsyncSession, event_id: str) -> list[uuid.UUID]:
+    """The event's pool ids in its own pool order."""
+    return list(
+        (
+            await db_session.execute(
+                select(TournamentEventPool.id)
+                .where(TournamentEventPool.event_id == uuid.UUID(event_id))
+                .order_by(TournamentEventPool.position)
+            )
+        )
+        .scalars()
+        .all()
+    )
 
 
 async def _tournament(client: AsyncClient) -> str:
@@ -666,8 +698,8 @@ async def test_the_cut_emits_the_pools_and_the_whole_bracket(
     pooled = [f for f in fixtures if f.pool_id is not None]
     bracket = [f for f in fixtures if f.pool_id is None]
     # Three pools of four: every pairing within a pool, six per pool.
-    assert sorted(p.pool_id for p in pooled) == sorted(
-        [pool["id"] for pool in POOLS] * 6
+    assert sorted(str(p.pool_id) for p in pooled) == sorted(
+        [str(pool_id) for pool_id in await _pool_ids(db_session, event_id)] * 6
     )
     assert all(f.entry_a_id is not None and f.entry_b_id is not None for f in pooled), (
         "every pool pairing is known at the cut"
@@ -810,13 +842,15 @@ async def test_a_finished_pool_seats_its_qualifiers_into_the_bracket(
         )
         assert live.status_code == 201, live.text
 
+        pool_a_id = await _pool_id(db_session, event_id, "Pool A")
         pool_a = [
-            f for f in await _fixtures(db_session, event_id) if f.pool_id == "p-a"
+            f for f in await _fixtures(db_session, event_id) if f.pool_id == pool_a_id
         ]
         assert len(pool_a) == 6, "a pool of four is six pairings"
         await _call(db_session, tournament_id, pool_a)
+        pool_a_id = await _pool_id(db_session, event_id, "Pool A")
         pool_a = [
-            f for f in await _fixtures(db_session, event_id) if f.pool_id == "p-a"
+            f for f in await _fixtures(db_session, event_id) if f.pool_id == pool_a_id
         ]
 
         clients = {
@@ -939,12 +973,14 @@ async def test_a_pool_holding_a_voided_pairing_still_seats_its_qualifiers(
             )
         ).status_code == 201
 
+        pool_a_id = await _pool_id(db_session, event_id, "Pool A")
         pool_a = [
-            f for f in await _fixtures(db_session, event_id) if f.pool_id == "p-a"
+            f for f in await _fixtures(db_session, event_id) if f.pool_id == pool_a_id
         ]
         await _call(db_session, tournament_id, pool_a)
+        pool_a_id = await _pool_id(db_session, event_id, "Pool A")
         pool_a = [
-            f for f in await _fixtures(db_session, event_id) if f.pool_id == "p-a"
+            f for f in await _fixtures(db_session, event_id) if f.pool_id == pool_a_id
         ]
         clients = {
             entries[1].id: client,
@@ -1003,7 +1039,11 @@ async def test_a_pool_holding_a_voided_pairing_still_seats_its_qualifiers(
     # And the two layers agree, which is the whole point: the pool the bracket treated
     # as over is the pool the director's table calls ``complete``, and the qualifiers
     # are its top two rows.
-    (pool_a_read,) = [pool for pool in results["pools"] if pool["pool_id"] == "p-a"]
+    (pool_a_read,) = [
+        pool
+        for pool in results["pools"]
+        if pool["pool_id"] == str(await _pool_id(db_session, event_id, "Pool A"))
+    ]
     assert pool_a_read["complete"] is True
     assert [row["entry_id"] for row in pool_a_read["rows"][:2]] == [
         str(entries[1].id),
@@ -1060,9 +1100,15 @@ async def test_the_results_read_out_as_both_stages(
     assert results["kind"] == "standings_then_finishes"
     assert results["complete"] is False
     assert results["champion"] is None
-    assert [pool["pool_id"] for pool in results["pools"]] == ["p-a", "p-b", "p-c"]
+    assert [pool["pool_id"] for pool in results["pools"]] == [
+        str(pool_id) for pool_id in await _pool_ids(db_session, event_id)
+    ]
     assert all(pool["complete"] is False for pool in results["pools"])
-    (pool_a,) = [pool for pool in results["pools"] if pool["pool_id"] == "p-a"]
+    (pool_a,) = [
+        pool
+        for pool in results["pools"]
+        if pool["pool_id"] == str(await _pool_id(db_session, event_id, "Pool A"))
+    ]
     leader = pool_a["rows"][0]
     assert leader["entry_id"] == str(entries[1].id)
     assert (leader["wins"], leader["games_won"], leader["games_lost"]) == (1, 2, 1)

--- a/api/tests/test_schedule_preview_route.py
+++ b/api/tests/test_schedule_preview_route.py
@@ -145,7 +145,6 @@ async def _make_tournament(
                 tournament,
                 [
                     {
-                        "id": "pool-a",
                         "name": "Pool A",
                         "slot": {
                             "date": "2030-01-01",

--- a/api/tests/test_schedule_preview_snapshot.py
+++ b/api/tests/test_schedule_preview_snapshot.py
@@ -54,7 +54,6 @@ def _one_pool(table_ids: list[str]) -> dict[str, object]:
     """A single pool over ``table_ids`` — one pool keeps the round-robin fixture
     count exactly ``C(N, 2)`` so a test can assert it precisely."""
     return {
-        "id": "p-a",
         "name": "Pool A",
         "slot": {"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         "table_ids": table_ids,
@@ -200,13 +199,11 @@ async def test_preview_snapshot_base_is_the_earliest_window_start(
         timezone="America/Los_Angeles",
         pools=[
             {
-                "id": "p-a",
                 "name": "Pool A",
                 "slot": {"date": "2026-06-13", "start": "09:00", "end": "18:00"},
                 "table_ids": ["t1"],
             },
             {
-                "id": "p-b",
                 "name": "Pool B",
                 "slot": {"date": "2026-06-13", "start": "08:15", "end": "18:00"},
                 "table_ids": ["t2"],
@@ -457,8 +454,12 @@ async def test_preview_snapshot_previews_an_rr_then_ko_events_pool_stage_only(
     preview = build_preview_snapshot(loaded)
 
     assert len(preview.snapshot.fixtures) == 15
+    # The solver's key is still ``{event}:{pool}`` (see
+    # ``app.schedule_preview.preview_pool_key`` for why the namespace stayed once the
+    # pool ids became globally unique uuids); the pool half is looked up, not spelled.
+    (pool,) = loaded.events[0].pools
     assert {f.pool_id for f in preview.snapshot.fixtures} == {
-        scheduling.PoolId(f"{loaded.events[0].id}:p-a")
+        scheduling.PoolId(f"{loaded.events[0].id}:{pool.id}")
     }
     assert preview.field_summaries[0].field_size == 6
     # What was dropped is *counted*, not silently discarded: the top 2 of the single

--- a/api/tests/test_schedule_preview_solve.py
+++ b/api/tests/test_schedule_preview_solve.py
@@ -81,7 +81,6 @@ def _pool(
     table_ids: list[str], *, start: str = "09:00", end: str = "18:00"
 ) -> dict[str, object]:
     return {
-        "id": "p-a",
         "name": "Pool A",
         "slot": {"date": "2026-06-13", "start": start, "end": end},
         "table_ids": table_ids,
@@ -295,7 +294,6 @@ async def test_preview_solve_finish_anchors_on_the_earliest_window_start(
         pools=[
             _pool(["t1"], start="09:00", end="18:00"),
             {
-                "id": "p-b",
                 "name": "Pool B",
                 "slot": {"date": "2026-06-13", "start": "08:30", "end": "18:00"},
                 "table_ids": ["t2"],
@@ -347,13 +345,11 @@ async def test_preview_solve_reports_byes_for_an_odd_field(
 #: ``_pool`` helper's id is fixed, and two pools of one event may not collide).
 _TWO_POOLS: list[dict[str, object]] = [
     {
-        "id": "p-a",
         "name": "Pool A",
         "slot": {"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         "table_ids": ["t1"],
     },
     {
-        "id": "p-b",
         "name": "Pool B",
         "slot": {"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         "table_ids": ["t2"],

--- a/api/tests/test_schedule_solve_models.py
+++ b/api/tests/test_schedule_solve_models.py
@@ -41,7 +41,7 @@ from app.models import (
     VenueTable,
 )
 from app.schemas.tournament import ScheduleSolveRead
-from tests._helpers import make_user, venue_tables
+from tests._helpers import event_pools, make_user, venue_tables
 
 
 async def _make_tournament(db_session: AsyncSession) -> Tournament:
@@ -89,7 +89,9 @@ async def _make_event(db_session: AsyncSession) -> TournamentEvent:
         timezone="America/Chicago",
         slot={"date": "2026-08-01", "start": "09:00", "end": "17:00"},
         match_settings={"rated": True, "length_games": 5},
-        pools=[{"id": "pool-a", "name": "Pool A", "slot": {}, "table_ids": []}],
+        pools=event_pools(
+            [{"id": "pool-a", "name": "Pool A", "slot": {}, "table_ids": []}]
+        ),
     )
     db_session.add(event)
     await db_session.commit()

--- a/api/tests/test_schedule_solve_models.py
+++ b/api/tests/test_schedule_solve_models.py
@@ -89,9 +89,7 @@ async def _make_event(db_session: AsyncSession) -> TournamentEvent:
         timezone="America/Chicago",
         slot={"date": "2026-08-01", "start": "09:00", "end": "17:00"},
         match_settings={"rated": True, "length_games": 5},
-        pools=event_pools(
-            [{"id": "pool-a", "name": "Pool A", "slot": {}, "table_ids": []}]
-        ),
+        pools=event_pools([{"name": "Pool A", "slot": {}, "table_ids": []}]),
     )
     db_session.add(event)
     await db_session.commit()
@@ -264,7 +262,7 @@ async def test_a_fresh_fixture_is_unpinned_and_never_notified(
     anything) — without either being supplied at insert."""
     event = await _make_event(db_session)
     fixture = TournamentFixture(
-        event_id=event.id, pool_id="pool-a", round=1, position=1
+        event_id=event.id, pool_id=event.pools[0].id, round=1, position=1
     )
     db_session.add(fixture)
     await db_session.commit()
@@ -297,7 +295,7 @@ async def test_a_pinned_fixture_round_trips_its_pin_facts(
     called_at = datetime(2026, 8, 1, 14, 30, tzinfo=UTC)
     fixture = TournamentFixture(
         event_id=event.id,
-        pool_id="pool-a",
+        pool_id=event.pools[0].id,
         round=1,
         position=1,
         table_id=table_id,

--- a/api/tests/test_schedule_solve_route.py
+++ b/api/tests/test_schedule_solve_route.py
@@ -54,6 +54,7 @@ from app.schedule_solves import RUN_SCHEDULE_SOLVE_JOB
 from app.tournament_draws import cut_draw
 from app.tournaments import NO_DRAWN_EVENTS_CODE, TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import (
+    event_pools,
     grant_permissions,
     make_client,
     make_user,
@@ -165,14 +166,16 @@ async def _make_tournament(
         timezone="America/Chicago",
         slot={"date": DATE, "start": "09:00", "end": "17:00"},
         match_settings={"rated": False, "length_games": 3},
-        pools=[
-            {
-                "id": "pool-a",
-                "name": "Pool A",
-                "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
-                "table_ids": [str(row.id) for row in catalogue],
-            }
-        ],
+        pools=event_pools(
+            [
+                {
+                    "id": "pool-a",
+                    "name": "Pool A",
+                    "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
+                    "table_ids": [str(row.id) for row in catalogue],
+                }
+            ]
+        ),
     )
     db.add(event)
     await db.flush()

--- a/api/tests/test_schedule_solve_route.py
+++ b/api/tests/test_schedule_solve_route.py
@@ -174,7 +174,8 @@ async def _make_tournament(
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": [str(row.id) for row in catalogue],
                 }
-            ]
+            ],
+            tournament=tournament,
         ),
     )
     db.add(event)

--- a/api/tests/test_schedule_solve_route.py
+++ b/api/tests/test_schedule_solve_route.py
@@ -169,7 +169,6 @@ async def _make_tournament(
         pools=event_pools(
             [
                 {
-                    "id": "pool-a",
                     "name": "Pool A",
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": [str(row.id) for row in catalogue],

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -196,7 +196,8 @@ async def _make_tournament(
                     "slot": {"date": slot_date, "start": window[0], "end": window[1]},
                     "table_ids": [str(row.id) for row in catalogue],
                 }
-            ]
+            ],
+            tournament=tournament,
         ),
     )
     db.add(event)

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -103,6 +103,7 @@ from app.schemas.schedule_solve import (
 from app.schemas.tournament import ScheduleSolveRead
 from app.tournament_draws import cut_draw
 from tests._helpers import (
+    event_pools,
     hijack_solve,
     make_user,
     table_ids_of,
@@ -187,14 +188,16 @@ async def _make_tournament(
         timezone="America/Chicago",
         slot={"date": slot_date, "start": window[0], "end": window[1]},
         match_settings={"rated": False, "length_games": length_games},
-        pools=[
-            {
-                "id": "pool-a",
-                "name": "Pool A",
-                "slot": {"date": slot_date, "start": window[0], "end": window[1]},
-                "table_ids": [str(row.id) for row in catalogue],
-            }
-        ],
+        pools=event_pools(
+            [
+                {
+                    "id": "pool-a",
+                    "name": "Pool A",
+                    "slot": {"date": slot_date, "start": window[0], "end": window[1]},
+                    "table_ids": [str(row.id) for row in catalogue],
+                }
+            ]
+        ),
     )
     db.add(event)
     await db.flush()

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -64,6 +64,7 @@ from app.models import (
     TournamentEntryStatus,
     TournamentEvent,
     TournamentEventDrawSettings,
+    TournamentEventPool,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -191,7 +192,6 @@ async def _make_tournament(
         pools=event_pools(
             [
                 {
-                    "id": "pool-a",
                     "name": "Pool A",
                     "slot": {"date": slot_date, "start": window[0], "end": window[1]},
                     "table_ids": [str(row.id) for row in catalogue],
@@ -211,6 +211,22 @@ async def _make_tournament(
     await cut_draw(db, event)
     await db.commit()
     return tournament.id, event.id
+
+
+async def _solver_pool_id(db: AsyncSession, event_id: uuid.UUID) -> PoolId:
+    """The solver's namespaced ``{event}:{pool}`` key for the event's one pool.
+
+    Looked up rather than spelled, because a pool id is a server-minted uuid now
+    (ADR 20260801). The namespacing itself is unchanged — see
+    ``app.schedule_preview.preview_pool_key`` for why it stayed."""
+    pool_id = (
+        await db.execute(
+            select(TournamentEventPool.id).where(
+                TournamentEventPool.event_id == event_id
+            )
+        )
+    ).scalar_one()
+    return PoolId(f"{event_id}:{pool_id}")
 
 
 async def _fixtures_of(
@@ -1321,7 +1337,7 @@ class TestSolveJob:
         row_id = row.id
         await db_session.commit()
 
-        pool_id = PoolId(f"{event_id}:pool-a")
+        pool_id = await _solver_pool_id(db_session, event_id)
 
         def infeasible(
             snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
@@ -1395,6 +1411,8 @@ class TestSolveJob:
             )
         ).one()
 
+        pool_id = await _solver_pool_id(db_session, event_id)
+
         def infeasible(
             snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
         ) -> SolveResult:
@@ -1404,7 +1422,7 @@ class TestSolveJob:
                 stats=SolveStats(wall_time_ms=42, objective=None),
                 reasons=(
                     PlayerOverSubscribed(
-                        pool_id=PoolId(f"{event_id}:pool-a"),
+                        pool_id=pool_id,
                         player_id=PlayerId(str(user_id)),
                         match_count=3,
                         required_min=95,

--- a/api/tests/test_schedule_triggers.py
+++ b/api/tests/test_schedule_triggers.py
@@ -43,6 +43,7 @@ from app.models import (
     TournamentEntry,
     TournamentEvent,
     TournamentEventDrawSettings,
+    TournamentEventPool,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -121,7 +122,6 @@ async def _make_tournament(
         pools=event_pools(
             [
                 {
-                    "id": "pool-a",
                     "name": "Pool A",
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": [str(row.id) for row in catalogue],
@@ -509,12 +509,28 @@ async def _catalogue_ids(db: AsyncSession, tournament_id: uuid.UUID) -> list[str
     ]
 
 
-def _pools_payload(*, end: str, table_ids: Sequence[str]) -> list[dict[str, Any]]:
-    """The event's one pool, re-sent with the same id (the pool-set freeze
-    demands it) and whatever window/tables the test is moving."""
+async def _pool_id(db: AsyncSession, event_id: uuid.UUID) -> str:
+    """The id of the event's one pool — server-minted (ADR 20260801), so a payload that
+    means to KEEP that pool has to look it up and cite it."""
+    return str(
+        (
+            await db.execute(
+                select(TournamentEventPool.id).where(
+                    TournamentEventPool.event_id == event_id
+                )
+            )
+        ).scalar_one()
+    )
+
+
+def _pools_payload(
+    *, pool_id: str, end: str, table_ids: Sequence[str]
+) -> list[dict[str, Any]]:
+    """The event's one pool, re-sent **citing its id** (the pool-set freeze demands it)
+    with whatever window/tables the test is moving."""
     return [
         {
-            "id": "pool-a",
+            "id": pool_id,
             "name": "Pool A",
             "slot": {"date": DATE, "start": "09:00", "end": end},
             "table_ids": list(table_ids),
@@ -622,7 +638,13 @@ async def test_a_pool_window_edit_requests_a_settings_solve(
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event.id}",
-        json={"pools": _pools_payload(end="18:00", table_ids=table_ids)},
+        json={
+            "pools": _pools_payload(
+                pool_id=await _pool_id(db_session, event.id),
+                end="18:00",
+                table_ids=table_ids,
+            )
+        },
     )
 
     assert response.status_code == 200, response.text
@@ -647,7 +669,13 @@ async def test_a_name_only_event_patch_requests_no_settings_solve(
     )
     resent = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event.id}",
-        json={"pools": _pools_payload(end="17:00", table_ids=table_ids)},
+        json={
+            "pools": _pools_payload(
+                pool_id=await _pool_id(db_session, event.id),
+                end="17:00",
+                table_ids=table_ids,
+            )
+        },
     )
 
     assert renamed.status_code == 200, renamed.text
@@ -831,7 +859,6 @@ async def test_uncutting_one_of_two_drawn_events_requests_a_settings_solve(
         pools=event_pools(
             [
                 {
-                    "id": "pool-b",
                     "name": "Pool B",
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": ["t1", "t2"],

--- a/api/tests/test_schedule_triggers.py
+++ b/api/tests/test_schedule_triggers.py
@@ -126,7 +126,8 @@ async def _make_tournament(
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": [str(row.id) for row in catalogue],
                 }
-            ]
+            ],
+            tournament=tournament,
         ),
     )
     db.add(event)
@@ -813,6 +814,10 @@ async def test_uncutting_one_of_two_drawn_events_requests_a_settings_solve(
     windows for the survivor — that IS a solver-input change: one row."""
     client, owner = authed_client
     tournament_id, event = await _make_tournament(db_session, owner)
+    # The tournament itself, not just its id: the second event's pool reserves the same
+    # two tables, and a reservation is a row keyed on the catalogue it names.
+    tournament = await db_session.get(Tournament, tournament_id)
+    assert tournament is not None
     second_event = TournamentEvent(
         tournament_id=tournament_id,
         name="Second Singles",
@@ -831,7 +836,8 @@ async def test_uncutting_one_of_two_drawn_events_requests_a_settings_solve(
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": ["t1", "t2"],
                 }
-            ]
+            ],
+            tournament=tournament,
         ),
     )
     db_session.add(second_event)

--- a/api/tests/test_schedule_triggers.py
+++ b/api/tests/test_schedule_triggers.py
@@ -51,6 +51,7 @@ from app.models import (
 from app.tournament_draws import cut_draw
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import (
+    event_pools,
     grant_permissions,
     make_user,
     opponent_session,
@@ -117,14 +118,16 @@ async def _make_tournament(
         timezone="America/Chicago",
         slot={"date": DATE, "start": "09:00", "end": "17:00"},
         match_settings={"rated": False, "length_games": 3},
-        pools=[
-            {
-                "id": "pool-a",
-                "name": "Pool A",
-                "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
-                "table_ids": [str(row.id) for row in catalogue],
-            }
-        ],
+        pools=event_pools(
+            [
+                {
+                    "id": "pool-a",
+                    "name": "Pool A",
+                    "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
+                    "table_ids": [str(row.id) for row in catalogue],
+                }
+            ]
+        ),
     )
     db.add(event)
     await db.flush()
@@ -820,14 +823,16 @@ async def test_uncutting_one_of_two_drawn_events_requests_a_settings_solve(
         timezone="America/Chicago",
         slot={"date": DATE, "start": "09:00", "end": "17:00"},
         match_settings={"rated": False, "length_games": 3},
-        pools=[
-            {
-                "id": "pool-b",
-                "name": "Pool B",
-                "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
-                "table_ids": ["t1", "t2"],
-            }
-        ],
+        pools=event_pools(
+            [
+                {
+                    "id": "pool-b",
+                    "name": "Pool B",
+                    "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
+                    "table_ids": ["t1", "t2"],
+                }
+            ]
+        ),
     )
     db_session.add(second_event)
     await db_session.flush()

--- a/api/tests/test_tournament_draw_service.py
+++ b/api/tests/test_tournament_draw_service.py
@@ -110,7 +110,9 @@ async def _make_event(
         slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         match_settings={"rated": True, "length_games": 5},
         predicates=[],
-        pools=event_pools([POOL_A, POOL_B] if pools is None else pools),
+        pools=event_pools(
+            [POOL_A, POOL_B] if pools is None else pools, tournament=tournament
+        ),
     )
     db.add(event)
     await db.commit()

--- a/api/tests/test_tournament_draw_service.py
+++ b/api/tests/test_tournament_draw_service.py
@@ -48,13 +48,11 @@ from tests._helpers import (
 # ref that resolves against the right one — the same shape ``test_tournaments.py``'s
 # draw tests cut across.
 POOL_A: dict[str, object] = {
-    "id": "p-a",
     "name": "Pool A",
     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
     "table_ids": ["t1"],
 }
 POOL_B: dict[str, object] = {
-    "id": "p-b",
     "name": "Pool B",
     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
     "table_ids": ["t2"],

--- a/api/tests/test_tournament_draw_service.py
+++ b/api/tests/test_tournament_draw_service.py
@@ -39,6 +39,7 @@ from app.tournament_errors import (
     TournamentNotFoundError,
 )
 from tests._helpers import (
+    event_pools,
     make_user,
     venue_tables,
 )
@@ -109,7 +110,7 @@ async def _make_event(
         slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         match_settings={"rated": True, "length_games": 5},
         predicates=[],
-        pools=[POOL_A, POOL_B] if pools is None else pools,
+        pools=event_pools([POOL_A, POOL_B] if pools is None else pools),
     )
     db.add(event)
     await db.commit()

--- a/api/tests/test_tournament_draws.py
+++ b/api/tests/test_tournament_draws.py
@@ -91,7 +91,7 @@ async def _make_event(
         slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         match_settings={"rated": True, "length_games": 5},
         predicates=[],
-        pools=event_pools([POOL_A]),
+        pools=event_pools([POOL_A], tournament=tournament),
     )
     db.add(event)
     await db.flush()

--- a/api/tests/test_tournament_draws.py
+++ b/api/tests/test_tournament_draws.py
@@ -31,6 +31,7 @@ from app.models import (
     TournamentEntryStatus,
     TournamentEvent,
     TournamentEventDrawSettings,
+    TournamentEventPool,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -43,6 +44,7 @@ from app.tournament_queries import (
     game_counts_by_match,
 )
 from tests._helpers import (
+    event_pools,
     make_user,
     venue_tables,
 )
@@ -89,7 +91,7 @@ async def _make_event(
         slot={"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         match_settings={"rated": True, "length_games": 5},
         predicates=[],
-        pools=[POOL_A],
+        pools=event_pools([POOL_A]),
     )
     db.add(event)
     await db.flush()
@@ -305,20 +307,20 @@ async def test_a_match_that_has_not_completed_projects_no_games(
 TEN_POOL_IDS = [f"p-{n}-x" for n in range(1, 11)]
 
 
-def _pools(ids: list[str], *, positions: bool = True) -> list[dict[str, object]]:
-    """These pool ids as stored JSONB, in this list's order — with or without the
-    ``position`` key, the latter being how every pool written before the field existed
-    still sits in the database today."""
-    return [
-        {
-            "id": pool_id,
-            "name": f"Pool {index + 1}",
-            "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
-            "table_ids": [],
-            **({"position": index} if positions else {}),
-        }
-        for index, pool_id in enumerate(ids)
-    ]
+def _pools(ids: list[str]) -> list[TournamentEventPool]:
+    """These pool ids as stored rows, in this list's order — each carrying the
+    ``position`` of its index, which is what the write boundary stamps."""
+    return event_pools(
+        [
+            {
+                "id": pool_id,
+                "name": f"Pool {index + 1}",
+                "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+                "table_ids": [],
+            }
+            for index, pool_id in enumerate(ids)
+        ]
+    )
 
 
 def test_draw_config_orders_the_pools_by_position_not_by_id() -> None:
@@ -336,14 +338,10 @@ def test_draw_config_orders_the_pools_by_position_not_by_id() -> None:
     assert draw_config(event).pool_ids == tuple(TEN_POOL_IDS)
 
 
-def test_draw_config_keeps_the_array_order_of_pools_that_have_no_position() -> None:
-    """Pools stored before ``position`` existed all parse to the default ``0``, and a
-    stable sort leaves them exactly where they were — the array order, which is the only
-    thing that ever carried their order. A read boundary must not re-seed a standing
-    draw's pools just because it cannot see their positions."""
-    event = TournamentEvent(pools=_pools(TEN_POOL_IDS, positions=False))
-
-    assert draw_config(event).pool_ids == tuple(TEN_POOL_IDS)
+# There is deliberately no "pools stored before ``position`` existed keep their array
+# order" test any more. That case was about a JSONB object with no ``position`` key;
+# pools are rows with a ``NOT NULL position`` (ADR 20260801), so the state it described
+# is not one the database will hold — and there is no pre-deploy data to describe.
 
 
 def test_pool_order_ranks_every_pool_id_by_the_events_order() -> None:

--- a/api/tests/test_tournament_draws.py
+++ b/api/tests/test_tournament_draws.py
@@ -50,7 +50,6 @@ from tests._helpers import (
 )
 
 POOL_A: dict[str, object] = {
-    "id": "p-a",
     "name": "Pool A",
     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
     "table_ids": ["t1"],
@@ -158,7 +157,7 @@ async def _fixture(
 ) -> TournamentFixture:
     fixture = TournamentFixture(
         event_id=event.id,
-        pool_id="p-a",
+        pool_id=event.pools[0].id,
         round=1,
         position=position,
         entry_a_id=entry_a_id,
@@ -300,25 +299,23 @@ async def test_a_match_that_has_not_completed_projects_no_games(
 # ``draw_config`` seeds the snake against it, ``pool_order`` is what a persisted
 # fixture's ``pool_position`` is resolved through, and both read it off
 # ``Pool.position`` (ADR 20260801) rather than off the pool id. The ids below are
-# minted the way the client mints them — ``p-1-…``, ``p-2-…``, ``p-10-…`` — whose
-# lexicographic order (1, 10, 2, 3…) is deliberately not the director's, so a sort
-# that fell back to the id cannot pass.
+# server-minted uuids, whose order is *random* — which is exactly why the position had
+# to become a column: a sort that fell back to the id deals a different draw every time.
 
-TEN_POOL_IDS = [f"p-{n}-x" for n in range(1, 11)]
+POOL_COUNT = 10
 
 
-def _pools(ids: list[str]) -> list[TournamentEventPool]:
-    """These pool ids as stored rows, in this list's order — each carrying the
-    ``position`` of its index, which is what the write boundary stamps."""
+def _pools() -> list[TournamentEventPool]:
+    """Ten pool rows in the director's order — each carrying the ``position`` of its
+    index, which is what the write boundary stamps, and a minted id."""
     return event_pools(
         [
             {
-                "id": pool_id,
                 "name": f"Pool {index + 1}",
                 "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
                 "table_ids": [],
             }
-            for index, pool_id in enumerate(ids)
+            for index in range(POOL_COUNT)
         ]
     )
 
@@ -332,10 +329,10 @@ def test_draw_config_orders_the_pools_by_position_not_by_id() -> None:
     positions disagree: what comes back has to be the positions' order, which is neither
     the array's nor the ids'.
     """
-    stored = _pools(TEN_POOL_IDS)
+    stored = _pools()
     event = TournamentEvent(pools=list(reversed(stored)))
 
-    assert draw_config(event).pool_ids == tuple(TEN_POOL_IDS)
+    assert draw_config(event).pool_ids == tuple(pool.id for pool in stored)
 
 
 # There is deliberately no "pools stored before ``position`` existed keep their array
@@ -348,20 +345,25 @@ def test_pool_order_ranks_every_pool_id_by_the_events_order() -> None:
     """The lookup the fixture projection resolves through: id → 0-based place, the same
     sequence ``draw_config`` hands the snake, so a draw is advanced in the order it was
     cut in."""
-    event = TournamentEvent(pools=list(reversed(_pools(TEN_POOL_IDS))))
+    stored = _pools()
+    event = TournamentEvent(pools=list(reversed(stored)))
 
-    assert pool_order(event) == {
-        pool_id: index for index, pool_id in enumerate(TEN_POOL_IDS)
-    }
+    assert pool_order(event) == {pool.id: index for index, pool in enumerate(stored)}
 
 
 def test_fixture_state_projects_its_pools_place_in_the_event_order() -> None:
     """The bridge fills ``pool_position`` from the passed lookup — the fact
-    ``ready_fixtures`` groups a plan by. Pool ``p-10-x`` is *last* in the director's
-    order and *second* in the ids', which is the discriminating case."""
-    event = TournamentEvent(pools=_pools(TEN_POOL_IDS))
+    ``ready_fixtures`` groups a plan by. The **tenth** pool is the discriminating case:
+    it is last in the director's order and, under random uuid ids, nowhere in particular
+    in theirs."""
+    stored = _pools()
+    event = TournamentEvent(pools=stored)
     fixture = TournamentFixture(
-        id=uuid.uuid4(), event_id=uuid.uuid4(), pool_id="p-10-x", round=1, position=1
+        id=uuid.uuid4(),
+        event_id=uuid.uuid4(),
+        pool_id=stored[9].id,
+        round=1,
+        position=1,
     )
 
     assert (
@@ -374,12 +376,17 @@ def test_fixture_state_projects_no_pool_position_when_there_is_no_pool() -> None
     pool, so there is no place to project — ``None``, whatever lookup is passed. And a
     caller that passes no lookup at all gets ``None`` for a *pooled* fixture too: the
     order was not resolved, which is a different thing from position zero."""
-    event = TournamentEvent(pools=_pools(TEN_POOL_IDS))
+    stored = _pools()
+    event = TournamentEvent(pools=stored)
     un_pooled = TournamentFixture(
         id=uuid.uuid4(), event_id=uuid.uuid4(), pool_id=None, round=1, position=1
     )
     pooled = TournamentFixture(
-        id=uuid.uuid4(), event_id=uuid.uuid4(), pool_id="p-1-x", round=1, position=1
+        id=uuid.uuid4(),
+        event_id=uuid.uuid4(),
+        pool_id=stored[0].id,
+        round=1,
+        position=1,
     )
 
     assert (

--- a/api/tests/test_tournament_event_draw_settings.py
+++ b/api/tests/test_tournament_event_draw_settings.py
@@ -87,7 +87,6 @@ def _event_payload(**overrides: Any) -> dict[str, Any]:
         "predicates": [],
         "pools": [
             {
-                "id": "p-os-1",
                 "name": "Pool A",
                 "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
                 "table_ids": ["t1"],

--- a/api/tests/test_tournament_events.py
+++ b/api/tests/test_tournament_events.py
@@ -13,7 +13,7 @@ the matrix is exactly: create (owned / non-owned / missing-tournament) and delet
 """
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime, time
 from decimal import Decimal
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -30,6 +30,7 @@ from app.models import (
     Tournament,
     TournamentEvent,
     TournamentEventDrawSettings,
+    TournamentEventPool,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -44,6 +45,7 @@ from app.tournament_errors import (
 )
 from app.tournament_events import create_event, delete_event, update_event
 from tests._helpers import (
+    event_pools,
     make_user,
     venue_tables,
 )
@@ -161,7 +163,8 @@ async def test_create_persists_an_event_on_an_owned_tournament(
     assert event.name == "Open Singles"
     # The nested value-objects persisted as plain JSONB.
     assert event.slot == {"date": "2026-06-13", "start": "09:00", "end": "18:00"}
-    assert event.pools[0]["id"] == "p-os-1"
+    # The pools persisted as rows of their own, not as a value inside the event.
+    assert [pool.id for pool in event.pools] == ["p-os-1"]
     event_id = event.id
 
     # Persisted, not merely returned.
@@ -250,14 +253,17 @@ def _pool(pool_id: str, name: str, **extra: Any) -> dict[str, Any]:
 
 
 def _named_positions(event: TournamentEvent) -> list[tuple[str, int]]:
-    """``(name, position)`` per stored pool, read off the JSONB in **column order**.
+    """``(name, position)`` per stored pool, read off the ROWS in the relationship's
+    order (which is ``position`` ascending).
 
     Names, not ids, because a pool named "Pool C" sitting at position 0 is the whole
     claim: it is the pool the director put first, and it is not the alphabetically first
-    one. Read from the raw column rather than through ``Pool`` so a default the schema
-    supplies could not stand in for a value the write path failed to store.
+    one. Read off the rows rather than through ``Pool`` so a default the schema supplies
+    could not stand in for a value the write path failed to store — and the names are
+    what discriminate, since ordering by position cannot itself reveal whether the
+    positions were stamped from the payload's order or from the pools' names.
     """
-    return [(pool["name"], pool["position"]) for pool in event.pools]
+    return [(pool.name, pool.position) for pool in event.pools]
 
 
 async def test_create_positions_pools_by_the_order_they_were_sent(
@@ -299,7 +305,7 @@ async def test_create_positions_pools_by_the_order_they_were_sent(
     ).scalar_one()
     assert _named_positions(row) == [("Pool C", 0), ("Pool A", 1), ("Pool B", 2)]
     # No two pools of one event share a position.
-    positions = [pool["position"] for pool in row.pools]
+    positions = [pool.position for pool in row.pools]
     assert len(set(positions)) == len(positions)
 
 
@@ -417,8 +423,98 @@ async def test_update_repositions_pools_by_the_order_they_were_patched(
         )
     ).scalar_one()
     assert _named_positions(row) == [("Pool B", 0), ("Pool C", 1), ("Pool A", 2)]
-    positions = [pool["position"] for pool in row.pools]
+    positions = [pool.position for pool in row.pools]
     assert len(set(positions)) == len(positions)
+
+
+async def test_an_events_pools_are_rows_of_its_own_keyed_by_the_event(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A created event's pools are **rows in ``tournament_event_pools``**, each carrying
+    the ``event_id`` that owns it and the window in the DATE/TIME columns the ADR pins
+    (ADR 20260801, "a pool belongs to its event, not to the event's draw settings").
+
+    Read with a **column-only** ``SELECT`` against the pools table, not off
+    ``event.pools``: the relationship would answer just as happily if the pools were
+    still a JSONB list on the event, and the claim here is precisely that they are not.
+
+    The slot columns are asserted as real ``date``/``time`` VALUES rather than as
+    strings, which is the same claim from the other side: a ``timestamptz`` column
+    (api/CLAUDE.md's default rule, which the ADR deliberately excepts here) would read
+    back as a ``datetime``, and this would fail on the type before the value.
+    """
+    owner = await make_user(db_session, "events-pools-are-rows")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+
+    event, _ = await create_event(
+        db_session,
+        tournament_id=tournament.id,
+        actor=owner,
+        payload=_event_payload(pools=[_pool("p-a", "Pool A"), _pool("p-b", "Pool B")]),
+    )
+    event_id = event.id
+
+    db_session.expire_all()
+    rows = (
+        await db_session.execute(
+            select(
+                TournamentEventPool.event_id,
+                TournamentEventPool.id,
+                TournamentEventPool.name,
+                TournamentEventPool.position,
+                TournamentEventPool.slot_date,
+                TournamentEventPool.slot_start,
+                TournamentEventPool.slot_end,
+            ).order_by(TournamentEventPool.position)
+        )
+    ).all()
+
+    assert rows == [
+        (event_id, "p-a", "Pool A", 0, date(2026, 6, 13), time(9, 0), time(12, 30)),
+        (event_id, "p-b", "Pool B", 1, date(2026, 6, 13), time(9, 0), time(12, 30)),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("slot", "field"),
+    [
+        pytest.param(
+            {"date": "next Tuesday", "start": "09:00", "end": "12:30"}, "date"
+        ),
+        pytest.param({"date": "2026-06-13", "start": "9am", "end": "12:30"}, "start"),
+        pytest.param(
+            {"date": "2026-06-13", "start": "09:00:30", "end": "12:30"}, "seconds"
+        ),
+    ],
+    ids=["unparseable-date", "unparseable-start", "a-time-carrying-seconds"],
+)
+def test_a_pool_window_the_columns_cannot_hold_is_refused(
+    slot: dict[str, str], field: str
+) -> None:
+    """A pool window that is not ``YYYY-MM-DD`` + ``HH:MM`` is a **422 at the
+    boundary**, not a driver error at the INSERT.
+
+    The three strings used to sit inside a JSONB blob that accepted anything at all;
+    they are ``slot_date DATE`` / ``slot_start TIME`` / ``slot_end TIME`` now (ADR
+    20260801), so a boundary that let ``"next Tuesday"`` through would be handing the
+    director a 500 for a payload it had just accepted — the ``EventMaxPlayers`` lesson
+    in another key (api/CLAUDE.md, "a boundary that admits what the interior cannot
+    hold is not a boundary").
+
+    Seconds are in the matrix deliberately: ``09:00:30`` parses perfectly well and is
+    the one case a *refusal* has to be argued for. It would be stored and then read
+    back as ``09:00``, moving a director's window by half a minute in a direction
+    nothing told them about; the wire shape says ``HH:MM``, so the round trip stays
+    lossless and the refusal says what to send.
+    """
+    with pytest.raises(ValidationError) as refusal:
+        TournamentEventCreate.model_validate(
+            _event_body(pools=[_pool("p-a", "Pool A", slot=slot)])
+        )
+
+    (error,) = refusal.value.errors()
+    assert error["loc"] == ("pools", 0, "slot"), field
 
 
 # ----- delete --------------------------------------------------------------
@@ -567,14 +663,16 @@ async def _add_cut_event(
         slot={"date": "2026-06-13", "start": "09:00", "end": "17:00"},
         match_settings={"rated": False, "length_games": 3},
         predicates=[],
-        pools=[
-            {
-                "id": "p-1",
-                "name": "Pool A",
-                "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
-                "table_ids": ["t1", "t2"],
-            }
-        ],
+        pools=event_pools(
+            [
+                {
+                    "id": "p-1",
+                    "name": "Pool A",
+                    "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+                    "table_ids": ["t1", "t2"],
+                }
+            ]
+        ),
     )
     db.add(event)
     await db.commit()
@@ -713,7 +811,7 @@ async def test_update_event_frozen_pool_set_change_is_refused(
         )
     ).scalar_one()
     assert row.name == "Cut Singles"
-    assert [pool["id"] for pool in row.pools] == ["p-1"]
+    assert [pool.id for pool in row.pools] == ["p-1"]
 
 
 async def test_update_event_frozen_draw_type_change_is_refused(

--- a/api/tests/test_tournament_events.py
+++ b/api/tests/test_tournament_events.py
@@ -90,9 +90,10 @@ def _event_body(**overrides: Any) -> dict[str, Any]:
         # minted for THIS tournament — which a module-level literal cannot know. The
         # reservation round trip has its own section at the foot of this file, built off
         # the tournament's real catalogue.
+        # No ``id`` either: a pool id is a server-minted uuid (ADR 20260801), so the
+        # create shape has no field for one and sending one is a 422.
         "pools": [
             {
-                "id": "p-os-1",
                 "name": "Pool A",
                 "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
                 "table_ids": [],
@@ -171,8 +172,10 @@ async def test_create_persists_an_event_on_an_owned_tournament(
     assert event.name == "Open Singles"
     # The nested value-objects persisted as plain JSONB.
     assert event.slot == {"date": "2026-06-13", "start": "09:00", "end": "18:00"}
-    # The pools persisted as rows of their own, not as a value inside the event.
-    assert [pool.id for pool in event.pools] == ["p-os-1"]
+    # The pools persisted as rows of their own, not as a value inside the event, each
+    # with an id the SERVER minted (ADR 20260801) — the payload carried none.
+    assert [pool.name for pool in event.pools] == ["Pool A"]
+    assert all(isinstance(pool.id, uuid.UUID) for pool in event.pools)
     event_id = event.id
 
     # Persisted, not merely returned.
@@ -243,16 +246,15 @@ async def test_create_on_a_missing_tournament_raises_not_found(
 #     schema, which a client can read, instead of a sentence in a docstring, which it
 #     cannot; and
 #   * a payload that does not is stored in the *order sent*, and nothing else. Every
-#     pool below is named and id'd so that alphabetical order (by either) is a DIFFERENT
-#     answer from the order sent, which is what makes these able to fail — asserting
-#     "each pool has a position" would pass against an implementation that assigned all
-#     zeros or sorted by name.
+#     pool below is named so that alphabetical order is a DIFFERENT answer from the
+#     order sent, which is what makes these able to fail — asserting "each pool has a
+#     position" would pass against an implementation that assigned all zeros or sorted
+#     by name.
 
 
-def _pool(pool_id: str, name: str, **extra: Any) -> dict[str, Any]:
+def _pool(name: str, **extra: Any) -> dict[str, Any]:
     """One pool payload, valid but for whatever ``extra`` the caller adds."""
     return {
-        "id": pool_id,
         "name": name,
         "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
         "table_ids": ["t1"],
@@ -280,8 +282,9 @@ async def test_create_positions_pools_by_the_order_they_were_sent(
 ) -> None:
     """Three pools sent as **C, A, B** are stored as positions 0, 1, 2 *in that order*.
 
-    Sorted by name — or by id, which is how pool order used to be recovered — the
-    answer would be C=2, A=0, B=1. Sorted by nothing at all it would be three zeros.
+    Sorted by name — or by id, which is how pool order used to be recovered and which is
+    now random — the answer would be C=2, A=0, B=1. Sorted by nothing at all it would
+    be three zeros.
     The event's pool order is the order the director sent, and this is the assertion
     that distinguishes the three.
     """
@@ -294,9 +297,9 @@ async def test_create_positions_pools_by_the_order_they_were_sent(
         actor=owner,
         payload=_event_payload(
             pools=[
-                _pool("p-c", "Pool C"),
-                _pool("p-a", "Pool A"),
-                _pool("p-b", "Pool B"),
+                _pool("Pool C"),
+                _pool("Pool A"),
+                _pool("Pool B"),
             ]
         ),
     )
@@ -318,9 +321,9 @@ async def test_create_positions_pools_by_the_order_they_were_sent(
 
 
 _POOLS_CLAIMING_A_POSITION = [
-    _pool("p-c", "Pool C", position=7),
-    _pool("p-a", "Pool A", position=7),
-    _pool("p-b", "Pool B", position=7),
+    _pool("Pool C", position=7),
+    _pool("Pool A", position=7),
+    _pool("Pool B", position=7),
 ]
 """Three pools that each claim position ``7`` — the payload a client writes when it
 mistakes a server-assigned field for one of its own."""
@@ -398,9 +401,9 @@ async def test_update_repositions_pools_by_the_order_they_were_patched(
         actor=owner,
         payload=_event_payload(
             pools=[
-                _pool("p-c", "Pool C"),
-                _pool("p-a", "Pool A"),
-                _pool("p-b", "Pool B"),
+                _pool("Pool C"),
+                _pool("Pool A"),
+                _pool("Pool B"),
             ]
         ),
     )
@@ -414,9 +417,9 @@ async def test_update_repositions_pools_by_the_order_they_were_patched(
         updates=TournamentEventUpdate.model_validate(
             {
                 "pools": [
-                    _pool("p-b", "Pool B"),
-                    _pool("p-c", "Pool C"),
-                    _pool("p-a", "Pool A"),
+                    _pool("Pool B"),
+                    _pool("Pool C"),
+                    _pool("Pool A"),
                 ]
             }
         ),
@@ -459,7 +462,7 @@ async def test_an_events_pools_are_rows_of_its_own_keyed_by_the_event(
         db_session,
         tournament_id=tournament.id,
         actor=owner,
-        payload=_event_payload(pools=[_pool("p-a", "Pool A"), _pool("p-b", "Pool B")]),
+        payload=_event_payload(pools=[_pool("Pool A"), _pool("Pool B")]),
     )
     event_id = event.id
 
@@ -478,10 +481,15 @@ async def test_an_events_pools_are_rows_of_its_own_keyed_by_the_event(
         )
     ).all()
 
-    assert rows == [
-        (event_id, "p-a", "Pool A", 0, date(2026, 6, 13), time(9, 0), time(12, 30)),
-        (event_id, "p-b", "Pool B", 1, date(2026, 6, 13), time(9, 0), time(12, 30)),
+    # The ids are the server's (``gen_random_uuid()``), so what is asserted about them
+    # is that they exist, are uuids, and are distinct — not their value, which no test
+    # could spell.
+    assert [(r[0], *r[2:]) for r in rows] == [
+        (event_id, "Pool A", 0, date(2026, 6, 13), time(9, 0), time(12, 30)),
+        (event_id, "Pool B", 1, date(2026, 6, 13), time(9, 0), time(12, 30)),
     ]
+    assert len({r[1] for r in rows}) == 2
+    assert all(isinstance(r[1], uuid.UUID) for r in rows)
 
 
 @pytest.mark.parametrize(
@@ -518,7 +526,7 @@ def test_a_pool_window_the_columns_cannot_hold_is_refused(
     """
     with pytest.raises(ValidationError) as refusal:
         TournamentEventCreate.model_validate(
-            _event_body(pools=[_pool("p-a", "Pool A", slot=slot)])
+            _event_body(pools=[_pool("Pool A", slot=slot)])
         )
 
     (error,) = refusal.value.errors()
@@ -657,9 +665,12 @@ async def _add_cut_event(
     timezone: str = "America/Chicago",
     scheduled_start: datetime | None = None,
 ) -> TournamentEvent:
-    """An event carrying one pool (``p-1``) AND a fixture — so ``event_has_draw`` is
-    True and the two freezes are live. The fixture optionally carries a
-    ``scheduled_start`` placement, for the timezone-reanchor path."""
+    """An event carrying one pool (named "Pool A") AND a fixture — so ``event_has_draw``
+    is True and the two freezes are live. The fixture optionally carries a
+    ``scheduled_start`` placement, for the timezone-reanchor path.
+
+    The pool's id is minted here (``event_pools``) rather than by the column's default,
+    because the fixture below has to name it before either row is flushed."""
     event = TournamentEvent(
         tournament_id=tournament.id,
         name="Cut Singles",
@@ -674,7 +685,6 @@ async def _add_cut_event(
         pools=event_pools(
             [
                 {
-                    "id": "p-1",
                     "name": "Pool A",
                     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
                     "table_ids": ["t1", "t2"],
@@ -688,7 +698,7 @@ async def _add_cut_event(
     await db.refresh(event)
     fixture = TournamentFixture(
         event_id=event.id,
-        pool_id="p-1",
+        pool_id=event.pools[0].id,
         round=1,
         position=1,
         scheduled_start=scheduled_start,
@@ -795,7 +805,6 @@ async def test_update_event_frozen_pool_set_change_is_refused(
             "name": "Should Not Apply",
             "pools": [
                 {
-                    "id": "p-2",
                     "name": "Pool B",
                     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
                     "table_ids": ["t1"],
@@ -820,7 +829,7 @@ async def test_update_event_frozen_pool_set_change_is_refused(
         )
     ).scalar_one()
     assert row.name == "Cut Singles"
-    assert [pool.id for pool in row.pools] == ["p-1"]
+    assert [pool.name for pool in row.pools] == ["Pool A"]
 
 
 async def test_update_event_frozen_draw_type_change_is_refused(
@@ -979,11 +988,10 @@ async def _reservation_rows(
     ]
 
 
-def _pool_payload(*table_ids: str, pool_id: str = "p-os-1") -> dict[str, Any]:
+def _pool_payload(*table_ids: str, name: str = "Pool A") -> dict[str, Any]:
     """One pool reserving exactly ``table_ids``, in that order."""
     return {
-        "id": pool_id,
-        "name": "Pool A",
+        "name": name,
         "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
         "table_ids": list(table_ids),
     }
@@ -1014,12 +1022,13 @@ async def test_a_pools_reservations_are_stored_as_rows_in_the_order_they_were_se
         payload=_event_payload(pools=[_pool_payload(table_2, table_1)]),
     )
     event_id = event.id
+    pool_id = event.pools[0].id
 
     # Rows, carrying the denormalized tournament and the order sent.
     db_session.expire_all()
     assert await _reservation_rows(db_session, event_id) == [
-        (tournament_id, "p-os-1", table_2, 0),
-        (tournament_id, "p-os-1", table_1, 1),
+        (tournament_id, pool_id, table_2, 0),
+        (tournament_id, pool_id, table_1, 1),
     ]
     # And the same order back through the read shape everything above the database uses.
     stored = (
@@ -1062,10 +1071,11 @@ async def test_a_reservation_of_another_tournaments_table_never_reaches_the_data
         payload=_event_payload(pools=[_pool_payload(mine, foreign_table)]),
     )
     event_id = event.id
+    pool_id = event.pools[0].id
 
     db_session.expire_all()
     assert await _reservation_rows(db_session, event_id) == [
-        (tournament_id, "p-os-1", mine, 0)
+        (tournament_id, pool_id, mine, 0)
     ]
 
 
@@ -1105,12 +1115,13 @@ async def test_a_pool_table_reservation_across_tournaments_is_refused_by_the_dat
         payload=_event_payload(pools=[_pool_payload()]),
     )
     event_id = event.id
+    pool_id = event.pools[0].id
 
     db_session.add(
         TournamentEventPoolTable(
             tournament_id=tournament_id,
             event_id=event_id,
-            pool_id="p-os-1",
+            pool_id=pool_id,
             table_id=foreign_table,
             position=0,
         )
@@ -1124,7 +1135,7 @@ async def test_a_pool_table_reservation_across_tournaments_is_refused_by_the_dat
         TournamentEventPoolTable(
             tournament_id=other_id,
             event_id=event_id,
-            pool_id="p-os-1",
+            pool_id=pool_id,
             table_id=foreign_table,
             position=0,
         )
@@ -1161,7 +1172,7 @@ async def test_a_reservation_naming_no_table_at_all_is_refused_by_the_database(
         TournamentEventPoolTable(
             tournament_id=tournament_id,
             event_id=event.id,
-            pool_id="p-os-1",
+            pool_id=event.pools[0].id,
             table_id=str(uuid.uuid4()),
             position=0,
         )
@@ -1203,13 +1214,14 @@ async def test_removing_a_table_drops_the_pool_reservations_that_named_it(
         payload=_event_payload(pools=[_pool_payload(table_1, table_2)]),
     )
     event_id = event.id
+    pool_id = event.pools[0].id
 
     await db_session.delete(doomed)
     await db_session.commit()
 
     db_session.expire_all()
     assert await _reservation_rows(db_session, event_id) == [
-        (tournament_id, "p-os-1", table_1, 0)
+        (tournament_id, pool_id, table_1, 0)
     ]
     # The pool itself is untouched — a reservation went, not a pool.
     assert (
@@ -1218,7 +1230,7 @@ async def test_removing_a_table_drops_the_pool_reservations_that_named_it(
                 TournamentEventPool.event_id == event_id
             )
         )
-    ).scalars().all() == ["p-os-1"]
+    ).scalars().all() == [pool_id]
 
 
 async def test_removing_a_pool_takes_its_table_reservations_with_it(
@@ -1282,6 +1294,7 @@ async def test_re_sending_a_reservation_keeps_its_row_and_re_orders_the_rest(
         payload=_event_payload(pools=[_pool_payload(table_1, table_2)]),
     )
     event_id = event.id
+    pool_id = event.pools[0].id
     created_at = (
         await db_session.execute(
             select(TournamentEventPoolTable.created_at).where(
@@ -1297,14 +1310,16 @@ async def test_re_sending_a_reservation_keeps_its_row_and_re_orders_the_rest(
         event_id=event_id,
         actor=owner,
         updates=TournamentEventUpdate.model_validate(
-            {"pools": [_pool_payload(table_2, table_1)]}
+            # The pool is CITED by the id the server minted, so the diff keeps its row —
+            # which is the whole premise of the claim below about its reservations.
+            {"pools": [{**_pool_payload(table_2, table_1), "id": str(pool_id)}]}
         ),
     )
 
     db_session.expire_all()
     assert await _reservation_rows(db_session, event_id) == [
-        (tournament_id, "p-os-1", table_2, 0),
-        (tournament_id, "p-os-1", table_1, 1),
+        (tournament_id, pool_id, table_2, 0),
+        (tournament_id, pool_id, table_1, 1),
     ]
     assert (
         await db_session.execute(

--- a/api/tests/test_tournament_events.py
+++ b/api/tests/test_tournament_events.py
@@ -21,6 +21,7 @@ from zoneinfo import ZoneInfo
 import pytest
 from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import (
@@ -31,6 +32,7 @@ from app.models import (
     TournamentEvent,
     TournamentEventDrawSettings,
     TournamentEventPool,
+    TournamentEventPoolTable,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -44,6 +46,7 @@ from app.tournament_errors import (
     TournamentNotFoundError,
 )
 from app.tournament_events import create_event, delete_event, update_event
+from app.tournament_pools import pool_read
 from tests._helpers import (
     event_pools,
     make_user,
@@ -82,12 +85,17 @@ def _event_body(**overrides: Any) -> dict[str, Any]:
         "slot": {"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         "match_settings": {"rated": True, "length_games": 5},
         "predicates": [{"id": "pr-1", "field": "rating", "op": "<", "value": 1500}],
+        # No ``table_ids``: a reservation is a row foreign-keyed to a real venue table
+        # (ADR 20260801), so the only ids a payload can name are the uuids the server
+        # minted for THIS tournament — which a module-level literal cannot know. The
+        # reservation round trip has its own section at the foot of this file, built off
+        # the tournament's real catalogue.
         "pools": [
             {
                 "id": "p-os-1",
                 "name": "Pool A",
                 "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
-                "table_ids": ["t1", "t2"],
+                "table_ids": [],
             }
         ],
     }
@@ -671,7 +679,8 @@ async def _add_cut_event(
                     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
                     "table_ids": ["t1", "t2"],
                 }
-            ]
+            ],
+            tournament=tournament,
         ),
     )
     db.add(event)
@@ -916,3 +925,392 @@ async def test_update_event_timezone_change_reanchors_placements(
     assert fixture.scheduled_start == datetime(
         2026, 6, 13, 18, 0, tzinfo=ZoneInfo("America/Denver")
     )
+
+
+# ----- a pool's table reservations (ADR 20260801) ---------------------------
+#
+# The tables a pool reserves are rows now — ``tournament_event_pool_tables`` — where
+# they were a JSONB array of strings that could name anything at all. Three claims live
+# down here, and only the first is visible through the wire shape:
+#
+#   * a reservation round-trips through rows, in the order it was sent;
+#   * a pool cannot reserve **another tournament's** table, and it is the DATABASE that
+#     says so — the two spellings of that illegal state are refused by two different
+#     legs of the same three-legged key;
+#   * removing a table takes the reservations that named it, quietly, because a
+#     reservation is a preference and only a placement is a commitment.
+
+#: The leg that catches a reservation naming a table of a tournament other than the one
+#: the row claims to be inside.
+POOL_TABLE_TABLE_CONSTRAINT = "fk_tournament_event_pool_tables_tournament_id_table_id"
+#: The leg that catches a reservation whose claimed tournament is not the one its pool's
+#: event belongs to — the one that looks redundant and is not (see the model).
+POOL_TABLE_EVENT_CONSTRAINT = "fk_tournament_event_pool_tables_tournament_id_event_id"
+
+
+async def _reservation_rows(
+    db: AsyncSession, event_id: uuid.UUID
+) -> list[tuple[uuid.UUID, str, str, int]]:
+    """``(tournament_id, pool_id, table_id, position)`` per stored reservation of this
+    event, in pool then position order.
+
+    A column-only ``SELECT`` so it reads the rows and not the session's opinion of them:
+    two of the tests below delete rows out from under loaded ORM instances (that is the
+    behaviour under test), and a collection read off those instances would answer with
+    what the session last saw.
+    """
+    return [
+        (tournament_id, pool_id, table_id, position)
+        for tournament_id, pool_id, table_id, position in (
+            await db.execute(
+                select(
+                    TournamentEventPoolTable.tournament_id,
+                    TournamentEventPoolTable.pool_id,
+                    TournamentEventPoolTable.table_id,
+                    TournamentEventPoolTable.position,
+                )
+                .where(TournamentEventPoolTable.event_id == event_id)
+                .order_by(
+                    TournamentEventPoolTable.pool_id,
+                    TournamentEventPoolTable.position,
+                )
+            )
+        ).all()
+    ]
+
+
+def _pool_payload(*table_ids: str, pool_id: str = "p-os-1") -> dict[str, Any]:
+    """One pool reserving exactly ``table_ids``, in that order."""
+    return {
+        "id": pool_id,
+        "name": "Pool A",
+        "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
+        "table_ids": list(table_ids),
+    }
+
+
+async def test_a_pools_reservations_are_stored_as_rows_in_the_order_they_were_sent(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A pool reserves its tables through **rows**, not a string array — and the wire
+    shape is unchanged, because ``table_ids`` is composed back from them.
+
+    The two tables are named in *reverse* catalogue order, which is what makes this able
+    to fail: rows have no inherent order, and reading them back by ``table_id`` (a
+    random uuid) or by insertion happenstance would give the director's list back
+    shuffled. ``position`` is what carries the order the payload stated, exactly as it
+    does for the pools themselves and for the venue catalogue.
+    """
+    owner = await make_user(db_session, "events-reservation-owner")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+    table_1, table_2 = [str(table.id) for table in tournament.tables]
+
+    event, _ = await create_event(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        payload=_event_payload(pools=[_pool_payload(table_2, table_1)]),
+    )
+    event_id = event.id
+
+    # Rows, carrying the denormalized tournament and the order sent.
+    db_session.expire_all()
+    assert await _reservation_rows(db_session, event_id) == [
+        (tournament_id, "p-os-1", table_2, 0),
+        (tournament_id, "p-os-1", table_1, 1),
+    ]
+    # And the same order back through the read shape everything above the database uses.
+    stored = (
+        await db_session.execute(
+            select(TournamentEventPool).where(TournamentEventPool.event_id == event_id)
+        )
+    ).scalar_one()
+    assert pool_read(stored).table_ids == [table_2, table_1]
+
+
+async def test_a_reservation_of_another_tournaments_table_never_reaches_the_database(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A payload naming a table of somebody *else's* tournament reserves nothing, and
+    the event is created anyway.
+
+    This is the quiet half of the ADR's split said at the write boundary: a reservation
+    is a **preference**, so an id that names no table of this tournament is simply not a
+    preference this schema can hold — where a *placement* naming an unknown table is the
+    422 ``test_tournament_placement`` pins. Nothing observable changes: every reader
+    already intersected ``table_ids`` with the catalogue, because a JSONB string could
+    name anything.
+
+    The row the write path declines to compose is one the database would refuse anyway,
+    which the next two tests prove directly.
+    """
+    owner = await make_user(db_session, "events-foreign-reservation-owner")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    stranger = await make_user(db_session, "events-foreign-reservation-other")
+    other = await _make_tournament(db_session, owner=stranger, league=default_league)
+    foreign_table = str(other.tables[0].id)
+    tournament_id = tournament.id
+    mine = str(tournament.tables[0].id)
+
+    event, _ = await create_event(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        payload=_event_payload(pools=[_pool_payload(mine, foreign_table)]),
+    )
+    event_id = event.id
+
+    db_session.expire_all()
+    assert await _reservation_rows(db_session, event_id) == [
+        (tournament_id, "p-os-1", mine, 0)
+    ]
+
+
+async def test_a_pool_table_reservation_across_tournaments_is_refused_by_the_database(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """The claim the composite foreign keys exist to make (ADR 20260801): a pool cannot
+    reserve another tournament's table — and it is the **database** that says so, not
+    the write path above it.
+
+    The illegal state has two spellings, and each is caught by a *different* leg of the
+    three-legged key, which is why it takes three:
+
+    * claim my own tournament, name the other one's table → the
+      ``(tournament_id, table_id)`` leg finds no such table under my tournament. **A
+      plain ``REFERENCES tournament_tables (id)`` would accept this row**: the table
+      exists, which was never the question. Compositeness is what is doing the work.
+    * claim the other tournament (so its table resolves) → the
+      ``(tournament_id, event_id)`` leg finds no such event under it. Without that third
+      leg the first two are both satisfied and the row goes in, which is exactly the
+      reservation this table exists to forbid.
+
+    Both are refused at the INSERT: unlike the fixture's ``(event_id, pool_id)``, none
+    of these constraints is deferred — no delete path needs them to be.
+    """
+    owner = await make_user(db_session, "events-cross-reservation-owner")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    stranger = await make_user(db_session, "events-cross-reservation-other")
+    other = await _make_tournament(db_session, owner=stranger, league=default_league)
+    foreign_table = str(other.tables[0].id)
+    tournament_id, other_id = tournament.id, other.id
+    event, _ = await create_event(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        payload=_event_payload(pools=[_pool_payload()]),
+    )
+    event_id = event.id
+
+    db_session.add(
+        TournamentEventPoolTable(
+            tournament_id=tournament_id,
+            event_id=event_id,
+            pool_id="p-os-1",
+            table_id=foreign_table,
+            position=0,
+        )
+    )
+    with pytest.raises(IntegrityError) as excinfo:
+        await db_session.commit()
+    assert POOL_TABLE_TABLE_CONSTRAINT in str(excinfo.value)
+    await db_session.rollback()
+
+    db_session.add(
+        TournamentEventPoolTable(
+            tournament_id=other_id,
+            event_id=event_id,
+            pool_id="p-os-1",
+            table_id=foreign_table,
+            position=0,
+        )
+    )
+    with pytest.raises(IntegrityError) as excinfo:
+        await db_session.commit()
+    assert POOL_TABLE_EVENT_CONSTRAINT in str(excinfo.value)
+    await db_session.rollback()
+
+    # Neither refusal left anything behind.
+    assert await _reservation_rows(db_session, event_id) == []
+
+
+async def test_a_reservation_naming_no_table_at_all_is_refused_by_the_database(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """The plainer half of the same key: a ``table_id`` naming no table anywhere.
+
+    It was storable for as long as a pool's tables were strings in a JSONB array — the
+    dangling reference ADR-0790 could only shrug at, and the reason "this id names a
+    table" had to be re-derived by every reader. It is a foreign-key violation now."""
+    owner = await make_user(db_session, "events-dangling-reservation-owner")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+    event, _ = await create_event(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        payload=_event_payload(pools=[_pool_payload()]),
+    )
+
+    db_session.add(
+        TournamentEventPoolTable(
+            tournament_id=tournament_id,
+            event_id=event.id,
+            pool_id="p-os-1",
+            table_id=str(uuid.uuid4()),
+            position=0,
+        )
+    )
+    with pytest.raises(IntegrityError) as excinfo:
+        await db_session.commit()
+    assert POOL_TABLE_TABLE_CONSTRAINT in str(excinfo.value)
+    await db_session.rollback()
+
+
+async def test_removing_a_table_drops_the_pool_reservations_that_named_it(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """Deleting a venue table takes the reservations naming it — and only those — with
+    no error and no ceremony.
+
+    This is the ADR's asymmetry, from the reservation's side. A fixture *placed* at a
+    table blocks the delete (``ON DELETE RESTRICT``) so the director can be asked; a
+    pool that merely *reserves* it is not consulted, because a table breaking or freeing
+    up is ordinary venue traffic and the pool simply reserves one fewer. Under the JSONB
+    array the pool went on listing the dead id forever; the CASCADE is what makes
+    "reserves one fewer" true in the database rather than derived by every reader.
+
+    Deleted at the row, deliberately, rather than through the tournament-edit verb: this
+    is a claim about the constraint, and the verb's own 409/opt-in path is pinned in
+    ``test_tournaments.py``. The surviving reservation is asserted too — a cascade that
+    took the whole pool's reservations would satisfy "the dead one is gone".
+    """
+    owner = await make_user(db_session, "events-table-cascade-owner")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+    table_1, table_2 = [str(table.id) for table in tournament.tables]
+    doomed = tournament.tables[1]
+    event, _ = await create_event(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        payload=_event_payload(pools=[_pool_payload(table_1, table_2)]),
+    )
+    event_id = event.id
+
+    await db_session.delete(doomed)
+    await db_session.commit()
+
+    db_session.expire_all()
+    assert await _reservation_rows(db_session, event_id) == [
+        (tournament_id, "p-os-1", table_1, 0)
+    ]
+    # The pool itself is untouched — a reservation went, not a pool.
+    assert (
+        await db_session.execute(
+            select(TournamentEventPool.id).where(
+                TournamentEventPool.event_id == event_id
+            )
+        )
+    ).scalars().all() == ["p-os-1"]
+
+
+async def test_removing_a_pool_takes_its_table_reservations_with_it(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A pool dropped from a PATCH takes its reservations with it, through the same
+    ``delete-orphan``/CASCADE pair the pool itself goes by — so no reservation outlives
+    the pool that made it."""
+    owner = await make_user(db_session, "events-pool-cascade-owner")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+    table_1, _table_2 = [str(table.id) for table in tournament.tables]
+    event, _ = await create_event(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        payload=_event_payload(pools=[_pool_payload(table_1)]),
+    )
+    event_id = event.id
+
+    await update_event(
+        db_session,
+        tournament_id=tournament_id,
+        event_id=event_id,
+        actor=owner,
+        updates=TournamentEventUpdate.model_validate({"pools": []}),
+    )
+
+    db_session.expire_all()
+    assert await _reservation_rows(db_session, event_id) == []
+
+
+async def test_re_sending_a_reservation_keeps_its_row_and_re_orders_the_rest(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """The reservations are written as a **diff** keyed on the table id, not replaced
+    wholesale — and a reorder is expressible.
+
+    Both halves matter and they are the same mechanism. A wholesale replace would ask
+    the unit of work to INSERT a primary key it is about to DELETE (it emits the inserts
+    first), so re-sending a table the pool already reserves would die on
+    ``pk_tournament_event_pool_tables``. And swapping two reservations moves one onto a
+    ``position`` the other has not vacated yet, which is why the uniqueness on
+    ``(event_id, pool_id, position)`` is ``DEFERRABLE INITIALLY DEFERRED`` — checked
+    immediately it would refuse a transaction whose end state is perfectly unique.
+
+    The ``created_at`` of the surviving row is what says its identity was *kept* rather
+    than deleted and re-made under the same key: a re-inserted row would carry a fresh
+    one.
+    """
+    owner = await make_user(db_session, "events-reservation-diff-owner")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    tournament_id = tournament.id
+    table_1, table_2 = [str(table.id) for table in tournament.tables]
+    event, _ = await create_event(
+        db_session,
+        tournament_id=tournament_id,
+        actor=owner,
+        payload=_event_payload(pools=[_pool_payload(table_1, table_2)]),
+    )
+    event_id = event.id
+    created_at = (
+        await db_session.execute(
+            select(TournamentEventPoolTable.created_at).where(
+                TournamentEventPoolTable.event_id == event_id,
+                TournamentEventPoolTable.table_id == table_1,
+            )
+        )
+    ).scalar_one()
+
+    await update_event(
+        db_session,
+        tournament_id=tournament_id,
+        event_id=event_id,
+        actor=owner,
+        updates=TournamentEventUpdate.model_validate(
+            {"pools": [_pool_payload(table_2, table_1)]}
+        ),
+    )
+
+    db_session.expire_all()
+    assert await _reservation_rows(db_session, event_id) == [
+        (tournament_id, "p-os-1", table_2, 0),
+        (tournament_id, "p-os-1", table_1, 1),
+    ]
+    assert (
+        await db_session.execute(
+            select(TournamentEventPoolTable.created_at).where(
+                TournamentEventPoolTable.event_id == event_id,
+                TournamentEventPoolTable.table_id == table_1,
+            )
+        )
+    ).scalar_one() == created_at

--- a/api/tests/test_tournament_fixtures.py
+++ b/api/tests/test_tournament_fixtures.py
@@ -95,10 +95,14 @@ async def _make_event(db_session: AsyncSession) -> TournamentEvent:
         timezone="America/Chicago",
         slot={"date": "2026-08-01", "start": "09:00", "end": "17:00"},
         match_settings={"rated": True, "length_games": 5},
+        # Two pools, whose ids the seed mints up front (``event_pools``) because a
+        # fixture below has to name one before the rows are flushed — and because a pool
+        # id is a server-minted uuid now (ADR 20260801), not a string a literal can
+        # spell. ``_pool_a`` / ``_pool_b`` read them back off the event.
         pools=event_pools(
             [
-                {"id": "pool-a", "name": "Pool A", "slot": {}, "table_ids": []},
-                {"id": "pool-b", "name": "Pool B", "slot": {}, "table_ids": []},
+                {"name": "Pool A", "slot": {}, "table_ids": []},
+                {"name": "Pool B", "slot": {}, "table_ids": []},
             ]
         ),
     )
@@ -106,6 +110,17 @@ async def _make_event(db_session: AsyncSession) -> TournamentEvent:
     await db_session.commit()
     await db_session.refresh(event)
     return event
+
+
+def _pool_a(event: TournamentEvent) -> uuid.UUID:
+    """The id of the event's first pool — ``event.pools`` is ordered by ``position``,
+    which is the order ``_make_event`` seeded them in."""
+    return event.pools[0].id
+
+
+def _pool_b(event: TournamentEvent) -> uuid.UUID:
+    """The id of the event's second pool."""
+    return event.pools[1].id
 
 
 async def _make_entry(db_session: AsyncSession, event: TournamentEvent) -> User:
@@ -165,7 +180,7 @@ async def test_a_fixture_holds_its_two_entries(
     db_session.add(
         TournamentFixture(
             event_id=event.id,
-            pool_id="pool-a",
+            pool_id=_pool_a(event),
             round=1,
             position=1,
             entry_a_id=entry_a.id,
@@ -189,12 +204,16 @@ async def test_duplicate_round_and_position_in_the_same_pool_is_rejected(
     ``(event, pool-a, round 1, position 1)`` is a corrupt draw, and the *database* —
     not a read-then-write check — is what refuses it."""
     db_session.add(
-        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+        TournamentFixture(
+            event_id=event.id, pool_id=_pool_a(event), round=1, position=1
+        )
     )
     await db_session.commit()
 
     db_session.add(
-        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+        TournamentFixture(
+            event_id=event.id, pool_id=_pool_a(event), round=1, position=1
+        )
     )
     with pytest.raises(IntegrityError) as excinfo:
         await db_session.commit()
@@ -254,10 +273,14 @@ async def test_the_same_round_and_position_in_a_different_pool_is_accepted(
     a round 1, position 1. A unique constraint that left ``pool_id`` out would reject
     this legitimate row, so this test is what pins the constraint's *scope*."""
     db_session.add(
-        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+        TournamentFixture(
+            event_id=event.id, pool_id=_pool_a(event), round=1, position=1
+        )
     )
     db_session.add(
-        TournamentFixture(event_id=event.id, pool_id="pool-b", round=1, position=1)
+        TournamentFixture(
+            event_id=event.id, pool_id=_pool_b(event), round=1, position=1
+        )
     )
     await db_session.commit()
 
@@ -270,23 +293,28 @@ async def test_the_same_round_and_position_in_a_different_pool_is_accepted(
         .scalars()
         .all()
     )
-    assert sorted(f.pool_id or "" for f in stored) == ["pool-a", "pool-b"]
+    assert {f.pool_id for f in stored} == {_pool_a(event), _pool_b(event)}
 
 
 async def test_the_same_round_and_position_in_a_different_event_is_accepted(
     db_session: AsyncSession, event: TournamentEvent
 ) -> None:
     """Fixture identity is scoped to its event: two events' draws both have a
-    ``(pool-a, round 1, position 1)``. A constraint that omitted ``event_id`` would
-    reject the second event's draw."""
+    ``(their first pool, round 1, position 1)``. A constraint that omitted ``event_id``
+    would reject the second event's draw."""
     other_event = await _make_event(db_session)
 
     db_session.add(
-        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+        TournamentFixture(
+            event_id=event.id, pool_id=_pool_a(event), round=1, position=1
+        )
     )
     db_session.add(
         TournamentFixture(
-            event_id=other_event.id, pool_id="pool-a", round=1, position=1
+            event_id=other_event.id,
+            pool_id=_pool_a(other_event),
+            round=1,
+            position=1,
         )
     )
     await db_session.commit()
@@ -314,9 +342,10 @@ async def test_a_fixture_in_another_events_pool_is_refused_by_the_database(
     that), which is a difference in *when*, not in *whether*.
     """
     other_event = await _make_event(db_session)
+    elsewhere = uuid.uuid4()
     db_session.add(
         TournamentEventPool(
-            id="pool-only-in-the-other-event",
+            id=elsewhere,
             event_id=other_event.id,
             name="Pool Elsewhere",
             position=2,
@@ -326,18 +355,21 @@ async def test_a_fixture_in_another_events_pool_is_refused_by_the_database(
         )
     )
     db_session.add(
-        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+        TournamentFixture(
+            event_id=event.id, pool_id=_pool_a(event), round=1, position=1
+        )
     )
     await db_session.commit()
     # Read before the refusal: the rollback below expires every instance in the session,
     # and re-reading an attribute off one afterwards is a lazy refresh in sync context.
     event_id = event.id
+    pool_a = _pool_a(event)
 
     db_session.add(
         TournamentFixture(
             # The other event's pool, under THIS event's id.
             event_id=event.id,
-            pool_id="pool-only-in-the-other-event",
+            pool_id=elsewhere,
             round=1,
             position=2,
         )
@@ -350,7 +382,7 @@ async def test_a_fixture_in_another_events_pool_is_refused_by_the_database(
     # And the legitimate row is still there: the refusal took the offending write, not
     # the draw around it.
     stored = (await db_session.execute(select(TournamentFixture))).scalars().all()
-    assert [(f.event_id, f.pool_id) for f in stored] == [(event_id, "pool-a")]
+    assert [(f.event_id, f.pool_id) for f in stored] == [(event_id, pool_a)]
 
 
 async def test_a_fixture_naming_a_pool_that_does_not_exist_is_refused(
@@ -362,7 +394,7 @@ async def test_a_fixture_naming_a_pool_that_does_not_exist_is_refused(
     at — the dangling ref ADR-0786 could only protect procedurally, with
     ``_enforce_pool_set_frozen``. It is a foreign-key violation now."""
     db_session.add(
-        TournamentFixture(event_id=event.id, pool_id="pool-z", round=1, position=1)
+        TournamentFixture(event_id=event.id, pool_id=uuid.uuid4(), round=1, position=1)
     )
     with pytest.raises(IntegrityError) as excinfo:
         await db_session.commit()
@@ -383,7 +415,9 @@ async def test_deleting_the_event_takes_its_pools_with_it(
     on a foreign-key violation. This test reds against ``RESTRICT``.
     """
     db_session.add(
-        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+        TournamentFixture(
+            event_id=event.id, pool_id=_pool_a(event), round=1, position=1
+        )
     )
     await db_session.commit()
     event_id = event.id
@@ -419,7 +453,7 @@ async def test_deleting_the_event_takes_its_fixtures_with_it(
     db_session.add(
         TournamentFixture(
             event_id=event.id,
-            pool_id="pool-a",
+            pool_id=_pool_a(event),
             round=1,
             position=1,
             entry_a_id=entry.id,
@@ -464,12 +498,13 @@ async def test_the_events_fixtures_relationship_is_ordered_pool_round_position(
     to no pool"), not a missing one, so it has a defined place in the order rather than
     wherever the dialect's default happens to put it.
     """
+    pool_a, pool_b = _pool_a(event), _pool_b(event)
     for pool_id, round_number, position in [
         (None, 1, 1),
-        ("pool-b", 1, 1),
-        ("pool-a", 2, 1),
-        ("pool-a", 1, 2),
-        ("pool-a", 1, 1),
+        (pool_b, 1, 1),
+        (pool_a, 2, 1),
+        (pool_a, 1, 2),
+        (pool_a, 1, 1),
     ]:
         db_session.add(
             TournamentFixture(
@@ -489,10 +524,16 @@ async def test_the_events_fixtures_relationship_is_ordered_pool_round_position(
         )
     ).scalar_one()
 
+    # The relationship orders by the pool **id**, which under server-minted uuids is
+    # arbitrary — so the expectation is written against whichever of the two sorts
+    # first. What is asserted is unchanged and is the whole claim: the pools do not
+    # INTERLEAVE (all of one pool's fixtures, then all of the other's), each pool's own
+    # fixtures run round → position, and the un-pooled fixture sorts LAST.
+    first, second = sorted([pool_a, pool_b])
     assert [(f.pool_id, f.round, f.position) for f in loaded.fixtures] == [
-        ("pool-a", 1, 1),
-        ("pool-a", 1, 2),
-        ("pool-a", 2, 1),
-        ("pool-b", 1, 1),
+        (first, 1, 1),
+        *([(first, 1, 2), (first, 2, 1)] if first == pool_a else []),
+        (second, 1, 1),
+        *([(second, 1, 2), (second, 2, 1)] if second == pool_a else []),
         (None, 1, 1),
     ]

--- a/api/tests/test_tournament_fixtures.py
+++ b/api/tests/test_tournament_fixtures.py
@@ -24,6 +24,7 @@ covered by running ``alembic upgrade head`` against a fresh database.
 """
 
 import uuid
+from datetime import date, time
 from decimal import Decimal
 
 import pytest
@@ -41,13 +42,18 @@ from app.models import (
     TournamentEntry,
     TournamentEvent,
     TournamentEventDrawSettings,
+    TournamentEventPool,
     TournamentFixture,
     TournamentStatus,
     User,
 )
-from tests._helpers import make_user
+from tests._helpers import event_pools, make_user
 
 FIXTURE_IDENTITY_CONSTRAINT = "uq_tournament_fixtures_event_id_pool_id_round_position"
+#: The composite foreign key that says a fixture's pool is its own event's pool
+#: (ADR 20260801). Asserted by name, so a test that reds proves the constraint refused
+#: this row — not that some other write in the transaction happened to fail.
+FIXTURE_POOL_CONSTRAINT = "fk_tournament_fixtures_event_id_pool_id"
 
 
 async def _make_event(db_session: AsyncSession) -> TournamentEvent:
@@ -89,10 +95,12 @@ async def _make_event(db_session: AsyncSession) -> TournamentEvent:
         timezone="America/Chicago",
         slot={"date": "2026-08-01", "start": "09:00", "end": "17:00"},
         match_settings={"rated": True, "length_games": 5},
-        pools=[
-            {"id": "pool-a", "name": "Pool A", "slot": {}, "table_ids": []},
-            {"id": "pool-b", "name": "Pool B", "slot": {}, "table_ids": []},
-        ],
+        pools=event_pools(
+            [
+                {"id": "pool-a", "name": "Pool A", "slot": {}, "table_ids": []},
+                {"id": "pool-b", "name": "Pool B", "slot": {}, "table_ids": []},
+            ]
+        ),
     )
     db_session.add(event)
     await db_session.commit()
@@ -286,6 +294,115 @@ async def test_the_same_round_and_position_in_a_different_event_is_accepted(
     assert (
         len((await db_session.execute(select(TournamentFixture))).scalars().all()) == 2
     )
+
+
+async def test_a_fixture_in_another_events_pool_is_refused_by_the_database(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    """The claim the **composite** foreign key exists to make (ADR 20260801): a
+    fixture's pool is one of *its own event's* pools.
+
+    The pool named here **exists** — it is a real row, belonging to the *other* event —
+    which is what makes this test able to fail. A plain
+    ``pool_id → tournament_event_pools.id`` foreign key would look that id up, find it,
+    and accept the row, seating one event's fixture inside another event's pool: exactly
+    the illegal state the ADR is about, and exactly the one a non-composite FK cannot
+    see. What is refused is the *pair*.
+
+    The refusal lands at COMMIT rather than at the INSERT because the constraint is
+    ``DEFERRABLE INITIALLY DEFERRED`` (see the model for why the event-delete path needs
+    that), which is a difference in *when*, not in *whether*.
+    """
+    other_event = await _make_event(db_session)
+    db_session.add(
+        TournamentEventPool(
+            id="pool-only-in-the-other-event",
+            event_id=other_event.id,
+            name="Pool Elsewhere",
+            position=2,
+            slot_date=date(2026, 8, 1),
+            slot_start=time(9, 0),
+            slot_end=time(12, 30),
+        )
+    )
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+    )
+    await db_session.commit()
+    # Read before the refusal: the rollback below expires every instance in the session,
+    # and re-reading an attribute off one afterwards is a lazy refresh in sync context.
+    event_id = event.id
+
+    db_session.add(
+        TournamentFixture(
+            # The other event's pool, under THIS event's id.
+            event_id=event.id,
+            pool_id="pool-only-in-the-other-event",
+            round=1,
+            position=2,
+        )
+    )
+    with pytest.raises(IntegrityError) as excinfo:
+        await db_session.commit()
+    assert FIXTURE_POOL_CONSTRAINT in str(excinfo.value)
+    await db_session.rollback()
+
+    # And the legitimate row is still there: the refusal took the offending write, not
+    # the draw around it.
+    stored = (await db_session.execute(select(TournamentFixture))).scalars().all()
+    assert [(f.event_id, f.pool_id) for f in stored] == [(event_id, "pool-a")]
+
+
+async def test_a_fixture_naming_a_pool_that_does_not_exist_is_refused(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    """The plainer half of the same key: a ``pool_id`` naming no pool at all.
+
+    It was storable for as long as pools were JSONB value-objects with nothing to point
+    at — the dangling ref ADR-0786 could only protect procedurally, with
+    ``_enforce_pool_set_frozen``. It is a foreign-key violation now."""
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id="pool-z", round=1, position=1)
+    )
+    with pytest.raises(IntegrityError) as excinfo:
+        await db_session.commit()
+    assert FIXTURE_POOL_CONSTRAINT in str(excinfo.value)
+    await db_session.rollback()
+
+
+async def test_deleting_the_event_takes_its_pools_with_it(
+    db_session: AsyncSession, event: TournamentEvent
+) -> None:
+    """An event's pools go with the event — and they do so while its **fixtures are
+    still there**, which is the case the composite FK's deferral is for.
+
+    Deleting the event removes the pools through the ORM (the collection is eagerly
+    loaded) and the fixtures through Postgres' ``ON DELETE CASCADE``, in that order, in
+    two separate statements. An immediately-checked constraint fires between them, on
+    fixtures that are about to be deleted one statement later, and the whole delete dies
+    on a foreign-key violation. This test reds against ``RESTRICT``.
+    """
+    db_session.add(
+        TournamentFixture(event_id=event.id, pool_id="pool-a", round=1, position=1)
+    )
+    await db_session.commit()
+    event_id = event.id
+
+    await db_session.delete(event)
+    await db_session.commit()
+
+    pools = (
+        (
+            await db_session.execute(
+                select(TournamentEventPool).where(
+                    TournamentEventPool.event_id == event_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert pools == []
 
 
 async def test_deleting_the_event_takes_its_fixtures_with_it(

--- a/api/tests/test_tournament_lifecycle.py
+++ b/api/tests/test_tournament_lifecycle.py
@@ -665,7 +665,8 @@ async def _make_tournament_at(
                         "slot": {"date": _DATE, "start": "09:00", "end": "17:00"},
                         "table_ids": ["t1", "t2"],
                     }
-                ]
+                ],
+                tournament=tournament,
             ),
         )
         db.add(event)

--- a/api/tests/test_tournament_lifecycle.py
+++ b/api/tests/test_tournament_lifecycle.py
@@ -660,7 +660,6 @@ async def _make_tournament_at(
             pools=event_pools(
                 [
                     {
-                        "id": "pool-a",
                         "name": "Pool A",
                         "slot": {"date": _DATE, "start": "09:00", "end": "17:00"},
                         "table_ids": ["t1", "t2"],

--- a/api/tests/test_tournament_lifecycle.py
+++ b/api/tests/test_tournament_lifecycle.py
@@ -61,6 +61,7 @@ from tests._helpers import (
     CountingGeocoder,
     assert_tournament_address_is_sql_null,
     blank_addresses,
+    event_pools,
     make_user,
     venue_tables,
 )
@@ -656,14 +657,16 @@ async def _make_tournament_at(
             timezone="America/Chicago",
             slot={"date": _DATE, "start": "09:00", "end": "17:00"},
             match_settings={"rated": False, "length_games": 3},
-            pools=[
-                {
-                    "id": "pool-a",
-                    "name": "Pool A",
-                    "slot": {"date": _DATE, "start": "09:00", "end": "17:00"},
-                    "table_ids": ["t1", "t2"],
-                }
-            ],
+            pools=event_pools(
+                [
+                    {
+                        "id": "pool-a",
+                        "name": "Pool A",
+                        "slot": {"date": _DATE, "start": "09:00", "end": "17:00"},
+                        "table_ids": ["t1", "t2"],
+                    }
+                ]
+            ),
         )
         db.add(event)
         await db.flush()

--- a/api/tests/test_tournament_placement.py
+++ b/api/tests/test_tournament_placement.py
@@ -124,7 +124,6 @@ async def _seed_placeable_fixture(
             tournament,
             [
                 {
-                    "id": "p-os-1",
                     "name": "Pool A",
                     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
                     "table_ids": ["t1"],
@@ -149,7 +148,7 @@ async def _seed_placeable_fixture(
     await db.commit()
     fixture = TournamentFixture(
         event_id=event.id,
-        pool_id="p-os-1",
+        pool_id=event.pools[0].id,
         round=1,
         position=1,
         entry_a_id=entry_a.id,

--- a/api/tests/test_tournament_queries.py
+++ b/api/tests/test_tournament_queries.py
@@ -6,11 +6,15 @@ the subject here: the pool's ``position`` in its event's own pool order — the
 server-stamped, 0-based field pools carry (ADR 20260801, "Pools carry an explicit
 ``position``") — and *not* the pool's id.
 
-The distinction is not academic and is not about the future. Pool ids are client-minted
-strings, ``p-1-…``, ``p-2-…``, ``p-10-…``, and lexicographically ``p-10-`` falls between
-``p-1-`` and ``p-2-``: an event with ten or more pools rendered its draw as pool 1, pool
-10, pool 2, pool 3, … Every test below is written to fail against an id sort, which is
-why the ids are chosen so their lexicographic order differs from the director's.
+The distinction is not academic and is not about the future. Pool ids were
+client-minted strings, ``p-1-…``, ``p-2-…``, ``p-10-…``, and lexicographically ``p-10-``
+falls between ``p-1-`` and ``p-2-``: an event with ten or more pools rendered its draw
+as pool 1, pool 10, pool 2, pool 3, … They are server-minted uuids now (ADR 20260801),
+which
+does not fix it — it makes it *worse*, because a uuid sort is not merely a different
+order, it is a random one. Every test below is written to fail against an id sort, and
+each asserts up front that the two orders really do disagree, so a run where the random
+ids happened to sort into the director's order cannot pass by luck.
 
 These go through the database, because the ordering *is* the query — asserting it
 against anything else would be asserting about a different artifact.
@@ -36,22 +40,28 @@ from app.models import (
 from app.tournament_queries import fixtures_by_event
 from tests._helpers import event_pools, make_user
 
-#: Ten pool ids in the **director's** order, minted the way the client mints them. Their
-#: lexicographic order is ``p-1-…, p-10-…, p-2-…, p-3-…`` — deliberately not this one,
-#: which is the whole point: a test whose ids happened to sort right could not tell an
-#: id sort from a position sort.
-POOL_IDS = [f"p-{n}-{uuid.uuid4().hex[:6]}" for n in range(1, 11)]
+#: How many pools the events below carry. Ten is the smallest field that used to tell an
+#: id sort from a position sort under the old client-minted ids (``p-10-`` sorts between
+#: ``p-1-`` and ``p-2-``); under server-minted uuids any two would do, and ten keeps the
+#: odds of a random id order coinciding with the director's at one in 3,628,800.
+POOL_COUNT = 10
 
 
-def _pool(pool_id: str, position: int) -> dict[str, Any]:
-    """One pool as it is stored — the JSONB shape the write boundary produces."""
+def _pool(position: int) -> dict[str, Any]:
+    """One pool as the seed helper takes it — no ``id``, because a pool id is the
+    database's to mint (ADR 20260801) and the seed reads it back off the event."""
     return {
-        "id": pool_id,
         "name": f"Pool {position + 1}",
         "position": position,
         "slot": {},
         "table_ids": [],
     }
+
+
+def _pool_ids(event: TournamentEvent) -> list[uuid.UUID]:
+    """The event's pool ids **in the director's order** — ``event.pools`` is ordered by
+    ``position``, which is the order they were seeded in."""
+    return [pool.id for pool in event.pools]
 
 
 async def _make_event(
@@ -107,7 +117,7 @@ async def _make_event(
 async def _seed_fixtures(
     db_session: AsyncSession,
     event: TournamentEvent,
-    rows: list[tuple[str | None, int, int]],
+    rows: list[tuple[uuid.UUID | None, int, int]],
 ) -> None:
     """Write ``(pool_id, round, position)`` fixtures — in the order given, which every
     caller below deliberately scrambles: insertion order is what an unsorted read
@@ -128,40 +138,40 @@ async def _seed_fixtures(
 @pytest_asyncio.fixture
 async def ten_pool_event(db_session: AsyncSession) -> TournamentEvent:
     """An event with ten pools, positions 0..9, in the director's order."""
-    return await _make_event(
-        db_session,
-        [_pool(pool_id, position) for position, pool_id in enumerate(POOL_IDS)],
-    )
+    return await _make_event(db_session, [_pool(n) for n in range(POOL_COUNT)])
 
 
 async def test_ten_pools_come_back_in_the_directors_pool_order(
     db_session: AsyncSession, ten_pool_event: TournamentEvent
 ) -> None:
-    """The one this exists for: ten pools read back 1..10, not 1, 10, 2, 3…
+    """The one this exists for: ten pools read back 1..10, not in the order their ids
+    happen to sort in.
 
-    Ten is the smallest field that tells the two rules apart, because ``p-10-`` is the
-    first client-minted id whose lexicographic place is not its director's place — it
-    sorts between ``p-1-`` and ``p-2-``. Under the old ``ORDER BY pool_id`` this event's
-    draw came back with pool 10's fixtures wedged between pool 1's and pool 2's, on
-    every read, for every client. Nothing about the response looked wrong; it was simply
-    the wrong draw on screen.
+    Under the old ``ORDER BY pool_id`` a ten-pool event's draw came back with pool 10's
+    fixtures wedged between pool 1's and pool 2's, on every read, for every client;
+    under server-minted uuids the same bug deals the pools in a *random* order. Nothing
+    about the response looks wrong either way; it is simply the wrong draw on screen.
 
     The assertion is the **full sequence**, so it fails on an id sort rather than merely
     on an unsorted one — a "the pools are contiguous" check would pass against both.
     """
+    pool_ids = _pool_ids(ten_pool_event)
+    # The premise, asserted rather than assumed: the ids do NOT sort into the director's
+    # order, so a loader that fell back to an id sort produces a different sequence.
+    assert sorted(pool_ids) != pool_ids
     await _seed_fixtures(
         db_session,
         ten_pool_event,
-        # Scrambled: the ids' own lexicographic order, which is the order the broken
-        # rule produced and the one a re-broken implementation would fall back into.
-        [(pool_id, 1, 1) for pool_id in sorted(POOL_IDS)],
+        # Scrambled: the ids' own order, which is the order the broken rule produced and
+        # the one a re-broken implementation would fall back into.
+        [(pool_id, 1, 1) for pool_id in sorted(pool_ids)],
     )
 
     fixtures = (await fixtures_by_event(db_session, [ten_pool_event.id]))[
         ten_pool_event.id
     ]
 
-    assert [fixture.pool_id for fixture in fixtures] == POOL_IDS
+    assert [fixture.pool_id for fixture in fixtures] == pool_ids
 
 
 async def test_a_pools_round_and_position_still_decide_within_the_pool(
@@ -169,7 +179,7 @@ async def test_a_pools_round_and_position_still_decide_within_the_pool(
 ) -> None:
     """Pool order is the *outermost* key, not the only one: inside a pool the order is
     still round then position, and the pools do not interleave."""
-    first, second = POOL_IDS[0], POOL_IDS[1]
+    first, second = _pool_ids(ten_pool_event)[:2]
     await _seed_fixtures(
         db_session,
         ten_pool_event,
@@ -212,8 +222,8 @@ async def test_un_pooled_fixtures_sort_last_behind_every_pool(
         [
             (None, 1, 1),
             (None, 1, 2),
-            (POOL_IDS[9], 1, 1),
-            (POOL_IDS[0], 1, 1),
+            (_pool_ids(ten_pool_event)[9], 1, 1),
+            (_pool_ids(ten_pool_event)[0], 1, 1),
         ],
     )
 
@@ -222,8 +232,8 @@ async def test_un_pooled_fixtures_sort_last_behind_every_pool(
     ]
 
     assert [(f.pool_id, f.position) for f in fixtures] == [
-        (POOL_IDS[0], 1),
-        (POOL_IDS[9], 1),
+        (_pool_ids(ten_pool_event)[0], 1),
+        (_pool_ids(ten_pool_event)[9], 1),
         (None, 1),
         (None, 2),
     ]
@@ -241,30 +251,31 @@ async def test_un_pooled_fixtures_sort_last_behind_every_pool(
 async def test_each_events_pool_order_is_read_from_its_own_pools(
     db_session: AsyncSession, ten_pool_event: TournamentEvent
 ) -> None:
-    """The loader is batched over many events at once, so the pool-order lookup has to
-    be correlated to *each fixture's own event* — a subquery that leaked across events
-    would resolve one event's pool ref against another's pools and read a position that
-    is not its own (or, with a shared id, the wrong one entirely).
+    """The loader is batched over many events at once, and each event's draw must come
+    back in **its own** pool order — not in one order the whole batch shares.
 
-    The second event reuses the **same ids in the opposite order**, which is the input
-    that tells a correlated lookup from a leaky one: under a leak both events come back
-    in one of the two orders, and the two assertions cannot both hold.
+    Two ten-pool events whose orders deliberately disagree with each other and with the
+    ids: the first is read back in its director's order, the second in its own, and no
+    single global sort key satisfies both. That is what tells a per-event lookup from a
+    batch-wide one — a loader that ordered by the id, or by any one column of its own
+    table, would satisfy at most one of the two assertions.
+
+    (Its predecessor gave the two events the **same** pool ids in opposite orders, to
+    catch a subquery that leaked across events. That input is no longer constructible:
+    a pool id is a server-minted uuid and its primary key is the id alone, so two events
+    cannot share one — the leak it was written against would now find the right pool
+    whatever event it looked in.)
     """
-    reversed_event = await _make_event(
-        db_session,
-        [
-            _pool(pool_id, position)
-            for position, pool_id in enumerate(reversed(POOL_IDS))
-        ],
-    )
-    for event in (ten_pool_event, reversed_event):
+    other_event = await _make_event(db_session, [_pool(n) for n in range(POOL_COUNT)])
+    ours, theirs = _pool_ids(ten_pool_event), _pool_ids(other_event)
+    # The premise: neither event's order is the id order, so an id sort reds both.
+    assert sorted(ours) != ours and sorted(theirs) != theirs
+    for event, pool_ids in ((ten_pool_event, ours), (other_event, theirs)):
         await _seed_fixtures(
-            db_session, event, [(pool_id, 1, 1) for pool_id in sorted(POOL_IDS)]
+            db_session, event, [(pool_id, 1, 1) for pool_id in sorted(pool_ids)]
         )
 
-    fixtures = await fixtures_by_event(
-        db_session, [ten_pool_event.id, reversed_event.id]
-    )
+    fixtures = await fixtures_by_event(db_session, [ten_pool_event.id, other_event.id])
 
-    assert [f.pool_id for f in fixtures[ten_pool_event.id]] == POOL_IDS
-    assert [f.pool_id for f in fixtures[reversed_event.id]] == list(reversed(POOL_IDS))
+    assert [f.pool_id for f in fixtures[ten_pool_event.id]] == ours
+    assert [f.pool_id for f in fixtures[other_event.id]] == theirs

--- a/api/tests/test_tournament_queries.py
+++ b/api/tests/test_tournament_queries.py
@@ -34,7 +34,7 @@ from app.models import (
     TournamentStatus,
 )
 from app.tournament_queries import fixtures_by_event
-from tests._helpers import make_user
+from tests._helpers import event_pools, make_user
 
 #: Ten pool ids in the **director's** order, minted the way the client mints them. Their
 #: lexicographic order is ``p-1-…, p-10-…, p-2-…, p-3-…`` — deliberately not this one,
@@ -60,8 +60,8 @@ async def _make_event(
     """A published round-robin event carrying exactly these pools.
 
     Written straight to the database: nothing here is about who may create a tournament,
-    and the pools are seeded in shapes (a stored ``position``, and a legacy one with no
-    such key) that only the write boundary can produce or refuse.
+    and the pool *order* these seed is the thing under test, which the write boundary
+    would take from the payload's own order rather than from the positions stated here.
     """
     owner = await make_user(db_session, f"director-{uuid.uuid4().hex[:8]}")
     league = await get_default_league(db_session)
@@ -96,7 +96,7 @@ async def _make_event(
         timezone="America/Chicago",
         slot={"date": "2026-08-01", "start": "09:00", "end": "17:00"},
         match_settings={"rated": True, "length_games": 5},
-        pools=pools,
+        pools=event_pools(pools),
     )
     db_session.add(event)
     await db_session.commit()
@@ -229,29 +229,13 @@ async def test_un_pooled_fixtures_sort_last_behind_every_pool(
     ]
 
 
-async def test_pools_stored_before_positions_existed_keep_their_id_order(
-    db_session: AsyncSession,
-) -> None:
-    """A pool written before ``position`` existed carries no such key, so the subquery
-    reads NULL for it — and the whole event degrades to exactly the id order the loader
-    had before this change, rather than to no order at all.
-
-    That is what the pool **id** is still doing as a secondary sort key. A read boundary
-    must not turn a history it cannot change into a scrambled draw, and there is no
-    migration in this slice: these rows exist today.
-    """
-    legacy = [
-        {"id": pool_id, "name": pool_id, "slot": {}, "table_ids": []}
-        for pool_id in POOL_IDS
-    ]
-    event = await _make_event(db_session, legacy)
-    await _seed_fixtures(
-        db_session, event, [(pool_id, 1, 1) for pool_id in reversed(POOL_IDS)]
-    )
-
-    fixtures = (await fixtures_by_event(db_session, [event.id]))[event.id]
-
-    assert [fixture.pool_id for fixture in fixtures] == sorted(POOL_IDS)
+# There is deliberately no "pools stored before ``position`` existed keep their id
+# order" test any more. It seeded pools with no ``position`` key at all, which a JSONB
+# array could hold and the ``NOT NULL position`` column of ``tournament_event_pools``
+# cannot (ADR 20260801) — and, pre-deploy, there are no such rows for it to describe.
+# The pool id remains the loader's secondary sort key for the case that IS still
+# reachable: an un-pooled draw, where the position subquery is NULL for every fixture
+# (``test_un_pooled_fixtures_sort_last_behind_every_pool``).
 
 
 async def test_each_events_pool_order_is_read_from_its_own_pools(

--- a/api/tests/test_tournament_solve_service.py
+++ b/api/tests/test_tournament_solve_service.py
@@ -117,7 +117,6 @@ async def _make_tournament(
         pools=event_pools(
             [
                 {
-                    "id": "pool-a",
                     "name": "Pool A",
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": [str(row.id) for row in catalogue],

--- a/api/tests/test_tournament_solve_service.py
+++ b/api/tests/test_tournament_solve_service.py
@@ -122,7 +122,8 @@ async def _make_tournament(
                     "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
                     "table_ids": [str(row.id) for row in catalogue],
                 }
-            ]
+            ],
+            tournament=tournament,
         ),
     )
     db.add(event)

--- a/api/tests/test_tournament_solve_service.py
+++ b/api/tests/test_tournament_solve_service.py
@@ -46,6 +46,7 @@ from app.tournament_errors import (
 )
 from app.tournament_solve_service import request_schedule_solve
 from tests._helpers import (
+    event_pools,
     make_user,
     venue_tables,
 )
@@ -113,14 +114,16 @@ async def _make_tournament(
         timezone="America/Chicago",
         slot={"date": DATE, "start": "09:00", "end": "17:00"},
         match_settings={"rated": False, "length_games": 3},
-        pools=[
-            {
-                "id": "pool-a",
-                "name": "Pool A",
-                "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
-                "table_ids": [str(row.id) for row in catalogue],
-            }
-        ],
+        pools=event_pools(
+            [
+                {
+                    "id": "pool-a",
+                    "name": "Pool A",
+                    "slot": {"date": DATE, "start": "09:00", "end": "17:00"},
+                    "table_ids": [str(row.id) for row in catalogue],
+                }
+            ]
+        ),
     )
     db.add(event)
     await db.flush()

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -18,6 +18,7 @@ from collections.abc import AsyncIterator, Callable, Sequence
 from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal
 from typing import Any
+from unittest.mock import ANY
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -175,7 +176,6 @@ def _event_payload(**overrides: Any) -> dict[str, Any]:
         # its own test, built off the tournament's real catalogue.
         "pools": [
             {
-                "id": "p-os-1",
                 "name": "Pool A",
                 "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
                 "table_ids": [],
@@ -685,17 +685,21 @@ async def test_create_event_round_trips_jsonb(
     assert body["predicates"] == [
         {"id": "pr-1", "field": "rating", "op": "<", "value": 1500}
     ]
-    # The pool round-trips with one field it was not sent: ``position``, stamped by the
-    # write boundary from its index in the ``pools`` list (ADR 20260801).
+    # The pool round-trips with two fields it was not sent: the ``id`` the server minted
+    # for it (ADR 20260801's ``id uuid PRIMARY KEY``) and the ``position`` the write
+    # boundary stamped from its index in the ``pools`` list. Neither is sendable — the
+    # create shape has no field for either — so this is the only place a client learns
+    # the id it must cite to keep this pool on a later PATCH.
     assert body["pools"] == [
         {
-            "id": "p-os-1",
+            "id": ANY,
             "name": "Pool A",
             "position": 0,
             "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
             "table_ids": [],
         }
     ]
+    assert uuid.UUID(body["pools"][0]["id"])
 
 
 async def test_create_event_with_an_unknown_timezone_is_422_and_writes_nothing(
@@ -1229,7 +1233,6 @@ async def test_patch_event_by_creator_updates_jsonb(
 
     new_pools = [
         {
-            "id": "p-new",
             "name": "Pool Z",
             "slot": {"date": "2026-06-14", "start": "10:00", "end": "14:00"},
             "table_ids": [],
@@ -1247,7 +1250,7 @@ async def test_patch_event_by_creator_updates_jsonb(
     assert response.status_code == 200
     body = response.json()
     assert body["draw_type"] == "single-elim"
-    assert body["pools"] == _positioned(*new_pools)
+    assert _anonymous(body["pools"]) == _positioned(*new_pools)
     assert body["predicates"] == new_predicates
     # Untouched fields survive.
     assert body["name"] == "Open Singles"
@@ -1660,9 +1663,15 @@ async def _enter(
 
 
 async def _ensure_pool(
-    db_session: AsyncSession, event_id: uuid.UUID, pool_id: str
-) -> None:
-    """Give ``event_id`` a pool called ``pool_id``, unless it has one already.
+    db_session: AsyncSession, event_id: uuid.UUID, name: str
+) -> uuid.UUID:
+    """Give ``event_id`` a pool **named** ``name``, unless it has one already, and
+    return its id.
+
+    Keyed on the name, not the id, and that is the whole shape of the change: a pool id
+    is a server-minted uuid (ADR 20260801), so a test cannot spell one as a literal and
+    the readable ``"p-a"`` a seed says is a *name*. The uuid it resolves to is what
+    every fixture, assertion and payload below actually carries.
 
     Positioned after whatever pools the event already has, so an event that gains two
     pools this way holds ``0`` and ``1`` and never trips
@@ -1674,12 +1683,12 @@ async def _ensure_pool(
         await db_session.execute(
             select(TournamentEventPool).where(
                 TournamentEventPool.event_id == event_id,
-                TournamentEventPool.id == pool_id,
+                TournamentEventPool.name == name,
             )
         )
     ).scalar_one_or_none()
     if existing is not None:
-        return
+        return existing.id
     position = (
         await db_session.execute(
             select(func.count())
@@ -1687,18 +1696,31 @@ async def _ensure_pool(
             .where(TournamentEventPool.event_id == event_id)
         )
     ).scalar_one()
-    db_session.add(
-        TournamentEventPool(
-            id=pool_id,
-            event_id=event_id,
-            name=pool_id,
-            position=position,
-            slot_date=date(2026, 6, 13),
-            slot_start=time(9, 0),
-            slot_end=time(12, 30),
-        )
+    pool = TournamentEventPool(
+        id=uuid.uuid4(),
+        event_id=event_id,
+        name=name,
+        position=position,
+        slot_date=date(2026, 6, 13),
+        slot_start=time(9, 0),
+        slot_end=time(12, 30),
     )
+    db_session.add(pool)
     await db_session.commit()
+    return pool.id
+
+
+async def _pool_id(db_session: AsyncSession, event_id: str, name: str) -> uuid.UUID:
+    """The id of the pool of ``event_id`` **named** ``name`` — the lookup an assertion
+    about a fixture's ``pool_id`` goes through, since the id is the server's."""
+    return (
+        await db_session.execute(
+            select(TournamentEventPool.id).where(
+                TournamentEventPool.event_id == uuid.UUID(event_id),
+                TournamentEventPool.name == name,
+            )
+        )
+    ).scalar_one()
 
 
 async def _cut(
@@ -1722,19 +1744,25 @@ async def _cut(
     it to describe a *drawn* event; and the play-guard tests need it to write the one
     state nothing can produce yet (a fixture with a winner, or with a match).
 
-    A named ``pool_id`` the event does not already have is **created** first
-    (:func:`_ensure_pool`). ``tournament_fixtures.(event_id, pool_id)`` is a composite
+    ``pool_id`` is the pool's **name** — a readable ``"p-a"`` — because the id itself is
+    a server-minted uuid no literal can spell (ADR 20260801). A pool of that name the
+    event does not already have is **created** first (:func:`_ensure_pool`), and the id
+    it resolves to is what the fixture row carries.
+    ``tournament_fixtures.(event_id, pool_id)`` is a composite
     foreign key onto ``tournament_event_pools`` now (ADR 20260801), so a fixture in a
     pool that does not exist is no longer a row the database will take — which is the
     point of the constraint, and which these tests are not about: they seed a *drawn*
     event and say which pool each fixture is in. Seeding the pool is part of seeding
     that state, exactly as seeding the event is.
     """
-    if pool_id is not None:
+    pool_uuid = (
         await _ensure_pool(db_session, uuid.UUID(event_id), pool_id)
+        if pool_id is not None
+        else None
+    )
     fixture = TournamentFixture(
         event_id=uuid.UUID(event_id),
-        pool_id=pool_id,
+        pool_id=pool_uuid,
         round=round,
         position=position,
         entry_a_id=entry_a.id if entry_a is not None else None,
@@ -1963,11 +1991,13 @@ async def test_list_tournaments_statement_count_does_not_grow_with_events(
         and not any(x.username.startswith("gone-") for x in e.entrants)
         for e in tournament.events
     )
-    assert all(
-        [(f.pool_id, f.round, f.position) for f in e.fixtures]
-        == [("p-a", 1, 1), ("p-a", 1, 2)]
-        for e in tournament.events
-    )
+    # The pool ids are the server's, and each event has its own "p-a" row, so the
+    # assertion is about the SHAPE of each event's draw: two fixtures, both in the one
+    # pool that event has, at (1, 1) and (1, 2).
+    for e in tournament.events:
+        pool_ids = {f.pool_id for f in e.fixtures}
+        assert len(pool_ids) == 1 and None not in pool_ids
+        assert [(f.round, f.position) for f in e.fixtures] == [(1, 1), (1, 2)]
 
 
 # ----- near-me radius filter (ADR "Distance is a haversine expression") ------
@@ -4553,8 +4583,23 @@ async def test_detail_statement_count_does_not_grow_with_entrants(
 
 
 def _coords(event: dict[str, Any]) -> list[tuple[str | None, int, int]]:
-    """An event's draw as the sequence of coordinates it came back in."""
-    return [(f["pool_id"], f["round"], f["position"]) for f in event["fixtures"]]
+    """An event's draw as the sequence of coordinates it came back in, with each pool
+    named rather than identified.
+
+    A pool id is a server-minted uuid (ADR 20260801), so no expectation below could
+    spell one; the pool's **name** is what a test can say and what a director reads. The
+    mapping comes off the event's own ``pools``, which is the same join a client makes
+    to title a bracket — so a fixture naming a pool this event does not have would show
+    up here as a ``KeyError`` rather than as a quietly unmatched id."""
+    names = {pool["id"]: pool["name"] for pool in event["pools"]}
+    return [
+        (
+            names[f["pool_id"]] if f["pool_id"] is not None else None,
+            f["round"],
+            f["position"],
+        )
+        for f in event["fixtures"]
+    ]
 
 
 async def _events_by_name(
@@ -4848,11 +4893,12 @@ async def test_detail_statement_count_does_not_grow_with_drawn_events(
     # And the counted block really did the work: every event came back with its own
     # two-fixture draw, in order.
     assert len(detail.events) == event_count
-    assert all(
-        [(f.pool_id, f.round, f.position) for f in e.fixtures]
-        == [("p-a", 1, 1), ("p-a", 1, 2)]
-        for e in detail.events
-    )
+    # Each event has its own "p-a" row (the id is the server's), so the claim is about
+    # the SHAPE of each event's draw: two fixtures, both in the one pool it has.
+    for e in detail.events:
+        pool_ids = {f.pool_id for f in e.fixtures}
+        assert len(pool_ids) == 1 and None not in pool_ids
+        assert [(f.round, f.position) for f in e.fixtures] == [(1, 1), (1, 2)]
 
 
 # ----- cutting and un-cutting the draw (ADR-0786) ---------------------------
@@ -4877,14 +4923,16 @@ async def test_detail_statement_count_does_not_grow_with_drawn_events(
 # build their pools off ``_catalogue_table_ids`` instead; these are about pool identity,
 # order and the freeze, and a table-less pool says that without pretending to reserve a
 # "t1" that names nothing.
+#
+# They carry **no ``id``** either: a pool id is a server-minted uuid (ADR 20260801) and
+# the create shape has no field for one, so a literal cannot spell it. What a payload
+# below cites, when it has to cite one, is read back off the event (``_kept``).
 POOL_A: dict[str, Any] = {
-    "id": "p-a",
     "name": "Pool A",
     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
     "table_ids": [],
 }
 POOL_B: dict[str, Any] = {
-    "id": "p-b",
     "name": "Pool B",
     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
     "table_ids": [],
@@ -4906,6 +4954,27 @@ def _positioned(*pools: dict[str, Any]) -> list[dict[str, Any]]:
     Which also makes it the ``pools`` payload a client must **not** send: the two
     refusal tests below post exactly this, and get a 422 naming ``position``."""
     return [{**pool, "position": index} for index, pool in enumerate(pools)]
+
+
+def _anonymous(pools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Stored pools with the server-minted ``id`` taken off, so they compare against the
+    literals that were posted.
+
+    A pool's id is the database's now (ADR 20260801), so no assertion can spell one and
+    ``== _positioned(POOL_A, POOL_B)`` would fail on the one key the test never chose.
+    Dropping it is not weakening the assertion: every OTHER key is still compared
+    exactly, and the tests that are about the id — the mint, the citation, the unknown
+    id — assert on it directly instead of through this."""
+    return [{k: v for k, v in pool.items() if k != "id"} for pool in pools]
+
+
+def _kept(stored: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """The stored pools as a PATCH must **cite** them: every field back, ``position``
+    dropped (it is the server's and sending one is a 422).
+
+    This is the round trip a client actually makes — read the event, edit, PATCH it all
+    back — and the only way to say "keep these pools" now that the ids are minted."""
+    return [{k: v for k, v in pool.items() if k != "position"} for pool in stored]
 
 
 def _rr_payload(*pools: dict[str, Any], **overrides: Any) -> dict[str, Any]:
@@ -4967,8 +5036,29 @@ async def _seed_field(
     ]
 
 
+async def _pool_names(
+    db_session: AsyncSession, event_id: str
+) -> dict[uuid.UUID | None, str | None]:
+    """The event's pool ids mapped to their names — the lookup every assertion about
+    "which pool" goes through now that the id is a server-minted uuid (ADR 20260801).
+
+    ``None`` maps to ``None`` so an un-pooled fixture keeps saying "no pool" rather than
+    tripping a ``KeyError``."""
+    names: dict[uuid.UUID | None, str | None] = {None: None}
+    for pool_id, name in (
+        await db_session.execute(
+            select(TournamentEventPool.id, TournamentEventPool.name).where(
+                TournamentEventPool.event_id == uuid.UUID(event_id)
+            )
+        )
+    ).all():
+        names[pool_id] = name
+    return names
+
+
 def _members_by_pool(
     rows: list[TournamentFixture],
+    names: dict[uuid.UUID | None, str | None],
 ) -> dict[str | None, set[uuid.UUID]]:
     """Who ended up in which pool — read back off the fixtures, because there is no pool
     membership table (ADR-0786): a pool *is* the fixtures drawn into it.
@@ -4982,7 +5072,7 @@ def _members_by_pool(
     members: dict[str | None, set[uuid.UUID]] = {}
     for row in rows:
         seated = {row.entry_a_id, row.entry_b_id} - {None}
-        members.setdefault(row.pool_id, set()).update(
+        members.setdefault(names[row.pool_id], set()).update(
             entry_id for entry_id in seated if entry_id is not None
         )
     return members
@@ -4995,14 +5085,28 @@ async def _fixture_rows(
 
     Read from the ROW, never from the response: a route that answered with a plan it
     never persisted would satisfy every assertion made about its body.
+
+    Ordered by the **pool's position** — the same key ``fixtures_by_event`` sorts on
+    (ADR 20260801) — and not by the pool id, which is a server-minted uuid whose order
+    is random. Sorting by the id here made the tests that compare this sequence against
+    the response's flaky at about one run in two, which is the failure mode the explicit
+    position column exists to kill.
     """
+    pool_position = (
+        select(TournamentEventPool.position)
+        .where(
+            TournamentEventPool.event_id == TournamentFixture.event_id,
+            TournamentEventPool.id == TournamentFixture.pool_id,
+        )
+        .scalar_subquery()
+    )
     return list(
         (
             await db_session.execute(
                 select(TournamentFixture)
                 .where(TournamentFixture.event_id == uuid.UUID(event_id))
                 .order_by(
-                    TournamentFixture.pool_id.asc().nulls_last(),
+                    pool_position.asc().nulls_last(),
                     TournamentFixture.round,
                     TournamentFixture.position,
                 )
@@ -5103,11 +5207,12 @@ async def test_cutting_a_draw_persists_the_fixtures_the_strategy_planned(
     # Pool A (seeds 1, 4, 5) is the odd one: three rounds, one fixture each, because the
     # entrant drawn against the phantom that round simply has no fixture. Pool B (seeds
     # 2, 3) is a single pairing. Ordered pool → round → position.
-    assert [(f.pool_id, f.round, f.position) for f in rows] == [
-        ("p-a", 1, 1),
-        ("p-a", 2, 1),
-        ("p-a", 3, 1),
-        ("p-b", 1, 1),
+    names = await _pool_names(db_session, event["id"])
+    assert [(names[f.pool_id], f.round, f.position) for f in rows] == [
+        ("Pool A", 1, 1),
+        ("Pool A", 2, 1),
+        ("Pool A", 3, 1),
+        ("Pool B", 1, 1),
     ]
     # All-play-all *within* each pool, and nobody paired across pools.
     assert _pairs(rows) == {
@@ -5175,9 +5280,9 @@ async def test_an_unseeded_field_is_drawn_in_registration_order(
 
     assert response.status_code == 201, response.text
     rows = await _fixture_rows(db_session, event["id"])
-    assert _members_by_pool(rows) == {
-        "p-a": {first.id, fourth.id, fifth.id},  # the snake's 1, 4, 5
-        "p-b": {second.id, third.id, sixth.id},  # its 2, 3, 6
+    assert _members_by_pool(rows, await _pool_names(db_session, event["id"])) == {
+        "Pool A": {first.id, fourth.id, fifth.id},  # the snake's 1, 4, 5
+        "Pool B": {second.id, third.id, sixth.id},  # its 2, 3, 6
     }
 
 
@@ -5212,11 +5317,11 @@ async def test_a_seed_outranks_the_registration_it_contradicts(
 
     assert response.status_code == 201, response.text
     rows = await _fixture_rows(db_session, event["id"])
-    assert _members_by_pool(rows) == {
+    assert _members_by_pool(rows, await _pool_names(db_session, event["id"])) == {
         # Draw order is 6, 5, 4, 3, 2, 1 (by seed), so the snake's 1st, 4th and 5th are
         # the players who registered 6th, 3rd and 2nd.
-        "p-a": {sixth.id, third.id, second.id},
-        "p-b": {fifth.id, fourth.id, first.id},
+        "Pool A": {sixth.id, third.id, second.id},
+        "Pool B": {fifth.id, fourth.id, first.id},
     }
 
 
@@ -5315,11 +5420,12 @@ async def test_a_second_cut_replaces_the_draw_wholesale(
     assert survivors == 0
     # And the new draw is the one the new field implies: pool A now holds three players
     # (three fixtures), pool B two (one).
-    assert [(f.pool_id, f.round, f.position) for f in rows] == [
-        ("p-a", 1, 1),
-        ("p-a", 2, 1),
-        ("p-a", 3, 1),
-        ("p-b", 1, 1),
+    names = await _pool_names(db_session, event["id"])
+    assert [(names[f.pool_id], f.round, f.position) for f in rows] == [
+        ("Pool A", 1, 1),
+        ("Pool A", 2, 1),
+        ("Pool A", 3, 1),
+        ("Pool B", 1, 1),
     ]
     assert {uuid.UUID(f["id"]) for f in second_cut.json()} == after
     # The page shows the same thing the mutation answered with — same rows, same order.
@@ -5947,7 +6053,6 @@ async def test_place_fixture_blocks_on_a_concurrent_uncut_then_404s_the_gone_fix
 
 # A third pool, for the payloads that try to grow the event's pool set.
 POOL_C: dict[str, Any] = {
-    "id": "p-c",
     "name": "Pool C",
     "slot": {"date": "2026-06-13", "start": "13:00", "end": "16:30"},
     "table_ids": [],
@@ -5985,7 +6090,7 @@ async def _pools_of(db_session: AsyncSession, event_id: str) -> list[dict[str, A
             .order_by(TournamentEventPool.position)
         )
     ).all()
-    reserved: dict[str, list[str]] = {}
+    reserved: dict[uuid.UUID, list[str]] = {}
     for pool_id, table_id in (
         await db_session.execute(
             select(TournamentEventPoolTable.pool_id, TournamentEventPoolTable.table_id)
@@ -5998,7 +6103,9 @@ async def _pools_of(db_session: AsyncSession, event_id: str) -> list[dict[str, A
         reserved.setdefault(pool_id, []).append(table_id)
     return [
         {
-            "id": pool_id,
+            # As the wire carries it: a JSON payload cannot hold a ``uuid.UUID``, and
+            # these dicts are posted straight back as citations (``_kept``).
+            "id": str(pool_id),
             "name": name,
             "slot": {
                 "date": slot_date.isoformat(),
@@ -6103,7 +6210,9 @@ async def test_patching_pools_that_carry_a_position_is_refused_and_writes_nothin
     ]
     # The order the event was created with, unmoved: nothing about this request was
     # applied, not even the re-ordering the payload also asked for.
-    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
+    assert _anonymous(await _pools_of(db_session, event["id"])) == _positioned(
+        POOL_A, POOL_B
+    )
 
 
 async def test_a_draw_of_one_fixture_still_freezes_the_pool_set(
@@ -6140,7 +6249,7 @@ async def test_a_draw_of_one_fixture_still_freezes_the_pool_set(
     )
 
     assert response.status_code == 409, response.text
-    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A)
+    assert _anonymous(await _pools_of(db_session, event["id"])) == _positioned(POOL_A)
     assert _snapshot(await _fixture_rows(db_session, event["id"])) == fixtures_before
 
 
@@ -6211,9 +6320,12 @@ async def test_a_cut_draw_still_lets_a_pools_venue_attributes_be_edited(
     client, _ = authed_client
     tournament_id, event = await _cut_two_pool_event(client, db_session)
     before = _snapshot(await _fixture_rows(db_session, event["id"]))
+    # Both pools are CITED by the ids the server minted — which is what makes this an
+    # edit of the pools the draw was cut across rather than a request to replace them.
+    pool_a, pool_b = _kept(await _pools_of(db_session, event["id"]))
     edited = [
-        {**POOL_A, **edit(await _catalogue_table_ids(client, tournament_id))},
-        POOL_B,
+        {**pool_a, **edit(await _catalogue_table_ids(client, tournament_id))},
+        pool_b,
     ]
 
     response = await client.patch(
@@ -6228,46 +6340,55 @@ async def test_a_cut_draw_still_lets_a_pools_venue_attributes_be_edited(
 
 
 @pytest.mark.parametrize(
-    ("pools", "named"),
+    ("payload", "named"),
     [
-        pytest.param([POOL_A, POOL_B, POOL_C], ["Pool C"], id="added"),
-        pytest.param([POOL_A], ["Pool B"], id="removed"),
-        pytest.param([], ["Pool A", "Pool B"], id="cleared"),
+        pytest.param(lambda kept: [*kept, POOL_C], ["Pool C"], id="added"),
+        pytest.param(lambda kept: kept[:1], ["Pool B"], id="removed"),
+        pytest.param(lambda _kept: [], ["Pool A", "Pool B"], id="cleared"),
         pytest.param(
-            [POOL_A, {**POOL_B, "id": "p-b2"}], ["Pool B"], id="re-identified"
+            lambda kept: [kept[0], {k: v for k, v in kept[1].items() if k != "id"}],
+            ["Pool B"],
+            id="re-added",
         ),
     ],
 )
 async def test_a_cut_draw_refuses_a_pools_patch_that_changes_which_pools_exist(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
-    pools: list[dict[str, Any]],
+    payload: Callable[[list[dict[str, Any]]], list[dict[str, Any]]],
     named: list[str],
 ) -> None:
-    """The freeze itself: with a draw standing, a ``pools`` payload must carry exactly
-    the pool ids the event already has.
+    """The freeze itself: with a draw standing, a ``pools`` payload must cite exactly
+    the pools the event already has.
 
-    Each arm is a different way to break the same reference, and none of them is a thing
-    the database can refuse (``pool_id`` is a string ref into JSONB, not a foreign key):
+    Each arm is a different way to break the same reference, and only one of them is a
+    thing the database could refuse on its own:
 
     * **added** — the new pool arrives with no fixtures, because the draw was dealt
-      across the pools that existed at the cut and nothing re-deals it;
-    * **removed** / **cleared** — every fixture drawn into the departing pool now names
-      a pool that does not exist;
-    * **re-identified** — a pool that keeps its name and changes its ``id`` is *both* of
-      the above at once, and it is the one a director would never see coming. The pools
-      page looks unchanged; the fixtures are all orphaned.
+      across the pools that existed at the cut and nothing re-deals it. **No constraint
+      says anything about this at all** — it is perfectly legal SQL and an incoherent
+      draw — so this guard is the only thing between a director and one;
+    * **removed** / **cleared** — every fixture drawn into the departing pool would name
+      a pool that does not exist. The composite foreign key *does* refuse that, but
+      *deferred*, at COMMIT, as an ``IntegrityError`` the director would read as a
+      **500**. The 409 here is what makes it actionable, and it is judged first;
+    * **re-added** — a pool re-sent with its ``id`` dropped is a removal and an addition
+      at once, and it is the one a director would never see coming: the pools page looks
+      unchanged and every fixture in Pool B is orphaned. (Its predecessor, a pool
+      *re-identified* by giving it a different id, is no longer expressible at all — the
+      id is minted by the server now, so the only two things a client can say are "keep
+      this one" and "add one".)
 
     409, not 403 (ADR-0017): the caller is the owner and the payload is well-formed — it
     is the event that is in the wrong *state* for it, and the same payload becomes legal
     the moment the draw is removed.
 
     The refusal must change **nothing**, and both halves of "nothing" are asserted: the
-    pools JSONB is the same list of dicts it was (not "still non-empty"), and the
+    stored pools are the same rows they were (not "still non-empty"), and the
     fixtures are the same rows, column for column. That is not decoration — it was
     measured. A guard that judged the pools correctly but raised *after* the ``setattr``
     loop (leaving the rollback to clean up) was mutated in, and it still 409s: only the
-    pools-JSONB assertion reds, because the dirty write is flushed ahead of the read. A
+    stored-pools assertion reds, because the dirty write is flushed ahead of the read. A
     status-code-only test passes that guard — which would persist the very edit it
     refuses the day somebody added a ``commit`` somewhere convenient.
     """
@@ -6275,11 +6396,11 @@ async def test_a_cut_draw_refuses_a_pools_patch_that_changes_which_pools_exist(
     tournament_id, event = await _cut_two_pool_event(client, db_session)
     fixtures_before = _snapshot(await _fixture_rows(db_session, event["id"]))
     pools_before = await _pools_of(db_session, event["id"])
-    assert pools_before == _positioned(POOL_A, POOL_B)
+    assert _anonymous(pools_before) == _positioned(POOL_A, POOL_B)
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event['id']}",
-        json={"pools": pools},
+        json={"pools": payload(_kept(pools_before))},
     )
 
     assert response.status_code == 409, response.text
@@ -6306,10 +6427,11 @@ async def test_a_refused_pools_patch_writes_none_of_the_rest_of_the_payload_eith
     """
     client, _ = authed_client
     tournament_id, event = await _cut_two_pool_event(client, db_session)
+    kept = _kept(await _pools_of(db_session, event["id"]))
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event['id']}",
-        json={"name": "Renamed Event", "pools": [POOL_A]},
+        json={"name": "Renamed Event", "pools": kept[:1]},
     )
 
     assert response.status_code == 409, response.text
@@ -6325,7 +6447,9 @@ async def test_a_refused_pools_patch_writes_none_of_the_rest_of_the_payload_eith
         .all()
     )
     assert name == event["name"]
-    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
+    assert _anonymous(await _pools_of(db_session, event["id"])) == _positioned(
+        POOL_A, POOL_B
+    )
 
 
 async def test_an_event_with_no_draw_replaces_its_pools_wholesale(
@@ -6351,7 +6475,7 @@ async def test_an_event_with_no_draw_replaces_its_pools_wholesale(
     )
 
     assert response.status_code == 200, response.text
-    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_C)
+    assert _anonymous(await _pools_of(db_session, event["id"])) == _positioned(POOL_C)
 
 
 async def test_removing_the_draw_un_freezes_the_pool_set(
@@ -6380,7 +6504,9 @@ async def test_removing_the_draw_un_freezes_the_pool_set(
     accepted = await client.patch(url, json={"pools": repooled})
 
     assert accepted.status_code == 200, accepted.text
-    assert await _pools_of(db_session, event["id"]) == _positioned(*repooled)
+    assert _anonymous(await _pools_of(db_session, event["id"])) == _positioned(
+        *repooled
+    )
     assert await _fixture_rows(db_session, event["id"]) == []
 
 
@@ -6406,7 +6532,9 @@ async def test_a_patch_that_does_not_send_pools_is_untouched_by_the_freeze(
 
     assert response.status_code == 200, response.text
     assert response.json()["name"] == "Open Singles (redrawn)"
-    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
+    assert _anonymous(await _pools_of(db_session, event["id"])) == _positioned(
+        POOL_A, POOL_B
+    )
     assert _snapshot(await _fixture_rows(db_session, event["id"])) == before
 
 
@@ -6442,7 +6570,7 @@ async def test_the_pool_freeze_is_scoped_to_the_event_being_patched(
         json={"pools": [POOL_C]},
     )
     assert free.status_code == 200, free.text
-    assert await _pools_of(db_session, undrawn["id"]) == _positioned(POOL_C)
+    assert _anonymous(await _pools_of(db_session, undrawn["id"])) == _positioned(POOL_C)
 
 
 async def test_the_event_patch_takes_the_tournaments_row_lock(
@@ -6481,22 +6609,19 @@ async def test_the_event_patch_takes_the_tournaments_row_lock(
     assert any("FOR UPDATE" in s for s in statements), statements
 
 
-# ----- a pool id identifies one pool (422) -----------------------------------
+# ----- the pool ids are the server's ----------------------------------------
 #
-# The freeze above protects the pool ids a draw was cut across. It rests on an
-# assumption nothing enforced: that an id names ONE pool. Pools are JSONB with
-# client-supplied string ids — there is no pools table, so no unique index — and an
-# event with two pools called ``p-a`` was stored verbatim (measured: 201). The bill
-# arrived at the cut, which deals the field across the event's pool ids: two pools with
-# one id deal onto the same ``(event_id, pool_id, round, position)``, and the fixture
-# table's unique constraint answers the director with a **500**.
+# A pool used to be a JSONB value-object whose ``id`` was a client-supplied string — the
+# reason a fixture could name a pool that did not exist, and the reason two pools of one
+# event could share an id and detonate the cut. It is a ``tournament_event_pools`` row
+# now (ADR 20260801) and its id is minted by ``gen_random_uuid()``.
 #
-# Worse, the freeze itself let the poison in by PATCH, because it compares SETS:
-# ``[A, A, B]`` against a cut event holding ``{A, B}`` is the same set, so the guard
-# that exists to protect the draw waved through the payload that breaks it (measured:
-# 200, then the next cut 500'd). So the rule lives at the BOUNDARY — one validator on
-# the ``pools`` list type both write schemas share, covering create and patch in one
-# place, in every state the event can be in.
+# Minting and CITING are different things, and the diff needs the second. A **create**
+# has no pools to cite, so its write shape has no ``id`` field at all and sending one is
+# a 422. A **patch** is a diff, so each entry may carry the id of a pool it is keeping —
+# but only one this event actually has: an id is something a client was *given*, never
+# something it authors. What is left of the duplicate rule is therefore a rule about
+# CITATIONS: one entry per pool you are keeping.
 
 
 def _pools_error(response: Response) -> str:
@@ -6512,56 +6637,133 @@ def _pools_error(response: Response) -> str:
     )
 
 
-@pytest.mark.parametrize(
-    ("pools", "named"),
-    [
-        pytest.param([POOL_A, POOL_A], ["p-a"], id="the-same-pool-twice"),
-        pytest.param([POOL_A, {**POOL_B, "id": "p-a"}], ["p-a"], id="two-pools-one-id"),
-        pytest.param(
-            [POOL_A, POOL_A, POOL_B, POOL_B], ["p-a", "p-b"], id="two-ids-duplicated"
-        ),
-    ],
-)
-async def test_creating_an_event_with_duplicate_pool_ids_is_refused(
+def _error_locs(response: Response) -> list[list[Any]]:
+    """Every ``loc`` a pydantic 422 named, as lists.
+
+    The refusal must be attributed to the FIELD, not merely to the request: a client
+    renders a validation error under the input that caused it, and a 422 that pointed at
+    ``body`` alone would leave the organizer hunting a blank box.
+    """
+    return [error["loc"] for error in response.json()["detail"]]
+
+
+async def test_creating_an_event_mints_an_id_for_every_pool(
     authed_client: tuple[AsyncClient, User],
-    db_session: AsyncSession,
-    pools: list[dict[str, Any]],
-    named: list[str],
 ) -> None:
-    """An event cannot be **born** holding two pools with the same id.
+    """The mint, on the create verb: three pools go in with no ids and come back with
+    three distinct uuids the client never sent.
 
-    ``two-pools-one-id`` is the arm that matters: two genuinely different pools
-    (different names, different tables, different windows) that happen to share an
-    ``id``. The pools page looks perfectly sane, and the draw is undrawable. Duplicating
-    a whole pool is the same fault with an easier tell.
+    This is the whole of ADR 20260801's ``id uuid PRIMARY KEY`` said over the wire. The
+    ids are asserted **distinct** and not merely present, because "every pool got the
+    same id" is a state a single-column primary key would refuse but a half-done mint
+    (one uuid computed once, outside the loop) would produce — and one that a
+    ``pools[0]["id"]`` assertion would sail past.
+    """
+    client, _ = authed_client
+    _tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B, POOL_C)
+    )
 
-    The refusal names the duplicated **id**, not a pool name: an id is what is
-    duplicated, the two pools sharing it may be named anything, and the id is the thing
-    the director has to go and change.
+    ids = [uuid.UUID(pool["id"]) for pool in event["pools"]]
 
-    422, not 409 — this is a malformed payload in *every* state the event could be in.
-    An event with no draw at all still cannot have two pools called ``p-a``; there is no
-    later moment at which this body becomes legal, which is exactly what separates it
-    from the pool-set freeze's conflict.
+    assert len(set(ids)) == 3
+    assert _anonymous(event["pools"]) == _positioned(POOL_A, POOL_B, POOL_C)
 
-    And the refusal creates **nothing**: a 422 that had already written the event would
-    be a 422 in name only.
+
+async def test_creating_an_event_whose_pool_carries_an_id_is_refused(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """A pool id is not the client's to author, and the create shape says so
+    **structurally**: there is no ``id`` field, so sending one is a 422 for an unknown
+    key and no event is created.
+
+    Refused rather than ignored, which is the same argument ``position`` gets one test
+    up: a client that mistakes "what I read" for "what I may write" is told exactly
+    which key to drop, in the same request, instead of being handed a 201 for an id that
+    decided nothing — and, worse, went on to name a pool that does not exist.
     """
     client, _ = authed_client
     created = (await client.post("/v1/tournaments", json=_create_payload())).json()
 
     response = await client.post(
-        f"/v1/tournaments/{created['id']}/events", json=_rr_payload(*pools)
+        f"/v1/tournaments/{created['id']}/events",
+        json=_rr_payload({**POOL_A, "id": str(uuid.uuid4())}),
     )
 
     assert response.status_code == 422, response.text
-    message = _pools_error(response)
-    for pool_id in named:
-        assert f"“{pool_id}”" in message, message
+    assert ["body", "pools", 0, "id"] in _error_locs(response), response.text
     assert await _events_of(client, created["id"]) == []
 
 
-async def test_a_pools_patch_that_duplicates_an_id_never_reaches_the_cut_draw(
+async def test_a_pools_patch_keeps_the_pool_it_cites_and_mints_one_for_the_rest(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The diff, in one request: an entry citing an id **keeps that row**, an entry with
+    a ``null`` id (or none at all) **adds** one, and a pool no entry cites is removed.
+
+    The kept pool's id is asserted **unchanged**, which is the claim that matters: it is
+    what every fixture drawn into it holds, and a diff that deleted and recreated the
+    row would either take the draw with it or be refused outright.
+    """
+    client, _ = authed_client
+    tournament_id, (event,) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B)
+    )
+    kept_a, dropped_b = _kept(await _pools_of(db_session, event["id"]))
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        # Pool A cited, Pool B not cited (removed), Pool C sent with an explicit null id
+        # (added). ``null`` and "omitted" are the same statement; both are exercised —
+        # the omitted form is every other create in this module.
+        json={"pools": [kept_a, {**POOL_C, "id": None}]},
+    )
+
+    assert response.status_code == 200, response.text
+    stored = await _pools_of(db_session, event["id"])
+    assert _anonymous(stored) == _positioned(POOL_A, POOL_C)
+    assert stored[0]["id"] == kept_a["id"]
+    assert stored[1]["id"] not in {kept_a["id"], dropped_b["id"]}
+
+
+async def test_a_pools_patch_citing_an_id_this_event_does_not_have_is_a_422(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """An ``id`` the server did not mint for **this** event names nothing, and is a 422
+    on that entry rather than a quietly minted new pool.
+
+    This arm could not exist while the id was the client's: an id the server had never
+    seen still named the pool the client meant, so it was an *addition*. Now it is
+    neither — minting a fresh pool for it would hand the client back a different id than
+    it asked for while removing the pool it meant to keep, which is the pair of failures
+    a diff must never confuse (the venue catalogue's ``TableNotInCatalogueError`` is the
+    same refusal one resource over).
+
+    The id used is a **real pool of another event**, not a random uuid: a plain
+    "does this uuid exist" check would let it through, and it would seat this event's
+    pools under another event's row.
+    """
+    client, _ = authed_client
+    tournament_id, (event, other) = await _tournament_with_events(
+        client, _rr_payload(POOL_A, POOL_B), _rr_payload(POOL_C)
+    )
+    kept_a, _kept_b = _kept(await _pools_of(db_session, event["id"]))
+    (elsewhere,) = _kept(await _pools_of(db_session, other["id"]))
+    before = await _pools_of(db_session, event["id"])
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event['id']}",
+        json={"pools": [kept_a, elsewhere]},
+    )
+
+    assert response.status_code == 422, response.text
+    assert ["body", "pools", 1, "id"] in _error_locs(response), response.text
+    assert await _pools_of(db_session, event["id"]) == before
+
+
+async def test_a_pools_patch_citing_one_pool_twice_never_reaches_the_cut_draw(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
 ) -> None:
@@ -6586,30 +6788,31 @@ async def test_a_pools_patch_that_duplicates_an_id_never_reaches_the_cut_draw(
     client, _ = authed_client
     tournament_id, event = await _cut_two_pool_event(client, db_session)
     fixtures_before = _snapshot(await _fixture_rows(db_session, event["id"]))
+    pools_before = await _pools_of(db_session, event["id"])
+    pool_a, pool_b = _kept(pools_before)
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event['id']}",
-        json={"pools": [POOL_A, POOL_A, POOL_B]},
+        json={"pools": [pool_a, pool_a, pool_b]},
     )
 
     assert response.status_code == 422, response.text
-    assert "“p-a”" in _pools_error(response)
+    assert f"“{pool_a['id']}”" in _pools_error(response)
     # Nothing written: the pools are the two they were, and the fixtures are the same
     # rows, column for column.
-    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
+    assert await _pools_of(db_session, event["id"]) == pools_before
     assert _snapshot(await _fixture_rows(db_session, event["id"])) == fixtures_before
     # And the cut the duplicate would have detonated still works.
     re_cut = await client.post(_draw_url(tournament_id, event["id"]))
     assert re_cut.status_code == 201, re_cut.text
 
 
-async def test_an_undrawn_event_also_refuses_a_pools_patch_that_duplicates_an_id(
+async def test_an_undrawn_event_also_refuses_a_pools_patch_that_cites_one_pool_twice(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
 ) -> None:
     """The rule is the **boundary's**, not the freeze's: an event with no draw at all —
-    where the pool set is not frozen and pools replace wholesale — still cannot be given
-    two pools with one id.
+    where the pool set is not frozen — still cannot cite one pool twice.
 
     A guard implemented inside ``_enforce_pool_set_frozen`` would pass the test above
     and fail this one, leaving every un-drawn event free to store the duplicate and 500
@@ -6620,68 +6823,38 @@ async def test_an_undrawn_event_also_refuses_a_pools_patch_that_duplicates_an_id
     tournament_id, (event,) = await _tournament_with_events(
         client, _rr_payload(POOL_A, POOL_B)
     )
+    before = await _pools_of(db_session, event["id"])
+    pool_a, _pool_b = _kept(before)
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event['id']}",
-        json={"pools": [POOL_C, POOL_C]},
+        json={"pools": [pool_a, pool_a]},
     )
 
     assert response.status_code == 422, response.text
-    assert "“p-c”" in _pools_error(response)
-    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
+    assert f"“{pool_a['id']}”" in _pools_error(response)
+    assert await _pools_of(db_session, event["id"]) == before
 
 
-# ----- an id is not the empty string (422) -----------------------------------
+# ----- a pool has a name (422) -----------------------------------------------
 #
-# The rule above says an id names ONE pool. This one says an id is a *thing*:
-# ``Pool.id`` was a bare ``str``, so ``Pool(id="")`` validated, and an event could be
-# created and patched holding a pool with no id at all (measured: 201).
+# The rules above are all about the ``id``, which the server now owns outright. The one
+# floor left on the client's side of a pool is its NAME: a pool is *called* something —
+# it is what the director clicks, what the double-booking warning quotes and what a
+# player reads off a wall — and a list of three blank rows is not a thing anyone can act
+# on. Like every other rule about a pools payload it holds on **both verbs**.
 #
-# An empty pool id is not a cosmetic defect, because a fixture names its pool by that
-# string (ADR-0786) and the domain asks two questions of the ref that DISAGREE about
-# ``""``. In ``app.draws.ready_fixtures``: "is this fixture pooled?" is ``pool_id is
-# None`` — and ``""`` is not ``None``, so *yes, pooled* — while the sort key that orders
-# the plan reads ``pool_id or ""``, where the empty id collapses onto the value the
-# UN-pooled fixtures sort under. One fixture, pooled by one rule and un-pooled by the
-# other, and a draw whose order depends on which of the two you asked.
-#
-# The fix is not a runtime check downstream, and not a defensive ``if not pool_id`` in
-# the sort: it is a floor on the type at the write boundary (``ValueObjectId``,
-# ``min_length=1``), so the state never exists to be reasoned about (api/CLAUDE.md,
-# "make illegal states unrepresentable"). Like every other rule about a pools payload it
-# holds on **both verbs** — an event that could not be born with an empty pool id but
-# could be *edited* into one is an event that can hold it.
+# (Its companion, the floor on an empty pool *id*, is gone with the string it floored: a
+# ``uuid`` cannot be ``""``, so the state ``ValueObjectId``'s ``min_length=1`` was
+# holding off — a fixture drawn into ``""``, pooled by ``pool_id is None`` and un-pooled
+# by the draw-order tie-break — is not expressible at all. A type that cannot hold the
+# bad value beats a validator that refuses it.)
 
 
-def _error_locs(response: Response) -> list[list[Any]]:
-    """Every ``loc`` a pydantic 422 named, as lists.
-
-    The refusal must be attributed to the FIELD, not merely to the request: a client
-    renders a validation error under the input that caused it, and a 422 that pointed at
-    ``body`` alone would leave the organizer hunting a blank box.
-    """
-    return [error["loc"] for error in response.json()["detail"]]
-
-
-@pytest.mark.parametrize(
-    ("pool", "field"),
-    [
-        pytest.param({**POOL_A, "id": ""}, "id", id="empty-id"),
-        pytest.param({**POOL_A, "name": ""}, "name", id="empty-name"),
-    ],
-)
-async def test_creating_an_event_with_an_empty_pool_id_or_name_is_refused(
+async def test_creating_an_event_with_an_empty_pool_name_is_refused(
     authed_client: tuple[AsyncClient, User],
-    pool: dict[str, Any],
-    field: str,
 ) -> None:
-    """An event cannot be **born** with a pool whose id — or whose name — is ``""``.
-
-    The id is the one with teeth (see the section comment: a fixture drawn into ``""``
-    is pooled and un-pooled at the same time). The name is refused for the plainer
-    reason that a pool is *called* something: it is what the director clicks, what the
-    double-booking warning quotes and what a player reads off a wall, and a list of
-    three blank rows is not a thing anyone can act on.
+    """An event cannot be **born** with a pool whose name is ``""``.
 
     And the refusal writes nothing: a 422 that had already stored the event would be a
     422 in name only.
@@ -6690,51 +6863,41 @@ async def test_creating_an_event_with_an_empty_pool_id_or_name_is_refused(
     created = (await client.post("/v1/tournaments", json=_create_payload())).json()
 
     response = await client.post(
-        f"/v1/tournaments/{created['id']}/events", json=_rr_payload(pool, POOL_B)
+        f"/v1/tournaments/{created['id']}/events",
+        json=_rr_payload({**POOL_A, "name": ""}, POOL_B),
     )
 
     assert response.status_code == 422, response.text
-    assert ["body", "pools", 0, field] in _error_locs(response), response.text
+    assert ["body", "pools", 0, "name"] in _error_locs(response), response.text
     assert await _events_of(client, created["id"]) == []
 
 
-@pytest.mark.parametrize(
-    ("pool", "field"),
-    [
-        pytest.param({**POOL_C, "id": ""}, "id", id="empty-id"),
-        pytest.param({**POOL_C, "name": ""}, "name", id="empty-name"),
-    ],
-)
-async def test_a_pools_patch_that_empties_a_pool_id_or_name_is_refused(
+async def test_a_pools_patch_that_empties_a_pool_name_is_refused(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
-    pool: dict[str, Any],
-    field: str,
 ) -> None:
     """The **other verb**, and the one that would otherwise be the hole: an event born
-    with two perfectly good pools, edited into holding one with no id.
+    with two perfectly good pools, edited into holding one with no name.
 
-    Deliberately an **un-drawn** event, where the pool-set freeze does not apply at
-    all. On a *cut* event this payload changes the pool set (``{"", p-b}`` is not
-    ``{p-a, p-b}``), so the freeze would 409 it and the test would pass without the
-    boundary rule existing — proving nothing about the boundary. Here there is no draw
-    and no freeze:
-    pools replace wholesale, and the only thing between the column and ``""`` is the
-    schema.
+    Deliberately an **un-drawn** event, where the pool-set freeze does not apply at all.
+    On a *cut* event a payload that adds a pool is refused by the freeze whatever it is
+    called, and the test would pass without the boundary rule existing — proving nothing
+    about the boundary.
     """
     client, _ = authed_client
     tournament_id, (event,) = await _tournament_with_events(
         client, _rr_payload(POOL_A, POOL_B)
     )
+    before = await _pools_of(db_session, event["id"])
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event['id']}",
-        json={"pools": [pool]},
+        json={"pools": [{**POOL_C, "name": ""}]},
     )
 
     assert response.status_code == 422, response.text
-    assert ["body", "pools", 0, field] in _error_locs(response), response.text
-    assert await _pools_of(db_session, event["id"]) == _positioned(POOL_A, POOL_B)
+    assert ["body", "pools", 0, "name"] in _error_locs(response), response.text
+    assert await _pools_of(db_session, event["id"]) == before
 
 
 # ----- the catalogue's ids are the server's ---------------------------------
@@ -7392,7 +7555,8 @@ async def test_re_sending_the_same_draw_type_with_a_venue_edit_still_succeeds(
     tournament_id, event = await _cut_two_pool_event(client, db_session)
     fixtures_before = _snapshot(await _fixture_rows(db_session, event["id"]))
     table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
-    moved = [{**POOL_A, "table_ids": [table_1]}, POOL_B]
+    pool_a, pool_b = _kept(await _pools_of(db_session, event["id"]))
+    moved = [{**pool_a, "table_ids": [table_1]}, pool_b]
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event['id']}",

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -14,7 +14,7 @@ import asyncio
 import json
 import math
 import uuid
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Callable, Sequence
 from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal
 from typing import Any
@@ -53,6 +53,7 @@ from app.models import (
     TournamentEvent,
     TournamentEventDrawSettings,
     TournamentEventPool,
+    TournamentEventPoolTable,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -169,12 +170,15 @@ def _event_payload(**overrides: Any) -> dict[str, Any]:
         "slot": {"date": "2026-06-13", "start": "09:00", "end": "18:00"},
         "match_settings": {"rated": True, "length_games": 5},
         "predicates": [{"id": "pr-1", "field": "rating", "op": "<", "value": 1500}],
+        # No ``table_ids``: a reservation names a table by the uuid the server minted
+        # (ADR 20260801), which this literal cannot know. The reservation round trip is
+        # its own test, built off the tournament's real catalogue.
         "pools": [
             {
                 "id": "p-os-1",
                 "name": "Pool A",
                 "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
-                "table_ids": ["t1", "t2"],
+                "table_ids": [],
             }
         ],
     }
@@ -689,7 +693,7 @@ async def test_create_event_round_trips_jsonb(
             "name": "Pool A",
             "position": 0,
             "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
-            "table_ids": ["t1", "t2"],
+            "table_ids": [],
         }
     ]
 
@@ -1228,7 +1232,7 @@ async def test_patch_event_by_creator_updates_jsonb(
             "id": "p-new",
             "name": "Pool Z",
             "slot": {"date": "2026-06-14", "start": "10:00", "end": "14:00"},
-            "table_ids": ["t3"],
+            "table_ids": [],
         }
     ]
     new_predicates = [{"id": "pr-9", "field": "rating", "op": ">=", "value": 1800}]
@@ -1864,11 +1868,15 @@ async def test_patch_event_answers_with_its_existing_entrants(
 # per card), the events, ONE batched load of every event's active entrants, ONE
 # batched load of every event's fixtures — its draw (ADR-0786) — and ONE batched load
 # of the caller's rating on every league those tournaments run on (which each event's
-# ``entry_state`` is judged against, ADR-0783), and ONE batched load of every event's
+# ``entry_state`` is judged against, ADR-0783), ONE batched load of every event's
 # pools (``TournamentEvent.pools``, ``lazy="selectin"`` — pools are rows now,
-# ADR 20260801, batched across the whole page exactly as the tables are). Seven,
-# whatever the number of tournaments, tables, events and pools.
-EXPECTED_TOURNAMENT_LIST_STATEMENTS = 7
+# ADR 20260801, batched across the whole page exactly as the tables are), and ONE
+# batched load of every one of THOSE pools' table reservations
+# (``TournamentEventPool.tables``, ``lazy="selectin"`` — the reservations are rows too
+# now, and selectin chains onto the pools' own batched load rather than costing a query
+# per pool). Eight, whatever the number of tournaments, tables, events, pools and
+# reservations.
+EXPECTED_TOURNAMENT_LIST_STATEMENTS = 8
 
 
 @pytest.mark.parametrize("event_count", [1, 4])
@@ -4404,7 +4412,10 @@ async def test_the_tournaments_list_does_not_carry_the_draw_type_catalogue(
 # ``draw_types`` catalogue the event form's picker renders (ADR "a draw type is a
 # seeded row, and the enum holds only what runs"), plus ONE batched load of every
 # event's pools (``TournamentEvent.pools``, ``lazy="selectin"`` — pools are rows now,
-# ADR 20260801). Nine, whatever the number of
+# ADR 20260801), plus ONE batched load of every one of those pools' table reservations
+# (``TournamentEventPool.tables``, ``lazy="selectin"`` — chained onto the pools' own
+# batched load, so it is one statement per page and not one per pool). Ten, whatever the
+# number of
 # events, whatever the number of entrants in them, whatever the size of their draws,
 # whatever the size of the venue, and whatever the length of the day's solve ledger.
 #
@@ -4412,7 +4423,7 @@ async def test_the_tournaments_list_does_not_carry_the_draw_type_catalogue(
 # catalogue is global reference data with nothing to key off the page, and the venue
 # tables are one batched read per *page*, not per card — which is exactly what the
 # parametrized cases below check by measuring the same number at one event and at four.
-EXPECTED_TOURNAMENT_DETAIL_STATEMENTS = 9
+EXPECTED_TOURNAMENT_DETAIL_STATEMENTS = 10
 
 
 @pytest.mark.parametrize("event_count", [1, 4])
@@ -4858,17 +4869,25 @@ async def test_detail_statement_count_does_not_grow_with_drawn_events(
 
 # The pools a round-robin event is cut across. Two, so the snake has somewhere to snake
 # to and a fixture's ``pool_id`` is a ref that has to resolve against the right one.
+#
+# They reserve **no tables**, and that is not laziness. A reservation is a row with a
+# composite foreign key onto ``tournament_tables`` now (ADR 20260801), so the only ids a
+# pool payload can name are the uuids the server minted when the tournament was created
+# — which a module-level literal cannot spell. The tests that are *about* reservations
+# build their pools off ``_catalogue_table_ids`` instead; these are about pool identity,
+# order and the freeze, and a table-less pool says that without pretending to reserve a
+# "t1" that names nothing.
 POOL_A: dict[str, Any] = {
     "id": "p-a",
     "name": "Pool A",
     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
-    "table_ids": ["t1"],
+    "table_ids": [],
 }
 POOL_B: dict[str, Any] = {
     "id": "p-b",
     "name": "Pool B",
     "slot": {"date": "2026-06-13", "start": "09:00", "end": "12:30"},
-    "table_ids": ["t2"],
+    "table_ids": [],
 }
 
 
@@ -5931,7 +5950,7 @@ POOL_C: dict[str, Any] = {
     "id": "p-c",
     "name": "Pool C",
     "slot": {"date": "2026-06-13", "start": "13:00", "end": "16:30"},
-    "table_ids": ["t3"],
+    "table_ids": [],
 }
 
 
@@ -5945,6 +5964,10 @@ async def _pools_of(db_session: AsyncSession, event_id: str) -> list[dict[str, A
     pools are rows now — ADR 20260801 — and the projection is here so every assertion
     below can go on comparing against the pool dicts it posted.)
 
+    ``table_ids`` takes a second column-only query, over the
+    ``tournament_event_pool_tables`` rows — the reservations are their own rows now too
+    — reassembled per pool in ``position`` order, which is the order they were named in.
+
     This is what "the refusal changed nothing" has to be asserted against. "The event
     still has pools" would pass against a guard that 409'd *after* writing them.
     """
@@ -5956,13 +5979,23 @@ async def _pools_of(db_session: AsyncSession, event_id: str) -> list[dict[str, A
                 TournamentEventPool.slot_date,
                 TournamentEventPool.slot_start,
                 TournamentEventPool.slot_end,
-                TournamentEventPool.table_ids,
                 TournamentEventPool.position,
             )
             .where(TournamentEventPool.event_id == uuid.UUID(event_id))
             .order_by(TournamentEventPool.position)
         )
     ).all()
+    reserved: dict[str, list[str]] = {}
+    for pool_id, table_id in (
+        await db_session.execute(
+            select(TournamentEventPoolTable.pool_id, TournamentEventPoolTable.table_id)
+            .where(TournamentEventPoolTable.event_id == uuid.UUID(event_id))
+            .order_by(
+                TournamentEventPoolTable.pool_id, TournamentEventPoolTable.position
+            )
+        )
+    ).all():
+        reserved.setdefault(pool_id, []).append(table_id)
     return [
         {
             "id": pool_id,
@@ -5972,10 +6005,10 @@ async def _pools_of(db_session: AsyncSession, event_id: str) -> list[dict[str, A
                 "start": slot_start.strftime("%H:%M"),
                 "end": slot_end.strftime("%H:%M"),
             },
-            "table_ids": list(table_ids),
+            "table_ids": reserved.get(pool_id, []),
             "position": position,
         }
-        for pool_id, name, slot_date, slot_start, slot_end, table_ids, position in rows
+        for pool_id, name, slot_date, slot_start, slot_end, position in rows
     ]
 
 
@@ -6129,19 +6162,33 @@ async def _cut_two_pool_event(
 @pytest.mark.parametrize(
     ("edit", "description"),
     [
-        pytest.param({"table_ids": ["t7", "t8"]}, "a table breaks", id="tables"),
+        # Taken as a function of the tournament's own catalogue rather than a literal:
+        # a reservation is a row foreign-keyed to a real table now (ADR 20260801), so
+        # "the director moves this pool onto the other table" can only be said in the
+        # uuids the server minted. It is also a better test than the ``["t7", "t8"]`` it
+        # replaces, which named no table at all and so proved only that the freeze let
+        # the field through.
         pytest.param(
-            {"slot": {"date": "2026-06-13", "start": "10:30", "end": "14:00"}},
+            lambda tables: {"table_ids": [tables[1]]}, "a table breaks", id="tables"
+        ),
+        pytest.param(
+            lambda _tables: {
+                "slot": {"date": "2026-06-13", "start": "10:30", "end": "14:00"}
+            },
             "the pool runs late",
             id="window",
         ),
-        pytest.param({"name": "Morning Pool"}, "the director renames it", id="name"),
+        pytest.param(
+            lambda _tables: {"name": "Morning Pool"},
+            "the director renames it",
+            id="name",
+        ),
     ],
 )
 async def test_a_cut_draw_still_lets_a_pools_venue_attributes_be_edited(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
-    edit: dict[str, Any],
+    edit: Callable[[list[str]], dict[str, Any]],
     description: str,
 ) -> None:
     """The case the freeze exists to **permit**. With the draw cut, the director changes
@@ -6164,7 +6211,10 @@ async def test_a_cut_draw_still_lets_a_pools_venue_attributes_be_edited(
     client, _ = authed_client
     tournament_id, event = await _cut_two_pool_event(client, db_session)
     before = _snapshot(await _fixture_rows(db_session, event["id"]))
-    edited = [{**POOL_A, **edit}, POOL_B]
+    edited = [
+        {**POOL_A, **edit(await _catalogue_table_ids(client, tournament_id))},
+        POOL_B,
+    ]
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event['id']}",
@@ -7151,11 +7201,12 @@ async def test_removing_a_catalogue_table_only_a_pool_reserves_succeeds_silently
 
     A pool's ``table_ids`` are a reservation, not a placement: "a table breaks, a table
     frees up" is ordinary venue traffic and is exactly why a pool's tables stay editable
-    mid-event. The pool simply reserves one fewer, which today is derived on read (the
-    solver intersects ``table_ids`` with the catalogue, ``_load_solver_inputs``) — the
-    stored JSONB still lists the dead id, and cleaning that up is Slice 3's
-    ``tournament_event_pool_tables`` CASCADE, not this verb's. Asserted, so that when
-    the join table lands the change is a decision rather than a surprise."""
+    mid-event. The pool simply reserves one fewer — and since ADR 20260801's
+    ``tournament_event_pool_tables`` that is *literally* what happens, in the database:
+    the reservation is a row with ``ON DELETE CASCADE`` onto ``tournament_tables``, so
+    removing the table takes the reservation with it. It used to be derived on read (the
+    solver intersected ``table_ids`` with the catalogue) while the stored JSONB went on
+    listing a dead id; the verb still says nothing, and now neither does the row."""
     client, _ = authed_client
     (
         tournament_id,
@@ -7181,9 +7232,12 @@ async def test_removing_a_catalogue_table_only_a_pool_reserves_succeeds_silently
     assert fixture.table_id == table_1
     assert fixture.scheduled_start is not None
 
+    # The reservation on the removed table is GONE — and the one on the surviving table
+    # is not, so the CASCADE took the row it named and nothing else.
+    db_session.expire_all()
     (event,) = await _events_of(client, tournament_id)
     (pool,) = event["pools"]
-    assert pool["table_ids"] == [table_1, table_2]  # Slice 3's to prune
+    assert pool["table_ids"] == [table_1]
 
 
 # ----- the draw-type freeze (409) -------------------------------------------
@@ -7337,7 +7391,8 @@ async def test_re_sending_the_same_draw_type_with_a_venue_edit_still_succeeds(
     client, _ = authed_client
     tournament_id, event = await _cut_two_pool_event(client, db_session)
     fixtures_before = _snapshot(await _fixture_rows(db_session, event["id"]))
-    moved = [{**POOL_A, "table_ids": ["t7"]}, POOL_B]
+    table_1, _table_2 = await _catalogue_table_ids(client, tournament_id)
+    moved = [{**POOL_A, "table_ids": [table_1]}, POOL_B]
 
     response = await client.patch(
         f"/v1/tournaments/{tournament_id}/events/{event['id']}",

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -15,7 +15,7 @@ import json
 import math
 import uuid
 from collections.abc import AsyncIterator, Sequence
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -52,6 +52,7 @@ from app.models import (
     TournamentEntryStatus,
     TournamentEvent,
     TournamentEventDrawSettings,
+    TournamentEventPool,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -1654,6 +1655,48 @@ async def _enter(
     return entry
 
 
+async def _ensure_pool(
+    db_session: AsyncSession, event_id: uuid.UUID, pool_id: str
+) -> None:
+    """Give ``event_id`` a pool called ``pool_id``, unless it has one already.
+
+    Positioned after whatever pools the event already has, so an event that gains two
+    pools this way holds ``0`` and ``1`` and never trips
+    ``uq_tournament_event_pools_event_id_position``. The window is the shared
+    09:00–12:30 the pool payloads in this module use; no test that seeds a fixture this
+    way asserts anything about it.
+    """
+    existing = (
+        await db_session.execute(
+            select(TournamentEventPool).where(
+                TournamentEventPool.event_id == event_id,
+                TournamentEventPool.id == pool_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return
+    position = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(TournamentEventPool)
+            .where(TournamentEventPool.event_id == event_id)
+        )
+    ).scalar_one()
+    db_session.add(
+        TournamentEventPool(
+            id=pool_id,
+            event_id=event_id,
+            name=pool_id,
+            position=position,
+            slot_date=date(2026, 6, 13),
+            slot_start=time(9, 0),
+            slot_end=time(12, 30),
+        )
+    )
+    await db_session.commit()
+
+
 async def _cut(
     db_session: AsyncSession,
     event_id: str,
@@ -1674,7 +1717,17 @@ async def _cut(
     read-path tests needed it before a cut route existed; the statement-count pins need
     it to describe a *drawn* event; and the play-guard tests need it to write the one
     state nothing can produce yet (a fixture with a winner, or with a match).
+
+    A named ``pool_id`` the event does not already have is **created** first
+    (:func:`_ensure_pool`). ``tournament_fixtures.(event_id, pool_id)`` is a composite
+    foreign key onto ``tournament_event_pools`` now (ADR 20260801), so a fixture in a
+    pool that does not exist is no longer a row the database will take — which is the
+    point of the constraint, and which these tests are not about: they seed a *drawn*
+    event and say which pool each fixture is in. Seeding the pool is part of seeding
+    that state, exactly as seeding the event is.
     """
+    if pool_id is not None:
+        await _ensure_pool(db_session, uuid.UUID(event_id), pool_id)
     fixture = TournamentFixture(
         event_id=uuid.UUID(event_id),
         pool_id=pool_id,
@@ -1811,9 +1864,11 @@ async def test_patch_event_answers_with_its_existing_entrants(
 # per card), the events, ONE batched load of every event's active entrants, ONE
 # batched load of every event's fixtures — its draw (ADR-0786) — and ONE batched load
 # of the caller's rating on every league those tournaments run on (which each event's
-# ``entry_state`` is judged against, ADR-0783). Six, whatever the number of
-# tournaments, tables and events.
-EXPECTED_TOURNAMENT_LIST_STATEMENTS = 6
+# ``entry_state`` is judged against, ADR-0783), and ONE batched load of every event's
+# pools (``TournamentEvent.pools``, ``lazy="selectin"`` — pools are rows now,
+# ADR 20260801, batched across the whole page exactly as the tables are). Seven,
+# whatever the number of tournaments, tables, events and pools.
+EXPECTED_TOURNAMENT_LIST_STATEMENTS = 7
 
 
 @pytest.mark.parametrize("event_count", [1, 4])
@@ -2143,13 +2198,13 @@ async def test_list_without_location_is_unchanged_with_null_distance(
     assert rows[str(far.id)]["distance_miles"] is None
 
 
-async def test_list_near_me_statement_count_stays_five(
+async def test_list_near_me_statement_count_does_not_grow_with_the_radius_filter(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
     engine: AsyncEngine,
 ):
-    """The near-me distance column and radius WHERE ride on the FIRST of the five
-    batched queries — a computed column and a predicate, not a per-row follow-up — so a
+    """The near-me distance column and radius WHERE ride on the FIRST of the batched
+    queries — a computed column and a predicate, not a per-row follow-up — so a
     located list is still exactly ``EXPECTED_TOURNAMENT_LIST_STATEMENTS`` statements (no
     N+1 reintroduced by the filter).
 
@@ -4347,15 +4402,17 @@ async def test_the_tournaments_list_does_not_carry_the_draw_type_catalogue(
 # tournament's league, ONE read of the newest solve-ledger row (the Schedule tab's
 # solve strip, ADR "the schedule is solved, the call is pinned"), and ONE read of the
 # ``draw_types`` catalogue the event form's picker renders (ADR "a draw type is a
-# seeded row, and the enum holds only what runs"). Eight, whatever the number of
+# seeded row, and the enum holds only what runs"), plus ONE batched load of every
+# event's pools (``TournamentEvent.pools``, ``lazy="selectin"`` — pools are rows now,
+# ADR 20260801). Nine, whatever the number of
 # events, whatever the number of entrants in them, whatever the size of their draws,
 # whatever the size of the venue, and whatever the length of the day's solve ledger.
 #
-# Two of the eight are deliberate flat reads that grow with nothing: the draw-type
+# Two of the nine are deliberate flat reads that grow with nothing: the draw-type
 # catalogue is global reference data with nothing to key off the page, and the venue
 # tables are one batched read per *page*, not per card — which is exactly what the
 # parametrized cases below check by measuring the same number at one event and at four.
-EXPECTED_TOURNAMENT_DETAIL_STATEMENTS = 8
+EXPECTED_TOURNAMENT_DETAIL_STATEMENTS = 9
 
 
 @pytest.mark.parametrize("event_count", [1, 4])
@@ -4520,6 +4577,13 @@ async def test_an_events_draw_comes_back_in_pool_round_position_order(
         _event_payload(name="Open Singles"),
         _event_payload(name="Under 1500"),
     )
+    # The event's pool ORDER, stated before any fixture names a pool, because that order
+    # is what the read sorts by (ADR 20260801) and it is not the order the fixtures are
+    # written in below — which is the whole point of writing them in the wrong one.
+    # ``_cut`` would otherwise create each pool as it first met it, and pool B would
+    # legitimately come first.
+    await _ensure_pool(db_session, uuid.UUID(drawn["id"]), "p-a")
+    await _ensure_pool(db_session, uuid.UUID(drawn["id"]), "p-b")
 
     await _cut(db_session, drawn["id"], pool_id="p-b", round=2, position=1)
     await _cut(db_session, drawn["id"], pool_id=None, round=1, position=1)
@@ -4673,6 +4737,10 @@ async def test_the_list_and_the_detail_agree_about_an_events_draw(
     a draw the detail page disagrees with — including its order."""
     client, _ = authed_client
     tournament_id, (event,) = await _tournament_with_events(client, _event_payload())
+    # Pool A first in the event's pool order, said here rather than left to the order
+    # the fixtures below happen to be seeded in (which is deliberately the reverse).
+    await _ensure_pool(db_session, uuid.UUID(event["id"]), "p-a")
+    await _ensure_pool(db_session, uuid.UUID(event["id"]), "p-b")
     await _cut(db_session, event["id"], pool_id="p-b", round=1, position=1)
     await _cut(db_session, event["id"], pool_id="p-a", round=1, position=1)
 
@@ -5868,23 +5936,47 @@ POOL_C: dict[str, Any] = {
 
 
 async def _pools_of(db_session: AsyncSession, event_id: str) -> list[dict[str, Any]]:
-    """The event's ``pools``, read straight from the JSONB column.
+    """The event's pools, read straight from the ``tournament_event_pools`` rows and
+    projected back into the wire shape the payloads in this module are written in.
 
     A column-only ``SELECT``, deliberately: it never touches the identity map, so what
-    comes back is what the *row* holds and not a stale ORM instance the test session
-    happened to be holding from before the request.
+    comes back is what the *rows* hold and not stale ORM instances the test session
+    happened to be holding from before the request. (It used to read one JSONB column;
+    pools are rows now — ADR 20260801 — and the projection is here so every assertion
+    below can go on comparing against the pool dicts it posted.)
 
     This is what "the refusal changed nothing" has to be asserted against. "The event
     still has pools" would pass against a guard that 409'd *after* writing them.
     """
-    pools = (
+    rows = (
         await db_session.execute(
-            select(TournamentEvent.pools).where(
-                TournamentEvent.id == uuid.UUID(event_id)
+            select(
+                TournamentEventPool.id,
+                TournamentEventPool.name,
+                TournamentEventPool.slot_date,
+                TournamentEventPool.slot_start,
+                TournamentEventPool.slot_end,
+                TournamentEventPool.table_ids,
+                TournamentEventPool.position,
             )
+            .where(TournamentEventPool.event_id == uuid.UUID(event_id))
+            .order_by(TournamentEventPool.position)
         )
-    ).scalar_one()
-    return list(pools)
+    ).all()
+    return [
+        {
+            "id": pool_id,
+            "name": name,
+            "slot": {
+                "date": slot_date.isoformat(),
+                "start": slot_start.strftime("%H:%M"),
+                "end": slot_end.strftime("%H:%M"),
+            },
+            "table_ids": list(table_ids),
+            "position": position,
+        }
+        for pool_id, name, slot_date, slot_start, slot_end, table_ids, position in rows
+    ]
 
 
 async def test_an_events_pools_are_read_back_in_the_order_they_were_posted(

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -211,8 +211,9 @@ export class TournamentDetailPage {
    *
    * Asserted with `toHaveText([...])`, which pins the count AND the order in one
    * statement — the only shape that can catch a draw rendering `Pool 1, Pool 10,
-   * Pool 2 …` (ADR 20260801: pool ids are client-minted `p-1-…`, `p-10-…`, and `p-10-`
-   * sorts between `p-1-` and `p-2-`). */
+   * Pool 2 …`, the bug that pool ids being client-minted `p-1-…`, `p-10-…` used to
+   * cause (`p-10-` sorts between `p-1-` and `p-2-`), and that ADR 20260801 ended by
+   * making pool ids server-minted UUIDs sorted by an explicit `position`. */
   poolDrawHeadings(eventId: string): Locator {
     return this.poolDraws(eventId).getByRole('heading', { level: 4 })
   }

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -170,13 +170,22 @@ export class TournamentDetailPage {
     return this.drawPanel(eventId).getByTestId('fixture-match-status')
   }
 
-  /** **Every pool section** of a cut draw, so a spec can count them. Addressed by the
-   * testid *pattern* rather than by pool id on purpose: the rr-then-ko spec authors its
-   * pools in the browser, where the ids are minted client-side and never handed back to
-   * the test. What the test knows — and what the format is about — is how MANY pools
-   * the draw was dealt across. */
+  /** **Every pool section** of a cut draw, so a spec can count them and read their order.
+   * Addressed by the testid *pattern* rather than by pool id, because "how many pools the
+   * draw was dealt across, in what order" is a fact about the draw that holds whatever the
+   * pools are called or keyed by. Use `poolDraw` when the point is the key itself. */
   poolDraws(eventId: string): Locator {
     return this.drawPanel(eventId).getByTestId(/^pool-draw-/)
+  }
+
+  /** One pool section **by the pool's own id** — the uuid the server minted for it (ADR
+   * 20260801), never a name.
+   *
+   * The seam that says the section on screen is keyed by the *server's* pool and not by
+   * something the client re-derived: a spec reads the ids off the create response and
+   * asks for them here, so a stack that keyed its sections any other way finds nothing. */
+  poolDraw(eventId: string, poolId: string): Locator {
+    return this.drawPanel(eventId).getByTestId(`pool-draw-${poolId}`)
   }
 
   /** One pool section of a cut draw, by the pool's displayed name ("Pool A").
@@ -259,5 +268,17 @@ export class TournamentDetailPage {
    * the first data row is rank 1. */
   poolStandings(poolId: string): Locator {
     return this.page.getByTestId(`pool-standings-${poolId}`)
+  }
+
+  /** The **two-stage** champion callout — the one a round-robin-then-knockout event
+   * crowns (ADR 20260727).
+   *
+   * A different callout from `standingsChampion`, and deliberately so: that one belongs to
+   * a complete **single-pool** round-robin and never renders for this format, while this
+   * one names the **knockout final's** winner and never a pool leader. Reading the wrong
+   * one would be a spec that could not tell "the bracket was played out" from "somebody
+   * topped a pool". It appears only once BOTH stages are decided. */
+  twoStageChampion(eventId: string): Locator {
+    return this.page.getByTestId(`two-stage-champion-${eventId}`)
   }
 }

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -30,9 +30,12 @@ const CSRF_HEADER = 'x-csrf-token'
  * A label, not an id, because the id is no longer the seed's to choose (see
  * `TableSpec`). */
 const TABLE_LABEL = 'Table 1'
-/** The id of the event's single pool — a round-robin needs ≥1 pool, and two
- * entrants in one pool is exactly one fixture: the minimal playable draw. */
-const POOL_ID = 'pool-a'
+/** The **name** of the event's single pool — a round-robin needs ≥1 pool, and two
+ * entrants in one pool is exactly one fixture: the minimal playable draw.
+ *
+ * A name, not an id, for the same reason `TABLE_LABEL` is a label: the id is no longer
+ * the seed's to choose (see `PoolSpec`). */
+const POOL_NAME = 'Pool A'
 
 /** A pool/event window (`Slot` on the wire): a date plus `HH:MM` bounds, all
  * naive wall-clock strings in the venue's frame (ADR-0790). */
@@ -98,31 +101,55 @@ export interface StoredTable {
   readonly court: string
 }
 
-/** One pool of the event's draw, as a **client sends it** (`PoolWrite` on the wire).
+/** One pool of the event's draw, as a **client sends it** (`PoolWrite` on the wire):
+ * what it is called and which tables it reserves, and deliberately **neither an `id` nor
+ * a `position`**.
  *
- * It carries no `position`, and that is not an omission this helper could choose to fix:
- * `PoolWrite` is `extra="forbid"`, so a create/patch body carrying a `position` is a
- * **422** naming the field. The server stamps the position from the pool's index in the
- * list it was sent (ADR 20260801, "Pools carry an explicit `position`"), which makes the
- * **order of `SeedTournamentOptions.pools`** the payload's one statement about pool
- * order — and the thing `tournament-pool-order.spec.ts` seeds deliberately at odds with
- * the ids' lexicographic order.
+ * Both absences are the wire's, not this helper's taste. `PoolWrite` is `extra="forbid"`
+ * and has no field for either, so a seed supplying its own `pool-a` is a **422 naming
+ * `body.pools[i].id`** — which is exactly how this helper broke when a pool became a real
+ * row with a `gen_random_uuid()` primary key (ADR 20260801). The id is the database's
+ * now, the same as a catalogue table's.
+ *
+ * So nothing here names a pool by id:
+ *
+ * - a pool is written down by **name**, which is also what the draw renders and what a
+ *   spec's ordering assertions read;
+ * - a pool cites the tables it reserves by **label** (`tableLabels`), resolved against
+ *   the catalogue `seedTournament` just created — the ids are minted too;
+ * - anything that needs the real pool id reads it back off the create response
+ *   (`StoredPool`, returned by `seedTournament`).
+ *
+ * The **order of `SeedTournamentOptions.pools`** is therefore the payload's one statement
+ * about pool order: the server stamps each pool's `position` from its index in the list
+ * it was sent (ADR 20260801, "Pools carry an explicit `position`"), and that is what the
+ * draw, the deal and the rendered pool sections are all ordered by.
  *
  * `tableLabels` is optional because the single-pool default reserves the whole catalogue;
  * a multi-pool seed usually wants a table each, so ten pools raise no double-booking
  * warning over one shared table.
  *
- * Tables are cited by **label**, not by id: the ids are minted by the server (see
- * `TableSpec`), so at the moment a caller writes down its pools there is no id to name.
- * `seedTournament` resolves each label against the catalogue it just created, and throws
- * on one that names no seeded table rather than sending a reservation the solver would
- * quietly intersect away to nothing. */
+ * `tableIdsFor` throws on a label that names no seeded table rather than sending a
+ * reservation the solver would quietly intersect away to nothing. */
 export interface PoolSpec {
-  readonly id: string
   readonly name: string
   /** The catalogue tables this pool reserves, **by label**. Omitted = **every** seeded
    * table. */
   readonly tableLabels?: ReadonlyArray<string>
+}
+
+/** One pool as the API **reads it back** (`Pool` on the wire): what was sent, plus the
+ * uuid the server minted for it and the 0-based `position` it stamped from the pool's
+ * index in the list it arrived in (ADR 20260801).
+ *
+ * The only place a spec can learn a pool id — and the id everything downstream is keyed
+ * by: a fixture's `pool_id`, the draw's pool sections, the `pool-standings-{id}` table.
+ * Only the three fields an ordering assertion is about are named; the window and tables
+ * ride along untyped. */
+export interface StoredPool {
+  readonly id: string
+  readonly name: string
+  readonly position: number
 }
 
 /** A venue's six free-text address components (`AddressInput` on the wire). The
@@ -215,12 +242,13 @@ export interface CreatedTournament {
 /** A seeded tournament and the ids a spec needs to address it and its event. */
 export interface SeededTournament extends CreatedTournament {
   readonly eventId: string
+  /** The event's pools **as stored** — read off the create response, so each carries the
+   * uuid the server minted and the `position` it stamped, in the order they were sent.
+   * The only handle a spec has on a pool id, and the order the draw must read in. */
+  readonly pools: ReadonlyArray<StoredPool>
   /** The event's **first** pool id — its only one under the default seed — so a spec
-   * can scope its standings assertions. */
+   * can scope its standings assertions without indexing `pools` itself. */
   readonly poolId: string
-  /** Every seeded pool id, **in the order they were sent** — which is the order the
-   * server stamped their positions from, and so the order the draw must read in. */
-  readonly poolIds: ReadonlyArray<string>
 }
 
 /**
@@ -317,7 +345,7 @@ export async function seedTournament(
     end: '17:00',
   }
   const tables = options.tables ?? [{ label: TABLE_LABEL, court: 'A' }]
-  const pools = options.pools ?? [{ id: POOL_ID, name: 'Pool A' }]
+  const pools = options.pools ?? [{ name: POOL_NAME }]
   // Resolve the catalogue HERE and pass it down, rather than letting
   // `createTournament` default it again: the pools below reserve tables out of the
   // catalogue it creates, so the two must be the same list by construction. What comes
@@ -354,11 +382,11 @@ export async function seedTournament(
         predicates: [],
         // Sent in the caller's order and NEVER re-sorted here: this array's order is
         // what `stored_pools` stamps the pools' `position`s from, so re-ordering it —
-        // even "tidily", by id — would silently seed a different event than the one the
-        // spec asked for. No pool carries a `position` key either; sending one is a 422
-        // (`PoolWrite` is `extra="forbid"`).
+        // even "tidily", by name — would silently seed a different event than the one the
+        // spec asked for. No pool carries an `id` or a `position` key either; sending
+        // either is a 422 naming it (`PoolWrite` is `extra="forbid"` and has neither
+        // field).
         pools: pools.map((pool) => ({
-          id: pool.id,
           name: pool.name,
           slot,
           // Labels resolved to the ids the server just minted — a pool's `table_ids`
@@ -375,14 +403,26 @@ export async function seedTournament(
       `create event failed: ${eventRes.status()} ${await eventRes.text()}`,
     )
   }
-  const eventId = ((await eventRes.json()) as { id: string }).id
+  // `TournamentEventRead` carries the stored pools, ordered by the `position` the server
+  // just stamped (the relationship's own `order_by`) — so the minted ids come back on the
+  // create itself, in the order they were sent, and no second read is needed to learn
+  // them.
+  const created = (await eventRes.json()) as {
+    id: string
+    pools: ReadonlyArray<StoredPool>
+  }
+  if (created.pools.length !== pools.length) {
+    throw new Error(
+      `seeded ${pools.length} pools but the event stored ${created.pools.length}`,
+    )
+  }
 
   return {
     tournamentId,
     tables: storedTables,
-    eventId,
-    poolId: pools[0].id,
-    poolIds: pools.map((pool) => pool.id),
+    eventId: created.id,
+    pools: created.pools,
+    poolId: created.pools[0].id,
   }
 }
 
@@ -489,16 +529,6 @@ export async function findEventByName(
     )
   }
   return event
-}
-
-/** A pool as the event **reads back** (`Pool` on the wire): what the client sent, plus
- * the 0-based `position` the server stamped on it from its index in the list it was sent
- * (ADR 20260801). Only the three fields an ordering assertion is about are named; the
- * window and tables ride along untyped. */
-export interface StoredPool {
-  readonly id: string
-  readonly name: string
-  readonly position: number
 }
 
 /**

--- a/e2e/support/tournament-play.ts
+++ b/e2e/support/tournament-play.ts
@@ -1,0 +1,232 @@
+import { acceptResult, type Guest, type ResultGame } from './match-api'
+
+// Composed-stack API helper for **playing a live tournament out** — every fixture the
+// draw has materialized, decided over the real API, until there is nothing left to play.
+//
+// It exists because some claims about a *draw* only become visible once its matches are
+// finished. An `rr-then-ko` event does not seat a single qualifier until a pool is
+// decided (ADR "rr-then-ko cuts both stages upfront and seeds qualifiers rematch-free"),
+// so a spec whose subject is the seating has to get fourteen matches played before it can
+// look at anything — and fourteen trips through the score-entry UI would be a test of the
+// score-entry UI. `tournament-lifecycle.spec.ts` already drives that surface in the
+// browser, once, deliberately; this is the seam for every spec whose subject is on the
+// other side of the play.
+//
+// Writes ride the double-submit CSRF defense the same way `match-api.ts` does, and the
+// acceptance leg is `match-api`'s own `acceptResult` rather than a second spelling of it.
+
+const API = '/api/v1'
+const CSRF_HEADER = 'x-csrf-token'
+
+/** How many passes over the draw this helper will make before giving up.
+ *
+ * A pass plays every fixture that is currently materialized and undecided; the
+ * completions advance the draw, which materializes the next round, which the next pass
+ * plays. A bracket seeded from three pools settles in three or four passes, so ten is
+ * generous — its job is to turn "the draw stopped advancing" into a **named error**
+ * instead of a test that hangs until Playwright's timeout and reports nothing about why. */
+const MAX_PASSES = 10
+
+/** The event slice this helper reads: who is entered, what has materialized, and the
+ * match settings the board it composes has to satisfy. Only these fields are named; the
+ * rest of the payload rides along untyped, as elsewhere in `support/`. */
+interface PlayableEvent {
+  readonly id: string
+  readonly match_settings: { readonly rated: boolean; readonly length_games: number }
+  readonly entrants: ReadonlyArray<{
+    readonly id: string
+    readonly username: string
+  }>
+  readonly fixtures: ReadonlyArray<{
+    readonly id: string
+    readonly pool_id: string | null
+    readonly entry_a_id: string | null
+    readonly entry_b_id: string | null
+    readonly match_id: string | null
+    readonly match_status: string | null
+  }>
+}
+
+/** Which fixtures a call to `playEvent` is willing to decide.
+ *
+ * `'pools'` stops at the pool stage, which is the whole point of having the option: an
+ * `rr-then-ko` spec needs a moment *between* the stages — pools decided, bracket seated,
+ * nothing knocked out yet — and that moment does not exist if the helper plays on. */
+export type PlayStage = 'pools' | 'all'
+
+/**
+ * Play `eventId`'s draw out over the API, **the earlier-registered entrant always
+ * winning**, until no materialized fixture is left undecided. Returns how many matches
+ * were decided.
+ *
+ * ## The winner rule is the seed's, and it is deliberately boring
+ *
+ * `entrants` is the field **in registration order** — what `seedEntrants` returns — and
+ * the entrant nearer its front wins. That makes every outcome in the tournament a
+ * function of the seeded field alone: a pool's finishing order is its members' order in
+ * this list, the qualifiers are the first `K` of them, and the champion is
+ * `entrants[0]`. A spec can therefore write down who *should* be in the bracket before a
+ * ball is hit, which is the only way an assertion about the seating can be more than "six
+ * names appeared".
+ *
+ * It also keeps the play free of ties: in a three-player pool the rule gives 2–0, 1–1 and
+ * 0–2, so the finishing order needs no tiebreak and the qualifier set is not a coin flip.
+ *
+ * ## Passes, not a queue
+ *
+ * A completion advances the draw inside the completion transaction (ADR-0788) and
+ * materializes whatever it just made ready, so the set of playable fixtures **grows while
+ * this runs**. Rather than predict that, each pass re-reads the event and plays what it
+ * finds; when a pass finds nothing, the draw is settled. `MAX_PASSES` bounds it.
+ *
+ * Sequential on purpose, and not merely for tidiness: every completion takes the
+ * tournament row lock (`on_match_completed`), so concurrent finishes would serialize
+ * anyway — and a burst of them would make which fixture materialized first a race, which
+ * is exactly the determinism the winner rule above is buying.
+ *
+ * ## Rated or not, one path
+ *
+ * The result is proposed by the winner; if the response leaves a **standing result** —
+ * which only a rated two-human match does — the loser accepts it. The helper reads that
+ * off the response rather than off `match_settings.rated`, so it plays an event however
+ * the director configured it, including one configured through the editor's defaults.
+ *
+ * The board is `target` straight games at 11–5, where `target` is the wins a
+ * `length_games` best-of needs: exactly decisive, with nothing after the decider (which
+ * `validate_finalize_games` refuses).
+ */
+export async function playEvent(
+  director: Guest,
+  tournamentId: string,
+  eventId: string,
+  entrants: ReadonlyArray<Guest>,
+  stage: PlayStage = 'all',
+): Promise<number> {
+  const byUsername = new Map(entrants.map((guest) => [guest.username, guest]))
+  const rank = new Map(entrants.map((guest, index) => [guest.username, index]))
+  let played = 0
+
+  for (let pass = 0; pass < MAX_PASSES; pass += 1) {
+    const event = await readPlayableEvent(director, tournamentId, eventId)
+    const seats = new Map(
+      event.entrants.map((entrant) => [entrant.id, entrant.username]),
+    )
+    const playable = event.fixtures.filter(
+      (fixture): fixture is typeof fixture & { match_id: string } =>
+        fixture.match_id !== null &&
+        fixture.match_status !== 'completed' &&
+        (stage === 'all' || fixture.pool_id !== null),
+    )
+    if (playable.length === 0) return played
+
+    for (const fixture of playable) {
+      const [a, b] = [fixture.entry_a_id, fixture.entry_b_id].map((entryId) =>
+        guestFor(byUsername, seats, entryId, fixture.id),
+      )
+      // Side 1 IS `entry_a` and side 2 IS `entry_b` — the fixed materialization
+      // convention (#788) — so the winner's seat decides which column of the board wins.
+      const winnerIsA = rank.get(a.username)! < rank.get(b.username)!
+      await decide(
+        winnerIsA ? a : b,
+        winnerIsA ? b : a,
+        fixture.match_id,
+        board(winnerIsA ? 1 : 2, gamesToWin(event.match_settings.length_games)),
+      )
+      played += 1
+    }
+  }
+
+  throw new Error(
+    `event ${eventId} still had playable fixtures after ${MAX_PASSES} passes ` +
+      `(${played} matches decided) — is the draw advancing?`,
+  )
+}
+
+/** The wins a best-of-`lengthGames` needs — the same `(n + 1) // 2` the server's
+ * `validate_finalize_games` computes, because a board short of it is refused ("No side
+ * reached N game wins") and a board past it is refused too ("games extend past the
+ * deciding game"). */
+function gamesToWin(lengthGames: number): number {
+  return Math.floor(lengthGames / 2) + 1
+}
+
+/** A straight-games board: `wins` games at 11–5 to `winnerSide`, numbered from 1. */
+function board(winnerSide: 1 | 2, wins: number): ResultGame[] {
+  return Array.from({ length: wins }, (_, index) => ({
+    game_number: index + 1,
+    side_1_points: winnerSide === 1 ? 11 : 5,
+    side_2_points: winnerSide === 2 ? 11 : 5,
+  }))
+}
+
+/** Resolve a fixture's entry ref to the guest sitting in it.
+ *
+ * Throws on every way it can miss — an unseated side, an entry the event does not list,
+ * an entrant this caller did not mint — because each of those means the helper is about
+ * to play the wrong match or none, and a silent skip would leave the draw un-advanced and
+ * the failure three passes away in `MAX_PASSES`. */
+function guestFor(
+  byUsername: ReadonlyMap<string, Guest>,
+  seats: ReadonlyMap<string, string>,
+  entryId: string | null,
+  fixtureId: string,
+): Guest {
+  if (entryId === null) {
+    throw new Error(`fixture ${fixtureId} materialized with an unseated side`)
+  }
+  const username = seats.get(entryId)
+  const guest = username === undefined ? undefined : byUsername.get(username)
+  if (!guest) {
+    throw new Error(
+      `fixture ${fixtureId} seats entry ${entryId} (${username ?? 'unknown entry'}), ` +
+        'who is not one of the entrants this spec minted',
+    )
+  }
+  return guest
+}
+
+/** Decide one match: `winner` proposes the board, and `loser` accepts it if the server
+ * left a standing result (the rated two-human path). */
+async function decide(
+  winner: Guest,
+  loser: Guest,
+  matchId: string,
+  games: ReadonlyArray<ResultGame>,
+): Promise<void> {
+  const res = await winner.ctx.post(`${API}/matches/${matchId}/results`, {
+    headers: { [CSRF_HEADER]: winner.csrf },
+    data: { games },
+  })
+  if (res.status() !== 201) {
+    throw new Error(`propose result failed: ${res.status()} ${await res.text()}`)
+  }
+  const standing = (
+    (await res.json()) as {
+      negotiation?: { standing_result?: { id?: string } | null }
+    }
+  ).negotiation?.standing_result?.id
+  // No standing result = the proposal self-accepted (an unrated or solo match) and the
+  // match is already complete. An acceptance here would be a second verb on a finished
+  // match, so the branch is the contract, not defensiveness.
+  if (standing != null) await acceptResult(loser, matchId, standing)
+}
+
+/** Read the tournament detail and return the one event, typed to the slice above. */
+async function readPlayableEvent(
+  viewer: Guest,
+  tournamentId: string,
+  eventId: string,
+): Promise<PlayableEvent> {
+  const res = await viewer.ctx.get(`${API}/tournaments/${tournamentId}`)
+  if (!res.ok()) {
+    throw new Error(`load tournament failed: ${res.status()} ${await res.text()}`)
+  }
+  const detail = (await res.json()) as {
+    events: ReadonlyArray<PlayableEvent>
+  }
+  const event = detail.events.find((candidate) => candidate.id === eventId)
+  if (!event) {
+    throw new Error(`no event ${eventId} on tournament ${tournamentId}`)
+  }
+  return event
+}

--- a/e2e/tests/tournament-lifecycle.spec.ts
+++ b/e2e/tests/tournament-lifecycle.spec.ts
@@ -59,6 +59,17 @@ test.describe('Tournament — round-robin lifecycle', () => {
     page,
     baseURL,
   }) => {
+    // Five full page loads off a Vite **dev** server (each paying for its route's
+    // on-demand transform), a second minted guest, a real draw cut, a go-live that
+    // materializes the fixture and enqueues a CP-SAT solve on the stack's own worker, and
+    // a scored match — measured at just over a minute here, against a 30s default this
+    // spec never declared. Every other tournament spec in this suite already carries an
+    // explicit budget for the same reason; this one predates them.
+    //
+    // It is a **budget, not a wait**: nothing below sleeps, and every assertion is
+    // web-first, so a genuine regression still reds on its own locator rather than
+    // burning the whole 3 minutes.
+    test.setTimeout(180_000)
     expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
 
     // The director IS the browser's own session (`page.request` shares the page

--- a/e2e/tests/tournament-pool-order.spec.ts
+++ b/e2e/tests/tournament-pool-order.spec.ts
@@ -11,15 +11,19 @@ import {
   seedTournament,
   transitionTournament,
   type PoolSpec,
+  type StoredPool,
   type TableSpec,
 } from '../support/tournament-api'
 
 const EVENT_NAME = 'Open Singles'
 
-/** **Ten** pools — the smallest number that reproduces the bug, and not negotiable.
- * The collision needs a two-digit pool number: `p-10-` sorts between `p-1-` and `p-2-`,
- * so ten pools ordered by id read 1, 10, 2, 3 … 9. With nine, the id order and the
- * position order coincide exactly and the spec would prove nothing. */
+/** **Ten** pools — the number that reproduced the bug, and still the number that gives
+ * this spec its teeth. When pool ids were client-minted strings the collision needed a
+ * two-digit pool number (`p-10-` sorts between `p-1-` and `p-2-`, so ten pools ordered by
+ * id read 1, 10, 2, 3 … 9). The ids are server-minted uuids now, so the wrong order is no
+ * longer *that* order — it is an arbitrary one — and what ten buys is that an arbitrary
+ * order is overwhelmingly unlikely to be the right one (one permutation in `10!`), which
+ * the guard below checks rather than assumes. */
 const POOL_COUNT = 10
 
 /** Two entrants per pool — the round-robin cut refuses a pool of fewer than two
@@ -29,12 +33,6 @@ const POOL_COUNT = 10
 const ENTRANTS_PER_POOL = 2
 const ENTRANT_COUNT = POOL_COUNT * ENTRANTS_PER_POOL
 
-/** The base-36 suffix `genId('p')` appends — one shared "timestamp" for a burst of pools
- * added in the editor, which is exactly how a real ten-pool event's ids look. Fixing it
- * here keeps the ids' lexicographic order a property of the *index*, which is the thing
- * under test, rather than of when the spec happened to run. */
-const ID_SUFFIX = 'mkq1x'
-
 /** Ten tables, one per pool: ten pools sharing one table is a double-booking the editor
  * warns about, and this spec's subject is the order, not the warning. */
 const TABLES: ReadonlyArray<TableSpec> = Array.from(
@@ -43,19 +41,19 @@ const TABLES: ReadonlyArray<TableSpec> = Array.from(
 )
 
 /**
- * The ten pools **in the director's order**, `Pool 1` … `Pool 10`, with the ids the
- * event editor would have minted for them (`p-1-…` … `p-10-…`).
+ * The ten pools **in the director's order**, `Pool 1` … `Pool 10`, carrying **no ids** —
+ * the server mints those (ADR 20260801), so the list's order is the only thing about
+ * order the payload can say at all.
  *
- * The list's order is the payload's only statement about pool order — the server stamps
- * each pool's `position` from its index here (ADR 20260801) — and it is deliberately at
- * odds with both the ids' and the names' lexicographic order. That disagreement is the
- * entire experiment: a seed whose id order matched its intended order could not tell a
- * stack that orders by position from one that orders by id.
+ * That is what the server stamps each pool's `position` from, and it is deliberately at
+ * odds with the names' lexicographic order (`Pool 10` sorts between `Pool 1` and
+ * `Pool 2`) and — checked below rather than assumed — with the minted ids'. That
+ * disagreement is the entire experiment: a seed whose id order matched its intended order
+ * could not tell a stack that orders by position from one that orders by id.
  */
 const POOLS: ReadonlyArray<PoolSpec> = Array.from(
   { length: POOL_COUNT },
   (_, i) => ({
-    id: `p-${i + 1}-${ID_SUFFIX}`,
     name: `Pool ${i + 1}`,
     tableLabels: [`Table ${i + 1}`],
   }),
@@ -64,14 +62,19 @@ const POOLS: ReadonlyArray<PoolSpec> = Array.from(
 /** What the draw must read, top to bottom: `Pool 1`, `Pool 2`, … `Pool 10`. */
 const NAMES_BY_POSITION = POOLS.map((pool) => pool.name)
 
-/** The same ten pools sorted by **id**, by codepoint — the wrong answer, and the one
- * this stack actually produced before pools carried a position: `Pool 1`, `Pool 10`,
- * `Pool 2` … `Pool 9`. Compared against, not asserted on: it is how the spec proves its
- * own fixture is capable of failing. (`localeCompare` is deliberately avoided — it
- * collates digits by locale rules and would quietly stop reproducing the bug.) */
-const NAMES_BY_ID = [...POOLS]
-  .sort((a, b) => (a.id < b.id ? -1 : 1))
-  .map((pool) => pool.name)
+/** The seeded pools' names sorted by **id**, by codepoint — the wrong answer, and the
+ * shape of the one this stack actually produced before pools carried a position.
+ *
+ * Computed from the pools the server minted rather than declared as a constant, because
+ * the ids are no longer the spec's to choose: a uuid's sort order is not knowable until
+ * the row exists. Compared against, never asserted on — it is how the spec proves its own
+ * fixture is capable of failing. (`localeCompare` is deliberately avoided: it collates by
+ * locale rules and would quietly stop being a codepoint sort.) */
+function namesById(pools: ReadonlyArray<StoredPool>): string[] {
+  return [...pools]
+    .sort((a, b) => (a.id < b.id ? -1 : 1))
+    .map((pool) => pool.name)
+}
 
 /**
  * Which entrants the snake deals into each pool, by **registration index**.
@@ -95,12 +98,19 @@ const dealtTo = (poolIndex: number): [number, number] => [
  * **A ten-pool event's draw reads 1 … 10, through the whole composed stack** (#1226,
  * ADR 20260801 "Pools carry an explicit `position`").
  *
- * Pool ids are client-minted strings — `p-1-…`, `p-2-…`, `p-10-…` — and sorted as
+ * Pool ids were client-minted strings — `p-1-…`, `p-2-…`, `p-10-…` — and sorted as
  * strings `p-10-` falls *between* `p-1-` and `p-2-`. Every site that ordered pools by id
  * therefore read a ten-pool event as 1, 10, 2, 3 … 9: the read query that returns the
  * fixtures, the `ready_fixtures` grouping, and `DrawConfig.pool_ids` — the order the
  * snake seeds against. A director with ten pools got a draw whose sections were in one
  * order and whose deal was in another.
+ *
+ * The ids are **server-minted uuids** now (ADR 20260801), which does not retire the
+ * claim — it generalises it. Ordering by id no longer produces that one memorable wrong
+ * order; it produces an arbitrary one, which is a *worse* bug and a less legible one. So
+ * the spec no longer writes the wrong answer down: it reads the minted ids back, sorts
+ * the pools by them, and checks that order really does disagree with the positions before
+ * trusting anything below it.
  *
  * ## Why this claim needs the composed stack
  *
@@ -118,8 +128,8 @@ const dealtTo = (poolIndex: number): [number, number] => [
  *    order they were sent — the fact a client cannot manufacture, since it cannot send
  *    the field at all.
  * 2. **The wire carries it.** The detail's fixtures arrive grouped by pool in position
- *    order, so the pool ids' first appearances read `p-1-…` … `p-10-…` and not
- *    `p-1-…, p-10-…, p-2-…`.
+ *    order, so the pool ids' first appearances read exactly the ids the create response
+ *    handed back, in that order — and not those ids in any other.
  * 3. **The browser renders it** — the ten headings top to bottom, *and* the membership
  *    the deal put under each one. The second is the assertion that would red for a stack
  *    that ordered `DrawConfig.pool_ids` by id, which the headings alone would not.
@@ -149,24 +159,27 @@ test.describe('Tournament — ten-pool draw order', () => {
     test.setTimeout(300_000)
     expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
 
-    // The fixture's own falsification guard: if the ids ever came to sort the way the
-    // positions do, every assertion below would still pass and none of them would mean
-    // anything. Fail here, where the reason is legible, rather than three screens away.
-    expect(
-      NAMES_BY_ID,
-      'the seeded pool ids must sort DIFFERENTLY from their positions, or this spec cannot fail',
-    ).not.toEqual(NAMES_BY_POSITION)
-
     // The director IS the browser's own session, so page navigations run as them.
     const director = await guestFromContext(page.request)
     grantBetaTester(director.username)
 
     // ----- seed: a tournament whose event has ten pools, in order -------------
     const name = `Pools ${faker.string.alphanumeric(8)}`
-    const { tournamentId, eventId, poolIds } = await seedTournament(director, name, {
+    const { tournamentId, eventId, pools } = await seedTournament(director, name, {
       tables: TABLES,
       pools: POOLS,
     })
+    const poolIds = pools.map((pool) => pool.id)
+
+    // The fixture's own falsification guard, and it can only be asked once the ids exist:
+    // if the minted ids happened to sort the way the positions do, every assertion below
+    // would still pass and none of them would mean anything. One uuid permutation in
+    // `10!` does, so this is a real (if rare) possibility and not a formality — fail here,
+    // where the reason is legible, rather than three screens away.
+    expect(
+      namesById(pools),
+      'the minted pool ids must sort DIFFERENTLY from their positions, or this spec cannot fail',
+    ).not.toEqual(NAMES_BY_POSITION)
 
     // ----- 1. the SERVER stamped the order the director sent ------------------
     // Positions 0…9 against the pools in the sent order. A client could not have

--- a/e2e/tests/tournament-rr-then-ko.spec.ts
+++ b/e2e/tests/tournament-rr-then-ko.spec.ts
@@ -7,9 +7,12 @@ import { grantBetaTester } from '../support/rbac-grant'
 import {
   createTournament,
   findEventByName,
+  getEventPools,
+  getScheduleDetail,
   seedEntrants,
   type TableSpec,
 } from '../support/tournament-api'
+import { playEvent } from '../support/tournament-play'
 
 /** The event the director authors in the browser, and the handle the spec finds it by
  * afterwards — its id is minted server-side and never crosses back through the UI. */
@@ -31,6 +34,11 @@ const QUALIFIERS_PER_POOL = 2
  * enough that each pool is a real round-robin rather than a single pairing. */
 const ENTRANT_COUNT = 9
 
+/** The names the editor's pool section mints, in the order it adds them — the director's
+ * order, and therefore the `position` order the server stamps and the draw must read in.
+ * Written down here because it is what every ordering assertion below compares against. */
+const POOL_NAMES = ['Pool A', 'Pool B', 'Pool C']
+
 /** `B` — the bracket the cut must derive: the smallest power of two that holds the
  * `P × K` = 6 qualifiers. **Eight, not sixteen** — the bracket is sized from the
  * qualifier count, never from the entrant count (ADR 20260727: "derived, never
@@ -41,8 +49,53 @@ const BRACKET_ROUNDS = 3
  * fixture** (ADR-0786) — so round one holds two fixtures, not four. */
 const ROUND_ONE_FIXTURES = 2
 
-/** Three tables, one per pool, so the seeded catalogue can furnish the pools the
- * director adds in the editor. */
+/** How many matches each stage is: three pools of three is `3 × C(3,2)` = **nine**, and
+ * an eight-slot bracket holding six qualifiers is 2 + 2 + 1 = **five** (the two byes cost
+ * no fixture). Asserted against what `playEvent` actually decided, so a stage that
+ * quietly materialized fewer matches than it owes is a red here — the "N passed against
+ * N collected" check, one layer down. */
+const POOL_MATCHES = 9
+const KNOCKOUT_MATCHES = 5
+
+/**
+ * **Who the snake deals into each pool**, by registration index (`_snake`, ADR-0786):
+ * nine entrants across three pools is one pass out, one back, one out again, so Pool A
+ * takes registrations 0, 5 and 6; Pool B 1, 4 and 7; Pool C 2, 3 and 8.
+ *
+ * Written down rather than read back off the draw, because the qualifier set below is
+ * *derived* from it: who advances is "the top `K` of each pool", and that is only a
+ * statement a test can make in advance if it knows who is in each pool. Asserting it on
+ * the page is a bonus — the deal following the pool order is `tournament-pool-order`'s
+ * subject at ten pools, and this is not a second copy of that proof.
+ */
+const POOL_MEMBERS: ReadonlyArray<ReadonlyArray<number>> = [
+  [0, 5, 6],
+  [1, 4, 7],
+  [2, 3, 8],
+]
+
+/** The six who **qualify**, by registration index, and the three who do not.
+ *
+ * `playEvent`'s winner rule is "the earlier-registered entrant wins", so a pool's
+ * finishing order is its members in registration order and its qualifiers are the first
+ * `K` of them. Flattened out of `POOL_MEMBERS`, never retyped: a hand-written list could
+ * drift from the deal it is supposed to follow, and would then be asserting a coincidence.
+ */
+const QUALIFIERS = POOL_MEMBERS.flatMap((members) =>
+  members.slice(0, QUALIFIERS_PER_POOL),
+)
+const ELIMINATED = POOL_MEMBERS.flatMap((members) =>
+  members.slice(QUALIFIERS_PER_POOL),
+)
+
+/** A uuid — what a pool id is now that a pool is a real row with a `gen_random_uuid()`
+ * primary key (ADR 20260801). Asserted on the seed so that "the pool ids are the
+ * server's" is established before the spec starts leaning on it. */
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Three tables, one per pool, so the tournament has a venue catalogue of a realistic
+ * shape. The editor's pool section reserves none of them (a draw is cut without regard to
+ * tables — placement is the scheduler's job), so they are scenery here, not scaffolding. */
 const TABLES: ReadonlyArray<TableSpec> = [
   { label: 'Table 1', court: 'A' },
   { label: 'Table 2', court: 'B' },
@@ -51,11 +104,14 @@ const TABLES: ReadonlyArray<TableSpec> = [
 
 /**
  * **Round-robin then knockout, through the whole composed stack** (#1227, ADR
- * "rr-then-ko cuts both stages upfront and seeds qualifiers rematch-free").
+ * "rr-then-ko cuts both stages upfront and seeds qualifiers rematch-free"; #1226, ADR
+ * 20260801 "a pool belongs to its event").
  *
  * A director creates a tournament, authors an `rr-then-ko` event **in the browser** with
  * a qualifiers-per-pool count and three pools, publishes, has nine players entered, cuts
- * the draw, and the page shows **three pools AND a knockout bracket**.
+ * the draw across three **server-minted** pools, takes the tournament live, and the event
+ * is played out to a champion — the pool stage seating its six qualifiers into a bracket
+ * that was cut before anyone played, and the bracket crowning one of them.
  *
  * ## Why this spec is the one that matters for this format
  *
@@ -77,20 +133,48 @@ const TABLES: ReadonlyArray<TableSpec> = [
  *
  * ## And the bracket must exist at cut time
  *
- * The other half of the ADR is that **both stages are cut in one stroke**: `plan_initial`
+ * The other half of that ADR is that **both stages are cut in one stroke**: `plan_initial`
  * emits the pool fixtures *and* the whole bracket, every side of it TBD. That is not an
  * optimization — an `advance()` can only ever fill a side of an *existing* fixture
  * (`SideFill`), so a bracket that did not exist at the cut could never come into being
  * at all. Pools without a bracket is therefore a real product failure and not a
  * selector miss: the second stage would be unreachable for the life of the event.
  *
+ * ## The pools are the SERVER's now, and the draw is dealt across them in ITS order
+ *
+ * A pool used to be a client-minted string inside a JSONB column; it is a row with a
+ * `gen_random_uuid()` primary key and an explicit `position` (ADR 20260801). Every claim
+ * this spec makes about the pooled stage therefore has to be keyed on ids the *server*
+ * chose, and the order has to be the one the director typed rather than any order those
+ * ids happen to sort in. Three readings say so, at three different depths:
+ *
+ * * **stored** — the three pools read back off the create response are uuids at positions
+ *   0, 1, 2, named `Pool A`, `Pool B`, `Pool C` in the order the editor added them;
+ * * **on the wire** — the detail's fixtures come back grouped by pool in position order,
+ *   so the pool ids' first appearances read as those three ids, in that order;
+ * * **on the page** — each pool section is keyed by its uuid, the headings read top to
+ *   bottom in the director's order, and the entrants under each are the ones the snake
+ *   dealt there.
+ *
+ * ## …and the qualifiers reach the bracket
+ *
+ * The claim no unit test makes. The api tests prove `advance()` seats a finished pool's
+ * qualifiers into their predetermined slots; the web-client tests prove a bracket renders
+ * the sides it is handed. Only here does a real pool, decided by real matches through the
+ * real completion hook, put a real name into a real bracket slot — so the spec plays the
+ * pool stage out and then asserts the bracket names **exactly** the six who qualified and
+ * **none** of the three who did not, on a bracket that named nobody at all an hour before.
+ * Then the knockout is played too, and the card crowns the champion the bracket produced.
+ *
  * ## Seed vs UI split
  *
- * Inert scaffolding over the API (`support/tournament-api.ts`): the tournament shell,
- * its table catalogue, and the nine entrants — director-entry, which has no web UI, and
- * nine browser sign-ins to test a *draw* would be nine chances to fail for an unrelated
- * reason. Load-bearing steps in the browser: authoring the event and its draw
- * configuration, publishing, and cutting the draw.
+ * Inert scaffolding over the API (`support/tournament-api.ts`, `support/tournament-play.ts`):
+ * the tournament shell, its table catalogue, the nine entrants — director-entry, which has
+ * no web UI, and nine browser sign-ins to test a *draw* would be nine chances to fail for
+ * an unrelated reason — and the fourteen matches, which `tournament-lifecycle.spec.ts`
+ * already drives through the score-entry UI once, deliberately. Load-bearing steps in the
+ * browser: authoring the event and its draw configuration, publishing, cutting the draw,
+ * going live, and every reading of the draw, the bracket and the champion.
  *
  * ## RBAC
  *
@@ -100,13 +184,14 @@ const TABLES: ReadonlyArray<TableSpec> = [
  * external `E2E_BASE_URL` stack, where the caller owns provisioning.
  */
 test.describe('Tournament — rr-then-ko draw', () => {
-  test('a director cuts an rr-then-ko draw and the page shows three pools and a bracket', async ({
+  test('a director cuts an rr-then-ko draw across three pools, and it is played to a champion', async ({
     page,
     baseURL,
   }) => {
-    // Nine minted guests, nine director-entries and a real CP-SAT-free draw cut, on top
-    // of the ordinary page work — comfortably past the 30s default.
-    test.setTimeout(120_000)
+    // Nine minted guests, nine director-entries, a real draw cut and fourteen real
+    // matches through the completion hook (each one advancing the draw and re-solving the
+    // schedule on the stack's own worker), on top of the ordinary page work.
+    test.setTimeout(600_000)
     expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
 
     // The director IS the browser's own session, so page navigations run as them.
@@ -142,7 +227,9 @@ test.describe('Tournament — rr-then-ko draw', () => {
 
     // THE 422 GATE. The create body is the client's own, and its status is asserted
     // directly: a body missing `qualifiers_per_pool` is refused at the request boundary,
-    // and this is the assertion that says so in those terms.
+    // and this is the assertion that says so in those terms. It is also the gate the pool
+    // ids cross — the editor mints none, so a client that still did would be refused here
+    // for `body.pools[0].id` instead.
     const createPost = page.waitForResponse(
       (r) => r.url().endsWith('/events') && r.request().method() === 'POST',
     )
@@ -162,6 +249,16 @@ test.describe('Tournament — rr-then-ko draw', () => {
     expect(event.draw_type).toBe('rr-then-ko')
     expect(event.qualifiers_per_pool).toBe(QUALIFIERS_PER_POOL)
     const eventId = event.id
+
+    // ----- …and three pools the SERVER minted, in the order they were added ---
+    // Positions 0, 1, 2 against the editor's own `Pool A`, `Pool B`, `Pool C`. The client
+    // sent neither an id nor a position (`PoolWrite` has a field for neither), so both
+    // columns here are the server's own work — and the ids being uuids is what makes
+    // every "by pool id" assertion below a statement about the server's pools.
+    const pools = await getEventPools(director, tournamentId, eventId)
+    expect(pools.map((pool) => pool.name)).toEqual(POOL_NAMES)
+    expect(pools.map((pool) => pool.position)).toEqual([0, 1, 2])
+    for (const pool of pools) expect(pool.id).toMatch(UUID)
 
     // ----- publish, then fill the field --------------------------------------
     await detail.publishButton.click()
@@ -195,18 +292,41 @@ test.describe('Tournament — rr-then-ko draw', () => {
       `cutting the draw was refused: ${await drawResponse.text()}`,
     ).toBe(201)
 
-    // ----- stage one: three pools, three players each ------------------------
+    // ----- stage one: three pools, keyed and ordered by the server -----------
     await expect(detail.poolDraws(eventId)).toHaveCount(POOL_COUNT)
-    for (const poolName of ['Pool A', 'Pool B', 'Pool C']) {
-      const pool = detail.poolDrawNamed(eventId, poolName)
-      await expect(pool).toBeVisible()
+    // Top to bottom in the director's order. One statement pinning both the count and the
+    // order — a draw whose sections came back in any other order reds here. (What that
+    // order is *derived from* — `position`, and never the pool ids — is
+    // `tournament-pool-order.spec.ts`'s subject, at the ten pools it takes to tell the two
+    // apart reliably.)
+    await expect(detail.poolDrawHeadings(eventId)).toHaveText(POOL_NAMES)
+    for (const [index, pool] of pools.entries()) {
+      // The section is keyed by the pool's uuid, so this asks for the server's pool by the
+      // server's id and would find nothing if the page keyed its sections any other way.
+      await expect(detail.poolDraw(eventId, pool.id)).toBeVisible()
       // Nine entrants snake-dealt across three pools is three apiece — the pool
       // membership is derived from the pool's own fixtures (ADR-0786), so this is also
-      // the statement that each pool really got a round-robin of its own.
+      // the statement that each pool really got a round-robin of its own, and that the
+      // deal followed the same pool order the headings above are in.
       await expect(
-        pool.getByRole('list', { name: `Entrants in ${poolName}` }).getByRole('listitem'),
-      ).toHaveCount(ENTRANT_COUNT / POOL_COUNT)
+        detail.poolEntrants(eventId, pool.name),
+        `${pool.name} holds the wrong entrants — the draw was dealt in the wrong pool order`,
+      ).toHaveText(POOL_MEMBERS[index].map((i) => entrants[i].username))
     }
+
+    // ----- …and the WIRE carried that order to get here -----------------------
+    // The detail's fixtures come back ordered by their pool's position, so the pool ids in
+    // first-appearance order are the server's own statement of the event's pool order —
+    // the one the page above rendered, read straight off the payload that fed it.
+    const schedule = await getScheduleDetail(director, tournamentId)
+    const fixtures = schedule.events.find((e) => e.id === eventId)?.fixtures ?? []
+    expect([
+      ...new Set(
+        fixtures.flatMap((fixture) =>
+          fixture.pool_id === null ? [] : [fixture.pool_id],
+        ),
+      ),
+    ]).toEqual(pools.map((pool) => pool.id))
 
     // ----- stage two: the bracket, present already, and entirely unknown -----
     await expect(detail.bracket(eventId)).toBeVisible()
@@ -220,13 +340,58 @@ test.describe('Tournament — rr-then-ko draw', () => {
     )
     // The final exists and both its sides are unknown: nobody has played, so every
     // knockout side is TBD and the bracket names NO entrant yet. `SideFill` seats them
-    // later, pool by pool, into slots that already exist.
+    // below, pool by pool, into slots that already exist.
     const final = detail.bracketRound(eventId, BRACKET_ROUNDS).getByRole('listitem')
     await expect(final).toHaveCount(1)
     await expect(final).toHaveText(/TBD\s*vs\s*TBD/)
     for (const entrant of entrants) {
       await expect(detail.bracket(eventId)).not.toContainText(entrant.username)
     }
+
+    // ----- go live: the pool fixtures become real matches --------------------
+    await detail.startButton.click()
+    await expect(detail.endButton).toBeVisible()
+
+    // ----- play the POOL STAGE, and only it, over the API --------------------
+    // Stopping here is the whole point of the `'pools'` stage: the moment worth looking
+    // at — pools decided, qualifiers seated, nobody knocked out — does not exist if the
+    // helper plays on. The earlier-registered entrant always wins, so each pool's
+    // qualifiers are exactly `POOL_MEMBERS`' first two.
+    expect(
+      await playEvent(director, tournamentId, eventId, entrants, 'pools'),
+      'the pool stage must materialize one match per pairing',
+    ).toBe(POOL_MATCHES)
+
+    // ----- the qualifiers are SEATED in the bracket that named nobody --------
+    await detail.reload(tournamentId)
+    for (const index of QUALIFIERS) {
+      await expect(
+        detail.bracket(eventId),
+        `${entrants[index].username} qualified but is not in the bracket`,
+      ).toContainText(entrants[index].username)
+    }
+    // The half that makes it an assertion about *seeding* rather than about names
+    // appearing: the three who did not qualify are still absent, so the bracket was
+    // filled from each pool's top K and not from the pool.
+    for (const index of ELIMINATED) {
+      await expect(
+        detail.bracket(eventId),
+        `${entrants[index].username} did not qualify but is in the bracket`,
+      ).not.toContainText(entrants[index].username)
+    }
+
+    // ----- play the KNOCKOUT out, and the card crowns its champion -----------
+    expect(
+      await playEvent(director, tournamentId, eventId, entrants, 'all'),
+      'the bracket must be five matches: two byes cost no fixture',
+    ).toBe(KNOCKOUT_MATCHES)
+
+    await detail.reload(tournamentId)
+    // The two-stage callout, never the round-robin one: in this format leading a pool
+    // wins nothing, so the name here is the knockout FINAL's winner. Under the winner
+    // rule that is the first entrant to register, who won every match they played.
+    await expect(detail.twoStageChampion(eventId)).toBeVisible()
+    await expect(detail.twoStageChampion(eventId)).toContainText(entrants[0].username)
 
     await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
   })

--- a/e2e/tests/tournament-table-removal.spec.ts
+++ b/e2e/tests/tournament-table-removal.spec.ts
@@ -47,7 +47,7 @@ const TABLES: ReadonlyArray<TableSpec> = [
  * no pool reserves — a spare, which is a perfectly ordinary thing for a venue to have.
  */
 const POOLS: ReadonlyArray<PoolSpec> = [
-  { id: 'pool-a', name: 'Pool A', tableLabels: [DOOMED] },
+  { name: 'Pool A', tableLabels: [DOOMED] },
 ]
 
 /** A uuid — what a table id is now that the catalogue is a real table with a

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -652,18 +652,26 @@ internal protocol APIProtocol: Sendable {
     func createEventV1TournamentsTournamentIdEventsPost(_ input: Operations.CreateEventV1TournamentsTournamentIdEventsPost.Input) async throws -> Operations.CreateEventV1TournamentsTournamentIdEventsPost.Output
     /// Update Event
     ///
-    /// Edit an event. Absent fields are left alone; `predicates` and `pools` replace
-    /// wholesale when sent. No two pools may share an `id`, in any state (`422`) — a pool
-    /// id identifies one pool, and the fixtures of a draw name their pool by it.
+    /// Edit an event. Absent fields are left alone; `predicates` replaces wholesale when
+    /// sent.
+    ///
+    /// **`pools` is an id-keyed diff, sent in full and in order.** Each entry either
+    /// carries the `id` of a pool this event already has — keeping that pool, with the
+    /// `name`, `slot`, `table_ids` and position this payload gives it — or omits the `id`
+    /// to add a new pool, whose id the server mints. **A pool no entry names is removed.**
+    /// Send back the pools you read, edited: the ids came from the read, and naming an id
+    /// this event does not have is a `422` on that entry. Citing the same pool twice is a
+    /// `422` too — a pool id identifies one pool, and the fixtures of a draw name their
+    /// pool by it.
     ///
     /// **Once the event's draw is cut, two things freeze** (ADR-0786) — the facts its
     /// fixtures were derived from:
     ///
-    /// * **its set of pools.** A `pools` payload must carry exactly the pool `id`s the
-    ///   event already has, or it is refused with a `409`: a removed (or re-`id`'d) pool
-    ///   would leave the fixtures drawn into it pointing at nothing, and an added one would
-    ///   arrive with no fixtures, since the draw was dealt across the pools that existed at
-    ///   the cut.
+    /// * **its set of pools.** A `pools` payload must cite exactly the pools the event
+    ///   already has, or it is refused with a `409`: a removed pool would leave the
+    ///   fixtures drawn into it pointing at nothing, and an added one would arrive with no
+    ///   fixtures, since the draw was dealt across the pools that existed at the cut.
+    ///   Re-ordering them, and editing each one, are still allowed.
     /// * **its `draw_type`.** The draw type chose the strategy that dealt those fixtures,
     ///   so changing it under a standing draw is a `409` too: the event would claim a shape
     ///   its draw does not have. Re-sending the draw type the event already has is not a
@@ -2098,18 +2106,26 @@ extension APIProtocol {
     }
     /// Update Event
     ///
-    /// Edit an event. Absent fields are left alone; `predicates` and `pools` replace
-    /// wholesale when sent. No two pools may share an `id`, in any state (`422`) — a pool
-    /// id identifies one pool, and the fixtures of a draw name their pool by it.
+    /// Edit an event. Absent fields are left alone; `predicates` replaces wholesale when
+    /// sent.
+    ///
+    /// **`pools` is an id-keyed diff, sent in full and in order.** Each entry either
+    /// carries the `id` of a pool this event already has — keeping that pool, with the
+    /// `name`, `slot`, `table_ids` and position this payload gives it — or omits the `id`
+    /// to add a new pool, whose id the server mints. **A pool no entry names is removed.**
+    /// Send back the pools you read, edited: the ids came from the read, and naming an id
+    /// this event does not have is a `422` on that entry. Citing the same pool twice is a
+    /// `422` too — a pool id identifies one pool, and the fixtures of a draw name their
+    /// pool by it.
     ///
     /// **Once the event's draw is cut, two things freeze** (ADR-0786) — the facts its
     /// fixtures were derived from:
     ///
-    /// * **its set of pools.** A `pools` payload must carry exactly the pool `id`s the
-    ///   event already has, or it is refused with a `409`: a removed (or re-`id`'d) pool
-    ///   would leave the fixtures drawn into it pointing at nothing, and an added one would
-    ///   arrive with no fixtures, since the draw was dealt across the pools that existed at
-    ///   the cut.
+    /// * **its set of pools.** A `pools` payload must cite exactly the pools the event
+    ///   already has, or it is refused with a `409`: a removed pool would leave the
+    ///   fixtures drawn into it pointing at nothing, and an added one would arrive with no
+    ///   fixtures, since the draw was dealt across the pools that existed at the cut.
+    ///   Re-ordering them, and editing each one, are still allowed.
     /// * **its `draw_type`.** The draw type chose the strategy that dealt those fixtures,
     ///   so changing it under a standing draw is a `409` too: the event would claim a shape
     ///   its draw does not have. Re-sending the draw type the event already has is not a
@@ -7660,34 +7676,35 @@ internal enum Components {
                 case rank
             }
         }
-        /// A pool as it is **read back**: everything a client wrote, plus the ``position``
-        /// the server stamped on it.
+        /// A pool as it is **read back**: everything a client wrote, plus the ``id`` the
+        /// server minted for it and the ``position`` it stamped on it.
         ///
-        /// It is also the model every interior read of an event's ``pools`` JSONB parses
-        /// through — ``_ordered_pools``, ``draw_config``, ``event_pools``, the schedule
-        /// snapshots — so the column becomes typed values at the read boundary rather than
-        /// stringly-keyed dict lookups (api/CLAUDE.md — "parse, don't validate"). Deriving it
-        /// from :class:`PoolWrite` is what keeps the two shapes one shape plus a field: a
-        /// column added to the write side is readable without a second edit, and the two can
-        /// never disagree about what a pool *is*.
+        /// It is also the model every interior read of an event's pools arrives through —
+        /// ``_ordered_pools``, ``draw_config``, ``event_pools``, the schedule snapshots — which
+        /// is why moving pools from a JSONB array into ``tournament_event_pools`` rows changed
+        /// nothing above ``app.tournament_pools.pool_read``: the projection composes this same
+        /// model out of typed columns where it used to validate it out of untyped dicts.
+        /// Deriving it from :class:`PoolWrite` is what keeps the two shapes one shape plus two
+        /// fields, exactly as :class:`TournamentTable` derives from
+        /// :class:`TournamentTableWrite`: a column added to the write side is readable without
+        /// a second edit, and the two can never disagree about what a pool *is*.
         ///
-        /// ``position`` defaults to ``0`` so that pools stored before the field existed stay
-        /// *readable* — a read boundary must not turn a history it cannot change into a
-        /// ``ValidationError`` (the same asymmetry :data:`AddressComponent` is about). Every
-        /// pool written since goes through :func:`stored_pools` and carries a real one. The
-        /// default is a **read** concession only; it is not a way to write one, because there
-        /// is no way to write one.
+        /// ``position`` keeps its ``0`` default even though the column is NOT NULL and every
+        /// row carries a real one: the default is what lets a **literal** ``Pool`` be built in
+        /// a test or a REPL without spelling an order out, and a read boundary that
+        /// hard-required it would gain nothing — the projection always supplies it. ``id`` has
+        /// no default, because there is no id a literal pool could sensibly default to.
         ///
         /// - Remark: Generated from `#/components/schemas/Pool`.
         internal struct Pool: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/Pool/id`.
-            internal var id: Swift.String
             /// - Remark: Generated from `#/components/schemas/Pool/name`.
             internal var name: Swift.String
             /// - Remark: Generated from `#/components/schemas/Pool/slot`.
             internal var slot: Components.Schemas.Slot
             /// - Remark: Generated from `#/components/schemas/Pool/table_ids`.
             internal var tableIds: [Swift.String]
+            /// - Remark: Generated from `#/components/schemas/Pool/id`.
+            internal var id: Swift.String
             /// Where this pool sits in its event's pool order: 0-based, contiguous, and **assigned by the server** from the pool's index in the `pools` list it arrived in. Read-only, and not merely by convention — it is absent from the pool shape the write verbs take, so sending one is a `422` for an unknown field. To reorder an event's pools, send them in the order you want. Two pools of one event never share a position.
             ///
             /// - Remark: Generated from `#/components/schemas/Pool/position`.
@@ -7695,37 +7712,33 @@ internal enum Components {
             /// Creates a new `Pool`.
             ///
             /// - Parameters:
-            ///   - id:
             ///   - name:
             ///   - slot:
             ///   - tableIds:
+            ///   - id:
             ///   - position: Where this pool sits in its event's pool order: 0-based, contiguous, and **assigned by the server** from the pool's index in the `pools` list it arrived in. Read-only, and not merely by convention — it is absent from the pool shape the write verbs take, so sending one is a `422` for an unknown field. To reorder an event's pools, send them in the order you want. Two pools of one event never share a position.
             internal init(
-                id: Swift.String,
                 name: Swift.String,
                 slot: Components.Schemas.Slot,
                 tableIds: [Swift.String],
+                id: Swift.String,
                 position: Swift.Int? = nil
             ) {
-                self.id = id
                 self.name = name
                 self.slot = slot
                 self.tableIds = tableIds
+                self.id = id
                 self.position = position
             }
             internal enum CodingKeys: String, CodingKey {
-                case id
                 case name
                 case slot
                 case tableIds = "table_ids"
+                case id
                 case position
             }
             internal init(from decoder: any Swift.Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
-                self.id = try container.decode(
-                    Swift.String.self,
-                    forKey: .id
-                )
                 self.name = try container.decode(
                     Swift.String.self,
                     forKey: .name
@@ -7738,15 +7751,19 @@ internal enum Components {
                     [Swift.String].self,
                     forKey: .tableIds
                 )
+                self.id = try container.decode(
+                    Swift.String.self,
+                    forKey: .id
+                )
                 self.position = try container.decodeIfPresent(
                     Swift.Int.self,
                     forKey: .position
                 )
                 try decoder.ensureNoAdditionalProperties(knownKeys: [
-                    "id",
                     "name",
                     "slot",
                     "table_ids",
+                    "id",
                     "position"
                 ])
             }
@@ -7846,9 +7863,8 @@ internal enum Components {
         /// One pool's standings: its rows in finishing order, and whether every one of its
         /// fixtures has been decided.
         ///
-        /// ``pool_id`` names a ``Pool`` in this same event's ``pools`` — the string ref a
-        /// fixture also carries — so a client titles the table from the pool it already
-        /// holds.
+        /// ``pool_id`` names a pool of this same event — the id a fixture also carries — so a
+        /// client titles the table from the pool it already holds.
         ///
         /// - Remark: Generated from `#/components/schemas/PoolStandingsRead`.
         internal struct PoolStandingsRead: Codable, Hashable, Sendable {
@@ -7879,23 +7895,111 @@ internal enum Components {
                 case complete
             }
         }
+        /// One pool of an event a client **edits** (``PATCH …/events/{id}``): everything
+        /// :class:`PoolWrite` carries, plus an **optional** ``id`` naming a pool the event
+        /// already has.
+        ///
+        /// The exact twin of :class:`TournamentTableUpsert`, one resource over, and the two
+        /// cases are exhaustive:
+        ///
+        /// * ``id`` **present** — "this is the pool you already have, with these words". The
+        ///   row keeps its id, and therefore every fixture drawn into it and every table it
+        ///   reserves, and takes the new ``name``/``slot``/``table_ids``; its place in the list
+        ///   is its new place in the event's pool order.
+        /// * ``id`` **omitted** (or ``null``) — "add a pool". The server mints its id, exactly
+        ///   as on create.
+        /// * a stored pool **no entry names** — "remove it".
+        ///
+        /// ``X | None = None`` and never a non-null default: an optional field on a *write*
+        /// schema whose default is not ``None`` generates as **required** in the TypeScript
+        /// client, which would make "omit the id to add a pool" unsayable there.
+        ///
+        /// An id that names no pool of *this* event is a 422 on the field
+        /// (:class:`~app.tournament_errors.PoolNotInEventError`), not a quietly minted new
+        /// pool. Until this chore that arm was an *addition*, because the id was the client's
+        /// and an id the server had never seen still named the pool the client meant. It is the
+        /// server's now, so an id it did not mint names nothing — and minting a fresh one would
+        /// hand the client back a different id than it asked for while *removing* the pool it
+        /// meant to keep, which is the pair of failures a diff must never confuse.
+        ///
+        /// - Remark: Generated from `#/components/schemas/PoolUpsert`.
+        internal struct PoolUpsert: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/PoolUpsert/name`.
+            internal var name: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PoolUpsert/slot`.
+            internal var slot: Components.Schemas.Slot
+            /// - Remark: Generated from `#/components/schemas/PoolUpsert/table_ids`.
+            internal var tableIds: [Swift.String]
+            /// - Remark: Generated from `#/components/schemas/PoolUpsert/id`.
+            internal var id: Swift.String?
+            /// Creates a new `PoolUpsert`.
+            ///
+            /// - Parameters:
+            ///   - name:
+            ///   - slot:
+            ///   - tableIds:
+            ///   - id:
+            internal init(
+                name: Swift.String,
+                slot: Components.Schemas.Slot,
+                tableIds: [Swift.String],
+                id: Swift.String? = nil
+            ) {
+                self.name = name
+                self.slot = slot
+                self.tableIds = tableIds
+                self.id = id
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case name
+                case slot
+                case tableIds = "table_ids"
+                case id
+            }
+            internal init(from decoder: any Swift.Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.name = try container.decode(
+                    Swift.String.self,
+                    forKey: .name
+                )
+                self.slot = try container.decode(
+                    Components.Schemas.Slot.self,
+                    forKey: .slot
+                )
+                self.tableIds = try container.decode(
+                    [Swift.String].self,
+                    forKey: .tableIds
+                )
+                self.id = try container.decodeIfPresent(
+                    Swift.String.self,
+                    forKey: .id
+                )
+                try decoder.ensureNoAdditionalProperties(knownKeys: [
+                    "name",
+                    "slot",
+                    "table_ids",
+                    "id"
+                ])
+            }
+        }
         /// A slice of tables reserved for a window of time within an event, as a client
-        /// **sends** it.
+        /// **creates** it.
         ///
-        /// Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
-        /// by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
-        /// these ids. Which is only a coherent thing to say if an id names one pool — see
-        /// ``EventPools``, the type the event's list of them actually has — and if an id is a
-        /// thing at all, which is what ``ValueObjectId`` says: the empty string is not one, and
-        /// a fixture drawn into it is pooled by one rule and un-pooled by another.
+        /// It has **no** ``id``, and that absence is the whole content of the chore that minted
+        /// them: a pool's id is a uuid the database mints (ADR 20260801's ``id uuid PRIMARY
+        /// KEY``), so it is not the client's to author and there is nothing here for it to
+        /// author. Sending one is a 422 for an unknown field — the same treatment
+        /// :class:`TournamentTableWrite` gives a venue table's id, and for the same reason. A
+        /// client that *cites* an id it was given is patching, not creating, and the shape for
+        /// that is :class:`PoolUpsert`.
         ///
-        /// Its ``name`` has the same floor for the plainer reason: a pool is *called*
-        /// something — it is what the director clicks, what the conflict warnings quote, and
-        /// what a player reads off a wall. ``""`` is not a name, and an event whose pools list
-        /// is three blank rows is not a thing anyone could act on.
+        /// Its ``name`` has a floor for the plainer reason: a pool is *called* something — it
+        /// is what the director clicks, what the conflict warnings quote, and what a player
+        /// reads off a wall. ``""`` is not a name, and an event whose pools list is three blank
+        /// rows is not a thing anyone could act on.
         ///
-        /// What is **absent** is as deliberate as what is here: ``position`` is the server's to
-        /// assign (:data:`PoolPosition`), so it is simply not a field of this model, and
+        /// ``position`` is absent for the same reason the id is: it is the server's to assign
+        /// (:data:`PoolPosition`), so it is simply not a field of this model, and
         /// ``extra="forbid"`` turns an attempt to send one into a 422 that names it. This is
         /// the treatment ``entered`` already gets on the event schemas — a server-managed value
         /// is kept **off** the write shape rather than accepted and then ignored. Accepting it
@@ -7906,8 +8010,6 @@ internal enum Components {
         ///
         /// - Remark: Generated from `#/components/schemas/PoolWrite`.
         internal struct PoolWrite: Codable, Hashable, Sendable {
-            /// - Remark: Generated from `#/components/schemas/PoolWrite/id`.
-            internal var id: Swift.String
             /// - Remark: Generated from `#/components/schemas/PoolWrite/name`.
             internal var name: Swift.String
             /// - Remark: Generated from `#/components/schemas/PoolWrite/slot`.
@@ -7917,33 +8019,25 @@ internal enum Components {
             /// Creates a new `PoolWrite`.
             ///
             /// - Parameters:
-            ///   - id:
             ///   - name:
             ///   - slot:
             ///   - tableIds:
             internal init(
-                id: Swift.String,
                 name: Swift.String,
                 slot: Components.Schemas.Slot,
                 tableIds: [Swift.String]
             ) {
-                self.id = id
                 self.name = name
                 self.slot = slot
                 self.tableIds = tableIds
             }
             internal enum CodingKeys: String, CodingKey {
-                case id
                 case name
                 case slot
                 case tableIds = "table_ids"
             }
             internal init(from decoder: any Swift.Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
-                self.id = try container.decode(
-                    Swift.String.self,
-                    forKey: .id
-                )
                 self.name = try container.decode(
                     Swift.String.self,
                     forKey: .name
@@ -7957,7 +8051,6 @@ internal enum Components {
                     forKey: .tableIds
                 )
                 try decoder.ensureNoAdditionalProperties(knownKeys: [
-                    "id",
                     "name",
                     "slot",
                     "table_ids"
@@ -10792,7 +10885,7 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/predicates`.
             internal var predicates: [Components.Schemas.Predicate]?
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/pools`.
-            internal var pools: [Components.Schemas.PoolWrite]?
+            internal var pools: [Components.Schemas.PoolUpsert]?
             /// Creates a new `TournamentEventUpdate`.
             ///
             /// - Parameters:
@@ -10818,7 +10911,7 @@ internal enum Components {
                 slot: Components.Schemas.TournamentEventUpdate.SlotPayload? = nil,
                 matchSettings: Components.Schemas.TournamentEventUpdate.MatchSettingsPayload? = nil,
                 predicates: [Components.Schemas.Predicate]? = nil,
-                pools: [Components.Schemas.PoolWrite]? = nil
+                pools: [Components.Schemas.PoolUpsert]? = nil
             ) {
                 self.name = name
                 self.format = format
@@ -10888,7 +10981,7 @@ internal enum Components {
                     forKey: .predicates
                 )
                 self.pools = try container.decodeIfPresent(
-                    [Components.Schemas.PoolWrite].self,
+                    [Components.Schemas.PoolUpsert].self,
                     forKey: .pools
                 )
                 try decoder.ensureNoAdditionalProperties(knownKeys: [
@@ -11010,8 +11103,9 @@ internal enum Components {
         ///   live, not a copy frozen at go-live.
         /// * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
         ///   un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
-        ///   set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
-        ///   JSONB, not a foreign key, because pools are value-objects with no table.
+        ///   set, it names a pool of **this same event**, and it is guaranteed to: the column
+        ///   is half of a composite foreign key onto ``tournament_event_pools (event_id, id)``,
+        ///   so it is neither a dangling ref nor another event's pool (ADR 20260801).
         /// * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means
         ///   **unassigned to a table**. When set, it names a ``TournamentTable`` in the
         ///   tournament's ``table_catalogue``, and it is guaranteed to: the column is a real
@@ -23386,18 +23480,26 @@ internal enum Operations {
     }
     /// Update Event
     ///
-    /// Edit an event. Absent fields are left alone; `predicates` and `pools` replace
-    /// wholesale when sent. No two pools may share an `id`, in any state (`422`) — a pool
-    /// id identifies one pool, and the fixtures of a draw name their pool by it.
+    /// Edit an event. Absent fields are left alone; `predicates` replaces wholesale when
+    /// sent.
+    ///
+    /// **`pools` is an id-keyed diff, sent in full and in order.** Each entry either
+    /// carries the `id` of a pool this event already has — keeping that pool, with the
+    /// `name`, `slot`, `table_ids` and position this payload gives it — or omits the `id`
+    /// to add a new pool, whose id the server mints. **A pool no entry names is removed.**
+    /// Send back the pools you read, edited: the ids came from the read, and naming an id
+    /// this event does not have is a `422` on that entry. Citing the same pool twice is a
+    /// `422` too — a pool id identifies one pool, and the fixtures of a draw name their
+    /// pool by it.
     ///
     /// **Once the event's draw is cut, two things freeze** (ADR-0786) — the facts its
     /// fixtures were derived from:
     ///
-    /// * **its set of pools.** A `pools` payload must carry exactly the pool `id`s the
-    ///   event already has, or it is refused with a `409`: a removed (or re-`id`'d) pool
-    ///   would leave the fixtures drawn into it pointing at nothing, and an added one would
-    ///   arrive with no fixtures, since the draw was dealt across the pools that existed at
-    ///   the cut.
+    /// * **its set of pools.** A `pools` payload must cite exactly the pools the event
+    ///   already has, or it is refused with a `409`: a removed pool would leave the
+    ///   fixtures drawn into it pointing at nothing, and an added one would arrive with no
+    ///   fixtures, since the draw was dealt across the pools that existed at the cut.
+    ///   Re-ordering them, and editing each one, are still allowed.
     /// * **its `draw_type`.** The draw type chose the strategy that dealt those fixtures,
     ///   so changing it under a standing draw is a `409` too: the event would claim a shape
     ///   its draw does not have. Re-sending the draw type the event already has is not a

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -38,6 +38,11 @@ type TournamentEventRead = components['schemas']['TournamentEventRead']
 type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
 type TournamentFixtureRead = components['schemas']['TournamentFixtureRead']
 type Pool = components['schemas']['Pool']
+/** A pool as a **write** body carries it: no `position` on either verb, and an `id` only
+ * on the PATCH shape — where it *cites* a pool the event already has rather than
+ * authoring one (ADR 20260801, `api/app/tournament_pools.py`). Omitted means "add this
+ * pool", and the server mints its uuid. */
+type PoolUpsert = components['schemas']['PoolUpsert']
 /** One row of the served **draw-type catalogue** (ADR 20260726). Its `key` is the
  * generated schema's `DrawType`, so a spec cannot serve a slug the API's enum does not
  * hold — the catalogue and the enum are the same set by construction. */
@@ -1029,36 +1034,80 @@ function planEventDraw(event: TournamentEventRead): DrawPlan {
   )
 }
 
+/** The server's sentence for a pools payload that would change WHICH pools a cut event
+ * has (`_pool_set_frozen_detail`, `api/app/tournament_events.py`) — verbatim, because the
+ * editor shows it verbatim in its inline banner.
+ *
+ * Both halves are named, from whichever side of the change still knows the name: a pool
+ * being removed is only described by the row the event holds, one being added only by the
+ * payload. */
+function poolSetFrozenDetail(
+  event: TournamentEventRead,
+  submitted: { id?: string | null; name?: string }[],
+): string {
+  const existing = new Set(event.pools.map((p) => p.id))
+  const incoming = new Set(
+    submitted.map((p) => p.id).filter((id): id is string => id != null),
+  )
+  const clauses: string[] = []
+  const removed = event.pools.filter((p) => !incoming.has(p.id)).map((p) => p.name)
+  const added = submitted
+    .filter((p) => p.id == null || !existing.has(p.id))
+    .map((p) => p.name ?? '')
+  if (removed.length > 0) {
+    clauses.push(
+      `${namedList(removed)} already has fixtures drawn into it, ` +
+        'which this change would leave pointing at a pool that no longer exists',
+    )
+  }
+  if (added.length > 0) {
+    clauses.push(
+      `${namedList(added)} would arrive with no fixtures in it, ` +
+        'because the draw was cut across the pools this event had at the time',
+    )
+  }
+  return (
+    "This event's draw is already cut, so its set of pools is frozen: " +
+    clauses.join('; and ') +
+    ". A pool's tables, its time and its name can all still be changed. " +
+    'To add or remove a pool, remove the draw first, then cut it again.'
+  )
+}
+
 /** Why this event PATCH is refused by a standing draw — or `null` when it is not
  * (`_enforce_pool_set_frozen` / `_enforce_draw_type_frozen`, both a 409).
  *
  * Two facts are frozen while fixtures exist, and **only** these two:
- * - the **set of pool ids**, because a fixture names its pool by a string ref into that
- *   very list — remove one (or re-`id` it) and its fixtures point at nothing;
+ * - the **set of pool ids**, because a fixture names the pool it was dealt into — remove
+ *   one and its fixtures point at nothing, add one and it arrives with no fixtures;
  * - the **draw type**, because it is not a label on an event but the strategy that DEALT
  *   these fixtures.
  *
- * Everything else about a pool — its name, its tables, its window — stays editable, and
- * so does the rest of the event. */
+ * Everything else about a pool — its name, its tables, its window, its place in the order
+ * — stays editable, and so does the rest of the event.
+ *
+ * **Re-identifying a pool is no longer one of the refusals**, because it is no longer a
+ * payload a client can send (ADR 20260801): a pool id is minted by the server, so an
+ * entry either cites one this event has or carries none at all — and an entry with no id
+ * is an *addition*, which is why it counts towards the change rather than towards the
+ * incoming set. */
 function frozenDetail(event: TournamentEventRead, body: unknown): string | null {
   if (event.fixtures.length === 0) return null
   const patch = body as {
-    pools?: { id: string }[] | null
+    pools?: { id?: string | null }[] | null
     draw_type?: string | null
   } | null
 
   if (patch?.pools) {
     const before = new Set(event.pools.map((p) => p.id))
-    const after = new Set(patch.pools.map((p) => p.id))
+    const after = new Set(
+      patch.pools.map((p) => p.id).filter((id): id is string => id != null),
+    )
     const same =
-      before.size === after.size && [...before].every((id) => after.has(id))
-    if (!same) {
-      return (
-        "This event's draw is already cut, so its set of pools is frozen: " +
-        'a pool cannot be added, removed or re-identified while fixtures refer to it. ' +
-        'To add, remove or re-identify a pool, remove the draw first, then cut it again.'
-      )
-    }
+      before.size === after.size &&
+      after.size === patch.pools.length &&
+      [...before].every((id) => after.has(id))
+    if (!same) return poolSetFrozenDetail(event, patch.pools)
   }
 
   if (patch?.draw_type && patch.draw_type !== event.draw_type) {
@@ -1082,6 +1131,7 @@ export class TournamentsStore {
   private detail: TournamentDetailRead
   private entryCounter = 0
   private tableCounter = 0
+  private poolCounter = 0
   private gate: Promise<void> | null = null
   private refusingWrites = false
   private refusingTournamentCreate = false
@@ -2005,6 +2055,27 @@ export class TournamentsStore {
     }
   }
 
+  /** One pool of an event write after the diff: the cited pool, re-worded and
+   * re-positioned — or a brand-new one whose **uuid the server mints**
+   * (`gen_random_uuid()`; `Pool.id` is `format: uuid` on the wire, so the stub must not
+   * hand back a slug, and a client cannot author one at all: ADR 20260801).
+   *
+   * The twin of `upsertTable` above, one resource over. On the create path the `id` arm
+   * is unreachable by construction — `PoolWrite` has no id — which is exactly the point:
+   * a created event's pools are all new, and all minted here. */
+  private upsertPool(entry: PoolUpsert, position: number): Pool {
+    const id =
+      entry.id ??
+      mockUuid(`e2e-tournament-event-pool-${(this.poolCounter += 1)}`)
+    return {
+      id,
+      name: entry.name,
+      slot: entry.slot,
+      table_ids: entry.table_ids,
+      position,
+    }
+  }
+
   /** The catalogue as the SERVER now holds it — so a spec asserts what was stored
    * (and which id it was stored under), not what the DOM happens to show. */
   get tables(): TournamentTable[] {
@@ -2030,14 +2101,17 @@ export class TournamentsStore {
 
     // The wire body (`TournamentEventCreate`) is the read shape minus the fields the
     // server owns — `entered` is derived, and a new event has no entrants.
-    const fields = body as Partial<Omit<TournamentEventRead, 'entered'>>
+    const { pools: submitted, ...fields } = body as Partial<
+      Omit<TournamentEventRead, 'entered' | 'pools'>
+    > & { pools?: PoolUpsert[] }
     const created = buildTournamentEventRead({
       ...fields,
-      // Positions assigned from the array index, as the server assigns them — the create
-      // body carries none (`PoolWrite` forbids the key), so the order of the list is what
-      // says which pool is first. See the same stamp in `updateEvent` below.
-      ...(fields.pools
-        ? { pools: fields.pools.map((pool, index) => ({ ...pool, position: index })) }
+      // Every pool of a created event is a NEW pool: `PoolWrite` has no `id` at all
+      // (ADR 20260801), so the server mints one for each and assigns the position from
+      // the array index — the body carries neither, and the order of the list is what
+      // says which pool is first. See the same pair in `updateEvent` below.
+      ...(submitted
+        ? { pools: submitted.map((pool, index) => this.upsertPool(pool, index)) }
         : {}),
       id: `ev-created-${this.detail.events.length + 1}`,
       entrants: [],
@@ -2070,22 +2144,26 @@ export class TournamentsStore {
     const frozen = frozenDetail(event, body)
     if (frozen) return json(route, 409, { detail: frozen })
 
-    const fields = body as Partial<Omit<TournamentEventRead, 'entered'>>
+    const fields = body as Partial<Omit<TournamentEventRead, 'entered' | 'pools'>> & {
+      pools?: PoolUpsert[]
+    }
     // `entrants` and `entered` are the server's, not the editor's — the write body
     // does not carry them, and echoing the client's view back would clobber
     // registrations it never saw.
     //
-    // Each pool's `position` is the server's too, and in a sharper way: `PoolWrite`
-    // FORBIDS the key, so the body carries no positions at all and the **order of the
-    // array** is the only thing saying which pool comes first. The server re-derives the
-    // positions from that order on every pools patch, so this stub does the same —
-    // spreading the write shape straight through would strip a required read field and
-    // leave the editor (which seeds its cards from `position`) sorting by nothing.
+    // A pool's `id` and its `position` are the server's too, and in a sharper way: both
+    // write shapes FORBID `position` and the create shape has no `id` at all, so the body
+    // carries neither and the **order of the array** is the only thing saying which pool
+    // comes first. So this stub applies the pools as the server does — an entry citing an
+    // id keeps that pool, an entry with none is minted a fresh uuid (`upsertPool`), and
+    // every one of them takes the position of its index. Spreading the write shape
+    // straight through would strip two required read fields and leave the editor (which
+    // seeds its cards from `position`) sorting by nothing.
     this.mutateEvent(eventId, (e) => ({
       ...e,
       ...fields,
       pools: fields.pools
-        ? fields.pools.map((pool, index) => ({ ...pool, position: index }))
+        ? fields.pools.map((pool, index) => this.upsertPool(pool, index))
         : e.pools,
       entrants: e.entrants,
     }))

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1167,18 +1167,26 @@ export interface paths {
         head?: never;
         /**
          * Update Event
-         * @description Edit an event. Absent fields are left alone; `predicates` and `pools` replace
-         *     wholesale when sent. No two pools may share an `id`, in any state (`422`) — a pool
-         *     id identifies one pool, and the fixtures of a draw name their pool by it.
+         * @description Edit an event. Absent fields are left alone; `predicates` replaces wholesale when
+         *     sent.
+         *
+         *     **`pools` is an id-keyed diff, sent in full and in order.** Each entry either
+         *     carries the `id` of a pool this event already has — keeping that pool, with the
+         *     `name`, `slot`, `table_ids` and position this payload gives it — or omits the `id`
+         *     to add a new pool, whose id the server mints. **A pool no entry names is removed.**
+         *     Send back the pools you read, edited: the ids came from the read, and naming an id
+         *     this event does not have is a `422` on that entry. Citing the same pool twice is a
+         *     `422` too — a pool id identifies one pool, and the fixtures of a draw name their
+         *     pool by it.
          *
          *     **Once the event's draw is cut, two things freeze** (ADR-0786) — the facts its
          *     fixtures were derived from:
          *
-         *     * **its set of pools.** A `pools` payload must carry exactly the pool `id`s the
-         *       event already has, or it is refused with a `409`: a removed (or re-`id`'d) pool
-         *       would leave the fixtures drawn into it pointing at nothing, and an added one would
-         *       arrive with no fixtures, since the draw was dealt across the pools that existed at
-         *       the cut.
+         *     * **its set of pools.** A `pools` payload must cite exactly the pools the event
+         *       already has, or it is refused with a `409`: a removed pool would leave the
+         *       fixtures drawn into it pointing at nothing, and an added one would arrive with no
+         *       fixtures, since the draw was dealt across the pools that existed at the cut.
+         *       Re-ordering them, and editing each one, are still allowed.
          *     * **its `draw_type`.** The draw type chose the strategy that dealt those fixtures,
          *       so changing it under a standing draw is a `409` too: the event would claim a shape
          *       its draw does not have. Re-sending the draw type the event already has is not a
@@ -3662,31 +3670,36 @@ export interface components {
         };
         /**
          * Pool
-         * @description A pool as it is **read back**: everything a client wrote, plus the ``position``
-         *     the server stamped on it.
+         * @description A pool as it is **read back**: everything a client wrote, plus the ``id`` the
+         *     server minted for it and the ``position`` it stamped on it.
          *
          *     It is also the model every interior read of an event's pools arrives through —
          *     ``_ordered_pools``, ``draw_config``, ``event_pools``, the schedule snapshots — which
          *     is why moving pools from a JSONB array into ``tournament_event_pools`` rows changed
          *     nothing above ``app.tournament_pools.pool_read``: the projection composes this same
          *     model out of typed columns where it used to validate it out of untyped dicts.
-         *     Deriving it from :class:`PoolWrite` is what keeps the two shapes one shape plus a
-         *     field: a column added to the write side is readable without a second edit, and the
-         *     two can never disagree about what a pool *is*.
+         *     Deriving it from :class:`PoolWrite` is what keeps the two shapes one shape plus two
+         *     fields, exactly as :class:`TournamentTable` derives from
+         *     :class:`TournamentTableWrite`: a column added to the write side is readable without
+         *     a second edit, and the two can never disagree about what a pool *is*.
          *
          *     ``position`` keeps its ``0`` default even though the column is NOT NULL and every
          *     row carries a real one: the default is what lets a **literal** ``Pool`` be built in
          *     a test or a REPL without spelling an order out, and a read boundary that
-         *     hard-required it would gain nothing — the projection always supplies it.
+         *     hard-required it would gain nothing — the projection always supplies it. ``id`` has
+         *     no default, because there is no id a literal pool could sensibly default to.
          */
         Pool: {
-            /** Id */
-            id: string;
             /** Name */
             name: string;
             slot: components["schemas"]["Slot"];
             /** Table Ids */
             table_ids: string[];
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
             /**
              * Position
              * @description Where this pool sits in its event's pool order: 0-based, contiguous, and **assigned by the server** from the pool's index in the `pools` list it arrived in. Read-only, and not merely by convention — it is absent from the pool shape the write verbs take, so sending one is a `422` for an unknown field. To reorder an event's pools, send them in the order you want. Two pools of one event never share a position.
@@ -3743,7 +3756,10 @@ export interface components {
          *     client titles the table from the pool it already holds.
          */
         PoolStandingsRead: {
-            /** Pool Id */
+            /**
+             * Pool Id
+             * Format: uuid
+             */
             pool_id: string;
             /** Rows */
             rows: components["schemas"]["StandingRowRead"][];
@@ -3751,24 +3767,63 @@ export interface components {
             complete: boolean;
         };
         /**
+         * PoolUpsert
+         * @description One pool of an event a client **edits** (``PATCH …/events/{id}``): everything
+         *     :class:`PoolWrite` carries, plus an **optional** ``id`` naming a pool the event
+         *     already has.
+         *
+         *     The exact twin of :class:`TournamentTableUpsert`, one resource over, and the two
+         *     cases are exhaustive:
+         *
+         *     * ``id`` **present** — "this is the pool you already have, with these words". The
+         *       row keeps its id, and therefore every fixture drawn into it and every table it
+         *       reserves, and takes the new ``name``/``slot``/``table_ids``; its place in the list
+         *       is its new place in the event's pool order.
+         *     * ``id`` **omitted** (or ``null``) — "add a pool". The server mints its id, exactly
+         *       as on create.
+         *     * a stored pool **no entry names** — "remove it".
+         *
+         *     ``X | None = None`` and never a non-null default: an optional field on a *write*
+         *     schema whose default is not ``None`` generates as **required** in the TypeScript
+         *     client, which would make "omit the id to add a pool" unsayable there.
+         *
+         *     An id that names no pool of *this* event is a 422 on the field
+         *     (:class:`~app.tournament_errors.PoolNotInEventError`), not a quietly minted new
+         *     pool. Until this chore that arm was an *addition*, because the id was the client's
+         *     and an id the server had never seen still named the pool the client meant. It is the
+         *     server's now, so an id it did not mint names nothing — and minting a fresh one would
+         *     hand the client back a different id than it asked for while *removing* the pool it
+         *     meant to keep, which is the pair of failures a diff must never confuse.
+         */
+        PoolUpsert: {
+            /** Name */
+            name: string;
+            slot: components["schemas"]["Slot"];
+            /** Table Ids */
+            table_ids: string[];
+            /** Id */
+            id?: string | null;
+        };
+        /**
          * PoolWrite
          * @description A slice of tables reserved for a window of time within an event, as a client
-         *     **sends** it.
+         *     **creates** it.
          *
-         *     Its ``id`` is the pool's **identity**: a fixture names the pool it was drawn into
-         *     by that string (ADR-0786), and the pool-set freeze is a rule about the *set* of
-         *     these ids. Which is only a coherent thing to say if an id names one pool — see
-         *     ``EventPools``, the type the event's list of them actually has — and if an id is a
-         *     thing at all, which is what ``ValueObjectId`` says: the empty string is not one, and
-         *     a fixture drawn into it is pooled by one rule and un-pooled by another.
+         *     It has **no** ``id``, and that absence is the whole content of the chore that minted
+         *     them: a pool's id is a uuid the database mints (ADR 20260801's ``id uuid PRIMARY
+         *     KEY``), so it is not the client's to author and there is nothing here for it to
+         *     author. Sending one is a 422 for an unknown field — the same treatment
+         *     :class:`TournamentTableWrite` gives a venue table's id, and for the same reason. A
+         *     client that *cites* an id it was given is patching, not creating, and the shape for
+         *     that is :class:`PoolUpsert`.
          *
-         *     Its ``name`` has the same floor for the plainer reason: a pool is *called*
-         *     something — it is what the director clicks, what the conflict warnings quote, and
-         *     what a player reads off a wall. ``""`` is not a name, and an event whose pools list
-         *     is three blank rows is not a thing anyone could act on.
+         *     Its ``name`` has a floor for the plainer reason: a pool is *called* something — it
+         *     is what the director clicks, what the conflict warnings quote, and what a player
+         *     reads off a wall. ``""`` is not a name, and an event whose pools list is three blank
+         *     rows is not a thing anyone could act on.
          *
-         *     What is **absent** is as deliberate as what is here: ``position`` is the server's to
-         *     assign (:data:`PoolPosition`), so it is simply not a field of this model, and
+         *     ``position`` is absent for the same reason the id is: it is the server's to assign
+         *     (:data:`PoolPosition`), so it is simply not a field of this model, and
          *     ``extra="forbid"`` turns an attempt to send one into a 422 that names it. This is
          *     the treatment ``entered`` already gets on the event schemas — a server-managed value
          *     is kept **off** the write shape rather than accepted and then ignored. Accepting it
@@ -3778,8 +3833,6 @@ export interface components {
          *     control is the order of the list itself.
          */
         PoolWrite: {
-            /** Id */
-            id: string;
             /** Name */
             name: string;
             slot: components["schemas"]["Slot"];
@@ -4862,7 +4915,7 @@ export interface components {
             /** Predicates */
             predicates?: components["schemas"]["Predicate"][] | null;
             /** Pools */
-            pools?: components["schemas"]["PoolWrite"][] | null;
+            pools?: components["schemas"]["PoolUpsert"][] | null;
         };
         /**
          * TournamentFixturePlacementUpdate

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -3665,20 +3665,19 @@ export interface components {
          * @description A pool as it is **read back**: everything a client wrote, plus the ``position``
          *     the server stamped on it.
          *
-         *     It is also the model every interior read of an event's ``pools`` JSONB parses
-         *     through — ``_ordered_pools``, ``draw_config``, ``event_pools``, the schedule
-         *     snapshots — so the column becomes typed values at the read boundary rather than
-         *     stringly-keyed dict lookups (api/CLAUDE.md — "parse, don't validate"). Deriving it
-         *     from :class:`PoolWrite` is what keeps the two shapes one shape plus a field: a
-         *     column added to the write side is readable without a second edit, and the two can
-         *     never disagree about what a pool *is*.
+         *     It is also the model every interior read of an event's pools arrives through —
+         *     ``_ordered_pools``, ``draw_config``, ``event_pools``, the schedule snapshots — which
+         *     is why moving pools from a JSONB array into ``tournament_event_pools`` rows changed
+         *     nothing above ``app.tournament_pools.pool_read``: the projection composes this same
+         *     model out of typed columns where it used to validate it out of untyped dicts.
+         *     Deriving it from :class:`PoolWrite` is what keeps the two shapes one shape plus a
+         *     field: a column added to the write side is readable without a second edit, and the
+         *     two can never disagree about what a pool *is*.
          *
-         *     ``position`` defaults to ``0`` so that pools stored before the field existed stay
-         *     *readable* — a read boundary must not turn a history it cannot change into a
-         *     ``ValidationError`` (the same asymmetry :data:`AddressComponent` is about). Every
-         *     pool written since goes through :func:`stored_pools` and carries a real one. The
-         *     default is a **read** concession only; it is not a way to write one, because there
-         *     is no way to write one.
+         *     ``position`` keeps its ``0`` default even though the column is NOT NULL and every
+         *     row carries a real one: the default is what lets a **literal** ``Pool`` be built in
+         *     a test or a REPL without spelling an order out, and a read boundary that
+         *     hard-required it would gain nothing — the projection always supplies it.
          */
         Pool: {
             /** Id */
@@ -3740,9 +3739,8 @@ export interface components {
          * @description One pool's standings: its rows in finishing order, and whether every one of its
          *     fixtures has been decided.
          *
-         *     ``pool_id`` names a ``Pool`` in this same event's ``pools`` — the string ref a
-         *     fixture also carries — so a client titles the table from the pool it already
-         *     holds.
+         *     ``pool_id`` names a pool of this same event — the id a fixture also carries — so a
+         *     client titles the table from the pool it already holds.
          */
         PoolStandingsRead: {
             /** Pool Id */
@@ -4942,8 +4940,9 @@ export interface components {
          *       live, not a copy frozen at go-live.
          *     * ``pool_id`` — ``null`` means this fixture belongs to no pool: the draw is
          *       un-pooled (single-elim), or this is the KO stage of an rr-then-ko event. When
-         *       set, it names a ``Pool`` in this same event's ``pools`` — a string ref into
-         *       JSONB, not a foreign key, because pools are value-objects with no table.
+         *       set, it names a pool of **this same event**, and it is guaranteed to: the column
+         *       is half of a composite foreign key onto ``tournament_event_pools (event_id, id)``,
+         *       so it is neither a dangling ref nor another event's pool (ADR 20260801).
          *     * ``table_id`` — the fixture's **placement** table (ADR-0790): ``null`` means
          *       **unassigned to a table**. When set, it names a ``TournamentTable`` in the
          *       tournament's ``table_catalogue``, and it is guaranteed to: the column is a real

--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -38,12 +38,14 @@ import type { CodedErrorBody } from '@/mocks/endpoints/error-body'
 import { server } from '@/mocks/server'
 import {
   cutDraw,
+  findTournament,
   markFixturePlayed,
   resetTournamentsStore,
 } from '@/mocks/tournaments-store'
-import { ApiError } from '@/api/client'
+import { ApiError, validationFields } from '@/api/client'
 import type { components } from '@/api/schema'
-import { buildEvent, buildTenPools } from './seed.factory'
+import { addedPool, keepPools } from './pool-entries'
+import { buildEditedEvent, buildTenPools } from './seed.factory'
 import {
   apiToEvent,
   eventToUpdateBody,
@@ -369,7 +371,7 @@ describe('useUpdateEvent — the draw configuration on the wire', () => {
     result.current.mutate({
       eventId: 'ev-1',
       body: eventToUpdateBody(
-        buildEvent({ drawType: 'rr-then-ko', qualifiersPerPool: 2 }),
+        buildEditedEvent({ drawType: 'rr-then-ko', qualifiersPerPool: 2 }),
       ),
     })
 
@@ -390,7 +392,7 @@ describe('useUpdateEvent — the draw configuration on the wire', () => {
     const { result } = renderHookRaw(() => useUpdateEvent('t-1'), { wrapper })
     result.current.mutate({
       eventId: 'ev-1',
-      body: eventToUpdateBody(buildEvent({ drawType: 'round-robin' })),
+      body: eventToUpdateBody(buildEditedEvent({ drawType: 'round-robin' })),
     })
 
     await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
@@ -408,7 +410,7 @@ describe('useUpdateEvent — the draw configuration on the wire', () => {
     result.current.mutate({
       eventId: 'ev-1',
       body: eventToUpdateBody(
-        buildEvent({ drawType: 'rr-then-ko', qualifiersPerPool: 2 }),
+        buildEditedEvent({ drawType: 'rr-then-ko', qualifiersPerPool: 2 }),
       ),
     })
 
@@ -423,7 +425,7 @@ describe('useUpdateEvent — the draw configuration on the wire', () => {
    * refused.
    *
    * Asserted on the bytes rather than on `eventToUpdateBody`'s return value for the same
-   * reason the qualifier count is: the domain `Pool` the editor holds *does* carry a
+   * reason the qualifier count is: the `Pool` these entries were built from *does* carry a
    * position, so a spread anywhere between the mapper and `openapi-fetch` would put it
    * back, and nothing else in the suite would notice.
    */
@@ -435,7 +437,9 @@ describe('useUpdateEvent — the draw configuration on the wire', () => {
     result.current.mutate({
       eventId: 'ev-1',
       // Ten pools, so a dropped position could not hide behind a single `0`.
-      body: eventToUpdateBody(buildEvent({ pools: buildTenPools() })),
+      body: eventToUpdateBody(
+        buildEditedEvent({ pools: keepPools(buildTenPools()) }),
+      ),
     })
 
     await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
@@ -449,6 +453,89 @@ describe('useUpdateEvent — the draw configuration on the wire', () => {
         'table_ids',
       ])
     }
+  })
+})
+
+/**
+ * **A pool's id, round trip** (ADR 20260801) — the client's write judged by the store
+ * that stands in for the server, rather than by an assertion about itself.
+ *
+ * This is the one claim of the chore that no mapper test can make: the mock applies the
+ * same id-keyed diff the route does (`applyEventPools`, `mocks/tournaments-store`), so a
+ * body that minted its own pool id is a **422 naming that entry** here exactly as it is
+ * in production — while every assertion about `eventToUpdateBody`'s return value would go
+ * on passing. The seeded tournament is used rather than a stubbed handler for that very
+ * reason: a stub would answer whatever it was told to.
+ */
+describe('an added pool, through the mock’s id-keyed diff', () => {
+  // The seed's owned, published tournament and its two-pool event.
+  const TOURNAMENT = 'bay-area-open-2026'
+  const EVENT = 'ev-open-singles'
+
+  beforeEach(() => resetTournamentsStore())
+
+  it('sends no id and reads the server’s minted uuid back', async () => {
+    const { wrapper } = setupClient()
+    const stored = apiToEvent(findTournament(TOURNAMENT)!.events[0])
+    expect(stored.id).toBe(EVENT)
+
+    const { result } = renderHookRaw(() => useUpdateEvent(TOURNAMENT), { wrapper })
+    result.current.mutate({
+      eventId: EVENT,
+      body: eventToUpdateBody({
+        ...stored,
+        pools: [
+          ...keepPools(stored.pools),
+          addedPool({
+            name: 'Pool Z',
+            slot: { date: '2026-06-14', start: '09:00', end: '12:00' },
+            tableIds: ['t7'],
+          }),
+        ],
+      }),
+    })
+
+    await waitForRaw(() => expect(result.current.isSuccess).toBe(true))
+    const saved = apiToEvent(result.current.data!)
+    // The pools it already had kept their ids — which is what keeps the fixtures dealt
+    // into them — and the new one came back with an id this client never authored.
+    expect(saved.pools.map((p) => p.id).slice(0, 2)).toEqual(
+      stored.pools.map((p) => p.id),
+    )
+    const added = saved.pools[2]
+    expect(added.name).toBe('Pool Z')
+    expect(added.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    )
+    // …and the server, not the array, decided where it sits.
+    expect(saved.pools.map((p) => p.position)).toEqual([0, 1, 2])
+  })
+
+  /** The other half of the diff, and the reason a client may never mint: an id the event
+   * does not hold is refused ON THAT ENTRY (`['body','pools',i,'id']`) rather than
+   * quietly minted — which would hand back a different id than was asked for while
+   * removing the pool the director meant to keep. */
+  it('refuses a body that cites an id this event does not have', async () => {
+    const { wrapper } = setupClient()
+    const stored = apiToEvent(findTournament(TOURNAMENT)!.events[0])
+
+    const { result } = renderHookRaw(() => useUpdateEvent(TOURNAMENT), { wrapper })
+    result.current.mutate({
+      eventId: EVENT,
+      body: eventToUpdateBody({
+        ...stored,
+        pools: keepPools([{ ...stored.pools[0], id: 'p-invented' }]),
+      }),
+    })
+
+    await waitForRaw(() => expect(result.current.isError).toBe(true))
+    const error = result.current.error as ApiError
+    expect(error.status).toBe(422)
+    // A per-field Pydantic body, not a sentence — so `saveFailure` classifies it as
+    // `invalid` and the editor says so in its own words rather than reading a
+    // validator's prose out to the director. The entry's index is in the `loc`
+    // (`['body','pools',0,'id']`), which is what a surface would blame the card by.
+    expect(validationFields(error)).toEqual(['pools'])
   })
 })
 

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -20,6 +20,8 @@ import {
   tournamentToUpdateBody,
 } from './api'
 import { blankAddress } from './helpers'
+import { addedPool, keepPools } from './pool-entries'
+import { asEditedEvent } from './seed.factory'
 import { addTable, keepTables } from './table-catalogue'
 import type { Tournament, TournamentEvent } from './types'
 
@@ -841,8 +843,9 @@ const event: TournamentEvent = {
       slot: { date: '2026-06-14', start: '09:00', end: '12:00' },
       tableIds: ['t1', 't2'],
       // The server's number, held on the read model. The write bodies below must NOT
-      // carry it — `PoolWrite` forbids the key — which is what the create/update
-      // assertions pin.
+      // carry it — both write shapes forbid the key — which is what the create/update
+      // assertions pin. The `id` above is the server's too, and only a PATCH may cite
+      // it: a create body carrying one is a 422 (ADR 20260801).
       position: 0,
     },
   ],
@@ -853,9 +856,15 @@ const event: TournamentEvent = {
   results: null,
 }
 
+/** The event as the **editor** hands it back with its pools untouched: each one cited by
+ * the id the server minted (`asEditedEvent` → `keepPools`). This is what the write
+ * mappers take — a read event no longer is one, which is the compile-time half of ADR
+ * 20260801. */
+const edited = asEditedEvent(event)
+
 describe('eventToCreateBody', () => {
   it('maps the event to a snake_case create body, excluding server-managed entered', () => {
-    const body = eventToCreateBody(event)
+    const body = eventToCreateBody(edited)
 
     expect(body.draw_type).toBe('round-robin')
     expect(body.max_players).toBe(48)
@@ -864,9 +873,11 @@ describe('eventToCreateBody', () => {
     // body, `NOT NULL` on the server.
     expect(body.timezone).toBe('America/Chicago')
     expect(body.match_settings).toEqual({ rated: true, length_games: 3 })
+    // NO `id` — a created event's pools are all new, and a pool's id is the server's to
+    // mint (`PoolWrite` has no such field, and `extra="forbid"` makes a supplied one a
+    // 422 on `body.pools[0].id`).
     expect(body.pools).toEqual([
       {
-        id: 'p-1',
         name: 'Pool A',
         slot: { date: '2026-06-14', start: '09:00', end: '12:00' },
         table_ids: ['t1', 't2'],
@@ -874,26 +885,55 @@ describe('eventToCreateBody', () => {
     ])
   })
 
+  /** ⚠️ The discriminating one. `toEqual` above would pass a body whose pool carried an
+   * `id: undefined` key — and JSON.stringify would drop it, so even the bytes would look
+   * right — but it would NOT pass one carrying a real id, which is what the editor used
+   * to send. Asked as a key question so the claim is about the shape, not about a value
+   * that happens to be absent. */
+  it('sends each pool with NO id key at all — the server mints it', () => {
+    const body = eventToCreateBody(
+      asEditedEvent(event, [
+        ...keepPools(event.pools),
+        addedPool({
+          name: 'Pool B',
+          slot: { date: '2026-06-14', start: '13:00', end: '16:00' },
+          tableIds: ['t3'],
+        }),
+      ]),
+    )
+
+    expect(body.pools).toHaveLength(2)
+    for (const pool of body.pools ?? []) {
+      expect('id' in pool).toBe(false)
+      expect('position' in pool).toBe(false)
+    }
+  })
+
   // A blank player limit is "no cap" (ADR-0935): it must reach the wire as an
   // explicit `null`, never `0` and never omitted.
   it('carries max_players: null for an uncapped event', () => {
-    const body = eventToCreateBody({ ...event, maxPlayers: null })
+    const body = eventToCreateBody(asEditedEvent({ ...event, maxPlayers: null }))
     expect(body.max_players).toBeNull()
   })
 
   it('round-trips through apiToEvent back to the prototype shape', () => {
-    const wire = eventToCreateBody(event)
+    const wire = eventToCreateBody(edited)
     const roundTripped = apiToEvent({
       ...wire,
       // eventToCreateBody always populates these, but they're typed optional on
       // the *create* body — coalesce so the value satisfies the *read* shape.
       predicates: wire.predicates ?? [],
-      // The create body carries NO `position` (`PoolWrite` forbids it), and the read
-      // shape requires one — so the round trip has to close the gap the way the SERVER
-      // closes it: each pool takes the position of its index in the list that was sent.
-      // A `0` typed in here instead would make the round trip pass while the app and the
-      // API disagreed about which pool is first.
-      pools: (wire.pools ?? []).map((pool, index) => ({ ...pool, position: index })),
+      // The create body carries neither an `id` nor a `position` (`PoolWrite` forbids
+      // both), and the read shape requires both — so the round trip has to close the gap
+      // the way the SERVER closes it: the id is MINTED, and the position is the pool's
+      // index in the list that was sent. Carrying either through from the write body
+      // instead would make the round trip pass while the app and the API disagreed about
+      // who owns a pool's identity — and on the position, about which pool is first.
+      pools: (wire.pools ?? []).map((pool, index) => ({
+        ...pool,
+        id: event.pools[index].id,
+        position: index,
+      })),
       // `max_players` is optional on the create body (`null`/absent = no cap,
       // ADR-0935); the read shape is `number | null`.
       max_players: wire.max_players ?? null,
@@ -944,7 +984,7 @@ describe('eventToCreateBody', () => {
   })
 
   it('sends NO fixtures — a draw is cut by POST …/draw, never authored in an event body', () => {
-    const body = eventToCreateBody(event)
+    const body = eventToCreateBody(edited)
 
     expect('fixtures' in body).toBe(false)
   })
@@ -952,13 +992,16 @@ describe('eventToCreateBody', () => {
 
 describe('eventToUpdateBody', () => {
   it('maps the same snake_case fields as create', () => {
-    const body = eventToUpdateBody(event)
+    const body = eventToUpdateBody(edited)
 
     expect(body.draw_type).toBe('round-robin')
     expect(body.max_players).toBe(48)
     expect(body.entry_fee).toBe(30)
     expect(body.timezone).toBe('America/Chicago')
     expect(body.match_settings).toEqual({ rated: true, length_games: 3 })
+    // A PATCH is the id-keyed diff (ADR 20260801), so a pool the event already has is
+    // CITED — that is what keeps its id, and every fixture drawn into it. Unlike the
+    // create body one describe up, which carries no id at all.
     expect(body.pools).toEqual([
       {
         id: 'p-1',
@@ -969,11 +1012,57 @@ describe('eventToUpdateBody', () => {
     ])
   })
 
+  /**
+   * The three statements a pools diff can make, in one body: keep this one, add that one,
+   * and — by saying nothing about it — remove the third.
+   *
+   * The renamed `kept` entry is the load-bearing half: it proves a re-worded pool still
+   * cites its id, rather than arriving as an add (which would mint a second pool and
+   * delete the one holding the fixtures).
+   */
+  it('expresses a pools edit as the id-keyed diff: cite, add, and omit', () => {
+    const stored = [
+      event.pools[0],
+      { ...event.pools[0], id: 'p-2', name: 'Pool B', position: 1 },
+    ]
+    const body = eventToUpdateBody(
+      asEditedEvent({ ...event, pools: stored }, [
+        // Pool A, renamed — still cited, so it keeps its id.
+        { ...keepPools([stored[0]])[0], name: 'Morning Pool' },
+        // …a brand-new one, with no id for the server to mint against.
+        addedPool({
+          name: 'Pool C',
+          slot: { date: '2026-06-14', start: '13:00', end: '16:00' },
+          tableIds: ['t3'],
+        }),
+        // …and Pool B is simply not here. An uncited stored pool is a removal.
+      ]),
+    )
+
+    expect(body.pools).toEqual([
+      {
+        id: 'p-1',
+        name: 'Morning Pool',
+        slot: { date: '2026-06-14', start: '09:00', end: '12:00' },
+        table_ids: ['t1', 't2'],
+      },
+      {
+        name: 'Pool C',
+        slot: { date: '2026-06-14', start: '13:00', end: '16:00' },
+        table_ids: ['t3'],
+      },
+    ])
+    // The added entry omits the KEY rather than sending `id: null`: both are accepted,
+    // but a payload a reader can eyeball and see "this entry cites nothing, so it is an
+    // insert" is the whole readability of a diff.
+    expect('id' in (body.pools ?? [])[1]).toBe(false)
+  })
+
   // Clearing the cap sends an explicit `null` — the PATCH handler distinguishes
   // "clear the cap" (null present) from "leave it alone" (key absent), so this
   // must not be omitted (ADR-0935).
   it('carries max_players: null when the cap is cleared', () => {
-    const body = eventToUpdateBody({ ...event, maxPlayers: null })
+    const body = eventToUpdateBody(asEditedEvent({ ...event, maxPlayers: null }))
     expect('max_players' in body).toBe(true)
     expect(body.max_players).toBeNull()
   })
@@ -990,15 +1079,17 @@ describe('eventToUpdateBody', () => {
     }
 
     it('SENDS the qualifier count for rr-then-ko, on both verbs', () => {
-      expect(eventToCreateBody(twoStage).qualifiers_per_pool).toBe(2)
-      expect(eventToUpdateBody(twoStage).qualifiers_per_pool).toBe(2)
+      expect(eventToCreateBody(asEditedEvent(twoStage)).qualifiers_per_pool).toBe(2)
+      expect(eventToUpdateBody(asEditedEvent(twoStage)).qualifiers_per_pool).toBe(2)
     })
 
     it('sends the DIRECTOR’s count, never a default', () => {
       // `1` is what the planner falls back to when nobody says otherwise, so a fixture
       // of 1 could not tell "threaded through" from "fell back". Three is neither the
       // fallback nor the convention.
-      const body = eventToUpdateBody({ ...twoStage, qualifiersPerPool: 3 })
+      const body = eventToUpdateBody(
+        asEditedEvent({ ...twoStage, qualifiersPerPool: 3 }),
+      )
       expect(body.qualifiers_per_pool).toBe(3)
     })
 
@@ -1009,8 +1100,8 @@ describe('eventToUpdateBody', () => {
     it.each(['round-robin', 'single-elim'] as const)(
       'OMITS the key entirely for %s — where sending it is a 422, not a no-op',
       (drawType) => {
-        const create = eventToCreateBody({ ...event, drawType })
-        const update = eventToUpdateBody({ ...event, drawType })
+        const create = eventToCreateBody(asEditedEvent({ ...event, drawType }))
+        const update = eventToUpdateBody(asEditedEvent({ ...event, drawType }))
 
         expect('qualifiers_per_pool' in create).toBe(false)
         expect('qualifiers_per_pool' in update).toBe(false)
@@ -1034,7 +1125,7 @@ describe('eventToUpdateBody', () => {
     })
 
     it('round-trips a two-stage event: configure 2, send 2, read 2 back', () => {
-      const sent = eventToUpdateBody(twoStage)
+      const sent = eventToUpdateBody(asEditedEvent(twoStage))
       const stored = buildTournamentEventRead({
         draw_type: 'rr-then-ko',
         qualifiers_per_pool: sent.qualifiers_per_pool,
@@ -1045,12 +1136,12 @@ describe('eventToUpdateBody', () => {
   })
 
   it('omits the server-owned entered count so a PATCH never clobbers it', () => {
-    const body = eventToUpdateBody(event)
+    const body = eventToUpdateBody(edited)
     expect('entered' in body).toBe(false)
   })
 
   it('omits the entrants too — registrations are written through the entries endpoints, never an event PATCH', () => {
-    const body = eventToUpdateBody(event)
+    const body = eventToUpdateBody(edited)
     expect('entrants' in body).toBe(false)
   })
 
@@ -1060,7 +1151,7 @@ describe('eventToUpdateBody', () => {
   // a re-cut. A draw moves only through `POST …/draw` and `DELETE …/draw` (ADR-0786).
   it('omits the draw — an event PATCH can neither cut, keep, nor clobber fixtures', () => {
     const body = eventToUpdateBody({
-      ...event,
+      ...edited,
       fixtures: [
         {
           id: 'fx-1',

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -33,10 +33,12 @@ import {
 import type { LifecycleEdge } from './lifecycle'
 import type {
   Address,
+  EditedEvent,
   Entrant,
   EventEntryState,
   Fixture,
   Pool,
+  PoolEntry,
   Predicate,
   PredicateValue,
   Tournament,
@@ -177,7 +179,7 @@ export function apiToEvent(e: TournamentEventRead): TournamentEvent {
 
 /** Map an API pool to the prototype's `Pool`. `position` is carried across as the server
  * assigned it — it is the *read* shape's field and appears on no write body (see
- * `eventPoolsToApi`). The order of `e.pools` is NOT relied on here: whoever lays pools out
+ * `poolEntriesToApi`). The order of `e.pools` is NOT relied on here: whoever lays pools out
  * sorts by `position` itself (`poolsInOrder`, `./helpers`). */
 function apiToPool(p: ApiPool): Pool {
   return {
@@ -372,13 +374,52 @@ export function catalogueToUpdateBody(
 }
 
 /**
- * The pools as a write body takes them (`PoolWrite`) — **without `position`**.
+ * The words of a pool, as **both** write shapes take them — **without `id` and without
+ * `position`**.
  *
- * Same category of field as `entered` one function down: server-managed, and echoing the
- * client's copy back is at best noise and at worst a lie. It is stronger here, though.
- * `entered` is merely *ignored* by the write schema; `PoolWrite` is `extra="forbid"` and
- * declares no `position` at all, so sending it is a **422 naming the field** — the whole
- * save refused, for a key the director never typed.
+ * Same category of field as `entered` two functions down: server-managed, and echoing
+ * the client's copy back is at best noise and at worst a lie. It is stronger here,
+ * though. `entered` is merely *ignored* by the write schema; `PoolWrite` is
+ * `extra="forbid"` and declares neither of these, so sending one is a **422 naming the
+ * field** — the whole save refused, for a key the director never typed.
+ */
+function poolDraftToApi(entry: PoolEntry) {
+  return { name: entry.name, slot: entry.slot, table_ids: entry.tableIds }
+}
+
+/**
+ * The pools as a **create** body takes them (`PoolWrite[]`): the words, and nothing
+ * else.
+ *
+ * An event being born has no pools to cite — every pool on it is new, and the server
+ * mints an id for each (ADR 20260801) — so there is no id arm here at all. A `kept` entry
+ * cannot arise on a create in practice, and if one did its id would name a pool of some
+ * *other* event: dropping it is the only honest reading, and it is also the only one the
+ * schema permits.
+ */
+function poolEntriesToWrite(pools: readonly PoolEntry[]) {
+  return pools.map(poolDraftToApi)
+}
+
+/**
+ * The pools as a **patch** body takes them (`PoolUpsert[]`) — the server's **id-keyed
+ * diff** (ADR 20260801), which is three statements in one array:
+ *
+ * - an entry **citing an id** keeps that pool, and therefore every fixture drawn into it,
+ *   while taking this payload's words and place;
+ * - an entry with **no id** adds a pool, whose id the server mints;
+ * - a stored pool **no entry cites** is removed.
+ *
+ * The `added` arm omits the `id` **key** rather than sending `null`. Both are accepted
+ * (`PoolUpsert.id` is `string | null` and optional), so this is not a correctness fix on
+ * today's schema — it is the discipline `tableEntryToApi` and `drawSettingsToApi` already
+ * follow: send the field only when there is a pool to name. A payload a reader can eyeball
+ * and see "this entry cites nothing, so it is an insert" is the whole readability of a
+ * diff.
+ *
+ * An id this event does not hold is a **422 on that entry** (`['body','pools',i,'id']`),
+ * never a quietly minted pool — which is why the ids reaching here may only ever have come
+ * from a read (`keepPools`, `./pool-entries`).
  *
  * **The order of this array IS the ordering.** The server assigns each pool the position
  * of its index in this very list, so reordering pools is done by sending them in the
@@ -386,13 +427,14 @@ export function catalogueToUpdateBody(
  * position order (`eventToFormValues`, `../event-form`): the array a save serializes has
  * to be the array the director was looking at, or the pools shuffle on the round trip.
  */
-function eventPoolsToApi(ev: TournamentEvent) {
-  return ev.pools.map((p) => ({
-    id: p.id,
-    name: p.name,
-    slot: p.slot,
-    table_ids: p.tableIds,
-  }))
+function poolEntriesToApi(
+  pools: readonly PoolEntry[],
+): components['schemas']['PoolUpsert'][] {
+  return pools.map((entry) =>
+    entry.kind === 'kept'
+      ? { id: entry.id, ...poolDraftToApi(entry) }
+      : poolDraftToApi(entry),
+  )
 }
 
 /**
@@ -419,16 +461,19 @@ function eventPoolsToApi(ev: TournamentEvent) {
  * first (`qualifiersPerPoolSchema`, `data/event-validation`); sending it is honest, and
  * far better than inventing a `1` the director never chose.
  */
-function drawSettingsToApi(ev: TournamentEvent) {
+function drawSettingsToApi(
+  ev: Pick<TournamentEvent, 'drawType' | 'qualifiersPerPool'>,
+) {
   return ev.drawType === 'rr-then-ko'
     ? { draw_type: ev.drawType, qualifiers_per_pool: ev.qualifiersPerPool }
     : { draw_type: ev.drawType }
 }
 
 /** The event fields shared by the create and update bodies — everything except the
- * server-managed values: the `entered` count, and each pool's `position`
- * (`eventPoolsToApi` above). */
-function eventToApiFields(ev: TournamentEvent) {
+ * server-managed values (the `entered` count, and each pool's `id` and `position`) and
+ * the pools themselves, whose two shapes are the one thing the two verbs do NOT share:
+ * a create writes `PoolWrite[]`, a patch writes the `PoolUpsert[]` diff. */
+function eventToApiFields(ev: EditedEvent) {
   return {
     name: ev.name,
     format: ev.format,
@@ -439,21 +484,30 @@ function eventToApiFields(ev: TournamentEvent) {
     slot: ev.slot,
     match_settings: { rated: ev.match.rated, length_games: ev.match.lengthGames },
     predicates: ev.predicates,
-    pools: eventPoolsToApi(ev),
   }
 }
 
-/** Build the event *create* body (POST) from a prototype `TournamentEvent`. */
-export function eventToCreateBody(ev: TournamentEvent): TournamentEventCreate {
-  return eventToApiFields(ev)
+/** Build the event *create* body (POST) from the editor's `EditedEvent`. Its pools carry
+ * **no ids at all** — the server mints one per pool (`poolEntriesToWrite`). */
+export function eventToCreateBody(ev: EditedEvent): TournamentEventCreate {
+  return { ...eventToApiFields(ev), pools: poolEntriesToWrite(ev.pools) }
 }
 
-/** Build the event *update* body (PATCH) from a prototype `TournamentEvent`.
+/** Build the event *update* body (PATCH) from the editor's `EditedEvent`, its pools as
+ * the id-keyed diff (`poolEntriesToApi`).
+ *
  * `entered` is deliberately omitted: it's a server-managed registration count
  * the editor never touches, so echoing the client's last-read value back would
- * clobber registrations that changed server-side since load (a lost update). */
-export function eventToUpdateBody(ev: TournamentEvent): TournamentEventUpdate {
-  return eventToApiFields(ev)
+ * clobber registrations that changed server-side since load (a lost update).
+ *
+ * ⚠️ **The pools are not optional here**, even for a surface that is editing something
+ * else about the event. A PATCH leaves an absent field alone, but a *present* one is the
+ * whole diff — so a body built from an event whose pools were dropped, or whose entries
+ * had lost their ids, reads as "remove every pool you have", and takes the draw dealt
+ * across them with it. Build the entries from a read (`keepPools`) and the ids come along
+ * for free; that is what `eventToFormValues` does, and it is the only path to here. */
+export function eventToUpdateBody(ev: EditedEvent): TournamentEventUpdate {
+  return { ...eventToApiFields(ev), pools: poolEntriesToApi(ev.pools) }
 }
 
 // ----- query keys ----------------------------------------------------------

--- a/web-client/src/components/tournaments/data/event-validation.test.ts
+++ b/web-client/src/components/tournaments/data/event-validation.test.ts
@@ -13,6 +13,12 @@ import {
   QUALIFIERS_PER_POOL_MIN,
   qualifiersPerPoolSchema,
 } from './event-validation'
+import { addedPool, keepPool, poolEntryKey } from './pool-entries'
+import { buildPool } from './seed.factory'
+import type { PoolEntry, Slot } from './types'
+
+/** Any window at all — the pool-name rules care about the name and nothing else. */
+const SLOT: Slot = { date: '2026-06-13', start: '09:00', end: '12:30' }
 
 /** Longer than `tournament_events.name` (`VARCHAR(255)`) — the 422 the organizer used
  * to meet only *after* the request had gone, in Pydantic's words. */
@@ -231,7 +237,9 @@ describe('poolNameSchema', () => {
 })
 
 describe('poolNameIssues', () => {
-  const pool = (id: string, name: string) => ({ id, name })
+  /** A pool the server already holds, cited by its id (`keepPool`). */
+  const pool = (id: string, name: string): PoolEntry =>
+    keepPool(buildPool({ id, name }))
 
   /** Keyed by pool id, so the red lands under the box that is empty. A director with six
    * pools and one blank name must not be pointed at all six. */
@@ -239,6 +247,23 @@ describe('poolNameIssues', () => {
     expect(
       poolNameIssues([pool('p-a', ''), pool('p-b', 'Pool B'), pool('p-c', '  ')]),
     ).toEqual({ 'p-a': 'Name is required.', 'p-c': 'Name is required.' })
+  })
+
+  /**
+   * ⚠️ **A pool the director added a moment ago has no id at all** (ADR 20260801: the
+   * server mints it), and it still has a name box they can still empty. Keyed off the id
+   * alone, every added pool would collide on `undefined` — one red under the wrong card,
+   * and none under the others — so the key is `poolEntryKey`, which is also what the
+   * cards are keyed on.
+   */
+  it('blames an ADDED pool too, by the key its card is rendered under', () => {
+    const blank = addedPool({ name: ' ', slot: SLOT, tableIds: [] })
+    const named = addedPool({ name: 'Pool B', slot: SLOT, tableIds: [] })
+
+    const issues = poolNameIssues([blank, named])
+
+    expect(issues).toEqual({ [poolEntryKey(blank)]: 'Name is required.' })
+    expect(poolEntryKey(blank)).not.toBe(poolEntryKey(named))
   })
 
   it('says nothing about a list of named pools', () => {

--- a/web-client/src/components/tournaments/data/event-validation.ts
+++ b/web-client/src/components/tournaments/data/event-validation.ts
@@ -67,6 +67,9 @@
 
 import { z } from 'zod'
 
+import { poolEntryKey } from './pool-entries'
+import type { PoolEntry } from './types'
+
 /** `tournament_events.name` is `VARCHAR(255)`, `NOT NULL` — the same column
  * constraint `NewTournamentModal` mirrors for the tournament's own name, and the
  * same copy, because it is the same field to the person typing it. */
@@ -117,7 +120,7 @@ export const nameSchema = z
  * same words as the event's own name — because to the organizer clearing a box it is
  * the same news, and a second wording for one fact is a second thing to drift.
  *
- * The pools editor *mints* a pool's id and its default name ("Pool A"), so the happy
+ * The pools editor *mints* a pool's default name ("Pool A"), so the happy
  * path could never author a blank one — but the name **box is live**, and an emptied
  * box was a save the form allowed and the server refused, with Pydantic's own prose
  * ("String should have at least 1 character") arriving in the editor's banner. That is
@@ -130,10 +133,12 @@ export const nameSchema = z
  * overflow). Mirroring a bound the API does not have would be inventing one, and a save
  * refused here is a save nothing on the server would ever have refused.
  *
- * A pool's **id** is not mirrored, though the server floors that too (`ValueObjectId`):
- * it is minted (`genId('p')`, `data/helpers`) and there is no box for it, so an error
- * about it is one no organizer could ever act on or even *see* — an unfixable red is
- * worse than the impossible 422 it guards. The same goes for a table's id.
+ * A pool's **id** is not mirrored at all, and since ADR 20260801 there is nothing left
+ * to mirror: the id is the SERVER's uuid, a new pool is sent with none, and this form
+ * cannot author one (`PoolEntry`, `./types`). Even when the client did mint them, an
+ * error about an id was one no organizer could act on or even *see* — there is no box —
+ * and an unfixable red is worse than the impossible 422 it guards. The same goes for a
+ * table's id.
  */
 export const poolNameSchema = z
   .string()
@@ -141,8 +146,14 @@ export const poolNameSchema = z
   .min(1, { error: 'Name is required.' })
 
 /**
- * What is wrong with each pool's **name**, keyed by pool id — `poolNameSchema` read a
- * second way, for the second reader.
+ * What is wrong with each pool's **name**, keyed by `poolEntryKey` — `poolNameSchema`
+ * read a second way, for the second reader.
+ *
+ * Keyed off the ENTRY rather than off an id, because half the pools in a live edit have
+ * no id: one the director added a moment ago is waiting for the server to mint it
+ * (ADR 20260801), and it still has a name box that can still be emptied. `poolEntryKey`
+ * is the same key the cards are keyed on, so the red lands under the box it is about
+ * whichever arm the entry is.
  *
  * The resolver's verdict on the array (`eventSchema`) is what refuses the *save*; this
  * is what puts the red under the *box*, and the two are the same rule and the same
@@ -160,12 +171,14 @@ export const poolNameSchema = z
  * by which mechanism.
  */
 export function poolNameIssues(
-  pools: readonly { id: string; name: string }[],
+  pools: readonly PoolEntry[],
 ): Record<string, string> {
   const issues: Record<string, string> = {}
   for (const pool of pools) {
     const result = poolNameSchema.safeParse(pool.name)
-    if (!result.success) issues[pool.id] = result.error.issues[0].message
+    if (!result.success) {
+      issues[poolEntryKey(pool)] = result.error.issues[0].message
+    }
   }
   return issues
 }

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -9,7 +9,7 @@ import type {
   Address,
   Entrant,
   Predicate,
-  Pool,
+  PoolDraft,
   Tournament,
   TournamentEvent,
 } from './types'
@@ -377,9 +377,10 @@ export function predicateSentence(p: Predicate): string {
  *
  * It exists because the two plausible alternatives are both wrong:
  *
- * - **By id** is the bug this field was added to kill. Ids are minted client-side
- *   (`genId('p')`), so a ten-pool event holds `p-1-…` … `p-10-…`, and sorted as strings
- *   `p-10-` lands between `p-1-` and `p-2-`: the draw rendered 1, 10, 2, 3 …
+ * - **By id** is the bug this field was added to kill. The ids were minted client-side
+ *   then (`p-1-…` … `p-10-…`, so as strings `p-10-` landed between `p-1-` and `p-2-`:
+ *   the draw rendered 1, 10, 2, 3 …) and are server-minted uuids now, which sort by
+ *   nothing whatsoever — the same wrong answer, arrived at faster.
  * - **Whatever order the array is in** is not an answer at all, only a coincidence. The
  *   server does send its pools in position order, but a client that merely *inherited*
  *   that order would state no rule, so nothing would fail when the order stopped holding.
@@ -395,16 +396,6 @@ export function poolsInOrder<T extends { position: number }>(
   return [...pools].sort((a, b) => a.position - b.position)
 }
 
-/** The position a pool appended to `pools` takes: **one past the highest**, never the
- * count. The two differ the moment a pool is removed from the middle — nine pools
- * numbered 0…4, 6…9 would hand a tenth the position `9`, a duplicate, and the two would
- * then order by nothing. (The server renumbers from the array index on the next write,
- * so this only has to hold until the save; "only until the save" is still long enough for
- * a director to add a pool and watch it jump.) */
-export function nextPoolPosition(pools: readonly { position: number }[]): number {
-  return pools.reduce((max, p) => Math.max(max, p.position + 1), 0)
-}
-
 export interface PoolConflict {
   table: string
   poolA: string
@@ -412,8 +403,13 @@ export interface PoolConflict {
 }
 
 /** Tables double-booked across two pools whose time windows overlap on the
- * same day — surfaced as a warning in the event editor's Table pools tab. */
-export function findPoolConflicts(pools: Pool[]): PoolConflict[] {
+ * same day — surfaced as a warning in the event editor's Table pools tab.
+ *
+ * Takes `PoolDraft`s — the three fields a director types — so it reads a pool the editor
+ * has just added (which has no id and no position yet) exactly as it reads a stored one.
+ * A double-booking is a fact about windows and tables; identity has nothing to do with
+ * it. */
+export function findPoolConflicts(pools: readonly PoolDraft[]): PoolConflict[] {
   const conflicts: PoolConflict[] = []
   for (let i = 0; i < pools.length; i++) {
     for (let j = i + 1; j < pools.length; j++) {

--- a/web-client/src/components/tournaments/data/pool-entries.test.ts
+++ b/web-client/src/components/tournaments/data/pool-entries.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import { addedPool, keepPool, keepPools, poolEntryKey } from './pool-entries'
+import { buildPool, buildTenPools } from './seed.factory'
+import type { Slot } from './types'
+
+/** Any window at all — none of these claims turn on when a pool plays. */
+const SLOT: Slot = { date: '2026-06-13', start: '09:00', end: '12:30' }
+
+describe('keepPool', () => {
+  // The point of taking a whole `Pool` rather than an id: the only ids that can reach
+  // the wire are ids a read handed back (ADR 20260801). One this event does not hold is
+  // a 422 on that entry, so an id the client made up is not a mistake it may make.
+  it('cites the pool the server sent, with the words it holds today', () => {
+    expect(
+      keepPool(buildPool({ id: 'p-7', name: 'Pool G', tableIds: ['t3'] })),
+    ).toEqual({
+      kind: 'kept',
+      id: 'p-7',
+      name: 'Pool G',
+      slot: SLOT,
+      tableIds: ['t3'],
+    })
+  })
+
+  /** ⚠️ **The `position` does NOT come along.** It is the server's, assigned from the
+   * index of the entry in the list it is sent, and both write shapes are
+   * `extra="forbid"` — so a position that rode along on an entry would be a 422 naming
+   * the field, and the director's whole save refused for a key they never typed. */
+  it('drops the server-assigned position', () => {
+    const entry = keepPool(buildPool({ position: 4 }))
+    expect('position' in entry).toBe(false)
+  })
+})
+
+describe('keepPools', () => {
+  /** The no-op diff, and the reason it has to exist: under an id-keyed diff a stored
+   * pool **no entry cites** is removed. So "I am editing something else about this
+   * event" is spelled by citing every pool, not by sending none. */
+  it('cites every stored pool, in the order it was given them', () => {
+    const pools = buildTenPools()
+    const entries = keepPools(pools)
+
+    expect(entries).toHaveLength(10)
+    expect(entries.map(poolEntryKey)).toEqual(pools.map((p) => p.id))
+    expect(new Set(entries.map((e) => e.kind))).toEqual(new Set(['kept']))
+  })
+
+  it('has nothing to say about an event with no pools', () => {
+    expect(keepPools([])).toEqual([])
+  })
+})
+
+describe('addedPool', () => {
+  /** The whole chore in one assertion: a pool the server has never seen carries **no id
+   * key at all**. `PoolWrite` has no such field and is `extra="forbid"`, so a supplied
+   * one is a 422 on `body.pools[i].id` — and the union arm is what makes that
+   * unsayable rather than merely untrue today. */
+  it('carries no id, because the client has none to give', () => {
+    const entry = addedPool({ name: 'Pool B', slot: SLOT, tableIds: ['t1'] })
+
+    expect(entry.kind).toBe('added')
+    expect('id' in entry).toBe(false)
+    expect(entry).toMatchObject({ name: 'Pool B', slot: SLOT, tableIds: ['t1'] })
+  })
+
+  /** Two pools added in the same session must be two cards, not one rendered twice: the
+   * key is what React and `poolNameIssues` address a card by, and every event has a
+   * “Pool A”, so it cannot be derived from anything the director typed. */
+  it('mints a distinct card key per pool', () => {
+    const draft = { name: 'Pool A', slot: SLOT, tableIds: [] }
+    expect(poolEntryKey(addedPool(draft))).not.toBe(
+      poolEntryKey(addedPool(draft)),
+    )
+  })
+})
+
+describe('poolEntryKey', () => {
+  it('is the server’s id for a stored pool and the card key for a new one', () => {
+    expect(poolEntryKey(keepPool(buildPool({ id: 'p-1' })))).toBe('p-1')
+
+    const added = addedPool({ name: 'Pool B', slot: SLOT, tableIds: [] })
+    expect(poolEntryKey(added)).toBe(
+      added.kind === 'added' ? added.key : undefined,
+    )
+  })
+})

--- a/web-client/src/components/tournaments/data/pool-entries.ts
+++ b/web-client/src/components/tournaments/data/pool-entries.ts
@@ -1,0 +1,62 @@
+// An event's pools as an **id-keyed diff** (ADR 20260801), on the client side of the
+// wire: how a Table-pools edit is expressed, and how a pool the director just added is
+// told apart from one the server already holds.
+//
+// The twin of `./table-catalogue`, one resource over, and it exists for the same two
+// server-side facts:
+//
+// 1. **The server mints pool ids.** `PoolWrite` is `extra="forbid"` and has no `id`
+//    field, so a client-minted one is a 422 naming the entry. A new pool therefore
+//    carries no id at all — which is what `PoolEntry`'s `added` arm makes structurally
+//    true rather than a rule to remember (`./types`).
+// 2. **An uncited stored pool is removed**, and an entry citing an id the event does not
+//    hold is a 422 on that entry (`['body','pools',i,'id']`) — never a quietly minted
+//    pool, which would hand back a different id than was asked for while removing the
+//    pool the client meant to keep.
+//
+// There is no classifier here to match `tableInUseRefusal`: the one refusal a pools edit
+// can meet that a director may act on — the pool-set freeze under a cut draw — is a 409
+// whose way out is "delete the draw", not "re-send with an opt-in". It is reported, in
+// the server's own sentence, by the editor's failure banner (`./save-failure`).
+
+import { genId } from './helpers'
+import type { Pool, PoolDraft, PoolEntry } from './types'
+
+/** "Keep this pool" — an entry citing a pool the server actually sent back. Built from
+ * the whole `Pool`, so there is no way to cite an id that came from anywhere but a
+ * read. */
+export const keepPool = (pool: Pool): PoolEntry => ({
+  kind: 'kept',
+  id: pool.id,
+  name: pool.name,
+  slot: pool.slot,
+  tableIds: pool.tableIds,
+})
+
+/** Every stored pool, cited — the "change nothing about the set" list. The base an edit
+ * is built by filtering, appending to, or re-wording; it is what `eventToFormValues`
+ * (`../tournament-detail-page/event-form`) seeds the editor's field array with, in
+ * position order. */
+export const keepPools = (pools: readonly Pool[]): PoolEntry[] => pools.map(keepPool)
+
+/** "Add this pool" — **no id**, because the client has none to give (ADR 20260801).
+ *
+ * The `key` is a React key and only ever that (see `PoolEntry`): the cards are keyed on
+ * something stable so an in-place `update()` re-renders a card instead of remounting it
+ * and dropping the director's cursor, and a pool the server has never seen has nothing
+ * else to be keyed on. It is not an id, is never sent, and cannot be mistaken for one —
+ * the arm that has an id is a different arm. */
+export const addedPool = (draft: PoolDraft): PoolEntry => ({
+  kind: 'added',
+  key: genId('new-pool'),
+  ...draft,
+})
+
+/** What to key this entry's card — and its name error — on: the server's id for a pool
+ * that has one, the client-side card key for one that does not.
+ *
+ * Keyed rather than indexed because an index renumbers: remove the first of three pools
+ * and an index-keyed error message is suddenly red under the wrong box (a bug this
+ * editor has already had once, `pools-section.test.tsx`). */
+export const poolEntryKey = (entry: PoolEntry): string =>
+  entry.kind === 'kept' ? entry.id : entry.key

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -583,19 +583,20 @@ export function buildDrawnEvent(
 }
 
 /** How many pools `buildTenPools` builds — ten, because ten is the smallest count at
- * which a client-minted id (`p-10-…`) sorts into the middle of the single digits. Nine
- * pools would order identically by id and by position, and prove nothing. */
+ * which a legacy client-minted id (`p-10-…`) sorts into the middle of the single digits.
+ * Nine pools would order identically by id and by position, and prove nothing. */
 const TEN = 10
 
 /**
  * **Ten pools whose ids sort differently from their positions** — the fixture the whole
  * ordering rule is about, and the only pool fixture that can falsify it.
  *
- * The ids are minted the way the editor mints them (`genId('p')` — `p-1-<ts>`,
- * `p-2-<ts>` … `p-10-<ts>`, one timestamp for the burst), and as strings `p-10-` falls
- * between `p-1-` and `p-2-`. So anything that sorted these by id renders **1, 10, 2, 3 …
- * 9** — which is not a hypothetical: it is exactly what a ten-pool event's draw did
- * before pools carried a position.
+ * The ids reproduce the legacy shape the editor used to mint before pool ids became
+ * server-minted UUIDs (`genId('p')` — `p-1-<ts>`, `p-2-<ts>` … `p-10-<ts>`, one
+ * timestamp for the burst), and as strings `p-10-` falls between `p-1-` and `p-2-`. So
+ * anything that sorted these by id renders **1, 10, 2, 3 … 9** — which is not a
+ * hypothetical: it is exactly what a ten-pool event's draw did before pools carried a
+ * position.
  *
  * They are returned **in that wrong order on purpose**, positions 0–9 telling the truth
  * underneath. A fixture handed over already sorted cannot tell "orders by position" from
@@ -610,7 +611,7 @@ export function buildTenPools(): Pool[] {
   const inPositionOrder = Array.from({ length: TEN }, (_, i) => {
     const n = i + 1
     return buildPool({
-      // The `genId('p')` shape: index, then the shared base-36 timestamp.
+      // The legacy `genId('p')` shape: index, then the shared base-36 timestamp.
       id: `p-${n}-mkq1x`,
       name: `Pool ${n}`,
       position: i,

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -7,9 +7,11 @@ import { DRAW_TYPE_CATALOGUE } from '@/mocks/factories/tournaments/tournament.fa
 
 import { parseDrawTypeCatalogue } from './draw-types'
 import type { ConflictFixture, PlacementConflict, ScheduleSolve } from './solve'
+import { keepPools } from './pool-entries'
 import type {
   Address,
   DrawTypeOption,
+  EditedEvent,
   Entrant,
   EventEntryState,
   FinishesResults,
@@ -17,6 +19,7 @@ import type {
   Fixture,
   FixtureTime,
   Pool,
+  PoolEntry,
   PoolStandings,
   Predicate,
   StandingRow,
@@ -189,6 +192,38 @@ export function buildEvent(
       ? { state: 'event_full' }
       : { state: 'open' })
   return { ...event, entryState, entered: event.entrants.length }
+}
+
+/**
+ * The same event as the **editor** would hand it back with nothing about its pools
+ * changed: every stored pool cited by the id the server minted (`keepPools`,
+ * `data/pool-entries`).
+ *
+ * This is the shape the write mappers take (`EditedEvent`), and building it through the
+ * production constructor is the point: a test that hand-wrote `kind: 'kept'` entries
+ * could keep passing after `keepPools` stopped citing ids, which is the exact regression
+ * — a no-op diff read as "remove every pool" — that shape exists to prevent.
+ *
+ * Pass `pools` to state a real edit: `[...keepPools(event.pools), addedPool({…})]` adds
+ * one, a shorter list removes one.
+ */
+export function buildEditedEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered' | 'pools'>> & {
+    pools?: PoolEntry[]
+  } = {},
+): EditedEvent {
+  const { pools, ...eventOverrides } = overrides
+  const event = buildEvent(eventOverrides)
+  return { ...event, pools: pools ?? keepPools(event.pools) }
+}
+
+/** One read event, re-expressed as the editor's no-op diff — `buildEditedEvent` for a
+ * test that already holds the event it means. */
+export function asEditedEvent(
+  event: TournamentEvent,
+  pools: PoolEntry[] = keepPools(event.pools),
+): EditedEvent {
+  return { ...event, pools }
 }
 
 /** An event with **no entrant cap** (`max_players: null`, ADR-0935): open to

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -213,8 +213,10 @@ export function buildEditedEvent(
   } = {},
 ): EditedEvent {
   const { pools, ...eventOverrides } = overrides
-  const event = buildEvent(eventOverrides)
-  return { ...event, pools: pools ?? keepPools(event.pools) }
+  // `pools: undefined` still triggers `asEditedEvent`'s own default (`keepPools`)
+  // — passing it through rather than repeating the default here is what keeps the
+  // no-op-diff default in the one place `asEditedEvent` already states it.
+  return asEditedEvent(buildEvent(eventOverrides), pools)
 }
 
 /** One read event, re-expressed as the editor's no-op diff — `buildEditedEvent` for a

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -85,8 +85,19 @@ export interface MatchSettings {
   lengthGames: MatchLength
 }
 
-/** A slice of tables reserved for a window of time within an event. */
+/** A slice of tables reserved for a window of time within an event, **as it is read
+ * back**: the words a client wrote, plus the two fields the server owns.
+ *
+ * This is the READ shape. What goes *out* is `PoolEntry` below — the same distinction
+ * `TournamentTable`/`TournamentTableEntry` draw one resource over, and for the same
+ * reason: since ADR 20260801 a pool is a row with a uuid primary key, so neither of the
+ * two fields here is the client's to author. */
 export interface Pool {
+  /** The SERVER's uuid — the `tournament_event_pools` row's primary key (ADR 20260801).
+   * A client never mints one: the create shape (`PoolWrite`) has no `id` field at all
+   * and `extra="forbid"` turns a supplied one into a 422, and the patch shape
+   * (`PoolUpsert`) takes an id only to *cite* a pool the event already has. An id this
+   * event does not hold is a 422 naming that entry — never a quietly minted pool. */
   id: string
   name: string
   slot: Slot
@@ -94,19 +105,77 @@ export interface Pool {
   /**
    * Where this pool sits in its event's ordering — **0-based, and assigned by the
    * server** from the index of the pool in the list a write body sent. To reorder
-   * pools you send them in the order you want; you never send a position (the write
-   * schema is `extra="forbid"`, so a `position` key on a write body is a 422 that
-   * names the field — see `eventPoolsToApi`, `data/api`).
+   * pools you send them in the order you want; you never send a position (both write
+   * schemas are `extra="forbid"`, so a `position` key on a write body is a 422 that
+   * names the field — see `poolEntriesToApi`, `data/api`).
    *
-   * It exists because **pool ids do not order pools**. They are minted client-side
-   * (`genId('p')` → `p-1-…`, `p-2-…`, `p-10-…`), and sorted as strings `p-10-` falls
-   * between `p-1-` and `p-2-` — so a ten-pool event read its draw back as 1, 10, 2, 3.
-   * That was a live bug, not a hypothetical. Everything that puts pools in an order
-   * therefore orders them by THIS field (`poolsInOrder`, `data/helpers`) — never by id,
-   * and never by whatever order the array happened to arrive in.
+   * It exists because **pool ids do not order pools**, and that was true of the
+   * client-minted ids it was introduced against (`p-10-…` sorted between `p-1-…` and
+   * `p-2-…`, so a ten-pool event read its draw back as 1, 10, 2, 3 — a live bug) and is
+   * even more true of the uuids that replaced them, which sort by nothing at all.
+   * Everything that puts pools in an order therefore orders them by THIS field
+   * (`poolsInOrder`, `data/helpers`) — never by id, and never by whatever order the
+   * array happened to arrive in.
    */
   position: number
 }
+
+/** The part of a pool a client actually **authors**: what it is called, when it runs,
+ * and which tables it holds. Exactly `PoolWrite` on the wire — no `id`, no `position`,
+ * because neither is the client's (see `Pool` above). It is also all a `PoolCard` is
+ * given, so the editor's one pool control literally cannot touch an identity. */
+export interface PoolDraft {
+  name: string
+  slot: Slot
+  tableIds: string[]
+}
+
+/**
+ * One pool of an **edited** event — what the editor's pools tab holds and
+ * `poolEntriesToApi` (`./api`) puts on the wire as a `PoolUpsert`.
+ *
+ * A pools write is an **id-keyed diff**, not a replace (ADR 20260801), and the two
+ * things an entry can mean are opposite:
+ *
+ * - **`kept`** — "this is the pool you already have, with these words." It carries the
+ *   `id` the server minted, so the row keeps its identity and therefore every fixture
+ *   drawn into it.
+ * - **`added`** — "mint me one." It has no `id` **field at all**, so a client-minted id
+ *   is not a value this type can hold — which is the point: `PoolWrite` is
+ *   `extra="forbid"`, so an `id` on a new pool is a 422, and an entry citing an id the
+ *   event does not have is a 422 on that entry (`['body','pools',i,'id']`).
+ *
+ * (And a stored pool **no entry cites** is a *removal* — which is why this is a tagged
+ * union rather than the obvious `id?: string`. With one optional field, a draft pool
+ * that had somehow acquired an id and a saved pool that had lost one are both
+ * representable, and each is a silent data-loss bug: the first is a 422 at best and a
+ * duplicate pool at worst, the second deletes the pool — and its fixtures' home — that
+ * the director only meant to rename. It is the shape `TournamentTableEntry` already
+ * has, one resource over.)
+ *
+ * `key` on the `added` arm is a **React key and nothing else**: it is never sent, never
+ * read by the server, and never mistaken for an id, because the arm that has an id is a
+ * different arm. The cards need a stable key across re-renders — `useFieldArray`
+ * regenerates its own key on every `update()`, which would remount the card mid-keystroke
+ * and drop focus — and a pool the server has never seen has nothing else to be keyed on.
+ */
+export type PoolEntry =
+  | ({ kind: 'kept'; id: string } & PoolDraft)
+  | ({ kind: 'added'; key: string } & PoolDraft)
+
+/**
+ * An event as the **editor** hands it back: every read field of the event it was opened
+ * on, with the pools replaced by the diff the organizer built (`PoolEntry`).
+ *
+ * It is a distinct type from `TournamentEvent` rather than a loosened one so that the
+ * two directions cannot be confused at a call site: what comes *back* from the API has
+ * pools with server ids and positions, and what goes *out* has entries that either cite
+ * an id or carry none. `eventToCreateBody` / `eventToUpdateBody` take this, so an event
+ * read straight off a query can no longer be posted back as-is — which is exactly the
+ * 422 (`extra_forbidden` on `body.pools[i].id`) that this shape exists to make
+ * unsayable.
+ */
+export type EditedEvent = Omit<TournamentEvent, 'pools'> & { pools: PoolEntry[] }
 
 /**
  * One planned pairing of an event's **draw** (ADR-0786): a round and a position —

--- a/web-client/src/components/tournaments/tournament-detail-page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.tsx
@@ -16,6 +16,7 @@ import {
 } from './data/helpers'
 import { lifecycleEdgeFor } from './data/lifecycle'
 import type {
+  EditedEvent,
   Tournament,
   TournamentEvent,
   TournamentTable,
@@ -48,9 +49,9 @@ export interface TournamentDetailPageProps {
    * awaits it, closes itself only when it RESOLVES, and stays open over a rejection —
    * so a refused create is reported instead of quietly binning everything the
    * organizer typed (#933, #934). */
-  onCreateEvent: (event: TournamentEvent) => Promise<void>
+  onCreateEvent: (event: EditedEvent) => Promise<void>
   /** Persist an edited event — same contract as `onCreateEvent`. */
-  onUpdateEvent: (event: TournamentEvent) => Promise<void>
+  onUpdateEvent: (event: EditedEvent) => Promise<void>
   onDeleteEvent: (eventId: string) => void
   /** Whether the create/update event mutation is still in flight — passed straight to
    * the `EventEditor`, which disables its one submit control on it. Owned by the route,
@@ -144,7 +145,7 @@ export const TournamentDetailPage = ({
    * and the work that must survive. Firing the mutation and closing regardless (what
    * this used to do) is how a 422 became an event that was never created, reported
    * nowhere (#933, #934). */
-  const saveEvent = (ev: TournamentEvent) =>
+  const saveEvent = (ev: EditedEvent) =>
     ev.id.startsWith('new')
       ? onCreateEvent({ ...ev, id: genId('ev') })
       : onUpdateEvent(ev)

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -6,7 +6,7 @@ import { ApiError } from '@/api/client'
 import { screen, waitFor } from '@/test/utilities'
 
 import { emptyEvent } from '../data/helpers'
-import { eventToUpdateBody } from '../data/api'
+import { eventToCreateBody, eventToUpdateBody } from '../data/api'
 import {
   buildEvent,
   buildFixture,
@@ -699,11 +699,17 @@ describe('EventEditor', () => {
     // which are never shown). This test is what stops a future tidy-up from collapsing
     // the two.
     it('surfaces a pool-set 409 with the server’s own sentence — the cut-draw race', async () => {
+      // The server's sentence, byte for byte (`_pool_set_frozen_detail`,
+      // `api/app/tournament_events.py`), because that is what this test is standing in
+      // for. It stopped offering "re-identify" as a third thing to do when the pool ids
+      // moved server-side (ADR 20260801): re-identifying a pool is no longer a payload a
+      // client can send, so it is no longer a refusal a client can meet.
       const refusal =
-        'This event’s draw is already cut, so its set of pools is frozen: “Pool B” ' +
-        'already has fixtures drawn into it. A pool’s tables, its time and its name ' +
-        'can all still be changed. To add, remove or re-identify a pool, remove the ' +
-        'draw first, then cut it again.'
+        "This event's draw is already cut, so its set of pools is frozen: “Pool B” " +
+        'already has fixtures drawn into it, which this change would leave pointing at ' +
+        "a pool that no longer exists. A pool's tables, its time and its name can all " +
+        'still be changed. To add or remove a pool, remove the draw first, then cut it ' +
+        'again.'
       const onSave = rejectWith(
         new ApiError(409, refusal, 'update event', { detail: refusal }),
       )
@@ -726,6 +732,96 @@ describe('EventEditor', () => {
       expect(eventEditorPage.queryFailure()).toHaveTextContent(
         'your changes are still here',
       )
+    })
+  })
+
+  /**
+   * **Who owns a pool id, from the card to the request body** (ADR 20260801).
+   *
+   * The section's own tests prove the form holds the right *entries*; these prove the
+   * thing only the editor can, and the thing that 422s if it is wrong: what
+   * `eventToCreateBody` / `eventToUpdateBody` make of them. `onSave` receives exactly the
+   * object the page maps, so mapping it here is what the client would really put on the
+   * wire — and a test that stopped at form state would pass just as happily against a
+   * mapper that put the ids back.
+   *
+   * The two failures are opposite and both silent. An id on a NEW pool is a 422
+   * (`extra_forbidden` on `body.pools[i].id`) — the whole save refused, for a key the
+   * director never typed. A missing id on a STORED pool is worse than a refusal: the
+   * PATCH is an id-keyed diff, so an uncited pool is REMOVED, and the fixtures dealt into
+   * it go with it.
+   */
+  describe('the pools a save puts on the wire', () => {
+    const addAPool = async () => {
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      await userEvent.click(screen.getByRole('button', { name: 'Add pool' }))
+    }
+
+    it('sends an added pool with NO id, and still cites the stored one', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({
+        event: buildEvent({ id: 'ev-1', pools: [buildPool({ id: 'p-1' })] }),
+        onSave,
+      })
+
+      await addAPool()
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      const pools = eventToUpdateBody(onSave.mock.calls[0][0]).pools ?? []
+      expect(pools).toHaveLength(2)
+      // The pool the event already has, cited — which is what keeps it (and its draw).
+      expect(pools[0]).toMatchObject({ id: 'p-1', name: 'Pool A' })
+      // …and the new one, with no id key at all for the server to trip over.
+      expect('id' in pools[1]).toBe(false)
+      expect(pools[1].name).toBe('Pool B')
+    })
+
+    // A rename is the case a mapper is most likely to get wrong, because it is the one
+    // where the pool's words all change: it must still cite the id, or the director's
+    // "Pool A → Morning Pool" arrives as one removal and one insertion.
+    it('keeps citing a stored pool the director has just renamed', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({
+        event: buildEvent({ id: 'ev-1', pools: [buildPool({ id: 'p-1' })] }),
+        onSave,
+      })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      fireEvent.change(screen.getByLabelText('Pool name'), {
+        target: { value: 'Morning Pool' },
+      })
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      expect(eventToUpdateBody(onSave.mock.calls[0][0]).pools).toEqual([
+        expect.objectContaining({ id: 'p-1', name: 'Morning Pool' }),
+      ])
+    })
+
+    // The create verb has no id arm at ALL (`PoolWrite`), so a brand-new event's pools
+    // carry none — the server mints one apiece and hands them back on the response the
+    // page then renders.
+    it('creates an event whose pools carry no ids whatsoever', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      // Named, because a blank name is refused in the form and nothing would be sent —
+      // the resolver is doing its job, and this test is about a different one.
+      eventEditorPage.render({
+        event: { ...emptyEvent(buildTournament()), name: 'New Event' },
+        onSave,
+      })
+
+      await addAPool()
+      await addAPool()
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      const pools = eventToCreateBody(onSave.mock.calls[0][0]).pools ?? []
+      expect(pools).toHaveLength(2)
+      for (const pool of pools) {
+        expect('id' in pool).toBe(false)
+        expect('position' in pool).toBe(false)
+      }
     })
   })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -26,6 +26,7 @@ import {
 } from '../data/save-failure'
 import type {
   DrawTypeOption,
+  EditedEvent,
   TournamentEvent,
   TournamentTable,
 } from '../data/types'
@@ -55,14 +56,17 @@ export interface EventEditorProps {
   /** When false (a non-creator), the Save and Delete actions are hidden and the
    * editor becomes a read-only view of the event. */
   canEdit: boolean
-  /** Persist the edited event. **May be async — and the editor awaits it**: it
+  /** Persist the edited event — an `EditedEvent`, whose pools are the organizer's
+   * **diff** (`PoolEntry`) rather than rows read back: each one either cites the id the
+   * server minted or carries none at all, and a stored pool no entry cites is a removal
+   * (ADR 20260801). **May be async — and the editor awaits it**: it
    * closes itself only when the promise RESOLVES, and a rejection keeps the sheet
    * open, with the work intact and the failure on screen. A caller that fires the
    * mutation and closes regardless turns every server refusal into a silently
    * discarded event (the #614 rule, learned again in #933 / #934, and once more here
    * from a `between` rule with no bounds: a 422 came back, the sheet shut, and
    * everything the organizer had typed went with it). */
-  onSave: (event: TournamentEvent) => void | Promise<void>
+  onSave: (event: EditedEvent) => void | Promise<void>
   onDelete: (id: string) => void
   /**
    * Whether the save MUTATION is still in flight — the repo's pending-mutation gate
@@ -221,7 +225,12 @@ export const EventEditor = ({
   const submit = form.handleSubmit(
     async (formValues) => {
       if (!event) return
-      const saved: TournamentEvent = { ...event, ...formValues }
+      // The event that was opened, with every editable field taken from the form —
+      // `pools` included, which is why this is an `EditedEvent` and not a
+      // `TournamentEvent`: the form holds entries, and an entry is not a pool. Handing
+      // the read model's pools back instead would re-send the ids on a create (a 422) and
+      // lose the added/kept distinction on a patch.
+      const saved: EditedEvent = { ...event, ...formValues }
       setFailure(null)
       try {
         await onSave(saved)

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.page.tsx
@@ -1,7 +1,7 @@
 import { interactiveControlsIn, interactiveElementsIn } from '@/test/read-only'
 import { render, screen, within, type Container } from '@/test/utilities'
 
-import type { Pool } from '../../data/types'
+import type { PoolEntry } from '../../data/types'
 import {
   buildPoolsSectionProps,
   type PoolsHarnessInputs,
@@ -70,10 +70,16 @@ const scoped = (container: Container) => ({
     return container.queryByTestId('pools-frozen-notice')
   },
   /** The live `pools` array in form state (via the probe), so a test can assert
-   * that an add / edit / remove flowed through `useFieldArray`. */
-  getPools(): Pool[] {
+   * that an add / edit / remove flowed through `useFieldArray`.
+   *
+   * `PoolEntry[]`, not `Pool[]`: what the form holds is the **diff** the save
+   * serializes (ADR 20260801) — entries that either cite the id the server minted
+   * (`kind: 'kept'`) or carry none at all (`kind: 'added'`). Read off the probe's JSON,
+   * so `'id' in entry` is a real question about the payload rather than about a
+   * TypeScript type. */
+  getPools(): PoolEntry[] {
     const el = container.queryByTestId('pools-probe')
-    return el ? (JSON.parse(el.textContent || '[]') as Pool[]) : []
+    return el ? (JSON.parse(el.textContent || '[]') as PoolEntry[]) : []
   },
   /** The double-booking warning. Addressed by testid rather than by `role="alert"`:
    * the freeze notice is an `Alert` too, and an event can be both frozen and

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.test.tsx
@@ -2,6 +2,7 @@ import userEvent from '@testing-library/user-event'
 
 import { fireEvent, screen } from '@/test/utilities'
 
+import { poolEntryKey } from '../../data/pool-entries'
 import {
   buildDrawnEvent,
   buildEvent,
@@ -88,7 +89,7 @@ describe('PoolsSection', () => {
       await userEvent.click(poolsSectionPage.getRemovePoolButtons()[0])
       const remaining = poolsSectionPage.getPools()
       expect(remaining).toHaveLength(1)
-      expect(remaining[0].id).toBe('p-2')
+      expect(remaining[0]).toMatchObject({ kind: 'kept', id: 'p-2' })
     })
   })
 
@@ -148,43 +149,152 @@ describe('PoolsSection', () => {
       expect(poolsSectionPage.getPools().map((p) => p.name)).toEqual(
         TEN_POOLS_BY_POSITION,
       )
-      expect(poolsSectionPage.getPools().map((p) => p.position)).toEqual([
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-      ])
+      // …and every one of them CITES the id the server minted (ADR 20260801). An entry
+      // that arrived as an `added` would be an insert, and the pool it stopped citing a
+      // removal — a no-op edit that silently replaced ten pools with ten new ones and
+      // took the draw dealt across them with it.
+      expect(poolsSectionPage.getPools().map((p) => p.kind)).toEqual(
+        Array(10).fill('kept'),
+      )
+      expect(poolsSectionPage.getPools().map((p) => poolEntryKey(p))).toEqual(
+        buildTenPools()
+          .sort((a, b) => a.position - b.position)
+          .map((p) => p.id),
+      )
     })
 
-    it('gives a pool added at the end the NEXT position, never a reused one', async () => {
+    /**
+     * **The order is now the only thing that says where a pool sits**, so a pool added
+     * at the end has to *be* at the end: the server derives each position from the index
+     * of the entry in the list it is sent (`PoolWrite` has no `position` — sending one is
+     * a 422 naming the field), and the array the editor serializes is this one.
+     *
+     * Ten pools, so "last" cannot be confused with anything else, and the removal case
+     * below is the one the old client-side position arithmetic got wrong.
+     */
+    it('appends an added pool at the END, with no id and no position', async () => {
       poolsSectionPage.render({ event: buildEvent({ pools: buildTenPools() }) })
 
       await userEvent.click(poolsSectionPage.getAddPoolButton())
 
-      const positions = poolsSectionPage.getPools().map((p) => p.position)
-      expect(positions).toHaveLength(11)
-      // 10 — one past the highest, and NOT a duplicate of any pool already there. (It is
-      // also the count here, which is why the interesting case is the one below.)
-      expect(positions.at(-1)).toBe(10)
-      expect(new Set(positions).size).toBe(11)
+      const pools = poolsSectionPage.getPools()
+      expect(pools).toHaveLength(11)
+      expect(pools.at(-1)?.kind).toBe('added')
+      // Structurally impossible to hold an id, and asserted on the JSON anyway: this is
+      // the claim the whole chore is about, and a key that came back as `undefined`
+      // would satisfy a value assertion while still being a key on the wire.
+      expect(pools.at(-1) && 'id' in pools.at(-1)!).toBe(false)
+      expect(pools.at(-1) && 'position' in pools.at(-1)!).toBe(false)
+      // The ten it joined are untouched — same ids, same order.
+      expect(pools.slice(0, 10).map((p) => p.kind)).toEqual(Array(10).fill('kept'))
     })
 
     /**
-     * The case the count and the next position part company: remove a pool from the
-     * MIDDLE, then add one. Ten pools minus one is nine, so `fields.length` would hand
-     * the newcomer position 9 — which pool 10 already holds. Two pools tied for last is
-     * an order that is no order, and it would show up as a pair of cards swapping places
-     * on the next read.
+     * Remove a pool from the MIDDLE, then add one. This is where the client's own
+     * position arithmetic used to matter (ten pools minus one is nine, so a
+     * count-derived position would have handed the newcomer a `9` that pool 10 already
+     * held) — and where it now matters that there is none: what is sent is nine cited
+     * pools in their director-chosen order, then one id-less entry, and the server reads
+     * the positions off that.
      */
-    it('does not reuse a position freed by removing a pool from the middle', async () => {
+    it('keeps the surviving pools cited, in order, with the newcomer last', async () => {
       poolsSectionPage.render({ event: buildEvent({ pools: buildTenPools() }) })
 
       // The third card is Pool 3 (position 2).
       await userEvent.click(poolsSectionPage.getRemovePoolButtons()[2])
       await userEvent.click(poolsSectionPage.getAddPoolButton())
 
-      const positions = poolsSectionPage.getPools().map((p) => p.position)
-      expect(positions).toEqual([0, 1, 3, 4, 5, 6, 7, 8, 9, 10])
-      // Nine pools were left, so the default name is the tenth letter — the naming and
-      // the positioning are independent, and only the positioning is load-bearing.
-      expect(poolsSectionPage.getPoolNames().at(-1)).toBe('Pool J')
+      const pools = poolsSectionPage.getPools()
+      expect(pools.map((p) => p.name)).toEqual([
+        'Pool 1',
+        'Pool 2',
+        'Pool 4',
+        'Pool 5',
+        'Pool 6',
+        'Pool 7',
+        'Pool 8',
+        'Pool 9',
+        'Pool 10',
+        // Nine pools were left, so the default name is the tenth letter — the naming and
+        // the diff are independent, and only the diff is load-bearing.
+        'Pool J',
+      ])
+      expect(pools.map((p) => p.kind)).toEqual([
+        ...Array(9).fill('kept'),
+        'added',
+      ])
+      // Pool 3 is simply gone from the payload — an uncited stored pool is what a
+      // removal IS on the wire (ADR 20260801), never a flag or a tombstone.
+      expect(pools.map((p) => p.name)).not.toContain('Pool 3')
+    })
+  })
+
+  /**
+   * The two things a pools save must get right about identity, asserted on the form
+   * state the save serializes.
+   *
+   * They are opposite failures and both are silent: an added pool that carried an id
+   * would be a 422 (`extra_forbidden` on `body.pools[i].id`) or — before the ids moved
+   * server-side — a duplicate, and a stored pool that lost one would be read as a
+   * removal, taking every fixture dealt into it.
+   */
+  describe('who owns a pool id', () => {
+    it('adds a pool with NO id — the server mints it', async () => {
+      poolsSectionPage.render({ event: buildEvent({ pools: [buildPool()] }) })
+
+      await userEvent.click(poolsSectionPage.getAddPoolButton())
+
+      const [kept, added] = poolsSectionPage.getPools()
+      expect(kept).toMatchObject({ kind: 'kept', id: 'p-1' })
+      expect(added.kind).toBe('added')
+      expect('id' in added).toBe(false)
+    })
+
+    // …and the other half: editing a stored pool re-words it, it does not re-create it.
+    // Every field the card can touch is exercised, because the card hands its whole draft
+    // back through one `onChange` — a mapper that rebuilt the entry from that draft would
+    // drop the id on the FIRST keystroke, whichever box it was in.
+    it('keeps a stored pool’s id through a rename, a re-window and a re-table', async () => {
+      poolsSectionPage.render({ event: buildEvent({ pools: [buildPool()] }) })
+
+      fireEvent.change(poolsSectionPage.getNameInput(), {
+        target: { value: 'Morning Pool' },
+      })
+      fireEvent.change(screen.getByLabelText('Start'), {
+        target: { value: '10:30' },
+      })
+      await userEvent.click(poolsSectionPage.getTableToggle('T9'))
+
+      expect(poolsSectionPage.getPools()).toEqual([
+        {
+          kind: 'kept',
+          id: 'p-1',
+          name: 'Morning Pool',
+          slot: { date: '2026-06-13', start: '10:30', end: '12:30' },
+          tableIds: ['t1', 't2', 't3', 't4', 't9'],
+        },
+      ])
+    })
+
+    /** A card is handed a `PoolDraft` — three fields — so the arm and the id are not
+     * values it can reach, let alone change. Proved by editing an ADDED pool, the case
+     * where a leaked identity would be a client-authored id: it stays id-less. */
+    it('cannot promote an added pool into a kept one by editing it', async () => {
+      // An event with no pools yet, so the one card on screen after the click is the
+      // added one and the card-scoped name box addresses it. (`getAddPoolButton` matches
+      // both the header's button and the empty state's, so the empty state's is named.)
+      poolsSectionPage.render({ event: buildEvent({ pools: [] }) })
+
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Add first pool' }),
+      )
+      fireEvent.change(poolsSectionPage.getNameInput(), {
+        target: { value: 'Pool Zero' },
+      })
+
+      const [added] = poolsSectionPage.getPools()
+      expect(added).toMatchObject({ kind: 'added', name: 'Pool Zero' })
+      expect('id' in added).toBe(false)
     })
   })
 
@@ -277,13 +387,15 @@ describe('PoolsSection', () => {
       expect(poolsSectionPage.getPools()[0].slot.start).toBe('10:30')
 
       // And the display name is only a display name — identity lives in the `id`, which
-      // no control here can touch, so every fixture still resolves.
+      // no control here can touch, so every fixture still resolves. (The card is handed
+      // three fields and the id is not one of them, which is what makes that structural
+      // rather than merely true today.)
       fireEvent.change(poolsSectionPage.getNameInput(), {
         target: { value: 'Morning Pool' },
       })
       const [pool] = poolsSectionPage.getPools()
       expect(pool.name).toBe('Morning Pool')
-      expect(pool.id).toBe('p-1')
+      expect(pool).toMatchObject({ kind: 'kept', id: 'p-1' })
 
       // None of which added or removed a pool.
       expect(poolsSectionPage.getPools()).toHaveLength(1)

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
@@ -6,8 +6,9 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 
 import type { EditFreeze } from '../../data/draw'
-import { findPoolConflicts, genId, nextPoolPosition } from '../../data/helpers'
-import type { Pool, TournamentTable } from '../../data/types'
+import { findPoolConflicts } from '../../data/helpers'
+import { addedPool, poolEntryKey } from '../../data/pool-entries'
+import type { PoolEntry, TournamentTable } from '../../data/types'
 import { EmptyState } from '../../empty-state'
 import type { EventFormValues } from '../event-form'
 import { SectionHeader } from '../section-header'
@@ -27,8 +28,11 @@ export interface PoolsSectionProps {
   /** Whether the event's **set of pools** may still change (`poolSetFreeze`,
    * `data/draw`). Frozen once its draw is cut — see the component doc below. */
   freeze: EditFreeze
-  /** What is wrong with each pool's **name**, keyed by pool id (`poolNameIssues`,
-   * `data/event-validation`) — rendered in red under the box it is about.
+  /** What is wrong with each pool's **name**, keyed by `poolEntryKey`
+   * (`poolNameIssues`, `data/event-validation`) — rendered in red under the box it is
+   * about. The key is the server's id for a stored pool and the card key for one the
+   * director has just added, which is the same thing the cards themselves are keyed on:
+   * a pool with no id yet still has a name box, and it can still be emptied.
    *
    * `undefined` is *"do not say anything yet"*, and it is what the editor passes until
    * the organizer has actually pressed Save: a name box they are halfway through
@@ -70,8 +74,9 @@ export interface PoolsSectionProps {
  * ## A pool is *called* something
  *
  * The name box being live is also the one way this editor can author a pool the server
- * refuses: an id and a default name are **minted** (`addPool`), but an emptied name box
- * is a `min_length=1` 422 (`Pool.name`, `api/app/schemas/tournament.py`). So the rule is
+ * refuses: a default name is **minted** (`addPool`) — the id is the server's, and this
+ * editor authors none — but an emptied name box is a `min_length=1` 422 (`PoolWrite.name`,
+ * `api/app/schemas/tournament.py`). So the rule is
  * mirrored client-side (`poolNameSchema`) and its verdict arrives here as `nameIssues`,
  * in red, under the box — and the save is refused in the form, which is what means
  * Pydantic's prose never reaches anybody.
@@ -87,9 +92,11 @@ export const PoolsSection = ({
   // `aria-describedby`: one explanation, in one place, said once.
   const freezeNoticeId = useId()
   const frozen = freeze.kind === 'frozen'
-  // `keyName: 'rhfKey'` keeps the field array's internal key off our domain
-  // `id`, so a card is keyed on the stable `id` and an in-place `update`
-  // re-renders it rather than remounting it (which would drop input focus).
+  // `keyName: 'rhfKey'` keeps the field array's internal key off our own fields — and
+  // the cards are NOT keyed on it, because `update()` regenerates it for the row it
+  // touches, which would remount the card the director is typing in and drop their
+  // cursor. They are keyed on `poolEntryKey` instead: the server's id for a stored pool,
+  // the card key for one that has just been added.
   const { fields, append, remove, update } = useFieldArray({
     control,
     name: 'pools',
@@ -102,21 +109,22 @@ export const PoolsSection = ({
   // window. Watched, so changing it on the Basics tab relabels the pools live.
   const timezone = useWatch({ control, name: 'timezone' })
 
-  // Clean domain pools (no `rhfKey`) for the conflict check and the cards, so an
-  // edit never writes the field array's internal key back into form state.
+  // Clean domain entries (no `rhfKey`) for the conflict check and the cards, so an
+  // edit never writes the field array's internal key back into form state. Rebuilt
+  // per arm rather than spread, so an entry cannot pick up a field its arm does not
+  // have — an `added` pool that grew an `id` would be the 422 this union exists to
+  // prevent.
   //
   // NOT re-sorted here. The field array arrived in position order (`eventToFormValues`
   // seeds it that way) and its order is the director's, kept across every add and remove
-  // — and it is the order a save puts on the wire, from which the server re-derives the
+  // — and it is the order a save puts on the wire, from which the server derives the
   // positions. Sorting the *render* while `update(i, …)` / `remove(i)` still addressed
   // the underlying array by index would edit the wrong card.
-  const pools: Pool[] = fields.map((f) => ({
-    id: f.id,
-    name: f.name,
-    slot: f.slot,
-    tableIds: f.tableIds,
-    position: f.position,
-  }))
+  const pools: PoolEntry[] = fields.map((f) =>
+    f.kind === 'kept'
+      ? { kind: 'kept', id: f.id, name: f.name, slot: f.slot, tableIds: f.tableIds }
+      : { kind: 'added', key: f.key, name: f.name, slot: f.slot, tableIds: f.tableIds },
+  )
 
   // Double-booking is a diagnostic only the organizer can act on, so a viewer
   // is neither shown it nor pays to compute it.
@@ -125,20 +133,23 @@ export const PoolsSection = ({
   // several overlapping pools yields multiple conflict entries.
   const conflictTableCount = new Set(conflicts.map((c) => c.table)).size
 
+  // A pool the server has never seen: a default name, the event's window, no tables —
+  // and, pointedly, **no id** (`addedPool`, `data/pool-entries`). The id is minted by the
+  // server when this entry reaches it with none (ADR 20260801); an id authored here would
+  // be a 422 naming this very entry, and before the ids moved server-side it was worse
+  // than that — the client's id was accepted, so a name collision was a silent identity
+  // swap.
+  //
+  // It joins at the END, which is where `append` puts it and where the server will
+  // therefore position it: the array order is the pool order, and nothing else is.
   const addPool = () =>
-    append({
-      id: genId('p'),
-      name: `Pool ${String.fromCharCode(65 + fields.length)}`,
-      slot: { ...eventSlot },
-      tableIds: [],
-      // One past the highest position in the list, never `fields.length` — the two part
-      // company as soon as a pool is removed from the middle, and a duplicate position is
-      // an order that is no order (`nextPoolPosition`, `data/helpers`). A new pool joins
-      // at the END, which is also where `append` puts it, so the array order and the
-      // positions agree — and they must, because the array order is what the save sends
-      // and the positions are what the next read comes back sorted by.
-      position: nextPoolPosition(pools),
-    })
+    append(
+      addedPool({
+        name: `Pool ${String.fromCharCode(65 + fields.length)}`,
+        slot: { ...eventSlot },
+        tableIds: [],
+      }),
+    )
 
   return (
     <div className="flex flex-col gap-4" data-testid="pools-section">
@@ -235,10 +246,14 @@ export const PoolsSection = ({
         />
       ) : (
         <div className="flex flex-col gap-3">
-          {fields.map((field, i) => (
+          {pools.map((entry, i) => (
             <PoolCard
-              key={field.id}
-              pool={pools[i]}
+              // The server's id, or the card key of a pool it has never seen — never the
+              // field array's `rhfKey`, which `update()` regenerates on the row being
+              // edited (a remount mid-keystroke), and never the index, which renumbers
+              // when a card above is removed.
+              key={poolEntryKey(entry)}
+              pool={entry}
               tables={tables}
               timezone={timezone ?? ''}
               canEdit={canEdit}
@@ -253,8 +268,13 @@ export const PoolsSection = ({
               // The one thing on this card the organizer can *clear* — and the server
               // now refuses a pool with no name (`min_length=1`). The card says so under
               // the box; the save never leaves the room.
-              nameError={nameIssues?.[pools[i].id]}
-              onChange={(np) => update(i, np)}
+              nameError={nameIssues?.[poolEntryKey(entry)]}
+              // The card hands back a `PoolDraft` — the three fields it can edit — and
+              // the entry's identity is re-attached HERE, from the entry that is already
+              // in form state. That is what makes it structurally impossible for a card
+              // to promote an added pool into a kept one (or the reverse): it never sees
+              // the arm, so it cannot change it.
+              onChange={(draft) => update(i, { ...entry, ...draft })}
               onRemove={() => remove(i)}
             />
           ))}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section/pool-card.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 
 import { fmtDate } from '../../../data/helpers'
-import type { Pool, TournamentTable } from '../../../data/types'
+import type { PoolDraft, TournamentTable } from '../../../data/types'
 import { Field } from '../../../field'
 import { ReadOnlyValue } from '../../../read-only-value'
 
@@ -30,7 +30,12 @@ export type PoolRemoval =
   | { kind: 'frozen'; reasonId: string }
 
 export interface PoolCardProps {
-  pool: Pool
+  /** The three fields this card can edit — a `PoolDraft`, never a whole `Pool`
+   * (`data/types`). The identity is deliberately out of reach: an id is the server's to
+   * mint (ADR 20260801) and a `position` is the server's to assign, so a card that could
+   * not see either is a card that cannot author either. Its owner re-attaches the entry's
+   * arm around what comes back through `onChange`. */
+  pool: PoolDraft
   /** The tables available to this tournament. */
   tables: TournamentTable[]
   /** The event's IANA timezone (ADR 20260719) — the frame this pool's wall-clock
@@ -54,7 +59,7 @@ export interface PoolCardProps {
    * because the sentence is the schema's: one rule, one wording, said wherever it is
    * shown. A viewer never sees it — a read-only card has no box to clear. */
   nameError?: string
-  onChange: (pool: Pool) => void
+  onChange: (pool: PoolDraft) => void
   onRemove: () => void
 }
 
@@ -103,7 +108,10 @@ const TableCount = ({ count }: { count: number }) => (
  *
  * An empty string is what `ReadOnlyValue` treats as unset — a pool that reserves
  * nothing renders as an em-dash, not as a blank. */
-const reservedTableLabels = (pool: Pool, tables: TournamentTable[]): string =>
+const reservedTableLabels = (
+  pool: PoolDraft,
+  tables: TournamentTable[],
+): string =>
   tables
     .filter((t) => pool.tableIds.includes(t.id))
     .map((t) => t.label)
@@ -128,12 +136,23 @@ export const PoolCard = ({
   // screen reader.
   const nameErrorId = useId()
 
-  const setSlot = (patch: Partial<Pool['slot']>) =>
-    onChange({ ...pool, slot: { ...pool.slot, ...patch } })
+  /** Hand back the three fields this card owns, with one of them changed — rebuilt by
+   * name rather than spread from `pool`, so nothing the *caller* happened to pass in
+   * (the arm and id of a `PoolEntry`, say) can make the return trip through here. The
+   * card edits a pool's words; who that pool is stays with the section. */
+  const change = (patch: Partial<PoolDraft>) =>
+    onChange({
+      name: pool.name,
+      slot: pool.slot,
+      tableIds: pool.tableIds,
+      ...patch,
+    })
+
+  const setSlot = (patch: Partial<PoolDraft['slot']>) =>
+    change({ slot: { ...pool.slot, ...patch } })
 
   const toggleTable = (id: string) =>
-    onChange({
-      ...pool,
+    change({
       tableIds: pool.tableIds.includes(id)
         ? pool.tableIds.filter((x) => x !== id)
         : [...pool.tableIds, id],
@@ -194,7 +213,7 @@ export const PoolCard = ({
           <Input
             aria-label="Pool name"
             value={pool.name}
-            onChange={(e) => onChange({ ...pool, name: e.target.value })}
+            onChange={(e) => change({ name: e.target.value })}
             aria-invalid={!!nameError}
             aria-describedby={nameError ? nameErrorId : undefined}
             className={cn(

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
@@ -12,9 +12,10 @@ import {
 } from '../data/event-validation'
 import { browserTimezone, poolsInOrder } from '../data/helpers'
 import { PRED_OPS_BY_TYPE, type PredicateOp } from '../data/options'
+import { keepPools } from '../data/pool-entries'
 import { eligibilityIssues } from '../data/predicate-validation'
 import type {
-  Pool,
+  PoolEntry,
   Predicate,
   PredicateValue,
   TournamentEvent,
@@ -73,27 +74,43 @@ const predicateSchema: z.ZodType<Predicate, Predicate> = z.object({
   value: predicateValueSchema,
 })
 
-/** A table pool — its name, its window, and the tables it reserves. Typed as the
- * domain's `Pool` for the same reason `predicateSchema` is: the pool cards hand a
- * form field back as a `Pool`, and a mirror that is merely *similar* would need a
- * cast to cross that seam.
+/** The three fields of a pool a director actually types — the `PoolDraft` both arms of
+ * `poolEntrySchema` carry, spelled once so the two arms cannot drift into disagreeing
+ * about what a pool *is*.
  *
  * `name` carries the server's floor (`poolNameSchema`, `data/event-validation`) — the
- * one field of a pool the organizer can *clear*. Its `id` is minted and boxless, so it
- * is left alone: see the note on `poolNameSchema`.
- *
- * `position` is here because it is part of a `Pool` and the form holds whole pools, not
- * because there is anything to check: it has no box either, it is the SERVER's to assign
- * (`eventPoolsToApi`, `data/api` — a `position` on a write body is a 422), and the value
- * the form carries is only what keeps the cards in the order the director left them in
- * until the next read. So the rule is a shape, not a floor. */
-const poolSchema: z.ZodType<Pool, Pool> = z.object({
-  id: z.string(),
+ * one field of a pool the organizer can *clear*, and a `min_length=1` 422 if they do. */
+const POOL_DRAFT_FIELDS = {
   name: poolNameSchema,
   slot: slotSchema,
   tableIds: z.array(z.string()),
-  position: z.number().int().nonnegative(),
-})
+}
+
+/**
+ * One pool of the edited event — the domain's `PoolEntry` (`data/types`), which is a
+ * **tagged union and not a pool with an optional id**, because the editor is building an
+ * id-keyed diff (ADR 20260801):
+ *
+ * - `kept` cites the uuid the server minted, so the pool keeps its identity and the
+ *   fixtures dealt into it;
+ * - `added` has no `id` field at all, so a client-minted one is not a value this form can
+ *   hold. That absence is the whole chore: `PoolWrite` is `extra="forbid"`, so an `id` on
+ *   a new pool is a 422 naming it.
+ *
+ * There is no `position` on either arm, for the same reason there is no id on one of
+ * them: it is the SERVER's to assign, from the index of each entry in the list that is
+ * sent (`poolEntriesToApi`, `data/api` — a `position` on a write body is a 422). **The
+ * order of the field array IS the ordering**, which is why `eventToFormValues` seeds it
+ * in position order below.
+ *
+ * Typed as `PoolEntry` for the same reason `predicateSchema` is typed as `Predicate`:
+ * the pools section hands a form field straight back as one, and a mirror that were
+ * merely *similar* would need a cast to cross that seam.
+ */
+const poolEntrySchema: z.ZodType<PoolEntry, PoolEntry> = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('kept'), id: z.string(), ...POOL_DRAFT_FIELDS }),
+  z.object({ kind: z.literal('added'), key: z.string(), ...POOL_DRAFT_FIELDS }),
+])
 
 /**
  * The one schema the editor's `zodResolver` runs — the whole event, scalars and
@@ -113,8 +130,9 @@ const poolSchema: z.ZodType<Pool, Pool> = z.object({
  *   half-written rule than the product is (it accepts `Rating < ?`, a restriction on
  *   nobody, and renders it on the card as though it were real).
  * - `pools` carries the newest of the server's floors: a pool's `name` may not be
- *   blank (`poolNameSchema`). The pools editor mints the id and the default name, so
- *   only the *box* could ever author one — and it did.
+ *   blank (`poolNameSchema`). The pools editor mints the default name, so only the *box*
+ *   could ever author a blank one — and it did. (The id it no longer mints at all; see
+ *   `poolEntrySchema`.)
  */
 export const eventSchema = z.object({
   name: nameSchema,
@@ -166,7 +184,7 @@ export const eventSchema = z.object({
       message: 'Every rule needs a value the server can evaluate.',
     })
   }),
-  pools: z.array(poolSchema),
+  pools: z.array(poolEntrySchema),
 })
   // The **draw configuration** is judged as a pair, because that is what it is: the
   // server parses `(draw_type, qualifiers_per_pool)` into a union tagged by the draw
@@ -194,9 +212,9 @@ export const eventSchema = z.object({
     })
   })
 
-// The schema mirrors the domain types (`Predicate`, `Pool`) so the nested-array
+// The schema mirrors the domain types (`Predicate`, `PoolEntry`) so the nested-array
 // sub-forms are validated by this one resolver; the section code that rebuilds a
-// clean `Predicate`/`Pool` from each `useFieldArray` field is the compile-time
+// clean `Predicate`/`PoolEntry` from each `useFieldArray` field is the compile-time
 // check that the mirror holds.
 export type EventFormValues = z.infer<typeof eventSchema>
 
@@ -243,16 +261,24 @@ export function eventToFormValues(event: TournamentEvent | null): EventFormValue
     slot: event.slot,
     match: event.match,
     predicates: event.predicates,
-    // **In POSITION order** (`poolsInOrder`, `data/helpers`), and this is the ONE place
+    // Every stored pool, **cited by the id the server minted** (`keepPools`,
+    // `data/pool-entries`) — the "change nothing about the set" diff the organizer then
+    // edits by adding to it, removing from it, or re-wording it. Seeding it any other way
+    // would be seeding a removal: under an id-keyed diff, a stored pool no entry cites is
+    // deleted, and its fixtures with it.
+    //
+    // …and **in POSITION order** (`poolsInOrder`, `data/helpers`), which is the ONE place
     // the pools editor's order is decided. From here on the field array's order IS the
     // order: the cards render in it, `addPool` appends to the end of it, and — the reason
     // it has to be settled here rather than at render time — a save serializes it, from
-    // which the server re-derives each pool's position (`eventPoolsToApi`, `data/api`).
+    // which the server re-derives each pool's position (`poolEntriesToApi`, `data/api`).
+    // The sort is the last thing that reads `position`; an entry does not carry one,
+    // because a client does not assign one.
     //
     // So sorting for *display* alone would be a bug with a delay on it: the director
     // would see A, B, C, save, and get back whatever order the array was really in. The
     // list they were looking at has to be the list that goes on the wire.
-    pools: poolsInOrder(event.pools),
+    pools: keepPools(poolsInOrder(event.pools)),
   }
 }
 

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
@@ -53,7 +53,7 @@ describe('DrawPanel', () => {
      * **Ten pools read 1 … 10, top to bottom** — the bug `Pool.position` was added to
      * kill, at the surface it was actually seen on.
      *
-     * Pool ids are minted client-side (`genId('p')`), so a ten-pool event holds
+     * Pool ids used to be minted client-side (`genId('p')`), so a ten-pool event held
      * `p-1-…` … `p-10-…`; sorted as strings `p-10-` lands between `p-1-` and `p-2-` and
      * the draw rendered **1, 10, 2, 3 …**. The fixture hands the panel its pools in that
      * very order (`buildTenPools`), so the assertion reds for a panel that sorts by id

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -6,7 +6,6 @@ import {
   type RatingRange,
 } from '@/api/players'
 import type { components } from '@/api/schema'
-import { conjoinWithAnd } from '@/components/tournaments/data/helpers'
 import { healthCheck, player, sessionResponse } from '@/test/factories'
 import {
   FORTYMM_LEAGUE_ID,
@@ -54,6 +53,7 @@ import {
   enterEvent as enterTournamentEvent,
   findTournament,
   listTournaments,
+  namedList,
   type NearMeFilter,
   placeFixture as placeTournamentFixture,
   requestScheduleSolve as requestTournamentScheduleSolve,
@@ -1108,9 +1108,8 @@ function validateEventBody(
     if (duplicated.length > 0) {
       const ids = [...new Set(duplicated)]
       return detail(
-        `A pool id identifies one pool: ${conjoinWithAnd(
-          ids.map((id) => `“${id}”`),
-        )} ${ids.length === 1 ? 'is' : 'are'} cited by more than one entry of this ` +
+        `A pool id identifies one pool: ${namedList(ids)} ` +
+          `${ids.length === 1 ? 'is' : 'are'} cited by more than one entry of this ` +
           "event's pools. Cite each pool you are keeping exactly once, and omit the id " +
           'of a pool you are adding.',
         422,

--- a/web-client/src/mocks/handlers.ts
+++ b/web-client/src/mocks/handlers.ts
@@ -6,6 +6,7 @@ import {
   type RatingRange,
 } from '@/api/players'
 import type { components } from '@/api/schema'
+import { conjoinWithAnd } from '@/components/tournaments/data/helpers'
 import { healthCheck, player, sessionResponse } from '@/test/factories'
 import {
   FORTYMM_LEAGUE_ID,
@@ -1076,30 +1077,42 @@ function validateEventBody(
       return detail('Entry fee can’t be negative.', 422)
     }
   }
-  // A pool id IDENTIFIES a pool, and a fixture names its pool by that string (ADR-0786).
-  // Two pools sharing one id is a payload the interior cannot hold: the cut deals onto
-  // the same `(event_id, pool_id, round, position)` twice and the fixture table's unique
-  // index fires — a **500** (`_pool_ids_are_unique`, `api/app/schemas/tournament.py`).
+  // A pool id IDENTIFIES a pool, and a fixture names the pool it was dealt into
+  // (ADR-0786). Two ENTRIES citing one id is a payload the interior cannot hold: the
+  // write is an id-keyed diff (`applyEventPools`), so both entries resolve onto the one
+  // stored pool and the payload is accepted as a single-pool event rather than refused as
+  // the two-pool one it claims to be (`_pool_ids_are_unique`,
+  // `api/app/schemas/tournament.py`).
   //
   // It lives HERE, at the mock's boundary rather than in the store's freeze, for the two
   // reasons the server's validator does:
   //  • it is a 422 in *every* state the event could be in — an event with no draw at all
-  //    still cannot have two pools called `p-a`;
-  //  • and the PATCH path is the worse of the two, because the pool-set freeze compares
-  //    SETS: `[A, A, B]` against a cut event holding `{A, B}` is the same set, so the
-  //    freeze waves it through and the next cut dies. The guard that protects the draw
-  //    was admitting the payload that poisons it.
-  if (body.pools !== undefined && body.pools !== null) {
+  //    still cannot cite one pool twice;
+  //  • and it is the PATCH path's rule, because the pool-set freeze compares SETS:
+  //    `[A, A, B]` against a cut event holding `{A, B}` is the same set, so the freeze
+  //    waves it through and the next cut dies. The guard that protects the draw was
+  //    admitting the payload that poisons it.
+  //
+  // **Entries with no `id` are ignored**: those are additions, and any number of pools may
+  // be added at once. The rule has no create-path twin and needs none — `PoolWrite` has no
+  // `id` at all (ADR 20260801), so "the patch path is the hole" is not a hole a create can
+  // have here.
+  if (body.pools != null) {
     const seen = new Set<string>()
     const duplicated = body.pools
-      .map((pool) => pool.id)
+      // `'id' in pool` is the narrowing, not a cast: the create shape declares no such
+      // key, so this is also where a `PoolWrite[]` body drops out of the rule entirely.
+      .map((pool) => ('id' in pool ? pool.id : null))
+      .filter((id): id is string => id != null)
       .filter((id) => (seen.has(id) ? true : (seen.add(id), false)))
     if (duplicated.length > 0) {
+      const ids = [...new Set(duplicated)]
       return detail(
-        `A pool id identifies one pool: ${[...new Set(duplicated)]
-          .map((id) => `“${id}”`)
-          .join(', ')} is used by more than one pool of this event. Give each pool an ` +
-          'id of its own.',
+        `A pool id identifies one pool: ${conjoinWithAnd(
+          ids.map((id) => `“${id}”`),
+        )} ${ids.length === 1 ? 'is' : 'are'} cited by more than one entry of this ` +
+          "event's pools. Cite each pool you are keeping exactly once, and omit the id " +
+          'of a pool you are adding.',
         422,
       )
     }
@@ -2158,10 +2171,29 @@ export const handlers = [
         body ?? {},
       )
       if (!result.ok) {
-        // The pool-set freeze (ADR-0786): this PATCH would add, remove or re-`id` a pool
-        // on an event whose draw is cut, orphaning the fixtures drawn into it. The
-        // store's sentence says so — and says how to get out of it.
+        // The pool-set freeze (ADR-0786): this PATCH would add or remove a pool on an
+        // event whose draw is cut, orphaning the fixtures drawn into it. The store's
+        // sentence says so — naming the pools — and says how to get out of it.
         if (result.status === 409) return detail(result.detail, 409)
+        // An entry citing an id this event does not have (ADR 20260801). Shaped as a
+        // **field** refusal — FastAPI's per-field array, `loc` naming the entry's index —
+        // because that is what the route really sends and what `validationFields`
+        // (`src/api/client.ts`) reads to blame the pool card.
+        if (result.status === 422) {
+          return HttpResponse.json(
+            {
+              detail: [
+                {
+                  type: 'value_error',
+                  loc: ['body', 'pools', result.index, 'id'],
+                  msg: result.detail,
+                  input: result.poolId,
+                },
+              ],
+            },
+            { status: 422 },
+          )
+        }
         return detail(
           result.status === 403
             ? 'Only the creator can edit this event.'

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -65,6 +65,14 @@ const CLOSED_PHRASE: Record<Exclude<TournamentStatus, 'published'>, string> = {
  * slot serves them all. */
 const SLOT = { date: '2026-06-14', start: '09:00', end: '12:00' }
 
+/** A v4 uuid, which is what a pool id is on the wire (`Pool.id` is `format: uuid`) now
+ * that the server mints it (ADR 20260801) — and what the store's own mint has to answer
+ * with, on the create path and on the patch path alike. Spelled out rather than merely
+ * "is a string", because "the id is missing" and "the id is the empty string" are exactly
+ * the two shapes a mint that quietly did nothing would leave behind. */
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
 const STATUSES: TournamentStatus[] = ['draft', 'published', 'live', 'archived']
 const CLOSED_STATUSES = ['draft', 'live', 'archived'] as const
 
@@ -608,23 +616,26 @@ describe('the rest of the event surface still holds', () => {
    * **The pool positions come from the array index, and nowhere else** — the store half
    * of the rule the editor and the draw panel both depend on.
    *
-   * `PoolWrite` has no `position` (it is `extra="forbid"`, so sending one is a 422), so
-   * the ORDER of the list is the only thing that says which pool is first. The server
-   * turns that order into numbers; if the mock did not, the app would look right in
-   * `npm run dev` while every pool came back tied for first — a mock/server disagreement
-   * about a rule the UI reads on every load.
+   * Neither write shape has a `position` (both are `extra="forbid"`, so sending one is a
+   * 422), so the ORDER of the list is the only thing that says which pool is first. The
+   * server turns that order into numbers; if the mock did not, the app would look right
+   * in `npm run dev` while every pool came back tied for first — a mock/server
+   * disagreement about a rule the UI reads on every load.
    *
-   * Ten pools, with ids whose lexicographic order is 1, 10, 2, 3 …, so a store that
-   * numbered them by id (or handed back a default `0`) cannot pass by coincidence.
+   * Ten of them, named `Pool 1`…`Pool 10` — a set whose lexicographic order is 1, 10, 2,
+   * 3 … — so a store that numbered them by name (or handed back a default `0`) cannot
+   * pass by coincidence. They carry **no id**: `PoolWrite` has none (ADR 20260801), and
+   * the ids the assertions below travel on are the ones the store minted.
    */
   const TEN_WRITE_POOLS = Array.from({ length: 10 }, (_, i) => ({
-    id: `p-${i + 1}-mkq1x`,
     name: `Pool ${i + 1}`,
     slot: SLOT,
     table_ids: [],
   }))
 
-  it('stamps a created event’s pools with the position of their index', () => {
+  /** Create the ten-pool event and hand back its pools **as read** — minted ids and
+   * all. */
+  function createTenPoolEvent() {
     const result = createEvent(TOURNAMENT, {
       name: 'Ten-pool Singles',
       format: 'singles',
@@ -636,25 +647,48 @@ describe('the rest of the event surface still holds', () => {
       pools: TEN_WRITE_POOLS,
     })
     if (!result.ok) throw new Error('create failed')
+    return result.event
+  }
 
-    expect(result.event.pools.map((p) => p.position)).toEqual([
+  it('stamps a created event’s pools with the position of their index', () => {
+    const event = createTenPoolEvent()
+
+    expect(event.pools.map((p) => p.position)).toEqual([
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
     ])
-    expect(result.event.pools.map((p) => p.name)).toEqual(
+    expect(event.pools.map((p) => p.name)).toEqual(
       TEN_WRITE_POOLS.map((p) => p.name),
     )
   })
 
-  // …and RE-stamps on every pools patch, because that is the whole reordering API:
-  // send them in the order you want and the positions follow.
+  // The create path has no id to send, so this is where the ids come from at all: the
+  // store mints one per pool (ADR 20260801), uuid-shaped and all different — the same
+  // thing `gen_random_uuid()` does on the server, and what every fixture drawn into a
+  // pool will hold.
+  it('mints a uuid id for every pool of a created event', () => {
+    const ids = createTenPoolEvent().pools.map((p) => p.id)
+
+    expect(new Set(ids).size).toBe(10)
+    for (const id of ids) expect(id).toMatch(UUID)
+  })
+
+  // …and RE-stamps on every pools patch, because that is the whole reordering API: send
+  // them in the order you want and the positions follow. The patch CITES the ids the
+  // create minted — that is what makes it a reorder of these ten pools rather than ten
+  // additions, and the ids travelling with the names is the proof.
   it('re-positions a patched event’s pools from the new order', () => {
-    const reversed = [...TEN_WRITE_POOLS].reverse()
-    const result = updateEvent(TOURNAMENT, EMPTY_SINGLES, { pools: reversed })
+    const created = createTenPoolEvent()
+    const reversed = [...created.pools]
+      .reverse()
+      .map((p) => ({ id: p.id, name: p.name, slot: p.slot, table_ids: p.table_ids }))
+
+    const result = updateEvent(TOURNAMENT, created.id, { pools: reversed })
     if (!result.ok) throw new Error('update failed')
 
     expect(result.event.pools.map((p) => p.name)).toEqual(
       reversed.map((p) => p.name),
     )
+    expect(result.event.pools.map((p) => p.id)).toEqual(reversed.map((p) => p.id))
     expect(result.event.pools.map((p) => p.position)).toEqual([
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
     ])
@@ -1055,9 +1089,10 @@ describe('cutting and un-cutting a draw', () => {
   const eventOf = (tournamentId: string, eventId: string) =>
     findTournament(tournamentId)!.events.find((e) => e.id === eventId)!
 
-  const poolNamed = (id: string) => ({
-    id,
-    name: id,
+  /** A pool to ADD, in a PATCH's own shape: no `id`, because a pool id is the server's
+   * to mint (ADR 20260801) and omitting one is how a payload says "add this pool". */
+  const poolNamed = (name: string) => ({
+    name,
     slot: SLOT,
     table_ids: [],
   })
@@ -1118,15 +1153,17 @@ describe('cutting and un-cutting a draw', () => {
     // pools of 5 + 4 (16 pairs) become one pool of 9 (36 pairs) — and the fixtures that
     // referred to the old pools are gone, not re-pointed.
     expect(uncutDraw(TOURNAMENT, ROUND_ROBIN).ok).toBe(true) // the freeze lifts first
-    updateEvent(TOURNAMENT, ROUND_ROBIN, { pools: [poolNamed('p-single')] })
+    updateEvent(TOURNAMENT, ROUND_ROBIN, { pools: [poolNamed('Pool One')] })
+    // The one pool the event now has — a freshly MINTED id, not a name the test chose,
+    // because the two old pools were dropped and this one was added.
+    const single = eventOf(TOURNAMENT, ROUND_ROBIN).pools.map((p) => p.id)
+    expect(single).toHaveLength(1)
 
     const result = cutDraw(TOURNAMENT, ROUND_ROBIN)
 
     if (!result.ok) throw new Error(`expected a cut, got ${result.status}`)
     expect(result.fixtures).toHaveLength(36) // C(9,2)
-    expect(new Set(result.fixtures.map((f) => f.pool_id))).toEqual(
-      new Set(['p-single']),
-    )
+    expect(new Set(result.fixtures.map((f) => f.pool_id))).toEqual(new Set(single))
   })
 
   it('un-cutting empties the draw; un-cutting again is still a success (idempotent DELETE)', () => {
@@ -1154,7 +1191,7 @@ describe('cutting and un-cutting a draw', () => {
     // so the mock must: a pool of one is not a competition.
     updateEvent(TOURNAMENT, EMPTY_SINGLES, {
       draw_type: 'round-robin',
-      pools: [poolNamed('p-1'), poolNamed('p-2'), poolNamed('p-3')],
+      pools: [poolNamed('Pool A'), poolNamed('Pool B'), poolNamed('Pool C')],
     })
     enterEvent(TOURNAMENT, EMPTY_SINGLES) // one entrant: the dev user
 
@@ -1383,7 +1420,9 @@ describe('cutting a round-robin-then-knockout draw', () => {
   const eventOf = (eventId: string) =>
     findTournament(TOURNAMENT)!.events.find((e) => e.id === eventId)!
 
-  const poolNamed = (id: string) => ({ id, name: id, slot: SLOT, table_ids: [] })
+  /** A pool to ADD: no `id`, which is how a PATCH says "add this one" now that the ids
+   * are the server's to mint (ADR 20260801). */
+  const poolNamed = (name: string) => ({ name, slot: SLOT, table_ids: [] })
 
   /** Re-type an event as two-stage, across `poolCount` pools, taking `qualifiers` out of
    * each. The draw type and the pool set both FREEZE while a draw stands (ADR-0786), so
@@ -1399,7 +1438,7 @@ describe('cutting a round-robin-then-knockout draw', () => {
     const patched = updateEvent(TOURNAMENT, eventId, {
       draw_type: 'rr-then-ko',
       qualifiers_per_pool: qualifiers,
-      pools: Array.from({ length: poolCount }, (_, i) => poolNamed(`p-${i + 1}`)),
+      pools: Array.from({ length: poolCount }, (_, i) => poolNamed(`Pool ${i + 1}`)),
     })
     if (!patched.ok) throw new Error(`could not re-type ${eventId}`)
   }
@@ -1692,10 +1731,15 @@ describe('the draw-type catalogue', () => {
 })
 
 // The pool-set FREEZE (ADR-0786): while a draw exists, an event's pools may change in
-// every way except identity. A fixture's `pool_id` is a string ref into this very JSONB
-// and there is no foreign key to stop a PATCH from orphaning it — "integrity is
-// procedural, not schematic" — so the procedure is here, in the mock, for the same
-// reason it is on the server.
+// every way except identity. A fixture names the pool it was dealt into, and removing
+// that pool leaves the fixture pointing at nothing — a refusal the composite foreign key
+// under `tournament_fixtures` would also make since ADR 20260801, but only at COMMIT and
+// only as a driver error, so the procedure is here (and there) to answer it as a 409 that
+// names the pools and the way out.
+//
+// **The freeze shrank when the ids were minted.** Re-identifying a pool is not one of the
+// things it refuses any more, because it is not a payload a client can send: an entry
+// either cites an id this event has or carries none at all.
 describe('the pool set freezes while a draw exists', () => {
   beforeEach(() => resetTournamentsStore())
 
@@ -1703,17 +1747,34 @@ describe('the pool set freezes while a draw exists', () => {
   const poolsOf = (eventId: string) =>
     findTournament(TOURNAMENT)!.events.find((e) => e.id === eventId)!.pools
 
-  it('refuses a PATCH that removes a pool the draw was dealt across', () => {
-    const [poolA] = poolsOf(ROUND_ROBIN)
+  /** A stored pool as a PATCH cites it: the id it was minted, and the words. The read
+   * shape's `position` is deliberately dropped — `PoolUpsert` is `extra="forbid"`, so a
+   * payload carrying one is a 422 at the server's boundary. */
+  const citing = (pool: ReturnType<typeof poolsOf>[number]) => ({
+    id: pool.id,
+    name: pool.name,
+    slot: pool.slot,
+    table_ids: pool.table_ids,
+  })
 
-    const result = updateEvent(TOURNAMENT, ROUND_ROBIN, { pools: [poolA] })
+  it('refuses a PATCH that removes a pool the draw was dealt across', () => {
+    const [poolA, poolB] = poolsOf(ROUND_ROBIN)
+
+    const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
+      pools: [citing(poolA)],
+    })
 
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.status).toBe(409)
+    if (result.status !== 409) return
+    // The refusal NAMES the pool that would go, because a director looking at a page of
+    // named pools cannot act on "a pool".
+    expect(result.detail).toContain(`“${poolB.name}”`)
+    expect(result.detail).toContain('already has fixtures drawn into it')
     // The sentence ends with the way OUT — remove the draw, change the pools, cut again
     // — because a refusal a director cannot act on is just a wall.
-    expect(result.status === 409 && result.detail).toContain('remove the draw first')
+    expect(result.detail).toContain('remove the draw first')
     // …and the pools are untouched: a refused write writes nothing.
     expect(poolsOf(ROUND_ROBIN)).toHaveLength(2)
   })
@@ -1722,11 +1783,15 @@ describe('the pool set freezes while a draw exists', () => {
     const pools = poolsOf(ROUND_ROBIN)
 
     const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
-      pools: [...pools, { id: 'p-new', name: 'Pool C', slot: SLOT, table_ids: [] }],
+      // No `id`: that IS the addition, now that a client cannot author one.
+      pools: [...pools.map(citing), { name: 'Pool C', slot: SLOT, table_ids: [] }],
     })
 
     expect(result.ok).toBe(false)
-    if (!result.ok) expect(result.status).toBe(409)
+    if (result.ok || result.status !== 409) throw new Error('expected a 409')
+    expect(result.detail).toContain('“Pool C”')
+    expect(result.detail).toContain('would arrive with no fixtures in it')
+    expect(poolsOf(ROUND_ROBIN)).toHaveLength(2)
   })
 
   // Only IDENTITY is frozen. A pool's tables and its window stay editable with a draw
@@ -1738,7 +1803,7 @@ describe('the pool set freezes while a draw exists', () => {
 
     const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
       pools: pools.map((p) => ({
-        ...p,
+        ...citing(p),
         name: `${p.name} (moved)`,
         table_ids: ['t9'],
         slot: SLOT,
@@ -1747,25 +1812,99 @@ describe('the pool set freezes while a draw exists', () => {
 
     expect(result.ok).toBe(true)
     expect(poolsOf(ROUND_ROBIN)[0].table_ids).toEqual(['t9'])
+    // The ids — and therefore every fixture drawn into them — survived the edit.
+    expect(poolsOf(ROUND_ROBIN).map((p) => p.id)).toEqual(pools.map((p) => p.id))
+  })
+
+  // …and a REORDER of the same pools is the same thing: the set is unchanged, so the
+  // freeze has nothing to say, and the positions follow the payload's order.
+  it('ALLOWS a reorder of exactly the pools the draw was cut across', () => {
+    const [poolA, poolB] = poolsOf(ROUND_ROBIN)
+
+    const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
+      pools: [citing(poolB), citing(poolA)],
+    })
+
+    expect(result.ok).toBe(true)
+    expect(poolsOf(ROUND_ROBIN).map((p) => p.id)).toEqual([poolB.id, poolA.id])
+    expect(poolsOf(ROUND_ROBIN).map((p) => p.position)).toEqual([0, 1])
   })
 
   it('leaves an UNDRAWN event’s pools wholesale-replaceable, as they have always been', () => {
     const result = updateEvent(TOURNAMENT, EMPTY_SINGLES, {
-      pools: [{ id: 'p-anything', name: 'A', slot: SLOT, table_ids: [] }],
+      pools: [{ name: 'A', slot: SLOT, table_ids: [] }],
     })
 
     expect(result.ok).toBe(true)
+    if (!result.ok) return
+    // The PATCH path mints too: an entry with no `id` is an addition, and the store hands
+    // it a uuid exactly as `gen_random_uuid()` would. Without this the pool would come
+    // back id-less — and every fixture later dealt into it would name nothing.
+    expect(result.event.pools).toHaveLength(1)
+    expect(result.event.pools[0].id).toMatch(UUID)
   })
 
   it('un-freezes the moment the draw is removed', () => {
+    const before = poolsOf(ROUND_ROBIN).map((p) => p.id)
     expect(uncutDraw(TOURNAMENT, ROUND_ROBIN).ok).toBe(true)
 
     const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
-      pools: [{ id: 'p-fresh', name: 'Pool A', slot: SLOT, table_ids: [] }],
+      pools: [{ name: 'Pool A', slot: SLOT, table_ids: [] }],
     })
 
     expect(result.ok).toBe(true)
-    expect(poolsOf(ROUND_ROBIN).map((p) => p.id)).toEqual(['p-fresh'])
+    const after = poolsOf(ROUND_ROBIN)
+    expect(after).toHaveLength(1)
+    // A brand-new pool, with a brand-new id: the two the draw was cut across are gone,
+    // and this one was MINTED rather than named by the payload.
+    expect(before).not.toContain(after[0].id)
+  })
+})
+
+// The diff's own refusal (ADR 20260801), and the reason it exists: a pool id is minted
+// here, so an id the store never minted names nothing. Quietly minting a pool for it
+// would hand the client back a different id than it asked for while *removing* the pool
+// it meant to keep — the two failures a diff must never confuse.
+describe('a pools PATCH citing an id the event does not have', () => {
+  beforeEach(() => resetTournamentsStore())
+
+  const ROUND_ROBIN = 'ev-u1200' // seeded WITH a draw
+  const eventOf = (eventId: string) =>
+    findTournament(TOURNAMENT)!.events.find((e) => e.id === eventId)!
+
+  const UNKNOWN = '11111111-2222-4333-8444-555555555555'
+
+  it('is a 422 naming the entry, and writes nothing', () => {
+    const before = eventOf(EMPTY_SINGLES).pools
+
+    const result = updateEvent(TOURNAMENT, EMPTY_SINGLES, {
+      pools: [
+        { name: 'Pool A', slot: SLOT, table_ids: [] },
+        { id: UNKNOWN, name: 'Pool B', slot: SLOT, table_ids: [] },
+      ],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok || result.status !== 422) throw new Error('expected a 422')
+    // The index is what lets the handler build `loc: ["body","pools",1,"id"]` — the pools
+    // are a list, and a refusal a client cannot attribute to a row it cannot render.
+    expect(result.index).toBe(1)
+    expect(result.poolId).toBe(UNKNOWN)
+    expect(result.detail).toBe('This event has no pool with that id.')
+    // Judged BEFORE anything is assigned: the id-less first entry was not minted either.
+    expect(eventOf(EMPTY_SINGLES).pools).toEqual(before)
+  })
+
+  // The ordering the server states out loud: the freeze runs first, so a cut event
+  // answers the 409 that names its pools rather than this 422. A cited-but-unknown id is
+  // an addition as far as a standing draw is concerned.
+  it('loses to the pool-set freeze on an event whose draw is cut', () => {
+    const result = updateEvent(TOURNAMENT, ROUND_ROBIN, {
+      pools: [{ id: UNKNOWN, name: 'Pool Z', slot: SLOT, table_ids: [] }],
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(409)
   })
 })
 

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -63,13 +63,17 @@ type TournamentTableWrite = components['schemas']['TournamentTableWrite']
  * means "this existing one". A stored table no entry names is removed. */
 type TournamentTableUpsert = components['schemas']['TournamentTableUpsert']
 type TournamentEntrantRead = components['schemas']['TournamentEntrantRead']
-/** The **read** pool — it carries `position`. Its write twin below deliberately does
- * not; see `positionPools`. */
+/** The **read** pool — it carries the `id` the server minted and the `position` it
+ * stamped. Its two write twins below deliberately carry neither; see `mintPool`. */
 type Pool = components['schemas']['Pool']
-/** A pool as a create/update body carries it: no `position`, because the server assigns
- * it from the pool's index in the list. `extra="forbid"`, so a `position` key on the way
- * in is a 422 that names the field. */
+/** A pool as a **create** body carries it: no `id` (the server mints it, ADR 20260801)
+ * and no `position` (the server assigns it from the pool's index in the list).
+ * `extra="forbid"`, so either key on the way in is a 422 that names the field. */
 type PoolWrite = components['schemas']['PoolWrite']
+/** A pool as a **PATCH** body carries it: the write shape plus an *optional* `id` naming
+ * a pool the event already has. Omitted means "add this one"; supplied means "this
+ * existing one". A stored pool no entry names is removed. */
+type PoolUpsert = components['schemas']['PoolUpsert']
 type ScheduleSolveRead = components['schemas']['ScheduleSolveRead']
 
 /** What the store actually holds for an event: everything the wire shape has
@@ -170,22 +174,36 @@ function otherEntrants(eventId: string, count: number): TournamentEntrantRead[] 
   }))
 }
 
+/** A seeded pool's id — a **uuid**, because that is what the wire says a pool id is
+ * (`Pool.id` is `format: uuid`, minted by the server: ADR 20260801), derived from a
+ * readable label so the seed stays greppable and the same tournament comes back the same
+ * on every reset.
+ *
+ * Not the mint below (`mintPool`): these rows are not created through a write verb, and
+ * routing them through the counter would make a seeded pool's id depend on how many
+ * pools the *previous* test happened to create. Distinct labels keep the two id spaces
+ * from ever colliding. */
+function seedPoolId(label: string): string {
+  return mockUuid(`tournament-event-pool:${label}`)
+}
+
 /** The two pools the seed's ONE drawn event is cut across (`ev-u1200` below). Pulled
  * out of the seed so the fixtures it is seeded with can be planned across the very same
- * pool ids: a fixture's `pool_id` is a string ref into its event's own `pools`
- * (ADR-0786 — not a foreign key, because pools are JSONB value-objects), so a seed that
- * spelled the ids twice could spell them differently, and every fixture would point at
- * a pool that does not exist. */
+ * pool ids: a fixture's `pool_id` names a pool of its own event (ADR-0786; a foreign key
+ * into `tournament_event_pools` since ADR 20260801), so a seed that spelled the ids
+ * twice could spell them differently, and every fixture would point at a pool that does
+ * not exist. Every reference below reads the id off this list rather than restating it,
+ * which is what makes that impossible rather than merely unlikely. */
 const U1200_POOLS: Pool[] = [
   {
-    id: 'p-u1200-a',
+    id: seedPoolId('u1200-a'),
     name: 'Pool A',
     slot: { date: '2026-06-14', start: '09:00', end: '10:30' },
     table_ids: ['t1', 't2'],
     position: 0,
   },
   {
-    id: 'p-u1200-b',
+    id: seedPoolId('u1200-b'),
     name: 'Pool B',
     slot: { date: '2026-06-14', start: '10:30', end: '12:00' },
     table_ids: ['t3', 't4'],
@@ -198,14 +216,14 @@ const U1200_POOLS: Pool[] = [
  * against these very ids, so they cannot be spelled twice and spelled differently. */
 const SLAM_POOLS: Pool[] = [
   {
-    id: 'p-slam-a',
+    id: seedPoolId('slam-a'),
     name: 'Pool A',
     slot: { date: '2026-08-22', start: '09:00', end: '11:00' },
     table_ids: ['t1', 't2'],
     position: 0,
   },
   {
-    id: 'p-slam-b',
+    id: seedPoolId('slam-b'),
     name: 'Pool B',
     slot: { date: '2026-08-22', start: '11:00', end: '13:00' },
     table_ids: ['t3', 't4'],
@@ -267,14 +285,14 @@ const shield = (n: number): string => SHIELD_ENTRY_IDS[n - 1]
  * spelled differently. */
 const CUP_POOLS: Pool[] = [
   {
-    id: 'p-cup-a',
+    id: seedPoolId('cup-a'),
     name: 'Pool A',
     slot: { date: '2026-06-06', start: '09:00', end: '11:00' },
     table_ids: ['t1', 't2'],
     position: 0,
   },
   {
-    id: 'p-cup-b',
+    id: seedPoolId('cup-b'),
     name: 'Pool B',
     slot: { date: '2026-06-06', start: '11:00', end: '13:00' },
     table_ids: ['t3', 't4'],
@@ -286,14 +304,14 @@ const CUP_POOLS: Pool[] = [
  * raises no double-booking diagnostic (`findPoolConflicts`). */
 const SHIELD_POOLS: Pool[] = [
   {
-    id: 'p-shield-a',
+    id: seedPoolId('shield-a'),
     name: 'Pool A',
     slot: { date: '2026-06-07', start: '09:00', end: '10:30' },
     table_ids: ['t5', 't6'],
     position: 0,
   },
   {
-    id: 'p-shield-b',
+    id: seedPoolId('shield-b'),
     name: 'Pool B',
     slot: { date: '2026-06-07', start: '10:30', end: '12:00' },
     table_ids: ['t7', 't8'],
@@ -674,16 +692,16 @@ function seed(): StoredTournament[] {
           // A still being played (`complete: false` — the table fills in as matches land),
           // Pool B decided. Multi-pool, so there is no single champion without a knockout
           // stage (a later slice) — `champion: null` even where a pool is done. The entry
-          // ids match this event's entrants (`entry-ev-u1200-N`) and its pool ids
-          // (`p-u1200-a/b`), so the name and pool joins land; the rows are in finishing
-          // order, which the client renders untouched.
+          // ids match this event's entrants (`entry-ev-u1200-N`) and its pool ids (read
+          // off `U1200_POOLS`, never respelled), so the name and pool joins land; the
+          // rows are in finishing order, which the client renders untouched.
           results: {
             kind: 'standings',
             complete: false,
             champion: null,
             pools: [
               {
-                pool_id: 'p-u1200-a',
+                pool_id: U1200_POOLS[0].id,
                 complete: false,
                 rows: [
                   { entry_id: 'entry-ev-u1200-1', rank: 1, played: 2, wins: 2, losses: 0, games_won: 4, games_lost: 1, game_difference: 3 },
@@ -694,7 +712,7 @@ function seed(): StoredTournament[] {
                 ],
               },
               {
-                pool_id: 'p-u1200-b',
+                pool_id: U1200_POOLS[1].id,
                 complete: true,
                 rows: [
                   { entry_id: 'entry-ev-u1200-2', rank: 1, played: 3, wins: 3, losses: 0, games_won: 6, games_lost: 2, game_difference: 4 },
@@ -1044,7 +1062,7 @@ function seed(): StoredTournament[] {
             champion: cup(2),
             pools: [
               {
-                pool_id: 'p-cup-a',
+                pool_id: CUP_POOLS[0].id,
                 complete: true,
                 rows: [
                   { entry_id: cup(5), rank: 1, played: 3, wins: 3, losses: 0, games_won: 6, games_lost: 1, game_difference: 5 },
@@ -1057,7 +1075,7 @@ function seed(): StoredTournament[] {
                 // Both of this pool's ties are broken by two-way head-to-head, so the
                 // rank column is NOT a re-reading of the wins column: `player.3` and
                 // `player.2` both went 2–1, and `player.3` won the match between them.
-                pool_id: 'p-cup-b',
+                pool_id: CUP_POOLS[1].id,
                 complete: true,
                 rows: [
                   { entry_id: cup(3), rank: 1, played: 3, wins: 2, losses: 1, games_won: 5, games_lost: 3, game_difference: 2 },
@@ -1126,7 +1144,7 @@ function seed(): StoredTournament[] {
               {
                 // A THREE-way tie — everyone 1–1 — which two-way head-to-head cannot
                 // break, so the order is game difference: +1, 0, −1.
-                pool_id: 'p-shield-a',
+                pool_id: SHIELD_POOLS[0].id,
                 complete: true,
                 rows: [
                   { entry_id: shield(1), rank: 1, played: 2, wins: 1, losses: 1, games_won: 3, games_lost: 2, game_difference: 1 },
@@ -1135,7 +1153,7 @@ function seed(): StoredTournament[] {
                 ],
               },
               {
-                pool_id: 'p-shield-b',
+                pool_id: SHIELD_POOLS[1].id,
                 complete: true,
                 rows: [
                   { entry_id: shield(2), rank: 1, played: 2, wins: 2, losses: 0, games_won: 4, games_lost: 1, game_difference: 3 },
@@ -1672,13 +1690,20 @@ export type StoreResult =
   | { ok: false; status: 422; index: number; tableId: string; detail: string }
 
 /** An event write fails four ways: 404 (no such tournament/event), 403 (not the
- * creator), and — on a PATCH that would move the pools out from under a cut draw — a
- * **409** carrying the server's sentence (ADR-0786's pool-set freeze; see
- * `poolSetFrozenDetail`). A create can never hit that 409: a new event has no draw. */
+ * creator), a **409** on a PATCH that would move the pools out from under a cut draw
+ * (ADR-0786's pool-set freeze; see `poolSetFrozenDetail`), and a **422** naming the
+ * `pools` entry that cited an id this event does not have (ADR 20260801's minted ids;
+ * see `applyEventPools`). A create can hit neither: a new event has no draw, and
+ * `PoolWrite` has no id to cite.
+ *
+ * The 422 carries the offending entry's `index` so the handler can build the `loc`
+ * (`["body", "pools", i, "id"]`) the real route sends — the pools are a list, and a
+ * refusal a client cannot attribute to a row is a refusal it cannot render. */
 export type EventResult =
   | { ok: true; event: TournamentEventRead }
   | { ok: false; status: 403 | 404 }
   | { ok: false; status: 409; detail: string }
+  | { ok: false; status: 422; index: number; poolId: string; detail: string }
 
 export type DeleteResult = { ok: true } | { ok: false; status: 403 | 404 }
 
@@ -2052,23 +2077,117 @@ export function deleteTournament(id: string): DeleteResult {
   return { ok: true }
 }
 
+// ----- an event's pools: server-minted ids, and an id-keyed diff ------------------
+//
+// A pool is a ROW now (ADR 20260801, `api/app/tournament_pools.py`) and its id is **the
+// server's to mint** — `PoolWrite` (create) has no `id` at all, and `PoolUpsert` (patch)
+// has an optional one that *cites* a pool rather than authoring it. So this store mints
+// too, exactly as it does for the venue catalogue one resource over (`mintTable`): a pool
+// that arrives without an id is a new pool and gets one here.
+//
+// And the patch is a **diff**, not an assignment: an entry citing an id keeps that pool
+// (re-named, re-timed, re-tabled, re-positioned), an entry with no id adds one, and a
+// stored pool no entry cites is REMOVED. Keying on the id is what makes a reorder move
+// pools instead of swapping labels between ids — and what keeps a fixture's `pool_id`
+// pointing at the pool it was dealt into.
+
+let poolCounter = 0
+
 /**
- * Stamp each pool with the **position of its index in the list the client sent** — the
- * server's rule (`stored_pools`, `api/app/schemas/tournament.py`), reproduced here
- * because a mock that is more permissive than the server it stands in for is a trap.
+ * A brand-new pool for an entry that carries no `id` — the mock's `gen_random_uuid()`,
+ * stamped with the **position of its index in the list the client sent**.
  *
- * The write schema (`PoolWrite`) has no `position`: it is `extra="forbid"`, so sending
- * one is a 422 naming the field, and **the order of the array is the only thing that
- * says which pool comes first**. The read schema (`Pool`) has it, so this is the seam
- * where the order the client expressed becomes the number the client reads back.
+ * UUID-shaped (`mockUuid`) because the wire says so (`Pool.id` is `format: uuid`), and
+ * counter-derived rather than name-derived because two pools may legitimately share a
+ * name (every event has a “Pool A”) — and two rows sharing an id is the one thing an
+ * id-keyed diff cannot survive. The counter deliberately does NOT reset with the store:
+ * a fresh seed re-creates the seeded rows, and an id minted for a *previous* test's pool
+ * must never be handed out again.
  *
- * Defaulting to `0`, or casting the write shape through, would make the mock disagree
- * with the API about a rule the app depends on — the pools editor seeds its cards from
- * `position` and the draw renders in it, so every pool would come back tied for first and
- * `npm run dev` would order them by nothing at all.
+ * The `position` is the server's rule (`stored_pools`/`apply_event_pools`,
+ * `api/app/tournament_pools.py`), reproduced because a mock that is more permissive than
+ * the server it stands in for is a trap. Neither write shape has a `position` — both are
+ * `extra="forbid"`, so sending one is a 422 naming the field — and **the order of the
+ * array is the only thing that says which pool comes first**. Defaulting to `0`, or
+ * casting a write shape through, would make the mock disagree with the API about a rule
+ * the app reads on every load: the pools editor seeds its cards from `position` and the
+ * draw renders in it, so every pool would come back tied for first.
+ *
+ * The fields are named rather than spread for the same reason `mintTable` names them: a
+ * payload carrying a key the write shape forbids must not leak into the stored row.
  */
-function positionPools(pools: PoolWrite[]): Pool[] {
-  return pools.map((pool, index) => ({ ...pool, position: index }))
+function mintPool(entry: PoolWrite, position: number): Pool {
+  poolCounter += 1
+  return {
+    id: mockUuid(`tournament-event-pool-${poolCounter}`),
+    name: entry.name,
+    slot: entry.slot,
+    table_ids: entry.table_ids,
+    position,
+  }
+}
+
+/** Every pool of a **created** event: all new, all minted, positioned by index
+ * (`stored_pools`). `TournamentEventCreate.pools` is `PoolWrite[]` — an event being born
+ * has no pools to cite, so there is no id arm here at all. */
+function mintPools(submitted: PoolWrite[]): Pool[] {
+  return submitted.map((entry, index) => mintPool(entry, index))
+}
+
+/** The server's message for an entry citing an id this **event** does not hold
+ * (`PoolNotInEventError`, `api/app/tournament_errors.py`) — a **422 on that entry's
+ * `id`**, never a silently minted pool: quietly minting one would hand the client back a
+ * different id than it asked for while *removing* the pool it meant to keep, which are
+ * the two failures a diff must never confuse. */
+const POOL_NOT_IN_EVENT = 'This event has no pool with that id.'
+
+/** What the pools diff produced, or the refusal that stopped it before anything was
+ * assigned. */
+type PoolsResult =
+  | { ok: true; pools: Pool[] }
+  | { ok: false; status: 422; index: number; poolId: string; detail: string }
+
+/** Apply a submitted pool list to `stored` as an id-keyed diff (`apply_event_pools`),
+ * judging the unknown-id refusal **before** anything is assigned so a refused write
+ * leaves the event byte-identical.
+ *
+ * Judged first and over the whole payload, for the reason the catalogue's twin is: a pool
+ * list naming a pool this event does not have is not a pool list, and every subsequent
+ * question (what is kept, and therefore what is removed) would be answered against a list
+ * the client did not mean. */
+function applyEventPools(
+  stored: Pool[],
+  submitted: PoolUpsert[],
+): PoolsResult {
+  const byId = new Map(stored.map((pool) => [pool.id, pool]))
+  for (const [index, entry] of submitted.entries()) {
+    if (entry.id != null && !byId.has(entry.id)) {
+      return {
+        ok: false,
+        status: 422,
+        index,
+        poolId: entry.id,
+        detail: POOL_NOT_IN_EVENT,
+      }
+    }
+  }
+  return {
+    ok: true,
+    // The list's ORDER is the event's pool order — a cited pool keeps its id (and every
+    // fixture drawn into it) while taking this payload's words and place; an entry with
+    // no id is an insert.
+    pools: submitted.map((entry, position) =>
+      entry.id == null
+        ? mintPool(entry, position)
+        : {
+            id: entry.id,
+            name: entry.name,
+            slot: entry.slot,
+            table_ids: entry.table_ids,
+            position,
+          },
+    ),
+  }
 }
 
 let eventCounter = 0
@@ -2108,10 +2227,11 @@ export function createEvent(
     slot: body.slot,
     match_settings: body.match_settings,
     predicates: body.predicates ?? [],
-    // The write body carries no positions, so the store assigns them here — from the
-    // index, exactly as the server does (`positionPools`). The order the editor sent its
-    // pools in IS the order, and this is where that becomes a number.
-    pools: positionPools(body.pools ?? []),
+    // Every pool on a create body is a NEW pool — `PoolWrite` has no `id` at all — so the
+    // store mints one for each and stamps the position of its index, exactly as the
+    // server does (`mintPools`). The order the editor sent its pools in IS the order, and
+    // this is where that becomes an id and a number.
+    pools: mintPools(body.pools ?? []),
     // A brand-new event has NO DRAW (ADR-0786). Cutting one is an explicit act against
     // a field that does not exist yet — there is nobody entered to draw.
     fixtures: [],
@@ -2126,14 +2246,23 @@ export function createEvent(
 
 /** Patch an event (full replace of the provided fields). Creator-only.
  *
- * **The pool SET freezes while a draw exists** (ADR-0786): a `pools` payload that would
- * add, remove or re-`id` a pool on an event whose draw is cut is refused with a 409,
- * because a fixture's `pool_id` is a string ref into this very JSONB and nothing in the
- * database stops the edit from orphaning it. Everything ELSE about a pool — its tables,
- * its window, its name — stays editable with a draw standing, because venues change
- * under running tournaments and recording that must not cost a director their draw.
+ * The `pools` payload is an **id-keyed diff** (`applyEventPools`), and it is judged
+ * twice:
  *
- * The mock enforces it because a mock that is more permissive than the server it stands
+ * **The pool SET freezes while a draw exists** (ADR-0786): a payload that would add or
+ * remove a pool on an event whose draw is cut is refused with a 409, because a fixture
+ * names the pool it was dealt into and the edit would orphan it. Everything ELSE about a
+ * pool — its tables, its window, its name — stays editable with a draw standing, because
+ * venues change under running tournaments and recording that must not cost a director
+ * their draw. (Re-*identifying* a pool is no longer one of the things this refuses,
+ * because it is no longer a payload a client can send: a pool id is minted here, so an
+ * entry either cites one this event has or carries none at all.)
+ *
+ * **An entry citing an id this event does not have is a 422** on that entry (ADR
+ * 20260801), judged *after* the freeze so a cut event answers the 409 that names its
+ * pools.
+ *
+ * The mock enforces both because a mock that is more permissive than the server it stands
  * in for is a trap: a pools editor that silently orphans a draw would look perfect in
  * `npm run dev` and 409 in production. */
 export function updateEvent(
@@ -2147,10 +2276,16 @@ export function updateEvent(
   const event = existing.events.find((e) => e.id === eventId)
   if (!event) return { ok: false, status: 404 }
   // 404 → 403 → 409, the server's ordering: the state of an event's draw is never the
-  // reason a stranger's request is refused. (The 422s come before all of it — they are
-  // the schema's, and the handler asks them at the boundary; see `validateEventBody`.)
+  // reason a stranger's request is refused. (The *schema's* 422s come before all of it —
+  // the handler asks them at the boundary; see `validateEventBody`. The diff's own 422,
+  // below, comes after, so a cut event answers the freeze.)
   const frozen = poolSetFrozenDetail(event, patch) ?? drawTypeFrozenDetail(event, patch)
   if (frozen !== null) return { ok: false, status: 409, detail: frozen }
+  // The diff runs BEFORE anything is written, so an entry citing an unknown id leaves the
+  // event exactly as it was — never written, not merely rolled back.
+  const pools =
+    patch.pools == null ? null : applyEventPools(event.pools, patch.pools)
+  if (pools !== null && !pools.ok) return pools
   const next: StoredEvent = {
     ...event,
     name: patch.name ?? event.name,
@@ -2182,11 +2317,12 @@ export function updateEvent(
     slot: patch.slot ?? event.slot,
     match_settings: patch.match_settings ?? event.match_settings,
     predicates: patch.predicates ?? event.predicates,
-    // RE-POSITIONED on every pools patch, from the array index (`positionPools`) — the
-    // server re-derives them the same way, which is what makes "send them in the order
-    // you want" the whole reordering API. An absent `pools` is not touching them at all,
-    // and the stored positions stand.
-    pools: patch.pools ? positionPools(patch.pools) : event.pools,
+    // The diff's answer: cited pools kept (with their ids, and therefore their fixtures),
+    // id-less entries minted, stored pools no entry cited dropped — and every one of them
+    // RE-POSITIONED from the array index, which is what makes "send them in the order you
+    // want" the whole reordering API. An absent `pools` is not touching them at all, and
+    // the stored positions stand.
+    pools: pools === null ? event.pools : pools.pools,
     // The DRAW survives an edit (ADR-0786): a PATCH is not a re-cut. `fixtures` is not
     // in the write body at all, and answering `[]` here would tell the director their
     // draw had just been thrown away by a rename.
@@ -2251,23 +2387,64 @@ function drawHasPlay(event: StoredEvent): boolean {
  * (a draw cut, nothing played yet) is exactly when a blunt play-guard would wave through
  * an edit that orphans every fixture.
  *
- * Identity is all that is frozen. A `pools` payload carrying the same ids in a different
- * order, with different tables, different windows or different names, is fine. */
+ * **The freeze shrank when the ids were minted** (ADR 20260801). Two categories still
+ * reach it — *removing* a pool the draw was dealt across, and *adding* one that would
+ * arrive with no fixtures — and the third, *re-identifying* a pool, is no longer
+ * expressible at all: a client cannot author a pool id, so an entry either cites one this
+ * event has (which keeps that pool) or carries none (which adds one).
+ *
+ * Identity is all that is frozen. A `pools` payload citing exactly the pools the event
+ * has, in a different order, with different tables, different windows or different names,
+ * is fine — that is the case this guard exists to *permit*.
+ *
+ * The sentence is the server's, verbatim (`_pool_set_frozen_detail`,
+ * `api/app/tournament_events.py`), because the client shows it verbatim: it names the
+ * pools on both sides and it names the way out. */
 function poolSetFrozenDetail(
   event: StoredEvent,
   patch: TournamentEventUpdate,
 ): string | null {
   if (patch.pools === undefined || patch.pools === null) return null
   if (event.fixtures.length === 0) return null
-  const before = new Set(event.pools.map((p) => p.id))
-  const after = new Set(patch.pools.map((p) => p.id))
+  const existing = new Set(event.pools.map((p) => p.id))
+  // An entry with no `id` is an addition and contributes nothing to the incoming SET —
+  // which is what makes the comparison below "you cited exactly the pools you have"
+  // rather than "you sent the same number of them".
+  const incoming = new Set(
+    patch.pools.map((p) => p.id).filter((id): id is string => id != null),
+  )
+  const cites = patch.pools.length === incoming.size
   const same =
-    before.size === after.size && [...before].every((id) => after.has(id))
-  if (same) return null
+    existing.size === incoming.size && [...existing].every((id) => incoming.has(id))
+  if (same && cites) return null
+  // Named from whichever side of the change still knows the name: a pool being removed is
+  // only described by the row we hold, one being added only by the payload. An entry
+  // citing an id this event does not have counts as an addition here — it is one in
+  // effect, and past this guard it is the 422 `applyEventPools` answers.
+  const removed = event.pools
+    .filter((p) => !incoming.has(p.id))
+    .map((p) => p.name)
+  const added = patch.pools
+    .filter((p) => p.id == null || !existing.has(p.id))
+    .map((p) => p.name)
+  const clauses: string[] = []
+  if (removed.length > 0) {
+    clauses.push(
+      `${namedList(removed)} already has fixtures drawn into it, ` +
+        'which this change would leave pointing at a pool that no longer exists',
+    )
+  }
+  if (added.length > 0) {
+    clauses.push(
+      `${namedList(added)} would arrive with no fixtures in it, ` +
+        'because the draw was cut across the pools this event had at the time',
+    )
+  }
   return (
     "This event's draw is already cut, so its set of pools is frozen: " +
-    'a pool cannot be added, removed or re-identified while fixtures refer to it. ' +
-    'To add, remove or re-identify a pool, remove the draw first, then cut it again.'
+    clauses.join('; and ') +
+    ". A pool's tables, its time and its name can all still be changed. " +
+    'To add or remove a pool, remove the draw first, then cut it again.'
   )
 }
 

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -1896,7 +1896,7 @@ const NOTHING_TO_START =
 
 /** The things a refusal is about, as a human would say them: `“Pool B”`, or
  * `“Pool B” and “Pool C”` (`named_list`, `api/app/schemas/tournament.py`). */
-function namedList(names: string[]): string {
+export function namedList(names: string[]): string {
   return conjoinWithAnd(names.map((name) => `“${name}”`))
 }
 


### PR DESCRIPTION
Slice 3 of #1226, and the last. **Stacked on #1259** (which is stacked on #1238) — review those first; this PR's diff is only the commits above slice 2.

## What this changes

An event's pools were a JSONB array, so a fixture's `pool_id` was a string that happened to match a key inside a blob on another table, and a pool's reserved tables were another array of strings that matched nothing at all. Both are rows now, and the relationships are foreign keys.

Per [ADR: a pool belongs to its event, not to the event's draw settings](docs/adr/20260801-a-pool-belongs-to-its-event-not-to-the-events-draw-settings.md), pools hang off `event_id` and carry an explicit `position`. Ids are minted by the server, so the write path splits the way slice 2's tables did: `PoolWrite` (create, no id) → `PoolUpsert` (patch, nullable id) → `Pool` (read).

## Three results worth reading the diff for

**The cross-tournament reservation takes three composite FKs, not two.** A pool hangs off its event, a table off its tournament, and they share no column until the join row supplies one. With only the pool leg and the table leg, a row can claim the tournament whose table it borrows while its pool's event lives under another — both constraints satisfied, and that row *is* the violation. The third leg closes it. Found by falsification, not by reasoning: deleting it reds at the *second* spelling of the attack, not the first.

**The primary key shrank from `(event_id, id)` to `id`.** 3a needed the composite because a *client-minted* string is unique only per event — two events of one tournament could each hold a `"pool-a"`, and `schedule_solves.py` namespaces the solver's `PoolId` by event id for exactly that reason. A minted uuid is globally unique by construction, so the reason is gone. `UNIQUE (event_id, id)` stays as the composite-FK target and earns its keep as the index for every "the pools of this event" read.

**The pool-set freeze shrank to what a foreign key cannot say.** Re-identifying a pool is no longer expressible — the client cannot author an id — so the refusal sentence lost that clause, in the server, the mock, and the test that stubbed it. What's left is addition (no constraint speaks to it) and removal (the deferred FK does refuse it, but at COMMIT, as a driver 500 — so the 409 keeps its place in front).

## Commits

| | |
| --- | --- |
| `3a` | pools become `tournament_event_pools` rows with a composite `(event_id, pool_id)` FK on fixtures |
| `3a2` | regen for 3a's docstring drift |
| `3b` | reservations become rows that cannot cross tournaments |
| `3cd` | uuid ids minted server-side, and the pure domain moved onto them |
| `3e` | regen `schema.d.ts` |
| — | regen `Types.swift` (operator-run) |
| `3g` | the mock layer mirrors minting and the id-keyed diff |
| `3f` | the event editor stops minting pool ids |
| `3h` | the pooled draw proven end to end |

`3c` and `3d` were **folded into `3cd`**. They cannot be separate commits: under `mypy --strict` the column flip, the minting, and `PoolId`'s underlying type all break together, and flipping the columns without minting would strand every client-minted `p-1-…`. The work order records why rather than silently reordering.

## Bugs found that the plan hadn't anticipated

- **`update_event` re-read its scheduling facts before flush**, so a newly added pool projected with `id=None`.
- **`event-editor.test.tsx` stubbed the old freeze wording**, so it passed while asserting against its own stub — green, and evidence of nothing.
- **The root `e2e` suite could not seed an event**, again: `PoolSpec` still minted ids, which `extra="forbid"` makes a 422. Same shape as the table-id breakage 2g repaired one slice ago. Twice now a shared write shape changed and its non-`web-client` consumers were in no chore's scope.

## An honest limit on 3h

Sorting pools by `str(pool.id)` — the literal ADR-20260801 regression — **passes** the rr-then-ko spec, because at three pools a random uuid order coincides with position order one time in six. The comment implying otherwise is softened. `tournament-pool-order` at ten pools is the id-vs-position proof, and it guards against that coincidence explicitly.

## Verification

- `pytest` — 2122 passed, against a dropped-and-recreated database
- `npm run test:run` — 3395 passed / 319 files
- `tsc -b` — clean
- root `e2e` — 24 collected in 15 files, 24 ran, 22 passed; the 2 failures are `dashboard-session` and `player-profile` timing out at the 30s default on this sandbox inside a `page.goto`, both green at `--timeout=120000`, neither touching anything this PR changes

Every guard was falsified and each red named its reason.

**Two things to weigh:**

`tournament-lifecycle` gained an explicit `test.setTimeout(180_000)`. It's outside 3h's scope and it is a judgement call — the stashed-tree control was unavailable because the pre-change tree can't reach that line at all (it 422s on the pool id, the thing this slice repairs), so it was discriminated the other way: same tree at 120s passes in 1.1 min, and the failure is the test budget, not a locator. Drop the hunk if you'd rather keep the sandbox red visible.

`schedule_solves.py`'s namespacing of pool ids by event id is now redundant for uniqueness but **kept** — the key is a wire value that `SchedulePreviewFixtureRead.pool_id` carries and stored solve plans are keyed by, so dropping it would change the wire *and* orphan every existing solve row.

**Not yet run:** `/simplify`, `/code-review`, `/security-review`, `/qa-review` — `land-the-plane`'s gates, and this is a draft.

## Migration note

Pre-deploy, so `0010` and `0012` were edited in place. `pytest` builds the schema with `create_all` and never invokes Alembic, so a green suite is not evidence the migration works — `alembic upgrade head` was run against fresh Postgres separately, with a downgrade→upgrade round-trip.

A trap worth recording: `create_all` is `checkfirst`, so a reused `TEST_DATABASE_URL` database serves a **stale** schema after a model change. One falsification run came back green for exactly that reason before it was caught.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCCG5jQq19dG8SDPFcmTwh)_