### PR TITLE
Slice 2: extract a real CP-SAT conflict core for infeasible solves (#1129)

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -50,6 +50,20 @@ class Settings(BaseSettings):
     #: ahead of pending real solves, so a low cap keeps a preview snappy.
     preview_solver_time_cap_s: float = 5.0
 
+    #: The CP-SAT wall-clock time cap, in seconds, for the **diagnostic** solve —
+    #: the second, max-placed solve that names the fixtures a proven-infeasible
+    #: day could not place (ADR "the conflict core is a second, max-placed solve
+    #: over optional placements"). Its own budget, not a share of
+    #: ``solver_time_cap_s``: it runs only after CP-SAT has already proved the
+    #: day infeasible, so a solved day never pays it and the two caps add up only
+    #: on the path where the extra answer is worth the extra seconds. 5s (the
+    #: ``preview_solver_time_cap_s`` precedent) sits inside the slack the RQ job
+    #: already holds — ``JOB_TIMEOUT_MARGIN_S`` on the real solve,
+    #: ``PREVIEW_JOB_TIMEOUT_MARGIN_S`` on a preview — so neither watchdog nor the
+    #: stale-running lease needs widening. Raising it past that slack is what
+    #: would.
+    diagnostic_solver_time_cap_s: float = 5.0
+
     #: Auth0 tenant domain (e.g. ``fortymm.us.auth0.com``) — the issuer the MCP
     #: JWT verifier trusts and the origin its JWKS is fetched from. Empty means
     #: Auth0 is unconfigured: the api still boots and MCP still mounts, but every

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -1992,7 +1992,9 @@ async def request_schedule_solve(tournament_id: uuid.UUID) -> ScheduleSolveRead:
 # ephemeral preview job to reach a terminal state before it gives up and returns a
 # retryable ``ToolError``. Bounded well under a minute (ADR "MCP waits internally
 # with a bounded timeout") — a preview solve is cap-bounded to a few seconds
-# (``preview_solver_time_cap_s`` defaults to 5s) and the MCP path is not behind the
+# (``preview_solver_time_cap_s`` defaults to 5s, plus at most
+# ``diagnostic_solver_time_cap_s`` again when the preview comes back infeasible and
+# the conflict-core diagnostic runs) and the MCP path is not behind the
 # browser-facing nginx ~60s hop, so a generous-but-finite ceiling lets a preview
 # queued behind an in-flight real solve still return in one call, while a stuck
 # wait fails loud (retry) rather than hanging.

--- a/api/app/schedule_preview_solve.py
+++ b/api/app/schedule_preview_solve.py
@@ -77,6 +77,7 @@ from app.scheduling import (
     PoolOverCapacity,
     ScheduleSnapshot,
     SolveResult,
+    UnplaceableFixtures,
     Verdict,
     WindowTooShortForMatch,
 )
@@ -91,12 +92,14 @@ from app.schemas.schedule_preview import (
     PreviewVerdict,
 )
 from app.schemas.schedule_solve import (
+    ConflictFixtureRead,
     NoSingleCauseRead,
     PastWindowReasonRead,
     PlayerOverSubscribedRead,
     PoolHasNoTablesRead,
     PoolOverCapacityRead,
     ResolvedReason,
+    UnplaceableFixturesRead,
     WindowTooShortForMatchRead,
 )
 from app.tournament_draws import event_pools
@@ -392,6 +395,11 @@ def run_schedule_preview(inputs: PreviewJobInputs) -> dict[str, object]:
         inputs.snapshot,
         time_cap_s=get_settings().preview_solver_time_cap_s,
         num_search_workers=_solve_num_workers(),
+        # The conflict-core diagnostic's own budget, spent only when the preview
+        # comes back INFEASIBLE — which is exactly when a director most wants to
+        # know *which* matches don't fit. Worst case it doubles the preview's own
+        # cap (5 + 5), still inside ``PREVIEW_JOB_TIMEOUT_MARGIN_S`` on top.
+        diagnostic_time_cap_s=get_settings().diagnostic_solver_time_cap_s,
     )
     return project_preview_result(inputs, result).model_dump(mode="json")
 
@@ -551,11 +559,14 @@ def _resolve_reasons(
     fixture-id → ``length_games`` map derived from the snapshot's events (a preview
     has no DB to read it from); a blamed *player* from their own synthetic id
     (``placeholder-7`` → ``Placeholder 7``), since a preview's entrants are
-    stand-ins with no name to look up. Exhaustive ``match`` with an
-    ``assert_never`` floor, like ``app.schedule_solves._resolve_reason``."""
+    stand-ins with no name to look up, and a conflict-core *fixture* from the two
+    such labels it pairs. Exhaustive ``match`` with an ``assert_never`` floor,
+    like ``app.schedule_solves._resolve_reason``."""
     best_of = _fixture_best_of(inputs.snapshot)
+    matchups = _fixture_matchups(inputs.snapshot)
     return [
-        _resolve_reason(reason, inputs.pool_resolutions, best_of) for reason in reasons
+        _resolve_reason(reason, inputs.pool_resolutions, best_of, matchups)
+        for reason in reasons
     ]
 
 
@@ -571,10 +582,27 @@ def _fixture_best_of(snapshot: ScheduleSnapshot) -> dict[str, MatchLength]:
     }
 
 
+def _fixture_matchups(snapshot: ScheduleSnapshot) -> dict[str, tuple[str, str]]:
+    """fixture id → its matchup as two *display* labels — the DB-blind twin of
+    ``app.schedule_solves``'s ``fixture_matchups``. A preview's entrants are
+    synthetic stand-ins, so each side resolves straight off its own id
+    (``placeholder-7`` → ``Placeholder 7``,
+    :func:`app.schedule_preview.placeholder_label`) with no DB read: exactly the
+    labels the preview surface already shows the director."""
+    return {
+        str(fixture.id): (
+            placeholder_label(fixture.player_a_id),
+            placeholder_label(fixture.player_b_id),
+        )
+        for fixture in snapshot.fixtures
+    }
+
+
 def _resolve_reason(
     reason: InfeasibilityReason,
     pool_resolutions: Mapping[str, _PreviewPoolResolution],
     best_of: Mapping[str, MatchLength],
+    matchups: Mapping[str, tuple[str, str]],
 ) -> ResolvedReason:
     """One pure, id-and-minute reason → its resolved read form, the DB-blind twin
     of ``app.schedule_solves._resolve_reason`` (same union, same arms) taking the
@@ -619,6 +647,21 @@ def _resolve_reason(
                 match_count=reason.match_count,
                 required_min=reason.required_min,
                 window_span_min=reason.window_span_min,
+            )
+        case UnplaceableFixtures():
+            # The conflict core, named by matchup in the same
+            # ``ConflictFixtureRead`` shape the real solve uses — with both sides
+            # resolved off their synthetic ids, so a preview explains *which*
+            # matches don't fit without any DB read.
+            return UnplaceableFixturesRead(
+                fixtures=[
+                    ConflictFixtureRead(
+                        fixture_id=fixture_id,
+                        player_a=matchups[fixture_id][0],
+                        player_b=matchups[fixture_id][1],
+                    )
+                    for fixture_id in reason.fixture_ids
+                ]
             )
         case NoSingleCause():
             return NoSingleCauseRead(

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -183,6 +183,7 @@ from app.scheduling import (
     SolveResult,
     TableConflict,
     TableId,
+    UnplaceableFixtures,
     Window,
     WindowTooShortForMatch,
     coalesce_rest_shadows,
@@ -199,6 +200,7 @@ from app.schemas.schedule_solve import (
     ResolvedConflict,
     ResolvedReason,
     TableConflictRead,
+    UnplaceableFixturesRead,
     WindowTooShortForMatchRead,
 )
 from app.schemas.tournament import MatchSettings as EventMatchSettings
@@ -536,11 +538,14 @@ class SolveInputs:
     usernames) are the sibling lookups the apply humanizes a solve's
     *placement conflicts* through (ADR "overlapping in-progress matches are
     tolerated and reported"). Same fingerprinted provenance, so the fresh read's
-    maps resolve exactly the ids a conflict carries. ``player_names`` does
-    double duty: it is also how the one *reason* that names a human
-    (:class:`~app.scheduling.PlayerOverSubscribed`) is resolved — it is built
+    maps resolve exactly the ids a conflict carries. Both do double duty for the
+    two *reason* arms that carry the same kinds of id: ``player_names`` resolves
+    the human named by :class:`~app.scheduling.PlayerOverSubscribed` (it is built
     from every drawn event's entrants, not just the in-progress ones, so it
-    covers any player a pre-check can blame."""
+    covers any player a pre-check can blame), and ``fixture_matchups`` names the
+    conflict core of :class:`~app.scheduling.UnplaceableFixtures` (it covers
+    every placeable fixture, which is a superset of the unpinned ones the core
+    can hold)."""
 
     snapshot: ScheduleSnapshot
     fingerprint: str
@@ -1118,6 +1123,19 @@ def _resolve_reason(reason: InfeasibilityReason, inputs: SolveInputs) -> Resolve
                 required_min=reason.required_min,
                 window_span_min=reason.window_span_min,
             )
+        case UnplaceableFixtures():
+            # The conflict core, named the way a director reads a fixture: by its
+            # matchup, through the SAME ``_named_fixture`` helper (and the same
+            # ``ConflictFixtureRead`` shape) a placement conflict names its
+            # colliding fixtures with. Only unpinned, placeable fixtures can be in
+            # the core, and every placeable fixture's matchup was recorded in this
+            # same fingerprinted read, so the lookups are total.
+            return UnplaceableFixturesRead(
+                fixtures=[
+                    _named_fixture(fixture_id, inputs)
+                    for fixture_id in reason.fixture_ids
+                ]
+            )
         case NoSingleCause():
             return NoSingleCauseRead(
                 required_min=reason.required_min,
@@ -1132,14 +1150,15 @@ def _resolve_reason(reason: InfeasibilityReason, inputs: SolveInputs) -> Resolve
             assert_never(reason)
 
 
-def _conflict_fixture(
-    fixture_id: FixtureId, inputs: SolveInputs
-) -> ConflictFixtureRead:
-    """Name one colliding in-progress fixture by its matchup — the two players
-    facing off (``inputs.fixture_matchups``). Direct lookup is safe: the apply
-    resolves only after the drift guard proved this read's inputs identical to
-    the ones the conflicts were computed against, and every in-progress fixture
-    a conflict names is a placeable fixture whose matchup was recorded here."""
+def _named_fixture(fixture_id: FixtureId, inputs: SolveInputs) -> ConflictFixtureRead:
+    """Name one fixture by its matchup — the two players facing off
+    (``inputs.fixture_matchups``). The one place a pure fixture id becomes
+    something a director can read, shared by both id-carrying unions: a placement
+    conflict's colliding in-progress matches, and an ``unplaceable_fixtures``
+    reason's conflict core. Direct lookup is safe: the apply resolves only after
+    the drift guard proved this read's inputs identical to the ones the reasons
+    and conflicts were computed against, and every fixture either can name is a
+    placeable fixture whose matchup was recorded here."""
     player_a, player_b = inputs.fixture_matchups[fixture_id]
     return ConflictFixtureRead(
         fixture_id=fixture_id, player_a=player_a, player_b=player_b
@@ -1160,7 +1179,7 @@ def _resolve_conflict(
     an arm to :data:`app.scheduling.PlacementConflict` is a type error here until
     it is handled."""
     fixtures = [
-        _conflict_fixture(fixture_id, inputs) for fixture_id in conflict.fixture_ids
+        _named_fixture(fixture_id, inputs) for fixture_id in conflict.fixture_ids
     ]
     match conflict:
         case TableConflict():
@@ -1241,6 +1260,11 @@ async def execute_solve(
             inputs.snapshot,
             time_cap_s=get_settings().solver_time_cap_s,
             num_search_workers=_solve_num_workers(),
+            # The second, max-placed solve's own budget — spent only when this
+            # one comes back INFEASIBLE, and absorbed by JOB_TIMEOUT_MARGIN_S
+            # (and by the stale-running lease, a multiple of the main cap), so
+            # neither watchdog needs widening for it.
+            diagnostic_time_cap_s=get_settings().diagnostic_solver_time_cap_s,
         )
 
         await _apply_result(sessionmaker, solve_id, tournament_id, inputs, result)

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -122,6 +122,20 @@ not a remedy a director can act on. With the flag off the ordinary path
 constructs exactly the model it always did — same variables, same objective,
 same hints, same determinism.
 
+**The conflict core is a second solve, run only after a proof.** When — and only
+when — CP-SAT returns ``INFEASIBLE``, :func:`solve` runs
+:func:`_diagnose_unplaceable`: the max-placed variant over the same snapshot,
+under its own ``diagnostic_time_cap_s`` budget and the same fixed seed and worker
+count, so the answer is deterministic. Its unplaced fixtures become
+:class:`UnplaceableFixtures` — *"these could not be placed"*, never *"you must
+remove exactly these"*: the diagnostic is an optimization under a cap and may
+stop at ``FEASIBLE``, so the set is an upper bound and minimality is never
+claimed. A solved day pays nothing for any of this, and ``unknown`` (the cap
+exhausted before any solution) still carries no reason at all — "did not finish"
+is not "does not fit". When the diagnostic itself cannot answer — infeasible
+because pins are undroppable, or its own cap exhausted — the whole-day
+:class:`NoSingleCause` aggregate survives underneath as the floor.
+
 **Verdict.** CP-SAT's OPTIMAL/FEASIBLE map directly; INFEASIBLE returns an
 empty placement set and *never raises* — infeasibility is the point of
 pre-live solves, a designed outcome, not an error. UNKNOWN (time cap exhausted
@@ -497,13 +511,46 @@ class PlayerOverSubscribed:
 
 
 @dataclass(frozen=True, slots=True)
+class UnplaceableFixtures:
+    """The **conflict core**: the fixtures a second, max-placed solve could not
+    place (ADR "the conflict core is a second, max-placed solve over optional
+    placements"). Reached only when CP-SAT *proved* the day infeasible and every
+    certain pre-check passed — so this is the timing conflict named by fixture
+    rather than left as a whole-day aggregate.
+
+    **It never claims minimality.** The diagnostic is an optimization under its
+    own time cap, so it may stop at ``FEASIBLE`` rather than ``OPTIMAL``: an
+    upper bound ("dropping these lets the day fit"), not a proven minimum ("you
+    must drop at least these"). Both statuses say the same true thing under the
+    wording this arm is for — *these could not be placed* — so it carries no
+    proven/partial flag to tempt a caller into the stronger claim.
+
+    **Fixtures only, no player list.** A provably over-subscribed player is
+    caught by :class:`PlayerOverSubscribed` in the cheap pre-check pass *before*
+    CP-SAT ever runs, so by construction none can appear here; naming players by
+    a heuristic ("appears in ≥2 dropped fixtures") would put an unprovable claim
+    inside a union whose every other arm is a proof.
+
+    Called (pinned) matches are never in the set: they are not droppable in the
+    diagnostic model, because "cancel this promise" is not a remedy a director
+    can act on. ``fixture_ids`` is sorted, so an unchanged infeasible day reports
+    the same core every time."""
+
+    fixture_ids: tuple[FixtureId, ...]
+    kind: Literal["unplaceable_fixtures"] = "unplaceable_fixtures"
+
+
+@dataclass(frozen=True, slots=True)
 class NoSingleCause:
-    """The honest residual: CP-SAT *proved* the day infeasible, yet no certain
-    structural cause (arms above) explains it — the infeasibility lives in the
-    combinatorial interaction of windows, rest, and no-double-booking that only
-    search sees. Carries the whole-day aggregate for context: ``required_min``
-    (Σ every active fixture's duration) against ``available_min`` (Σ over pools
-    of ``window_span × table_count``). Typically ``required_min ≤ available_min``
+    """The honest **floor**: CP-SAT *proved* the day infeasible, no certain
+    structural cause (arms above) explains it, and the diagnostic solve could not
+    extract a conflict core either — it came back infeasible itself (the called
+    matches alone do not fit, and pins are not droppable) or exhausted its own
+    cap with no solution. The infeasibility lives in the combinatorial
+    interaction of windows, rest, and no-double-booking that only search sees.
+    Carries the whole-day aggregate for context: ``required_min`` (Σ every active
+    fixture's duration) against ``available_min`` (Σ over pools of
+    ``window_span × table_count``). Typically ``required_min ≤ available_min``
     here — aggregate room exists, but it cannot be packed."""
 
     required_min: int
@@ -544,16 +591,20 @@ class PastWindow:
 #: ``PlayerOverSubscribed`` about a single *human* (ADR "the conflict core is a
 #: second, max-placed solve") — ``PastWindow`` is the equally-certain pre-live
 #: "the day is dated in the past" cause (ADR "a past day is named, not
-#: disguised", #1101), and ``NoSingleCause`` is the best-effort residual when
-#: CP-SAT refuses but no structure does. Frozen dataclasses + a ``kind``
-#: discriminator so a downstream humanizer can ``match`` exhaustively with no
-#: catch-all. Ids + minute-ints only: turning these into names and wall-clock
-#: is a later, DB-aware layer's job, not this pure module's.
+#: disguised", #1101), ``UnplaceableFixtures`` is the conflict core a second,
+#: max-placed solve extracts once CP-SAT has proved infeasibility, and
+#: ``NoSingleCause`` is the floor beneath it — the whole-day aggregate, for when
+#: CP-SAT refuses, no structure explains it, *and* the diagnostic cannot answer.
+#: Frozen dataclasses + a ``kind`` discriminator so a downstream humanizer can
+#: ``match`` exhaustively with no catch-all. Ids + minute-ints only: turning
+#: these into names and wall-clock is a later, DB-aware layer's job, not this
+#: pure module's.
 InfeasibilityReason = (
     PoolHasNoTables
     | WindowTooShortForMatch
     | PoolOverCapacity
     | PlayerOverSubscribed
+    | UnplaceableFixtures
     | NoSingleCause
     | PastWindow
 )
@@ -1453,10 +1504,87 @@ def _build_model(
     )
 
 
+#: The diagnostic solve's own wall-clock budget, in seconds — the default for
+#: :func:`solve`'s ``diagnostic_time_cap_s``. Kept separate from the main cap:
+#: the diagnostic is a *second* solve that only ever runs after a proven
+#: infeasibility, and it must fit inside the slack the caller's job already
+#: holds (the DB-aware layer overrides it from
+#: ``Settings.diagnostic_solver_time_cap_s``).
+DIAGNOSTIC_TIME_CAP_S = 5.0
+
+
+def _diagnose_unplaceable(
+    snapshot: ScheduleSnapshot,
+    *,
+    time_cap_s: float,
+    num_search_workers: int,
+) -> tuple[UnplaceableFixtures | None, int]:
+    """The conflict core, from a **second** solve over the same snapshot (ADR
+    "the conflict core is a second, max-placed solve over optional placements").
+
+    Called by :func:`solve` on one path only — CP-SAT *proved* the ordinary model
+    infeasible — so a feasible day, a trivially-optimal one, a structural
+    pre-check refusal and an ``unknown`` (time-cap) outcome all pay nothing. The
+    max-placed variant of the model (``optional_placement=True``) makes every
+    *unpinned* fixture droppable and maximizes how many are placed; the ones it
+    could not place are the core. Returns ``(core, wall_time_ms)`` — the elapsed
+    time so the caller can report the run's whole cost honestly, not just the
+    first solve's.
+
+    Returns ``(None, …)`` — the caller then falls back to the
+    :class:`NoSingleCause` floor — whenever the diagnostic cannot answer:
+
+    * the model is **infeasible** itself. Pins are not droppable, so the called
+      matches alone can overflow the horizon and no drop set exists;
+    * it **exhausted its cap** with no solution at all (``UNKNOWN``);
+    * it answered but dropped **nothing**, which cannot happen while the ordinary
+      model is infeasible (placing everything satisfies the ordinary model) —
+      belt-and-braces, since an empty core would claim nothing;
+    * the builder returned a finished :class:`SolveResult` rather than a model,
+      which likewise cannot happen on this path (the same snapshot just built a
+      model) but is handled rather than asserted.
+
+    ``MODEL_INVALID`` is deliberately folded into that same fallback rather than
+    raising the way the ordinary path does: at this point the tournament already
+    has a *proven* answer, and a bug in the diagnostic variant must degrade the
+    explanation, never destroy the verdict.
+
+    Determinism is the ordinary path's: ``random_seed = 0`` and the caller's
+    ``num_search_workers``, so an unchanged infeasible day names the same
+    fixtures on every re-run.
+    """
+    built = _build_model(snapshot, optional_placement=True)
+    if isinstance(built, SolveResult):
+        return None, 0
+
+    solver = cp_model.CpSolver()
+    solver.parameters.max_time_in_seconds = time_cap_s
+    solver.parameters.num_search_workers = num_search_workers
+    solver.parameters.random_seed = 0
+    status = solver.Solve(built.model)
+    wall_time_ms = int(solver.WallTime() * 1000)
+    if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        return None, wall_time_ms
+
+    # Sorted, like every other fixture-id tuple this module emits, so the core is
+    # a stable value rather than a search-order artefact.
+    unplaceable = tuple(
+        sorted(
+            fixture_id
+            for fixture_id, placed in built.placed_literals.items()
+            if solver.Value(placed) == 0
+        )
+    )
+    if not unplaceable:
+        return None, wall_time_ms
+    return UnplaceableFixtures(fixture_ids=unplaceable), wall_time_ms
+
+
 def solve(
     snapshot: ScheduleSnapshot,
     time_cap_s: float = 10.0,
     num_search_workers: int = 1,
+    diagnostic_time_cap_s: float = DIAGNOSTIC_TIME_CAP_S,
 ) -> SolveResult:
     """Place every active fixture: a called match on its fixed table at the
     promised start or a slid-later one (never earlier), everything else solved
@@ -1473,6 +1601,12 @@ def solve(
     available, and a value above the caller's CPU limit gets CFS-throttled.
     The default of 1 is also what keeps ``random_seed = 0`` below pinning the
     result: CP-SAT's parallel portfolio is not deterministic across workers.
+
+    ``diagnostic_time_cap_s`` is the budget for the **second**, max-placed solve
+    that explains a proven infeasibility (:func:`_diagnose_unplaceable`). It is a
+    separate budget because that solve runs only on the proven-``INFEASIBLE``
+    path: a solved day never pays it, and the two caps therefore add up only in
+    the one case where the extra answer is worth the extra seconds.
     """
     built = _build_model(snapshot)
     if isinstance(built, SolveResult):
@@ -1494,15 +1628,34 @@ def solve(
         )
     if status == cp_model.INFEASIBLE:
         # CP-SAT proved it, but the structural pre-check found no certain cause
-        # (by construction: it returns before we ever build the model). Attach
-        # the honest residual — the whole-day aggregate, no single blamed pool.
-        required_min, available_min = _aggregate_capacity(snapshot)
+        # (by construction: it returns before we ever build the model). THIS —
+        # and only this — is where the diagnostic runs: a second, max-placed
+        # solve that names the fixtures which could not be placed (the conflict
+        # core). It cannot run earlier, because a proof of infeasibility is what
+        # makes the question meaningful, and it must not run on `unknown` (that
+        # is "did not finish", not "does not fit", and carries no reason at all).
+        core, diagnostic_ms = _diagnose_unplaceable(
+            snapshot,
+            time_cap_s=diagnostic_time_cap_s,
+            num_search_workers=num_search_workers,
+        )
+        reason: InfeasibilityReason
+        if core is not None:
+            reason = core
+        else:
+            # The diagnostic could not answer (see :func:`_diagnose_unplaceable`)
+            # — fall back to the honest whole-day aggregate floor, no single
+            # blamed pool.
+            required_min, available_min = _aggregate_capacity(snapshot)
+            reason = NoSingleCause(
+                required_min=required_min, available_min=available_min
+            )
         return _no_plan(
             Verdict.infeasible,
-            wall_time_ms,
-            reasons=(
-                NoSingleCause(required_min=required_min, available_min=available_min),
-            ),
+            # Both solves really ran, so the ledger records both: an infeasible
+            # run's wall time is the cost of proving it AND of explaining it.
+            wall_time_ms + diagnostic_ms,
+            reasons=(reason,),
             conflicts=built.conflicts,
         )
     if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -110,6 +110,18 @@ get no hint and solve fresh; the solver derives ``same_start``/``kept``/
 infeasibility. Crucially a hint only *orders the search* — it can never change
 which solution is optimal, so correctness is untouched and only speed changes.
 
+**One builder, flagged.** :func:`_build_model` takes an ``optional_placement``
+flag (default ``False``) that swaps the model into a **max-placed** variant used
+only for diagnosing a proven infeasibility (ADR "the conflict core is a second,
+max-placed solve over optional placements"). In that variant every *unpinned*
+fixture gets a ``placed`` literal, **both** its table intervals and its player
+intervals become optional on it, and the objective becomes ``maximize Σ placed``
+— so the fixtures the solve cannot place are the conflict core. Pins stay hard:
+a called match is a promise already made to two humans, so "drop this one" is
+not a remedy a director can act on. With the flag off the ordinary path
+constructs exactly the model it always did — same variables, same objective,
+same hints, same determinism.
+
 **Verdict.** CP-SAT's OPTIMAL/FEASIBLE map directly; INFEASIBLE returns an
 empty placement set and *never raises* — infeasibility is the point of
 pre-live solves, a designed outcome, not an error. UNKNOWN (time cap exhausted
@@ -770,6 +782,14 @@ class _SolverModel:
     #: whether the applied plan overran a planned window.
     planned_ends: dict[FixtureId, int]
     is_live: bool
+    #: The per-unpinned-fixture ``placed`` literal of the **max-placed variant**
+    #: (``optional_placement=True``), so a caller can read back *which* fixtures
+    #: the diagnostic solve could place and take the rest as the conflict core.
+    #: Empty (``{}``) on the ordinary path, where every fixture is placed by
+    #: construction — an empty mapping is exactly the true statement "this model
+    #: has no droppable fixtures". Pinned fixtures never appear: pins stay hard
+    #: in both variants.
+    placed_literals: dict[FixtureId, Any]
 
 
 def _merge_spans(spans: Iterable[tuple[int, int]]) -> list[tuple[int, int]]:
@@ -812,13 +832,45 @@ def _overlapping_fixture_ids(
     return tuple(sorted(colliding))
 
 
-def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
+def _build_model(
+    snapshot: ScheduleSnapshot, *, optional_placement: bool = False
+) -> SolveResult | _SolverModel:
     """Construct the CP-SAT model for one solve, warm-start hints and all.
 
     Returns a finished :class:`SolveResult` for the cases that need no solver —
     nothing to place (trivially optimal) or a structural infeasibility a guard
     can prove without search — and otherwise a :class:`_SolverModel` carrying
     the model and the index :func:`solve` reads its answer back out of.
+
+    ``optional_placement`` swaps in the **max-placed diagnostic variant** (ADR
+    "the conflict core is a second, max-placed solve over optional placements").
+    One flagged builder rather than a parallel ``_build_diagnostic_model``,
+    because a duplicate would re-implement bucket bounds, pin handling, the
+    fixed-obstacle union and snapshot validation — and then silently drift, and
+    a diagnostic that drifts explains a model the tournament never solved. It
+    changes three things and only for *unpinned* fixtures:
+
+    * each gets a ``placed`` literal, exposed on
+      :attr:`_SolverModel.placed_literals`;
+    * **both** its table intervals and its rest-padded player intervals become
+      optional on that literal. Both families, one literal: gating only the
+      table intervals would leave the per-player rest constraint binding on a
+      fixture that was supposedly dropped, so dropping it would relieve nothing
+      and a rest-driven conflict could never be explained at all;
+    * the objective becomes ``maximize Σ placed``, replacing the lexicographic
+      makespan/wait/stability minimization. Stability, the warm-start hints and
+      the instance-computed tier weights are all meaningless when the question
+      is "how many fit?", so the variant simply does not build them.
+
+    Called (pinned) matches are **not** droppable in either variant: a call is a
+    promise already made to two humans, so "drop this one" is not a remedy a
+    director can act on, and the drop set should hold only fixtures they can
+    actually move. The cost is that the variant can itself be infeasible (pins
+    alone overflowing the horizon), which the caller must handle.
+
+    With the flag off — the default, and the only way the ordinary path ever
+    calls it — the model, its objective, its hints and its determinism are
+    exactly what they were before the flag existed.
 
     Raises :class:`IncoherentSnapshot` for inputs that reference things they do
     not contain (via :func:`_validated`).
@@ -1234,10 +1286,21 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
     # REST_MIN makes per-player NoOverlap enforce "gap ≥ rest floor" between
     # any two of that player's matches, in either order, with no sequencing
     # variables.
+    #
+    # Under `optional_placement` the fixture becomes droppable instead: a
+    # `placed` literal replaces AddExactlyOne with `Σ present == placed` (so no
+    # table is chosen when the fixture is dropped, and choosing one forces
+    # `placed`), and the per-player intervals become optional on that SAME
+    # literal. Both interval families or the variant is a lie: a dropped fixture
+    # whose player intervals stayed mandatory still consumes its two humans'
+    # time and their rest floor, so dropping it relieves nothing and the
+    # diagnostic can never explain a rest-driven conflict — it would simply come
+    # back infeasible, or blame the wrong fixtures, without erroring.
     starts: dict[FixtureId, Any] = {}
     presences: dict[FixtureId, dict[TableId, Any]] = {}
     buckets: dict[FixtureId, Any] = {}
     durations: dict[FixtureId, int] = {}
+    placed_literals: dict[FixtureId, Any] = {}
     for fixture in unpinned:
         pool = pools[fixture.pool_id]
         duration = duration_of(fixture)
@@ -1254,13 +1317,27 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
                     start, duration, present, f"fx_{fixture.id}_{table}"
                 )
             )
-        model.AddExactlyOne(list(by_table.values()))
-        for player in (fixture.player_a_id, fixture.player_b_id):
-            player_intervals[player].append(
-                model.NewFixedSizeIntervalVar(
-                    start, duration + REST_MIN, f"fx_{fixture.id}_{player}"
+        if optional_placement:
+            placed = model.NewBoolVar(f"placed_{fixture.id}")
+            placed_literals[fixture.id] = placed
+            model.Add(sum(by_table.values()) == placed)
+            for player in (fixture.player_a_id, fixture.player_b_id):
+                player_intervals[player].append(
+                    model.NewOptionalFixedSizeIntervalVar(
+                        start,
+                        duration + REST_MIN,
+                        placed,
+                        f"fx_{fixture.id}_{player}",
+                    )
                 )
-            )
+        else:
+            model.AddExactlyOne(list(by_table.values()))
+            for player in (fixture.player_a_id, fixture.player_b_id):
+                player_intervals[player].append(
+                    model.NewFixedSizeIntervalVar(
+                        start, duration + REST_MIN, f"fx_{fixture.id}_{player}"
+                    )
+                )
         starts[fixture.id] = start
         presences[fixture.id] = by_table
         buckets[fixture.id] = bucket
@@ -1275,73 +1352,89 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
         if len(intervals) > 1:
             model.AddNoOverlap(intervals)
 
-    makespan = model.NewIntVar(0, horizon, "makespan")
-    for end_expr in variable_ends:
-        model.Add(makespan >= end_expr)
-    if fixed_ends:
-        model.Add(makespan >= max(fixed_ends))
+    if optional_placement:
+        # The max-placed variant asks one question — how many of these fixtures
+        # can run at all? — so it carries only that objective. No makespan var,
+        # no wait tier, no stability literals, no instance-computed weights and
+        # no warm-start hints: "finish early", "start promptly" and "don't churn
+        # the board" are all meaningless while the day provably does not fit,
+        # and a hint seeded from a plan that was never feasible would only slow
+        # the search it was meant to speed up.
+        model.Maximize(sum(placed_literals.values()))
+    else:
+        makespan = model.NewIntVar(0, horizon, "makespan")
+        for end_expr in variable_ends:
+            model.Add(makespan >= end_expr)
+        if fixed_ends:
+            model.Add(makespan >= max(fixed_ends))
 
-    # Stability: an unpinned fixture "kept" its previous plan iff it sits on
-    # the same table at the same start. A previous table no longer in the
-    # pool means it must move — a constant 1 in the moved count.
-    previous = {p.fixture_id: p for p in snapshot.previous_plan}
-    kept_literals: list[Any] = []
-    forced_moves = 0
-    stability_span = 0
-    for fixture in unpinned:
-        prior = previous.get(fixture.id)
-        if prior is None:
-            continue
-        stability_span += 1
-        same_table = presences[fixture.id].get(prior.table_id)
-        if same_table is None:
-            forced_moves += 1
-            continue
-        same_start = model.NewBoolVar(f"same_start_{fixture.id}")
-        model.Add(starts[fixture.id] == prior.start_min).OnlyEnforceIf(same_start)
-        model.Add(starts[fixture.id] != prior.start_min).OnlyEnforceIf(same_start.Not())
-        kept = model.NewBoolVar(f"kept_{fixture.id}")
-        model.AddBoolAnd([same_table, same_start]).OnlyEnforceIf(kept)
-        model.AddBoolOr([same_table.Not(), same_start.Not()]).OnlyEnforceIf(kept.Not())
-        kept_literals.append(kept)
+        # Stability: an unpinned fixture "kept" its previous plan iff it sits on
+        # the same table at the same start. A previous table no longer in the
+        # pool means it must move — a constant 1 in the moved count.
+        previous = {p.fixture_id: p for p in snapshot.previous_plan}
+        kept_literals: list[Any] = []
+        forced_moves = 0
+        stability_span = 0
+        for fixture in unpinned:
+            prior = previous.get(fixture.id)
+            if prior is None:
+                continue
+            stability_span += 1
+            same_table = presences[fixture.id].get(prior.table_id)
+            if same_table is None:
+                forced_moves += 1
+                continue
+            same_start = model.NewBoolVar(f"same_start_{fixture.id}")
+            model.Add(starts[fixture.id] == prior.start_min).OnlyEnforceIf(same_start)
+            model.Add(starts[fixture.id] != prior.start_min).OnlyEnforceIf(
+                same_start.Not()
+            )
+            kept = model.NewBoolVar(f"kept_{fixture.id}")
+            model.AddBoolAnd([same_table, same_start]).OnlyEnforceIf(kept)
+            model.AddBoolOr([same_table.Not(), same_start.Not()]).OnlyEnforceIf(
+                kept.Not()
+            )
+            kept_literals.append(kept)
 
-    # Instance-computed strictly-lexicographic weights — see module docstring.
-    # The wait tier now has one term per unpinned *and* per called fixture, so
-    # the count bounding the max total wait swing is len(unpinned) + len(pinned).
-    # A called match's `pin_start - now` can be negative (a floor before now),
-    # which only lowers the total, so `count * span` still bounds the positive
-    # swing and the tiers provably never trade.
-    span = max(1, horizon - now)
-    w_stability = 1
-    w_wait = w_stability * stability_span + 1
-    w_makespan = w_wait * max(1, len(unpinned) + len(pinned)) * span + 1
+        # Instance-computed strictly-lexicographic weights — see module
+        # docstring. The wait tier now has one term per unpinned *and* per called
+        # fixture, so the count bounding the max total wait swing is
+        # len(unpinned) + len(pinned). A called match's `pin_start - now` can be
+        # negative (a floor before now), which only lowers the total, so
+        # `count * span` still bounds the positive swing and the tiers provably
+        # never trade.
+        span = max(1, horizon - now)
+        w_stability = 1
+        w_wait = w_stability * stability_span + 1
+        w_makespan = w_wait * max(1, len(unpinned) + len(pinned)) * span + 1
 
-    objective = w_makespan * makespan
-    for term in wait_terms:
-        objective = objective + w_wait * term
-    for kept in kept_literals:
-        objective = objective + w_stability * (1 - kept)
-    objective = objective + w_stability * forced_moves
-    model.Minimize(objective)
+        objective = w_makespan * makespan
+        for term in wait_terms:
+            objective = objective + w_wait * term
+        for kept in kept_literals:
+            objective = objective + w_stability * (1 - kept)
+        objective = objective + w_stability * forced_moves
+        model.Minimize(objective)
 
-    # Warm start: seed each unpinned fixture's prior (table, start) as a hint so
-    # a mostly-unchanged re-solve begins *at* the previous plan and only repairs
-    # the local delta. A hint whose prior table has left the pool (a forced move)
-    # or that has no prior entry is simply omitted — that fixture solves fresh.
-    # Hints never change which solution is optimal; they only order the search.
-    for fixture in unpinned:
-        prior = previous.get(fixture.id)
-        if prior is None or prior.table_id not in presences[fixture.id]:
-            continue
-        model.AddHint(buckets[fixture.id], prior.start_min // BUCKET_MIN)
-        model.AddHint(starts[fixture.id], prior.start_min)
-        for table, present in presences[fixture.id].items():
-            model.AddHint(present, 1 if table == prior.table_id else 0)
+        # Warm start: seed each unpinned fixture's prior (table, start) as a hint
+        # so a mostly-unchanged re-solve begins *at* the previous plan and only
+        # repairs the local delta. A hint whose prior table has left the pool (a
+        # forced move) or that has no prior entry is simply omitted — that
+        # fixture solves fresh. Hints never change which solution is optimal;
+        # they only order the search.
+        for fixture in unpinned:
+            prior = previous.get(fixture.id)
+            if prior is None or prior.table_id not in presences[fixture.id]:
+                continue
+            model.AddHint(buckets[fixture.id], prior.start_min // BUCKET_MIN)
+            model.AddHint(starts[fixture.id], prior.start_min)
+            for table, present in presences[fixture.id].items():
+                model.AddHint(present, 1 if table == prior.table_id else 0)
 
-    # Warm start each called match's slide variable at its promised time so a
-    # re-solve begins at what the player was told and only slides if forced.
-    for fixture, pin in pinned:
-        model.AddHint(pin_starts[fixture.id], pin.start_min)
+        # Warm start each called match's slide variable at its promised time so a
+        # re-solve begins at what the player was told and only slides if forced.
+        for fixture, pin in pinned:
+            model.AddHint(pin_starts[fixture.id], pin.start_min)
 
     return _SolverModel(
         model=model,
@@ -1356,6 +1449,7 @@ def _build_model(snapshot: ScheduleSnapshot) -> SolveResult | _SolverModel:
         conflicts=conflicts,
         planned_ends=planned_ends,
         is_live=is_live,
+        placed_literals=placed_literals,
     )
 
 

--- a/api/app/schemas/schedule_solve.py
+++ b/api/app/schemas/schedule_solve.py
@@ -24,6 +24,23 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field, TypeAdapter
 
 
+class ConflictFixtureRead(BaseModel):
+    """One fixture, named the way the director reads a fixture — by its
+    **matchup**, the two players facing off (:attr:`player_a` / :attr:`player_b`,
+    their display usernames). The raw ``fixture_id`` rides along so a surface can
+    key/deep-link without re-deriving it from the names. Resolved once at apply
+    from the pure fixture ids; the client formats the ``a vs b`` label itself.
+
+    Shared by both id-carrying unions: the in-progress matches caught in a
+    :class:`TableConflictRead` / :class:`PlayerConflictRead`, and the fixtures an
+    :class:`UnplaceableFixturesRead` says could not be placed. One shape, so the
+    client renders a named fixture the same way wherever it appears."""
+
+    fixture_id: str
+    player_a: str
+    player_b: str
+
+
 class PoolHasNoTablesRead(BaseModel):
     """A pool with active fixtures but no tables at all — nowhere to place them.
     Resolved: the pool's display ``name`` (never the namespaced solver id)."""
@@ -81,9 +98,28 @@ class PlayerOverSubscribedRead(BaseModel):
     window_span_min: int
 
 
+class UnplaceableFixturesRead(BaseModel):
+    """The **conflict core**: the fixtures a proven-infeasible day could not
+    place, each named by its matchup (:class:`ConflictFixtureRead` — the same
+    shape a placement conflict names a fixture with). The client's sentence is
+    *"these could not be placed"*, never *"you must remove exactly these"*: the
+    core is the drop set of a capped optimization, so it is an upper bound and
+    **minimality is never claimed** — which is why there is no proven/partial
+    flag here to hang a stronger claim on.
+
+    Fixtures only, no players: an over-subscribed human is proved earlier and
+    more cheaply by :class:`PlayerOverSubscribedRead`, so naming players here
+    could only be a guess. The DB-aware mirror of
+    :class:`app.scheduling.UnplaceableFixtures`."""
+
+    kind: Literal["unplaceable_fixtures"] = "unplaceable_fixtures"
+    fixtures: list[ConflictFixtureRead]
+
+
 class NoSingleCauseRead(BaseModel):
-    """CP-SAT proved the day infeasible yet no structural arm explains it — the
-    whole-day residual. No pool: it carries only the day aggregate,
+    """CP-SAT proved the day infeasible, no structural arm explains it, and the
+    diagnostic solve could not extract a conflict core either — the whole-day
+    floor. No pool and no fixtures: it carries only the day aggregate,
     ``required_min`` against ``available_min``, as integer minutes."""
 
     kind: Literal["no_single_cause"] = "no_single_cause"
@@ -115,6 +151,7 @@ ResolvedReason = Annotated[
     | WindowTooShortForMatchRead
     | PoolOverCapacityRead
     | PlayerOverSubscribedRead
+    | UnplaceableFixturesRead
     | NoSingleCauseRead
     | PastWindowReasonRead,
     Field(discriminator="kind"),
@@ -136,19 +173,6 @@ def parse_infeasibility_reasons(
     if raw is None:
         return []
     return _REASONS_ADAPTER.validate_python(raw)
-
-
-class ConflictFixtureRead(BaseModel):
-    """One of the in-progress matches caught in a conflict, named the way the
-    director reads a fixture — by its **matchup**, the two players facing off
-    (:attr:`player_a` / :attr:`player_b`, their display usernames). The raw
-    ``fixture_id`` rides along so a surface can key/deep-link without re-deriving
-    it from the names. Resolved once at apply from the pure conflict's fixture
-    ids; the client formats the ``a vs b`` label itself."""
-
-    fixture_id: str
-    player_a: str
-    player_b: str
 
 
 class TableConflictRead(BaseModel):

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -47,10 +47,16 @@ def hijack_solve(
     real = scheduling.solve
 
     def wrapper(
-        snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+        snapshot: ScheduleSnapshot,
+        time_cap_s: float,
+        num_search_workers: int,
+        diagnostic_time_cap_s: float,
     ) -> SolveResult:
         result = real(
-            snapshot, time_cap_s=time_cap_s, num_search_workers=num_search_workers
+            snapshot,
+            time_cap_s=time_cap_s,
+            num_search_workers=num_search_workers,
+            diagnostic_time_cap_s=diagnostic_time_cap_s,
         )
         after_solve()
         return result

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -34,6 +34,28 @@ def test_solver_time_cap_reads_from_env(
     assert get_settings().solver_time_cap_s == expected
 
 
+def test_diagnostic_solver_time_cap_defaults_to_five_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The conflict-core diagnostic's own budget (ADR decision 6) — 5s, the
+    ``preview_solver_time_cap_s`` precedent, chosen to sit inside the slack the
+    RQ job already holds so no watchdog or lease needs widening."""
+    monkeypatch.delenv("DIAGNOSTIC_SOLVER_TIME_CAP_S", raising=False)
+    assert get_settings().diagnostic_solver_time_cap_s == 5.0
+
+
+def test_diagnostic_solver_time_cap_reads_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Its own knob, independent of the main solver cap: raising one must not
+    move the other."""
+    monkeypatch.setenv("DIAGNOSTIC_SOLVER_TIME_CAP_S", "12.5")
+    monkeypatch.delenv("SOLVER_TIME_CAP_S", raising=False)
+    settings = get_settings()
+    assert settings.diagnostic_solver_time_cap_s == 12.5
+    assert settings.solver_time_cap_s == 10.0
+
+
 def test_get_settings_rereads_env_on_every_call(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/api/tests/test_schedule_preview_solve.py
+++ b/api/tests/test_schedule_preview_solve.py
@@ -62,6 +62,7 @@ from app.schemas.schedule_preview import (
 from app.schemas.schedule_solve import (
     PastWindowReasonRead,
     PlayerOverSubscribedRead,
+    UnplaceableFixturesRead,
     WindowTooShortForMatchRead,
 )
 from app.tournament_errors import (
@@ -617,6 +618,53 @@ async def test_preview_over_subscribed_placeholder_resolves_to_its_label(
     assert first.match_count == 3
     assert first.required_min == 125  # 3 * 35 + 2 * REST_MIN
     assert first.window_span_min == 120
+
+
+async def test_preview_conflict_core_names_its_fixtures_by_placeholder_matchup(
+    db_session: AsyncSession,
+    default_league: League,
+    preview_queue: Queue,
+) -> None:
+    """The conflict core on the DB-blind preview path: the fixtures the
+    diagnostic could not place, each named by its matchup — both sides resolved
+    off their synthetic ids (``Placeholder N``), with no DB read, in the same
+    ``ConflictFixtureRead`` shape a real solve records.
+
+    Three entrants in a round-robin means three matches that *all* pairwise share
+    a player, so they can only run one after another: 3 × 25 plus two 10-minute
+    rests needs 95 minutes against a 65-minute window. No certain arm can prove
+    that — one match fits (25 ≤ 65), the pool is far under capacity (75 ≤ 65 × 2),
+    and each player has only two matches (25 + 10 + 25 = 60 ≤ 65) — so CP-SAT has
+    to prove it, and the diagnostic answers with the one fixture whose removal
+    lets the other two fit."""
+    owner = await make_user(db_session, "prev-conflict-core")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    await _add_event(
+        db_session,
+        tournament,
+        max_players=3,
+        length_games=3,
+        pools=[_pool(["t1", "t2"], start="09:00", end="10:05")],
+    )
+
+    enqueued = await request_schedule_preview(
+        db_session, tournament_id=tournament.id, actor=owner
+    )
+    (job,) = preview_queue.jobs
+    (inputs,) = job.args
+    result = PreviewResult.model_validate(run_schedule_preview(inputs))
+
+    assert result.verdict is PreviewVerdict.infeasible
+    (reason,) = result.infeasibility_reasons
+    assert isinstance(reason, UnplaceableFixturesRead)
+    (unplaceable,) = reason.fixtures
+    # A fixture the preview itself drew and handed back to the caller.
+    assert unplaceable.fixture_id in {f.fixture_id for f in enqueued.fixtures}
+    # Both sides shown the way the preview surface shows a synthetic entrant —
+    # never the raw ``placeholder-2`` spelling.
+    assert {unplaceable.player_a, unplaceable.player_b} < {
+        f"Placeholder {k}" for k in (1, 2, 3)
+    }
 
 
 async def test_preview_solve_past_dated_window_resolves_past_window(

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -78,6 +78,7 @@ from app.schedule_solves import (
 )
 from app.scheduling import (
     REST_MIN,
+    FixtureId,
     PlacedFixture,
     PlayerId,
     PlayerOverSubscribed,
@@ -87,6 +88,7 @@ from app.scheduling import (
     ScheduleSnapshot,
     SolveResult,
     SolveStats,
+    UnplaceableFixtures,
     Verdict,
 )
 from app.schemas.notification import NotificationJob
@@ -97,6 +99,7 @@ from app.schemas.schedule_solve import (
     PoolHasNoTablesRead,
     PoolOverCapacityRead,
     TableConflictRead,
+    UnplaceableFixturesRead,
     parse_infeasibility_reasons,
     parse_placement_conflicts,
 )
@@ -413,7 +416,7 @@ def _fanout_jobs(notifications_queue: Queue) -> list[NotificationJob]:
 
 def _slide_pin_later(
     target_fixture_id: uuid.UUID, extra_min: int
-) -> Callable[[ScheduleSnapshot, float, int], SolveResult]:
+) -> Callable[[ScheduleSnapshot, float, int, float], SolveResult]:
     """Interpose on the ``_solve`` seam: run the real solver, then push only
     the target pin's placement ``extra_min`` minutes later on its (unchanged)
     table — exactly the "predecessor overran" outcome 1a's solver produces
@@ -423,10 +426,16 @@ def _slide_pin_later(
     target_id = str(target_fixture_id)
 
     def wrapper(
-        snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+        snapshot: ScheduleSnapshot,
+        time_cap_s: float,
+        num_search_workers: int,
+        diagnostic_time_cap_s: float,
     ) -> SolveResult:
         result = real(
-            snapshot, time_cap_s=time_cap_s, num_search_workers=num_search_workers
+            snapshot,
+            time_cap_s=time_cap_s,
+            num_search_workers=num_search_workers,
+            diagnostic_time_cap_s=diagnostic_time_cap_s,
         )
         placements = tuple(
             PlacedFixture(
@@ -1028,12 +1037,20 @@ class TestSolveJob:
         real = schedule_solves._solve
 
         def wrapper(
-            snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+            snapshot: ScheduleSnapshot,
+            time_cap_s: float,
+            num_search_workers: int,
+            diagnostic_time_cap_s: float,
         ) -> SolveResult:
             seen.append(time_cap_s)
             # Don't actually run the real solver for the full budget — the
             # cap value reaching the seam is what's under test.
-            return real(snapshot, time_cap_s=1.0, num_search_workers=num_search_workers)
+            return real(
+                snapshot,
+                time_cap_s=1.0,
+                num_search_workers=num_search_workers,
+                diagnostic_time_cap_s=diagnostic_time_cap_s,
+            )
 
         monkeypatch.setattr(schedule_solves, "_solve", wrapper)
 
@@ -1202,7 +1219,10 @@ class TestSolveJob:
         await db_session.commit()
 
         def exhausted(
-            snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+            snapshot: ScheduleSnapshot,
+            time_cap_s: float,
+            num_search_workers: int,
+            diagnostic_time_cap_s: float,
         ) -> SolveResult:
             return SolveResult(
                 verdict=Verdict.unknown,
@@ -1237,7 +1257,10 @@ class TestSolveJob:
         await db_session.commit()
 
         def broken(
-            snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+            snapshot: ScheduleSnapshot,
+            time_cap_s: float,
+            num_search_workers: int,
+            diagnostic_time_cap_s: float,
         ) -> SolveResult:
             raise RuntimeError("the solver caught fire")
 
@@ -1312,7 +1335,10 @@ class TestSolveJob:
         pool_id = PoolId(f"{event_id}:pool-a")
 
         def infeasible(
-            snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+            snapshot: ScheduleSnapshot,
+            time_cap_s: float,
+            num_search_workers: int,
+            diagnostic_time_cap_s: float,
         ) -> SolveResult:
             return SolveResult(
                 verdict=Verdict.infeasible,
@@ -1384,7 +1410,10 @@ class TestSolveJob:
         ).one()
 
         def infeasible(
-            snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+            snapshot: ScheduleSnapshot,
+            time_cap_s: float,
+            num_search_workers: int,
+            diagnostic_time_cap_s: float,
         ) -> SolveResult:
             return SolveResult(
                 verdict=Verdict.infeasible,
@@ -1417,6 +1446,72 @@ class TestSolveJob:
         assert reason.match_count == 3
         assert reason.required_min == 95
         assert reason.window_span_min == 60
+
+    async def test_the_conflict_core_is_resolved_to_fixture_matchups(
+        self,
+        db_session: AsyncSession,
+        solver_queue: Queue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The conflict core reaches the ledger as *named fixtures*, not raw
+        uuids: each is humanized at apply through the same ``fixture_matchups``
+        map — and the same ``ConflictFixtureRead`` shape — a placement conflict
+        names its colliding matches with, so a surface renders a named fixture
+        one way wherever it appears."""
+        tournament_id, event_id = await _make_tournament(db_session)
+        fixtures = await _fixtures_of(db_session, event_id)
+        core = fixtures[:2]
+        core_ids = [fixture.id for fixture in core]
+        expected_matchups = {}
+        for fixture in core:
+            assert fixture.entry_a_id is not None and fixture.entry_b_id is not None
+            expected_matchups[str(fixture.id)] = (
+                await _entry_username(db_session, fixture.entry_a_id),
+                await _entry_username(db_session, fixture.entry_b_id),
+            )
+
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+        assert row is not None
+        row_id = row.id
+        await db_session.commit()
+
+        def infeasible(
+            snapshot: ScheduleSnapshot,
+            time_cap_s: float,
+            num_search_workers: int,
+            diagnostic_time_cap_s: float,
+        ) -> SolveResult:
+            return SolveResult(
+                verdict=Verdict.infeasible,
+                placements=(),
+                stats=SolveStats(wall_time_ms=42, objective=None),
+                reasons=(
+                    UnplaceableFixtures(
+                        fixture_ids=tuple(
+                            FixtureId(str(fixture_id)) for fixture_id in core_ids
+                        )
+                    ),
+                ),
+            )
+
+        monkeypatch.setattr(schedule_solves, "_solve", infeasible)
+        _run_recorded_job(solver_queue, row_id)
+
+        db_session.expire_all()
+        (ledger,) = await _solve_rows(db_session, tournament_id)
+        assert ledger.status is ScheduleSolveStatus.infeasible
+
+        (reason,) = parse_infeasibility_reasons(ledger.infeasibility_reasons)
+        assert isinstance(reason, UnplaceableFixturesRead)
+        assert [named.fixture_id for named in reason.fixtures] == [
+            str(fixture_id) for fixture_id in core_ids
+        ]
+        assert {
+            named.fixture_id: (named.player_a, named.player_b)
+            for named in reason.fixtures
+        } == expected_matchups
 
     async def test_succeeded_apply_leaves_infeasibility_reasons_null(
         self, db_session: AsyncSession, solver_queue: Queue
@@ -1455,7 +1550,10 @@ class TestSolveJob:
         await db_session.commit()
 
         def exhausted(
-            snapshot: ScheduleSnapshot, time_cap_s: float, num_search_workers: int
+            snapshot: ScheduleSnapshot,
+            time_cap_s: float,
+            num_search_workers: int,
+            diagnostic_time_cap_s: float,
         ) -> SolveResult:
             return SolveResult(
                 verdict=Verdict.unknown,
@@ -1538,7 +1636,9 @@ class TestSolveJob:
         monkeypatch.setattr(
             schedule_solves,
             "_solve",
-            lambda snapshot, time_cap_s, num_search_workers: genuine,
+            lambda snapshot, time_cap_s, num_search_workers, diagnostic_time_cap_s: (
+                genuine
+            ),
         )
 
         row = await request_solve(

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -1663,3 +1663,281 @@ class TestWarmStart:
         # the same deterministic search finds is a *different* board.
         built.model.ClearHints()
         assert _first_solution_board(built) != previous
+
+
+def _golden_snapshot() -> ScheduleSnapshot:
+    """The characterization instance for the **ordinary** (flag-off) path.
+
+    Deliberately exercises every family the builder knows at once — three
+    unpinned fixtures chained on one star player and one pool table, a called
+    match on an off-pool table, an in-progress match on a third, a rest shadow
+    on the star player, and a previous plan — so a stray edit inside the shared
+    builder has nowhere to hide.
+
+    Its optimum is **unique**, not merely one of several equally good boards,
+    which is what lets the test below assert an exact board and objective. The
+    makespan is fixed at the pin's end (115) whatever the unpinned fixtures do,
+    so the wait tier alone fixes the start multiset: the shadow blocks the star
+    until 10 and the rest floor spaces the chain 25 apart, giving 10/35/60. The
+    stability tier then breaks the remaining permutation tie toward the previous
+    plan. Forbidding that board raises the proven optimum from 442535 to 442537,
+    so a solver that tie-broke differently could not produce a different green.
+    """
+    star = PlayerId("STAR")
+    table_ids = _tables(3)
+    return ScheduleSnapshot(
+        table_ids=table_ids,
+        pools=(SchedulePool(PoolId("A"), (table_ids[0],), Window(0, 240)),),
+        events=(EventSettings(EventId("E1"), 1),),
+        fixtures=(
+            _fixture(1, star, PlayerId("Q1")),
+            _fixture(2, star, PlayerId("Q2")),
+            _fixture(3, star, PlayerId("Q3")),
+            _fixture(4, PlayerId("Q4"), PlayerId("Q5"), pin=Pin(table_ids[1], 100)),
+            _fixture(5, PlayerId("Q6"), PlayerId("Q7")),
+        ),
+        now_min=0,
+        in_progress=(InProgressMatch(FixtureId("F5"), table_ids[2], 0),),
+        previous_plan=(
+            PreviousPlacement(FixtureId("F1"), table_ids[0], 10),
+            PreviousPlacement(FixtureId("F2"), table_ids[0], 35),
+            PreviousPlacement(FixtureId("F3"), table_ids[0], 60),
+        ),
+        rest_shadows=(RestShadow(star, 0),),
+    )
+
+
+#: The frozen board and objective of :func:`_golden_snapshot` on the ordinary
+#: path — what the solver produced before ``optional_placement`` existed.
+GOLDEN_PLACEMENTS = (
+    PlacedFixture(FixtureId("F1"), TableId("T1"), 10, 25),
+    PlacedFixture(FixtureId("F2"), TableId("T1"), 35, 50),
+    PlacedFixture(FixtureId("F3"), TableId("T1"), 60, 75),
+    PlacedFixture(FixtureId("F4"), TableId("T2"), 100, 115),
+)
+GOLDEN_OBJECTIVE = 442535
+
+
+def _rest_conflict_snapshot() -> ScheduleSnapshot:
+    """A day that is infeasible **because of the per-player rest floor**, and
+    for no other reason — the case the optional-placement variant exists to
+    explain, and the one that silently breaks if only the table intervals are
+    made optional.
+
+    Four tables for two 15-minute fixtures, so table contention is nowhere near
+    binding: both could run *simultaneously* if they did not share a human.
+    They do — ``P1`` plays both — and ``P1`` also carries a rest shadow from a
+    match completed at 0, blocking them until 10. Inside a window whose last
+    legal grid start is 25, ``P1``'s two rest-padded intervals need 25 minutes
+    of separation and have at most 15 available, so the day cannot fit.
+
+    No certain pre-check fires on it (that is the point — it must reach CP-SAT):
+    the pool has tables, one match fits the window, unpinned demand is 30
+    against 160 table-minutes, and ``PlayerOverSubscribed`` charges
+    ``15 + 15 + 10 = 40`` against a 40-minute span, which is not *greater*. The
+    pre-check is blind to rest shadows and to the 5-minute grid, which is
+    exactly why the residual diagnostic has to answer for this shape.
+    """
+    table_ids = _tables(4)
+    return ScheduleSnapshot(
+        table_ids=table_ids,
+        pools=(SchedulePool(PoolId("A"), table_ids, Window(0, 40)),),
+        events=(EventSettings(EventId("E1"), 1),),
+        fixtures=(
+            _fixture(1, PlayerId("P1"), PlayerId("P2")),
+            _fixture(2, PlayerId("P1"), PlayerId("P3")),
+        ),
+        now_min=0,
+        rest_shadows=(RestShadow(PlayerId("P1"), 0),),
+    )
+
+
+def _enforcements(built: _SolverModel) -> dict[str, tuple[int, ...]]:
+    """Every unpinned fixture interval in the built model, by constraint name,
+    mapped to the variable indices enforcing it — ``()`` for a *mandatory*
+    interval. Table intervals are named ``fx_<fixture>_<table>`` and per-player
+    intervals ``fx_<fixture>_<player>``, so this reads back which families the
+    builder actually made optional rather than trusting the source."""
+    return {
+        constraint.name: tuple(constraint.enforcement_literal)
+        for constraint in built.model.Proto().constraints
+        if constraint.name.startswith("fx_")
+    }
+
+
+def _solve_max_placed(built: _SolverModel) -> tuple[int, set[str]]:
+    """Solve a max-placed model with the production solver parameters, returning
+    ``(status, the ids of the fixtures it placed)``."""
+    solver = cp_model.CpSolver()
+    solver.parameters.random_seed = 0
+    solver.parameters.num_search_workers = 1
+    solver.parameters.max_time_in_seconds = CAP
+    status = solver.Solve(built.model)
+    if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        return status, set()
+    return status, {
+        str(fixture_id)
+        for fixture_id, placed in built.placed_literals.items()
+        if solver.Value(placed) == 1
+    }
+
+
+class TestOrdinaryPathIsUnchanged:
+    """The flag defaults off and the fast path must be constructed *exactly* as
+    it was before it existed — same variables, same mandatory intervals, same
+    objective, same warm start, same deterministic answer. These are the guard
+    that a future edit to the now-shared builder cannot silently change the
+    model the tournament actually solves."""
+
+    def test_default_build_carries_no_placement_literals(self) -> None:
+        """No ``placed`` booleans leak into the fast path: the model gains no
+        new variables, so it gains no new presolve work or hint churn."""
+        built = _build_model(_golden_snapshot())
+        assert isinstance(built, _SolverModel)
+        assert built.placed_literals == {}
+        names = [variable.name for variable in built.model.Proto().variables]
+        assert not [name for name in names if name.startswith("placed_")]
+
+    def test_default_build_keeps_every_player_interval_mandatory(self) -> None:
+        """Read back off the proto, not the source: on the fast path every
+        per-player interval is unconditional and every table interval is
+        enforced by exactly its own table-choice literal."""
+        built = _build_model(_rest_conflict_snapshot())
+        assert isinstance(built, _SolverModel)
+        enforcements = _enforcements(built)
+        for fixture in ("F1", "F2"):
+            for player in ("P1", "P2", "P3"):
+                assert enforcements.get(f"fx_{fixture}_{player}", ()) == ()
+            for table in _tables(4):
+                assert len(enforcements[f"fx_{fixture}_{table}"]) == 1
+
+    def test_default_solve_reproduces_its_frozen_board_and_objective(self) -> None:
+        """The characterization: the ordinary path still returns the board and
+        the objective it returned before the flag existed. The objective is
+        asserted too — it pins the instance-computed tier weights, which a board
+        assertion alone would not notice."""
+        result = solve(_golden_snapshot(), time_cap_s=30.0)
+        assert result.verdict is Verdict.optimal
+        assert result.placements == GOLDEN_PLACEMENTS
+        assert result.stats.objective == GOLDEN_OBJECTIVE
+
+    def test_default_solve_is_deterministic_across_repeats(self) -> None:
+        """Determinism is a requirement of the fast path, not an accident of one
+        run: the same snapshot solved twice gives the same board."""
+        first = solve(_golden_snapshot(), time_cap_s=30.0)
+        second = solve(_golden_snapshot(), time_cap_s=30.0)
+        assert first.placements == second.placements == GOLDEN_PLACEMENTS
+
+
+class TestOptionalPlacementVariant:
+    """``_build_model(..., optional_placement=True)`` — the max-placed model the
+    residual diagnostic will run (ADR "the conflict core is a second, max-placed
+    solve over optional placements"). Nothing calls it in production yet; these
+    tests are the whole of its coverage."""
+
+    def test_both_interval_families_are_optional_on_the_same_literal(self) -> None:
+        """The trap this variant exists to avoid, asserted structurally: an
+        unpinned fixture's **player** intervals must be enforced by its own
+        ``placed`` literal, not left mandatory. If only the table intervals were
+        made optional, a dropped fixture would go on consuming its two humans'
+        time and their rest floor — the drop would relieve nothing."""
+        built = _build_model(_rest_conflict_snapshot(), optional_placement=True)
+        assert isinstance(built, _SolverModel)
+        enforcements = _enforcements(built)
+        for fixture, opponent in (("F1", "P2"), ("F2", "P3")):
+            placed = built.placed_literals[FixtureId(fixture)].Index()
+            for player in ("P1", opponent):
+                assert enforcements[f"fx_{fixture}_{player}"] == (placed,)
+
+    def test_a_rest_driven_infeasibility_is_relieved_by_dropping_a_fixture(
+        self,
+    ) -> None:
+        """The behavioural half, and the falsification this chore turns on.
+
+        The day is infeasible *only* because of one human's rest floor (see
+        :func:`_rest_conflict_snapshot`) — the ordinary solve proves it and can
+        say nothing but ``NoSingleCause``. The max-placed model must be able to
+        drop one of the two fixtures and become satisfiable, placing exactly
+        one. It can do that only if the *player* intervals are optional: with
+        them left mandatory the model stays infeasible however the ``placed``
+        literals are set, so this test reds — which is the check that the trap
+        above is really disarmed."""
+        snapshot = _rest_conflict_snapshot()
+
+        ordinary = solve(snapshot, time_cap_s=CAP)
+        assert ordinary.verdict is Verdict.infeasible
+        assert [type(reason) for reason in ordinary.reasons] == [NoSingleCause]
+
+        built = _build_model(snapshot, optional_placement=True)
+        assert isinstance(built, _SolverModel)
+        status, placed = _solve_max_placed(built)
+        assert status == cp_model.OPTIMAL
+        assert len(placed) == 1, "the rest conflict admits exactly one of the two"
+        assert placed < {"F1", "F2"}
+
+    def test_a_feasible_day_places_everything(self) -> None:
+        """Sanity in the other direction: where the ordinary solve succeeds, the
+        variant drops nothing — the drop set is a symptom of infeasibility, not
+        of the encoding."""
+        snapshot = _star_chain_snapshot()
+        assert solve(snapshot, time_cap_s=CAP).verdict in SOLVED
+
+        built = _build_model(snapshot, optional_placement=True)
+        assert isinstance(built, _SolverModel)
+        status, placed = _solve_max_placed(built)
+        assert status == cp_model.OPTIMAL
+        assert placed == {"F1", "F2", "F3", "F4"}
+
+    def test_called_matches_are_not_droppable(self) -> None:
+        """Pins stay hard: a called match is a promise already made to two
+        humans, so "drop this one" is not a remedy a director can act on and it
+        never gets a ``placed`` literal.
+
+        The instance is infeasible only because the pin holds the pool's single
+        table and one of its players from minute 0, leaving the unpinned fixture
+        no legal grid start inside the window. The variant answers by dropping
+        the *unpinned* fixture — placing nothing — rather than by dropping the
+        promise, and the pin still sits at the time its players were told."""
+        table_ids = _tables(1)
+        snapshot = ScheduleSnapshot(
+            table_ids=table_ids,
+            pools=(SchedulePool(PoolId("A"), table_ids, Window(0, 35)),),
+            events=(EventSettings(EventId("E1"), 1),),
+            fixtures=(
+                _fixture(1, PlayerId("P1"), PlayerId("P2")),
+                _fixture(2, PlayerId("P1"), PlayerId("P3"), pin=Pin(table_ids[0], 0)),
+            ),
+            now_min=0,
+        )
+        assert solve(snapshot, time_cap_s=CAP).verdict is Verdict.infeasible
+
+        built = _build_model(snapshot, optional_placement=True)
+        assert isinstance(built, _SolverModel)
+        assert set(built.placed_literals) == {FixtureId("F1")}
+
+        solver = cp_model.CpSolver()
+        solver.parameters.random_seed = 0
+        solver.parameters.num_search_workers = 1
+        solver.parameters.max_time_in_seconds = CAP
+        status = solver.Solve(built.model)
+        assert status == cp_model.OPTIMAL
+        assert solver.Value(built.placed_literals[FixtureId("F1")]) == 0
+        assert solver.Value(built.pin_starts[FixtureId("F2")]) == 0
+
+    def test_a_dropped_fixture_takes_no_table(self) -> None:
+        """``Σ present == placed`` both ways: an unplaced fixture claims no
+        table (so a caller can never read a phantom placement off it), and a
+        fixture that claims a table is necessarily placed."""
+        built = _build_model(_rest_conflict_snapshot(), optional_placement=True)
+        assert isinstance(built, _SolverModel)
+        solver = cp_model.CpSolver()
+        solver.parameters.random_seed = 0
+        solver.parameters.num_search_workers = 1
+        solver.parameters.max_time_in_seconds = CAP
+        assert solver.Solve(built.model) == cp_model.OPTIMAL
+        for fixture in built.unpinned:
+            chosen = sum(
+                int(solver.Value(present))
+                for present in built.presences[fixture.id].values()
+            )
+            assert chosen == int(solver.Value(built.placed_literals[fixture.id]))

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -9,11 +9,13 @@ cap so the suite stays fast and deterministic.
 
 import dataclasses
 import random
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from ortools.sat.python import cp_model
 
+from app import scheduling
 from app.scheduling import (
     BUCKET_MIN,
     REST_MIN,
@@ -42,11 +44,13 @@ from app.scheduling import (
     SolveResult,
     TableConflict,
     TableId,
+    UnplaceableFixtures,
     Verdict,
     Window,
     WindowTooShortForMatch,
     _build_model,
     _chosen_table,
+    _diagnose_unplaceable,
     _SolverModel,
     match_minutes,
     solve,
@@ -570,8 +574,9 @@ class TestInfeasibility:
         its own (25 <= 45), so the pool is never reported as over capacity even
         though pinned + unpinned would exceed it. This is the completeness
         trade-off: with a single shared table the pin's occupancy genuinely does
-        leave no room, so CP-SAT proves it infeasible and it surfaces as the
-        honest NoSingleCause residual, never a false PoolOverCapacity."""
+        leave no room, so CP-SAT proves it infeasible and the residual explains
+        it — as the conflict core naming the *unpinned* fixture (the promise is
+        not droppable), never as a false PoolOverCapacity."""
         p1, p2, p3, p4 = _players(4)
         fixtures = (
             _fixture(1, p1, p2, pin=Pin(TableId("T1"), 0)),  # 25 min pinned [0,25]
@@ -585,7 +590,7 @@ class TestInfeasibility:
         assert result.verdict is Verdict.infeasible
         by_kind = _reasons_by_kind(result)
         assert "pool_over_capacity" not in by_kind
-        assert result.reasons == (NoSingleCause(required_min=50, available_min=45),)
+        assert result.reasons == (UnplaceableFixtures(fixture_ids=(FixtureId("F2"),)),)
 
     def test_no_tables_pool_with_only_a_pinned_fixture_is_not_flagged(self) -> None:
         """Regression: a pool with no tables whose only fixture is *pinned* to a
@@ -642,7 +647,7 @@ class TestInfeasibility:
         assert "pool_over_capacity" not in by_kind
         assert result.reasons == ()
 
-    def test_a_player_shared_across_pools_is_no_single_cause(self) -> None:
+    def test_a_player_shared_across_pools_is_named_by_the_conflict_core(self) -> None:
         """Every certain guard passes — each match fits its own pool's window,
         each pool has a table to itself and is well under aggregate capacity, and
         no *single pool* over-subscribes anyone (one match each) — yet the two
@@ -652,9 +657,9 @@ class TestInfeasibility:
 
         This is the shape of infeasibility the per-(pool, player) pre-check
         deliberately does NOT claim: it is scoped to one pool, so a human split
-        across pools is beyond what it can prove. No single structural cause
-        explains it, so the residual :class:`NoSingleCause` is attached, with
-        aggregate room to spare (``required_min <= available_min``)."""
+        across pools is beyond what it can prove. The diagnostic solve answers
+        instead — dropping either one of the two makes the day fit, so the core
+        names exactly one fixture."""
         p1, p2, p3 = _players(3)
         table_ids = _tables(2)
         snapshot = ScheduleSnapshot(
@@ -674,10 +679,9 @@ class TestInfeasibility:
         result = solve(snapshot, time_cap_s=CAP)
         assert result.verdict is Verdict.infeasible
         assert result.placements == ()
-        assert result.reasons == (NoSingleCause(required_min=50, available_min=60),)
         (only,) = result.reasons
-        assert isinstance(only, NoSingleCause)
-        assert only.required_min <= only.available_min
+        assert isinstance(only, UnplaceableFixtures)
+        assert only.fixture_ids in ((FixtureId("F1"),), (FixtureId("F2"),))
 
     def test_pool_with_no_tables_is_infeasible(self) -> None:
         p1, p2 = _players(2)
@@ -1855,9 +1859,9 @@ class TestOptionalPlacementVariant:
         """The behavioural half, and the falsification this chore turns on.
 
         The day is infeasible *only* because of one human's rest floor (see
-        :func:`_rest_conflict_snapshot`) — the ordinary solve proves it and can
-        say nothing but ``NoSingleCause``. The max-placed model must be able to
-        drop one of the two fixtures and become satisfiable, placing exactly
+        :func:`_rest_conflict_snapshot`) — no certain pre-check can prove it, so
+        the ordinary solve has to reach CP-SAT. The max-placed model must be able
+        to drop one of the two fixtures and become satisfiable, placing exactly
         one. It can do that only if the *player* intervals are optional: with
         them left mandatory the model stays infeasible however the ``placed``
         literals are set, so this test reds — which is the check that the trap
@@ -1866,7 +1870,7 @@ class TestOptionalPlacementVariant:
 
         ordinary = solve(snapshot, time_cap_s=CAP)
         assert ordinary.verdict is Verdict.infeasible
-        assert [type(reason) for reason in ordinary.reasons] == [NoSingleCause]
+        assert [type(reason) for reason in ordinary.reasons] == [UnplaceableFixtures]
 
         built = _build_model(snapshot, optional_placement=True)
         assert isinstance(built, _SolverModel)
@@ -1941,3 +1945,252 @@ class TestOptionalPlacementVariant:
                 for present in built.presences[fixture.id].values()
             )
             assert chosen == int(solver.Value(built.placed_literals[fixture.id]))
+
+
+def _pin_blocked_snapshot() -> ScheduleSnapshot:
+    """A day whose *only* unplaceable fixture is unambiguous.
+
+    One table, a 35-minute window, and a called 15-minute match (``F2``) holding
+    that table from minute 0 with ``P1`` in it. ``F1`` is unpinned and also has
+    ``P1``, so it can start no earlier than 25 (the pin ends at 15, ``P1`` owes
+    10 minutes of rest) — but a 15-minute match must start by 20 to end inside
+    the window. No legal start exists, and no certain pre-check can prove it: the
+    pool has a table, one match fits the 35-minute window, unpinned demand is 15
+    against 35 table-minutes, and ``P1`` has only one *unpinned* match, so the
+    per-player pigeonhole does not apply.
+
+    The core is therefore exactly ``F1``: the promise is not droppable, so it is
+    the only fixture the diagnostic may name."""
+    table_ids = _tables(1)
+    return ScheduleSnapshot(
+        table_ids=table_ids,
+        pools=(SchedulePool(PoolId("A"), table_ids, Window(0, 35)),),
+        events=(EventSettings(EventId("E1"), 1),),
+        fixtures=(
+            _fixture(1, PlayerId("P1"), PlayerId("P2")),
+            _fixture(2, PlayerId("P1"), PlayerId("P3"), pin=Pin(table_ids[0], 0)),
+        ),
+        now_min=0,
+    )
+
+
+class _DiagnosticSpy:
+    """Counts the diagnostic solves :func:`solve` actually runs (and the caps it
+    runs them under), delegating to the real one so the answer is unchanged.
+
+    Interposed on the module attribute, which is how ``solve`` looks the helper
+    up — so "the fast path pays nothing" is *asserted*, not assumed."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.caps: list[float] = []
+
+    def __call__(
+        self,
+        snapshot: ScheduleSnapshot,
+        *,
+        time_cap_s: float,
+        num_search_workers: int,
+    ) -> tuple[UnplaceableFixtures | None, int]:
+        self.calls += 1
+        self.caps.append(time_cap_s)
+        return _diagnose_unplaceable(
+            snapshot, time_cap_s=time_cap_s, num_search_workers=num_search_workers
+        )
+
+
+class _UnknownSolver:
+    """A ``CpSolver`` stand-in that reports UNKNOWN without searching — the
+    time-cap outcome, which is otherwise reachable only by racing a real cap.
+    Mirrors the three members :func:`solve` uses."""
+
+    def __init__(self) -> None:
+        self.parameters = SimpleNamespace()
+
+    def Solve(self, model: Any) -> int:  # noqa: N802 - mirrors CpSolver's API
+        return cp_model.UNKNOWN
+
+    def WallTime(self) -> float:  # noqa: N802 - mirrors CpSolver's API
+        return 0.0
+
+
+class TestConflictCoreDiagnostic:
+    """The second, max-placed solve behind a *proven* infeasibility (ADR "the
+    conflict core is a second, max-placed solve over optional placements"): it
+    runs on that one path and nowhere else, names the fixtures it could not
+    place, never claims minimality, answers the same way every time, and leaves
+    ``NoSingleCause`` underneath as the floor."""
+
+    def test_a_proven_infeasible_day_names_the_fixtures_it_could_not_place(
+        self,
+    ) -> None:
+        """The headline: CP-SAT proves the day does not fit, and the reason is no
+        longer a whole-day aggregate but the fixture that could not be placed —
+        the unpinned one. The called match is never named: it is not droppable,
+        so "cancel it" is not a remedy this arm is allowed to imply."""
+        result = solve(_pin_blocked_snapshot(), time_cap_s=CAP)
+        assert result.verdict is Verdict.infeasible
+        assert result.placements == ()
+        assert result.reasons == (UnplaceableFixtures(fixture_ids=(FixtureId("F1"),)),)
+
+    def test_the_core_holds_every_fixture_that_had_to_be_dropped(self) -> None:
+        """Not just the first one found: two independent, identical conflicts in
+        one day (two pools, each with a pin blocking its own single table) yield
+        a core naming both unplaceable fixtures, sorted."""
+        table_ids = _tables(2)
+        snapshot = ScheduleSnapshot(
+            table_ids=table_ids,
+            pools=(
+                SchedulePool(PoolId("A"), (TableId("T1"),), Window(0, 35)),
+                SchedulePool(PoolId("B"), (TableId("T2"),), Window(0, 35)),
+            ),
+            events=(EventSettings(EventId("E1"), 1),),
+            fixtures=(
+                _fixture(1, PlayerId("P1"), PlayerId("P2"), pool="A"),
+                _fixture(
+                    2,
+                    PlayerId("P1"),
+                    PlayerId("P3"),
+                    pool="A",
+                    pin=Pin(TableId("T1"), 0),
+                ),
+                _fixture(3, PlayerId("P4"), PlayerId("P5"), pool="B"),
+                _fixture(
+                    4,
+                    PlayerId("P4"),
+                    PlayerId("P6"),
+                    pool="B",
+                    pin=Pin(TableId("T2"), 0),
+                ),
+            ),
+            now_min=0,
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict is Verdict.infeasible
+        assert result.reasons == (
+            UnplaceableFixtures(fixture_ids=(FixtureId("F1"), FixtureId("F3"))),
+        )
+
+    def test_a_feasible_day_runs_no_diagnostic_solve(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The fast path pays nothing — asserted, not assumed. A day that solves
+        never enters the diagnostic branch at all, so the extra budget is spent
+        only where the extra answer is wanted."""
+        spy = _DiagnosticSpy()
+        monkeypatch.setattr(scheduling, "_diagnose_unplaceable", spy)
+
+        result = solve(_golden_snapshot(), time_cap_s=CAP)
+
+        assert result.verdict in SOLVED
+        assert result.reasons == ()
+        assert spy.calls == 0
+
+    def test_a_certain_pre_check_runs_no_diagnostic_solve(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A structurally-proven infeasibility never reaches CP-SAT, so it never
+        reaches the diagnostic either: a certain arm is a cheaper and more
+        specific answer than a drop set, and paying for a second solve to
+        re-explain it would be pure waste."""
+        spy = _DiagnosticSpy()
+        monkeypatch.setattr(scheduling, "_diagnose_unplaceable", spy)
+
+        players = _players(6)
+        fixtures = tuple(
+            _fixture(n, players[2 * (n - 1)], players[2 * n - 1]) for n in (1, 2, 3)
+        )
+        result = solve(
+            _one_pool_snapshot(fixtures, tables=1, window=(0, 60)), time_cap_s=CAP
+        )
+
+        assert [reason.kind for reason in result.reasons] == ["pool_over_capacity"]
+        assert spy.calls == 0
+
+    def test_an_unknown_outcome_carries_no_reasons_and_no_diagnostic(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``unknown`` is "did not finish", not "does not fit": there is nothing
+        proven to explain, so no reason is attached and no second solve is run.
+        Running one here would spend a *further* budget on a run that already
+        exhausted its own."""
+        spy = _DiagnosticSpy()
+        monkeypatch.setattr(scheduling, "_diagnose_unplaceable", spy)
+        monkeypatch.setattr(scheduling.cp_model, "CpSolver", _UnknownSolver)
+
+        result = solve(_rest_conflict_snapshot(), time_cap_s=CAP)
+
+        assert result.verdict is Verdict.unknown
+        assert result.reasons == ()
+        assert spy.calls == 0
+
+    def test_the_diagnostic_runs_under_its_own_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Its own budget, not a share of the main solve's: the cap the caller
+        passes for the diagnostic is the one it runs under."""
+        spy = _DiagnosticSpy()
+        monkeypatch.setattr(scheduling, "_diagnose_unplaceable", spy)
+
+        result = solve(
+            _pin_blocked_snapshot(), time_cap_s=CAP, diagnostic_time_cap_s=1.5
+        )
+
+        assert result.verdict is Verdict.infeasible
+        assert spy.calls == 1
+        assert spy.caps == [1.5]
+
+    def test_the_core_is_identical_on_every_re_run(self) -> None:
+        """Determinism, on the instance most able to break it: the rest conflict
+        admits *either* fixture as the drop, so a tie-broken answer would drift
+        between runs. Same seed, same worker count, same model construction —
+        same core, three times over."""
+        snapshot = _rest_conflict_snapshot()
+        cores = [solve(snapshot, time_cap_s=CAP).reasons for _ in range(3)]
+        assert cores[0] == cores[1] == cores[2]
+        (only,) = cores[0]
+        assert isinstance(only, UnplaceableFixtures)
+        assert len(only.fixture_ids) == 1
+
+    def test_no_single_cause_survives_as_the_floor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the diagnostic cannot answer — it came back infeasible itself
+        (pins are not droppable), or exhausted its own cap with no solution — the
+        whole-day aggregate is still there underneath. The stub stands in for
+        those outcomes because they are hard to *stage*: a pin can always slide
+        later on its own table, so pins-alone infeasibility is nearly
+        unreachable, and racing a real cap would be flaky. What the helper
+        returns on each of them is asserted directly below."""
+        monkeypatch.setattr(
+            scheduling, "_diagnose_unplaceable", lambda *a, **k: (None, 7)
+        )
+
+        result = solve(_rest_conflict_snapshot(), time_cap_s=CAP)
+
+        assert result.verdict is Verdict.infeasible
+        assert result.reasons == (NoSingleCause(required_min=30, available_min=160),)
+        # The diagnostic's own wall time is folded into the run's: an infeasible
+        # run costs proving it AND trying to explain it.
+        assert result.stats.wall_time_ms >= 7
+
+    def test_the_helper_declines_to_answer_when_it_finds_no_solution(self) -> None:
+        """The floor's trigger, at the seam: a diagnostic solve that reaches no
+        solution (here because its cap is exhausted — the ``_UnknownSolver`` says
+        so without racing a real clock) reports *no* core rather than an empty
+        one. An empty core would claim nothing while looking like an answer."""
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(scheduling.cp_model, "CpSolver", _UnknownSolver)
+            core, _wall_ms = _diagnose_unplaceable(
+                _rest_conflict_snapshot(), time_cap_s=CAP, num_search_workers=1
+            )
+        assert core is None
+
+    def test_the_arm_carries_no_minimality_flag(self) -> None:
+        """The drop set is an upper bound, never a proven minimum (the
+        diagnostic may stop at FEASIBLE under its cap). The arm therefore carries
+        the fixtures and nothing else — no proven/partial field for a caller to
+        build a stronger claim on, and no nested player list (a provably
+        over-subscribed player is caught earlier, by PlayerOverSubscribed)."""
+        names = [f.name for f in dataclasses.fields(UnplaceableFixtures)]
+        assert names == ["fixture_ids", "kind"]

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -2912,6 +2912,8 @@ internal enum Components {
                 case poolHasNoTables(Components.Schemas.PoolHasNoTablesRead)
                 /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload/PoolOverCapacityRead`.
                 case poolOverCapacity(Components.Schemas.PoolOverCapacityRead)
+                /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload/UnplaceableFixturesRead`.
+                case unplaceableFixtures(Components.Schemas.UnplaceableFixturesRead)
                 /// - Remark: Generated from `#/components/schemas/AdminScheduleSolveRead/InfeasibilityReasonsPayload/WindowTooShortForMatchRead`.
                 case windowTooShortForMatch(Components.Schemas.WindowTooShortForMatchRead)
                 internal enum CodingKeys: String, CodingKey {
@@ -2934,6 +2936,8 @@ internal enum Components {
                         self = .poolHasNoTables(try .init(from: decoder))
                     case "pool_over_capacity":
                         self = .poolOverCapacity(try .init(from: decoder))
+                    case "unplaceable_fixtures":
+                        self = .unplaceableFixtures(try .init(from: decoder))
                     case "window_too_short_for_match":
                         self = .windowTooShortForMatch(try .init(from: decoder))
                     default:
@@ -2955,6 +2959,8 @@ internal enum Components {
                     case let .poolHasNoTables(value):
                         try value.encode(to: encoder)
                     case let .poolOverCapacity(value):
+                        try value.encode(to: encoder)
+                    case let .unplaceableFixtures(value):
                         try value.encode(to: encoder)
                     case let .windowTooShortForMatch(value):
                         try value.encode(to: encoder)
@@ -3404,12 +3410,16 @@ internal enum Components {
                 case skipMerge = "skip_merge"
             }
         }
-        /// One of the in-progress matches caught in a conflict, named the way the
-        /// director reads a fixture — by its **matchup**, the two players facing off
-        /// (:attr:`player_a` / :attr:`player_b`, their display usernames). The raw
-        /// ``fixture_id`` rides along so a surface can key/deep-link without re-deriving
-        /// it from the names. Resolved once at apply from the pure conflict's fixture
-        /// ids; the client formats the ``a vs b`` label itself.
+        /// One fixture, named the way the director reads a fixture — by its
+        /// **matchup**, the two players facing off (:attr:`player_a` / :attr:`player_b`,
+        /// their display usernames). The raw ``fixture_id`` rides along so a surface can
+        /// key/deep-link without re-deriving it from the names. Resolved once at apply
+        /// from the pure fixture ids; the client formats the ``a vs b`` label itself.
+        ///
+        /// Shared by both id-carrying unions: the in-progress matches caught in a
+        /// :class:`TableConflictRead` / :class:`PlayerConflictRead`, and the fixtures an
+        /// :class:`UnplaceableFixturesRead` says could not be placed. One shape, so the
+        /// client renders a named fixture the same way wherever it appears.
         ///
         /// - Remark: Generated from `#/components/schemas/ConflictFixtureRead`.
         internal struct ConflictFixtureRead: Codable, Hashable, Sendable {
@@ -6102,8 +6112,9 @@ internal enum Components {
                 case submittedAt = "submitted_at"
             }
         }
-        /// CP-SAT proved the day infeasible yet no structural arm explains it — the
-        /// whole-day residual. No pool: it carries only the day aggregate,
+        /// CP-SAT proved the day infeasible, no structural arm explains it, and the
+        /// diagnostic solve could not extract a conflict core either — the whole-day
+        /// floor. No pool and no fixtures: it carries only the day aggregate,
         /// ``required_min`` against ``available_min``, as integer minutes.
         ///
         /// - Remark: Generated from `#/components/schemas/NoSingleCauseRead`.
@@ -8283,6 +8294,8 @@ internal enum Components {
                 case poolHasNoTables(Components.Schemas.PoolHasNoTablesRead)
                 /// - Remark: Generated from `#/components/schemas/PreviewResult/InfeasibilityReasonsPayload/PoolOverCapacityRead`.
                 case poolOverCapacity(Components.Schemas.PoolOverCapacityRead)
+                /// - Remark: Generated from `#/components/schemas/PreviewResult/InfeasibilityReasonsPayload/UnplaceableFixturesRead`.
+                case unplaceableFixtures(Components.Schemas.UnplaceableFixturesRead)
                 /// - Remark: Generated from `#/components/schemas/PreviewResult/InfeasibilityReasonsPayload/WindowTooShortForMatchRead`.
                 case windowTooShortForMatch(Components.Schemas.WindowTooShortForMatchRead)
                 internal enum CodingKeys: String, CodingKey {
@@ -8305,6 +8318,8 @@ internal enum Components {
                         self = .poolHasNoTables(try .init(from: decoder))
                     case "pool_over_capacity":
                         self = .poolOverCapacity(try .init(from: decoder))
+                    case "unplaceable_fixtures":
+                        self = .unplaceableFixtures(try .init(from: decoder))
                     case "window_too_short_for_match":
                         self = .windowTooShortForMatch(try .init(from: decoder))
                     default:
@@ -8326,6 +8341,8 @@ internal enum Components {
                     case let .poolHasNoTables(value):
                         try value.encode(to: encoder)
                     case let .poolOverCapacity(value):
+                        try value.encode(to: encoder)
+                    case let .unplaceableFixtures(value):
                         try value.encode(to: encoder)
                     case let .windowTooShortForMatch(value):
                         try value.encode(to: encoder)
@@ -9091,6 +9108,8 @@ internal enum Components {
                 case poolHasNoTables(Components.Schemas.PoolHasNoTablesRead)
                 /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload/PoolOverCapacityRead`.
                 case poolOverCapacity(Components.Schemas.PoolOverCapacityRead)
+                /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload/UnplaceableFixturesRead`.
+                case unplaceableFixtures(Components.Schemas.UnplaceableFixturesRead)
                 /// - Remark: Generated from `#/components/schemas/ScheduleSolveRead/InfeasibilityReasonsPayload/WindowTooShortForMatchRead`.
                 case windowTooShortForMatch(Components.Schemas.WindowTooShortForMatchRead)
                 internal enum CodingKeys: String, CodingKey {
@@ -9113,6 +9132,8 @@ internal enum Components {
                         self = .poolHasNoTables(try .init(from: decoder))
                     case "pool_over_capacity":
                         self = .poolOverCapacity(try .init(from: decoder))
+                    case "unplaceable_fixtures":
+                        self = .unplaceableFixtures(try .init(from: decoder))
                     case "window_too_short_for_match":
                         self = .windowTooShortForMatch(try .init(from: decoder))
                     default:
@@ -9134,6 +9155,8 @@ internal enum Components {
                     case let .poolHasNoTables(value):
                         try value.encode(to: encoder)
                     case let .poolOverCapacity(value):
+                        try value.encode(to: encoder)
+                    case let .unplaceableFixtures(value):
                         try value.encode(to: encoder)
                     case let .windowTooShortForMatch(value):
                         try value.encode(to: encoder)
@@ -11376,6 +11399,46 @@ internal enum Components {
                     "table_catalogue",
                     "league_id"
                 ])
+            }
+        }
+        /// The **conflict core**: the fixtures a proven-infeasible day could not
+        /// place, each named by its matchup (:class:`ConflictFixtureRead` — the same
+        /// shape a placement conflict names a fixture with). The client's sentence is
+        /// *"these could not be placed"*, never *"you must remove exactly these"*: the
+        /// core is the drop set of a capped optimization, so it is an upper bound and
+        /// **minimality is never claimed** — which is why there is no proven/partial
+        /// flag here to hang a stronger claim on.
+        ///
+        /// Fixtures only, no players: an over-subscribed human is proved earlier and
+        /// more cheaply by :class:`PlayerOverSubscribedRead`, so naming players here
+        /// could only be a guess. The DB-aware mirror of
+        /// :class:`app.scheduling.UnplaceableFixtures`.
+        ///
+        /// - Remark: Generated from `#/components/schemas/UnplaceableFixturesRead`.
+        internal struct UnplaceableFixturesRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/UnplaceableFixturesRead/kind`.
+            internal enum KindPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case unplaceableFixtures = "unplaceable_fixtures"
+            }
+            /// - Remark: Generated from `#/components/schemas/UnplaceableFixturesRead/kind`.
+            internal var kind: Components.Schemas.UnplaceableFixturesRead.KindPayload?
+            /// - Remark: Generated from `#/components/schemas/UnplaceableFixturesRead/fixtures`.
+            internal var fixtures: [Components.Schemas.ConflictFixtureRead]
+            /// Creates a new `UnplaceableFixturesRead`.
+            ///
+            /// - Parameters:
+            ///   - kind:
+            ///   - fixtures:
+            internal init(
+                kind: Components.Schemas.UnplaceableFixturesRead.KindPayload? = nil,
+                fixtures: [Components.Schemas.ConflictFixtureRead]
+            ) {
+                self.kind = kind
+                self.fixtures = fixtures
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case kind
+                case fixtures
             }
         }
         /// Just the unread total — the cheap endpoint the bell badge polls.

--- a/web-client/e2e/tournaments/tournament-schedule-solve.spec.ts
+++ b/web-client/e2e/tournaments/tournament-schedule-solve.spec.ts
@@ -298,6 +298,69 @@ test.describe('Tournaments · schedule solve strip', () => {
     )
   })
 
+  test('names the CONFLICT CORE — the `unplaceable_fixtures` matches cross the real wire by matchup, and the sentence never claims they are the minimum', async ({
+    page,
+  }) => {
+    // An `unplaceable_fixtures` arm of `infeasibility_reasons` crosses the real
+    // wire (MSW off, this stub IS the API) carrying the SAME nested fixture shape
+    // a placement conflict uses; the client Zod-parses it in the queryFn and the
+    // strip names the matches by who is playing whom (ADR "the conflict core is a
+    // second, max-placed solve", decision 2).
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      ...DRAWN_SEED,
+      latestSolve: buildScheduleSolveRead({
+        status: 'infeasible',
+        verdict: 'infeasible',
+        trigger: 'manual',
+        fixtures_placed: null,
+        fixtures_pinned: null,
+        infeasibility_reasons: [
+          {
+            kind: 'unplaceable_fixtures',
+            fixtures: [
+              {
+                fixture_id: 'fx-1',
+                player_a: 'crafty-otter',
+                player_b: 'spiked-frigatebird',
+              },
+              {
+                fixture_id: 'fx-2',
+                player_a: 'dazed-marmot',
+                player_b: 'wily-heron',
+              },
+            ],
+          },
+        ],
+      }),
+    })
+    await pom.openScheduleTab()
+
+    const state = pom.solveStripState('infeasible')
+    await expect(state).toBeVisible()
+    // WHICH matches, by who is playing whom — every one of them named.
+    await expect(state).toContainText("2 matches couldn't all be placed")
+    await expect(state).toContainText('crafty-otter-vs-spiked-frigatebird')
+    await expect(state).toContainText('dazed-marmot-vs-wily-heron')
+    // …and NEVER as a minimum: the set comes off a capped optimization that may
+    // stop at good-enough, and the API carries no proven/partial flag to lean on
+    // (ADR decision 4).
+    await expect(state).toContainText("aren't necessarily the smallest set")
+    await expect(state).not.toContainText('minimum')
+    await expect(state).not.toContainText('must remove')
+    // Capacity already passed to reach this arm, so: not the add-tables trap.
+    await expect(state).toContainText("adding tables won't help here")
+    await expect(state).not.toContainText('Add tables, widen a pool window')
+    // Still a designed state, not an error; the raw wire code and the fixture ids
+    // both stay off screen.
+    await expect(pom.runSchedulerNotice).not.toBeVisible()
+    await expect(pom.toasts).toHaveCount(0)
+    await expect(state).not.toContainText('unplaceable_fixtures')
+    await expect(state).not.toContainText('fx-1')
+    await expect(pom.runScheduler).toBeEnabled()
+
+    await expectAxeClean(page, 'schedule tab — conflict-core infeasible solve on the strip')
+  })
+
   test('answers the coded 422 with the designed "cut a draw first" message, inline on the strip', async ({
     page,
   }) => {

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -1794,7 +1794,7 @@ export interface components {
             /** Error */
             error: string | null;
             /** Infeasibility Reasons */
-            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["PlayerOverSubscribedRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
+            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["PlayerOverSubscribedRead"] | components["schemas"]["UnplaceableFixturesRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
             /** Placement Conflicts */
             placement_conflicts: (components["schemas"]["TableConflictRead"] | components["schemas"]["PlayerConflictRead"])[];
             /** Input Fingerprint */
@@ -1912,12 +1912,16 @@ export interface components {
         };
         /**
          * ConflictFixtureRead
-         * @description One of the in-progress matches caught in a conflict, named the way the
-         *     director reads a fixture — by its **matchup**, the two players facing off
-         *     (:attr:`player_a` / :attr:`player_b`, their display usernames). The raw
-         *     ``fixture_id`` rides along so a surface can key/deep-link without re-deriving
-         *     it from the names. Resolved once at apply from the pure conflict's fixture
-         *     ids; the client formats the ``a vs b`` label itself.
+         * @description One fixture, named the way the director reads a fixture — by its
+         *     **matchup**, the two players facing off (:attr:`player_a` / :attr:`player_b`,
+         *     their display usernames). The raw ``fixture_id`` rides along so a surface can
+         *     key/deep-link without re-deriving it from the names. Resolved once at apply
+         *     from the pure fixture ids; the client formats the ``a vs b`` label itself.
+         *
+         *     Shared by both id-carrying unions: the in-progress matches caught in a
+         *     :class:`TableConflictRead` / :class:`PlayerConflictRead`, and the fixtures an
+         *     :class:`UnplaceableFixturesRead` says could not be placed. One shape, so the
+         *     client renders a named fixture the same way wherever it appears.
          */
         ConflictFixtureRead: {
             /** Fixture Id */
@@ -3013,8 +3017,9 @@ export interface components {
         };
         /**
          * NoSingleCauseRead
-         * @description CP-SAT proved the day infeasible yet no structural arm explains it — the
-         *     whole-day residual. No pool: it carries only the day aggregate,
+         * @description CP-SAT proved the day infeasible, no structural arm explains it, and the
+         *     diagnostic solve could not extract a conflict core either — the whole-day
+         *     floor. No pool and no fixtures: it carries only the day aggregate,
          *     ``required_min`` against ``available_min``, as integer minutes.
          */
         NoSingleCauseRead: {
@@ -3913,7 +3918,7 @@ export interface components {
             /** Events */
             events: components["schemas"]["PreviewEventBreakdown"][];
             /** Infeasibility Reasons */
-            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["PlayerOverSubscribedRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
+            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["PlayerOverSubscribedRead"] | components["schemas"]["UnplaceableFixturesRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
             /** Notes */
             notes: string[];
             /**
@@ -4271,7 +4276,7 @@ export interface components {
             /** Error */
             error: string | null;
             /** Infeasibility Reasons */
-            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["PlayerOverSubscribedRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
+            infeasibility_reasons: (components["schemas"]["PoolHasNoTablesRead"] | components["schemas"]["WindowTooShortForMatchRead"] | components["schemas"]["PoolOverCapacityRead"] | components["schemas"]["PlayerOverSubscribedRead"] | components["schemas"]["UnplaceableFixturesRead"] | components["schemas"]["NoSingleCauseRead"] | components["schemas"]["PastWindowReasonRead"])[];
             /** Placement Conflicts */
             placement_conflicts: (components["schemas"]["TableConflictRead"] | components["schemas"]["PlayerConflictRead"])[];
         };
@@ -5036,6 +5041,30 @@ export interface components {
             table_catalogue?: components["schemas"]["TournamentTable"][] | null;
             /** League Id */
             league_id?: string | null;
+        };
+        /**
+         * UnplaceableFixturesRead
+         * @description The **conflict core**: the fixtures a proven-infeasible day could not
+         *     place, each named by its matchup (:class:`ConflictFixtureRead` — the same
+         *     shape a placement conflict names a fixture with). The client's sentence is
+         *     *"these could not be placed"*, never *"you must remove exactly these"*: the
+         *     core is the drop set of a capped optimization, so it is an upper bound and
+         *     **minimality is never claimed** — which is why there is no proven/partial
+         *     flag here to hang a stronger claim on.
+         *
+         *     Fixtures only, no players: an over-subscribed human is proved earlier and
+         *     more cheaply by :class:`PlayerOverSubscribedRead`, so naming players here
+         *     could only be a guess. The DB-aware mirror of
+         *     :class:`app.scheduling.UnplaceableFixtures`.
+         */
+        UnplaceableFixturesRead: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "unplaceable_fixtures";
+            /** Fixtures */
+            fixtures: components["schemas"]["ConflictFixtureRead"][];
         };
         /**
          * UnreadCountResponse

--- a/web-client/src/components/scheduling/solve-ledger-page.factory.ts
+++ b/web-client/src/components/scheduling/solve-ledger-page.factory.ts
@@ -64,10 +64,12 @@ export function buildLedgerVariety(): AdminScheduleSolveRead[] {
       fixtures_pinned: null,
       tournament_id: 'summer-slam-2026',
       tournament_name: 'Summer Slam 2026',
-      // The resolved causes the day doesn't fit — three arms, so the expansion
+      // The resolved causes the day doesn't fit — four arms, so the expansion
       // proves it renders each reason's sentence + remedy (the same list the
-      // Schedule-tab strip shows), including the one that names a *human*
-      // (`player_over_subscribed`) rather than a pool or a fixture.
+      // Schedule-tab strip shows): the one that names a *human*
+      // (`player_over_subscribed`), the one that names the *matches* that
+      // couldn't all be placed (`unplaceable_fixtures`, the conflict core), and
+      // the whole-day floor.
       infeasibility_reasons: [
         {
           kind: 'window_too_short_for_match',
@@ -87,6 +89,17 @@ export function buildLedgerVariety(): AdminScheduleSolveRead[] {
           match_count: 4,
           required_min: 150,
           window_span_min: 90,
+        },
+        {
+          kind: 'unplaceable_fixtures',
+          fixtures: [
+            {
+              fixture_id: 'fx-1',
+              player_a: 'crafty-otter',
+              player_b: 'spiked-frigatebird',
+            },
+            { fixture_id: 'fx-2', player_a: 'dazed-marmot', player_b: 'wily-heron' },
+          ],
         },
         {
           kind: 'no_single_cause',

--- a/web-client/src/components/scheduling/solve-ledger-page.test.tsx
+++ b/web-client/src/components/scheduling/solve-ledger-page.test.tsx
@@ -34,6 +34,13 @@ const overSubscribedCopy = infeasibilityReasonCopy({
   requiredMin: 150,
   windowSpanMin: 90,
 })
+const conflictCoreCopy = infeasibilityReasonCopy({
+  kind: 'unplaceable_fixtures',
+  fixtures: [
+    { fixtureId: 'fx-1', playerA: 'crafty-otter', playerB: 'spiked-frigatebird' },
+    { fixtureId: 'fx-2', playerA: 'dazed-marmot', playerB: 'wily-heron' },
+  ],
+})
 const noSingleCauseCopy = infeasibilityReasonCopy({
   kind: 'no_single_cause',
   requiredMin: 420,
@@ -147,6 +154,17 @@ describe('SolveLedgerPage', () => {
     expect(detail).toHaveTextContent(overSubscribedCopy.sentence)
     expect(detail).toHaveTextContent(overSubscribedCopy.remedy)
     expect(overSubscribedCopy.remedy).not.toMatch(/add (a |another |more )?tables?/i)
+    // The arm that names the MATCHES: which fixtures couldn't all be placed, by
+    // matchup — and never as a minimum (ADR "the conflict core is a second,
+    // max-placed solve", decision 4).
+    expect(detail).toHaveTextContent("2 matches couldn't all be placed")
+    expect(detail).toHaveTextContent('crafty-otter-vs-spiked-frigatebird')
+    expect(detail).toHaveTextContent('dazed-marmot-vs-wily-heron')
+    expect(detail).toHaveTextContent(conflictCoreCopy.sentence)
+    expect(detail).toHaveTextContent(conflictCoreCopy.remedy)
+    expect(`${conflictCoreCopy.sentence} ${conflictCoreCopy.remedy}`).not.toMatch(
+      /\bminimum\b|\bminimal\b|must (remove|drop|cut)/i,
+    )
     expect(detail).toHaveTextContent(noSingleCauseCopy.sentence)
     expect(detail).toHaveTextContent(noSingleCauseCopy.remedy)
     // An infeasible run carries no failed `error` sentence.

--- a/web-client/src/components/tournaments/data/solve.test.ts
+++ b/web-client/src/components/tournaments/data/solve.test.ts
@@ -24,8 +24,17 @@ import {
   scheduleRefetchInterval,
   solveInFlight,
   solveStripState,
+  type ConflictFixture,
   type InfeasibilityReason,
 } from './solve'
+
+/** A conflict core's fixtures, in the domain spelling — the same `ConflictFixture`
+ * shape a placement conflict carries, which is the point of the shared type. */
+const CORE_FIXTURES: ConflictFixture[] = [
+  { fixtureId: 'fx-1', playerA: 'crafty-otter', playerB: 'spiked-frigatebird' },
+  { fixtureId: 'fx-2', playerA: 'dazed-marmot', playerB: 'wily-heron' },
+  { fixtureId: 'fx-3', playerA: 'mellow-quokka', playerB: 'brisk-tapir' },
+]
 
 // ----- the parse boundary ----------------------------------------------------
 
@@ -155,6 +164,33 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
       requiredMin: 150,
       windowSpanMin: 90,
     })
+  })
+
+  it('parses unplaceable_fixtures — the conflict core, through the SAME fixture shape a placement conflict uses', () => {
+    expect(
+      infeasibilityReasonSchema.parse({
+        kind: 'unplaceable_fixtures',
+        fixtures: [
+          { fixture_id: 'fx-1', player_a: 'crafty-otter', player_b: 'spiked-frigatebird' },
+          { fixture_id: 'fx-2', player_a: 'dazed-marmot', player_b: 'wily-heron' },
+        ],
+      }),
+    ).toEqual({
+      kind: 'unplaceable_fixtures',
+      fixtures: [
+        { fixtureId: 'fx-1', playerA: 'crafty-otter', playerB: 'spiked-frigatebird' },
+        { fixtureId: 'fx-2', playerA: 'dazed-marmot', playerB: 'wily-heron' },
+      ],
+    })
+  })
+
+  it('refuses an unplaceable_fixtures arm whose fixtures are malformed — a half-named match must fail the parse, not render half a matchup', () => {
+    expect(() =>
+      infeasibilityReasonSchema.parse({
+        kind: 'unplaceable_fixtures',
+        fixtures: [{ fixture_id: 'fx-1', player_a: 'crafty-otter' }],
+      }),
+    ).toThrow()
   })
 
   it('parses no_single_cause (the residual, no pool)', () => {
@@ -436,6 +472,90 @@ describe('infeasibilityReasonCopy', () => {
     expect(copy.remedy).toContain('widen its window')
   })
 
+  it('words unplaceable_fixtures by naming every match, by who is playing whom', () => {
+    expect(
+      infeasibilityReasonCopy({
+        kind: 'unplaceable_fixtures',
+        fixtures: CORE_FIXTURES,
+      }),
+    ).toEqual({
+      sentence:
+        "3 matches couldn't all be placed: crafty-otter-vs-spiked-frigatebird, dazed-marmot-vs-wily-heron and mellow-quokka-vs-brisk-tapir — the rest of the day fits once they're out of it, though they aren't necessarily the smallest set to change.",
+      remedy:
+        "Trim one of these matches from the field, widen its pool's window, or split the event across days — adding tables won't help here.",
+    })
+  })
+
+  it('never claims the conflict core is minimal — the diagnostic is a capped optimization, so "these could not all be placed" is the strongest true sentence', () => {
+    // THE regression this arm exists to avoid (ADR "the conflict core is a second,
+    // max-placed solve", decision 4; CONTEXT.md "Conflict core"). The API extracts
+    // this set from an optimization under a time cap and carries NO proven/partial
+    // flag, so the copy has to be true whether the solver proved optimality or ran
+    // out of time. Anything that promises a minimum is a lie in the second case.
+    for (const fixtures of [CORE_FIXTURES, [CORE_FIXTURES[0]!]]) {
+      const copy = infeasibilityReasonCopy({ kind: 'unplaceable_fixtures', fixtures })
+      const said = `${copy.sentence} ${copy.remedy}`
+      // No minimality vocabulary, in any casing…
+      expect(said).not.toMatch(/\bminimum\b|\bminimal\b|\bfewest\b/i)
+      expect(said).not.toMatch(/\b(is|are) the smallest\b/i)
+      // …no imperative that turns the set into an instruction…
+      expect(said).not.toMatch(/must (remove|drop|delete|cut|take out)/i)
+      expect(said).not.toMatch(/exactly these|these exact|remove all of these/i)
+      // …and the hedge is on screen, not merely absent-by-luck: a future edit that
+      // drops it reds here.
+      expect(copy.sentence).toMatch(/aren't necessarily|isn't necessarily/)
+    }
+    // The sanctioned phrasing, verbatim from CONTEXT.md's "Conflict core".
+    expect(
+      infeasibilityReasonCopy({ kind: 'unplaceable_fixtures', fixtures: CORE_FIXTURES })
+        .sentence,
+    ).toContain("couldn't all be placed")
+  })
+
+  it('never steers the director toward adding tables for a conflict core — capacity already passed, so this is arrangement, not tables', () => {
+    // Same trap as `no_single_cause`, for the same reason: this arm is only
+    // reached once every capacity pre-check passed, so there IS table-time to
+    // spare. The remedy stays consistent with the residual's wording.
+    const copy = infeasibilityReasonCopy({
+      kind: 'unplaceable_fixtures',
+      fixtures: CORE_FIXTURES,
+    })
+    expect(copy.remedy).not.toMatch(/add (a |another |more )?tables?/i)
+    expect(copy.remedy).toContain("adding tables won't help here")
+  })
+
+  it('names EVERY match in a long core — nothing is elided behind an "and N more"', () => {
+    // A drop set a director can only half-see is not actionable, and a truncated
+    // list would read as *the* set — the one claim this arm may not make.
+    const many = Array.from({ length: 7 }, (_, i) => ({
+      fixtureId: `fx-${i}`,
+      playerA: `player-a${i}`,
+      playerB: `player-b${i}`,
+    }))
+    const { sentence } = infeasibilityReasonCopy({
+      kind: 'unplaceable_fixtures',
+      fixtures: many,
+    })
+    for (const f of many) {
+      expect(sentence).toContain(`${f.playerA}-vs-${f.playerB}`)
+    }
+    expect(sentence).not.toMatch(/\bmore\b|…|\.\.\./)
+    expect(sentence).toContain("7 matches couldn't all be placed")
+  })
+
+  it('words a one-match core in the singular — the sentence stays grammatical at the smallest core', () => {
+    const copy = infeasibilityReasonCopy({
+      kind: 'unplaceable_fixtures',
+      fixtures: [CORE_FIXTURES[0]!],
+    })
+    expect(copy.sentence).toBe(
+      "1 match couldn't be placed: crafty-otter-vs-spiked-frigatebird — the rest of the day fits without it, though freeing it up isn't necessarily the only way to make the day work.",
+    )
+    expect(copy.remedy).toBe(
+      "Trim this match from the field, widen its pool's window, or split the event across days — adding tables won't help here.",
+    )
+  })
+
   it('words no_single_cause as a timing conflict that steers away from adding tables', () => {
     const copy = infeasibilityReasonCopy({
       kind: 'no_single_cause',
@@ -496,6 +616,7 @@ describe('infeasibilityReasonCopy', () => {
         requiredMin: 150,
         windowSpanMin: 90,
       },
+      { kind: 'unplaceable_fixtures', fixtures: CORE_FIXTURES },
       { kind: 'no_single_cause', requiredMin: 360, availableMin: 480 },
       { kind: 'past_window', date: '2026-07-18' },
     ]

--- a/web-client/src/components/tournaments/data/solve.ts
+++ b/web-client/src/components/tournaments/data/solve.ts
@@ -69,6 +69,47 @@ export type ScheduleSolveTrigger = z.infer<typeof scheduleSolveTriggerSchema>
 export type ScheduleSolveStatus = z.infer<typeof scheduleSolveStatusSchema>
 export type SolverVerdict = z.infer<typeof solverVerdictSchema>
 
+// ----- a named fixture: the one shape BOTH unions carry -----------------------
+//
+// `ConflictFixtureRead` is deliberately shared on the wire (see its docstring in
+// `schema.d.ts`): a placement conflict names the fixtures it caught, and the
+// conflict core names the fixtures it could not place, with the *same* shape — so
+// the client renders a named fixture identically wherever it appears. It lives
+// above both unions because both parse through it at module-init time; hoisting a
+// `const` schema is not a thing, so ordering here is load-bearing.
+
+type ConflictFixtureWire = components['schemas']['ConflictFixtureRead']
+
+/** One fixture named the way the director reads a match — by its **matchup**, the
+ * two players facing off. The raw `fixtureId` rides along so a surface can
+ * key/deep-link without re-deriving it. Carried by the placement-conflict arms
+ * *and* by the infeasibility union's `unplaceable_fixtures` (the conflict core). */
+export interface ConflictFixture {
+  fixtureId: string
+  playerA: string
+  playerB: string
+}
+
+/** The wire fixture, as it really arrives: snake_case. `satisfies` it against the
+ * generated schema so a field renamed in the API is a compile error here. */
+const conflictFixtureWireSchema = z.object({
+  fixture_id: z.string(),
+  player_a: z.string(),
+  player_b: z.string(),
+}) satisfies z.ZodType<ConflictFixtureWire>
+
+function conflictFixtureFromWire(f: ConflictFixtureWire): ConflictFixture {
+  return { fixtureId: f.fixture_id, playerA: f.player_a, playerB: f.player_b }
+}
+
+/** A fixture's matchup label — the two players facing off, `crafty-vs-spiked`.
+ * How the director already reads a match, so every sentence built out of these
+ * names matches rather than ids. Shared by the placement-conflict caution and by
+ * the conflict core's sentence, so the two cannot drift on how a match reads. */
+export function conflictFixtureLabel(fixture: ConflictFixture): string {
+  return `${fixture.playerA}-vs-${fixture.playerB}`
+}
+
 // ----- why the day doesn't fit: the resolved infeasibility reasons ------------
 //
 // An `infeasible` solve no longer speaks in one opaque "Doesn't fit" — the API
@@ -91,6 +132,8 @@ type PoolOverCapacityWire =
   components['schemas']['PoolOverCapacityRead']
 type PlayerOverSubscribedWire =
   components['schemas']['PlayerOverSubscribedRead']
+type UnplaceableFixturesWire =
+  components['schemas']['UnplaceableFixturesRead']
 type NoSingleCauseWire =
   components['schemas']['NoSingleCauseRead']
 type PastWindowReasonWire =
@@ -115,8 +158,16 @@ type PastWindowReasonWire =
  *   one structural cause that names a *person* rather than a pool or fixture —
  *   and the one where adding tables is provably useless (extra tables let *other*
  *   people play in parallel, never this one).
- * - **`no_single_cause`** — CP-SAT proved infeasible but arms 1–4 all passed: a
- *   *timing* conflict, never a raw-capacity shortfall (so: don't add tables).
+ * - **`unplaceable_fixtures`** — the **conflict core** (CONTEXT.md): the matches a
+ *   proven-infeasible day could not place, each named by its matchup. It is the
+ *   *which* behind a timing conflict, and the one arm that is explicitly **not** a
+ *   proof of anything minimal: the API extracts it from a capped optimization, so
+ *   it is a set whose removal lets the day fit (an upper bound), never "the
+ *   smallest set" (ADR "the conflict core is a second, max-placed solve",
+ *   decision 4). Nothing in this client may word it as a minimum.
+ * - **`no_single_cause`** — CP-SAT proved infeasible but arms 1–4 all passed and
+ *   no core could be extracted either: a *timing* conflict, never a raw-capacity
+ *   shortfall (so: don't add tables). The floor, not the residual.
  * - **`past_window`** — a pool's ENTIRE planned window is already a day behind
  *   now (ADR "a past day is named, not disguised"), fixed by moving the date, not
  *   by adding tables/time. Carries the offending venue-local `date` (`YYYY-MM-DD`,
@@ -153,6 +204,7 @@ export type InfeasibilityReason =
       requiredMin: number
       windowSpanMin: number
     }
+  | { kind: 'unplaceable_fixtures'; fixtures: ConflictFixture[] }
   | { kind: 'no_single_cause'; requiredMin: number; availableMin: number }
   | { kind: 'past_window'; date: string }
 
@@ -196,6 +248,14 @@ const playerOverSubscribedWireSchema = z.object({
   window_span_min: z.number().int(),
 }) satisfies z.ZodType<PlayerOverSubscribedWire>
 
+/** The conflict core. `fixtures` reuses the shared `conflictFixtureWireSchema`
+ * above — one shape on the wire, one parser here, so a fixture named by a
+ * placement conflict and a fixture named by the core can never drift apart. */
+const unplaceableFixturesWireSchema = z.object({
+  kind: z.literal('unplaceable_fixtures'),
+  fixtures: z.array(conflictFixtureWireSchema),
+}) satisfies z.ZodType<UnplaceableFixturesWire>
+
 const noSingleCauseWireSchema = z.object({
   kind: z.literal('no_single_cause'),
   required_min: z.number().int(),
@@ -207,7 +267,7 @@ const pastWindowReasonWireSchema = z.object({
   date: z.string(),
 }) satisfies z.ZodType<PastWindowReasonWire>
 
-/** The six arms as one `z.discriminatedUnion('kind', …)` — an unknown `kind`
+/** The seven arms as one `z.discriminatedUnion('kind', …)` — an unknown `kind`
  * has no arm and throws, which is exactly the boundary rule: a reason this
  * client cannot render must fail the parse, not blank the row. */
 export const infeasibilityReasonWireSchema = z.discriminatedUnion('kind', [
@@ -215,6 +275,7 @@ export const infeasibilityReasonWireSchema = z.discriminatedUnion('kind', [
   windowTooShortForMatchWireSchema,
   poolOverCapacityWireSchema,
   playerOverSubscribedWireSchema,
+  unplaceableFixturesWireSchema,
   noSingleCauseWireSchema,
   pastWindowReasonWireSchema,
 ])
@@ -260,6 +321,13 @@ export function infeasibilityReasonFromWire(
         requiredMin: r.required_min,
         windowSpanMin: r.window_span_min,
       }
+    case 'unplaceable_fixtures':
+      return {
+        kind: r.kind,
+        // The same `conflictFixtureFromWire` the placement conflicts use — one
+        // mapping for one wire shape.
+        fixtures: r.fixtures.map(conflictFixtureFromWire),
+      }
     case 'no_single_cause':
       return {
         kind: r.kind,
@@ -299,18 +367,8 @@ export const infeasibilityReasonSchema =
 // are data (a `player_name` is like a username); the *sentence* is the client's,
 // minted in `placementConflictSentence` below.
 
-type ConflictFixtureWire = components['schemas']['ConflictFixtureRead']
 type TableConflictWire = components['schemas']['TableConflictRead']
 type PlayerConflictWire = components['schemas']['PlayerConflictRead']
-
-/** One in-progress match caught in a conflict, named the way the director reads
- * a fixture — by its **matchup**, the two players facing off. The raw `fixtureId`
- * rides along so a surface can key/deep-link without re-deriving it. */
-export interface ConflictFixture {
-  fixtureId: string
-  playerA: string
-  playerB: string
-}
 
 /**
  * One resolved placement conflict a solve carries, in the domain's camelCase — a
@@ -326,14 +384,6 @@ export interface ConflictFixture {
 export type PlacementConflict =
   | { kind: 'table_conflict'; tableLabel: string; fixtures: ConflictFixture[] }
   | { kind: 'player_conflict'; playerName: string; fixtures: ConflictFixture[] }
-
-/** The wire fixture, as it really arrives: snake_case. `satisfies` it against the
- * generated schema so a field renamed in the API is a compile error here. */
-const conflictFixtureWireSchema = z.object({
-  fixture_id: z.string(),
-  player_a: z.string(),
-  player_b: z.string(),
-}) satisfies z.ZodType<ConflictFixtureWire>
 
 const tableConflictWireSchema = z.object({
   kind: z.literal('table_conflict'),
@@ -354,10 +404,6 @@ export const placementConflictWireSchema = z.discriminatedUnion('kind', [
   tableConflictWireSchema,
   playerConflictWireSchema,
 ])
-
-function conflictFixtureFromWire(f: ConflictFixtureWire): ConflictFixture {
-  return { fixtureId: f.fixture_id, playerA: f.player_a, playerB: f.player_b }
-}
 
 /** One wire arm → one domain `PlacementConflict`. Annotated so the union above
  * and the wire arms are one thing. Exhaustive over `kind` (a `never` default), so
@@ -673,16 +719,27 @@ export interface InfeasibilityReasonCopy {
  * default makes a further arm added to the API a compile error here until it is
  * given words, so a reason can never reach the UI as a blank line.
  *
- * Two arms are deliberately worded to steer the director *away* from adding
- * tables, for two different reasons:
+ * Three arms are deliberately worded to steer the director *away* from adding
+ * tables, for three different reasons:
  *
- * - the residual (`no_single_cause`), because by construction there is a
+ * - the floor (`no_single_cause`), because by construction there is a
  *   table-time surplus — the problem is timing, not capacity;
  * - `player_over_subscribed`, because a table is parallelism and this is a
  *   pigeonhole over ONE human — a second table lets somebody *else* play, never
  *   this person twice at once. Its remedies are fewer matches for them in that
  *   pool, or a longer window (ADR "the conflict core is a second, max-placed
- *   solve", decision 1).
+ *   solve", decision 1);
+ * - `unplaceable_fixtures`, which is that same timing conflict *named* — it is
+ *   reached only once every capacity pre-check has passed, so there is table-time
+ *   to spare here too.
+ *
+ * And `unplaceable_fixtures` carries a second, harder rule: **it must never claim
+ * minimality.** The API extracts that set from an optimization under a time cap,
+ * so it may be a good-enough answer rather than a proven-smallest one, and it
+ * carries no proven/partial flag to tell the two apart — deliberately (ADR
+ * decision 4). The sentence therefore has to be true under *both* outcomes: "these
+ * couldn't all be placed" and "not necessarily the smallest set", never "you must
+ * remove exactly these" or "the minimum set is". A test pins that.
  */
 export function infeasibilityReasonCopy(
   reason: InfeasibilityReason,
@@ -717,6 +774,34 @@ export function infeasibilityReasonCopy(
         // trap `no_single_cause`'s remedy avoids, for a different reason).
         remedy: `Give ${reason.playerName} fewer matches in ${reason.poolName} — a smaller pool, or a shorter match format — or widen its window; adding tables won't help one player.`,
       }
+    case 'unplaceable_fixtures': {
+      // The conflict core, said in matchups — WHICH matches form the timing
+      // conflict, which is the whole point of the arm. Every fixture is named,
+      // conjoined the way `placementConflictSentence` names its colliding matches
+      // (the existing pattern for a fixture list); nothing is elided behind an
+      // "and N more", because a director cannot act on a set they can only see
+      // part of — and a truncated list would read as *the* set, which is exactly
+      // the claim this arm may not make.
+      const matches = conjoinWithAnd(reason.fixtures.map(conflictFixtureLabel))
+      const one = reason.fixtures.length === 1
+      return {
+        // NEVER "you must remove exactly these" / "the minimum set is": the core
+        // is the drop set of a capped optimization, so "the rest fits without
+        // them" is an upper bound that holds whether the solver proved optimality
+        // or ran out of time, and the "not necessarily the smallest" clause keeps
+        // the honest half of that on screen.
+        sentence: one
+          ? `1 match couldn't be placed: ${matches} — the rest of the day fits without it, though freeing it up isn't necessarily the only way to make the day work.`
+          : `${reason.fixtures.length} matches couldn't all be placed: ${matches} — the rest of the day fits once they're out of it, though they aren't necessarily the smallest set to change.`,
+        // NOT "add tables": every capacity pre-check passed before this arm was
+        // reached, so there is table-time to spare and the obstacle is
+        // arrangement — the same trap `no_single_cause`'s remedy avoids, worded
+        // consistently with it.
+        remedy: one
+          ? `Trim this match from the field, widen its pool's window, or split the event across days — adding tables won't help here.`
+          : `Trim one of these matches from the field, widen its pool's window, or split the event across days — adding tables won't help here.`,
+      }
+    }
     case 'no_single_cause':
       return {
         sentence: `There's enough total table-time (about ${fmtTableTime(reason.availableMin)} available for about ${fmtTableTime(reason.requiredMin)} of matches), so this is a timing conflict — a player is in too many matches too close together, or tables are shared across overlapping windows.`,
@@ -753,13 +838,6 @@ export function infeasibilityReasonKey(reason: InfeasibilityReason, i: number): 
 // Schedule-tab solve strip and the admin solve ledger import
 // `placementConflictSentence` and render the SAME warning, so the two surfaces
 // cannot drift on how a conflict reads. Pure functions, unit-tested here.
-
-/** A fixture's matchup label — the two players facing off, `crafty-vs-spiked`.
- * How the director already reads a fixture, so the warning names matches, not
- * ids. */
-export function conflictFixtureLabel(fixture: ConflictFixture): string {
-  return `${fixture.playerA}-vs-${fixture.playerB}`
-}
 
 /** One conflict as the director's caution sentence, naming the colliding matches
  * and the shared resource: `crafty-vs-spiked and dazed-vs-confused overlap on

--- a/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
@@ -229,6 +229,44 @@ describe('SolveStrip', () => {
     expect(text).not.toContain('player_over_subscribed')
   })
 
+  it('names the conflict core by matchup — WHICH matches could not all be placed — without ever claiming that set is the minimum', () => {
+    solveStripPage.render({
+      solve: buildScheduleSolve({
+        status: 'infeasible',
+        verdict: 'infeasible',
+        fixturesPlaced: null,
+        fixturesPinned: null,
+        infeasibilityReasons: [
+          {
+            kind: 'unplaceable_fixtures',
+            fixtures: [
+              { fixtureId: 'fx-1', playerA: 'crafty-otter', playerB: 'spiked-frigatebird' },
+              { fixtureId: 'fx-2', playerA: 'dazed-marmot', playerB: 'wily-heron' },
+            ],
+          },
+        ],
+      }),
+    })
+    const text = solveStripPage.getStateText('infeasible')
+    expect(text).toContain("The day doesn't fit")
+    // The ticket's headline: WHICH matches, by who is playing whom — every one of
+    // them, named.
+    expect(text).toContain("2 matches couldn't all be placed")
+    expect(text).toContain('crafty-otter-vs-spiked-frigatebird')
+    expect(text).toContain('dazed-marmot-vs-wily-heron')
+    // …and NEVER as a minimum. The set comes off a capped optimization, so the
+    // strip may only ever say "these couldn't all be placed" (ADR decision 4).
+    expect(text).toContain("aren't necessarily the smallest set")
+    expect(text).not.toMatch(/\bminimum\b|\bminimal\b/i)
+    expect(text).not.toMatch(/must (remove|drop|cut)/i)
+    // Enough table-time exists by construction here, so: not the add-tables trap.
+    expect(text).toContain("adding tables won't help here")
+    expect(text).not.toContain('Add tables, widen a pool window')
+    // The raw wire code never reaches the UI, and neither do the fixture ids.
+    expect(text).not.toContain('unplaceable_fixtures')
+    expect(text).not.toContain('fx-1')
+  })
+
   it('falls back to the generic sentence if an infeasible row carries no reasons — the strip never renders bodyless', () => {
     solveStripPage.render({
       solve: buildScheduleSolve({


### PR DESCRIPTION
Draft — slice 2 of 2 for #1129. **Stacked on #1263**, which is stacked on #1262. Merge bottom-up.

> A director whose day fails for no single structural reason is told **which matches cannot be placed together**, by matchup.

## What this adds

When CP-SAT proves a day infeasible, a **second solve** over an optional-placement model maximizes the count of placed fixtures. The ones it could not place are the conflict core, reported as `UnplaceableFixtures(fixture_ids)`.

This is the residual half of the ticket (acceptance criteria 1 and 3); slice 1 already shipped the certain per-player pre-check (criterion 2).

## Why max-placed and not an unsat core

Both routes the issue proposes need the **same** remodel — a per-fixture `placed` literal — because CP-SAT cannot reify `AddNoOverlap` behind an enforcement literal, so that literal is the only thing worth gating. The choice was what to *read off* it. A max-placed drop set always answers "here is a set whose removal makes the day fit"; `SufficientAssumptionsForInfeasibility` carries no minimality guarantee and can come back near-everything.

## The trap this was most likely to fall into

**Both interval families must be optional on the same literal.** `2a` makes the player intervals `NewOptionalFixedSizeIntervalVar(..., placed, ...)` and relaxes the table side from `AddExactlyOne` to `Σ present == placed`. Gating only the tables would leave the per-player rest constraint binding on a *dropped* fixture — so the drop relieves nothing, and rest-driven conflicts become permanently unexplainable.

That failure is invisible without the right test, and the falsification demonstrates exactly why: reverting the player intervals to mandatory reds the rest-driven drop test **while `test_a_feasible_day_places_everything` stays green**. The model builds, ordinary solves look fine, and only the explanation is silently broken.

## Minimality is never claimed

The diagnostic is an optimization under a cap and may stop at `FEASIBLE` rather than `OPTIMAL` — an upper bound, not a proven minimum. There is deliberately **no proven/partial flag**: because the claim is only "these could not be placed", both statuses say the same true thing. The client copy carries an explicit hedge, pinned by a test — swapping it for "you must remove exactly these" reds four tests across the data, strip and ledger layers.

The full list is always named, never truncated: a visible subset would read as *the* set, which is precisely the claim this arm may not make.

## The fast path pays nothing

The diagnostic runs **only** on the proven-infeasible branch — never on a solved day, never on `unknown` (a time cap is "did not finish", not "does not fit"). Falsification: hoisting the call above the status dispatch reds three tests that assert it was never invoked.

It gets its own budget, `diagnostic_solver_time_cap_s` (default 5s), not the main cap. **The RQ job timeout and stale lease are unchanged, and the margin arithmetic was checked rather than assumed** — worst case moves 10s → 15s inside a 70s timeout, and the run paying the 5s is the infeasible one, whose apply writes no fixtures and sends no notifications. Determinism preserved (fixed seed, same worker count), and tested across repeated runs.

`NoSingleCause` stays in the union as the floor for a diagnostic that is itself infeasible, caps out, or finds no core.

## Two things reviewers should weigh

- **The preview path runs the diagnostic too.** This is broader than the ticket asked for. The rationale: the resolution arm was compile-required there regardless, and an infeasible preview is exactly when a director wants fixtures named. Budget checked (5+5s against a 20s job timeout). Easy to gate off if you'd rather it didn't.
- **The `NoSingleCause` fallback is real but close to unreachable in practice**, so its test uses a stub. Staging a genuinely diagnostic-infeasible day is very hard: pins are not droppable, but a pin can always slide later on its own table and the horizon already accounts for total pin duration. Worth knowing the floor is theoretical rather than routinely exercised.

Also flagged, not fixed: an empty `fixtures: []` would render awkwardly, but the API returns the `NoSingleCause` fallback instead of an empty core, so it is unreachable by construction — and the existing placement-conflict copy has the identical exposure.

## Commits

`2a [api]` optional-placement model behind a defaulted-off flag · `2b [api]` the diagnostic solve, the setting, the arm, and both wire resolvers · `2c [main]` OpenAPI regen · `2d [web-client]` the copy

No migration: the reasons column is JSONB and takes new arms as-is.

## Verification

`ruff` / `ruff format` clean · `mypy` clean (165 files) · `pytest` **2105 passed** · web-client `build` clean · `test:run` **3357 passed**. Falsification runs on the interval trap, the infeasible-only guard, and the anti-minimality wording. Re-run independently in the main session before this PR was opened, rather than taken from the implementing agents' reports.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVaEuNi4R9Lozdfp5x1XZx)_