### PR TITLE
Slice 1: CI publishes both Helm charts to GHCR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,7 @@ GOOGLE_GEOCODING_API_KEY=
 # this line no longer reaches UAT: UAT runs the web image CI publishes, and that
 # image was built before this file was ever read. For UAT/prod the key is the
 # `VITE_GOOGLE_MAPS_API_KEY` REPOSITORY SECRET consumed by
-# .github/workflows/publish-images.yml — setting it here has no effect there.
+# .github/workflows/publish.yml — setting it here has no effect there.
 # This line still applies to the QA/dev compose stacks, which do build locally
 # and accept it as a build arg / dev-server env. Distinct from the server-side
 # GOOGLE_GEOCODING_API_KEY above.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,13 @@ env:
   REGISTRY: ghcr.io
   API_IMAGE: ghcr.io/mightymoose/fortymm-api
   WEB_IMAGE: ghcr.io/mightymoose/fortymm-web-client
+  # `helm push` appends the chart name, so the two charts land at
+  # `${CHART_REPO}/fortymm-uat` and `${CHART_REPO}/observability`. Named once
+  # here because the step summaries advertise a pull command a human copies and
+  # runs -- if the summary and the push target can drift apart, the copyable
+  # line is the one that gets it wrong.
+  CHART_REPO: ghcr.io/mightymoose/fortymm/charts
+  HELM_VERSION: v4.2.2
   # UAT's k3d cluster runs on the operator's own machine, not on a runner, and
   # this repo neither pins nor can check that machine's architecture -- an
   # amd64-only image would either fail to run there or run under emulation,
@@ -75,6 +82,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       short-sha: ${{ steps.sha.outputs.short-sha }}
+      # The chart version, derived here so it has exactly one spelling. Both
+      # chart jobs publish under it, `deploy/CLAUDE.md` documents it, and an
+      # outside puller passes it to `--version` -- so it is the one string
+      # everything downstream must agree on.
+      chart-version: ${{ steps.sha.outputs.chart-version }}
     steps:
       - name: Refuse to publish from a non-main ref
         run: |
@@ -102,6 +114,18 @@ jobs:
           set -euo pipefail
           short="${GITHUB_SHA::12}"
           echo "short-sha=${short}" >> "$GITHUB_OUTPUT"
+
+          # The `sha` prefix is LOAD-BEARING, not decoration. Helm validates a
+          # chart version as SemVer, and SemVer forbids a leading zero in a
+          # NUMERIC pre-release identifier -- so a bare `0.1.0-${short}` is
+          # rejected outright whenever the truncated SHA happens to be all
+          # digits: `helm package --version 0.1.0-000123456789` fails with
+          # "version segment starts with 0". That is roughly one commit in
+          # three thousand, failing in CI on a commit that is otherwise
+          # perfectly good. Gluing `sha` to the front makes the identifier
+          # alphanumeric, and therefore always legal, whatever the SHA is.
+          echo "chart-version=0.1.0-sha${short}" >> "$GITHUB_OUTPUT"
+
           echo "Publishing \`${GITHUB_SHA}\` as \`:${short}\` (and moving \`:main\`)." >> "$GITHUB_STEP_SUMMARY"
 
   api:
@@ -226,18 +250,13 @@ jobs:
       # pin to mirror -- this is the version the packaging was rehearsed on.
       - uses: azure/setup-helm@v4
         with:
-          version: v4.2.2
+          version: ${{ env.HELM_VERSION }}
 
       - name: Package and push the stack chart
         env:
-          # `sha` glued to the front is LOAD-BEARING, not decoration. SemVer
-          # forbids a leading zero in a *numeric* pre-release identifier, so the
-          # tidier-looking `0.1.0-<sha>` is rejected outright whenever a commit's
-          # 12-char truncation happens to be all digits starting with 0 (roughly
-          # one commit in 3000) -- failing in CI, at publish time, on a commit
-          # that is otherwise perfectly good. The `sha` prefix makes the
-          # identifier alphanumeric and therefore always legal. Do not tidy.
-          CHART_VERSION: 0.1.0-sha${{ needs.tag.outputs.short-sha }}
+          # Derived once, by the `tag` job. The `sha` prefix in it is
+          # load-bearing -- see the comment there.
+          CHART_VERSION: ${{ needs.tag.outputs.chart-version }}
           # Chart.yaml says `appVersion: "uat"`, which is not a version of
           # anything. Stamp the commit instead -- at package time, so no commit
           # has to bump a chart file and the version cannot drift from the
@@ -304,13 +323,13 @@ jobs:
           # version, so exactly one tag exists per commit -- charts get NO moving
           # `main` tag (a second tag would mean packaging twice or reaching for
           # `oras`, and nothing would consume it).
-          helm push "$chart" "oci://${REGISTRY}/mightymoose/fortymm/charts"
+          helm push "$chart" "oci://${CHART_REPO}"
 
           {
-            echo "Published \`${CHART_VERSION}\` to \`${REGISTRY}/mightymoose/fortymm/charts\`."
+            echo "Published \`${CHART_VERSION}\` to \`${CHART_REPO}\`."
             echo ""
             echo "    helm upgrade --install fortymm-uat \\"
-            echo "      oci://${REGISTRY}/mightymoose/fortymm/charts/fortymm-uat --version ${CHART_VERSION}"
+            echo "      oci://${CHART_REPO}/fortymm-uat --version ${CHART_VERSION}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   observability:
@@ -333,15 +352,13 @@ jobs:
       # below asserts against that layout.
       - uses: azure/setup-helm@v4
         with:
-          version: v4.2.2
+          version: ${{ env.HELM_VERSION }}
 
       - name: Package and push the observability chart
         env:
-          # `sha` glued to the front is LOAD-BEARING -- see the identical
-          # comment on the `chart` job. SemVer forbids a leading zero in a
-          # numeric pre-release identifier, so `0.1.0-<sha>` is rejected
-          # whenever the 12-char truncation is all digits starting with 0.
-          CHART_VERSION: 0.1.0-sha${{ needs.tag.outputs.short-sha }}
+          # Derived once, by the `tag` job. The `sha` prefix in it is
+          # load-bearing -- see the comment there.
+          CHART_VERSION: ${{ needs.tag.outputs.chart-version }}
           # Chart.yaml says `appVersion: "uat"`, which is not a version of
           # anything. Stamp the commit at package time instead, so no commit has
           # to bump a chart file.
@@ -360,7 +377,6 @@ jobs:
           # here, and swallowing a real failure would only relocate the error.
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo add grafana https://grafana.github.io/helm-charts
-          helm repo update prometheus-community grafana
 
           # `build`, NEVER `update`. `helm dependency build` resolves from the
           # committed `Chart.lock`, so the published chart vendors exactly the
@@ -368,7 +384,12 @@ jobs:
           # re-resolves against the upstream repositories and would silently
           # pull whatever they publish next -- turning a tagged, immutable chart
           # into something whose contents depend on the day CI ran.
-          helm dependency build deploy/observability
+          #
+          # `--skip-refresh` because `helm repo add` above already downloaded
+          # both indexes seconds ago (~10 MB of them). Without it `build`
+          # re-fetches both, and there is nothing a fresh index could change:
+          # `Chart.lock` pins exact versions, so resolution is identical.
+          helm dependency build deploy/observability --skip-refresh
 
           mkdir -p dist/charts
           helm package deploy/observability \
@@ -402,11 +423,11 @@ jobs:
           # `helm push` appends the chart name, so this lands at
           # <repo>/charts/observability. As with the stack chart, helm derives
           # the OCI tag from the chart version and there is NO moving `main` tag.
-          helm push "$chart" "oci://${REGISTRY}/mightymoose/fortymm/charts"
+          helm push "$chart" "oci://${CHART_REPO}"
 
           {
-            echo "Published \`observability-${CHART_VERSION}\` to \`${REGISTRY}/mightymoose/fortymm/charts\`."
+            echo "Published \`observability-${CHART_VERSION}\` to \`${CHART_REPO}\`."
             echo ""
             echo "    helm upgrade --install observability \\"
-            echo "      oci://${REGISTRY}/mightymoose/fortymm/charts/observability --version ${CHART_VERSION}"
+            echo "      oci://${CHART_REPO}/observability --version ${CHART_VERSION}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -313,8 +313,100 @@ jobs:
             echo "      oci://${REGISTRY}/mightymoose/fortymm/charts/fortymm-uat --version ${CHART_VERSION}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-# The observability chart publishes from this workflow too, and belongs here as
-# a job of its own rather than another step in `chart`. It bakes no fortymm
-# images, so it must NOT `needs` the image jobs -- waiting ~25 minutes on an
-# emulated arm64 build it does not consume would be pure delay. It also carries
-# subcharts, so it needs `helm dependency build`, which `deploy/uat/` does not.
+  observability:
+    name: observability chart
+    # `needs: [tag]` ONLY, and that is the point of it being a separate job
+    # rather than another step in `chart`. This chart bakes no fortymm image
+    # digests, so it consumes nothing the image jobs produce -- making it wait
+    # on the ~25-minute emulated-arm64 build would be pure delay for an artifact
+    # that does not depend on it. It still takes the 12-char SHA from `tag`,
+    # because every published artifact must be addressable by the same commit
+    # string (never `git rev-parse --short` -- see the `tag` job).
+    needs: [tag]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      # Same pin as the `chart` job. It matters more here: helm decides how
+      # subchart dependencies are laid out inside the package, and the readback
+      # below asserts against that layout.
+      - uses: azure/setup-helm@v4
+        with:
+          version: v4.2.2
+
+      - name: Package and push the observability chart
+        env:
+          # `sha` glued to the front is LOAD-BEARING -- see the identical
+          # comment on the `chart` job. SemVer forbids a leading zero in a
+          # numeric pre-release identifier, so `0.1.0-<sha>` is rejected
+          # whenever the 12-char truncation is all digits starting with 0.
+          CHART_VERSION: 0.1.0-sha${{ needs.tag.outputs.short-sha }}
+          # Chart.yaml says `appVersion: "uat"`, which is not a version of
+          # anything. Stamp the commit at package time instead, so no commit has
+          # to bump a chart file.
+          APP_VERSION: ${{ needs.tag.outputs.short-sha }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # `deploy/observability/charts/` is GITIGNORED -- only `Chart.lock` is
+          # committed -- so a runner starts with no subcharts on disk and an
+          # empty repo cache. Both `helm repo add`s are therefore mandatory, not
+          # best-effort: without them the next command dies with "no repository
+          # definition for ...". They carry no `|| true` for that reason. A
+          # runner is always fresh, so an "already exists" failure cannot happen
+          # here, and swallowing a real failure would only relocate the error.
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
+          helm repo update prometheus-community grafana
+
+          # `build`, NEVER `update`. `helm dependency build` resolves from the
+          # committed `Chart.lock`, so the published chart vendors exactly the
+          # subchart versions this repo has run in UAT. `helm dependency update`
+          # re-resolves against the upstream repositories and would silently
+          # pull whatever they publish next -- turning a tagged, immutable chart
+          # into something whose contents depend on the day CI ran.
+          helm dependency build deploy/observability
+
+          mkdir -p dist/charts
+          helm package deploy/observability \
+            --version "$CHART_VERSION" \
+            --app-version "$APP_VERSION" \
+            -d dist/charts
+
+          chart="$(ls dist/charts/*.tgz)"
+
+          # Prove the subcharts are inside the artifact about to be pushed. The
+          # entire point of publishing this chart is that a deploy stops
+          # reaching out to prometheus-community.github.io and grafana.github.io
+          # (see the ADR's consequences), and a chart that packaged cleanly with
+          # an empty `charts/` would break exactly that, at pull time, on
+          # someone else's machine. Read the bytes rather than trusting the
+          # three steps above -- the repo's verify-the-artifact-under-test rule.
+          #
+          # `helm package` UNPACKS each vendored `.tgz` into a directory, so the
+          # anchor is `observability/charts/<name>/Chart.yaml` and NOT the
+          # `<name>-<version>.tgz` the `charts/` dir holds on disk. The single
+          # path segment also keeps loki-stack's own nested subcharts (promtail,
+          # filebeat, and five more) from inflating the count.
+          vendored="$(tar -tzf "$chart" | grep -cE '^observability/charts/(kube-prometheus-stack|loki-stack|tempo)/Chart\.yaml$' || true)"
+          if [ "$vendored" -ne 3 ]; then
+            echo "::error::packaged chart vendors ${vendored} of 3 subcharts (kube-prometheus-stack, loki-stack, tempo) -- refusing to publish a chart whose deploy would still fetch from upstream Helm repos."
+            exit 1
+          fi
+
+          printf '%s' "$GHCR_TOKEN" | helm registry login "$REGISTRY" -u "$GHCR_USER" --password-stdin
+
+          # `helm push` appends the chart name, so this lands at
+          # <repo>/charts/observability. As with the stack chart, helm derives
+          # the OCI tag from the chart version and there is NO moving `main` tag.
+          helm push "$chart" "oci://${REGISTRY}/mightymoose/fortymm/charts"
+
+          {
+            echo "Published \`observability-${CHART_VERSION}\` to \`${REGISTRY}/mightymoose/fortymm/charts\`."
+            echo ""
+            echo "    helm upgrade --install observability \\"
+            echo "      oci://${REGISTRY}/mightymoose/fortymm/charts/observability --version ${CHART_VERSION}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,14 @@
-name: publish-images
+name: publish
 
 # Builds the two images UAT actually runs -- `api/Dockerfile.dev` and
 # `web-client/Dockerfile.uat` -- and pushes them to GHCR, so a deploy pulls a
 # published artifact instead of one built on the operator's laptop. See
 # docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md.
+#
+# Named `publish` rather than `publish-images` because the Helm charts publish
+# from here too: the chart job needs the image digests these jobs report, which
+# is why each image job exposes its push step's `digest` as a job output. See
+# docs/adr/20260805-charts-publish-to-ghcr-versioned-by-commit-with-image-digests-baked-in.md.
 #
 # Trigger: push to `main` only. Deliberately NOT on `pull_request` -- an image
 # built from a PR head is not deployable (`redeploy-uat.sh` refuses any ref but
@@ -43,7 +48,7 @@ on:
 # deployed, and the newest queued run is the one that survives, so the tip always
 # publishes. See the header comment.
 concurrency:
-  group: publish-images-${{ github.ref }}
+  group: publish-${{ github.ref }}
   cancel-in-progress: false
 
 # `packages: write` is what pushes to GHCR; the built-in GITHUB_TOKEN covers
@@ -75,7 +80,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
-            echo "::error::publish-images only publishes main (got ${GITHUB_REF}); a non-main run would move the :main tag onto an unreviewed commit."
+            echo "::error::publish.yml only publishes main (got ${GITHUB_REF}); a non-main run would move the :main tag onto an unreviewed commit."
             exit 1
           fi
 
@@ -106,6 +111,13 @@ jobs:
     # The emulated arm64 leg is slow; ~25 min is normal, so allow headroom
     # without letting a wedged build hold a runner all day.
     timeout-minutes: 90
+    # The manifest-list digest of the image this job just pushed, taken from the
+    # push step itself. A downstream job bakes it into the chart, and it reads it
+    # from here rather than asking the GHCR API what CI just published --
+    # skipping that round trip is a stated goal of the charts ADR, and the step
+    # output is the only source that cannot answer about a different push.
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v7
 
@@ -122,6 +134,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: api
@@ -146,6 +159,10 @@ jobs:
     needs: tag
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # Same as the api job: the pushed manifest digest, straight from the push
+    # step, for a downstream job to bake into the chart.
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v7
 
@@ -162,6 +179,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: web-client

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -207,3 +207,114 @@ jobs:
           cache-from: type=gha,scope=web-client
           cache-to: type=gha,mode=max,scope=web-client
           provenance: false
+
+  chart:
+    name: fortymm-uat chart
+    # The digests come from the image jobs' own push steps, as job outputs --
+    # NOT from a GHCR API lookup. A lookup can answer about a different push;
+    # the step output cannot. Skipping that round trip is a stated goal of
+    # docs/adr/20260805-charts-publish-to-ghcr-versioned-by-commit-with-image-digests-baked-in.md.
+    needs: [tag, api, web-client]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      # Pinned rather than taking whatever the runner image ships: the chart CI
+      # publishes should be packaged by a helm version we have actually run this
+      # path against. `mise.toml` tracks `helm = "latest"`, so there is no repo
+      # pin to mirror -- this is the version the packaging was rehearsed on.
+      - uses: azure/setup-helm@v4
+        with:
+          version: v4.2.2
+
+      - name: Package and push the stack chart
+        env:
+          # `sha` glued to the front is LOAD-BEARING, not decoration. SemVer
+          # forbids a leading zero in a *numeric* pre-release identifier, so the
+          # tidier-looking `0.1.0-<sha>` is rejected outright whenever a commit's
+          # 12-char truncation happens to be all digits starting with 0 (roughly
+          # one commit in 3000) -- failing in CI, at publish time, on a commit
+          # that is otherwise perfectly good. The `sha` prefix makes the
+          # identifier alphanumeric and therefore always legal. Do not tidy.
+          CHART_VERSION: 0.1.0-sha${{ needs.tag.outputs.short-sha }}
+          # Chart.yaml says `appVersion: "uat"`, which is not a version of
+          # anything. Stamp the commit instead -- at package time, so no commit
+          # has to bump a chart file and the version cannot drift from the
+          # commit it was built from.
+          APP_VERSION: ${{ needs.tag.outputs.short-sha }}
+          API_DIGEST: ${{ needs.api.outputs.digest }}
+          WEB_DIGEST: ${{ needs.web-client.outputs.digest }}
+          # The built-in token already carries `packages: write` (see the
+          # workflow-level permissions), so the chart push needs no secret of
+          # its own. Passed through the environment rather than interpolated
+          # into the script body.
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # An EMPTY digest is not malformed to the chart -- `fortymm-uat.imageRef`
+          # treats it as the documented render-only fallback and renders
+          # `repository:main`, the moving tag. So without this guard a run with a
+          # broken input publishes a chart that packages, pulls and renders
+          # cleanly while pinning nothing: the blank-white-page failure mode in
+          # deploy/CLAUDE.md, shipped as an artifact other people pull.
+          # `redeploy-uat.sh` asserts this today and stops resolving digests at
+          # all once the chart carries them, so the check relocates here.
+          for d in "$API_DIGEST" "$WEB_DIGEST"; do
+            if [[ ! "$d" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::image digest must be sha256:<64 hex chars>, got '${d}' -- refusing to publish a chart that would fall back to the moving :main tag."
+              exit 1
+            fi
+          done
+
+          # `helm package` has no `--set`, so the digests are written into the
+          # runner's checkout of values.yaml before packaging. This is the one
+          # documented difference between the published chart and `deploy/uat/`
+          # in git; nothing is committed here. `yq` is preinstalled on
+          # GitHub-hosted ubuntu runners.
+          yq -i '.images.api.digest = strenv(API_DIGEST) | .images.web.digest = strenv(WEB_DIGEST)' deploy/uat/values.yaml
+
+          mkdir -p dist/charts
+          helm package deploy/uat \
+            --version "$CHART_VERSION" \
+            --app-version "$APP_VERSION" \
+            -d dist/charts
+
+          chart="$(ls dist/charts/*.tgz)"
+
+          # Read the digests back OUT of the packaged artifact rather than
+          # trusting the write. This catches a `yq` that vanished from a future
+          # runner image, a renamed values key, and a wrong path -- all of which
+          # fail silently and produce a chart pinned to nothing.
+          # `yq` writes the value quoted (`digest: "sha256:…"`), so the pattern
+          # tolerates the quotes; `|| true` keeps a zero count from exiting on
+          # grep's own status before the error message below can be printed.
+          baked="$(helm show values "$chart" | grep -cE '^[[:space:]]*digest: "?sha256:[0-9a-f]{64}"?$' || true)"
+          if [ "$baked" -ne 2 ]; then
+            echo "::error::packaged chart carries ${baked} image digests, expected 2 -- the values rewrite did not take."
+            exit 1
+          fi
+
+          printf '%s' "$GHCR_TOKEN" | helm registry login "$REGISTRY" -u "$GHCR_USER" --password-stdin
+
+          # `helm push` appends the chart name, so this lands at
+          # <repo>/charts/<chart name>. Helm derives the OCI tag from the chart
+          # version, so exactly one tag exists per commit -- charts get NO moving
+          # `main` tag (a second tag would mean packaging twice or reaching for
+          # `oras`, and nothing would consume it).
+          helm push "$chart" "oci://${REGISTRY}/mightymoose/fortymm/charts"
+
+          {
+            echo "Published \`${CHART_VERSION}\` to \`${REGISTRY}/mightymoose/fortymm/charts\`."
+            echo ""
+            echo "    helm upgrade --install fortymm-uat \\"
+            echo "      oci://${REGISTRY}/mightymoose/fortymm/charts/fortymm-uat --version ${CHART_VERSION}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+# The observability chart publishes from this workflow too, and belongs here as
+# a job of its own rather than another step in `chart`. It bakes no fortymm
+# images, so it must NOT `needs` the image jobs -- waiting ~25 minutes on an
+# emulated arm64 build it does not consume would be pure delay. It also carries
+# subcharts, so it needs `helm dependency build`, which `deploy/uat/` does not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Full stack via Docker: `docker compose -f docker-compose.dev.yml up`. Nginx on *
 | QA | up: `scripts/qa-up.sh [id]` · **down: `scripts/qa-down.sh [id]`** | :8085 | captured in **Mailpit** :8087 — never sends real mail |
 | UAT | `mise run redeploy-uat` — Helm + **k3d**, *not* compose, chart at `deploy/uat/` | :8084, `uat.fortymm.com`, and `https://fortymm-uat.<tailnet>.ts.net` | **real Postmark** — lands in real inboxes |
 
-**CI publishes both Helm charts to GHCR**, alongside the api and web images. Every push to `main` pushes `ghcr.io/mightymoose/fortymm/charts/{fortymm-uat,observability}`, versioned `0.1.0-sha<12-char sha>`, with the stack chart's image digests baked into its values. See `deploy/CLAUDE.md` for the version scheme, the pull command, and why the `sha` prefix cannot be tidied away.
+**CI publishes both Helm charts to GHCR**, alongside the api and web images, so a deploy needs `helm` and no checkout. See `deploy/CLAUDE.md` for the registry paths, the version scheme, the pull command, and why the stack chart carries its own image digests.
 
 **Always reap a QA stack once its branch merges** (`land-the-plane` Step 6). `docker compose down -v` is *not* enough — it leaves the stack's locally-built images and buildx cache behind. Skipping this grew `Docker.raw` to 230 GB and wedged the daemon; with ~78 worktrees each able to spawn a `fortymm-qa-<id>` stack, it compounds fast. Use `scripts/qa-down.sh` (`--all` for every QA stack, `--dry-run` to preview, opt-in `--prune-cache` for the global build cache). **Never** blanket-`prune`: `fortymm-uat_postgres-data` is unattached and would be silently destroyed along with the k3d `tailscale-state` Secrets.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,8 @@ Full stack via Docker: `docker compose -f docker-compose.dev.yml up`. Nginx on *
 | QA | up: `scripts/qa-up.sh [id]` · **down: `scripts/qa-down.sh [id]`** | :8085 | captured in **Mailpit** :8087 — never sends real mail |
 | UAT | `mise run redeploy-uat` — Helm + **k3d**, *not* compose, chart at `deploy/uat/` | :8084, `uat.fortymm.com`, and `https://fortymm-uat.<tailnet>.ts.net` | **real Postmark** — lands in real inboxes |
 
+**CI publishes both Helm charts to GHCR**, alongside the api and web images. Every push to `main` pushes `ghcr.io/mightymoose/fortymm/charts/{fortymm-uat,observability}`, versioned `0.1.0-sha<12-char sha>`, with the stack chart's image digests baked into its values. See `deploy/CLAUDE.md` for the version scheme, the pull command, and why the `sha` prefix cannot be tidied away.
+
 **Always reap a QA stack once its branch merges** (`land-the-plane` Step 6). `docker compose down -v` is *not* enough — it leaves the stack's locally-built images and buildx cache behind. Skipping this grew `Docker.raw` to 230 GB and wedged the daemon; with ~78 worktrees each able to spawn a `fortymm-qa-<id>` stack, it compounds fast. Use `scripts/qa-down.sh` (`--all` for every QA stack, `--dry-run` to preview, opt-in `--prune-cache` for the global build cache). **Never** blanket-`prune`: `fortymm-uat_postgres-data` is unattached and would be silently destroyed along with the k3d `tailscale-state` Secrets.
 
 ## Cloud sessions

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -153,6 +153,105 @@ deploy it to, its Google-console restrictions must cover **all** of them
 name, plus any later prod origin) — a restriction list that misses one origin
 breaks the map only on that origin.
 
+## Published charts (GHCR)
+
+The same `.github/workflows/publish.yml` packages both Helm charts and pushes
+them to GHCR as OCI artifacts, so a deploy needs `helm` and no checkout:
+
+- `ghcr.io/mightymoose/fortymm/charts/fortymm-uat`, the **stack chart**, packaged
+  from `deploy/uat/`
+- `ghcr.io/mightymoose/fortymm/charts/observability`, the **observability
+  chart**, packaged from `deploy/observability/`
+
+`helm push` appends the chart name to the repository path, so each path ends in
+that chart's `name:` from `Chart.yaml`. A later change renames the stack chart
+to `fortymm`. If you read this after that rename lands, the path is
+`.../charts/fortymm`.
+
+**The chart version is `0.1.0-sha<12-char sha>`, and the `sha` prefix is
+load-bearing.** Helm validates the version as SemVer, and the bare 12-char
+truncation the images use as a tag is not a version at all. `helm package
+--version b17a29fa1234` fails with `Error: invalid semantic version`. So the
+SHA has to be encoded into a SemVer string, and the obvious encoding carries
+its own trap. SemVer forbids a leading zero in a *numeric* pre-release
+identifier, so the tidier-looking
+`0.1.0-<sha>` is rejected whenever the truncation is all digits starting with
+0. `helm package --version 0.1.0-000123456789` fails with
+`Error: version segment starts with 0`. That is roughly one commit in three
+thousand, and it fails **in CI, at publish time, on a commit that is otherwise
+perfectly good**. Gluing `sha` to the front makes the identifier alphanumeric
+and therefore always legal. **Do not tidy the prefix away.**
+
+`Chart.yaml` keeps `version: 0.1.0` in the repo. CI stamps the real version and
+`appVersion` at package time, so no commit has to bump a chart file and the
+version cannot drift from the commit it was built from.
+
+**The stack chart carries its own image digests.** CI rewrites
+`images.api.digest` and `images.web.digest` into the chart's values before
+packaging, using the digests the two image jobs report from their own push
+steps. A published chart is therefore a complete description of one commit's
+stack. The chart version is the **single coordinate** an install or a rollback
+names. Chart and images cannot drift apart, because CI welded them together at
+publish time:
+
+```bash
+helm upgrade --install fortymm-uat \
+  oci://ghcr.io/mightymoose/fortymm/charts/fortymm-uat \
+  --version "0.1.0-sha$(git rev-parse HEAD | cut -c1-12)" \
+  --namespace fortymm-uat --create-namespace
+```
+
+Rollback is the same command naming an older version, and the older chart
+brings its matching image digests with it. Secrets stay out of band: the
+`fortymm-uat-env` and `-apns` Secrets come from the operator's `.env`, and no
+published artifact can carry them. `mise run redeploy-uat` still deploys the
+chart directory at `deploy/uat/` today. A later change switches the script to
+the published chart.
+
+**The published chart is not byte-identical to `deploy/uat/` in the repo.**
+CI rewrites the two digest values before packaging. `helm package` then stamps
+`version` and `appVersion` into the packaged `Chart.yaml` and reserializes it,
+so key order, comments and line wrapping all change too. Expect those
+differences when you diff the published chart against the repo. CI reads the
+digests back out of the packaged file and refuses to push unless it finds two,
+because an *empty* digest is not malformed to the chart. The chart treats it as
+the documented render fallback and renders the moving `:main` tag, which is the
+blank-white-page failure mode below.
+
+**Charts get no moving `main` tag.** Helm derives the OCI tag from the chart
+version, so exactly one tag exists per commit. A second tag would mean
+packaging twice or reaching for `oras`, and nothing would consume it: an
+outside deployer wants a pinned version, not a moving one. The images keep
+`:main` only because `values.yaml` uses it as the render fallback.
+
+**No credentials needed to pull.** A package pushed by `GITHUB_TOKEN` with
+`packages: write` is linked to the publishing repository and inherits its
+visibility, and this repo is public. That mechanism was verified for the two
+images (see the visibility subsection above), so the charts are public by the
+same route. No chart carries `imagePullSecrets`.
+
+**The observability chart resolves dependencies with `helm dependency build`,
+never `update`.** `deploy/observability/charts/` is **gitignored** and only
+`Chart.lock` is committed, so a runner starts with no subcharts on disk. CI
+therefore has to `helm repo add` both `prometheus-community` and `grafana`
+first, or the next command cannot find the repositories. `build` resolves from
+the committed `Chart.lock`, so the published chart vendors exactly the subchart
+versions this repo has run in UAT. `update` re-resolves against the upstream
+repositories and could pull newer than the lock, which would make a tagged,
+immutable chart depend on the day CI ran. The published package carries the
+expanded subcharts inside it, and that is what takes the upstream fetch off the
+**deploy** path. CI checks the packaged tarball for all three subchart
+`Chart.yaml` files and refuses to push if any is missing.
+
+**The observability chart does not wait on the image builds.** It bakes no
+fortymm digests, so it needs only the tag job. The stack chart `needs` both
+image jobs for their digests, so it inherits their **~25-minute critical
+path**.
+
+**The chart jobs cannot be proven from a pull request.** `publish.yml` runs on
+push to `main` only, so no chart package can exist until the change merges. The
+first real evidence is the run after merge.
+
 ## Topology
 
 **UAT runs on Kubernetes (Helm + k3d).** UAT is the one prod-like stack that does *not* use docker-compose. `scripts/redeploy-uat.sh` (a.k.a. `mise run redeploy-uat`) **builds nothing** — it deploys the images CI already published for the commit being deployed. It refuses any branch but `main` (or the legacy `uat-deploy` worktree), merges `origin/main` into it first so the deploy names the newest main, provisions a single-node **k3d** cluster `fortymm-uat`, resolves each package's `:<12-char sha>` tag to its **manifest-list digest** over the GHCR v2 API, syncs Secrets from the gitignored `.env` + `secrets/*.p8`, and `helm upgrade --install`s the chart at **`deploy/uat/`** with `--set images.api.digest=sha256:… --set images.web.digest=sha256:…` (`--wait --timeout 5m`). The chart reproduces the old compose topology (postgres, redis, api, worker, web-client, routing nginx); migrations + seeds run as a `post-install,post-upgrade` Helm hook **Job** (not in the api boot command). Routing nginx is a **NodePort** (30084); k3d maps host **:8084** → that NodePort, so host Caddy (still pointing at `127.0.0.1:8084`) fronts uat.fortymm.com unchanged. Needs `helm` + `k3d` (`brew install helm k3d`). Inspect with `KUBECONFIG=$(k3d kubeconfig write fortymm-uat) kubectl get pods -n fortymm-uat`.

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -28,7 +28,7 @@ Infra has no single directory — it spans:
   `deploy/uat/templates/_helpers.tpl` (`fortymm-uat.nginxConf`, which also adds a
   `/faro/` block). When you touch `uat.conf`, update the helper copy too.
 - `.github/workflows/*.yml` — CI (api, web-client, e2e, openapi-schema, ios, …),
-  including **`publish-images.yml`**, which pushes the api/web images to GHCR on
+  including **`publish.yml`**, which pushes the api/web images to GHCR on
   every push to `main` (see `## Published images (GHCR)`).
 - `mise.toml` — toolchain pins (node, python, `helm`, `k3d`) + task runner:
   `redeploy-uat` (deploy published, digest-pinned images to k3d), `qa-down`,
@@ -40,11 +40,11 @@ Infra has no single directory — it spans:
 |-------|-----|----------|-------|
 | dev   | `docker compose -f docker-compose.dev.yml up` | :8080 | dev servers, MSW off; real API |
 | QA    | up `scripts/qa-up.sh [id]` / down `scripts/qa-down.sh [id]` | :8085 (auto) | built artifacts, MSW off, **Mailpit :8087** captures all mail; multi-stack; **reap on merge** |
-| UAT   | `mise run redeploy-uat` | host :8084 → NodePort 30084 | **k3d/Helm — the one prod-like stack NOT on compose**; deploys **CI-published GHCR images pinned by digest** (builds nothing, so a merge isn't deployable until `publish-images` finishes); sends REAL Postmark email |
+| UAT   | `mise run redeploy-uat` | host :8084 → NodePort 30084 | **k3d/Helm — the one prod-like stack NOT on compose**; deploys **CI-published GHCR images pinned by digest** (builds nothing, so a merge isn't deployable until `publish` finishes); sends REAL Postmark email |
 
 ## Published images (GHCR)
 
-`.github/workflows/publish-images.yml` builds the two Dockerfiles UAT runs —
+`.github/workflows/publish.yml` builds the two Dockerfiles UAT runs —
 `api/Dockerfile.dev` and `web-client/Dockerfile.uat` — and pushes them to two
 GHCR packages:
 
@@ -159,7 +159,7 @@ breaks the map only on that origin.
 
 **Why a digest and not the tag.** `fortymm-uat.imageRef` in `_helpers.tpl` renders `repository@sha256:…` whenever a digest is set, and every workload that runs app code (api, worker, migrate Job, retirement CronJob, web-client) goes through it. A digest is content-addressed, so "every replica runs the same bytes" stops being a convention the deploy script has to maintain and becomes structural — two pods naming one digest *cannot* be running different content, and re-running the publish workflow for an already-published commit cannot change what UAT is serving the way overwriting a `:<sha>` tag would. Empty `digest` in `values.yaml` falls back to `repository:tag` (the moving `:main`) purely so `helm template deploy/uat` renders on its own; a real deploy always passes digests, and a set-but-malformed one fails the render rather than being tolerated. The old `$(short-sha)-$(epoch)` unique-tag scheme is gone and should not come back — it existed because a *local* rebuild could produce different content under one commit, so the pod template had to change to force a roll. Published images are immutable, so a same-commit redeploy is a correct no-op. See `docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md`.
 
-**Deploying now depends on CI.** The images for a commit exist only once `publish-images.yml` has finished for it (~25 min, dominated by the emulated arm64 leg), so a just-merged commit is not immediately deployable. The script polls GHCR every 30s for up to `DIGEST_WAIT_TIMEOUT_S` (default `2400`, i.e. 40 min) and then fails naming the commit and linking the workflow runs, rather than deploying an older commit without saying so. `DIGEST_WAIT_TIMEOUT_S=0` fails immediately instead of waiting. The anonymous digest read doubles as the public-visibility preflight (see the one-time flip under `## Published images (GHCR)`): if it resolves, the cluster can pull, which is why the chart carries no `imagePullSecrets` — and a package still private fails here with the click-path instead of dying as an `ErrImagePull` five minutes into `helm --wait`.
+**Deploying now depends on CI.** The images for a commit exist only once `publish.yml` has finished for it (~25 min, dominated by the emulated arm64 leg), so a just-merged commit is not immediately deployable. The script polls GHCR every 30s for up to `DIGEST_WAIT_TIMEOUT_S` (default `2400`, i.e. 40 min) and then fails naming the commit and linking the workflow runs, rather than deploying an older commit without saying so. `DIGEST_WAIT_TIMEOUT_S=0` fails immediately instead of waiting. The anonymous digest read doubles as the public-visibility preflight (see the one-time flip under `## Published images (GHCR)`): if it resolves, the cluster can pull, which is why the chart carries no `imagePullSecrets` — and a package still private fails here with the click-path instead of dying as an `ErrImagePull` five minutes into `helm --wait`.
 
 **UAT is also on the tailnet.** The chart runs a `tailscale/tailscale` proxy (`deploy/uat/templates/tailscale.yaml`, `tailscale.enabled` in values, on by default) that fronts the routing nginx via `tailscale serve`, so UAT is reachable privately at **`https://fortymm-uat.<tailnet>.ts.net`** with auto-HTTPS — independent of the DDNS/router/Caddy chain (which still serves `uat.fortymm.com` unchanged; Tailscale is purely additive). It reads `TS_AUTHKEY` (a reusable, non-ephemeral key from the Tailscale admin console) straight from the `.env`-backed secret, so just add a `TS_AUTHKEY=tskey-...` line to `.env`; `redeploy-uat.sh` errors early if it's missing. The proxy persists its node identity in the `tailscale-state` Secret (survives restarts; no re-auth). Requires HTTPS certs + MagicDNS enabled in the tailnet. Set `tailscale.enabled=false` to skip it.
 
@@ -175,7 +175,7 @@ Prod-like compose stacks (built artifacts, no dev server, isolated volumes; only
 ```bash
 mise run redeploy-uat                 # helm upgrade the k3d UAT stack onto this commit's published GHCR images (digest-pinned); smoke-check uat.fortymm.com
 DEPLOY_OBSERVABILITY=false mise run redeploy-uat   # skip the monitoring chart
-DIGEST_WAIT_TIMEOUT_S=0 mise run redeploy-uat      # don't wait on publish-images; fail now if this commit has no images
+DIGEST_WAIT_TIMEOUT_S=0 mise run redeploy-uat      # don't wait on publish; fail now if this commit has no images
 scripts/qa-up.sh [id]                 # bring up an isolated QA stack on a free port trio; prints QA_URL / Mailpit URL
 scripts/qa-down.sh [id]               # reap that stack: containers, volumes (named + anonymous), networks, built images
 scripts/qa-down.sh --dry-run [id]     # preview what would be removed
@@ -255,7 +255,7 @@ unprompted.**
 - **Symptom:** The script prints `ghcr.io/mightymoose/fortymm-<pkg>:<12-char
   sha> not published yet — waiting up to 2400s`, then eventually
   `ERROR: no image published for … after 2400s` and exits without deploying.
-- **Cause:** `publish-images.yml` has not produced images for the commit at
+- **Cause:** `publish.yml` has not produced images for the commit at
   HEAD (after the script's `git merge origin/main`). Either the run is still
   going (~25 min, emulated arm64), or it failed for that commit, or HEAD is not
   a commit that exists on `origin/main` — only pushed `main` commits are ever

--- a/deploy/uat/values.yaml
+++ b/deploy/uat/values.yaml
@@ -3,7 +3,7 @@
 
 # The api and web images are the ones CI publishes to GHCR from
 # api/Dockerfile.dev and web-client/Dockerfile.uat on every push to `main`
-# (.github/workflows/publish-images.yml). UAT deploys what CI built; it no
+# (.github/workflows/publish.yml). UAT deploys what CI built; it no
 # longer builds its own. The package names are NOT the repo's internal
 # `fortymm/{api,web}` — they are what the workflow pushes.
 #

--- a/deploy/uat/values.yaml
+++ b/deploy/uat/values.yaml
@@ -7,9 +7,13 @@
 # longer builds its own. The package names are NOT the repo's internal
 # `fortymm/{api,web}` — they are what the workflow pushes.
 #
-# `digest` is empty here and filled in at deploy time
-# (`--set images.api.digest=sha256:…` from scripts/redeploy-uat.sh), which is
-# what a real deploy always does. Naming the manifest digest rather than the
+# `digest` is empty in the repo and filled in by CI when the chart is
+# PACKAGED (.github/workflows/publish.yml), from the digests the image jobs
+# report for that commit. So in a chart pulled from
+# ghcr.io/mightymoose/fortymm/charts these two fields are already populated,
+# and the chart version alone names a complete, coherent stack — you do not
+# pass image digests to install it. Only a chart rendered straight from a
+# checkout sees them empty. Naming the manifest digest rather than the
 # tag makes "every replica runs the same code" structural instead of
 # conventional: a tag can be moved or resolved differently by two nodes, a
 # digest cannot. The blank-white-page incident in deploy/CLAUDE.md is what
@@ -19,7 +23,9 @@
 # The tag is only the fallback for rendering the chart without a deploy
 # (`helm template deploy/uat`), so it names the moving `:main` tag the same
 # workflow publishes — something that actually exists and is pullable, rather
-# than a label no registry would answer for.
+# than a label no registry would answer for. That fallback is why CI reads the
+# packaged chart back and refuses to push unless both digests are in it: an
+# empty digest is not malformed here, it just quietly renders a moving tag.
 images:
   api:
     repository: ghcr.io/mightymoose/fortymm-api

--- a/docs/adr/20260805-charts-publish-to-ghcr-versioned-by-commit-with-image-digests-baked-in.md
+++ b/docs/adr/20260805-charts-publish-to-ghcr-versioned-by-commit-with-image-digests-baked-in.md
@@ -119,6 +119,15 @@ set; charts have no equivalent need.
   with `packages: write` is linked to the publishing repository and inherits
   its visibility, and `mightymoose/fortymm` is public. Anonymous `helm pull`
   works, and no chart needs `imagePullSecrets`.
+- **Publishing lands before anything consumes it.** `publish.yml` runs on push
+  to `main` only, so the first chart package cannot exist until the PR that adds
+  the job has merged — there is no way to prove the job works from a PR. If the
+  same merge also switched `redeploy-uat.sh` to pulling from the registry, a bug
+  in the new job would leave UAT undeployable with the local-directory path
+  already deleted, and the images ADR removed the `--local` escape hatch that
+  would otherwise have been the way back. So the chart job ships and is
+  confirmed publishing first; the script switch and the rename follow in a
+  separate change.
 - **Secrets remain out of band.** The `fortymm-uat-env` and `-apns` Secrets are
   created from the operator's `.env`, and no published artifact can carry them.
   A checkout-free deploy still means the deployer supplies their own secrets.

--- a/docs/adr/20260805-charts-publish-to-ghcr-versioned-by-commit-with-image-digests-baked-in.md
+++ b/docs/adr/20260805-charts-publish-to-ghcr-versioned-by-commit-with-image-digests-baked-in.md
@@ -69,8 +69,13 @@ apart because they were welded together at publish time. This does not replace
 deploy and needs no registry at all.
 
 The cost is that the published chart is **not byte-identical to `deploy/fortymm/`
-in the repo** — CI rewrites two values before packaging. Anyone comparing the
-two should expect exactly that difference and nothing else.
+in the repo**. CI rewrites the two digest values before packaging, and
+`helm package` then stamps the version and appVersion and reserializes
+`Chart.yaml` — which reorders keys, drops comments and reflows the description.
+So a diff between the repo and a published chart is expected to be noisy, and
+"the values differ" is the wrong thing to read it for. The claim worth checking
+is narrower: the published `images.{api,web}.digest` are the digests that
+commit's images actually published.
 
 ## Publishing is one job in one workflow
 

--- a/docs/adr/20260805-charts-publish-to-ghcr-versioned-by-commit-with-image-digests-baked-in.md
+++ b/docs/adr/20260805-charts-publish-to-ghcr-versioned-by-commit-with-image-digests-baked-in.md
@@ -1,0 +1,124 @@
+# Charts publish to GHCR, versioned by commit, with image digests baked in
+
+`docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md` moved the
+api and web *images* out of the operator's laptop and into GHCR, so a deploy
+pulls an artifact CI built. The **chart** never made that move. `helm upgrade`
+still pointed at `deploy/uat/` in a git checkout, so deploying required cloning
+this repo, and `scripts/redeploy-uat.sh` had to resolve both image digests from
+the GHCR API itself before it could render anything.
+
+CI now packages both charts and pushes them to
+`ghcr.io/mightymoose/fortymm/charts/{fortymm,observability}`. The goal is that
+anyone can deploy fortymm from any machine with `helm` and no checkout.
+
+## The chart version encodes the commit, because a bare SHA is not a version
+
+Helm validates `Chart.yaml`'s `version` as SemVer, so the 12-character commit
+truncation the images use as a tag is rejected outright:
+`chart.metadata.version "b17a29fa1234" is invalid`. The SHA has to be *encoded*
+into a SemVer string, and the obvious encodings are not equally safe.
+
+We publish **`0.1.0-sha<12-char-sha>`** — the `sha` prefix is load-bearing.
+SemVer forbids a leading zero in a *numeric* pre-release identifier, so the
+tidier-looking `0.1.0-<sha>` fails whenever a commit's truncated SHA happens to
+be all digits with a leading zero. That is roughly one commit in three
+thousand, and it would fail **in CI, at publish time, on a commit that is
+otherwise perfectly good** — a rare, unreproducible break landing on whoever
+merged next. Gluing `sha` to the front makes the identifier alphanumeric and
+therefore always legal, whatever the SHA turns out to be. This is the same
+class of trap the images ADR recorded about `git rev-parse --short`, and it is
+written down here for the same reason: it is invisible until it bites.
+
+The rejected alternative is SemVer *build metadata*, `0.1.0+<sha>`, which is
+also always legal. It loses on ergonomics. `+` is not a valid character in an
+OCI tag, so Helm rewrites it to `_` on push and back on pull, and prints a
+four-line explanation of that convention on **every push and every pull**. For
+a chart whose entire purpose is being pulled by people who did not write it,
+that is a permanent wart on the first thing they see.
+
+**`Chart.yaml` keeps `version: 0.1.0` in the repo.** CI stamps the real version
+with `helm package --version`, so no commit ever has to bump a chart file and
+the version cannot drift from the commit it was built from.
+
+## The published chart carries its own image digests
+
+CI rewrites `images.{api,web}.digest` into the chart's values at package time,
+using the manifest digests that the image jobs' own push steps report. A
+published chart is therefore a complete, coherent description of one commit's
+stack, and this is the property the whole change turns on.
+
+Before, a deploy was three coordinates — chart at commit X, api digest at
+commit X, web digest at commit X — held together *only* by the fact that one
+git checkout produced all three. Publishing the chart separately would have
+dissolved that guarantee silently: nothing structural stops someone pulling
+chart `sha-ABC` and pointing it at images from `sha-XYZ`, and the result would
+be a stack that renders, deploys, and is subtly wrong.
+
+Baking the digests in replaces that lost guarantee with a stronger one. The
+chart version becomes the **single** coordinate:
+
+```bash
+helm upgrade --install fortymm \
+  oci://ghcr.io/mightymoose/fortymm/charts/fortymm --version 0.1.0-sha<commit>
+```
+
+Rollback is the same command naming an older version, and the older chart
+brings its own matching image digests with it — chart and images cannot drift
+apart because they were welded together at publish time. This does not replace
+`helm rollback <revision>`, which stays the quickest way to undo the last
+deploy and needs no registry at all.
+
+The cost is that the published chart is **not byte-identical to `deploy/fortymm/`
+in the repo** — CI rewrites two values before packaging. Anyone comparing the
+two should expect exactly that difference and nothing else.
+
+## Publishing is one job in one workflow
+
+`publish-images.yml` is renamed `publish.yml`, and the charts are a job in it
+rather than a workflow of their own. The chart job `needs` the two image jobs,
+which buys three things a separate workflow would have to rebuild: the ordering
+constraint is native rather than `workflow_run` plumbing, the image digests
+arrive as job outputs rather than as a second GHCR API lookup, and both
+artifacts share one concurrency group so two merges cannot race.
+
+The observability chart bakes no fortymm images and so does not wait for them.
+
+Consequently the chart inherits the images' critical path — a chart is not
+pullable until the ~25-minute emulated-arm64 image build finishes. That is not
+a new delay, only a relocated one: `redeploy-uat.sh` already waited for exactly
+those digests. The wait now happens against the chart, and waiting for the
+chart implicitly waits for the images.
+
+**Charts get no moving `main` tag.** Helm derives the OCI tag from the chart
+version, so a second tag would mean packaging twice or reaching for `oras`, and
+nothing would consume it: the deploy script resolves by commit, and an outside
+deployer wants a pinned version rather than a moving one. The images keep
+`:main` because `values.yaml` uses it as the render fallback when no digest is
+set; charts have no equivalent need.
+
+## Consequences
+
+- **`redeploy-uat.sh` deploys the published chart, not the working tree.** It
+  would have been easier to keep rendering `deploy/fortymm/` from disk, but then
+  nothing would ever exercise the published artifact and the first person to
+  discover it was broken would be someone outside this repo. See
+  `.claude/rules/verify-the-artifact-under-test.md` — UAT is the only thing that
+  proves the chart we publish is the chart that works.
+- **The script gets substantially smaller.** `ghcr_manifest_digest`,
+  `resolve_published_digest` and `assert_digest` exist to resolve two image
+  digests that now ride inside the chart. What remains is one chart lookup,
+  resolved to a digest at deploy time so the operator names a commit while the
+  cluster gets content-addressed bytes.
+- **The observability deploy stops depending on two external Helm repos.**
+  `helm dependency build` plus `helm repo add prometheus-community` and
+  `grafana` run at deploy time today. Packaging vendors those dependencies
+  inside the artifact, so the deploy path no longer reaches out to
+  `prometheus-community.github.io` or `grafana.github.io` at all.
+- **The packages are public without anyone flipping a switch.** Per the
+  correction recorded in the images ADR, a package pushed by `GITHUB_TOKEN`
+  with `packages: write` is linked to the publishing repository and inherits
+  its visibility, and `mightymoose/fortymm` is public. Anonymous `helm pull`
+  works, and no chart needs `imagePullSecrets`.
+- **Secrets remain out of band.** The `fortymm-uat-env` and `-apns` Secrets are
+  created from the operator's `.env`, and no published artifact can carry them.
+  A checkout-free deploy still means the deployer supplies their own secrets.

--- a/docs/adr/20260805-the-stack-chart-is-environment-neutral-and-named-fortymm.md
+++ b/docs/adr/20260805-the-stack-chart-is-environment-neutral-and-named-fortymm.md
@@ -21,7 +21,17 @@ baked into three places only:
 
 1. the chart name, and therefore the published package name,
 2. `app.kubernetes.io/name: fortymm-uat`, a literal in the labels and selector,
-3. the directory, and the UAT-shaped defaults in `values.yaml`.
+3. the directory, and the UAT-shaped defaults in `values.yaml`,
+4. `appVersion: "uat"` — in **both** `Chart.yaml` files, including
+   observability's.
+
+The fourth is the odd one, because `appVersion` is supposed to name the version
+of the application the chart deploys, and `"uat"` is not a version of anything.
+It was harmless while the chart was a local directory. Published, it appears in
+`helm show chart` output as the answer to "what does this deploy?", so CI stamps
+the commit with `helm package --app-version` alongside `--version`. Both charts
+get this; it is the one environment-neutrality fix the observability chart also
+needs.
 
 So this is a rename plus a values split, not a re-architecture, and it is worth
 recording that the structure was already right — a future reader should not go

--- a/docs/adr/20260805-the-stack-chart-is-environment-neutral-and-named-fortymm.md
+++ b/docs/adr/20260805-the-stack-chart-is-environment-neutral-and-named-fortymm.md
@@ -1,0 +1,89 @@
+# The stack chart is environment-neutral and named `fortymm`
+
+The chart that describes the fortymm stack was named `fortymm-uat` and lived in
+`deploy/uat/`, because UAT was the only thing that ran it. Publishing it to a
+registry makes that name a public fact rather than a local one — `helm push`
+appends the chart name to the repository path, so the package would have been
+`…/charts/fortymm-uat`, and the Hetzner production deploy (issue #1255) would
+have installed a chart whose name asserts it is not production.
+
+The chart is renamed **`fortymm`** and moved to `deploy/fortymm/`. Environment
+is a property of the *values*, not of the chart.
+
+## The chart was already neutral; only its labelling was not
+
+This rename is cheap because the templates never encoded the environment. A
+sweep for `uat` across `deploy/uat/templates/` finds two passing mentions in
+comments and nothing else — every environment-specific fact (the
+`uat.fortymm.com` hostnames, the MCP public URLs, the tailnet hostname, the
+names of the out-of-band Secrets) was already a value. The environment was
+baked into three places only:
+
+1. the chart name, and therefore the published package name,
+2. `app.kubernetes.io/name: fortymm-uat`, a literal in the labels and selector,
+3. the directory, and the UAT-shaped defaults in `values.yaml`.
+
+So this is a rename plus a values split, not a re-architecture, and it is worth
+recording that the structure was already right — a future reader should not go
+looking for the parameterisation work, because there wasn't any.
+
+## Renaming the selector label costs one UAT reinstall
+
+`app.kubernetes.io/name` appears in `fortymm-uat.selector`, which renders into
+`spec.selector.matchLabels`. **That field is immutable in Kubernetes**, so
+changing the literal makes `helm upgrade` fail outright rather than roll. The
+existing release must be `helm uninstall`ed and reinstalled once.
+
+That deletes the `postgres-data` PVC, since no resource in the chart carries
+`helm.sh/resource-policy: keep`, so **UAT's database is wiped** and rebuilt by
+the migrate-and-seed hook that already runs on every install. UAT data is
+disposable by design, so the price is a reseed.
+
+The tailscale state Secret is created by the tailscale container on first run
+under its own RBAC rule, not templated by Helm, so `helm uninstall` does not
+remove it and the tailnet identity survives. This matters: losing it is what
+produces the `fortymm-uat-1` / `grafana-1` / `loki-1` node renames that a full
+cluster delete causes. **Confirm the Secret is still there before reinstalling**
+rather than trusting this paragraph — the claim is read off the templates, not
+off a cluster.
+
+The alternative was to rename the chart while leaving the label literal at
+`fortymm-uat` forever. It avoids the reinstall and leaves a permanent lie in
+every object's labels. Rejected: the reinstall only ever gets more expensive,
+and doing it while the sole consumer is a disposable UAT stack is the cheapest
+this will ever be. Once a Hetzner production release exists, the same immutable
+field costs a production reinstall.
+
+## Environment values live beside the chart, not inside it
+
+`deploy/fortymm/values.yaml` carries neutral defaults. UAT's concrete values
+move to `deploy/environments/uat.yaml`, which `redeploy-uat.sh` passes with
+`-f`. The observability chart's one environment-specific value — the
+`uat.fortymm.com` entry in the Faro CORS allowlist — moves the same way.
+
+The rejected alternative was shipping `values-uat.yaml` *inside* the packaged
+chart, so a deployer could `helm pull --untar` and reference it with zero git.
+It is genuinely more self-sufficient, and it was turned down because it puts one
+environment's hostnames back inside the artifact this ADR exists to make
+environment-neutral. The consequence is accepted deliberately: **a UAT deploy
+still needs this repo checked out for its values file.** The checkout-free
+promise is for *other* environments, which bring their own values, and for
+reading or inspecting the chart anywhere.
+
+## Consequences
+
+- **Every `fortymm-uat.*` template helper is renamed `fortymm.*`** across
+  `_helpers.tpl` and the ten templates that call them. Purely mechanical: no
+  resource name derives from the chart name, because `metadata.name` values are
+  hardcoded literals (`api`, `postgres`) and the chart has no `fullname` helper.
+- **The release name is unaffected.** It is a CLI argument, and
+  `app.kubernetes.io/instance` reads `.Release.Name`, so the release may stay
+  `fortymm-uat` to name the *environment* even though the chart no longer does.
+- **`deploy/CLAUDE.md` and `scripts/redeploy-uat.sh` reference `deploy/uat/`
+  throughout** and move with the directory. So does the `nginxConf` note about
+  keeping `nginx/uat.conf` in sync with the inline copy in `_helpers.tpl`.
+- **The observability chart keeps its name.** `observability` says nothing about
+  an environment, and renaming it would rename its resources for no gain. The
+  `fortymm/` segment in the registry path is what scopes it — a bare
+  `ghcr.io/mightymoose/observability` package would be far too generic for an
+  account that may host other projects.

--- a/scripts/redeploy-uat.sh
+++ b/scripts/redeploy-uat.sh
@@ -4,7 +4,7 @@
 # to the repo root.
 #
 # This script BUILDS NOTHING. The api and web-client images come from GHCR,
-# published per commit on `main` by .github/workflows/publish-images.yml, and
+# published per commit on `main` by .github/workflows/publish.yml, and
 # are deployed pinned by manifest digest. A merge is therefore not deployable
 # until that workflow finishes (~20-30 min, dominated by the emulated arm64
 # leg). See docs/adr/20260802-uat-deploys-published-images-pinned-by-digest.md.
@@ -35,14 +35,14 @@ NODE_PORT=30084
 APNS_KEY="secrets/AuthKey_68VYRLMWWR.p8"
 UAT_URL="${UAT_URL:-https://uat.fortymm.com}"
 
-# The two GHCR packages publish-images.yml pushes. These three files must name
+# The two GHCR packages publish.yml pushes. These three files must name
 # the same packages: the workflow's API_IMAGE/WEB_IMAGE env, deploy/uat/values.yaml's
 # images.{api,web}.repository, and here. (A mismatch is loud, not silent: the
 # digest resolved from one package does not exist in another, so the pull fails.)
 GHCR_OWNER="mightymoose"
 API_PACKAGE="fortymm-api"
 WEB_PACKAGE="fortymm-web-client"
-PUBLISH_RUNS_URL="https://github.com/${GHCR_OWNER}/fortymm/actions/workflows/publish-images.yml"
+PUBLISH_RUNS_URL="https://github.com/${GHCR_OWNER}/fortymm/actions/workflows/publish.yml"
 
 # How long to wait for the deploying commit's images to appear in GHCR before
 # giving up. The publish is multi-arch and its arm64 leg is QEMU-emulated on an
@@ -95,7 +95,7 @@ fi
 # Deliberately NOT `git rev-parse --short`. That picks its length from the
 # repository's object count (`core.abbrev=auto`) and from any `core.abbrev` the
 # operator has set — 8 characters in this clone today, 9 once it grows, 7 in a
-# shallow clone. publish-images.yml tags with `${GITHUB_SHA::12}`, and the two
+# shallow clone. publish.yml tags with `${GITHUB_SHA::12}`, and the two
 # MUST agree exactly: a length that drifts turns a commit that published
 # perfectly well into a tag-not-found. Keep this line and that one in lockstep.
 #
@@ -252,7 +252,7 @@ resolve_published_digest() {
     now="$(date +%s)"
     if [ "$now" -ge "$deadline" ]; then
       echo "ERROR: no image published for ghcr.io/${GHCR_OWNER}/${pkg}:${tag} after ${DIGEST_WAIT_TIMEOUT_S}s." >&2
-      echo "       Commit $(git rev-parse HEAD) has no images. Either publish-images is still" >&2
+      echo "       Commit $(git rev-parse HEAD) has no images. Either publish is still" >&2
       echo "       running or it failed for this commit, or HEAD is not a commit that exists on" >&2
       echo "       origin/main (only pushed main commits are ever published)." >&2
       echo "       Check $PUBLISH_RUNS_URL, then re-run this script." >&2


### PR DESCRIPTION
Part 1 of 2 for #1277. **Nothing consumes the published charts yet** — `deploy/uat/` stays put and `scripts/redeploy-uat.sh` is untouched. That split is deliberate: `publish.yml` runs on push to `main` only, so this job cannot be proven from a pull request. It has to merge and be observed publishing before anything is allowed to depend on it. Slice 2 does the switch.

## What this does

CI now packages both Helm charts and pushes them to `ghcr.io/mightymoose/fortymm/charts/{fortymm-uat,observability}`, so deploying no longer requires a checkout of this repo.

- **`1a`** renames `publish-images.yml` → `publish.yml` and exposes each image job's pushed manifest digest as a job output, taken from the build-push step rather than a GHCR API lookup.
- **`1b`** publishes the stack chart, baking that commit's api and web image digests into its values.
- **`1c`** publishes the observability chart, which bakes no images and so does not wait on the ~25-minute image builds.
- **`1d`** documents all of it in the infra runbook.

## The two decisions worth reviewing

**The chart version is `0.1.0-sha<12-char-sha>`, and the `sha` prefix is load-bearing.** A bare SHA is not valid SemVer, so it has to be encoded — and the tidier-looking `0.1.0-<sha>` fails whenever the truncated SHA is all digits with a leading zero, because SemVer forbids a leading zero in a numeric pre-release identifier. Verified: `helm package --version 0.1.0-000123456789` gives `Error: version segment starts with 0`. That is roughly one commit in three thousand, failing in CI on an otherwise-good commit. Please do not tidy the prefix away.

**The image digests are baked into the published values.** A published chart is a complete description of one commit's stack, which makes the chart version the single coordinate a rollback names — chart and images cannot drift apart. Before, a deploy was three coordinates held together only by a single git checkout producing all three.

Both jobs guard against publishing something quietly wrong. The stack chart shape-checks the digests before writing them and reads the packaged tarball back to prove both landed, because an empty digest is *not* malformed to the `imageRef` helper — it is the documented render-only fallback, so a bad input would publish a chart that packages and renders cleanly while silently pinning the moving `:main` tag. The observability job asserts all three subcharts are inside the package it pushes.

## Verification

Each chart job was rehearsed end-to-end against a local `registry:2`: package, push, pull back, and confirm the pulled artifact really carries the baked digests / vendored subcharts. Both readback guards were falsified — broken inputs fail the job for the stated reason. Note the honest limit: `publish.yml` does not run on pull requests, so the GHCR push and `helm registry login` legs are only substituted for locally. **First real evidence is the run on `main` after this merges**, and confirming it is a required step before slice 2.

Decisions recorded in `docs/adr/20260805-charts-publish-to-ghcr-versioned-by-commit-with-image-digests-baked-in.md` and `docs/adr/20260805-the-stack-chart-is-environment-neutral-and-named-fortymm.md`, both included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)