### PR TITLE
Slice 1: a draw type's settings are one NOT NULL JSON object

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -390,7 +390,7 @@ rating rank, never the player's index on the current page).
 
 **Draw**:
 The complete set of **fixtures** an event's draw type prescribes for its
-entrants — a bracket, a set of pools, pools feeding a bracket, or (later)
+entrants — a bracket, a set of pools, pools feeding a bracket, or **swiss**
 rounds of pairings. A draw is
 **cut** (the deliberate, reviewable act of generating it; re-cutting replaces
 it wholesale and is refused once there is any evidence of play), and it is
@@ -414,6 +414,35 @@ the fixture). *Ready* is the state that ends the moment the match is created:
 `match_id` is no longer ready, and so is never proposed twice.
 _Avoid_: slot (a *Slot* is a window of time), tournament match (a fixture is
 the pre-play pairing; the match is the contest it becomes), tie.
+
+**Swiss**:
+A draw type that plays a fixed number of **rounds**, pairing each round by
+current **standings** rather than by a bracket. Nobody is eliminated, and every
+entrant plays every round. The round count is a required setting the director
+chooses, not a number derived from the field. All rounds are **cut** up front
+with their sides unknown, and `advance()` pairs each round once the previous one
+is fully decided (ADR 20260805). A **rematch** is avoided where possible and
+allowed as a last resort, because refusing to pair would strand a live event.
+_Avoid_: monrad, ladder, league (a swiss event ends, a league runs on).
+
+**Bye**:
+The entrant left over when a **round** has an odd number of players. It is the
+*absence of a fixture row*, never a row with a NULL side, so the byed entrant is
+derived as the one with no fixture that round. In **swiss** it goes to the
+lowest-ranked entrant who has not yet had one, and it scores as a **win worth
+zero games** — the win because nobody should be punished for a scheduling
+artifact, the zero games so it stays neutral on every tiebreak below the win.
+_Avoid_: walkover (that is an opponent who failed to appear), forfeit, default.
+
+**Buchholz**:
+The sum of an entrant's opponents' win counts — a **swiss** tiebreak measuring
+how strong a field that entrant had to beat. It ranks above game difference,
+because who you played carries more information than your margin when the format
+deliberately pairs you against your own score. A **bye** contributes nothing,
+having produced no opponent. It moves as the event runs: an opponent winning a
+later match raises your Buchholz without you playing.
+_Avoid_: strength of schedule (fine in prose, but the computed term is Buchholz),
+sonneborn-berger (a different measure we do not compute).
 
 **Venue**:
 Where a tournament is played: a postal address, plus the coordinates it resolves

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -45,6 +45,12 @@ from typing import NewType, Protocol
 
 from app.models.tournament import DrawType, EventFormat
 from app.pool_finishing_order import EntryTally, MatchOutcome, finishing_order
+from app.schemas.tournament import (
+    DrawSettingsWriteArm,
+    RoundRobinDrawSettingsWrite,
+    RrThenKoDrawSettingsWrite,
+    SingleElimDrawSettingsWrite,
+)
 
 # Distinct id types, so the checker rejects handing a fixture id to something that
 # wants an entry id. They are plain ``uuid.UUID`` at runtime.
@@ -1016,51 +1022,37 @@ def ready_fixtures(fixtures: Sequence[FixtureState]) -> tuple[FixtureId, ...]:
     return tuple(f.fixture_id for f in ready)
 
 
-def strategy_for(
-    draw_type: DrawType, *, qualifiers_per_pool: int | None
-) -> DrawStrategy:
-    """The strategy that cuts and advances this draw type, configured as the event's
-    draw-settings row configures it.
+def strategy_for(settings: DrawSettingsWriteArm) -> DrawStrategy:
+    """The strategy that cuts and advances this draw configuration.
 
-    **Total** — every :class:`DrawType` returns a strategy, and there is no refusal arm
-    left to reach. That is the whole point of holding only what runs in the enum (ADR
-    "a draw type is a seeded row, and the enum holds only what runs"): a slug with no
-    strategy is not a value this function can be handed, because Pydantic refuses it at
-    the request boundary.
+    **Total** — every arm returns a strategy, and there is no refusal arm left to reach.
+    That is the point of holding only what runs in the enum (ADR "a draw type is a
+    seeded row, and the enum holds only what runs"): a slug with no strategy is not a
+    value this function can be handed, because Pydantic refuses it at the request
+    boundary.
 
-    Still an exhaustive ``match`` with **no catch-all**, and now with nowhere to park a
-    new member lazily: adding one to :class:`DrawType` fails to type-check here until
-    its strategy exists.
+    Still an exhaustive ``match`` with **no catch-all**, and nowhere to park a new
+    member lazily: adding a :class:`DrawType` and its union arm fails to type-check here
+    until its strategy exists.
 
-    ``qualifiers_per_pool`` is the settings row's **K** column, passed straight through:
-    ``rr-then-ko`` is the first draw type whose strategy takes a *parameter*, and the
-    parameter lives on the event, not in this module. It is keyword-only and has **no
-    default**, so every call site has to answer "where does K come from" rather than
-    silently taking a strategy configured by omission — and the two draw types that take
-    no configuration say ``None`` out loud. Production callers do not spell the pair
-    themselves; :func:`app.tournament_draws.strategy_for_event` reads both facts off the
-    one row that holds them.
-
-    A ``None`` on the ``rr-then-ko`` arm is a **programmer** error, not a director's,
-    and raises :class:`ValueError` — the same status
-    :meth:`RrThenKoStrategy.__post_init__` gives ``K < 1``. Nothing a director can type
-    reaches it: the request boundary refuses an ``rr-then-ko`` payload with no qualifier
-    count (422) and the settings table's ``CHECK`` refuses such a row outright, so the
-    only way here is a caller that dropped the column on the floor — which is exactly
-    the silent-wrong-answer this refuses to give.
+    It takes the **parsed settings arm**, not a draw type plus a loose ``K`` (ADR "a
+    draw type's settings are one NOT NULL JSON object"). The pair was never really two
+    values: ``rr-then-ko`` is the one draw type whose strategy is configured, and the
+    arm is what carries the configuration each draw type actually has. So the old
+    ``qualifiers_per_pool=None`` refusal is **gone**, not moved: a
+    :class:`RrThenKoDrawSettingsWrite` without its count is not a value that can be
+    constructed, which is a stronger guarantee than a ``ValueError`` at the point of
+    dispatch. Production callers do not build the arm themselves;
+    :func:`app.tournament_draws.strategy_for_event` parses it off the one row that holds
+    it.
     """
-    match draw_type:
-        case DrawType.round_robin:
+    match settings:
+        case RoundRobinDrawSettingsWrite():
             return RoundRobinStrategy()
-        case DrawType.single_elim:
+        case SingleElimDrawSettingsWrite():
             return SingleElimStrategy()
-        case DrawType.rr_then_ko:
-            if qualifiers_per_pool is None:
-                raise ValueError(
-                    f"A {DrawType.rr_then_ko.value!r} draw needs a qualifiers_per_pool "
-                    "— the event's draw settings carry it, and the caller passed None."
-                )
-            return RrThenKoStrategy(qualifiers_per_pool=qualifiers_per_pool)
+        case RrThenKoDrawSettingsWrite():
+            return RrThenKoStrategy(qualifiers_per_pool=settings.qualifiers_per_pool)
 
 
 def reads_fixture_games(draw_type: DrawType) -> bool:

--- a/api/app/models/tournament_event_draw_settings.py
+++ b/api/app/models/tournament_event_draw_settings.py
@@ -103,11 +103,13 @@ class TournamentEventDrawSettings(Base):
     # setting per draw type. Adding a draw type's settings is now an arm in
     # ``app.schemas.tournament.DrawSettingsWriteArm`` and no migration at all.
     #
-    # A ``dict`` is what SQLAlchemy hands back, and it goes no further than
-    # ``app.tournament_draw_settings``: that module parses it into the union arm at
-    # the boundary, so nothing inward of it holds an untyped blob (api/CLAUDE.md,
-    # "parse, don't validate"). Writers go through ``configure`` below, never
-    # through this attribute.
+    # A ``dict`` is what SQLAlchemy hands back. ``app.tournament_draw_settings`` is the
+    # boundary that parses it — it hands the blob to
+    # ``app.schemas.tournament.draw_settings_from_storage``, which is where the union
+    # actually validates, since the model cannot import the schemas. What matters is the
+    # property that holds either way: no CALLER of that module ever receives an untyped
+    # blob (api/CLAUDE.md, "parse, don't validate"). App writers go through
+    # ``configure`` below, never through this attribute.
     #
     # The server default is for the raw-SQL writer (tests, psql) — every writer in
     # the app supplies the object — and it is ``{}`` rather than ``NULL`` for the
@@ -144,9 +146,17 @@ class TournamentEventDrawSettings(Base):
     ) -> "TournamentEventDrawSettings":
         """Build the settings row for ``draw_type``, carrying ``settings``.
 
-        The create path's door onto :meth:`configure` below, which is the ONE place a
-        :class:`DrawType` member becomes the persisted slug and the settings object
-        beside it.
+        **Test seeding only, and it does NOT parse.** No app code calls this: the create
+        path builds its row through ``app.tournament_draw_settings.draw_settings_row``
+        and the edit path through ``store_draw_settings``, both of which take an already
+        parsed :data:`~app.schemas.tournament.DrawSettingsWriteArm`. This method takes a
+        raw mapping and writes it straight through, so it is the one door onto
+        ``settings`` that the union does not stand behind. That matters more than it
+        used to: the ``CASE`` ``CHECK`` that once refused a configured draw type with no
+        settings is gone, so ``for_draw_type(DrawType.rr_then_ko)`` now writes ``{}``
+        happily and fails at *read* instead, when the arm cannot be parsed. Seed through
+        ``tests/_helpers.event_draw_settings``, which routes the same pair through the
+        parse, unless the point of the test is to write a blob the union would refuse.
 
         It takes the draw type and a plain mapping rather than the parsed union arm
         (``app.schemas.tournament.DrawSettingsWrite``), and that is a **layering**
@@ -167,8 +177,10 @@ class TournamentEventDrawSettings(Base):
     def configure(self, draw_type: DrawType, *, settings: Mapping[str, Any]) -> None:
         """Write this row's whole draw configuration — the ONE place the pair is set.
 
-        Both writers go through here: :meth:`for_draw_type` at create, and
-        ``app.tournament_events.update_event`` at edit. The two columns are written
+        Every writer goes through here: ``app.tournament_draw_settings``'s
+        :func:`~app.tournament_draw_settings.store_draw_settings` on both the create and
+        the edit path, and :meth:`for_draw_type` when a test seeds a row. The two
+        columns are written
         **together**, because they are one fact: setting the draw type without
         replacing the settings object beside it is how a round-robin row ends up
         carrying an ``rr-then-ko``'s qualifier count — and it is the edit path (draw

--- a/api/app/models/tournament_event_draw_settings.py
+++ b/api/app/models/tournament_event_draw_settings.py
@@ -1,17 +1,18 @@
 import uuid
+from collections.abc import Mapping
 from datetime import datetime
-from typing import TYPE_CHECKING
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
     CheckConstraint,
     DateTime,
     ForeignKey,
-    Integer,
     String,
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db import Base
@@ -19,6 +20,18 @@ from app.models.tournament import DrawType
 
 if TYPE_CHECKING:
     from app.models.tournament import TournamentEvent
+
+
+NO_SETTINGS: Mapping[str, Any] = MappingProxyType({})
+"""What a draw type that takes no configuration stores: the **empty object**.
+
+Not ``None`` (ADR "a draw type's settings are one NOT NULL JSON object"). An empty
+object and a ``NULL`` would read the same to every caller, so only one of them may be
+representable, and the empty object is the one every reader already expects — nothing
+has to test for absence before it reads.
+
+A ``MappingProxyType``, so the shared default cannot be mutated by whoever receives it.
+"""
 
 
 class TournamentEventDrawSettings(Base):
@@ -39,31 +52,29 @@ class TournamentEventDrawSettings(Base):
     has a seeded row — i.e. one ``app.draws.strategy_for`` can actually dispatch —
     and a seeded row cannot be deleted out from under an event that uses it.
 
-    Two columns of configuration today: the draw type, and ``qualifiers_per_pool``
-    — the **K** of "the top K from each pool advance", which only ``rr-then-ko``
-    has (#1227). The follow-on pools ticket moves ``TournamentEvent.pools`` in
-    here.
+    Two columns of configuration today: the draw type, and the ``settings`` object
+    beside it — the serialized form of the draw type's own settings arm (ADR "a draw
+    type's settings are one NOT NULL JSON object"). The follow-on pools ticket moves
+    ``TournamentEvent.pools`` in here.
     """
 
     __tablename__ = "tournament_event_draw_settings"
     __table_args__ = (
-        # ``qualifiers_per_pool`` belongs to exactly one draw type, and this is
-        # what says so at the storage layer: it is NOT NULL and at least 1 when
-        # the row names ``rr-then-ko``, and NULL for every other draw type. A
-        # round-robin row carrying a qualifier count is not a row Postgres will
-        # accept, so the pairing cannot drift no matter which writer produced it.
+        # All the database has an opinion on now: ``settings`` is a JSON **object**.
+        # A list, a number, a string or a JSON ``null`` would each parse as "settings"
+        # and mean nothing, so they are refused here rather than deep in a reader.
         #
-        # The slug is spelled out in the DDL on purpose. It is the same
-        # hand-copied seed data migration 0010 already carries (``DRAW_TYPE_SEED``)
-        # — a constraint cannot import ``DrawType``, and a lookup-driven
-        # "does this draw type take qualifiers?" column on ``draw_types`` would be
-        # a second, mutable home for a fact the code already dispatches on.
+        # It is deliberately weaker than the ``CASE`` constraint it replaces, which
+        # paired a nullable ``qualifiers_per_pool`` column with the one draw type that
+        # has one. Which settings belong to which draw type is no longer a storage
+        # fact — it is the discriminated union at the request boundary
+        # (``app.schemas.tournament.DrawSettingsWrite``), which refuses a qualifier
+        # count on a round-robin event with a 422. That is the loss the ADR accepts on
+        # purpose: the constraint grew one branch per draw type per setting, and the
+        # union already says the same thing in one place.
         CheckConstraint(
-            "CASE WHEN draw_type_key = 'rr-then-ko'"
-            " THEN qualifiers_per_pool IS NOT NULL AND qualifiers_per_pool >= 1"
-            " ELSE qualifiers_per_pool IS NULL"
-            " END",
-            name="ck_tournament_event_draw_settings_qualifiers_per_pool",
+            "jsonb_typeof(settings) = 'object'",
+            name="ck_tournament_event_draw_settings_settings_object",
         ),
     )
 
@@ -81,23 +92,29 @@ class TournamentEventDrawSettings(Base):
         ForeignKey("draw_types.key", ondelete="RESTRICT"),
         nullable=False,
     )
-    # **K** — how many of each pool's finishers advance into the knockout stage of
-    # an ``rr-then-ko`` draw (ADR "rr-then-ko cuts both stages upfront and seeds
-    # qualifiers rematch-free"). The knockout bracket's size is
-    # ``next_power_of_two(P × K)`` and is DERIVED at the cut, never stored beside
-    # this — carrying both lets them contradict.
+    # The draw type's settings, as one NOT NULL JSON object (ADR "a draw type's
+    # settings are one NOT NULL JSON object"). ``{}`` for a draw type that takes no
+    # configuration — ``round-robin`` and ``single-elim`` today —
+    # ``{"qualifiers_per_pool": K}`` for ``rr-then-ko``.
     #
-    # Nullable because it is meaningless for every other draw type: a round-robin
-    # event has no cut to size and a single-elim event has no pools to cut from,
-    # so ``NULL`` here is "this draw type takes no qualifier count", not "unknown".
-    # The ``CASE`` constraint above is what keeps NULL and the draw type in step.
+    # This is the **serialized form of a union**: which keys are in here depends
+    # entirely on the draw type beside it, which is what a wide row of nullable
+    # columns could only express with a ``CASE`` constraint that grew a branch per
+    # setting per draw type. Adding a draw type's settings is now an arm in
+    # ``app.schemas.tournament.DrawSettingsWriteArm`` and no migration at all.
     #
-    # ``K >= 1`` is the STATIC half of the ADR's legal configuration space and so
-    # is enforced here (and at the request boundary). The two bounds that move with
-    # the entrant count — ``P × K >= 2`` and ``K <= ⌊N/P⌋`` — are refused at the cut
-    # as ``DegenerateDraw``, because a row that was legal when it was written must
-    # not become unwritable when a player withdraws.
-    qualifiers_per_pool: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # A ``dict`` is what SQLAlchemy hands back, and it goes no further than
+    # ``app.tournament_draw_settings``: that module parses it into the union arm at
+    # the boundary, so nothing inward of it holds an untyped blob (api/CLAUDE.md,
+    # "parse, don't validate"). Writers go through ``configure`` below, never
+    # through this attribute.
+    #
+    # The server default is for the raw-SQL writer (tests, psql) — every writer in
+    # the app supplies the object — and it is ``{}`` rather than ``NULL`` for the
+    # reason ``NO_SETTINGS`` gives.
+    settings: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -123,48 +140,49 @@ class TournamentEventDrawSettings(Base):
 
     @classmethod
     def for_draw_type(
-        cls, draw_type: DrawType, *, qualifiers_per_pool: int | None = None
+        cls, draw_type: DrawType, *, settings: Mapping[str, Any] = NO_SETTINGS
     ) -> "TournamentEventDrawSettings":
-        """Build the settings row for ``draw_type``, configured as ``draw_type``
-        configures.
+        """Build the settings row for ``draw_type``, carrying ``settings``.
 
         The create path's door onto :meth:`configure` below, which is the ONE place a
-        :class:`DrawType` member becomes the persisted slug and the qualifier count
+        :class:`DrawType` member becomes the persisted slug and the settings object
         beside it.
 
-        It takes the draw type and the count as two values rather than the request
-        boundary's parsed union arm (``app.schemas.tournament.DrawSettingsWrite``), and
-        that is a **layering** choice, not an oversight: the schemas import the models,
-        so a model naming a request schema inverts the direction the rest of the package
-        points in. The union arm is consumed one layer up, in
-        ``app.tournament_events``, which already holds both — so the pair reaching here
-        has been parsed, and "a round-robin row with a qualifier count" was refused at
-        the boundary before it could be spelled. The ``CHECK`` on this table is the
-        second, unconditional lock: a caller that assembles an illegal pair by hand gets
-        an ``IntegrityError``, not a stored contradiction.
+        It takes the draw type and a plain mapping rather than the parsed union arm
+        (``app.schemas.tournament.DrawSettingsWrite``), and that is a **layering**
+        choice, not an oversight: the schemas import the models, so a model naming a
+        schema inverts the direction the rest of the package points in. The arm is
+        serialized one layer up, by ``app.tournament_draw_settings.draw_settings_row``
+        (and ``store_draw_settings`` on the edit path), which is the module that owns
+        both directions of this column.
 
-        ``qualifiers_per_pool`` defaults to ``None`` because that is what all but one
-        draw type carry, and it keeps every construction site that names a
-        configuration-free draw type reading as it always did.
+        ``settings`` defaults to :data:`NO_SETTINGS` — the empty object — because that
+        is what every draw type but one carries, and it keeps each construction site
+        that names a configuration-free draw type reading as it always did.
         """
-        settings = cls()
-        settings.configure(draw_type, qualifiers_per_pool=qualifiers_per_pool)
-        return settings
+        row = cls()
+        row.configure(draw_type, settings=settings)
+        return row
 
-    def configure(
-        self, draw_type: DrawType, *, qualifiers_per_pool: int | None = None
-    ) -> None:
+    def configure(self, draw_type: DrawType, *, settings: Mapping[str, Any]) -> None:
         """Write this row's whole draw configuration — the ONE place the pair is set.
 
         Both writers go through here: :meth:`for_draw_type` at create, and
         ``app.tournament_events.update_event`` at edit. The two columns are written
-        **together**, because they are one fact: setting the draw type without clearing
-        the qualifier count beside it is how a round-robin row ends up carrying a ``K``
-        the ``CHECK`` refuses — and it is the edit path (draw type patched from
-        ``rr-then-ko`` back to ``round-robin``) where that would happen.
+        **together**, because they are one fact: setting the draw type without
+        replacing the settings object beside it is how a round-robin row ends up
+        carrying an ``rr-then-ko``'s qualifier count — and it is the edit path (draw
+        type patched from ``rr-then-ko`` back to ``round-robin``) where that would
+        happen. So ``settings`` is a **required** keyword here, unlike on
+        :meth:`for_draw_type`: at create "no configuration" is the common case, at edit
+        an omitted settings object is the bug this method exists to prevent.
+
+        Copied into a plain ``dict`` on the way in, because the value the caller passes
+        may be the shared :data:`NO_SETTINGS` proxy and the column's value belongs to
+        this row alone.
         """
         self.draw_type = draw_type
-        self.qualifiers_per_pool = qualifiers_per_pool
+        self.settings = dict(settings)
 
     @property
     def draw_type(self) -> DrawType:

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -1,5 +1,6 @@
 import uuid
 from collections import Counter
+from collections.abc import Mapping
 from datetime import date, datetime, time
 from decimal import ROUND_DOWN, Decimal
 from typing import Annotated, Any, Literal
@@ -154,19 +155,48 @@ become unwritable when a player withdraws (the same split ``_snake`` already use
 its own pool floor)."""
 
 
-class RoundRobinDrawSettingsWrite(BaseModel):
-    """A round-robin event's draw configuration: the draw type, and nothing else.
+class DrawSettingsWriteBase(BaseModel):
+    """What every arm of the draw-settings union shares: ``extra="forbid"``, and the
+    serialization onto the settings column.
 
-    ``extra="forbid"`` is doing real work on this arm — it is what makes
-    ``qualifiers_per_pool`` on a round-robin event a **422 at the boundary** rather than
-    a value silently dropped on the way to a column that cannot hold it (the settings
-    table's ``CHECK`` says ``NULL`` for every draw type but ``rr-then-ko``). A director
-    who names a qualifier count for a format that has no knockout stage has
-    misunderstood something, and the useful answer is to say so, not to run the event
-    they did not ask for.
+    A base class rather than three copies, because the storage form is one rule (ADR "a
+    draw type's settings are one NOT NULL JSON object") and a new arm that spelled it
+    differently would store a shape the read side could not parse back.
+
+    It adds **no field**, so it moves nothing on the wire and mints no OpenAPI
+    component of its own.
     """
 
     model_config = ConfigDict(extra="forbid")
+
+    def stored_settings(self) -> dict[str, Any]:
+        """This arm as the object the settings column stores: its settings, **without**
+        the discriminator.
+
+        ``draw_type`` is excluded because it is not a setting — it is the column beside
+        this one (``draw_type_key``, the FK onto ``draw_types``), and storing it twice
+        would let the two disagree. The read side puts it back
+        (``app.tournament_draw_settings.draw_settings_of``), which is what makes the
+        round trip total.
+
+        ``{}`` for the two draw types that take no configuration, and that is the whole
+        representation of "no configuration" — never ``NULL``.
+        """
+        return self.model_dump(mode="json", exclude={"draw_type"})
+
+
+class RoundRobinDrawSettingsWrite(DrawSettingsWriteBase):
+    """A round-robin event's draw configuration: the draw type, and nothing else.
+
+    ``extra="forbid"`` (inherited) is doing real work on this arm — it is what makes
+    ``qualifiers_per_pool`` on a round-robin event a **422 at the boundary** rather than
+    a value silently dropped on the way to storage. Since the settings column became one
+    JSON object, this union is the **only** thing that says which settings belong to
+    which draw type: the table's old ``CASE`` constraint went with the column it
+    guarded. A director who names a qualifier count for a format that has no knockout
+    stage has misunderstood something, and the useful answer is to say so, not to run
+    the event they did not ask for.
+    """
 
     draw_type: Literal[DrawType.round_robin] = DrawType.round_robin
 
@@ -180,12 +210,10 @@ class RoundRobinDrawSettingsWrite(BaseModel):
         return None
 
 
-class SingleElimDrawSettingsWrite(BaseModel):
+class SingleElimDrawSettingsWrite(DrawSettingsWriteBase):
     """A single-elimination event's draw configuration: the draw type, and nothing else.
     See :class:`RoundRobinDrawSettingsWrite` for why ``extra="forbid"`` is the rule and
     not decoration."""
-
-    model_config = ConfigDict(extra="forbid")
 
     draw_type: Literal[DrawType.single_elim] = DrawType.single_elim
 
@@ -195,7 +223,7 @@ class SingleElimDrawSettingsWrite(BaseModel):
         return None
 
 
-class RrThenKoDrawSettingsWrite(BaseModel):
+class RrThenKoDrawSettingsWrite(DrawSettingsWriteBase):
     """A round-robin-then-knockout event's draw configuration: the draw type **and** its
     qualifier count (ADR 20260727).
 
@@ -203,8 +231,6 @@ class RrThenKoDrawSettingsWrite(BaseModel):
     defensible number to assume — "2" is a convention, not a fact about the event — and
     a draw silently cut for a K the director never chose is the worst of the available
     failures: it looks like it worked."""
-
-    model_config = ConfigDict(extra="forbid")
 
     draw_type: Literal[DrawType.rr_then_ko] = DrawType.rr_then_ko
     qualifiers_per_pool: QualifiersPerPool
@@ -280,6 +306,29 @@ def _draw_settings_write(
                 for error in exc.errors()
             )
         ) from exc
+
+
+def draw_settings_from_storage(
+    draw_type: DrawType, settings: Mapping[str, Any]
+) -> DrawSettingsWriteArm:
+    """Parse a stored ``(draw_type, settings)`` pair back into the union arm it is the
+    serialized form of — the READ half of the settings column (ADR "a draw type's
+    settings are one NOT NULL JSON object").
+
+    The discriminator is not in the blob (``stored_settings`` leaves it out, because the
+    row carries it in ``draw_type_key`` beside it), so it is put back here. It is put
+    back as the **enum member**, never as the slug, because that is the shape
+    :func:`_draw_settings_write` has always validated and the one place slug→enum
+    happens is ``TournamentEventDrawSettings.draw_type``.
+
+    Raises :class:`~pydantic.ValidationError` — deliberately NOT the ``ValueError`` its
+    request-side sibling raises. That wrapper exists to render a **client's** bad pair
+    as a 422; a stored blob that will not parse is nobody's request and must not be
+    dressed up as one. It is a row that should not exist, and the loud failure is the
+    point: the alternative is a settings object silently read as empty, which cuts a
+    draw for a configuration nobody chose.
+    """
+    return _DRAW_SETTINGS_WRITE.validate_python({"draw_type": draw_type, **settings})
 
 
 # ----- value-objects (typed JSONB) -----------------------------------------

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -329,7 +329,15 @@ def draw_settings_from_storage(
     point: the alternative is a settings object silently read as empty, which cuts a
     draw for a configuration nobody chose.
     """
-    return _DRAW_SETTINGS_WRITE.validate_python({"draw_type": draw_type, **settings})
+    # ``draw_type`` goes LAST so the column wins. Splatting the blob last instead would
+    # let a stored ``draw_type`` key override the discriminator this function was handed
+    # — ``draw_type`` is a declared field on every arm, so ``extra="forbid"`` does not
+    # catch it — and a row whose ``draw_type_key`` says ``round-robin`` would parse as
+    # whatever arm its own JSON named. Nothing writes such a blob today
+    # (``stored_settings()`` excludes the key), but "the union is the only enforcement"
+    # is exactly the claim this change rests on, so it must hold against a writer that
+    # did not go through it.
+    return _DRAW_SETTINGS_WRITE.validate_python({**settings, "draw_type": draw_type})
 
 
 # ----- value-objects (typed JSONB) -----------------------------------------

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -258,9 +258,10 @@ here).
 One arm per :class:`DrawType`, carrying exactly the configuration that draw type has —
 which for two of the three is nothing at all. That is the whole point: "a round-robin
 event with 2 qualifiers per pool" is not a payload this type can hold, so it cannot be
-half-honoured, and the settings table's ``CHECK`` and this union say the same thing at
-two different boundaries rather than one of them silently absorbing what the other
-refuses.
+half-honoured. This union is now the **sole** enforcement of that pairing: the settings
+table's ``CASE`` ``CHECK`` was dropped with the column it named (ADR "a draw type's
+settings are one NOT NULL JSON object"), so nothing underneath catches a pair this type
+lets through.
 
 Adding a draw type is an arm in :data:`DrawSettingsWriteArm` above (one list, read by
 this alias, its ``TypeAdapter`` and the parse alike), and it is *not* a type error until
@@ -1593,10 +1594,11 @@ class TournamentEventRead(BaseModel):
     # so this is the stored configuration and not a second copy of it.
     #
     # ``null`` for a round-robin or single-elim event, and that is a *fact* rather than
-    # missing data: neither draw type has a qualifier count, which is what the settings
-    # table's ``CHECK`` says in DDL and what the write union says at the boundary. This
-    # read is the third statement of the same pairing and it cannot disagree with
-    # either, because it does not decide anything — it reports the column.
+    # missing data: neither draw type has a qualifier count, which is what the write
+    # union says at the boundary. (It is no longer also said in DDL — the settings
+    # table's ``CASE`` ``CHECK`` was dropped with the column it named.) This read is the
+    # second statement of the same pairing and it cannot disagree with the union,
+    # because it does not decide anything — it reports the parsed arm.
     #
     # It is on the read at all because the client edits the pair as a unit. The event
     # editor always sends ``draw_type``, and the server parses ``(draw_type, K)``
@@ -2064,9 +2066,12 @@ class TournamentEventCreate(BaseModel):
     @model_validator(mode="after")
     def _parse_draw_settings(self) -> "TournamentEventCreate":
         """Parse at the boundary: an illegal ``(draw_type, qualifiers_per_pool)`` pair
-        is a 422 on the create, not a row the settings table's ``CHECK`` rejects later
-        with a 500. The arm it parses is **kept** (:attr:`_draw_settings`) rather than
-        discarded — parse once, at the boundary, and carry the parsed value inward."""
+        is a 422 on the create. This is now the **only** guard on that pairing — the
+        settings table's ``CASE`` ``CHECK`` went away with the column it named (ADR "a
+        draw type's settings are one NOT NULL JSON object"), so there is no longer a
+        database refusal behind this one. The arm it parses is **kept**
+        (:attr:`_draw_settings`) rather than discarded — parse once, at the boundary,
+        and carry the parsed value inward."""
         self._draw_settings = _draw_settings_write(
             self.draw_type, self.qualifiers_per_pool
         )

--- a/api/app/tournament_draw_settings.py
+++ b/api/app/tournament_draw_settings.py
@@ -5,11 +5,19 @@ storage boundary, and their cleanup.
 object (ADR "a draw type's settings are one NOT NULL JSON object") and it is the
 serialized form of a union that already exists: ``DrawSettingsWriteArm``, the
 discriminated union the request boundary parses into. :func:`draw_settings_of` decodes a
-row into that arm and :func:`stored_settings` encodes an arm back, so the untyped blob
-lives in exactly these two functions and nothing inward of them holds a
-``dict[str, Any]`` (api/CLAUDE.md, "parse, don't validate"). Both directions are here,
-in one module, because a settings object written one way and read another is the single
-failure this column can have.
+row into that arm, and :func:`store_draw_settings` encodes an arm back onto one
+(:func:`draw_settings_row` is the same write for a row that does not exist yet, and
+delegates). Both directions are here, in one module, because a settings object written
+one way and read another is the single failure this column can have.
+
+**Where the untyped blob is allowed to exist.** It crosses this module's boundary
+functions and the two ends they call —
+:meth:`~app.schemas.tournament.DrawSettingsWriteBase.stored_settings` encoding on the
+schema side, and ``TournamentEventDrawSettings.configure`` storing on the model side.
+That is the whole of it: no caller of this module ever holds a ``dict[str, Any]``, which
+is the property api/CLAUDE.md's "parse, don't validate" asks for. The claim is about
+*callers*, not about a literal two-function count — the encode necessarily lives on the
+schema because the model cannot import the schemas.
 
 They live beside the row rather than on it: the model cannot import the schemas (the
 schemas import the models, and the arrow only points one way), so the model takes the
@@ -83,12 +91,13 @@ def draw_settings_row(
     """A **new** settings row carrying ``settings`` — what the event-create path builds
     its event's ``draw_settings`` with.
 
-    The create-shaped face of :func:`store_draw_settings`, so create and edit serialize
-    an arm exactly one way between them.
+    The create-shaped face of :func:`store_draw_settings` — and it *delegates* to it
+    rather than restating the split, so create and edit serialize an arm exactly one way
+    between them by construction rather than by two spellings that happen to agree.
     """
-    return TournamentEventDrawSettings.for_draw_type(
-        settings.draw_type, settings=settings.stored_settings()
-    )
+    row = TournamentEventDrawSettings()
+    store_draw_settings(row, settings)
+    return row
 
 
 async def draw_settings_ids_for_tournament(

--- a/api/app/tournament_draw_settings.py
+++ b/api/app/tournament_draw_settings.py
@@ -1,6 +1,22 @@
-"""Cleanup for the rows behind ``tournament_events.draw_settings_id``.
+"""The rows behind ``tournament_events.draw_settings_id`` — their settings column's
+storage boundary, and their cleanup.
 
-An event's draw configuration is a row, not a column (ADR "an event's draw
+**The boundary.** ``tournament_event_draw_settings.settings`` is one NOT NULL JSON
+object (ADR "a draw type's settings are one NOT NULL JSON object") and it is the
+serialized form of a union that already exists: ``DrawSettingsWriteArm``, the
+discriminated union the request boundary parses into. :func:`draw_settings_of` decodes a
+row into that arm and :func:`stored_settings` encodes an arm back, so the untyped blob
+lives in exactly these two functions and nothing inward of them holds a
+``dict[str, Any]`` (api/CLAUDE.md, "parse, don't validate"). Both directions are here,
+in one module, because a settings object written one way and read another is the single
+failure this column can have.
+
+They live beside the row rather than on it: the model cannot import the schemas (the
+schemas import the models, and the arrow only points one way), so the model takes the
+draw type and a plain mapping and this module is what turns an arm into that pair.
+
+**The cleanup.** An event's draw configuration is a row, not a column (ADR "an event's
+draw
 configuration is a row, not a column"), and the FK lives on the *parent*: the
 event points at its settings row, never the other way round. That direction is
 what makes "every event has exactly one settings row" a database fact — and it is
@@ -29,6 +45,50 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import TournamentEvent, TournamentEventDrawSettings
+from app.schemas.tournament import DrawSettingsWriteArm, draw_settings_from_storage
+
+
+def draw_settings_of(row: TournamentEventDrawSettings) -> DrawSettingsWriteArm:
+    """This settings row's draw configuration, parsed — the ONE read boundary onto the
+    ``settings`` column.
+
+    Every reader of an event's draw configuration goes through here and holds the
+    **arm**, never the row's two columns: the draw type and the settings that belong to
+    it are one fact, and reading them apart is how a strategy ends up configured from a
+    blob that names a different draw type.
+
+    Raises :class:`~pydantic.ValidationError` on a blob that is not the arm its draw
+    type names — see :func:`app.schemas.tournament.draw_settings_from_storage` for why
+    that is louder than the request side's 422.
+    """
+    return draw_settings_from_storage(row.draw_type, row.settings)
+
+
+def store_draw_settings(
+    row: TournamentEventDrawSettings, settings: DrawSettingsWriteArm
+) -> None:
+    """Write ``settings`` onto ``row`` — the ONE write boundary onto that column.
+
+    The inverse of :func:`draw_settings_of`, and the reason both are in one module: the
+    arm's discriminator becomes the ``draw_type_key`` slug and the rest of it becomes
+    the JSON object, in a single call, so the pair cannot be written half-way. Delegates
+    to ``configure``, which is the model's own "these two columns are one fact" door.
+    """
+    row.configure(settings.draw_type, settings=settings.stored_settings())
+
+
+def draw_settings_row(
+    settings: DrawSettingsWriteArm,
+) -> TournamentEventDrawSettings:
+    """A **new** settings row carrying ``settings`` — what the event-create path builds
+    its event's ``draw_settings`` with.
+
+    The create-shaped face of :func:`store_draw_settings`, so create and edit serialize
+    an arm exactly one way between them.
+    """
+    return TournamentEventDrawSettings.for_draw_type(
+        settings.draw_type, settings=settings.stored_settings()
+    )
 
 
 async def draw_settings_ids_for_tournament(

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -56,6 +56,7 @@ from app.models import (
     TournamentFixture,
 )
 from app.schemas.tournament import Pool
+from app.tournament_draw_settings import draw_settings_of
 from app.tournament_pools import pool_read
 
 
@@ -260,21 +261,18 @@ def strategy_for_event(event: TournamentEvent) -> DrawStrategy:
     """The strategy that cuts and advances **this event's** draw — the one production
     door onto :func:`app.draws.strategy_for`.
 
-    ``strategy_for`` is keyword-strict about the qualifier count and has no default, so
-    somebody has to read it off the event; this is that somebody, and it is one function
-    rather than three call sites each reaching into ``event.draw_settings`` for a pair
-    of columns. Which matters because forgetting the second column does not fail — it
-    produces a differently-configured strategy — and because the two facts live on one
-    row precisely so they are read together (ADR "an event's draw configuration is a
-    row, not a column").
+    ``strategy_for`` takes the **parsed settings arm**, so somebody has to decode it off
+    the event's settings row; this is that somebody, and it is one function rather than
+    three call sites each parsing the same blob. Which matters because the draw type and
+    the settings beside it are one fact and live on one row precisely so they are read
+    together (ADR "an event's draw configuration is a row, not a column").
 
-    The settings row rides along with the event (``lazy="joined"``), so this is
-    attribute access, not a lazy load in async context.
+    The settings row rides along with the event (``lazy="joined"``), so the read is
+    attribute access, not a lazy load in async context; the parse it feeds is
+    :func:`app.tournament_draw_settings.draw_settings_of`, the single read boundary onto
+    that column.
     """
-    return strategy_for(
-        event.draw_settings.draw_type,
-        qualifiers_per_pool=event.draw_settings.qualifiers_per_pool,
-    )
+    return strategy_for(draw_settings_of(event.draw_settings))
 
 
 async def event_has_draw(db: AsyncSession, event_id: uuid.UUID) -> bool:

--- a/api/app/tournament_events.py
+++ b/api/app/tournament_events.py
@@ -604,7 +604,9 @@ async def update_event(
     changes.pop("pools", None)
     # The parsed union arm, not the loose keys: it is ``None`` exactly when the patch
     # does not touch the draw configuration, and when it is not, the pair it carries is
-    # one the settings table's ``CHECK`` accepts (ADR 20260727).
+    # one the write union accepted at the request boundary (ADR 20260727). That union is
+    # the only thing that checks the pairing now — the settings table's ``CASE``
+    # ``CHECK`` was dropped with the column it named.
     draw_settings = updates.draw_settings
     for key, value in changes.items():
         setattr(event, key, value)

--- a/api/app/tournament_events.py
+++ b/api/app/tournament_events.py
@@ -579,7 +579,8 @@ async def update_event(
     changes = updates.model_dump(exclude_unset=True)
     # Neither half of the draw configuration is a column on the event — the draw type is
     # the ``draw_type_key`` slug on the settings row the event points at, and the
-    # qualifier count is that row's ``qualifiers_per_pool`` — so both are routed OUT of
+    # qualifier count is a key inside that row's ``settings`` JSON object — so both are
+    # routed OUT of
     # the generic setattr loop rather than through it. This is not decoration:
     # SQLAlchemy's declarative instances accept any attribute, so
     # ``setattr(event, "draw_type", ...)`` would bind a plain Python attribute the

--- a/api/app/tournament_events.py
+++ b/api/app/tournament_events.py
@@ -31,7 +31,6 @@ from app.models import (
     DrawType,
     ScheduleSolveTrigger,
     TournamentEvent,
-    TournamentEventDrawSettings,
     TournamentFixture,
     User,
 )
@@ -42,6 +41,11 @@ from app.schemas.tournament import (
     TournamentEventCreate,
     TournamentEventUpdate,
     named_list,
+)
+from app.tournament_draw_settings import (
+    draw_settings_of,
+    draw_settings_row,
+    store_draw_settings,
 )
 from app.tournament_draws import event_has_draw, event_pools
 from app.tournament_edit import _load_owned_tournament_for_update
@@ -123,12 +127,10 @@ async def create_event(
         #
         # Written from the parsed union arm, never from the two loose payload fields:
         # the boundary has already refused a qualifier count that does not belong to
-        # the draw type beside it (ADR 20260727), so what is written here is a pair
-        # the settings table's ``CHECK`` will accept.
-        draw_settings=TournamentEventDrawSettings.for_draw_type(
-            payload.draw_settings.draw_type,
-            qualifiers_per_pool=payload.draw_settings.qualifiers_per_pool,
-        ),
+        # the draw type beside it (ADR 20260727), and ``draw_settings_row`` serializes
+        # that arm onto the row's ``draw_type_key`` + ``settings`` pair in the one place
+        # that knows how (ADR "a draw type's settings are one NOT NULL JSON object").
+        draw_settings=draw_settings_row(payload.draw_settings),
         max_players=payload.max_players,
         entry_fee=payload.entry_fee,
         timezone=payload.timezone,
@@ -378,7 +380,10 @@ async def _enforce_draw_settings_frozen(
     What the event *currently* has is read off its ``draw_settings`` row — the one home
     of that fact (ADR "an event's draw configuration is a row, not a column") — and read
     once, before the caller's ``setattr`` loop, so what is compared is the stored
-    configuration and not the one the payload is asking for.
+    configuration and not the one the payload is asking for. Both sides of the
+    comparison are the **parsed arm**, so "did the configuration move" is one equality
+    over the whole union rather than a field-by-field walk that a new setting could fall
+    out of.
     """
     # ``None`` is "this patch does not touch the draw configuration": the schema refuses
     # an explicit ``null`` on ``draw_type`` (422) and refuses a ``qualifiers_per_pool``
@@ -386,13 +391,10 @@ async def _enforce_draw_settings_frozen(
     incoming = updates.draw_settings
     if incoming is None:
         return
-    current = event.draw_settings.draw_type
-    current_qualifiers = event.draw_settings.qualifiers_per_pool
-    if (
-        incoming.draw_type is current
-        and incoming.qualifiers_per_pool == current_qualifiers
-    ):
+    stored = draw_settings_of(event.draw_settings)
+    if incoming == stored:
         return
+    current = stored.draw_type
     # Only now the query — and only for a payload that really moves the configuration.
     # It is the same ``event_has_draw`` the pool freeze asks; a payload that changes
     # both
@@ -406,7 +408,7 @@ async def _enforce_draw_settings_frozen(
     detail = (
         _draw_type_frozen_detail(current)
         if incoming.draw_type is not current
-        else _qualifiers_per_pool_frozen_detail(current, current_qualifiers)
+        else _qualifiers_per_pool_frozen_detail(current, stored.qualifiers_per_pool)
     )
     raise DrawTypeFrozenError(detail, draw_type=current.value)
 
@@ -610,17 +612,16 @@ async def update_event(
         apply_event_pools(tournament, event, updates.pools)
     if draw_settings is not None:
         # The one place an event's draw configuration moves after create (the freeze
-        # above has already refused this on a cut draw). Assigned through the settings
-        # row's ``configure``, not its columns, so the enum→slug conversion and the
-        # "these two columns are one fact" pairing stay in the single place that owns
-        # them — the same door ``for_draw_type`` goes through at create. The settings
-        # row
-        # is loaded with the event (``lazy="joined"``), so this is a plain attribute
-        # write, not a lazy load in async context.
-        event.draw_settings.configure(
-            draw_settings.draw_type,
-            qualifiers_per_pool=draw_settings.qualifiers_per_pool,
-        )
+        # above has already refused this on a cut draw). Assigned through
+        # ``store_draw_settings``, not through the row's columns, so serializing the arm
+        # onto ``draw_type_key`` + ``settings`` stays in the single place that owns it —
+        # the same door ``draw_settings_row`` goes through at create. That matters most
+        # on THIS path: a draw type patched from ``rr-then-ko`` back to ``round-robin``
+        # has to drop the qualifier count with it, and writing the pair together is what
+        # makes that automatic. The settings row is loaded with the event
+        # (``lazy="joined"``), so this is a plain attribute write, not a lazy load in
+        # async context.
+        store_draw_settings(event.draw_settings, draw_settings)
     if event.timezone != old_timezone:
         # The zone truly moved (a PATCH re-sending the same zone falls through as a
         # no-op): recompose every placement so its local reading is unchanged and only

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -59,6 +59,7 @@ from app.schemas.tournament import (
     TournamentFixtureRead,
     TournamentRead,
 )
+from app.tournament_draw_settings import draw_settings_of
 from app.tournament_eligibility import (
     Eligible,
     RatingIneligible,
@@ -446,6 +447,11 @@ def serialize_event(
     # body can see. It is loaded once, in a batch, by ``fixtures_by_event``, which
     # also owns the pool → round → position ordering, so the serializer never sorts
     # and no two call sites can order a bracket differently.
+    #
+    # The draw configuration is parsed ONCE, here, off the settings row that rides along
+    # with the event (``lazy="joined"``): both wire fields below come off this one arm,
+    # so the type and the count cannot be read from two different places and disagree.
+    draw_settings = draw_settings_of(e.draw_settings)
     return TournamentEventRead.model_validate(
         {
             "id": e.id,
@@ -457,16 +463,16 @@ def serialize_event(
             # configuration is a row, not a column"), which is joined onto every query
             # that loads an event (``lazy="joined"``), so the list endpoint's
             # per-event serialization still issues no query of its own.
-            "draw_type": e.draw_settings.draw_type,
-            # The other half of the same fact, off the same already-joined row: the
-            # slug through the ``draw_type`` property (which owns the slug→enum parse,
-            # so this serializer never spells one), and **K** through the column beside
-            # it. Read as a pair because they are stored as a pair — taking the type
-            # from the settings row and the count from anywhere else is how the two
-            # start disagreeing. ``None`` for the two draw types that have no knockout
-            # stage to qualify for, which the table's ``CHECK`` guarantees rather than
-            # this line assuming.
-            "qualifiers_per_pool": e.draw_settings.qualifiers_per_pool,
+            "draw_type": draw_settings.draw_type,
+            # The other half of the same fact, off the same parsed arm: **K**, which
+            # only the ``rr-then-ko`` arm carries as a field. ``None`` for the two draw
+            # types that have no knockout stage to qualify for — a property on those
+            # arms, so this reads the same question of every arm without an
+            # ``isinstance`` ladder, and the answer comes from the union rather than
+            # from this line assuming it. **Flat beside ``draw_type`` on the wire**,
+            # exactly as before: the settings object is a storage shape, not a wire one
+            # (ADR "a draw type's settings are one NOT NULL JSON object").
+            "qualifiers_per_pool": draw_settings.qualifiers_per_pool,
             "max_players": e.max_players,
             "entry_fee": e.entry_fee,
             # The event's venue timezone anchors its wall-clock ``Slot`` windows to

--- a/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
+++ b/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
@@ -160,13 +160,26 @@ def upgrade() -> None:
             sa.ForeignKey("draw_types.key", ondelete="RESTRICT"),
             nullable=False,
         ),
-        # **K** — how many of each pool's finishers advance into the knockout
-        # stage. Only ``rr-then-ko`` has one, so the column is NULLABLE and the
-        # CHECK below is what pairs it with the draw type: NOT NULL and >= 1 for
-        # ``rr-then-ko``, NULL for every other slug. Added in place per the
-        # pre-deploy convention (api/CLAUDE.md), not as a chained ALTER —
+        # The draw type's settings, as ONE NOT NULL JSON object (ADR "a draw
+        # type's settings are one NOT NULL JSON object"). ``{}`` for a draw type
+        # that takes no configuration — ``round-robin`` and ``single-elim`` —
+        # and ``{"qualifiers_per_pool": K}`` for ``rr-then-ko``. A draw type with
+        # no configuration stores the empty object and never NULL, so no reader
+        # has to test for absence before it reads.
+        #
+        # It replaces a nullable ``qualifiers_per_pool`` integer column and the
+        # CASE constraint that paired it with its draw type. Which settings a
+        # draw type has is a union, and a union modelled as a wide row of
+        # nullable columns is what forced that constraint to exist: each new
+        # setting cost a column, a branch and a migration. Edited in place per
+        # the pre-deploy convention (api/CLAUDE.md), not as a chained ALTER —
         # revision ids and the down_revision chain stay frozen.
-        sa.Column("qualifiers_per_pool", sa.Integer(), nullable=True),
+        sa.Column(
+            "settings",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -179,12 +192,20 @@ def upgrade() -> None:
             server_default=sa.func.now(),
             nullable=False,
         ),
+        # All the database has an opinion on: ``settings`` is a JSON **object**.
+        # A list, a number, a string or a JSON ``null`` would each be a stored
+        # "settings" that means nothing, so they are refused here.
+        #
+        # Deliberately weaker than the CASE constraint it replaces, which knew
+        # that only ``rr-then-ko`` carries a qualifier count. Which settings
+        # belong to which draw type now lives in the discriminated union at the
+        # request boundary (``app.schemas.tournament.DrawSettingsWrite``), which
+        # refuses a mismatched pair with a 422. That trade is the ADR's, made on
+        # purpose: the constraint grew one branch per draw type per setting, and
+        # a migration cannot import the enum it would have to keep agreeing with.
         sa.CheckConstraint(
-            "CASE WHEN draw_type_key = 'rr-then-ko'"
-            " THEN qualifiers_per_pool IS NOT NULL AND qualifiers_per_pool >= 1"
-            " ELSE qualifiers_per_pool IS NULL"
-            " END",
-            name="ck_tournament_event_draw_settings_qualifiers_per_pool",
+            "jsonb_typeof(settings) = 'object'",
+            name="ck_tournament_event_draw_settings_settings_object",
         ),
     )
 

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -21,6 +21,7 @@ from app import schedule_solves, scheduling
 from app.geocoding import FakeGeocoder, GeocodeResult
 from app.main import app as fastapi_app
 from app.models import (
+    DrawType,
     League,
     Permission,
     RatingHistory,
@@ -28,6 +29,7 @@ from app.models import (
     Role,
     RolePermission,
     Tournament,
+    TournamentEventDrawSettings,
     TournamentEventPool,
     TournamentEventPoolTable,
     User,
@@ -40,7 +42,9 @@ from app.notifications.dependencies import get_push_sender
 from app.notifications.jobs import DELIVER_NOTIFICATION_JOB
 from app.scheduling import ScheduleSnapshot, SolveResult
 from app.schemas.notification import NotificationJob
+from app.schemas.tournament import draw_settings_from_storage
 from app.sessions import CSRF_COOKIE_NAME, CSRF_HEADER_NAME, CSRF_SAFE_METHODS
+from app.tournament_draw_settings import draw_settings_row
 
 
 def hijack_solve(
@@ -146,6 +150,31 @@ def venue_tables(*specs: tuple[str, str]) -> list[VenueTable]:
         VenueTable(id=uuid.uuid4(), label=label, court=court, position=position)
         for position, (label, court) in enumerate(specs)
     ]
+
+
+def event_draw_settings(
+    draw_type: DrawType, *, qualifiers_per_pool: int | None = None
+) -> TournamentEventDrawSettings:
+    """The draw-settings row for an event a test seeds straight through the ORM, built
+    from the ``(draw_type, qualifiers_per_pool)`` pair the tests already speak.
+
+    The qualifier count is not a column any more — it is a key inside the row's
+    ``settings`` JSON object (ADR "a draw type's settings are one NOT NULL JSON
+    object") — so this is the one translation from the pair to the stored shape, and it
+    goes through the same parse and the same writer the request boundary uses. Which
+    means a seed that names a count for a draw type with no knockout stage reds here
+    with a ``ValidationError``, rather than writing a row the app could not have made.
+
+    ``None`` is "this draw type takes no configuration", and it stores ``{}``.
+    """
+    return draw_settings_row(
+        draw_settings_from_storage(
+            draw_type,
+            {}
+            if qualifiers_per_pool is None
+            else {"qualifiers_per_pool": qualifiers_per_pool},
+        )
+    )
 
 
 def event_pools(

--- a/api/tests/test_draw_type_seed_migration.py
+++ b/api/tests/test_draw_type_seed_migration.py
@@ -217,125 +217,154 @@ async def test_every_seeded_draw_type_carries_picker_copy(
     )
 
 
-async def test_migration_creates_the_qualifiers_per_pool_column(
-    migrated_database_url: str,
-) -> None:
-    """The qualifier count exists, as a NULLABLE integer, on a database built by
-    Alembic — not by ``create_all``.
-
-    Worth its own test precisely because ``create_all`` is what the rest of the
-    suite runs on: a column added to the model and forgotten in the migration is
-    invisible to every other test in this repo and fails on the first real
-    deployment (api/CLAUDE.md, "pytest never runs the migrations"). Nullability is
-    asserted, not just presence, because ``NULL`` is the whole representation of
-    "this draw type takes no qualifier count" — a NOT NULL column would make every
-    round-robin row carry a number.
-    """
-    engine = create_async_engine(migrated_database_url)
+async def _draw_settings_column(
+    url: str, column_name: str
+) -> sa.Row[tuple[str, str, str | None]] | None:
+    """One column of ``tournament_event_draw_settings`` as the **migrated** database
+    describes it, or ``None`` when the migration did not create it."""
+    engine = create_async_engine(url)
     try:
         async with engine.connect() as conn:
-            column = (
+            return (
                 await conn.execute(
                     sa.text(
                         "SELECT data_type, is_nullable, column_default"
                         " FROM information_schema.columns"
                         " WHERE table_name = 'tournament_event_draw_settings'"
-                        "   AND column_name = 'qualifiers_per_pool'"
-                    )
+                        "   AND column_name = :column_name"
+                    ),
+                    {"column_name": column_name},
                 )
             ).one_or_none()
     finally:
         await engine.dispose()
 
+
+async def test_migration_creates_the_settings_column(
+    migrated_database_url: str,
+) -> None:
+    """The settings object exists, as a NOT NULL ``jsonb`` defaulting to ``{}``, on a
+    database built by Alembic — not by ``create_all``.
+
+    Worth its own test precisely because ``create_all`` is what the rest of the
+    suite runs on: a column added to the model and forgotten in the migration is
+    invisible to every other test in this repo and fails on the first real
+    deployment (api/CLAUDE.md, "pytest never runs the migrations").
+
+    All three facts are asserted, not just presence, because each is load-bearing (ADR
+    "a draw type's settings are one NOT NULL JSON object"): ``jsonb`` because the
+    ``jsonb_typeof`` check and every read depend on it, NOT NULL because ``NULL`` and
+    ``{}`` would be two spellings of "no configuration", and the default because it is
+    what makes the NOT NULL survivable for a writer that omits the column.
+    """
+    column = await _draw_settings_column(migrated_database_url, "settings")
+
     assert column is not None, (
-        "migrated database has no tournament_event_draw_settings.qualifiers_per_pool"
-        " column — the model has it and create_all builds it, so the whole suite is"
-        " green without the migration"
+        "migrated database has no tournament_event_draw_settings.settings column —"
+        " the model has it and create_all builds it, so the whole suite is green"
+        " without the migration"
     )
-    assert column.data_type == "integer", column
-    assert column.is_nullable == "YES", column
-    assert column.column_default is None, column
+    assert column.data_type == "jsonb", column
+    assert column.is_nullable == "NO", column
+    assert column.column_default is not None, column
+    assert "'{}'" in column.column_default, column
 
 
-# Every ``(draw_type_key, qualifiers_per_pool)`` pair the CHECK has an opinion
-# about, and the opinion. Written as data so the test below reports the WHOLE
-# outcome table on a failure rather than dying at the first disagreement — a
-# constraint that has lost one arm and a constraint that was never created look
-# very different here, and that difference is the finding.
+async def test_migration_no_longer_creates_the_qualifiers_per_pool_column(
+    migrated_database_url: str,
+) -> None:
+    """The column the settings object replaced is **gone** from a migrated database.
+
+    The half of an edit-in-place that is easy to leave half-done: adding ``settings``
+    to migration 0010 and forgetting to delete ``qualifiers_per_pool`` beside it leaves
+    a database with two homes for one fact, and every other test in this repo — built
+    by ``create_all`` from the model, which has only one — stays green over it.
+    """
+    assert (
+        await _draw_settings_column(migrated_database_url, "qualifiers_per_pool")
+        is None
+    ), (
+        "migrated database still has tournament_event_draw_settings."
+        "qualifiers_per_pool — migration 0010 replaced it with the settings object,"
+        " so the column is a second, stale home for the qualifier count"
+    )
+
+
+# Every ``settings`` value the CHECK has an opinion about, and the opinion. Written
+# as data so the test below reports the WHOLE outcome table on a failure rather than
+# dying at the first disagreement — a constraint that was never created and one that
+# refuses everything look very different here, and that difference is the finding.
 #
-# ``count`` is SQL text, not a bound parameter, because ``NULL`` is one of the
-# values under test and a bound ``None`` would be indistinguishable from the
-# literal in the failure message. The values are this module's own constants and
-# never touch user input.
-QUALIFIER_COUNT_CASES: list[tuple[str, str, bool]] = [
-    # No other draw type may carry a count at all: there is no cut to size for a
-    # round-robin, and no pools to cut from for a single-elim. Both are asked,
-    # because a constraint that had lost one of them looks identical on a
-    # one-slug test.
-    ("round-robin", "2", False),
-    ("single-elim", "2", False),
-    # ...and NULL is how they say so. This is the arm the verifier's `ELSE TRUE`
-    # corruption destroys while leaving everything else intact.
-    ("round-robin", "NULL", True),
-    ("single-elim", "NULL", True),
-    # ``K >= 1`` is the ADR's static bound: zero advances nobody, negative is not
-    # a count, and absent leaves the cut with no answer to "how many advance".
-    ("rr-then-ko", "0", False),
-    ("rr-then-ko", "-1", False),
-    ("rr-then-ko", "NULL", False),
-    # One qualifier per pool IS legal — two pools at K=1 is a single final
-    # between the pool winners, which the ADR names as a supported shape. Without
-    # an accepted case the refusals above would also be satisfied by a constraint
-    # that rejects everything.
-    ("rr-then-ko", "1", True),
-    ("rr-then-ko", "2", True),
+# The value is SQL text, not a bound parameter, because ``NULL`` and the JSON literal
+# ``null`` are both under test and a bound ``None`` could not tell them apart in the
+# failure message. The values are this module's own constants and never touch user
+# input.
+#
+# There are deliberately **no cases pairing a draw type with the wrong settings**. The
+# ``CASE`` constraint that refused ``('round-robin', 2)`` went away with the column it
+# guarded, and a migrated database now accepts a round-robin row carrying a qualifier
+# count (ADR "a draw type's settings are one NOT NULL JSON object"). That rule lives in
+# the discriminated union at the request boundary now, where
+# ``test_tournament_event_draw_settings.py`` pins it.
+SETTINGS_VALUE_CASES: list[tuple[str, bool]] = [
+    # The empty object is what a draw type with no configuration stores, and the
+    # populated one is what ``rr-then-ko`` stores. Both must be accepted, or the
+    # refusals below would also be satisfied by a constraint that rejects everything.
+    ("'{}'::jsonb", True),
+    ("'{\"qualifiers_per_pool\": 2}'::jsonb", True),
+    # Everything that is JSON but not an object. Each is asked, because a constraint
+    # mistakenly written as ``settings IS NOT NULL`` accepts all four and would look
+    # green on any one of them alone.
+    ("'[]'::jsonb", False),
+    ("'1'::jsonb", False),
+    ("'\"nope\"'::jsonb", False),
+    # JSON ``null`` is the sly one: it is a legal jsonb value, it is NOT SQL NULL, and
+    # ``jsonb_typeof`` calls it ``'null'``.
+    ("'null'::jsonb", False),
+    # And SQL NULL, which the NOT NULL refuses rather than the CHECK — one column, two
+    # guards, and the row must be refused either way.
+    ("NULL", False),
 ]
 
 
-async def test_migration_pairs_the_qualifier_count_with_its_draw_type(
+async def test_migration_lets_the_settings_column_hold_objects_and_nothing_else(
     migrated_database_url: str,
 ) -> None:
     """What the CHECK **does** on a migrated database, not what its text says.
 
-    An earlier version of this test asserted only that ``rr-then-ko`` and
-    ``qualifiers_per_pool`` appeared in ``pg_get_constraintdef``. That caught a
-    *missing* constraint but not a *wrong* one: corrupting the migration's ``ELSE
-    qualifiers_per_pool IS NULL`` to ``ELSE TRUE`` — keeping the ``THEN`` arm,
-    keeping the model correct — left this file green while shipping a database
-    that happily stores ``round-robin`` with two qualifiers. A wrong constraint is
-    the *likelier* mistake the next time someone edits migration 0010, since the
-    edit-in-place convention means that expression gets rewritten rather than
-    replaced.
+    An earlier version of this test asserted only that a constraint's text appeared in
+    ``pg_get_constraintdef``. That caught a *missing* constraint but not a *wrong* one,
+    and a wrong constraint is the likelier mistake the next time someone edits
+    migration 0010, since the edit-in-place convention means the expression gets
+    rewritten rather than replaced.
 
-    So every case in :data:`QUALIFIER_COUNT_CASES` is actually attempted, and it
-    is the accept/reject outcome that is asserted. That also makes the test
-    immune to Postgres re-rendering the expression (it already normalises
-    ``'rr-then-ko'`` to ``'rr-then-ko'::text`` and adds its own parentheses).
+    So every case in :data:`SETTINGS_VALUE_CASES` is actually attempted, and it is the
+    accept/reject outcome that is asserted. That also makes the test immune to Postgres
+    re-rendering the expression.
 
     The model's copy of this rule is exercised by
     ``test_tournament_event_draw_settings.py`` against a ``create_all`` schema.
     This is the same questions asked of the schema **Alembic** built — which is
     the only way the two descriptions can be shown to agree.
 
-    Every slug the cases name — ``rr-then-ko`` included, since #1227 seeded it —
-    is a row the migration itself inserted, so the settings rows below FK against
-    the real seed rather than a test-local stand-in. Everything runs inside one
-    transaction that is **rolled back**, so the session-scoped migrated database
-    is left exactly as Alembic made it and the seed assertions in this file
+    The slug the cases name is a row the migration itself inserted, so the settings
+    rows below FK against the real seed rather than a test-local stand-in. Everything
+    runs inside one transaction that is **rolled back**, so the session-scoped migrated
+    database is left exactly as Alembic made it and the seed assertions in this file
     cannot be affected by test ordering.
     """
     engine = create_async_engine(migrated_database_url)
-    outcomes: dict[tuple[str, str], bool] = {}
+    outcomes: dict[str, bool] = {}
     try:
         conn = await engine.connect()
         try:
             transaction = await conn.begin()
             try:
-                for slug, count, _ in QUALIFIER_COUNT_CASES:
+                for value, _ in SETTINGS_VALUE_CASES:
                     statement = sa.text(
                         "INSERT INTO tournament_event_draw_settings"
-                        " (draw_type_key, qualifiers_per_pool)"
-                        f" VALUES (:slug, {count})"
+                        " (draw_type_key, settings)"
+                        f" VALUES (:slug, {value})"
                     )
                     try:
                         # A SAVEPOINT per case: a refused INSERT poisons the
@@ -343,11 +372,11 @@ async def test_migration_pairs_the_qualifier_count_with_its_draw_type(
                         # rejection would abort every case after it and the
                         # outcome table would be a lie.
                         async with conn.begin_nested():
-                            await conn.execute(statement, {"slug": slug})
+                            await conn.execute(statement, {"slug": "rr-then-ko"})
                     except IntegrityError:
-                        outcomes[(slug, count)] = False
+                        outcomes[value] = False
                     else:
-                        outcomes[(slug, count)] = True
+                        outcomes[value] = True
             finally:
                 await transaction.rollback()
         finally:
@@ -355,18 +384,16 @@ async def test_migration_pairs_the_qualifier_count_with_its_draw_type(
     finally:
         await engine.dispose()
 
-    expected = {
-        (slug, count): accepted for slug, count, accepted in QUALIFIER_COUNT_CASES
-    }
+    expected = dict(SETTINGS_VALUE_CASES)
     disagreed = {
-        case: f"expected {'accepted' if want else 'REFUSED'}, "
-        f"got {'accepted' if outcomes[case] else 'REFUSED'}"
-        for case, want in expected.items()
-        if outcomes[case] != want
+        value: f"expected {'accepted' if want else 'REFUSED'}, "
+        f"got {'accepted' if outcomes[value] else 'REFUSED'}"
+        for value, want in expected.items()
+        if outcomes[value] != want
     }
     assert not disagreed, (
-        "migration 0010's ck_tournament_event_draw_settings_qualifiers_per_pool "
-        "does not behave like the model's copy on a migrated database: "
+        "migration 0010's tournament_event_draw_settings.settings column does not "
+        "behave like the model's copy on a migrated database: "
         f"{disagreed}"
     )
 

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime, timedelta
 from itertools import combinations
 
 import pytest
+from pydantic import ValidationError
 
 from app.draws import (
     AdvancePlan,
@@ -42,8 +43,30 @@ from app.draws import (
     strategy_for,
 )
 from app.models.tournament import DrawType
+from app.schemas.tournament import (
+    DrawSettingsWriteArm,
+    RoundRobinDrawSettingsWrite,
+    RrThenKoDrawSettingsWrite,
+    SingleElimDrawSettingsWrite,
+    draw_settings_from_storage,
+)
 
 REGISTRATION_OPENED = datetime(2026, 7, 1, 9, 0, tzinfo=UTC)
+
+
+def _settings(draw_type: DrawType) -> DrawSettingsWriteArm:
+    """The union arm ``draw_type`` names, with whatever configuration that arm
+    **requires** filled in — the shape ``strategy_for`` takes since the settings column
+    became one JSON object (ADR "a draw type's settings are one NOT NULL JSON object").
+
+    Built through the same parse the storage boundary uses, so a draw type whose arm
+    needs a setting this helper does not supply reds here with a ``ValidationError``
+    rather than resolving to a strategy configured by omission.
+    """
+    return draw_settings_from_storage(
+        draw_type,
+        {"qualifiers_per_pool": 2} if draw_type is DrawType.rr_then_ko else {},
+    )
 
 
 def _entry_id(n: int) -> EntryId:
@@ -227,14 +250,14 @@ class TestOrderEntrants:
 class TestStrategyRegistry:
     def test_round_robin_resolves_to_the_round_robin_strategy(self) -> None:
         assert isinstance(
-            strategy_for(DrawType.round_robin, qualifiers_per_pool=None),
+            strategy_for(RoundRobinDrawSettingsWrite()),
             RoundRobinStrategy,
         )
 
     def test_single_elim_resolves_to_the_single_elim_strategy(self) -> None:
         # The second implemented arm (ADR-0785).
         assert isinstance(
-            strategy_for(DrawType.single_elim, qualifiers_per_pool=None),
+            strategy_for(SingleElimDrawSettingsWrite()),
             SingleElimStrategy,
         )
 
@@ -243,17 +266,20 @@ class TestStrategyRegistry:
         the qualifier count is not a detail of the dispatch, it is what the strategy
         cuts with, so it is asserted to have arrived rather than merely to have been
         accepted."""
-        strategy = strategy_for(DrawType.rr_then_ko, qualifiers_per_pool=3)
+        strategy = strategy_for(RrThenKoDrawSettingsWrite(qualifiers_per_pool=3))
 
         assert strategy == RrThenKoStrategy(qualifiers_per_pool=3)
 
-    def test_rr_then_ko_without_a_qualifier_count_refuses_loudly(self) -> None:
-        """A wiring bug, not a director's mistake: the request boundary and the settings
-        table's CHECK both refuse an ``rr-then-ko`` configuration with no count, so the
-        only way here is a caller that dropped the column. Silently defaulting it would
-        cut a bracket for a K nobody chose."""
-        with pytest.raises(ValueError, match="qualifiers_per_pool"):
-            strategy_for(DrawType.rr_then_ko, qualifiers_per_pool=None)
+    def test_an_rr_then_ko_arm_cannot_be_built_without_a_qualifier_count(self) -> None:
+        """The old "``strategy_for`` refuses ``qualifiers_per_pool=None``" test, moved
+        one layer out and made stronger.
+
+        ``strategy_for`` now takes the **arm**, so a configuration with no count is not
+        a value it can be handed at all: the count is a required field, and the refusal
+        happens where the arm would be built (ADR "a draw type's settings are one NOT
+        NULL JSON object"). A K nobody chose is unrepresentable rather than caught."""
+        with pytest.raises(ValidationError, match="qualifiers_per_pool"):
+            RrThenKoDrawSettingsWrite()  # type: ignore[call-arg]  # the point of the test
 
     def test_every_draw_type_resolves_to_a_strategy_and_none_refuses(self) -> None:
         """``strategy_for`` is **total** — the enum holds only draw types that run (ADR
@@ -266,11 +292,11 @@ class TestStrategyRegistry:
         no input any more, because Pydantic rejects an un-backed slug at the request
         boundary instead.
 
-        Every member is handed a qualifier count, because handing one to a draw type
-        that takes none must be *harmless* — a configuration-free strategy ignores it —
-        while the one that needs it must not be left guessing."""
+        Every member goes through :func:`_settings`, which is also the assertion that
+        each one HAS an arm: a member with none reds here on the parse, before the
+        dispatch is even reached."""
         for draw_type in DrawType:
-            assert strategy_for(draw_type, qualifiers_per_pool=2) is not None
+            assert strategy_for(_settings(draw_type)) is not None
 
     def test_the_games_gate_names_every_draw_type_and_only_the_one_that_reads_them(
         self,
@@ -307,7 +333,7 @@ class TestStrategyRegistry:
         for draw_type in DrawType:
             if reads_fixture_games(draw_type):
                 continue
-            strategy = strategy_for(draw_type, qualifiers_per_pool=None)
+            strategy = strategy_for(_settings(draw_type))
             cut = _persisted(strategy.plan_initial(_config(2), _ordered(8)))
             with_games = _played(
                 cut,

--- a/api/tests/test_rr_then_ko.py
+++ b/api/tests/test_rr_then_ko.py
@@ -44,6 +44,7 @@ from app.models import (
     User,
 )
 from app.schemas.tournament import MAX_QUALIFIERS_PER_POOL
+from app.tournament_draw_settings import draw_settings_of
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import (
     grant_permissions,
@@ -196,6 +197,17 @@ async def _fixtures(db: AsyncSession, event_id: str) -> list[TournamentFixture]:
     )
 
 
+def _stored_qualifiers(event: TournamentEvent) -> int | None:
+    """The qualifier count this event has **stored**, parsed back out of its settings
+    row's JSON object (ADR "a draw type's settings are one NOT NULL JSON object").
+
+    Read through the storage boundary rather than off a column, because there is no
+    column any more: ``{"qualifiers_per_pool": K}`` is the whole of an ``rr-then-ko``
+    row's settings, and ``None`` is what the arms with no knockout stage answer.
+    """
+    return draw_settings_of(event.draw_settings).qualifiers_per_pool
+
+
 async def _settings_of(db: AsyncSession, event_id: str) -> TournamentEvent:
     db.expire_all()
     return (
@@ -305,7 +317,7 @@ async def test_creating_an_rr_then_ko_event_persists_its_qualifier_count(
     assert created.status_code == 201, created.text
     event = await _settings_of(db_session, created.json()["id"])
     assert event.draw_settings.draw_type is DrawType.rr_then_ko
-    assert event.draw_settings.qualifiers_per_pool == 3
+    assert _stored_qualifiers(event) == 3
 
 
 @pytest.mark.parametrize("draw_type", ["round-robin", "single-elim"])
@@ -434,7 +446,7 @@ async def test_a_qualifier_count_at_the_ceiling_is_accepted(
 
     assert created.status_code == 201, created.text
     event = await _settings_of(db_session, created.json()["id"])
-    assert event.draw_settings.qualifiers_per_pool == MAX_QUALIFIERS_PER_POOL
+    assert _stored_qualifiers(event) == MAX_QUALIFIERS_PER_POOL
 
 
 @pytest.mark.parametrize("count", [MAX_QUALIFIERS_PER_POOL + 1, INT32_OVERFLOW])
@@ -457,7 +469,7 @@ async def test_patching_a_qualifier_count_above_the_ceiling_is_422(
     assert response.status_code == 422, response.text
     assert "qualifiers_per_pool" in response.text
     event = await _settings_of(db_session, event_id)
-    assert event.draw_settings.qualifiers_per_pool == 2, "a refusal wrote nothing"
+    assert _stored_qualifiers(event) == 2, "a refusal wrote nothing"
 
 
 async def test_patching_a_qualifier_count_at_the_ceiling_is_accepted(
@@ -480,7 +492,7 @@ async def test_patching_a_qualifier_count_at_the_ceiling_is_accepted(
 
     assert response.status_code == 200, response.text
     event = await _settings_of(db_session, event_id)
-    assert event.draw_settings.qualifiers_per_pool == MAX_QUALIFIERS_PER_POOL
+    assert _stored_qualifiers(event) == MAX_QUALIFIERS_PER_POOL
 
 
 async def test_patching_a_qualifier_count_without_its_draw_type_is_422(
@@ -524,7 +536,7 @@ async def test_the_qualifier_count_is_editable_while_no_draw_exists(
 
     assert response.status_code == 200, response.text
     event = await _settings_of(db_session, event_id)
-    assert event.draw_settings.qualifiers_per_pool == 3
+    assert _stored_qualifiers(event) == 3
 
 
 async def test_patching_away_from_rr_then_ko_clears_the_qualifier_count(
@@ -545,7 +557,7 @@ async def test_patching_away_from_rr_then_ko_clears_the_qualifier_count(
     assert response.status_code == 200, response.text
     event = await _settings_of(db_session, event_id)
     assert event.draw_settings.draw_type is DrawType.round_robin
-    assert event.draw_settings.qualifiers_per_pool is None
+    assert _stored_qualifiers(event) is None
 
 
 # ----- the read: the stored qualifier count comes back ------------------------------
@@ -578,7 +590,7 @@ async def test_an_rr_then_ko_events_qualifier_count_reads_back(
     assert created.json()["qualifiers_per_pool"] == 3
     assert (await _event_read(client, tournament_id))["qualifiers_per_pool"] == 3
     event = await _settings_of(db_session, created.json()["id"])
-    assert event.draw_settings.qualifiers_per_pool == 3
+    assert _stored_qualifiers(event) == 3
 
 
 @pytest.mark.parametrize("draw_type", ["round-robin", "single-elim"])
@@ -790,7 +802,7 @@ async def test_the_qualifier_count_is_frozen_once_the_draw_is_cut(
         "again."
     )
     event = await _settings_of(db_session, event_id)
-    assert event.draw_settings.qualifiers_per_pool == 2, "a refusal wrote nothing"
+    assert _stored_qualifiers(event) == 2, "a refusal wrote nothing"
 
 
 # ----- the seam: a finished pool seats its qualifiers -------------------------------

--- a/api/tests/test_rr_then_ko.py
+++ b/api/tests/test_rr_then_ko.py
@@ -329,9 +329,11 @@ async def test_a_qualifier_count_on_another_draw_type_is_422(
     "The top 2 from each pool advance" is meaningless for a round-robin (there is no
     cut to size) and for a single-elim (there are no pools to cut from). Accepting the
     number and dropping it would run an event the director did not ask for and show
-    them nothing; the settings table's CHECK would refuse the row anyway, which is a
-    500, not an answer. Both other draw types are asked, because a union that had lost
-    one arm's ``extra="forbid"`` would look identical on a one-slug test.
+    them nothing. This 422 is now the ONLY thing standing there: the settings table's
+    ``CASE`` ``CHECK`` was dropped with the column it named, so a blob carrying a
+    qualifier count for a round-robin is a row Postgres accepts. Both other draw types
+    are asked, because a union that had lost one arm's ``extra="forbid"`` would look
+    identical on a one-slug test.
     """
     client, _ = authed_client
     tournament_id = await _tournament(client)
@@ -542,9 +544,11 @@ async def test_the_qualifier_count_is_editable_while_no_draw_exists(
 async def test_patching_away_from_rr_then_ko_clears_the_qualifier_count(
     authed_client: tuple[AsyncClient, User], db_session: AsyncSession
 ) -> None:
-    """The two columns are one fact, written together: a draw type moved back to
-    round-robin leaves NULL behind, not the K the event used to take. Writing the slug
-    alone would leave a pairing the settings table's CHECK refuses outright."""
+    """The draw type and its settings are one fact, written together: a draw type moved
+    back to round-robin leaves an empty settings object behind, not the K the event used
+    to take. Nothing in the database refuses the slug-only write any more — the ``CASE``
+    ``CHECK`` is gone — so ``store_draw_settings`` writing the pair together is all
+    that prevents it, which is exactly why this test exists."""
     client, _ = authed_client
     tournament_id = await _tournament(client)
     event_id = (await _create_event(client, tournament_id)).json()["id"]
@@ -602,9 +606,11 @@ async def test_a_draw_type_with_no_knockout_stage_reads_back_no_qualifier_count(
     The other side of the pairing, and it has to be asserted or the read is one-sided:
     a field hard-wired to the requested K, or defaulted to some convention, would pass
     the rr-then-ko test above and quietly tell a director that their round-robin
-    advances two per pool — a configuration the settings table's ``CHECK`` says cannot
-    exist. Both of the count-less draw types are asked, because a read keyed off a
-    single slug would look right on a one-slug test.
+    advances two per pool — a configuration the write union says cannot exist. (It used
+    to be the settings table's ``CASE`` ``CHECK`` saying so too; that constraint went
+    with the column, so the union is the only one saying it now.) Both of the count-less
+    draw types are asked, because a read keyed off a single slug would look right on a
+    one-slug test.
 
     ``in`` before the value, so "the field vanished from the response" reds as itself
     rather than as ``KeyError`` — the client distinguishes *absent* (an older server)

--- a/api/tests/test_schedule_preview_snapshot.py
+++ b/api/tests/test_schedule_preview_snapshot.py
@@ -34,14 +34,18 @@ from app.models import (
     Tournament,
     TournamentEntry,
     TournamentEvent,
-    TournamentEventDrawSettings,
     TournamentFixture,
     TournamentStatus,
     User,
 )
 from app.models.tournament import DrawType, EventFormat
 from app.schedule_preview import DEFAULT_UNCAPPED_FIELD, build_preview_snapshot
-from tests._helpers import make_user, venue_tables, with_table_aliases
+from tests._helpers import (
+    event_draw_settings,
+    make_user,
+    venue_tables,
+    with_table_aliases,
+)
 
 # A venue with two tables, so a pool can be given one or both. Built per tournament,
 # never as a module constant: a catalogue is ``tournament_tables`` rows now
@@ -102,7 +106,7 @@ async def _add_event(
         tournament_id=tournament.id,
         name=name,
         format=EventFormat.singles,
-        draw_settings=TournamentEventDrawSettings.for_draw_type(
+        draw_settings=event_draw_settings(
             draw_type, qualifiers_per_pool=qualifiers_per_pool
         ),
         max_players=max_players,

--- a/api/tests/test_schedule_preview_solve.py
+++ b/api/tests/test_schedule_preview_solve.py
@@ -38,7 +38,6 @@ from app.models import (
     Tournament,
     TournamentEntry,
     TournamentEvent,
-    TournamentEventDrawSettings,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -69,7 +68,12 @@ from app.tournament_errors import (
     TournamentNotFoundError,
     TournamentNotPreLiveError,
 )
-from tests._helpers import make_user, venue_tables, with_table_aliases
+from tests._helpers import (
+    event_draw_settings,
+    make_user,
+    venue_tables,
+    with_table_aliases,
+)
 
 # Built per tournament, never as a module constant: a catalogue is
 # ``tournament_tables`` rows now (ADR 20260801). The pools name them by the positional
@@ -160,7 +164,7 @@ async def _add_event(
         tournament_id=tournament.id,
         name=name,
         format=EventFormat.singles,
-        draw_settings=TournamentEventDrawSettings.for_draw_type(
+        draw_settings=event_draw_settings(
             draw_type, qualifiers_per_pool=qualifiers_per_pool
         ),
         max_players=max_players,

--- a/api/tests/test_tournament_event_draw_settings.py
+++ b/api/tests/test_tournament_event_draw_settings.py
@@ -1,7 +1,7 @@
 """An event's draw configuration is a row, and the row is what the database
 constrains (ADR "an event's draw configuration is a row, not a column").
 
-Three claims, and they are separate ones:
+Four claims, and they are separate ones:
 
 * **Creating an event creates exactly one settings row carrying that event's draw
   type** — driven through the real HTTP route, not the service verb, because the
@@ -18,6 +18,10 @@ Three claims, and they are separate ones:
   ``TournamentEvent.draw_settings``, the tournament path by an explicit reap in
   ``delete_tournament``, because the tournament's ``ON DELETE CASCADE`` sweeps its
   events in the DATABASE and a database cascade cannot run a Python-side one.
+* **The row's ``settings`` column is one NOT NULL JSON object, and an arm round-trips
+  through it** (ADR "a draw type's settings are one NOT NULL JSON object"). The
+  database's remaining opinion is only that the value is an object; which settings
+  belong to which draw type is the discriminated union's rule, at the request boundary.
 
 The draw type has exactly one home — ``tournament_event_draw_settings.draw_type_key``
 — so these tests read it from there and nowhere else. There is no ``draw_type``
@@ -32,6 +36,7 @@ import pytest
 import pytest_asyncio
 import sqlalchemy as sa
 from httpx import AsyncClient
+from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -42,7 +47,15 @@ from app.models import (
     TournamentEventDrawSettings,
     User,
 )
-from app.schemas.tournament import DrawSettingsWrite
+from app.schemas.tournament import (
+    DrawSettingsWrite,
+    DrawSettingsWriteArm,
+    RoundRobinDrawSettingsWrite,
+    RrThenKoDrawSettingsWrite,
+    SingleElimDrawSettingsWrite,
+    draw_settings_from_storage,
+)
+from app.tournament_draw_settings import draw_settings_of, draw_settings_row
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import grant_permissions, start_session
 
@@ -416,147 +429,175 @@ def test_every_draw_type_has_an_arm_in_the_write_union() -> None:
     assert len(discriminators) == len(DrawType)
 
 
-async def test_a_new_events_settings_row_carries_no_qualifier_count(
+async def test_a_new_events_settings_row_carries_an_empty_settings_object(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
 ) -> None:
-    """A round-robin event's settings row has ``qualifiers_per_pool`` NULL — not 0,
-    and not "unset but present".
+    """A round-robin event's settings row stores ``{}`` — not ``NULL``, and not a
+    key with an empty value.
 
-    ``NULL`` is the whole representation of "this draw type takes no qualifier
-    count" (ADR "rr-then-ko cuts both stages upfront"). A default of ``0`` would
-    make every round-robin event carry a number that reads as a real configuration
-    and that the ``K >= 1`` floor would then contradict.
+    The empty object is the whole representation of "this draw type takes no
+    configuration" (ADR "a draw type's settings are one NOT NULL JSON object"). A
+    ``NULL`` would mean the same thing to every reader, which is precisely why only
+    one of the two may be representable: nothing has to test for absence before it
+    reads, and the parse below has one shape to handle rather than two.
     """
     client, _ = authed_client
     _, event_id = await _create_event(client, draw_type="round-robin")
 
     (event,) = await _load_events(db_session, event_id)
     assert event.draw_settings.draw_type is DrawType.round_robin
-    assert event.draw_settings.qualifiers_per_pool is None
+    assert event.draw_settings.settings == {}
+    assert draw_settings_of(event.draw_settings) == RoundRobinDrawSettingsWrite()
 
 
-async def test_a_settings_row_that_is_not_rr_then_ko_may_not_carry_a_qualifier_count(
+async def test_the_settings_column_holds_an_object_or_nothing_at_all(
     db_session: AsyncSession,
 ) -> None:
-    """The qualifier count is unrepresentable on any other draw type — refused by
-    the database, not dropped on the way in.
+    """What the database still has an opinion on: ``settings`` is a JSON **object**,
+    and it is NOT NULL.
 
-    This is the storage-layer half of the claim the request boundary makes: "top K
-    from each pool advance" is meaningless for a round-robin (there is no cut to
-    size) and for a single-elim (there are no pools to cut from), so a row pairing
-    either slug with a number is not a row Postgres will accept. Both other slugs
-    are asked, because a constraint that only covered one of them would look
-    identical on a one-slug test.
+    This is all that is left of the storage-layer guard, and deliberately so (ADR "a
+    draw type's settings are one NOT NULL JSON object"). The ``CASE`` constraint that
+    paired a qualifier count with its draw type went away with the column it guarded;
+    which settings belong to which draw type is now the discriminated union's rule,
+    refused at the request boundary with a 422 and pinned by
+    :func:`test_every_draw_type_has_an_arm_in_the_write_union` above.
 
-    A NULL-carrying row of each slug is inserted first, so a green result cannot be
-    explained by the table or the statements being wrong.
+    A list, a number, a string and a JSON ``null`` are each a stored "settings" that
+    means nothing, so each is asked separately — a constraint that had been written as
+    ``settings IS NOT NULL`` would accept every one of them and still look green on a
+    one-case test. Accepted objects are asked too, so the refusals are the constraint
+    discriminating rather than rejecting everything.
     """
-    for slug in ("round-robin", "single-elim"):
-        accepted = await db_session.execute(
-            sa.text(
-                "INSERT INTO tournament_event_draw_settings"
-                " (draw_type_key, qualifiers_per_pool)"
-                " VALUES (:slug, NULL) RETURNING qualifiers_per_pool"
-            ),
-            {"slug": slug},
-        )
-        assert accepted.scalar_one() is None
+    accepted = ("'{}'::jsonb", "'{\"qualifiers_per_pool\": 2}'::jsonb")
+    refused = ("'[]'::jsonb", "'1'::jsonb", "'\"nope\"'::jsonb", "'null'::jsonb")
 
-        with pytest.raises(IntegrityError) as refusal:
-            async with db_session.begin_nested():
-                await db_session.execute(
-                    sa.text(
-                        "INSERT INTO tournament_event_draw_settings"
-                        " (draw_type_key, qualifiers_per_pool)"
-                        " VALUES (:slug, 2)"
-                    ),
-                    {"slug": slug},
-                )
-        assert "ck_tournament_event_draw_settings_qualifiers_per_pool" in str(
-            refusal.value
-        ), f"{slug} accepted a qualifier count: {refusal.value}"
-
-    await db_session.rollback()
-
-
-async def test_an_rr_then_ko_settings_row_round_trips_its_qualifier_count(
-    db_session: AsyncSession,
-) -> None:
-    """The column is a real, readable configuration for the one draw type that has
-    one: written as 2, read back as 2.
-
-    Driven through raw SQL rather than through the HTTP boundary because the subject
-    is the **column and its CHECK**, not the route: the end-to-end path an
-    ``rr-then-ko`` event now takes is covered in ``test_tournaments.py``.
-    """
-    settings_id = (
-        await db_session.execute(
-            sa.text(
-                "INSERT INTO tournament_event_draw_settings"
-                " (draw_type_key, qualifiers_per_pool)"
-                " VALUES (:key, 2) RETURNING id"
-            ),
-            {"key": RR_THEN_KO},
-        )
-    ).scalar_one()
-
-    db_session.expire_all()
-    stored = (
-        await db_session.execute(
-            select(TournamentEventDrawSettings).where(
-                TournamentEventDrawSettings.id == settings_id
+    for value in accepted:
+        async with db_session.begin_nested():
+            stored = await db_session.execute(
+                sa.text(
+                    "INSERT INTO tournament_event_draw_settings"
+                    " (draw_type_key, settings)"
+                    f" VALUES (:key, {value}) RETURNING settings"
+                ),
+                {"key": RR_THEN_KO},
             )
-        )
-    ).scalar_one()
-    assert stored.draw_type_key == RR_THEN_KO
-    assert stored.qualifiers_per_pool == 2
+            assert stored.scalar_one() is not None, value
 
-    await db_session.rollback()
-
-
-async def test_an_rr_then_ko_settings_row_needs_at_least_one_qualifier(
-    db_session: AsyncSession,
-) -> None:
-    """``K >= 1`` is the STATIC half of the ADR's legal configuration space, so it
-    is a floor the row itself carries — zero, negative and absent are all refused.
-
-    A qualifier count of zero advances nobody, which is not a knockout stage; a
-    negative one is not a count at all; and an absent one leaves an ``rr-then-ko``
-    row with no answer to "how many advance", which the cut has no default for. The
-    two bounds that MOVE with the entrant count — ``P × K >= 2`` and ``K <= ⌊N/P⌋``
-    — are deliberately NOT here: they are refused at the cut as ``DegenerateDraw``,
-    because a row that was legal when written must not become unwritable when a
-    player withdraws.
-    """
-    for count in ("0", "-1", "NULL"):
+    for value in (*refused, "NULL"):
         with pytest.raises(IntegrityError) as refusal:
             async with db_session.begin_nested():
                 await db_session.execute(
                     sa.text(
                         "INSERT INTO tournament_event_draw_settings"
-                        " (draw_type_key, qualifiers_per_pool)"
-                        f" VALUES (:key, {count})"
+                        " (draw_type_key, settings)"
+                        f" VALUES (:key, {value})"
                     ),
                     {"key": RR_THEN_KO},
                 )
-        assert "ck_tournament_event_draw_settings_qualifiers_per_pool" in str(
-            refusal.value
-        ), f"qualifiers_per_pool={count} was accepted: {refusal.value}"
+        assert "settings" in str(refusal.value), (
+            f"settings={value} was refused by something other than the settings "
+            f"column: {refusal.value}"
+        )
+
+    await db_session.rollback()
+
+
+async def test_every_arm_round_trips_through_the_settings_column(
+    db_session: AsyncSession,
+) -> None:
+    """The claim the whole change turns on: an arm written onto a row and read back
+    off it is the **same arm**.
+
+    Both directions go through ``app.tournament_draw_settings`` — the one storage
+    boundary for this column — so this is what says the encode and the decode agree.
+    Every arm is asked, including the configured one, because a round trip that only
+    covers the empty object would be satisfied by an encoder that drops every setting
+    on the floor.
+
+    The row is flushed and expired before the read, so what is parsed is what Postgres
+    stored and not the dict the encoder left in memory.
+    """
+    arms: list[DrawSettingsWriteArm] = [
+        RoundRobinDrawSettingsWrite(),
+        SingleElimDrawSettingsWrite(),
+        RrThenKoDrawSettingsWrite(qualifiers_per_pool=2),
+    ]
+    assert len(arms) == len(DrawType), (
+        "a draw type has been added without an arm in this round trip: "
+        f"{sorted(t.value for t in DrawType)}"
+    )
+
+    rows = [draw_settings_row(arm) for arm in arms]
+    db_session.add_all(rows)
+    await db_session.flush()
+    ids = [row.id for row in rows]
+    db_session.expire_all()
+
+    for arm, settings_id in zip(arms, ids, strict=True):
+        stored = (
+            await db_session.execute(
+                select(TournamentEventDrawSettings).where(
+                    TournamentEventDrawSettings.id == settings_id
+                )
+            )
+        ).scalar_one()
+        assert stored.draw_type_key == arm.draw_type.value
+        assert draw_settings_of(stored) == arm
+
+    await db_session.rollback()
+
+
+async def test_the_qualifier_floor_is_the_unions_now_that_the_column_is_gone(
+    db_session: AsyncSession,
+) -> None:
+    """``K >= 1`` is the STATIC half of the ADR's legal configuration space, and since
+    the settings column became one JSON object it is enforced in exactly one place: the
+    union arm.
+
+    Zero advances nobody, a negative one is not a count, and an absent one leaves an
+    ``rr-then-ko`` configuration with no answer to "how many advance". All three are a
+    refusal where the arm is built — at the request boundary, as a 422 naming the field
+    — rather than an ``IntegrityError`` from a ``CHECK`` that no longer exists.
+
+    The database's part is asserted too, and it is the *absence* of an opinion: a
+    settings object carrying ``0`` is a row Postgres now accepts. That is the loss the
+    ADR takes deliberately, and stating it here is what keeps it a decision rather than
+    a regression somebody discovers.
+
+    The two bounds that MOVE with the entrant count — ``P × K >= 2`` and
+    ``K <= ⌊N/P⌋`` — are deliberately NOT here: they are refused at the cut as
+    ``DegenerateDraw``, because a configuration that was legal when written must not
+    become unwritable when a player withdraws.
+    """
+    for count in (0, -1):
+        with pytest.raises(ValidationError, match="qualifiers_per_pool"):
+            draw_settings_from_storage(
+                DrawType.rr_then_ko, {"qualifiers_per_pool": count}
+            )
+    with pytest.raises(ValidationError, match="qualifiers_per_pool"):
+        draw_settings_from_storage(DrawType.rr_then_ko, {})
 
     # One qualifier per pool IS legal — a two-pool event at K=1 is a single final
     # between the two pool winners, which the ADR names as a supported shape. So the
-    # floor is at 1, not at 2, and this is what says the refusals above are the
-    # constraint discriminating rather than rejecting everything.
-    accepted = await db_session.execute(
+    # floor is at 1, not at 2, and this is what says the refusals above are the union
+    # discriminating rather than rejecting everything.
+    assert draw_settings_from_storage(
+        DrawType.rr_then_ko, {"qualifiers_per_pool": 1}
+    ) == RrThenKoDrawSettingsWrite(qualifiers_per_pool=1)
+
+    # And the storage layer no longer has a view: the same K the union refuses is a row
+    # the database stores. Named out loud, because a reader who assumes the old CHECK
+    # is still there would be wrong about where this rule lives.
+    stored = await db_session.execute(
         sa.text(
-            "INSERT INTO tournament_event_draw_settings"
-            " (draw_type_key, qualifiers_per_pool)"
-            " VALUES (:key, 1) RETURNING qualifiers_per_pool"
+            "INSERT INTO tournament_event_draw_settings (draw_type_key, settings)"
+            " VALUES (:key, '{\"qualifiers_per_pool\": 0}'::jsonb) RETURNING settings"
         ),
         {"key": RR_THEN_KO},
     )
-    assert accepted.scalar_one() == 1
+    assert stored.scalar_one() == {"qualifiers_per_pool": 0}
 
     await db_session.rollback()
 

--- a/api/tests/test_tournament_event_draw_settings.py
+++ b/api/tests/test_tournament_event_draw_settings.py
@@ -485,7 +485,17 @@ async def test_the_settings_column_holds_an_object_or_nothing_at_all(
             )
             assert stored.scalar_one() is not None, value
 
-    for value in (*refused, "NULL"):
+    # Each refusal names the constraint that must produce it, not merely "something
+    # refused this". SQLAlchemy embeds the failing statement in the error, and that
+    # statement always contains the word "settings" — it is the column being inserted —
+    # so a substring check for "settings" passes for ANY IntegrityError this INSERT can
+    # raise and discriminates nothing at all.
+    #
+    # The two refusals are genuinely different constraints and are asked separately: a
+    # JSON value that is not an object is the CHECK's job, and a SQL NULL is
+    # ``nullable=False``'s. Asserting one name over both cases would have to be loose
+    # enough to accept either, which is how the non-discriminating version got written.
+    for value in refused:
         with pytest.raises(IntegrityError) as refusal:
             async with db_session.begin_nested():
                 await db_session.execute(
@@ -496,10 +506,27 @@ async def test_the_settings_column_holds_an_object_or_nothing_at_all(
                     ),
                     {"key": RR_THEN_KO},
                 )
-        assert "settings" in str(refusal.value), (
-            f"settings={value} was refused by something other than the settings "
-            f"column: {refusal.value}"
+        assert "ck_tournament_event_draw_settings_settings_object" in str(
+            refusal.value
+        ), (
+            f"settings={value} is a JSON value that is not an object, so the object "
+            f"CHECK must be what refuses it: {refusal.value}"
         )
+
+    with pytest.raises(IntegrityError) as null_refusal:
+        async with db_session.begin_nested():
+            await db_session.execute(
+                sa.text(
+                    "INSERT INTO tournament_event_draw_settings"
+                    " (draw_type_key, settings)"
+                    " VALUES (:key, NULL)"
+                ),
+                {"key": RR_THEN_KO},
+            )
+    assert "not-null" in str(null_refusal.value).lower(), (
+        "a SQL NULL must be refused by the column's NOT NULL, not by the object CHECK "
+        f"— jsonb_typeof(NULL) is NULL, which a CHECK passes: {null_refusal.value}"
+    )
 
     await db_session.rollback()
 

--- a/docs/adr/20260805-a-draw-types-settings-are-one-not-null-json-object.md
+++ b/docs/adr/20260805-a-draw-types-settings-are-one-not-null-json-object.md
@@ -74,8 +74,26 @@ union, which refuses a qualifier count on a round-robin event with a 422 at the
 request boundary.
 
 This is a genuine loss and it is accepted deliberately. The constraint protected
-against a writer that bypasses the schema. There is one writer, it parses through
-the union, and a test pins that a mismatched pair is refused.
+against a writer that bypasses the schema.
+
+**Corrected during review:** an earlier draft of this section said "there is one
+writer, it parses through the union". That is true of the *application* — create
+and edit both go through `store_draw_settings`, which takes an already-parsed arm
+— but it is not true of the codebase. `TournamentEventDrawSettings.for_draw_type`
+takes a raw mapping and writes it straight through, and around thirty test seeds
+still use it.
+
+The consequence is narrower than it sounds, and worth stating exactly. It is a
+**test-seeding** hazard, not a production one: no app code calls `for_draw_type`.
+But the old `CASE` constraint refused a configured draw type carrying no settings,
+and nothing refuses it now, so `for_draw_type(DrawType.rr_then_ko)` writes `{}`
+and fails at the next *read* rather than at the write. A seed that used to blow up
+loudly and locally now blows up somewhere else.
+
+`for_draw_type`'s docstring now says this out loud rather than advertising itself
+as the create path's door, which is what it claimed while no app code called it at
+all. The safer seeding door is `tests/_helpers.event_draw_settings`, which routes
+the same pair through the parse.
 
 Reading a settings value now costs a parse rather than a column read. The parse is
 the point. It is what keeps the untyped blob from leaking inward.

--- a/docs/adr/20260805-a-draw-types-settings-are-one-not-null-json-object.md
+++ b/docs/adr/20260805-a-draw-types-settings-are-one-not-null-json-object.md
@@ -1,0 +1,81 @@
+# A draw type's settings are one NOT NULL JSON object
+
+Date: 2026-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+`tournament_event_draw_settings` joins an event to its draw type. It carries the
+draw type key and one settings column, `qualifiers_per_pool`. That column is the
+**K** of "the top K from each pool advance". Only `rr-then-ko` uses it.
+
+A `CASE` check constraint keeps the column and the draw type in step. The column
+is NOT NULL and at least 1 when the row names `rr-then-ko`. It is NULL for every
+other draw type.
+
+That shape does not scale. Swiss needs a round count. A future double-elimination
+draw may need a grand-final reset flag. Each new setting under the current shape
+costs a new nullable column, a new arm in the `CASE` constraint, and a migration.
+The constraint grows one branch per draw type per setting. Every draw type also
+pays for every other draw type's columns by carrying a NULL.
+
+The wider problem is that the table describes a **union**. Which settings exist
+depends entirely on the draw type. Modelling a union as a wide row of nullable
+columns is what forces the check constraint to exist at all.
+
+## Decision
+
+### One `settings` JSON column, NOT NULL, defaulting to an empty object
+
+`tournament_event_draw_settings` carries a single `settings` JSONB column. It is
+NOT NULL with a server default of `{}`.
+
+A draw type that takes no configuration stores `{}`. It does not store NULL.
+`round-robin` and `single-elim` store `{}` today. `rr-then-ko` stores
+`{"qualifiers_per_pool": 2}`. Swiss stores `{"rounds": 5}`.
+
+An empty object and a NULL would mean the same thing to a reader, so only one of
+them may be representable. The empty object wins because it is the shape every
+reader already expects. Nothing has to test for absence before it reads.
+
+`qualifiers_per_pool` is dropped as a column. fortymm is pre-deploy, so migration
+`0010` is edited in place rather than chained with an `ALTER`.
+
+### The column is the serialized form of a union that already exists
+
+`app.schemas.tournament` already holds `DrawSettingsWriteArm`, a Pydantic
+discriminated union over `draw_type`. This column stores exactly that arm.
+
+The blob is decoded into that union **at read time**, at the boundary. Nothing
+below the boundary holds a `dict[str, Any]`. This is the rule `api/CLAUDE.md`
+states for JSONB columns, and the union it asks for is already written.
+
+### The wire shape does not change
+
+Settings stay **flat beside `draw_type`** on the request and response schemas,
+which is where `qualifiers_per_pool` already sits. Only storage changes.
+
+Keeping the wire flat means the event editor and both generated clients are
+untouched by the storage move. It also preserves the whole point of the change:
+a new draw type's settings need no migration.
+
+## Consequences
+
+Adding a draw type's settings is now a Pydantic arm and nothing else. No column,
+no constraint branch, no migration.
+
+**The database stops enforcing which settings belong to which draw type.** The
+`CASE` constraint went away with the column it guarded. A weaker check remains,
+that `settings` is a JSON object. The real enforcement moves to the discriminated
+union, which refuses a qualifier count on a round-robin event with a 422 at the
+request boundary.
+
+This is a genuine loss and it is accepted deliberately. The constraint protected
+against a writer that bypasses the schema. There is one writer, it parses through
+the union, and a test pins that a mismatched pair is refused.
+
+Reading a settings value now costs a parse rather than a column read. The parse is
+the point. It is what keeps the untyped blob from leaking inward.

--- a/docs/adr/20260805-swiss-pre-cuts-every-round-and-pairs-each-one-on-advance.md
+++ b/docs/adr/20260805-swiss-pre-cuts-every-round-and-pairs-each-one-on-advance.md
@@ -101,6 +101,13 @@ The scheduler needs no change either. It already asserts both sides are known an
 its caller already drops fixtures that do not qualify, so an unpaired later round
 is skipped until it is filled.
 
+**The schedule preview refuses swiss**, exactly as it refuses single-elim. The
+preview covers the pool stage, and a pool-less draw type raises
+`UnsupportedDrawType` rather than returning a preview that silently covers
+nothing. Swiss is pool-less, so it takes the same path. A director previewing a
+swiss event is told the format has no preview, instead of being shown an empty
+day.
+
 **An unplayed swiss round is visible as empty fixtures.** A director looking at a
 5-round draw sees rounds 2 to 5 as rows with no players. This is the same thing a
 single-elim bracket already shows for its later rounds, so it is consistent, but

--- a/docs/adr/20260805-swiss-pre-cuts-every-round-and-pairs-each-one-on-advance.md
+++ b/docs/adr/20260805-swiss-pre-cuts-every-round-and-pairs-each-one-on-advance.md
@@ -1,0 +1,112 @@
+# Swiss pre-cuts every round and pairs each one on advance
+
+Date: 2026-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+A draw is cut explicitly, and `advance()` is re-run after every result (ADR-0786).
+`plan_initial` returns the complete set of fixtures. `advance()` returns
+`side_fills` and `ready_fixture_ids`. It cannot create a fixture.
+
+Swiss appears to break that model. Round 3 pairs players by their standings after
+round 2, so who meets whom is unknown when the draw is cut. `api/app/draws.py`
+says as much in its own module docstring: "a swiss draw could not know its next
+round until the current one finished."
+
+The obvious reading is that `advance()` must grow the power to create fixtures.
+That reading is wrong, and two facts in this codebase are why.
+
+**Single-elimination already pre-cuts rounds whose sides are unknown.** A side is
+`None` "only when it is genuinely TBD (single-elim's later rounds)". The whole
+bracket is written at the cut, and `advance()` fills the later rounds in as
+results arrive. A fixture row with two unknown sides is an ordinary, already
+supported state.
+
+**The field is frozen once the tournament is live.** Withdrawing an active entry
+is refused outside the registration window
+(`_enforce_withdrawal_registration_open`). So the entrant count `n` cannot move
+after the cut.
+
+Those two together remove the reason to change the strategy contract. With `n`
+frozen and the round count `R` known, every swiss round holds exactly
+`floor(n / 2)` fixtures. The fixture set is fully determined at the cut. Only the
+*sides* are unknown, which is the one thing this model already handles.
+
+## Decision
+
+### `plan_initial` cuts all `R` rounds, with sides unknown past round 1
+
+Swiss writes `R * floor(n / 2)` fixtures at the cut. Round 1 has both sides set,
+seeded from the draw order. Every later round is written with `entry_a_id` and
+`entry_b_id` NULL.
+
+NULL keeps meaning exactly what it means everywhere else: TBD, and `advance()`
+will fill it. No new meaning is added, and no `is_bye` style flag appears.
+
+### `advance()` pairs a round once the previous round is decided
+
+When every fixture in round `r` has a completed match, `advance()` computes the
+standings, pairs the field for round `r + 1`, and returns ordinary `SideFill`s
+against that round's already-written rows.
+
+This needs **no change to `AdvancePlan`** and no amendment to ADR-0786. The draw
+is still cut exactly once, explicitly. Filling a known-empty side is what
+`advance()` has always done.
+
+Idempotency holds for the same reason it holds for single-elim. Once a round's
+sides are filled, a re-run finds nothing to fill and returns an empty plan.
+
+`advance()` only ever fills a side that is NULL. It never rewrites one. So a
+correction to an earlier round's result does not re-pair a round that is already
+paired and possibly played.
+
+### A fixture's `position` is its pairing rank within the round
+
+Position 1 is the pairing containing the highest-ranked player, position 2 the
+next, and so on. `position` is assigned when the round is paired.
+
+In single-elim `(round, position)` is a topology and `_successor` does arithmetic
+on it. Swiss has no successor arithmetic, so position could have been an arbitrary
+allocation. Defining it as pairing rank instead keeps
+`UNIQUE (event_id, pool_id, round, position)` a real identity, and makes the draw
+read top-down in standings order.
+
+### The round count `R` is a required, explicit setting
+
+Swiss stores `{"rounds": R}` in the draw settings JSON object. It is required.
+There is no derived default.
+
+`R` is not computed from the entrant count, even though `ceil(log2(n))` is the
+conventional answer. A director books tables and a venue window before
+registration opens. A derived `R` would move as entrants arrive, changing the
+length of a day that is already booked. The schedule preview also has to answer
+"how long is this day" before anyone has registered, and an explicit `R` is what
+lets it answer honestly.
+
+`R > n - 1` is refused at the cut as `DegenerateDraw`. With `n` entrants a player
+has at most `n - 1` distinct opponents, so beyond that a rematch-free swiss cannot
+exist. This is refused at the cut rather than at configure time, because `n` is
+not known when the setting is written.
+
+## Consequences
+
+Swiss costs no change to the strategy contract, no change to `AdvancePlan`, and no
+migration beyond the settings object it shares with every other draw type.
+
+The scheduler needs no change either. It already asserts both sides are known and
+its caller already drops fixtures that do not qualify, so an unpaired later round
+is skipped until it is filled.
+
+**An unplayed swiss round is visible as empty fixtures.** A director looking at a
+5-round draw sees rounds 2 to 5 as rows with no players. This is the same thing a
+single-elim bracket already shows for its later rounds, so it is consistent, but
+swiss shows more of it.
+
+**A stalled round stalls the whole event.** Round `r + 1` cannot pair until every
+match in round `r` is complete. One unreported result blocks the rest of the
+field. Single-elim has no equivalent, because there only the two players feeding a
+given fixture can block it.

--- a/docs/adr/20260805-swiss-standings-add-buchholz-and-guard-head-to-head.md
+++ b/docs/adr/20260805-swiss-standings-add-buchholz-and-guard-head-to-head.md
@@ -1,0 +1,90 @@
+# Swiss standings add Buchholz, and head-to-head is guarded on having met
+
+Date: 2026-08-05
+
+## Status
+
+Accepted
+
+## Context
+
+`app/pool_finishing_order.py` holds the one definition of the tiebreak chain that
+orders a round-robin pool. The draw layer and the results layer both import it, so
+"the qualifiers" and "the top of the table" cannot disagree (ADR 20260727).
+
+The chain is wins, then head-to-head when exactly two entries are tied, then game
+difference, then games won, then the entry id.
+
+Swiss orders its field with the same kind of table, but two steps in that chain
+rest on a round-robin assumption that swiss breaks.
+
+**Head-to-head assumes the tied pair met.** In a round-robin everyone plays
+everyone, so a two-way tie always has a head-to-head result to read. In swiss a
+pair tied on wins may never have been paired. The existing step has no way to say
+"they did not meet", because in its own format that cannot happen.
+
+**Strength of schedule is invisible.** A round-robin gives every entrant the same
+opponents, so who you played carries no information and the chain rightly ignores
+it. Swiss is the opposite. It deliberately pairs you against players on your own
+score, so two entrants on the same number of wins may have faced completely
+different halves of the field. Ordering them on game difference ranks them by
+margin against unequal opposition.
+
+## Decision
+
+### Swiss gets its own ordering function, in the same shared module
+
+A second function lands beside `finishing_order` in `app/pool_finishing_order.py`.
+It does not go in a new module, and it does not go in either caller. The reason
+the existing function lives there is that both `app.draws` and `app.results` must
+read one definition, and that reason applies unchanged to swiss.
+
+### The swiss chain
+
+1. **wins** — most match wins first.
+2. **head-to-head**, only when exactly two entries are tied **and they actually
+   met**. When they did not meet, the step falls through.
+3. **Buchholz** — the sum of the entrant's opponents' win counts, highest first.
+4. **game difference** — games won minus games lost.
+5. **games won**.
+6. the **entry id**, a total deterministic fallback.
+
+Buchholz sits above game difference because it measures who you had to beat, and
+game difference measures margin. In a format that pairs by score, the first is the
+stronger signal.
+
+Buchholz needs no new input. `MatchOutcome` already records who was in each match,
+so an entrant's opponents are derivable from data the function already receives.
+
+### A bye contributes nothing to Buchholz
+
+A bye is the absence of a fixture row, so a byed round produced no opponent and
+adds no term to the sum. This falls out of the definition rather than needing a
+special case.
+
+A bye still scores as a **win worth zero games** in step 1. The win is granted
+because a player must not be punished for a scheduling artifact. The games are
+zero so the bye stays neutral on steps 4 and 5, rather than awarding difference
+nobody earned.
+
+### The head-to-head guard is a correctness fix for both formats
+
+The guard is written into the shared understanding of the step, not bolted onto
+the swiss copy. A round-robin pool cannot reach it, because its entrants always
+met. Adding it costs a round-robin nothing and stops the swiss chain reading a
+result that does not exist.
+
+## Consequences
+
+There are now two ordering functions to keep in step. That is the real cost, and
+it is why they stay in one module where a reader sees both at once.
+
+**A bye is slightly under-credited, deliberately.** An entrant who won 3-0 gains
+game difference the byed entrant does not. Erring toward under-crediting a result
+nobody played is the right direction to err.
+
+**Buchholz moves as the event runs.** It is a function of opponents' current win
+counts, so an entrant's tiebreak position changes when an opponent wins a later
+match, without that entrant playing. This is inherent to the measure and is true
+of every swiss event. Standings are computed live from completed matches, which
+this module already does, so nothing needs to be recomputed or invalidated.


### PR DESCRIPTION
Slice 1 of the swiss tournament format stack (#1276). This slice contains **no swiss code**. It is the storage refactor swiss needs, landed on its own so it can be reviewed and merged independently.

## What changes

`tournament_event_draw_settings.qualifiers_per_pool` is replaced by a single `settings jsonb NOT NULL DEFAULT '{}'`.

- A draw type with no configuration stores `{}`, never `NULL`. `round-robin` and `single-elim` store `{}`; `rr-then-ko` stores `{"qualifiers_per_pool": K}`.
- The `CASE` constraint pairing the old column with its draw type is replaced by `CHECK (jsonb_typeof(settings) = 'object')`.
- The blob is decoded into the existing `DrawSettingsWriteArm` discriminated union **at the boundary**, so nothing below the boundary holds a `dict[str, Any]`.
- `strategy_for` takes the parsed arm instead of a bare qualifier count, so its "needs a qualifiers_per_pool" `ValueError` is deleted rather than moved — the arm cannot be constructed without one.

## Why

The table describes a union: which settings exist depends entirely on the draw type. Modelling that as a wide row of nullable columns is what forced the `CASE` constraint to exist. Each new setting cost a column, a constraint branch and a migration. Adding a draw type's settings is now a Pydantic arm and nothing else.

Design is recorded in `docs/adr/20260805-a-draw-types-settings-are-one-not-null-json-object.md`, included in this PR.

## Deliberate trade-off

**The database no longer enforces which settings belong to which draw type**, and no longer enforces `K >= 1`. That moves to the discriminated union, which refuses a mismatched pair with a 422 at the request boundary. The constraint protected against a writer bypassing the schema; there is one writer, it parses through the union, and a test pins the refusal. `tests/test_tournament_event_draw_settings.py` states the loss out loud, including asserting that a `{"qualifiers_per_pool": 0}` row is now one Postgres accepts, so it reads as a decision rather than a regression.

## Verification

- `ruff check` / `ruff format --check` — clean
- `mypy --strict` — no issues in 170 source files, no new `# type: ignore`
- `pytest` — 2135 passed
- **`alembic upgrade head` against a fresh, empty Postgres** — `pytest` builds the schema with `Base.metadata.create_all` and never runs the migrations, so a green suite is not evidence here. Confirmed `settings` is present, NOT NULL, defaulted to `{}`, and that `qualifiers_per_pool` is gone.
- `tests/test_draw_type_seed_migration.py` was **falsified**: re-adding the old column and relaxing `settings` to nullable reds three tests, each naming its own reason.
- **No OpenAPI drift**, verified by diffing the full `app.openapi()` document against `main`: byte-identical at 403,734 bytes. This is the intended outcome — the change is storage-only and the wire shape stays flat.

## Operational note for whoever merges

This edits an already-applied migration in place (the pre-deploy convention). `alembic_version` is unchanged, so `alembic upgrade head` is a **no-op** against any database that already ran `0010` — it keeps `qualifiers_per_pool`, never gets `settings`, and the app fails on the first event read. **Wipe and re-migrate UAT, local dev databases, and any live QA stack volume before running this branch against them.**

Chores: `1ab` (folded from `1a`+`1b` — dropping the column and migrating its readers cannot be two green commits under `mypy --strict`), `1c` (no-op regen, no drift).

Part of #1276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
