### PR TITLE
Slice 2: a director creates a swiss event, cuts the draw, and sees round 1 paired

### DIFF
--- a/api/app/dashboard_tournaments.py
+++ b/api/app/dashboard_tournaments.py
@@ -64,6 +64,7 @@ from app.schemas.tournament import (
     MatchSettings,
     StandingsResultsRead,
     StandingsThenFinishesResultsRead,
+    SwissStandingsResultsRead,
     TournamentEntrantRead,
     TournamentFixtureRead,
     TournamentTable,
@@ -290,6 +291,7 @@ def _build_event(
 
     results = event_results(
         event,
+        entrants=entrants,
         fixtures=all_fixtures,
         game_counts=game_counts,
     )
@@ -317,6 +319,18 @@ def _build_event(
                     break
             if my_standing is not None:
                 break
+    elif isinstance(results, SwissStandingsResultsRead):
+        # The third shape that carries the caller's row — swiss, which is POOL-LESS
+        # (ADR "swiss pre-cuts every round and pairs each one on advance"): one table
+        # over the whole field, so there is no pool to filter by and the field size is
+        # that table's own length. Without this arm a swiss player's panel would show
+        # no rank at all while the table holding their row rode along on the same
+        # payload, and ``stage_complete`` below could never be true for them.
+        for row in results.rows:
+            if row.entry_id == my_entry_id:
+                my_standing = row
+                field_size = len(results.rows)
+                break
     # What ``stage_label`` is judged on, and it is NOT always the pool's completeness.
     # For a round-robin the two coincide — the pool finishing IS the event finishing,
     # and "Group complete" is the right thing to say. For a two-stage event they come
@@ -325,9 +339,16 @@ def _build_event(
     # over an event still being played. The two-stage shape's own ``complete`` is both
     # stages decided (ADR 20260727) — the only honest answer this minimal label can
     # give.
+    # Swiss joins the two-stage shape on the left of this: it has no pool whose
+    # completeness could stand in, and its own ``complete`` is every round decided —
+    # which is exactly what "is this event over" means for a format that eliminates
+    # nobody. Reading ``pool_complete`` for it would leave the label stuck on "In play"
+    # through the final round and past it.
     stage_complete = (
         results.complete
-        if isinstance(results, StandingsThenFinishesResultsRead)
+        if isinstance(
+            results, StandingsThenFinishesResultsRead | SwissStandingsResultsRead
+        )
         else pool_complete
     )
 
@@ -619,6 +640,11 @@ def _round_label(
                 if pool_id is not None
                 else f"Round {round_number}"
             )
+        case DrawType.swiss:
+            # A swiss round IS the vocabulary — "round 3" is what a director and a
+            # player both call it — and it needs none of the bracket's caveats, because
+            # the number is not a distance from a final.
+            return f"Round {round_number}"
         case _:
             assert_never(draw_type)
 
@@ -635,6 +661,10 @@ def _stage_label(draw_type: DrawType, *, complete: bool) -> str:
             # its knockout stage is still being played. Naming *which* stage is live
             # needs more plumbing than this ticket buys (ADR 20260727), so the label
             # says only whether the event has finished.
+            return "Complete" if complete else "In play"
+        case DrawType.swiss:
+            # Not the round-robin wording: a swiss event has no group to complete, and
+            # "Group complete" over a pool-less field would name a stage it never had.
             return "Complete" if complete else "In play"
         case _:
             assert_never(draw_type)

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -50,6 +50,7 @@ from app.schemas.tournament import (
     RoundRobinDrawSettingsWrite,
     RrThenKoDrawSettingsWrite,
     SingleElimDrawSettingsWrite,
+    SwissDrawSettingsWrite,
 )
 
 # Distinct id types, so the checker rejects handing a fixture id to something that
@@ -871,6 +872,111 @@ class RrThenKoStrategy:
         return fills
 
 
+@dataclass(frozen=True, slots=True)
+class SwissStrategy:
+    """Swiss: a fixed number of rounds, nobody eliminated, each round paired by the
+    standings the round before it produced (ADR "swiss pre-cuts every round and pairs
+    each one on advance").
+
+    **Every round is cut up front**, all ``R`` of them: ``R × ⌊n/2⌋`` fixtures. Round 1
+    carries both sides, seeded from the draw order; every later round is written with
+    both sides ``None``. That is not a workaround for :class:`AdvancePlan` being unable
+    to create a fixture — it is what makes swiss expressible without changing the
+    contract at all. With the field frozen at the cut (withdrawal is refused outside the
+    registration window) and ``R`` an explicit setting, the *number* of fixtures is
+    fully determined; only the *sides* are unknown, and a ``None`` side already means
+    exactly "TBD, ``advance()`` will fill it" — the state single-elim's later rounds
+    have always been in.
+
+    **Round 1 is top half against bottom half**: with ``m = 2⌊n/2⌋`` playing entrants,
+    draw-order position ``i`` meets position ``i + m/2``, so the top seed meets the best
+    of the bottom half. An odd field byes the **lowest**-ranked entrant, who simply has
+    no fixture — a bye is the absence of a row (ADR-0786), never a row with a ``NULL``
+    side, which here would be indistinguishable from a later round awaiting its pairing.
+
+    **This strategy does not pair anything past round 1 yet.** :meth:`advance` fills no
+    sides; it reports readiness exactly as :class:`RoundRobinStrategy`'s does. Pairing
+    round ``r + 1`` from the standings once round ``r`` is decided is its own slice, and
+    stubbing it would mean writing pairings nobody computed.
+
+    Fixtures are **un-pooled** (``pool_id=None``): swiss ranks the whole field in one
+    table, which is why the schedule preview refuses it exactly as it refuses a bracket.
+    """
+
+    #: How many rounds the event plays. ``R >= 1`` is static — a Pydantic constraint at
+    #: the request boundary — so a smaller value is a *programmer* error and is refused
+    #: in the constructor; the refusal that depends on the entrant count
+    #: (``R <= n - 1``, which moves as the field does) is a :class:`DegenerateDraw` at
+    #: the cut.
+    rounds: int
+
+    def __post_init__(self) -> None:
+        if self.rounds < 1:
+            raise ValueError(f"rounds must be at least 1, got {self.rounds}.")
+
+    def plan_initial(
+        self, config: DrawConfig, ordered_entrants: Sequence[OrderedEntrant]
+    ) -> list[PlannedFixture]:
+        entrants = list(ordered_entrants)
+        size = len(entrants)
+        if size < 2:
+            raise DegenerateDraw(
+                "A swiss draw needs at least 2 entrants — a field of one has nobody to "
+                "play."
+            )
+        if self.rounds > size - 1:
+            # ``n - 1`` is the number of distinct opponents an entrant can have, so past
+            # it a rematch-free swiss cannot exist. Refused at the CUT and not at
+            # configure time, because ``n`` is not known when the setting is written —
+            # the same split every entrant-count-dependent refusal in this module uses.
+            round_noun = "round" if self.rounds == 1 else "rounds"
+            opponent_noun = "opponent" if size - 1 == 1 else "opponents"
+            raise DegenerateDraw(
+                f"{self.rounds} {round_noun} is more than the {size - 1} "
+                f"{opponent_noun} each of {size} entrants can have — play fewer "
+                "rounds, or add entrants."
+            )
+        # The odd entrant out sits the round; ``m`` is the field that actually plays, so
+        # every round holds ⌊n/2⌋ fixtures whatever the parity.
+        pairs_per_round = size // 2
+        fixtures = [
+            PlannedFixture(
+                pool_id=None,
+                round=1,
+                position=position,
+                # Top half against bottom half, in draw order. ``entrants`` is
+                # 1-based by ``position`` but indexed 0-based here, so the pairing is
+                # index ``i`` against index ``i + pairs_per_round``.
+                entry_a_id=entrants[position - 1].entry_id,
+                entry_b_id=entrants[position - 1 + pairs_per_round].entry_id,
+            )
+            for position in range(1, pairs_per_round + 1)
+        ]
+        # Every later round, whole, with both sides TBD. ``position`` becomes the
+        # pairing's rank in the standings when the round is paired; until then it is
+        # only the row's identity within its round.
+        fixtures.extend(
+            PlannedFixture(pool_id=None, round=round_number, position=position)
+            for round_number in range(2, self.rounds + 1)
+            for position in range(1, pairs_per_round + 1)
+        )
+        return fixtures
+
+    def advance(self, fixtures: Sequence[FixtureState]) -> AdvancePlan:
+        """Report which fixtures are ready to become matches, and fill nothing.
+
+        Round 1 was paired at the cut, so on a freshly cut draw this is round 1's
+        fixtures and nothing else: the later rounds are ``is_pending`` (both sides
+        unknown) and :func:`ready_fixtures` already leaves those out.
+
+        Pairing round ``r + 1`` from round ``r``'s standings is the next slice's work,
+        deliberately absent rather than stubbed — a stub here would either write
+        pairings nothing computed or quietly report a round ready that has no players in
+        it.
+        """
+        return AdvancePlan(side_fills=(), ready_fixture_ids=ready_fixtures(fixtures))
+
+
 def _finished_pool_order(
     pool_fixtures: Sequence[FixtureState],
 ) -> list[EntryTally] | None:
@@ -1053,6 +1159,8 @@ def strategy_for(settings: DrawSettingsWriteArm) -> DrawStrategy:
             return SingleElimStrategy()
         case RrThenKoDrawSettingsWrite():
             return RrThenKoStrategy(qualifiers_per_pool=settings.qualifiers_per_pool)
+        case SwissDrawSettingsWrite():
+            return SwissStrategy(rounds=settings.rounds)
 
 
 def reads_fixture_games(draw_type: DrawType) -> bool:
@@ -1066,6 +1174,14 @@ def reads_fixture_games(draw_type: DrawType) -> bool:
     a SQL statement and a few hundred score rows discarded, on the completion seam,
     inside the score-accept transaction, once per result.
 
+    ``swiss`` declares **true** for the same reason ``rr-then-ko`` does, and declares it
+    now rather than when its pairing lands: it pairs each round off the standings, whose
+    chain runs through Buchholz and game difference — both of which are counts of games
+    — so a swiss draw advanced without them would pair the field in an order that
+    disagrees with the table on screen. The cut needs no games; being handed them costs
+    nothing, and being *without* them at the moment the pairing arrives would be the
+    silent failure :class:`MissingFixtureGames` exists to prevent.
+
     An exhaustive ``match`` with **no catch-all**, exactly like :func:`strategy_for`: a
     new :class:`DrawType` member has to *declare* whether it needs the games, and until
     it does this fails to type-check. The alternative — a default of ``False`` — is a
@@ -1078,6 +1194,8 @@ def reads_fixture_games(draw_type: DrawType) -> bool:
         case DrawType.single_elim:
             return False
         case DrawType.rr_then_ko:
+            return True
+        case DrawType.swiss:
             return True
 
 

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -1199,6 +1199,61 @@ def reads_fixture_games(draw_type: DrawType) -> bool:
             return True
 
 
+def unseated_entrant_allowance(draw_type: DrawType, field_size: int) -> int:
+    """How many of a field's entrants this draw type's fixtures may legitimately fail
+    to seat — the **bye allowance**, and the one thing "these fixtures cover this
+    field" cannot be asked without.
+
+    A draw's currency (:class:`~app.tournament_draws.DrawCurrency`) is "the fixtures
+    seat exactly the active entrants", and for three of the four draw types that is
+    literally true. Not because they have no byes — an odd round-robin pool byes
+    somebody every round — but because their byed entrants are **still seated
+    somewhere**: a round-robin bye sits out one round of a schedule that seats them in
+    every other, and a single-elim bye is seated directly onto its round-2 side at cut
+    time (:func:`_knockout_seats`). So zero of their entrants are unseated, and an
+    unseated entrant is exactly what it looks like — somebody who entered after the cut.
+
+    **Swiss is the exception, and it is arithmetic rather than a special case.** Its cut
+    emits ``⌊n/2⌋`` fixtures a round, so an odd field leaves exactly one entrant with no
+    fixture at all — a bye is the absence of a row (ADR-0786), never a row with a
+    ``NULL`` side. That entrant is covered by the draw; the draw simply has no row that
+    says so. Hence ``field_size % 2``: one for an odd field, none for an even one.
+
+    It is an **allowance**, i.e. an upper bound, not a required count. Once a later
+    round is paired (the next slice) the round-1 bye is seated in it, and a draw that
+    seats its whole field must stay current.
+
+    What the allowance **cannot** do is tell a byed entrant from a single latecomer who
+    leaves the field odd: a swiss draw cut for eight and joined by a ninth holds exactly
+    the rows a draw cut for nine holds. The ambiguity is irreducible, not a shortcut. A
+    bye is an absence, so the parity of the field the draw was cut for is recorded
+    nowhere, and no arithmetic recovers it — ``⌊8/2⌋`` and ``⌊9/2⌋`` are the same number
+    of fixtures.
+
+    It is also the one shape where being wrong is survivable, and only for swiss. The
+    latecomer is treated as that round's bye, which is a state the format puts somebody
+    in every odd round anyway — where the same slip on a round-robin would seat a player
+    in no match for the whole tournament. Everything else still reds: two latecomers,
+    a latecomer that leaves the field **even** (``7 → 8``: two unseated against an
+    allowance of none), and any withdrawal of a **seated** entry, which fails the subset
+    half of the comparison rather than this count.
+
+    An exhaustive ``match`` with no catch-all, exactly like :func:`reads_fixture_games`:
+    a new :class:`DrawType` has to state its own answer, and until it does this fails to
+    type-check. A default of ``0`` would be the ``stale`` this function exists to stop;
+    a default of ``1`` would quietly stop catching the latecomer.
+    """
+    match draw_type:
+        case DrawType.round_robin:
+            return 0
+        case DrawType.single_elim:
+            return 0
+        case DrawType.rr_then_ko:
+            return 0
+        case DrawType.swiss:
+            return field_size % 2
+
+
 def _snake(
     ordered_entrants: Sequence[OrderedEntrant], pool_ids: Sequence[PoolId]
 ) -> list[tuple[PoolId, tuple[EntryId, ...]]]:

--- a/api/app/models/tournament.py
+++ b/api/app/models/tournament.py
@@ -66,6 +66,7 @@ class DrawType(enum.Enum):
     single_elim = "single-elim"
     round_robin = "round-robin"
     rr_then_ko = "rr-then-ko"
+    swiss = "swiss"
 
 
 class Tournament(Base):

--- a/api/app/results.py
+++ b/api/app/results.py
@@ -27,13 +27,14 @@ already imports ``app.draws``, so a shared third module is the only place both c
 reach (ADR 20260727). ``MatchOutcome`` is re-exported from here for the callers that
 already know it by this name.
 
-Three arms are implemented: :class:`RoundRobinResults`, whose shape is a **standings**
+Four arms are implemented: :class:`RoundRobinResults`, whose shape is a **standings**
 table per pool; :class:`SingleElimResults` (ADR-0785), whose shape is the bracket's
-**finishes** — each entrant's finishing position by the round it was eliminated in; and
+**finishes** — each entrant's finishing position by the round it was eliminated in;
 :class:`RrThenKoResults` (ADR 20260727), a two-**stage** event whose shape is **both**,
-one block per stage. The shapes cross the wire as a discriminated union tagged by
-``kind`` (ADR-0785); here they are simply different value objects returned by different
-``tabulate`` methods.
+one block per stage; and :class:`SwissResults` (ADR "swiss pre-cuts every round and
+pairs each one on advance"), whose shape is a single **pool-less** table over the whole
+field. The shapes cross the wire as a discriminated union tagged by ``kind`` (ADR-0785);
+here they are simply different value objects returned by different ``tabulate`` methods.
 """
 
 from __future__ import annotations
@@ -49,6 +50,7 @@ __all__ = [
     "BracketFinishes",
     "BracketFixture",
     "EventResults",
+    "FieldInput",
     "FinishRow",
     # Re-exported: the value object the tabulation consumes lives in
     # ``app.pool_finishing_order`` so the draw layer can reach it too, but every
@@ -61,6 +63,8 @@ __all__ = [
     "SingleElimResults",
     "StandingRow",
     "StandingsThenFinishes",
+    "SwissResults",
+    "SwissStandings",
     "results_for",
 ]
 
@@ -80,6 +84,29 @@ class PoolInput:
     """
 
     pool_id: PoolId
+    entrants: tuple[EntryId, ...]
+    fixture_count: int
+    outcomes: tuple[MatchOutcome, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class FieldInput:
+    """A **pool-less** field's whole input to its standings: every entry in the event,
+    how many fixtures it has, and the outcomes of the ones already decided.
+
+    :class:`PoolInput` without the ``pool_id``, because swiss has no pool to name (ADR
+    "swiss pre-cuts every round and pairs each one on advance") — the whole field stands
+    in one table. The three fields mean exactly what they mean there, and are read the
+    same way: ``entrants`` is the full seated field so an entrant yet to play still has
+    a row of zeros, and ``fixture_count`` counts the pairings that can still yield a
+    result, which for swiss includes the later rounds that are cut but not yet paired.
+
+    It is deliberately not a shared base class with :class:`PoolInput`. One is keyed by
+    a pool and one is not, which is the only difference there will ever be, and a base
+    would buy a name for three fields at the cost of a hierarchy in a module that is
+    otherwise flat value objects.
+    """
+
     entrants: tuple[EntryId, ...]
     fixture_count: int
     outcomes: tuple[MatchOutcome, ...]
@@ -218,9 +245,30 @@ class StandingsThenFinishes:
     champion: EntryId | None
 
 
+@dataclass(frozen=True, slots=True)
+class SwissStandings:
+    """A swiss event's results: **one** standings table over the whole field, whether
+    every round has been decided, and its champion when it has.
+
+    One table and not a tuple of them, because swiss is pool-less: everybody is ranked
+    against everybody, which is the whole point of pairing by score. That is the only
+    structural difference from :class:`EventResults`, and it is why this is its own
+    shape rather than a pool-less flavour of that one — a ``pools`` list of length one
+    with a made-up id would be a lie about a pool that does not exist.
+
+    ``champion`` is the leader of a **complete** event, with no single-pool carve-out to
+    make: a swiss event ranks the whole field, so its table's top row is its winner
+    (CONTEXT.md, "Swiss"). ``None`` while any round is still to be decided.
+    """
+
+    rows: tuple[StandingRow, ...]
+    complete: bool
+    champion: EntryId | None
+
+
 def results_for(
     draw_type: DrawType,
-) -> RoundRobinResults | SingleElimResults | RrThenKoResults:
+) -> RoundRobinResults | SingleElimResults | RrThenKoResults | SwissResults:
     """The results strategy for this draw type.
 
     **Total**, exactly as ``app.draws.strategy_for``: an exhaustive ``match`` with
@@ -231,9 +279,11 @@ def results_for(
 
     The return type is a **union tagged by shape** (ADR-0785): round-robin's
     :class:`RoundRobinResults` reads out a **standings** table, single-elim's
-    :class:`SingleElimResults` reads out the bracket's **finishes**, and rr-then-ko's
-    :class:`RrThenKoResults` reads out **both**. A caller narrows the union (an
-    exhaustive ``match`` over the concrete strategies) to call the right ``tabulate`` —
+    :class:`SingleElimResults` reads out the bracket's **finishes**, rr-then-ko's
+    :class:`RrThenKoResults` reads out **both**, and swiss's :class:`SwissResults` reads
+    out a single **pool-less** table over the whole field. A caller narrows the union
+    (an exhaustive ``match`` over the concrete strategies) to call the right
+    ``tabulate`` —
     so a further strategy is a type error at every call site until handled.
 
     The narrowing is not uniform, and cannot be: :meth:`RrThenKoResults.tabulate` takes
@@ -249,6 +299,8 @@ def results_for(
             return SingleElimResults()
         case DrawType.rr_then_ko:
             return RrThenKoResults()
+        case DrawType.swiss:
+            return SwissResults()
 
 
 @dataclass(frozen=True, slots=True)
@@ -380,9 +432,55 @@ class RrThenKoResults:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class SwissResults:
+    """A swiss event's results: one standings table over the whole field (ADR "swiss
+    pre-cuts every round and pairs each one on advance").
+
+    Ordered by :func:`~app.pool_finishing_order.finishing_order` — the *same* chain a
+    round-robin pool is ordered by — through the same :func:`_standing_rows` a pool's
+    table is built with. That is deliberate and temporary: swiss gets its own ordering
+    function, with Buchholz above game difference and the head-to-head step guarded on
+    the pair having met, in its own slice (ADR "swiss standings add Buchholz, and
+    head-to-head is guarded on having met"). Until then this reads out the chain that
+    exists rather than a swiss-shaped approximation of the one that does not.
+
+    Live and partial like every other shape: an entrant appears from the moment they are
+    seated, and a correction re-orders the table the instant it lands.
+    """
+
+    def tabulate(self, field: FieldInput) -> SwissStandings:
+        rows = _standing_rows(field.entrants, field.outcomes)
+        # Every round decided — which, since the later rounds are cut up front with
+        # their sides unknown, includes the ones nobody has been paired into yet. An
+        # event with no fixtures that can still yield a result is deliberately NOT
+        # complete: ``0 == 0`` would call an uncut (or wholly voided) swiss finished.
+        complete = (
+            field.fixture_count > 0 and len(field.outcomes) == field.fixture_count
+        )
+        champion = rows[0].entry_id if complete and rows else None
+        return SwissStandings(rows=rows, complete=complete, champion=champion)
+
+
 def _pool_standings(pool: PoolInput) -> PoolStandings:
-    ordered = finishing_order(pool.entrants, pool.outcomes)
-    rows = tuple(
+    return PoolStandings(
+        pool_id=pool.pool_id,
+        rows=_standing_rows(pool.entrants, pool.outcomes),
+        complete=len(pool.outcomes) == pool.fixture_count,
+    )
+
+
+def _standing_rows(
+    entrants: Sequence[EntryId], outcomes: Sequence[MatchOutcome]
+) -> tuple[StandingRow, ...]:
+    """These entrants' rows, at their settled ranks — the one place a table is built,
+    for the two shapes that carry one (a pool's, and a swiss field's).
+
+    Shared so that "a standings row means the same thing whichever event it is read
+    off" is true structurally: the ordering is
+    :func:`~app.pool_finishing_order.finishing_order` and the counts come off the
+    tallies it returns, in one function rather than two that agree today."""
+    return tuple(
         StandingRow(
             entry_id=tally.entry_id,
             rank=rank,
@@ -392,10 +490,5 @@ def _pool_standings(pool: PoolInput) -> PoolStandings:
             games_won=tally.games_won,
             games_lost=tally.games_lost,
         )
-        for rank, tally in enumerate(ordered, start=1)
-    )
-    return PoolStandings(
-        pool_id=pool.pool_id,
-        rows=rows,
-        complete=len(pool.outcomes) == pool.fixture_count,
+        for rank, tally in enumerate(finishing_order(entrants, outcomes), start=1)
     )

--- a/api/app/schedule_preview.py
+++ b/api/app/schedule_preview.py
@@ -329,7 +329,12 @@ def build_preview_snapshot(
                 fixtures = strategy_for_event(event).plan_initial(
                     draw_config(event), ordered_entrants
                 )
-            case DrawType.single_elim:
+            case DrawType.single_elim | DrawType.swiss:
+                # Swiss takes single-elim's path for single-elim's reason: it is
+                # POOL-LESS (ADR "swiss pre-cuts every round and pairs each one on
+                # advance"), and the preview covers the pool stage. A director asking
+                # for one is told the format has no preview, rather than shown an empty
+                # day that silently covers nothing.
                 raise UnsupportedDrawType(draw_type)
             case _:
                 assert_never(draw_type)

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -154,6 +154,32 @@ The two bounds that **move with the entrant count** — ``P × K >= 2`` and
 become unwritable when a player withdraws (the same split ``_snake`` already uses for
 its own pool floor)."""
 
+MAX_SWISS_ROUNDS = 32
+"""The ceiling on **R** — how many rounds a swiss event plays.
+
+The same kind of bound as ``MAX_QUALIFIERS_PER_POOL``, and not the domain rule either.
+The rule that matters moves with the field: ``R <= N - 1``, because with ``N`` entrants
+nobody has more than ``N - 1`` distinct opponents, and the cut refuses more with a
+message naming both numbers (``DegenerateDraw``). This is the *boundary* refusing round
+counts that are nonsense on their face and would otherwise reach the column. A swiss
+field of 512 — the largest event this API will hold — is conventionally paired out in
+nine rounds (``ceil(log2 N)``), so 32 is far above any event a table-tennis director
+will run and far below the ``Integer`` column's 2,147,483,647."""
+
+SwissRounds = Annotated[int, Field(ge=1, le=MAX_SWISS_ROUNDS)]
+"""**R** — how many rounds a ``swiss`` draw plays.
+
+``1 <= R <= MAX_SWISS_ROUNDS`` is the **static** half of the legal space (ADR "swiss
+pre-cuts every round and pairs each one on advance"): a swiss of zero rounds plays
+nothing, a negative count is not a count, and a count in the thousands is not a round
+count whatever the field looks like. Stated once and shared by the create schema, the
+patch schema and the union arm below, so the three cannot drift.
+
+The bound that **moves with the entrant count** — ``R <= N - 1`` — is deliberately not
+here, for the reason ``QualifiersPerPool`` gives: ``N`` is not known when the setting is
+written, and a configuration that was legal when it was written must not become
+unwritable when a player withdraws."""
+
 
 class DrawSettingsWriteBase(BaseModel):
     """What every arm of the draw-settings union shares: ``extra="forbid"``, and the
@@ -209,6 +235,14 @@ class RoundRobinDrawSettingsWrite(DrawSettingsWriteBase):
         every arm the same question without an ``isinstance`` ladder."""
         return None
 
+    @property
+    def rounds(self) -> int | None:
+        """``None`` — a round-robin's round count is dealt by the circle method, not
+        chosen. Only ``swiss`` carries one, and for the reason
+        :meth:`qualifiers_per_pool` is a property here: every arm answers the same
+        question, and the field's absence is what refuses the key on the wire."""
+        return None
+
 
 class SingleElimDrawSettingsWrite(DrawSettingsWriteBase):
     """A single-elimination event's draw configuration: the draw type, and nothing else.
@@ -220,6 +254,11 @@ class SingleElimDrawSettingsWrite(DrawSettingsWriteBase):
     @property
     def qualifiers_per_pool(self) -> int | None:
         """``None`` — a bracket has no pools to qualify out of."""
+        return None
+
+    @property
+    def rounds(self) -> int | None:
+        """``None`` — a bracket's depth is derived from the field, not chosen."""
         return None
 
 
@@ -235,11 +274,41 @@ class RrThenKoDrawSettingsWrite(DrawSettingsWriteBase):
     draw_type: Literal[DrawType.rr_then_ko] = DrawType.rr_then_ko
     qualifiers_per_pool: QualifiersPerPool
 
+    @property
+    def rounds(self) -> int | None:
+        """``None`` — neither of this draw type's two stages has a chosen round count:
+        the pools are dealt by the circle method and the bracket's depth follows from
+        the qualifier count."""
+        return None
+
+
+class SwissDrawSettingsWrite(DrawSettingsWriteBase):
+    """A swiss event's draw configuration: the draw type **and** its round count (ADR
+    "swiss pre-cuts every round and pairs each one on advance").
+
+    ``rounds`` is **required** here, with no default, for the reason
+    :class:`RrThenKoDrawSettingsWrite`'s qualifier count is: there is no defensible
+    number to assume. ``ceil(log2 N)`` is the convention, and it is deliberately *not*
+    a derived default — a director books tables and a venue window before registration
+    opens, so a round count that moved as entrants arrived would change the length of a
+    day that is already booked. A swiss cut for a round count nobody chose is the worst
+    of the available failures: it looks like it worked."""
+
+    draw_type: Literal[DrawType.swiss] = DrawType.swiss
+    rounds: SwissRounds
+
+    @property
+    def qualifiers_per_pool(self) -> int | None:
+        """``None`` — swiss is pool-less and eliminates nobody, so there is nothing to
+        qualify out of or into."""
+        return None
+
 
 DrawSettingsWriteArm = (
     RoundRobinDrawSettingsWrite
     | SingleElimDrawSettingsWrite
     | RrThenKoDrawSettingsWrite
+    | SwissDrawSettingsWrite
 )
 """The **arms** of the draw-settings union, listed once.
 
@@ -274,21 +343,25 @@ _DRAW_SETTINGS_WRITE: TypeAdapter[DrawSettingsWriteArm] = TypeAdapter(DrawSettin
 
 
 def _draw_settings_write(
-    draw_type: DrawType, qualifiers_per_pool: int | None
+    draw_type: DrawType, qualifiers_per_pool: int | None, rounds: int | None
 ) -> DrawSettingsWriteArm:
-    """Parse a ``(draw_type, qualifiers_per_pool)`` pair into the union arm it names, or
-    raise :class:`ValueError` — a 422 — when it names none.
+    """Parse a ``(draw_type, qualifiers_per_pool, rounds)`` triple into the union arm it
+    names, or raise :class:`ValueError` — a 422 — when it names none.
 
-    The pair is **flat on the wire** and a union in the interior. Nesting it
+    The settings are **flat on the wire** and a union in the interior. Nesting them
     (``draw: {…}``) would express the union in the generated clients too, at the cost of
     changing the shape of every event create and patch that has ever been written; the
     same rule is enforced either way, and this is the shape that lets the draw type stay
     where every existing caller already sends it.
 
-    ``None`` means "no qualifier count was sent" and is therefore *omitted* rather than
+    ``None`` means "this setting was not sent" and is therefore *omitted* rather than
     passed as ``null``: an absent key and an explicit ``null`` mean the same thing for
-    this field — the draw type takes no count — and ``extra="forbid"`` would reject the
-    explicit one on the two arms that have no such field.
+    these fields — the draw type takes no such setting — and ``extra="forbid"`` would
+    reject the explicit one on the arms that have no such field. Omitting the key is
+    also what makes a **missing** required setting the arm's own refusal: a ``swiss``
+    payload with no round count reaches the union with no ``rounds`` key at all, so
+    Pydantic answers "Field required" against the field, which is the 422 the director
+    needs.
 
     The refusal text is the **union's own**, re-raised as a ``ValueError`` so FastAPI
     renders it as an ordinary 422 body. Composing a friendlier sentence here would be a
@@ -297,6 +370,8 @@ def _draw_settings_write(
     payload: dict[str, object] = {"draw_type": draw_type}
     if qualifiers_per_pool is not None:
         payload["qualifiers_per_pool"] = qualifiers_per_pool
+    if rounds is not None:
+        payload["rounds"] = rounds
     try:
         return _DRAW_SETTINGS_WRITE.validate_python(payload)
     except ValidationError as exc:
@@ -1575,15 +1650,43 @@ class StandingsThenFinishesResultsRead(BaseModel):
     champion: uuid.UUID | None
 
 
+class SwissStandingsResultsRead(BaseModel):
+    """The **pool-less standings** shape of an event's results — the swiss arm of the
+    ``results`` discriminated union, tagged ``kind: "swiss_standings"`` (ADR "swiss
+    pre-cuts every round and pairs each one on advance").
+
+    One table over the whole field, because swiss has no pools: everybody is ranked
+    against everybody, which is what pairing by score is for. The rows are the *same*
+    :class:`StandingRowRead` a round-robin pool carries, so a client renders this with
+    the table it already has — the difference is that they arrive as one list rather
+    than grouped under a pool, which is a fact about the format and not a second row
+    shape.
+
+    ``complete`` is every round decided, including the later rounds that are cut up
+    front with their sides still unknown. ``champion`` is the leader of a complete
+    event — a swiss ranks its whole field, so unlike the round-robin arm there is no
+    multi-pool carve-out — and ``null`` until then. Derived live from the fixtures'
+    completed matches like every other results shape."""
+
+    kind: Literal["swiss_standings"] = "swiss_standings"
+    rows: list[StandingRowRead]
+    complete: bool
+    champion: uuid.UUID | None
+
+
 # An event's results cross the wire as a **discriminated union tagged by shape**
 # (ADR-0785): a round-robin reads out ``standings``, a single-elim reads out
-# ``finishes``, and a round-robin-then-knockout reads out ``standings_then_finishes`` —
-# both blocks at once (ADR 20260727). Coercing finishes into the standings row shape was
+# ``finishes``, a round-robin-then-knockout reads out ``standings_then_finishes`` —
+# both blocks at once (ADR 20260727) — and a swiss event reads out ``swiss_standings``,
+# one pool-less table. Coercing finishes into the standings row shape was
 # rejected — a bracket has no wins/game-difference columns, so every such row would
 # carry meaningless nullable fields, the tri-state smell ``api/CLAUDE.md`` warns
 # against. Each shape is its own model; the client switches on ``kind``.
 EventResultsRead = Annotated[
-    StandingsResultsRead | FinishesResultsRead | StandingsThenFinishesResultsRead,
+    StandingsResultsRead
+    | FinishesResultsRead
+    | StandingsThenFinishesResultsRead
+    | SwissStandingsResultsRead,
     Field(discriminator="kind"),
 ]
 
@@ -1615,6 +1718,12 @@ class TournamentEventRead(BaseModel):
     # one, which pre-draw silently overwrites the director's number and post-draw trips
     # the freeze with a 409 for an edit nobody made.
     qualifiers_per_pool: int | None
+    # **R** — how many rounds a swiss event plays — read back flat beside its draw type
+    # for exactly the reasons the qualifier count above is: it is the other setting the
+    # editor has to send back on every PATCH of a swiss event, because the arm requires
+    # it and has no default. ``null`` for every other draw type, and that is a fact
+    # rather than missing data — none of them has a chosen round count.
+    rounds: int | None
     # ``null`` means the event is uncapped — there is no entrant limit (ADR-0935).
     max_players: int | None
     # Typed ``float`` so JSON emits a number, not a Decimal string. The
@@ -2019,6 +2128,13 @@ class TournamentEventCreate(BaseModel):
     # union arm carries, restated on the field so both bounds reach the generated
     # clients too.
     qualifiers_per_pool: QualifiersPerPool | None = None
+    # **R**, and only for the one draw type that has one — the same flat-beside-the-type
+    # shape ``qualifiers_per_pool`` takes, parsed into the same union by the validator
+    # below, so a round count on a round-robin event is a 422 here and a *missing* one
+    # on a swiss event is a 422 too (``SwissDrawSettingsWrite.rounds`` is required).
+    # ``SwissRounds`` restates the ``1 <= R <= 32`` bound the arm carries so both reach
+    # the generated clients.
+    rounds: SwissRounds | None = None
     # ``None`` (or omitted) is the uncapped event — the "no cap" sentinel of ADR-0935,
     # not a cap of zero. When a cap IS supplied it is an ``EventMaxPlayers``: ``gt=0``
     # (a cap of zero admits nobody, which is not an event) and ``le=512`` (the column
@@ -2081,7 +2197,7 @@ class TournamentEventCreate(BaseModel):
         (:attr:`_draw_settings`) rather than discarded — parse once, at the boundary,
         and carry the parsed value inward."""
         self._draw_settings = _draw_settings_write(
-            self.draw_type, self.qualifiers_per_pool
+            self.draw_type, self.qualifiers_per_pool, self.rounds
         )
         return self
 
@@ -2117,6 +2233,10 @@ class TournamentEventUpdate(BaseModel):
     # the pair's point of view ("this draw type takes no qualifier count"), which is why
     # it is not in the ``_reject_explicit_null`` list.
     qualifiers_per_pool: QualifiersPerPool | None = None
+    # **R**, patched with its draw type and never alone, exactly as the qualifier count
+    # is — and ``null`` means the same thing here as absent does ("this draw type takes
+    # no round count"), which is what patching a swiss event back to a round-robin says.
+    rounds: SwissRounds | None = None
     max_players: EventMaxPlayers | None = None
     entry_fee: EventEntryFee | None = None
     # The same validated IANA zone create requires — correcting the venue timezone is a
@@ -2195,9 +2315,14 @@ class TournamentEventUpdate(BaseModel):
                 "qualifiers_per_pool is part of an event's draw configuration and is "
                 "patched with it: send draw_type alongside it."
             )
+        if self.draw_type is None and self.rounds is not None:
+            raise ValueError(
+                "rounds is part of an event's draw configuration and is patched with "
+                "it: send draw_type alongside it."
+            )
         if self.draw_type is not None:
             self._draw_settings = _draw_settings_write(
-                self.draw_type, self.qualifiers_per_pool
+                self.draw_type, self.qualifiers_per_pool, self.rounds
             )
         return self
 

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -47,12 +47,15 @@ from app.draws import (
     PoolId,
     order_entrants,
     strategy_for,
+    unseated_entrant_allowance,
 )
 from app.models import (
+    DrawType,
     EventFormat,
     TournamentEntry,
     TournamentEntryStatus,
     TournamentEvent,
+    TournamentEventDrawSettings,
     TournamentFixture,
 )
 from app.schemas.tournament import Pool
@@ -412,10 +415,24 @@ async def draw_currency_by_event(
 
     A ``NULL`` side counts as nothing: it means TBD (a KO round whose feeder is
     undecided), never a bye and never an absent player. The seated set is therefore
-    the union of the non-NULL ``entry_a_id`` / ``entry_b_id`` refs — which, for
-    every strategy that exists today (and every one designed: a byed seed is placed
-    directly into round 2, so it is still *seated somewhere*), is exactly the set of
-    entrants the draw covers.
+    the union of the non-NULL ``entry_a_id`` / ``entry_b_id`` refs.
+
+    **That set is the field itself for three draw types, and one short of it for a
+    swiss draw over an odd field.** It used to be assumed exactly equal, on the strength
+    of every strategy then designed seating its byed entrants somewhere — a round-robin
+    bye sits out one round of a schedule that seats it in the others, a single-elim bye
+    is seated onto its round-2 side at the cut. Swiss breaks that: it emits ``⌊n/2⌋``
+    fixtures a round, and a bye is the *absence* of a row, so an odd field leaves one
+    entrant referenced nowhere. Under the plain equality such a draw read ``stale`` the
+    moment it was cut and go-live refused it with a 409 no re-cut could clear.
+
+    So the comparison is now: **nobody seated has left** (``seated <= active``, which is
+    what a withdrawal breaks) **and no more entrants are unseated than this draw type's
+    byes can account for** (:func:`~app.draws.unseated_entrant_allowance`, which is
+    ``0`` for the three and the field's parity for swiss). For every draw type but
+    swiss the pair is exactly the old equality, so the check they are protected by has
+    not moved: an entry that lands after the cut is still ``stale``, by name, on the
+    same 409. See that function for what the swiss allowance can and cannot tell apart.
 
     ``uncut`` is decided on the fixtures EXISTING, not on the seated set being
     empty. The two come apart on the event nobody has entered: no entrants and no
@@ -425,11 +442,14 @@ async def draw_currency_by_event(
     fiction, and it would be the fiction that carried an unplayable event into
     ``live``.
 
-    TWO statements for the whole batch, whatever the number of events (none at all
+    THREE statements for the whole batch, whatever the number of events (none at all
     when there are none), for the same reason every other loader here is batched:
     this runs on the go-live path with the tournament's row lock held, and a
-    per-event pair of queries would hold that lock for a time that grows with the
-    tournament.
+    per-event set of queries would hold that lock for a time that grows with the
+    tournament. The third is the events' draw types, which the allowance above turns
+    on; it is read here rather than off ``TournamentEvent.draw_settings`` because this
+    loader is handed **ids**, not rows, and a relationship walk would be the per-event
+    query this function exists not to issue.
     """
     if not event_ids:
         return {}
@@ -472,16 +492,70 @@ async def draw_currency_by_event(
             entry_id for entry_id in (entry_a_id, entry_b_id) if entry_id is not None
         )
 
+    # The third statement: each event's draw type, which decides how many of its
+    # entrants its fixtures may legitimately leave unseated. Read as the FK slug and
+    # parsed here — ``DrawType(slug)`` is the same parse the settings row's own
+    # ``draw_type`` property does, and the FK plus the seed-vs-enum migration test are
+    # what make an unparseable slug unreachable.
+    draw_types = {
+        event_id: DrawType(slug)
+        for event_id, slug in (
+            await db.execute(
+                select(TournamentEvent.id, TournamentEventDrawSettings.draw_type_key)
+                .join(
+                    TournamentEventDrawSettings,
+                    TournamentEvent.draw_settings_id == TournamentEventDrawSettings.id,
+                )
+                # ``in_`` over the same ids, so this scales with the batch and not with
+                # the table.
+                .where(TournamentEvent.id.in_(active.keys()))
+            )
+        ).all()
+    }
+
     return {
         event_id: (
             DrawCurrency.uncut
             if event_id not in cut
             else DrawCurrency.current
-            if seated[event_id] == active[event_id]
+            if _covers_the_field(
+                draw_types[event_id],
+                active=active[event_id],
+                seated=seated[event_id],
+            )
             else DrawCurrency.stale
         )
         for event_id in active
     }
+
+
+def _covers_the_field(
+    draw_type: DrawType, *, active: set[uuid.UUID], seated: set[uuid.UUID]
+) -> bool:
+    """Do these fixtures cover this field — the comparison
+    :func:`draw_currency_by_event` calls ``current``.
+
+    Two questions, and both have to hold:
+
+    * **nobody the fixtures seat has left.** A withdrawn entry is not an entrant
+      (ADR-0016), so a draw that still names one is stale however many byes the format
+      has. This is the subset test, and it is the half a bye allowance must never reach
+      — "the draw seats somebody who is gone" is the opposite complaint from "an
+      entrant the draw does not seat".
+    * **no more entrants are unseated than this draw type byes.**
+      :func:`~app.draws.unseated_entrant_allowance` is ``0`` for every draw type whose
+      byed entrants are seated somewhere anyway, which makes this pair exactly the
+      equality it replaced for all of them.
+
+    The allowance is measured against the **active** field, not the seated set: it is
+    a question about the tournament's parity ("does somebody have to sit out?"), and
+    reading it off the fixtures would ask the draw to justify itself.
+    """
+    if not seated <= active:
+        return False
+    return len(active) - len(seated) <= unseated_entrant_allowance(
+        draw_type, len(active)
+    )
 
 
 async def cut_draw(db: AsyncSession, event: TournamentEvent) -> None:

--- a/api/app/tournament_events.py
+++ b/api/app/tournament_events.py
@@ -36,8 +36,13 @@ from app.models import (
 )
 from app.schedule_solves import request_solve
 from app.schemas.tournament import (
+    DrawSettingsWriteArm,
     MatchSettings,
+    RoundRobinDrawSettingsWrite,
+    RrThenKoDrawSettingsWrite,
+    SingleElimDrawSettingsWrite,
     Slot,
+    SwissDrawSettingsWrite,
     TournamentEventCreate,
     TournamentEventUpdate,
     named_list,
@@ -274,6 +279,46 @@ def _qualifiers_per_pool_frozen_detail(
     )
 
 
+def _rounds_frozen_detail(rounds: int | None) -> str:
+    """The 409 sentence for a ``rounds`` change on a swiss event whose draw is already
+    cut — the qualifier count's sibling, about the other configured setting.
+
+    Not hypothetical either: a swiss draw writes **every** round's fixtures at the cut
+    (ADR "swiss pre-cuts every round and pairs each one on advance"), so the round count
+    is the number of rows standing in the database. Raising it would leave the added
+    rounds with no fixtures and lowering it would leave fixtures no round claims.
+    """
+    round_noun = "round" if rounds == 1 else "rounds"
+    return (
+        "This event's draw is already cut, so its number of rounds is frozen: all "
+        f"{rounds} {round_noun} were cut at once, and changing the count would leave "
+        "the draw with rounds it has no fixtures for. To change it, remove the draw "
+        "first, then cut it again."
+    )
+
+
+def _draw_settings_frozen_detail(stored: DrawSettingsWriteArm) -> str:
+    """The 409 sentence for a settings change on an event whose draw type is unchanged —
+    which setting moved is a question about the arm, so it is asked of the arm.
+
+    An exhaustive ``match`` with no catch-all: a draw type that grows a setting is a
+    type error here until it says how a change to it reads."""
+    match stored:
+        case RrThenKoDrawSettingsWrite():
+            return _qualifiers_per_pool_frozen_detail(
+                stored.draw_type, stored.qualifiers_per_pool
+            )
+        case SwissDrawSettingsWrite():
+            return _rounds_frozen_detail(stored.rounds)
+        case RoundRobinDrawSettingsWrite() | SingleElimDrawSettingsWrite():
+            # Unreachable: these arms carry no setting, so an incoming arm of the same
+            # draw type is EQUAL to the stored one and the caller has already returned.
+            # Answered with the draw type's own sentence rather than an ``assert``,
+            # because the honest fallback for "the configuration moved" is to name the
+            # configuration.
+            return _draw_type_frozen_detail(stored.draw_type)
+
+
 async def _enforce_pool_set_frozen(
     db: AsyncSession, event: TournamentEvent, updates: TournamentEventUpdate
 ) -> None:
@@ -408,7 +453,7 @@ async def _enforce_draw_settings_frozen(
     detail = (
         _draw_type_frozen_detail(current)
         if incoming.draw_type is not current
-        else _qualifiers_per_pool_frozen_detail(current, stored.qualifiers_per_pool)
+        else _draw_settings_frozen_detail(stored)
     )
     raise DrawTypeFrozenError(detail, draw_type=current.value)
 
@@ -589,6 +634,10 @@ async def update_event(
     # them leaves the loop below touching mapped columns only.
     changes.pop("draw_type", None)
     changes.pop("qualifiers_per_pool", None)
+    # The swiss round count is the same kind of key for the same reason: it lives in the
+    # settings row's JSON object, not on the event, so the loop would bind an unmapped
+    # attribute and drop the edit silently.
+    changes.pop("rounds", None)
     # Pools are rows, so they are taken OUT of the generic setattr loop entirely and
     # applied as a diff (:func:`app.tournament_pools.apply_event_pools`) — assigning the
     # dumped payload would put dicts where the relationship expects

--- a/api/app/tournament_lifecycle.py
+++ b/api/app/tournament_lifecycle.py
@@ -356,9 +356,10 @@ async def _enforce_ready_to_go_live(db: AsyncSession, tournament: Tournament) ->
         raise TournamentNotReadyToGoLiveError(
             _NOTHING_TO_START, uncut=[], stale=[], no_events=True
         )
-    # ONE batched read for the whole tournament (two statements, whatever the number
-    # of events): this runs with the row lock held, and a per-event query would hold
-    # it for a time that grows with the tournament.
+    # ONE batched read for the whole tournament (three statements, whatever the number
+    # of events — entries, fixtures, and the draw types the bye allowance turns on):
+    # this runs with the row lock held, and a per-event query would hold it for a time
+    # that grows with the tournament.
     currency = await draw_currency_by_event(db, [event_id for event_id, _ in events])
     uncut: list[str] = []
     stale: list[str] = []

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -29,6 +29,7 @@ from app.results import (
     BracketFinishes,
     BracketFixture,
     EventResults,
+    FieldInput,
     FinishRow,
     MatchOutcome,
     PoolInput,
@@ -36,7 +37,10 @@ from app.results import (
     RoundRobinResults,
     RrThenKoResults,
     SingleElimResults,
+    StandingRow,
     StandingsThenFinishes,
+    SwissResults,
+    SwissStandings,
     results_for,
 )
 from app.schemas.tournament import (
@@ -53,6 +57,7 @@ from app.schemas.tournament import (
     StandingRowRead,
     StandingsResultsRead,
     StandingsThenFinishesResultsRead,
+    SwissStandingsResultsRead,
     TournamentDetailRead,
     TournamentEntrantRead,
     TournamentEventRead,
@@ -212,6 +217,7 @@ def _entry_state(
 def event_results(
     e: TournamentEvent,
     *,
+    entrants: Sequence[TournamentEntrantRead],
     fixtures: list[TournamentFixtureRead],
     game_counts: dict[uuid.UUID, tuple[int, int]],
 ) -> EventResultsRead | None:
@@ -219,7 +225,15 @@ def event_results(
     when there are none to compute — a **discriminated union tagged by shape**
     (ADR-0785): ``kind: "standings"`` for a round-robin (ADR-0788), ``kind: "finishes"``
     for a single-elimination bracket, ``kind: "standings_then_finishes"`` for a
-    round-robin-then-knockout event, which carries one block per stage (ADR 20260727).
+    round-robin-then-knockout event, which carries one block per stage (ADR 20260727),
+    and ``kind: "swiss_standings"`` for a swiss event's one pool-less table.
+
+    ``entrants`` is the event's **active** field, and only the pool-less swiss shape
+    reads it: a pool's membership is defined by its own fixtures, but a swiss entrant
+    with a **bye** has no fixture that round at all (a bye is the absence of a row,
+    ADR-0786), so a field derived from fixtures alone would drop them from the table
+    they belong at the top of. The pooled shapes are deliberately left fixture-derived,
+    unchanged.
 
     ``None`` in exactly one case, meaning "no results here" rather than an empty table:
     an event whose draw has not been cut (no fixtures to stand). There used to be a
@@ -262,6 +276,12 @@ def event_results(
                         [f for f in fixtures if f.pool_id is None], game_counts
                     ),
                 )
+            )
+        case SwissResults():
+            # One table over the whole field: swiss is pool-less, so there is no
+            # grouping to do and every fixture in the event feeds the same input.
+            return _serialize_swiss_standings(
+                strategy.tabulate(_field_input(entrants, fixtures, game_counts))
             )
         case _:
             assert_never(strategy)
@@ -311,6 +331,51 @@ def _pool_inputs(
     return pool_inputs
 
 
+def _field_input(
+    entrants: Sequence[TournamentEntrantRead],
+    fixtures: list[TournamentFixtureRead],
+    game_counts: dict[uuid.UUID, tuple[int, int]],
+) -> FieldInput:
+    """The whole field as one standings input — the swiss projection of
+    :func:`_pool_inputs`, with nothing to group by.
+
+    The field is the event's **active entrants**, not the entries its fixtures seat.
+    That difference is the whole reason this takes an argument :func:`_pool_inputs` does
+    not: a swiss entrant with a **bye** has no fixture that round (a bye is the absence
+    of a row, ADR-0786), and every later round is cut with both sides unknown, so a
+    seven-player draw derived from fixtures alone would stand a six-player table.
+
+    The entries seated in fixtures are **unioned in** rather than assumed to be a
+    subset. A player who withdraws after the draw is cut leaves the active list while
+    their played fixtures stay, and :func:`~app.pool_finishing_order.finishing_order`
+    indexes its tallies by entrant — so dropping them would be a ``KeyError`` on the
+    first outcome that names them, on the detail page of any event that had a
+    withdrawal.
+
+    A round nobody has been paired into yet is still **counted**: it can very much still
+    yield a result. Only a **voided** pairing is left out of the count, exactly as it is
+    for a pool — it never will produce one, and counting it would hold the event one
+    outcome short of complete forever."""
+    field = {EntryId(entrant.id) for entrant in entrants} | {
+        EntryId(entry_id)
+        for f in fixtures
+        for entry_id in (f.entry_a_id, f.entry_b_id)
+        if entry_id is not None
+    }
+    outcomes = [
+        outcome
+        for outcome in (_fixture_outcome(f, game_counts) for f in fixtures)
+        if outcome is not None
+    ]
+    return FieldInput(
+        entrants=tuple(field),
+        fixture_count=sum(
+            1 for f in fixtures if f.match_status is not MatchStatus.voided
+        ),
+        outcomes=tuple(outcomes),
+    )
+
+
 def _bracket_fixtures(
     fixtures: list[TournamentFixtureRead],
     game_counts: dict[uuid.UUID, tuple[int, int]],
@@ -358,21 +423,27 @@ def _pool_standings_read(pools: Sequence[PoolStandings]) -> list[PoolStandingsRe
     return [
         PoolStandingsRead(
             pool_id=pool.pool_id,
-            rows=[
-                StandingRowRead(
-                    entry_id=row.entry_id,
-                    rank=row.rank,
-                    played=row.played,
-                    wins=row.wins,
-                    losses=row.losses,
-                    games_won=row.games_won,
-                    games_lost=row.games_lost,
-                )
-                for row in pool.rows
-            ],
+            rows=_standing_rows_read(pool.rows),
             complete=pool.complete,
         )
         for pool in pools
+    ]
+
+
+def _standing_rows_read(rows: Sequence[StandingRow]) -> list[StandingRowRead]:
+    """One standings table's rows, shared by every shape that carries a table — a pool's
+    and a swiss field's — so a row means the same thing on either."""
+    return [
+        StandingRowRead(
+            entry_id=row.entry_id,
+            rank=row.rank,
+            played=row.played,
+            wins=row.wins,
+            losses=row.losses,
+            games_won=row.games_won,
+            games_lost=row.games_lost,
+        )
+        for row in rows
     ]
 
 
@@ -400,6 +471,17 @@ def _serialize_standings(results: EventResults) -> StandingsResultsRead:
 def _serialize_finishes(results: BracketFinishes) -> FinishesResultsRead:
     return FinishesResultsRead(
         finishes=_finish_rows_read(results.finishes),
+        complete=results.complete,
+        champion=results.champion,
+    )
+
+
+def _serialize_swiss_standings(results: SwissStandings) -> SwissStandingsResultsRead:
+    """The swiss table, whose rows are serialized by the same helper a pool's are — so
+    "a swiss event's standings rows cross the wire exactly as a round-robin pool's do"
+    is true structurally rather than by two serializers agreeing."""
+    return SwissStandingsResultsRead(
+        rows=_standing_rows_read(results.rows),
         complete=results.complete,
         champion=results.champion,
     )
@@ -473,6 +555,10 @@ def serialize_event(
             # exactly as before: the settings object is a storage shape, not a wire one
             # (ADR "a draw type's settings are one NOT NULL JSON object").
             "qualifiers_per_pool": draw_settings.qualifiers_per_pool,
+            # And **R**, the swiss round count, off the same parsed arm and by the same
+            # rule: a property on the arms that have no round count, so this line asks
+            # every arm one question rather than deciding which draw types have one.
+            "rounds": draw_settings.rounds,
             "max_players": e.max_players,
             "entry_fee": e.entry_fee,
             # The event's venue timezone anchors its wall-clock ``Slot`` windows to
@@ -506,7 +592,12 @@ def serialize_event(
             "results": (
                 None
                 if game_counts is None
-                else event_results(e, fixtures=fixtures, game_counts=game_counts)
+                else event_results(
+                    e,
+                    entrants=entrants,
+                    fixtures=fixtures,
+                    game_counts=game_counts,
+                )
             ),
         }
     )

--- a/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
+++ b/api/migrations/versions/20260617_0000_0010_create_tournaments_table.py
@@ -91,6 +91,19 @@ DRAW_TYPE_SEED = [
         "knockout bracket.",
         3,
     ),
+    (
+        "swiss",
+        # The director-facing copy is pinned by the ADR "swiss pre-cuts every
+        # round and pairs each one on advance" — it is seed data, so changing
+        # either string is a migration.
+        "Swiss",
+        "A fixed number of rounds, each pairing entrants who are on similar "
+        "scores. Nobody is eliminated and everybody plays every round, so a "
+        "large field is ranked in far fewer matches than a round robin — but a "
+        "round's pairings are only known once the round before it has finished, "
+        "and a long event may repeat a pairing.",
+        4,
+    ),
 ]
 
 

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -153,28 +153,31 @@ def venue_tables(*specs: tuple[str, str]) -> list[VenueTable]:
 
 
 def event_draw_settings(
-    draw_type: DrawType, *, qualifiers_per_pool: int | None = None
+    draw_type: DrawType,
+    *,
+    qualifiers_per_pool: int | None = None,
+    rounds: int | None = None,
 ) -> TournamentEventDrawSettings:
     """The draw-settings row for an event a test seeds straight through the ORM, built
-    from the ``(draw_type, qualifiers_per_pool)`` pair the tests already speak.
+    from the draw type and whichever setting that draw type carries — the qualifier
+    count for ``rr-then-ko``, the round count for ``swiss``.
 
-    The qualifier count is not a column any more — it is a key inside the row's
-    ``settings`` JSON object (ADR "a draw type's settings are one NOT NULL JSON
-    object") — so this is the one translation from the pair to the stored shape, and it
-    goes through the same parse and the same writer the request boundary uses. Which
-    means a seed that names a count for a draw type with no knockout stage reds here
-    with a ``ValidationError``, rather than writing a row the app could not have made.
+    Neither is a column any more — both are keys inside the row's ``settings`` JSON
+    object (ADR "a draw type's settings are one NOT NULL JSON object") — so this is the
+    one translation from the values the tests speak to the stored shape, and it goes
+    through the same parse and the same writer the request boundary uses. Which means a
+    seed that names a count for a draw type that has no such setting (or omits one a
+    draw type requires) reds here with a ``ValidationError``, rather than writing a row
+    the app could not have made.
 
-    ``None`` is "this draw type takes no configuration", and it stores ``{}``.
+    Both ``None`` is "this draw type takes no configuration", and it stores ``{}``.
     """
-    return draw_settings_row(
-        draw_settings_from_storage(
-            draw_type,
-            {}
-            if qualifiers_per_pool is None
-            else {"qualifiers_per_pool": qualifiers_per_pool},
-        )
-    )
+    settings: dict[str, int] = {}
+    if qualifiers_per_pool is not None:
+        settings["qualifiers_per_pool"] = qualifiers_per_pool
+    if rounds is not None:
+        settings["rounds"] = rounds
+    return draw_settings_row(draw_settings_from_storage(draw_type, settings))
 
 
 def event_pools(

--- a/api/tests/test_dashboard_tournaments.py
+++ b/api/tests/test_dashboard_tournaments.py
@@ -830,6 +830,86 @@ async def test_panel_statement_count_does_not_grow_with_events(
         ), (event.name, event.match.round_label)
 
 
+async def test_a_swiss_panel_reads_the_callers_rank_off_the_pool_less_table(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A swiss event's results are one table over the whole field, with no pool to key
+    it by — so the panel has to read that shape, or a swiss player is shown no rank at
+    all while the table carrying their row rides along on the same payload.
+
+    Driven end to end over the smallest event that can finish: **two** players and one
+    round. One pairing, and the caller wins it — which makes their rank a fact of the
+    result rather than of a tiebreak. A four-player round would leave two winners level
+    on wins who never met, separated by the entry-id fallback, so the test would pass or
+    fail on which uuid the database minted. ``position`` comes off the standings row
+    (counting the caller's own fixtures cannot produce a rank at all), and
+    ``stage_label`` reads the event's own completeness rather than a pool's, because
+    swiss has no pool whose flag could stand in.
+
+    An **odd** field is deliberately not the subject: its byed entrant is seated in no
+    fixture, so ``draw_currency_by_event`` reads the draw as stale and go-live refuses
+    it (409) — the bye lands with the pairing, in its own slice.
+    """
+    client, owner = authed_client
+    async with opponent_session(db_session, "swiss-panel-2") as (client_2, user_2):
+        tournament_id, (event,) = await _tournament_with_events(
+            client,
+            _event_payload(
+                draw_type="swiss",
+                rounds=1,
+                pools=[],
+                match_settings={"rated": False, "length_games": 3},
+                predicates=[],
+            ),
+        )
+        base = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+        entries = [
+            await _enter(
+                db_session,
+                event["id"],
+                user,
+                seed=seed,
+                created_at=base + timedelta(minutes=seed),
+            )
+            for seed, user in ((1, owner), (2, user_2))
+        ]
+        await _cut_the_draw(client, tournament_id, event["id"])
+        await _set_status(db_session, tournament_id, TournamentStatus.published)
+        assert (await _go_live(client, tournament_id)).status_code == 201
+        clients = dict(
+            zip(
+                [entry.id for entry in entries],
+                [client, client_2],
+                strict=True,
+            )
+        )
+
+        fixtures = await _fixture_rows(db_session, event["id"])
+        await _call_fixtures(db_session, tournament_id, fixtures)
+        fixtures = await _fixture_rows(db_session, event["id"])
+        # One round of a two-player field is one fixture, and the caller is seed 1.
+        (fixture,) = fixtures
+        assert fixture.entry_a_id is not None
+        await _win_fixture_match(
+            fixture,
+            clients_by_entry=clients,
+            winner_entry_id=fixture.entry_a_id,
+            rated=False,
+        )
+
+        (panel,) = await _panels(client)
+
+    (swiss_event,) = panel["events"]
+    assert swiss_event["draw_type"] == "swiss"
+    assert swiss_event["position"] == 1, "the caller won the only match, so they lead"
+    assert (swiss_event["wins"], swiss_event["losses"]) == (1, 0)
+    assert swiss_event["stage_label"] == "Complete", (
+        "the only round is decided, so the event is over — and swiss has no pool whose "
+        "completeness could have answered this instead"
+    )
+
+
 async def test_an_rr_then_ko_panel_names_the_stage_each_fixture_is_in(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -36,6 +36,7 @@ from app.draws import (
     Side,
     SideFill,
     SingleElimStrategy,
+    SwissStrategy,
     order_entrants,
     qualifier_seed_assignment,
     reads_fixture_games,
@@ -48,6 +49,7 @@ from app.schemas.tournament import (
     RoundRobinDrawSettingsWrite,
     RrThenKoDrawSettingsWrite,
     SingleElimDrawSettingsWrite,
+    SwissDrawSettingsWrite,
     draw_settings_from_storage,
 )
 
@@ -63,10 +65,11 @@ def _settings(draw_type: DrawType) -> DrawSettingsWriteArm:
     needs a setting this helper does not supply reds here with a ``ValidationError``
     rather than resolving to a strategy configured by omission.
     """
-    return draw_settings_from_storage(
-        draw_type,
-        {"qualifiers_per_pool": 2} if draw_type is DrawType.rr_then_ko else {},
-    )
+    required: dict[DrawType, dict[str, int]] = {
+        DrawType.rr_then_ko: {"qualifiers_per_pool": 2},
+        DrawType.swiss: {"rounds": 3},
+    }
+    return draw_settings_from_storage(draw_type, required.get(draw_type, {}))
 
 
 def _entry_id(n: int) -> EntryId:
@@ -261,6 +264,23 @@ class TestStrategyRegistry:
             SingleElimStrategy,
         )
 
+    def test_swiss_resolves_to_the_configured_swiss_strategy(self) -> None:
+        """The fourth arm (ADR "swiss pre-cuts every round and pairs each one on
+        advance") — configured, like rr-then-ko's: the round count is not a detail of
+        the dispatch, it is the number of rounds the cut writes, so it is asserted to
+        have arrived rather than merely to have been accepted."""
+        strategy = strategy_for(SwissDrawSettingsWrite(rounds=5))
+
+        assert strategy == SwissStrategy(rounds=5)
+
+    def test_a_swiss_arm_cannot_be_built_without_a_round_count(self) -> None:
+        """A swiss configuration with no round count is not a value ``strategy_for`` can
+        be handed: ``rounds`` is required on the arm, with no default, so the refusal is
+        at the boundary where the arm is built rather than a strategy configured by
+        omission (ADR: "``R`` is a required, explicit setting")."""
+        with pytest.raises(ValidationError, match="rounds"):
+            SwissDrawSettingsWrite()  # type: ignore[call-arg]  # the point of the test
+
     def test_rr_then_ko_resolves_to_the_configured_rr_then_ko_strategy(self) -> None:
         """The third arm (ADR 20260727) — and the first whose strategy is *configured*:
         the qualifier count is not a detail of the dispatch, it is what the strategy
@@ -317,6 +337,9 @@ class TestStrategyRegistry:
             DrawType.round_robin: False,
             DrawType.single_elim: False,
             DrawType.rr_then_ko: True,
+            # Swiss pairs each round off the standings, whose chain counts games
+            # (Buchholz, then game difference), so it declares the games it will read.
+            DrawType.swiss: True,
         }
 
     def test_a_draw_type_the_gate_clears_advances_the_same_without_its_games(
@@ -2022,3 +2045,212 @@ class TestRrThenKoAdvance:
             _rr_then_ko(2).advance(fixtures)
 
         assert "5 decided pool fixtures" in str(excinfo.value)
+
+
+class TestSwissCut:
+    """The cut pre-writes **every** round: ``R × ⌊n/2⌋`` fixtures, round 1 seeded from
+    the draw order and every later round left with both sides TBD (ADR "swiss pre-cuts
+    every round and pairs each one on advance")."""
+
+    @pytest.mark.parametrize(
+        ("entrants", "rounds", "per_round"),
+        [
+            (8, 3, 4),
+            (7, 3, 3),  # odd: one entrant sits out, so ⌊7/2⌋ = 3 pairings a round
+            (6, 5, 3),  # R = n − 1, the most rounds this field can carry
+            (2, 1, 1),
+            (9, 4, 4),
+        ],
+        ids=["n=8,R=3", "n=7,R=3", "n=6,R=5", "n=2,R=1", "n=9,R=4"],
+    )
+    def test_every_round_is_cut_with_floor_n_over_two_fixtures(
+        self, entrants: int, rounds: int, per_round: int
+    ) -> None:
+        """The count is the whole claim of the pre-cut: ``R`` rounds exist the moment
+        the draw does, each holding ⌊n/2⌋ pairings — the odd entrant's absence, not a
+        row with a NULL side, is what an odd field costs."""
+        fixtures = SwissStrategy(rounds=rounds).plan_initial(
+            DrawConfig(), _ordered(entrants)
+        )
+
+        assert len(fixtures) == rounds * per_round
+        assert Counter(f.round for f in fixtures) == {
+            round_number: per_round for round_number in range(1, rounds + 1)
+        }
+
+    def test_round_one_pairs_the_top_half_against_the_bottom_half(self) -> None:
+        """Round 1 is seeded from the draw order: with eight entrants seed 1 meets seed
+        5, 2 meets 6, and so on — the top seed drawn against the best of the bottom
+        half, which is what "seeded from the draw order" buys over pairing 1 with 2."""
+        fixtures = SwissStrategy(rounds=3).plan_initial(DrawConfig(), _ordered(8))
+
+        round_one = sorted(
+            (f for f in fixtures if f.round == 1), key=lambda f: f.position
+        )
+        assert [
+            (f.position, _seed_of(f.entry_a_id), _seed_of(f.entry_b_id))
+            for f in round_one
+        ] == [(1, 1, 5), (2, 2, 6), (3, 3, 7), (4, 4, 8)]
+
+    def test_an_odd_field_byes_the_lowest_ranked_entrant_by_absence(self) -> None:
+        """Seven entrants: three pairings, and seed 7 has no round-1 fixture at all.
+
+        A bye is the *absence* of a row (ADR-0786), never a row with one side NULL —
+        which here would be indistinguishable from a later round waiting to be paired.
+        The lowest-ranked entrant takes it, which is the swiss rule (CONTEXT.md, "Bye")
+        applied to a first round in which nobody has a score yet."""
+        fixtures = SwissStrategy(rounds=3).plan_initial(DrawConfig(), _ordered(7))
+
+        round_one = [f for f in fixtures if f.round == 1]
+        assert len(round_one) == 3
+        seated = {
+            seed
+            for f in round_one
+            for seed in (_seed_of(f.entry_a_id), _seed_of(f.entry_b_id))
+        }
+        assert seated == {1, 2, 3, 4, 5, 6}
+
+    def test_every_later_round_is_written_with_both_sides_unknown(self) -> None:
+        """Rounds 2..R exist as rows with no players: ``advance()`` fills them once the
+        round before is decided, exactly as it fills a single-elim bracket's later
+        rounds."""
+        fixtures = SwissStrategy(rounds=4).plan_initial(DrawConfig(), _ordered(8))
+
+        later = [f for f in fixtures if f.round > 1]
+        assert len(later) == 12
+        assert all(f.entry_a_id is None and f.entry_b_id is None for f in later)
+
+    def test_positions_are_contiguous_within_each_round_and_unpooled(self) -> None:
+        """``(round, position)`` is a fixture's identity — the uniqueness constraint is
+        ``(event_id, pool_id, round, position)`` — so positions run 1..⌊n/2⌋ inside each
+        round with no gaps. Every fixture is un-pooled: swiss ranks one field in one
+        table, which is why the schedule preview refuses it."""
+        fixtures = SwissStrategy(rounds=3).plan_initial(DrawConfig(), _ordered(9))
+
+        by_round: dict[int, list[int]] = {}
+        for f in fixtures:
+            by_round.setdefault(f.round, []).append(f.position)
+        assert by_round == {1: [1, 2, 3, 4], 2: [1, 2, 3, 4], 3: [1, 2, 3, 4]}
+        assert all(f.pool_id is None for f in fixtures)
+
+    def test_a_draw_ignores_the_events_pools(self) -> None:
+        """Swiss is pool-less whatever the event's pool list says: a director who
+        configured pools and then chose swiss gets one un-pooled field, not a draw
+        dealt across them."""
+        fixtures = SwissStrategy(rounds=2).plan_initial(_config(2), _ordered(6))
+
+        assert all(f.pool_id is None for f in fixtures)
+        assert len(fixtures) == 6
+
+    def test_more_rounds_than_distinct_opponents_is_refused(self) -> None:
+        """``R > n − 1`` is a :class:`DegenerateDraw` at the CUT: with five entrants
+        nobody has more than four distinct opponents, so a rematch-free swiss of nine
+        rounds does not exist. Refused here rather than at configure time because ``n``
+        is not known when the setting is written — and the message names both numbers,
+        because it is director-facing copy the endpoint passes straight through."""
+        with pytest.raises(DegenerateDraw) as refusal:
+            SwissStrategy(rounds=9).plan_initial(DrawConfig(), _ordered(5))
+
+        message = str(refusal.value)
+        assert "9 rounds" in message
+        assert "4 opponents" in message
+        assert "5 entrants" in message
+
+    def test_the_refusal_inflects_its_nouns_for_the_smallest_field(self) -> None:
+        """Two entrants have exactly **one** opponent each, so the sentence is the one
+        shape where both nouns are singular. Director-facing copy is passed through to
+        the director verbatim, and "the 1 opponents" reads as a bug in the product."""
+        with pytest.raises(DegenerateDraw) as refusal:
+            SwissStrategy(rounds=2).plan_initial(DrawConfig(), _ordered(2))
+
+        assert str(refusal.value) == (
+            "2 rounds is more than the 1 opponent each of 2 entrants can have — play "
+            "fewer rounds, or add entrants."
+        )
+
+    def test_exactly_n_minus_one_rounds_is_allowed(self) -> None:
+        """The boundary is inclusive on the legal side: five entrants can play four
+        rounds, which is every distinct opponent one of them has. A cut refused here
+        would refuse the fullest swiss a field can play."""
+        fixtures = SwissStrategy(rounds=4).plan_initial(DrawConfig(), _ordered(5))
+
+        assert len(fixtures) == 8  # 4 rounds × ⌊5/2⌋
+
+    def test_a_field_of_one_is_refused(self) -> None:
+        """Mirrors single-elim's floor: a swiss of one has nobody to play, and the
+        entrant-count refusal has to be said before the round-count one so the message
+        names the real problem."""
+        with pytest.raises(DegenerateDraw, match="at least 2 entrants"):
+            SwissStrategy(rounds=1).plan_initial(DrawConfig(), _ordered(1))
+
+    def test_a_round_count_below_one_is_a_programmer_error(self) -> None:
+        """``R >= 1`` is static — a Pydantic constraint at the request boundary — so a
+        strategy constructed below it is a wiring bug, not a director's mistake, and is
+        a ``ValueError`` rather than a ``DegenerateDraw``."""
+        with pytest.raises(ValueError, match="rounds must be at least 1"):
+            SwissStrategy(rounds=0)
+
+
+class TestSwissAdvance:
+    """Round 1 was paired at the cut, so all ``advance`` has to report today is
+    readiness. Pairing rounds 2..R off the standings is its own slice, and its absence
+    is asserted here rather than stubbed."""
+
+    def _cut(self, *, rounds: int = 3, entrants: int = 8) -> list[FixtureState]:
+        return _persisted(
+            SwissStrategy(rounds=rounds).plan_initial(DrawConfig(), _ordered(entrants))
+        )
+
+    def test_a_freshly_cut_draw_is_ready_in_round_one_only_and_fills_nothing(
+        self,
+    ) -> None:
+        fixtures = self._cut()
+
+        plan = SwissStrategy(rounds=3).advance(fixtures)
+
+        assert plan.side_fills == ()
+        assert set(plan.ready_fixture_ids) == {
+            f.fixture_id for f in fixtures if f.round == 1
+        }
+        assert not plan.is_empty
+
+    def test_a_materialized_round_one_leaves_an_empty_plan(self) -> None:
+        """Idempotence: apply the plan (the fixtures now carry matches) and re-running
+        it proposes nothing — the later rounds are still pending, so they are not
+        ready, and round 1 is no longer."""
+        fixtures = [
+            dataclasses.replace(f, match_id=MatchId(uuid.UUID(int=4000 + i)))
+            if f.round == 1
+            else f
+            for i, f in enumerate(self._cut())
+        ]
+
+        plan = SwissStrategy(rounds=3).advance(fixtures)
+
+        assert plan.is_empty
+
+    def test_a_decided_round_one_pairs_nothing_yet(self) -> None:
+        """**The honest limit of this slice.** Round 1 played out in full still fills no
+        side of round 2: pairing by standings is the next chore, and a stub that seated
+        somebody here would be writing pairings nothing computed.
+
+        It is asserted rather than left unsaid so that the chore landing the pairing has
+        a test to *change*, and so nothing quietly reports a round ready that has no
+        players in it."""
+        played = _played(
+            self._cut(),
+            {
+                frozenset({1, 5}): (1, 3, 0),
+                frozenset({2, 6}): (2, 3, 1),
+                frozenset({3, 7}): (7, 3, 2),
+                frozenset({4, 8}): (4, 3, 0),
+            },
+        )
+
+        plan = SwissStrategy(rounds=3).advance(played)
+
+        assert plan.side_fills == ()
+        assert plan.ready_fixture_ids == ()
+        assert all(
+            f.entry_a_id is None and f.entry_b_id is None for f in played if f.round > 1
+        )

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -42,6 +42,7 @@ from app.draws import (
     reads_fixture_games,
     ready_fixtures,
     strategy_for,
+    unseated_entrant_allowance,
 )
 from app.models.tournament import DrawType
 from app.schemas.tournament import (
@@ -341,6 +342,57 @@ class TestStrategyRegistry:
             # (Buchholz, then game difference), so it declares the games it will read.
             DrawType.swiss: True,
         }
+
+    @pytest.mark.parametrize("field_size", [6, 7])
+    def test_the_bye_allowance_names_every_draw_type_and_only_swiss_byes_absently(
+        self, field_size: int
+    ) -> None:
+        """``unseated_entrant_allowance`` is what lets a draw's currency tell a **byed**
+        entrant from one who entered after the cut.
+
+        A whole-enum equality at both parities, so a new ``DrawType`` reds here as well
+        as failing to type-check in the catch-all-free ``match``. The three zeros are
+        not "these formats have no byes" — an odd round-robin pool byes somebody every
+        round — they are "their byed entrants are seated in some *other* fixture", which
+        is what makes the strict comparison right for them and wrong for swiss.
+        """
+        assert {
+            draw_type: unseated_entrant_allowance(draw_type, field_size)
+            for draw_type in DrawType
+        } == {
+            DrawType.round_robin: 0,
+            DrawType.single_elim: 0,
+            DrawType.rr_then_ko: 0,
+            # A swiss round seats ⌊n/2⌋ pairs, so an odd field leaves exactly one
+            # entrant in no fixture at all.
+            DrawType.swiss: field_size % 2,
+        }
+
+    def test_the_bye_allowance_matches_what_the_swiss_cut_actually_leaves_unseated(
+        self,
+    ) -> None:
+        """And the allowance is *true of the strategy*, not merely asserted about it:
+        for each field size, the entrants the cut leaves in no fixture are counted off
+        the fixtures it emits.
+
+        This is the falsifiable half. A cut that started seating its byed entrant (or a
+        parity slip in either direction) would part company with the allowance here,
+        rather than in a go-live 409 three layers away.
+        """
+        for field_size in range(2, 10):
+            ordered = _ordered(field_size)
+            fixtures = SwissStrategy(rounds=1).plan_initial(DrawConfig(), ordered)
+            seated = {
+                entry_id
+                for f in fixtures
+                for entry_id in (f.entry_a_id, f.entry_b_id)
+                if entry_id is not None
+            }
+            unseated = {entrant.entry_id for entrant in ordered} - seated
+
+            assert len(unseated) == unseated_entrant_allowance(
+                DrawType.swiss, field_size
+            ), f"field of {field_size}"
 
     def test_a_draw_type_the_gate_clears_advances_the_same_without_its_games(
         self,

--- a/api/tests/test_results.py
+++ b/api/tests/test_results.py
@@ -15,11 +15,13 @@ from app.draws import EntryId, PoolId
 from app.models.tournament import DrawType
 from app.results import (
     BracketFixture,
+    FieldInput,
     MatchOutcome,
     PoolInput,
     RoundRobinResults,
     RrThenKoResults,
     SingleElimResults,
+    SwissResults,
     results_for,
 )
 
@@ -88,6 +90,87 @@ def test_results_for_returns_the_single_elim_strategy() -> None:
 def test_results_for_returns_the_rr_then_ko_strategy() -> None:
     """The third arm (ADR 20260727) — a two-stage event reads out as both blocks."""
     assert isinstance(results_for(DrawType.rr_then_ko), RrThenKoResults)
+
+
+def test_results_for_returns_the_swiss_strategy() -> None:
+    """The fourth arm (ADR "swiss pre-cuts every round and pairs each one on
+    advance") — a pool-less event reads out as one table over the whole field."""
+    assert isinstance(results_for(DrawType.swiss), SwissResults)
+
+
+def test_a_swiss_field_stands_in_one_table_ordered_by_the_shared_chain() -> None:
+    """Four entrants over two rounds, no pools: A wins both, B wins one, C wins one, D
+    wins none. The table is one list, ordered by the same chain a pool is ordered by —
+    wins first, then (B before C) the head-to-head they played.
+
+    Buchholz is deliberately NOT part of this ordering yet (ADR "swiss standings add
+    Buchholz"): this slice reads out through the chain that exists rather than a
+    swiss-shaped approximation of the one that does not.
+    """
+    field = FieldInput(
+        entrants=(A, B, C, D),
+        fixture_count=4,
+        outcomes=(
+            _outcome(A, C, 3, 0),
+            _outcome(B, D, 3, 1),
+            _outcome(A, B, 3, 2),
+            _outcome(C, D, 3, 1),
+        ),
+    )
+
+    standings = SwissResults().tabulate(field)
+
+    assert [(row.entry_id, row.wins, row.losses) for row in standings.rows] == [
+        (A, 2, 0),
+        (B, 1, 1),
+        (C, 1, 1),
+        (D, 0, 2),
+    ]
+    assert [row.rank for row in standings.rows] == [1, 2, 3, 4]
+
+
+def test_a_swiss_event_is_complete_and_crowned_when_every_round_is_decided() -> None:
+    """A swiss ranks the whole field, so its complete table's top row is the champion —
+    no single-pool carve-out, because there are no pools to have more than one of."""
+    field = FieldInput(
+        entrants=(A, B),
+        fixture_count=1,
+        outcomes=(_outcome(A, B, 3, 1),),
+    )
+
+    standings = SwissResults().tabulate(field)
+
+    assert standings.complete
+    assert standings.champion == A
+
+
+def test_a_swiss_event_with_rounds_left_is_live_and_uncrowned() -> None:
+    """The later rounds are cut up front with their sides unknown, so they *count*
+    toward completeness: a draw one round in is a live table, not a finished one, and
+    an entrant who has not played yet is on it with a row of zeros."""
+    field = FieldInput(
+        entrants=(A, B, C, D),
+        fixture_count=4,  # two rounds of two, only the first round played
+        outcomes=(_outcome(A, B, 3, 0), _outcome(C, D, 3, 2)),
+    )
+
+    standings = SwissResults().tabulate(field)
+
+    assert not standings.complete
+    assert standings.champion is None
+    assert {row.entry_id for row in standings.rows} == {A, B, C, D}
+
+
+def test_an_uncut_swiss_event_is_not_complete() -> None:
+    """``0 == 0`` must not read as finished: an event with no fixture that can still
+    yield a result has not been played, it has not been cut."""
+    standings = SwissResults().tabulate(
+        FieldInput(entrants=(), fixture_count=0, outcomes=())
+    )
+
+    assert not standings.complete
+    assert standings.champion is None
+    assert standings.rows == ()
 
 
 def test_every_draw_type_reads_out_and_none_refuses() -> None:

--- a/api/tests/test_schedule_preview_snapshot.py
+++ b/api/tests/test_schedule_preview_snapshot.py
@@ -96,6 +96,7 @@ async def _add_event(
     *,
     draw_type: DrawType = DrawType.round_robin,
     qualifiers_per_pool: int | None = None,
+    rounds: int | None = None,
     max_players: int | None = 6,
     pools: list[dict[str, object]] | None = None,
     length_games: int = 5,
@@ -107,7 +108,7 @@ async def _add_event(
         name=name,
         format=EventFormat.singles,
         draw_settings=event_draw_settings(
-            draw_type, qualifiers_per_pool=qualifiers_per_pool
+            draw_type, qualifiers_per_pool=qualifiers_per_pool, rounds=rounds
         ),
         max_players=max_players,
         entry_fee=Decimal("0"),
@@ -408,21 +409,30 @@ async def test_preview_snapshot_count_override_resizes_field(
 
 @pytest.mark.parametrize(
     "draw_type",
-    # Single-elim is the whole live subject now the enum holds only draw types that
-    # run (ADR "a draw type is a seeded row, …"): it *can* be cut (#785), but the
-    # CP-SAT table scheduler is pool-based and a pool-less bracket has no windows to
-    # solve over, so the preview must refuse it rather than invent a grid. The old
-    # double-elim / swiss subjects are no longer enum members, and ``rr-then-ko`` is
+    # The two POOL-LESS draw types, which is the whole criterion: both *can* be cut,
+    # but the CP-SAT table scheduler is pool-based and a draw with no pools has no
+    # windows to solve over, so the preview refuses them rather than invent a grid.
+    # Single-elim is the bracket (#785); swiss ranks one field in one table (ADR "swiss
+    # pre-cuts every round and pairs each one on advance"). ``rr-then-ko`` is
     # deliberately NOT here: it has a pool stage that schedules perfectly well, so it
     # is previewed in part rather than refused (see the two tests below).
-    [DrawType.single_elim],
+    [DrawType.single_elim, DrawType.swiss],
 )
 async def test_preview_snapshot_unsupported_draw_raises(
     db_session: AsyncSession, default_league: League, draw_type: DrawType
 ) -> None:
     owner = await make_user(db_session, f"prev-unsup-{draw_type.value}")
     tournament = await _make_tournament(db_session, owner=owner, league=default_league)
-    await _add_event(db_session, tournament, draw_type=draw_type, max_players=8)
+    await _add_event(
+        db_session,
+        tournament,
+        draw_type=draw_type,
+        # Swiss requires a round count on its settings arm; single-elim carries no
+        # setting at all. The refusal is about neither — it is about the pools these
+        # draw types do not have.
+        rounds=3 if draw_type is DrawType.swiss else None,
+        max_players=8,
+    )
     loaded = await _load(db_session, tournament.id)
 
     with pytest.raises(UnsupportedDrawType):

--- a/api/tests/test_swiss.py
+++ b/api/tests/test_swiss.py
@@ -30,12 +30,18 @@ from app.models import (
     TournamentEntryStatus,
     TournamentEvent,
     TournamentFixture,
+    TournamentStatus,
     User,
 )
 from app.schemas.tournament import MAX_SWISS_ROUNDS
 from app.tournament_draw_settings import draw_settings_of
+from app.tournament_draws import DrawCurrency, draw_currency_by_event
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import grant_permissions, make_user, start_session
+
+# The tournament suite's own lifecycle helpers, imported rather than re-declared so a
+# change to how a tournament is started (or a status is staged) reaches this file too.
+from tests.test_tournaments import _go_live, _set_status, _withdraw
 
 SWISS = DrawType.swiss.value
 
@@ -511,6 +517,146 @@ async def test_the_round_count_is_editable_while_no_draw_exists(
     assert response.json()["rounds"] == 6
     event = await _settings_of(db_session, event_id)
     assert _stored_rounds(event) == 6
+
+
+# ----- draw currency: a byed entrant is covered, a latecomer is not ------------------
+
+
+async def _currency(db: AsyncSession, event_id: str) -> DrawCurrency:
+    """Where this event's draw stands relative to its field — read through the same
+    loader the go-live precondition asks."""
+    event_uuid = uuid.UUID(event_id)
+    db.expire_all()
+    return (await draw_currency_by_event(db, [event_uuid]))[event_uuid]
+
+
+async def test_an_odd_swiss_field_reads_current_and_can_go_live(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """**A bye is not a missing player.** Seven entrants across two rounds means one of
+    them sits out round 1, and a bye is the absence of a fixture row — so the byed
+    entrant is seated in no fixture at all.
+
+    Currency compares the fixtures' seated entries against the active ones, and that
+    comparison read the bye as an entrant the draw had failed to cover: the draw came
+    back ``stale`` and go-live answered 409 for an odd field that had just been cut
+    from exactly those entrants. Nothing a director could do would clear it — re-cutting
+    deals the same bye — so an odd-field swiss event could be configured, entered and
+    cut, and then never start.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, _ = await _field(client, db_session, 7, rounds=2)
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+
+    assert await _currency(db_session, event_id) is DrawCurrency.current
+
+    started = await _go_live(client, tournament_id)
+    assert started.status_code == 201, started.text
+
+
+async def test_a_swiss_draw_is_stale_when_an_entry_lands_after_the_cut(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The check the bye must not blunt: somebody entered after the cut.
+
+    Seven entrants are cut (six seated, one byed) and an eighth arrives. Two of the
+    eight are now seated nowhere, which is one more than a single round's bye can
+    account for — so the draw is stale and the director is told to cut it again, exactly
+    as they would be for a round-robin.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, _ = await _field(client, db_session, 7, rounds=2)
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    await _enter(
+        db_session,
+        event_id,
+        await make_user(db_session, "swiss-latecomer"),
+        seed=8,
+        minutes=8,
+    )
+
+    assert await _currency(db_session, event_id) is DrawCurrency.stale
+
+    refused = await _go_live(client, tournament_id)
+    assert refused.status_code == 409, refused.text
+    assert "no longer matches its entrants" in refused.json()["detail"]
+
+
+async def test_a_swiss_draw_is_stale_when_a_seated_entrant_withdraws(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The other direction, and the one a bye allowance must not swallow: the draw seats
+    somebody who has **left**. An entry the fixtures still name is not covered by "one
+    entrant may be unseated" — it is the opposite complaint, and it stays a 409."""
+    client, _ = authed_client
+    tournament_id, event_id, entries = await _field(client, db_session, 8, rounds=2)
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    await _withdraw(db_session, entries[0])
+
+    assert await _currency(db_session, event_id) is DrawCurrency.stale
+
+    refused = await _go_live(client, tournament_id)
+    assert refused.status_code == 409, refused.text
+
+
+async def test_two_late_entries_exhaust_the_bye_allowance_and_are_stale(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The allowance is **one** entrant, not "swiss stopped checking": eight are cut and
+    two more arrive, so two of the ten are seated nowhere and no single round's bye can
+    account for them."""
+    client, _ = authed_client
+    tournament_id, event_id, _ = await _field(client, db_session, 8, rounds=2)
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    for n in (9, 10):
+        await _enter(
+            db_session,
+            event_id,
+            await make_user(db_session, f"swiss-late-{n}"),
+            seed=n,
+            minutes=n,
+        )
+
+    assert await _currency(db_session, event_id) is DrawCurrency.stale
+    assert (await _go_live(client, tournament_id)).status_code == 409
+
+
+async def test_a_lone_latecomer_leaving_an_odd_field_reads_as_that_rounds_bye(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """**The known limit of the allowance, pinned rather than left to be discovered.**
+
+    Eight entrants are cut and a ninth arrives. That draw holds exactly the rows a draw
+    cut for nine holds — ⌊8/2⌋ and ⌊9/2⌋ are the same four fixtures a round, and the
+    byed entrant of a nine-player cut is recorded nowhere either. So the two states are
+    indistinguishable, and this one reads ``current``: the latecomer is treated as the
+    entrant sitting round 1 out.
+
+    The direction of the error is deliberate. On swiss it costs the newcomer a bye,
+    which the format hands somebody every odd round anyway. It is *not* a licence taken
+    for the other draw types, where an unseated entrant would play no match at all: the
+    test above them still shows a round-robin refusing the identical movement of the
+    field, and ``test_two_late_entries_exhaust_the_bye_allowance_and_are_stale`` shows
+    the allowance stops at one.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, _ = await _field(client, db_session, 8, rounds=2)
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    await _enter(
+        db_session,
+        event_id,
+        await make_user(db_session, "swiss-ninth"),
+        seed=9,
+        minutes=9,
+    )
+
+    assert await _currency(db_session, event_id) is DrawCurrency.current
+    assert (await _go_live(client, tournament_id)).status_code == 201
 
 
 async def test_a_swiss_event_has_no_schedule_preview(

--- a/api/tests/test_swiss.py
+++ b/api/tests/test_swiss.py
@@ -1,0 +1,529 @@
+"""Swiss, end to end as far as this slice goes (#1276, ADR "swiss pre-cuts every round
+and pairs each one on advance").
+
+The strategy itself is pure and is tested from literals in ``test_draws.py``; the
+standings shape is tested the same way in ``test_results.py``. What this file tests is
+everything *between* them and a director: the request boundary that requires a round
+count for exactly one draw type, the settings row it lands on, the wire it reads back
+on, and the cut that writes every round at once.
+
+**What is deliberately absent.** ``advance()`` does not pair rounds 2..R yet — that is
+the next slice — so there is no test here of a decided round producing pairings. The
+absence is asserted in ``test_draws.py`` rather than papered over, because a stub would
+write pairings nothing computed.
+"""
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    DrawType,
+    TournamentEntry,
+    TournamentEntryStatus,
+    TournamentEvent,
+    TournamentFixture,
+    User,
+)
+from app.schemas.tournament import MAX_SWISS_ROUNDS
+from app.tournament_draw_settings import draw_settings_of
+from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
+from tests._helpers import grant_permissions, make_user, start_session
+
+SWISS = DrawType.swiss.value
+
+
+@pytest_asyncio.fixture
+async def authed_client(
+    api_client: AsyncClient, db_session: AsyncSession
+) -> AsyncIterator[tuple[AsyncClient, User]]:
+    user = await start_session(api_client, db_session)
+    await grant_permissions(db_session, user, (TOURNAMENT_VIEW, TOURNAMENT_CREATE))
+    yield api_client, user
+
+
+def _tournament_payload() -> dict[str, Any]:
+    return {
+        "name": "Swiss Open",
+        "address": {
+            "venue": "Berkeley TT Club",
+            "street": "2727 Milvia St",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94703",
+            "country": "USA",
+        },
+        "table_catalogue": [{"label": "Table 1", "court": "A"}],
+    }
+
+
+def _event_payload(**overrides: Any) -> dict[str, Any]:
+    """A swiss event of three rounds.
+
+    **No pools**: swiss is pool-less, and sending pools an un-pooled draw type ignores
+    would make every assertion below about a shape the format does not have.
+    """
+    payload: dict[str, Any] = {
+        "name": "Open Singles",
+        "format": "singles",
+        "draw_type": SWISS,
+        "rounds": 3,
+        "max_players": 64,
+        "entry_fee": 0,
+        "timezone": "America/Chicago",
+        "slot": {"date": "2026-06-13", "start": "09:00", "end": "18:00"},
+        "match_settings": {"rated": False, "length_games": 3},
+        "predicates": [],
+        "pools": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+async def _tournament(client: AsyncClient) -> str:
+    created = await client.post("/v1/tournaments", json=_tournament_payload())
+    assert created.status_code == 201, created.text
+    tournament_id: str = created.json()["id"]
+    return tournament_id
+
+
+async def _create_event(
+    client: AsyncClient, tournament_id: str, **overrides: Any
+) -> Any:
+    return await client.post(
+        f"/v1/tournaments/{tournament_id}/events", json=_event_payload(**overrides)
+    )
+
+
+async def _settings_of(db: AsyncSession, event_id: str) -> TournamentEvent:
+    db.expire_all()
+    return (
+        await db.execute(
+            select(TournamentEvent).where(TournamentEvent.id == uuid.UUID(event_id))
+        )
+    ).scalar_one()
+
+
+def _stored_rounds(event: TournamentEvent) -> int | None:
+    """The round count this event has **stored**, parsed back out of its settings row's
+    JSON object (ADR "a draw type's settings are one NOT NULL JSON object")."""
+    return draw_settings_of(event.draw_settings).rounds
+
+
+async def _enter(
+    db: AsyncSession, event_id: str, user: User, *, seed: int, minutes: int
+) -> TournamentEntry:
+    entry = TournamentEntry(
+        event_id=uuid.UUID(event_id),
+        user_id=user.id,
+        status=TournamentEntryStatus.entered,
+        seed=seed,
+        created_at=datetime(2026, 6, 1, 9, 0, tzinfo=UTC) + timedelta(minutes=minutes),
+    )
+    db.add(entry)
+    await db.commit()
+    return entry
+
+
+async def _field(
+    client: AsyncClient, db: AsyncSession, size: int, **overrides: Any
+) -> tuple[str, str, list[TournamentEntry]]:
+    """A swiss event with a stated field of ``size`` seeded entrants, seed ``n`` being
+    the ``n``-th in the draw order."""
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id, **overrides)).json()["id"]
+    entries = [
+        await _enter(db, event_id, await make_user(db, f"swiss{n}"), seed=n, minutes=n)
+        for n in range(1, size + 1)
+    ]
+    return tournament_id, event_id, entries
+
+
+async def _cut(client: AsyncClient, tournament_id: str, event_id: str) -> Any:
+    return await client.post(f"/v1/tournaments/{tournament_id}/events/{event_id}/draw")
+
+
+async def _fixtures(db: AsyncSession, event_id: str) -> list[TournamentFixture]:
+    return list(
+        (
+            await db.execute(
+                select(TournamentFixture)
+                .where(TournamentFixture.event_id == uuid.UUID(event_id))
+                .order_by(TournamentFixture.round, TournamentFixture.position)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def _event_read(client: AsyncClient, tournament_id: str) -> dict[str, Any]:
+    response = await client.get(f"/v1/tournaments/{tournament_id}")
+    assert response.status_code == 200, response.text
+    (event,) = response.json()["events"]
+    read: dict[str, Any] = event
+    return read
+
+
+# ----- the request boundary: a round count belongs to exactly one draw type ----------
+
+
+async def test_creating_a_swiss_event_persists_its_round_count(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The whole configuration lands on the settings row: the slug *and* the R.
+
+    Asserted from the database rather than the response, because the row is what the
+    cut reads — a response echoing a number nothing stored would satisfy a wire
+    assertion and then cut a draw of a different length.
+    """
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    created = await _create_event(client, tournament_id, rounds=5)
+
+    assert created.status_code == 201, created.text
+    event = await _settings_of(db_session, created.json()["id"])
+    assert event.draw_settings.draw_type is DrawType.swiss
+    assert _stored_rounds(event) == 5
+
+
+async def test_a_swiss_event_without_a_round_count_is_422(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """There is no defensible default. ``ceil(log2 N)`` is the convention, and deriving
+    it would move the length of a day the director has already booked tables for — so
+    the omission is refused at the boundary, naming the field, and no event is written.
+    """
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    payload = _event_payload()
+    del payload["rounds"]
+
+    response = await client.post(
+        f"/v1/tournaments/{tournament_id}/events", json=payload
+    )
+
+    assert response.status_code == 422, response.text
+    assert "rounds" in response.text
+    events = (
+        await db_session.execute(
+            select(TournamentEvent).where(
+                TournamentEvent.tournament_id == uuid.UUID(tournament_id)
+            )
+        )
+    ).scalars()
+    assert list(events) == [], "a refusal at the boundary writes nothing"
+
+
+@pytest.mark.parametrize("draw_type", ["round-robin", "single-elim", "rr-then-ko"])
+async def test_a_round_count_on_another_draw_type_is_422(
+    authed_client: tuple[AsyncClient, User], draw_type: str
+) -> None:
+    """**Refused at the boundary, never silently dropped.** "Play 3 rounds" means
+    nothing to a round-robin (the circle method decides how many there are), to a
+    bracket (its depth follows from the field) or to a two-stage draw (neither stage
+    has a chosen count). Every other draw type is asked, because a union that had lost
+    one arm's ``extra="forbid"`` would look identical on a one-slug test."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    response = await _create_event(
+        client,
+        tournament_id,
+        draw_type=draw_type,
+        rounds=3,
+        **({"qualifiers_per_pool": 2} if draw_type == "rr-then-ko" else {}),
+    )
+
+    assert response.status_code == 422, response.text
+    assert "rounds" in response.text
+
+
+@pytest.mark.parametrize("rounds", [0, -1, MAX_SWISS_ROUNDS + 1, 2_147_483_648])
+async def test_a_round_count_outside_the_static_bounds_is_422(
+    authed_client: tuple[AsyncClient, User], rounds: int
+) -> None:
+    """``1 <= R <= MAX_SWISS_ROUNDS`` is the static half of the legal space: zero rounds
+    play nothing, a negative is not a count, and the top end keeps a form value from
+    walking into an ``Integer`` column as a 500. The bound that moves with the field
+    (``R <= N - 1``) is deliberately not here — it is refused at the cut."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    response = await _create_event(client, tournament_id, rounds=rounds)
+
+    assert response.status_code == 422, response.text
+    assert "rounds" in response.text
+
+
+async def test_a_round_count_at_the_ceiling_is_accepted(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The bound is **inclusive**, pinned so the refusal above cannot be satisfied by an
+    off-by-one that also refuses the last legal number."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    created = await _create_event(client, tournament_id, rounds=MAX_SWISS_ROUNDS)
+
+    assert created.status_code == 201, created.text
+    event = await _settings_of(db_session, created.json()["id"])
+    assert _stored_rounds(event) == MAX_SWISS_ROUNDS
+
+
+async def test_the_round_count_reads_back_flat_beside_the_draw_type(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """The editor has to see the stored R, because the arm requires one on every PATCH
+    of a swiss event — a rename that guessed a round count would silently re-cut the
+    director's day."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    created = await _create_event(client, tournament_id, rounds=4)
+
+    assert created.json()["rounds"] == 4
+    assert created.json()["qualifiers_per_pool"] is None
+    read = await _event_read(client, tournament_id)
+    assert read["rounds"] == 4
+    assert read["draw_type"] == SWISS
+
+
+async def test_another_draw_type_reads_back_no_round_count(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """``null`` for every draw type that has no chosen round count — a fact, not
+    missing data, and the same shape the qualifier count takes on the arms with no
+    knockout stage."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+
+    created = await _create_event(
+        client, tournament_id, draw_type="round-robin", rounds=None
+    )
+
+    assert created.status_code == 201, created.text
+    assert created.json()["rounds"] is None
+
+
+async def test_patching_a_round_count_without_its_draw_type_is_422(
+    authed_client: tuple[AsyncClient, User],
+) -> None:
+    """The draw configuration is patched **as a unit**, exactly as the qualifier count
+    is: which draw types carry a round count is a fact about the pair, and a patch
+    carrying only ``rounds`` does not hold it."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id)).json()["id"]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={"rounds": 5},
+    )
+
+    assert response.status_code == 422, response.text
+    assert "draw_type" in response.text
+
+
+async def test_patching_away_from_swiss_clears_the_round_count(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The pair is written together, so a draw type moved to round-robin leaves no
+    round count behind — and the wire says so, or the editor re-sends a number the
+    boundary now refuses."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id)).json()["id"]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={"draw_type": "round-robin"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["rounds"] is None
+    event = await _settings_of(db_session, event_id)
+    assert _stored_rounds(event) is None
+
+
+# ----- the cut: every round at once --------------------------------------------------
+
+
+async def test_the_cut_writes_every_round_with_round_one_seated(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """Eight entrants, three rounds: 12 fixtures, cut in one stroke.
+
+    Round 1 carries both sides, seeded from the draw order — top half against bottom
+    half, so seed 1 meets seed 5. Rounds 2 and 3 exist with both sides NULL, which
+    means TBD and nothing else (ADR-0786). Every fixture is un-pooled, because swiss
+    ranks one field in one table.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, entries = await _field(client, db_session, 8)
+
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+
+    fixtures = await _fixtures(db_session, event_id)
+    assert len(fixtures) == 12
+    assert all(f.pool_id is None for f in fixtures)
+
+    by_seed = {entry.seed: entry.id for entry in entries}
+    round_one = [f for f in fixtures if f.round == 1]
+    assert [(f.position, f.entry_a_id, f.entry_b_id) for f in round_one] == [
+        (1, by_seed[1], by_seed[5]),
+        (2, by_seed[2], by_seed[6]),
+        (3, by_seed[3], by_seed[7]),
+        (4, by_seed[4], by_seed[8]),
+    ]
+
+    later = [f for f in fixtures if f.round > 1]
+    assert sorted((f.round, f.position) for f in later) == [
+        (2, 1),
+        (2, 2),
+        (2, 3),
+        (2, 4),
+        (3, 1),
+        (3, 2),
+        (3, 3),
+        (3, 4),
+    ]
+    assert all(f.entry_a_id is None and f.entry_b_id is None for f in later)
+
+
+async def test_an_odd_field_cuts_one_fewer_pairing_a_round(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """Seven entrants, two rounds: three pairings a round, and the entrant sitting out
+    has **no fixture** — a bye is the absence of a row, never a row with a NULL side
+    (CONTEXT.md, "Bye"). Which entrant that is, round by round, is the next slice's
+    problem; in round 1, with nobody yet on a score, it is the lowest seed."""
+    client, _ = authed_client
+    tournament_id, event_id, entries = await _field(client, db_session, 7, rounds=2)
+
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+
+    fixtures = await _fixtures(db_session, event_id)
+    assert len(fixtures) == 6
+    round_one = [f for f in fixtures if f.round == 1]
+    seated = {f.entry_a_id for f in round_one} | {f.entry_b_id for f in round_one}
+    by_seed = {entry.seed: entry.id for entry in entries}
+    assert seated == {by_seed[seed] for seed in range(1, 7)}
+    assert by_seed[7] not in seated
+
+
+async def test_the_standings_carry_the_whole_field_including_the_byed_entrant(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """A cut swiss event reads out as one pool-less table over **every** entrant.
+
+    Seven entrants means one of them has no round-1 fixture at all — a bye is the
+    absence of a row — so a table derived from the fixtures' sides would seat six and
+    quietly leave the seventh off the standings they are entitled to a row on. The
+    field comes off the event's entrants for exactly that reason.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, entries = await _field(client, db_session, 7, rounds=2)
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+
+    results = (await _event_read(client, tournament_id))["results"]
+
+    assert results["kind"] == "swiss_standings"
+    assert {row["entry_id"] for row in results["rows"]} == {
+        str(entry.id) for entry in entries
+    }
+    assert [row["rank"] for row in results["rows"]] == [1, 2, 3, 4, 5, 6, 7]
+    assert all(row["played"] == 0 for row in results["rows"]), "nobody has played yet"
+    assert results["complete"] is False
+    assert results["champion"] is None
+
+
+async def test_cutting_more_rounds_than_the_field_has_opponents_is_refused(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """A moving bound, refused at the cut in the director's own language, naming both
+    ways out — and nothing is written.
+
+    It cannot live at the request boundary: it depends on the entrant count, which
+    moves. A round count that was legal when it was written must not become unwritable
+    because a player withdrew.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, _ = await _field(client, db_session, 5, rounds=9)
+
+    response = await _cut(client, tournament_id, event_id)
+
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"] == (
+        "9 rounds is more than the 4 opponents each of 5 entrants can have — play "
+        "fewer rounds, or add entrants."
+    )
+    assert await _fixtures(db_session, event_id) == [], (
+        "a refused cut writes nothing at all"
+    )
+
+
+async def test_the_round_count_is_frozen_once_the_draw_is_cut(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """409, exactly as the draw type freezes, and for the same concrete reason: every
+    round's fixtures are already rows in the database, so raising R would leave the
+    added rounds with none and lowering it would leave fixtures no round claims."""
+    client, _ = authed_client
+    tournament_id, event_id, _ = await _field(client, db_session, 8)
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={"draw_type": SWISS, "rounds": 5},
+    )
+
+    assert response.status_code == 409, response.text
+    assert "rounds is frozen" in response.json()["detail"]
+    event = await _settings_of(db_session, event_id)
+    assert _stored_rounds(event) == 3, "a refusal wrote nothing"
+
+
+async def test_the_round_count_is_editable_while_no_draw_exists(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The freeze above is about a **cut** draw. Before one, the round count is ordinary
+    editable configuration — without this the 409 test could pass against a rule that
+    refused every change."""
+    client, _ = authed_client
+    tournament_id = await _tournament(client)
+    event_id = (await _create_event(client, tournament_id)).json()["id"]
+
+    response = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={"draw_type": SWISS, "rounds": 6},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["rounds"] == 6
+    event = await _settings_of(db_session, event_id)
+    assert _stored_rounds(event) == 6
+
+
+async def test_a_swiss_event_has_no_schedule_preview(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """The preview covers the **pool stage**, and swiss has no pools — so a director
+    asking for one is told the format has no preview rather than shown an empty day
+    (ADR). The pure refusal is asserted in ``test_schedule_preview_snapshot.py``; this
+    is that refusal reaching the director as a 422 rather than a 500."""
+    client, _ = authed_client
+    tournament_id, _, _ = await _field(client, db_session, 8)
+
+    response = await client.post(f"/v1/tournaments/{tournament_id}/schedule/preview")
+
+    assert response.status_code == 422, response.text
+    assert SWISS in response.text

--- a/api/tests/test_tournament_event_draw_settings.py
+++ b/api/tests/test_tournament_event_draw_settings.py
@@ -53,6 +53,7 @@ from app.schemas.tournament import (
     RoundRobinDrawSettingsWrite,
     RrThenKoDrawSettingsWrite,
     SingleElimDrawSettingsWrite,
+    SwissDrawSettingsWrite,
     draw_settings_from_storage,
 )
 from app.tournament_draw_settings import draw_settings_of, draw_settings_row
@@ -365,9 +366,11 @@ async def test_a_settings_row_naming_an_unseeded_draw_type_is_refused(
     """The FK to ``draw_types.key`` is the enforcement, and this is the test that
     makes it one.
 
-    ``swiss`` is a draw type the product does not run: it has no ``DrawType``
+    ``double-elim`` is a draw type the product does not run: it has no ``DrawType``
     member and therefore no seeded row (ADR "a draw type is a seeded row, and the
-    enum holds only what runs"). Written with raw SQL on purpose — the ORM path
+    enum holds only what runs"). It took this test's place from ``swiss``, which
+    shipped — the list of unseeded slugs shrinks by exactly the format that lands,
+    which is the mechanism working. Written with raw SQL on purpose — the ORM path
     goes through ``for_draw_type``, which cannot produce an unseeded slug, so only
     a hand-written INSERT can ask the database the question.
 
@@ -386,7 +389,7 @@ async def test_a_settings_row_naming_an_unseeded_draw_type_is_refused(
         await db_session.execute(
             sa.text(
                 "INSERT INTO tournament_event_draw_settings (draw_type_key)"
-                " VALUES ('swiss')"
+                " VALUES ('double-elim')"
             )
         )
     assert "draw_type_key" in str(refusal.value)
@@ -550,6 +553,7 @@ async def test_every_arm_round_trips_through_the_settings_column(
         RoundRobinDrawSettingsWrite(),
         SingleElimDrawSettingsWrite(),
         RrThenKoDrawSettingsWrite(qualifiers_per_pool=2),
+        SwissDrawSettingsWrite(rounds=5),
     ]
     assert len(arms) == len(DrawType), (
         "a draw type has been added without an arm in this round trip: "

--- a/api/tests/test_tournaments.py
+++ b/api/tests/test_tournaments.py
@@ -4306,8 +4306,8 @@ async def test_the_detail_payload_carries_the_seeded_draw_types_in_display_order
     seeded one, in ``display_order``, each with the copy to render it.
 
     Order is asserted as a list, not a set: a picker whose options move between two
-    loads is a real defect, and the round-robin/single-elim/rr-then-ko sequence is the
-    one the seed states."""
+    loads is a real defect, and the round-robin/single-elim/rr-then-ko/swiss sequence is
+    the one the seed states."""
     client, _ = authed_client
     tournament_id, _ = await _tournament_with_events(client)
 
@@ -4317,6 +4317,7 @@ async def test_the_detail_payload_carries_the_seeded_draw_types_in_display_order
         "round-robin",
         "single-elim",
         "rr-then-ko",
+        "swiss",
     ]
     assert [row["display_order"] for row in catalogue] == sorted(
         row["display_order"] for row in catalogue
@@ -4353,10 +4354,15 @@ async def test_the_draw_type_catalogue_is_the_table_not_the_draw_type_enum(
 
     catalogue = await _catalogue_of(client, tournament_id)
 
-    assert [row["key"] for row in catalogue] == ["round-robin", "rr-then-ko"]
+    assert [row["key"] for row in catalogue] == ["round-robin", "rr-then-ko", "swiss"]
     # And the enum still holds the deleted one, so "it followed the table" is the only
     # reading of the assertion above.
-    assert {t.value for t in DrawType} == {"round-robin", "single-elim", "rr-then-ko"}
+    assert {t.value for t in DrawType} == {
+        "round-robin",
+        "single-elim",
+        "rr-then-ko",
+        "swiss",
+    }
 
 
 async def test_the_draw_type_copy_and_order_are_the_rows_not_hardcoded(
@@ -4368,8 +4374,9 @@ async def test_the_draw_type_copy_and_order_are_the_rows_not_hardcoded(
 
     Rewriting two of the rows swaps their order and their words; a catalogue assembled
     from a Python dict of labels keyed by enum member would answer the old copy in the
-    old order, whatever the table says. The third row is left alone and asserted last,
-    so the rewrite is shown to have moved the two it names and nothing else."""
+    old order, whatever the table says. The rows it does not name are left alone and
+    asserted last, so the rewrite is shown to have moved the two it names and nothing
+    else."""
     client, _ = authed_client
     tournament_id, _ = await _tournament_with_events(client)
     await db_session.execute(
@@ -4406,6 +4413,15 @@ async def test_the_draw_type_copy_and_order_are_the_rows_not_hardcoded(
             "Round-robin then knockout",
             "Pools play all-play-all, then the top finishers from each pool meet in "
             "a knockout bracket.",
+        ),
+        (
+            "swiss",
+            "Swiss",
+            "A fixed number of rounds, each pairing entrants who are on similar "
+            "scores. Nobody is eliminated and everybody plays every round, so a "
+            "large field is ranked in far fewer matches than a round robin — but a "
+            "round's pairings are only known once the round before it has finished, "
+            "and a long event may repeat a pairing.",
         ),
     ]
 
@@ -5552,7 +5568,7 @@ async def test_a_draw_on_a_tournament_or_event_that_does_not_exist_is_404(
 # ----- the draws this event cannot produce (422) ----------------------------
 
 
-@pytest.mark.parametrize("draw_type", ["double-elim", "swiss"])
+@pytest.mark.parametrize("draw_type", ["double-elim"])
 async def test_creating_an_event_with_an_unimplemented_draw_type_is_422_at_the_boundary(
     authed_client: tuple[AsyncClient, User],
     draw_type: str,
@@ -5568,12 +5584,13 @@ async def test_creating_an_event_with_an_unimplemented_draw_type_is_422_at_the_b
     Pydantic rejects the slug at the edge with a 422 that NAMES the valid values, no
     custom validator required — and no event row is written at all.
 
-    The parametrized subjects are the ex-members that are STILL unimplemented: they are
-    the values a stale client (or a stale hardcoded picker) would still send.
-    ``rr-then-ko`` used to be among them and is deliberately gone — #1227 gave it a
-    strategy, a results strategy and a seeded row, so it is now a slug this boundary
-    ACCEPTS, which the create tests beside this one assert. That is the mechanism
-    working: the list of refused slugs shrinks by exactly the format that shipped.
+    The parametrized subject is the ex-member that is STILL unimplemented: it is the
+    value a stale client (or a stale hardcoded picker) would still send. ``rr-then-ko``
+    used to be among them and is deliberately gone — #1227 gave it a strategy, a results
+    strategy and a seeded row — and so is ``swiss``, which #1276 gave the same. Both are
+    now slugs this boundary ACCEPTS, which the create tests beside this one assert. That
+    is the mechanism working: the list of refused slugs shrinks by exactly the format
+    that shipped.
 
     **The accepted slugs are pinned as literals, never re-derived from ``DrawType``.**
     Pydantic composes that ``expected`` message *out of* the enum, so comparing it back
@@ -5596,11 +5613,11 @@ async def test_creating_an_event_with_an_unimplemented_draw_type_is_422_at_the_b
     body = response.json()
     (error,) = [e for e in body["detail"] if e["loc"][-1] == "draw_type"]
     # The 422 names the slugs that run, and nothing else — a client reading it learns
-    # exactly what it may send. Pydantic renders a three-member list as
-    # ``'a', 'b' or 'c'``, so the final " or " becomes a comma before the split.
+    # exactly what it may send. Pydantic renders the list as ``'a', 'b', 'c' or 'd'``,
+    # so the final " or " becomes a comma before the split.
     assert set(
         error["ctx"]["expected"].replace("'", "").replace(" or ", ", ").split(", ")
-    ) == {"round-robin", "single-elim", "rr-then-ko"}, error
+    ) == {"round-robin", "single-elim", "rr-then-ko", "swiss"}, error
     # Refused at the boundary means refused before persistence: no event exists.
     detail = (await client.get(f"/v1/tournaments/{created['id']}")).json()
     assert detail["events"] == []

--- a/e2e/page-objects/tournament-detail-page/event-editor.page.ts
+++ b/e2e/page-objects/tournament-detail-page/event-editor.page.ts
@@ -42,6 +42,17 @@ export class EventEditorPage {
     return this.page.getByLabel('Qualifiers per pool')
   }
 
+  /** **R** — the round count a `swiss` event plays. Present for `swiss` and for nothing
+   * else, exactly as `qualifiersInput` is present only for `rr-then-ko`: a round count is
+   * a question the other three formats do not ask, and the server's draw-settings union
+   * says the same by refusing the key on their arms.
+   *
+   * Matched by a `^Rounds` regex rather than an exact label, because the row is `required`
+   * and the `Field` renders its asterisk into the accessible name. */
+  get roundsInput(): Locator {
+    return this.page.getByLabel(/^Rounds/)
+  }
+
   /** The refusal the sheet shows when a save is rejected — the surface a 422 from the
    * server lands on. A spec asserts it is HIDDEN after a successful create: a create
    * that failed leaves the sheet open with this alert in it, and "the sheet is still
@@ -67,6 +78,14 @@ export class EventEditorPage {
   async setQualifiersPerPool(count: number): Promise<void> {
     await this.qualifiersInput.fill(String(count))
     await expect(this.qualifiersInput).toHaveValue(String(count))
+  }
+
+  /** Type the round count. A blank box is a *missing answer* for this draw type (never
+   * `0`, which would be a swiss that plays nothing), so it is filled with a real number
+   * and read back — the same shape `setQualifiersPerPool` takes. */
+  async setRounds(rounds: number): Promise<void> {
+    await this.roundsInput.fill(String(rounds))
+    await expect(this.roundsInput).toHaveValue(String(rounds))
   }
 
   // ----- Table pools --------------------------------------------------------

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -250,6 +250,49 @@ export class TournamentDetailPage {
     return this.bracket(eventId).getByTestId(`bracket-round-${round}`)
   }
 
+  // ----- swiss rounds (event card) ------------------------------------------
+
+  /** The **swiss rounds** view — a flat, numbered list of rounds, which is what a
+   * pool-less swiss draw's fixtures render as (ADR "swiss pre-cuts every round and pairs
+   * each one on advance").
+   *
+   * A *different* block from `bracket`, and the difference is the point: both draw types
+   * put their fixtures in `pool_id IS NULL`, and routing on that null alone rendered a
+   * swiss draw through single-elimination's successor arithmetic — columns named back
+   * from a Final ("Semifinals", "Quarterfinals") that a format eliminating nobody does
+   * not have. So a spec asserts this is visible AND that `bracket` is absent; either
+   * alone would pass against the view it is not about. */
+  swissRounds(eventId: string): Locator {
+    return this.drawPanel(eventId).getByTestId('draw-swiss-rounds')
+  }
+
+  /** One **paired** round's fixture list, by round number — present only once somebody
+   * is seated in the round. Its fixtures are `<li>`s in position order, so a spec reads
+   * them with `toHaveText([...])`, which pins the count, the order and the pairings in
+   * one statement. */
+  swissRound(eventId: string, round: number): Locator {
+    return this.swissRounds(eventId).getByTestId(`swiss-round-${round}`)
+  }
+
+  /** One paired round's fixture lines. */
+  swissRoundFixtures(eventId: string, round: number): Locator {
+    return this.swissRound(eventId, round).getByRole('listitem')
+  }
+
+  /** One **forthcoming** round's line — the round that is already cut, holds its
+   * `⌊n/2⌋` fixtures, and has nobody in it yet.
+   *
+   * The cut writes all `R` rounds at once, so a round past the first exists from the
+   * moment the draw is dealt with both of every fixture's sides NULL. It is announced
+   * (its match count, and what has to finish first) rather than drawn as rows of "TBD vs
+   * TBD" — so the presence of THIS and the absence of `swissRound` are what "the later
+   * rounds are present but not yet paired" means on screen. */
+  swissRoundForthcoming(eventId: string, round: number): Locator {
+    return this.swissRounds(eventId).getByTestId(
+      `swiss-round-forthcoming-${round}`,
+    )
+  }
+
   // ----- standings (event card) ---------------------------------------------
 
   /** The event's standings section — present only once the round-robin has a

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -492,6 +492,15 @@ export interface EventDrawConfig {
   readonly draw_type: string
   /** **K**. `null` for every draw type that has no knockout stage to qualify for. */
   readonly qualifiers_per_pool: number | null
+  /** **R** — how many rounds a `swiss` event plays. `null` for every other draw type,
+   * which does not ask the question (a round-robin's rounds fall out of the circle
+   * method, a bracket's depth out of the field).
+   *
+   * Read back for the reason `qualifiers_per_pool` is: it is **required with no default**
+   * on the swiss arm of the server's draw-settings union, so it is the field a create
+   * body is refused for omitting — and a 201 alone would also come back from a server
+   * that accepted the body and dropped R on the floor. */
+  readonly rounds: number | null
   /** The server's own count of active entries. Read here rather than counted off the
    * roster on screen, which **truncates** at eight chips and a `+N more` line: a spec
    * counting list items there would be counting the truncation, and at nine entrants
@@ -529,6 +538,47 @@ export async function findEventByName(
     )
   }
   return event
+}
+
+/** One row of the served **draw-type catalogue** (`DrawTypeRead` on the wire): the slug
+ * an event stores, and the director-facing copy for it.
+ *
+ * The copy is **seed data** — a `draw_types` row a migration inserts — and the tournament
+ * detail carries the whole catalogue so a picker renders what it was sent rather than a
+ * list of its own (ADR 20260726). So this is the one seam that can say the copy exists at
+ * all: the client's own parser keeps only `key`/`name`/`display_order`, so `description`
+ * reaches no surface a browser assertion could read. */
+export interface DrawTypeRow {
+  readonly key: string
+  readonly name: string
+  readonly description: string
+}
+
+/**
+ * Read the **served draw-type catalogue** off a tournament's detail payload.
+ *
+ * Throws when the payload carries none. `draw_type_catalogue` is nullable on the wire —
+ * the LIST route withholds it, since it is page data for the one page that picks a draw
+ * type — and a caller asking for it has a detail read in hand, so a `null` here means the
+ * shape changed rather than "this tournament offers no formats".
+ */
+export async function getDrawTypeCatalogue(
+  viewer: Guest,
+  tournamentId: string,
+): Promise<ReadonlyArray<DrawTypeRow>> {
+  const res = await viewer.ctx.get(`${API}/tournaments/${tournamentId}`)
+  if (!res.ok()) {
+    throw new Error(`load tournament failed: ${res.status()} ${await res.text()}`)
+  }
+  const detail = (await res.json()) as {
+    draw_type_catalogue: ReadonlyArray<DrawTypeRow> | null
+  }
+  if (detail.draw_type_catalogue === null) {
+    throw new Error(
+      `tournament ${tournamentId} came back with NO draw-type catalogue — the detail read carries one`,
+    )
+  }
+  return detail.draw_type_catalogue
 }
 
 /**

--- a/e2e/tests/tournament-swiss.spec.ts
+++ b/e2e/tests/tournament-swiss.spec.ts
@@ -1,0 +1,401 @@
+import { test, expect, type Page } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+
+import { TournamentDetailPage } from '../page-objects/tournament-detail.page'
+import { guestFromContext, type Guest } from '../support/match-api'
+import { grantBetaTester } from '../support/rbac-grant'
+import {
+  createTournament,
+  findEventByName,
+  getDrawTypeCatalogue,
+  seedEntrants,
+} from '../support/tournament-api'
+
+/** The event the director authors in the browser, and the handle the spec finds it by
+ * afterwards — its id is minted server-side and never crosses back through the UI. */
+const EVENT_NAME = 'Open Singles'
+
+/** The draw type's **server-authored** label. The picker renders the served catalogue
+ * (ADR 20260726), so this string is the `draw_types` seed row's `name` column, not the
+ * client's — which is why choosing by it is itself the "a real name, not a raw slug"
+ * assertion. */
+const DRAW_TYPE_LABEL = 'Swiss'
+/** The slug the same row is keyed by, and the value the event stores as its `draw_type`.
+ * Named separately from the label precisely so the two can be compared. */
+const DRAW_TYPE_KEY = 'swiss'
+
+/** **R** — the round count, a **required** setting with no derived default (ADR "swiss
+ * pre-cuts every round and pairs each one on advance"). Three, because the demoable
+ * outcome is "round 1 paired, the later rounds present but not yet paired" and one later
+ * round could be a coincidence of an off-by-one. It also stays under the cut's
+ * `R <= n - 1` refusal for both fields below. */
+const ROUNDS = 3
+
+/** `n` for the two parities, which are two different code paths and not two sizes of the
+ * same one. Eight pairs the whole field every round; seven leaves exactly one entrant
+ * with **no fixture at all**, because a bye is the absence of a row (ADR-0786) — and that
+ * is the case whose fixtures seat one fewer entrant than the event has, which is what
+ * used to read as a stale draw and refuse go-live. */
+const EVEN_FIELD = 8
+const ODD_FIELD = 7
+
+/**
+ * Round one, as the ADR seeds it: **top half against bottom half in draw order**.
+ *
+ * With `m = 2⌊n/2⌋` entrants actually playing, draw-order position `i` meets position
+ * `i + m/2`, so `⌊n/2⌋` fixtures come out in position order. The draw order is
+ * registration order here: `order_entrants` sorts by seed, then `created_at`, and nothing
+ * seeds these entries — while `seedEntrants` enters its guests **sequentially**, on
+ * purpose, exactly so this is derivable rather than a race.
+ *
+ * An odd field's last-registered entrant is therefore the lowest-ranked, and is the one
+ * this function never names: they are the round's **bye**.
+ *
+ * Written as the arithmetic rather than a hand-listed table, so the expectation cannot
+ * drift from the rule it is supposed to be checking.
+ */
+function roundOneLines(entrants: ReadonlyArray<Guest>): string[] {
+  const half = Math.floor(entrants.length / 2)
+  return Array.from(
+    { length: half },
+    (_, i) => `${entrants[i].username} vs ${entrants[i + half].username}`,
+  )
+}
+
+/**
+ * Author a `swiss` event **through the editor sheet** and return its id.
+ *
+ * Through the sheet, not seeded over the API, for the reason `tournament-rr-then-ko`
+ * drives its own create: the body is `drawSettingsToApi`'s, and `rounds` is **required
+ * with no default** on the swiss arm of the server's draw-settings union. A client that
+ * names the format and sends no round count is a 422 at the request boundary, and nothing
+ * that stubs the network can see it — the disagreement is *between* the two halves.
+ *
+ * Asserts the POST's status directly so that refusal names itself here, rather than
+ * surfacing three steps later as a missing event.
+ */
+async function authorSwissEvent(
+  page: Page,
+  detail: TournamentDetailPage,
+  director: Guest,
+  tournamentId: string,
+): Promise<string> {
+  const editor = await detail.openNewEvent()
+  await editor.nameInput.fill(EVENT_NAME)
+  await editor.chooseDrawType(DRAW_TYPE_LABEL)
+  // The round-count box exists ONLY for this draw type — it is absent, not disabled, for
+  // a format that does not ask the question. So its appearance is the proof the picker's
+  // choice reached the form, before anything is submitted.
+  await expect(editor.roundsInput).toBeVisible()
+  await editor.setRounds(ROUNDS)
+
+  const createPost = page.waitForResponse(
+    (r) => r.url().endsWith('/events') && r.request().method() === 'POST',
+  )
+  await editor.createEventButton.click()
+  const createResponse = await createPost
+  expect(
+    createResponse.status(),
+    `create event was refused: ${await createResponse.text()}`,
+  ).toBe(201)
+  // The sheet closes on success alone and keeps its refusal inline, so an empty error
+  // slot is the second, independent word on the same fact.
+  await expect(editor.errorAlert).toBeHidden()
+
+  // A 201 says the body was accepted; only the read-back says R survived it. A server
+  // that dropped the round count on the floor would answer 201 too — and then cut one
+  // round, or none.
+  const event = await findEventByName(director, tournamentId, EVENT_NAME)
+  expect(event.draw_type).toBe(DRAW_TYPE_KEY)
+  expect(event.rounds).toBe(ROUNDS)
+  return event.id
+}
+
+/**
+ * **Swiss, through the composed stack** (#1276, ADR "swiss pre-cuts every round and pairs
+ * each one on advance").
+ *
+ * A director creates a swiss event **in the browser**, sets its round count, publishes,
+ * has a field entered, cuts the draw, and reads it: round 1 paired with real players, and
+ * every later round present, cut, and announced as forthcoming.
+ *
+ * ## Both parities, because they are different code
+ *
+ * A swiss round emits `⌊n/2⌋` fixtures whatever the parity, so an **even** field is
+ * wholly seated by its own draw and an **odd** one leaves exactly one entrant referenced
+ * by no fixture at all — a bye is the *absence of a row* (ADR-0786), never a row with a
+ * NULL side, which here would be indistinguishable from a later round awaiting its
+ * pairing.
+ *
+ * That difference is not cosmetic. Draw currency ("the fixtures seat exactly the active
+ * entrants") compared the two sets for equality, so a seven-player swiss cut from exactly
+ * those seven read **stale** the moment it was cut, and go-live refused it with a 409 no
+ * re-cut could clear. Hence the odd test does not stop at the cut: it takes the
+ * tournament **live**, which is the assertion that would have failed.
+ *
+ * ## What this spec deliberately does NOT test
+ *
+ * Round 2 is never paired here, because nothing pairs it yet: `SwissStrategy.advance`
+ * fills no sides — it reports round 1's readiness and nothing else. Pairing a round from
+ * the standings, a bye scoring as a win, and Buchholz are later slices. A spec asserting
+ * round 2 gets paired would be testing an implementation that does not exist, and would
+ * either red for the wrong reason or be written weak enough to pass.
+ *
+ * ## Seed vs UI split
+ *
+ * Inert scaffolding over the API (`support/tournament-api.ts`): the tournament shell and
+ * the entrants — director-entry has no web UI, and fifteen browser sign-ins to test a
+ * *draw* would be fifteen chances to fail for an unrelated reason. Load-bearing steps in
+ * the browser: authoring the event and its round count, publishing, cutting the draw,
+ * going live, and every reading of the draw.
+ *
+ * ## RBAC
+ *
+ * As in `tournament-lifecycle.spec.ts`: a minted user holds only the permissionless
+ * default role, so `grantBetaTester` hands the director the tournament bundle over the
+ * stack's own `postgres` container before any tournament write. Skipped against an
+ * external `E2E_BASE_URL` stack, where the caller owns provisioning.
+ */
+test.describe('Tournament — swiss draw', () => {
+  test('a director cuts an even swiss field into a paired round 1 and forthcoming later rounds', async ({
+    page,
+    baseURL,
+  }) => {
+    // Eight minted guests, eight director-entries and a real cut, on top of the ordinary
+    // page work.
+    test.setTimeout(300_000)
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    // The director IS the browser's own session, so page navigations run as them.
+    const director = await guestFromContext(page.request)
+    grantBetaTester(director.username)
+
+    const name = `Swiss ${faker.string.alphanumeric(8)}`
+    const { tournamentId } = await createTournament(director, name)
+
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    // `toContainText`, not `toHaveText`: the hero sets its own full stop after the name.
+    //
+    // The long timeout is for the FIRST navigation only, and it is about the stack rather
+    // than the app: the composed web-client is a Vite **dev** server, so the very first
+    // request for a route pays for transforming it on demand.
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    // ----- the format is OFFERED, with the server's own copy ------------------
+    // Read first, before anything is authored: a stack serving a build without swiss
+    // fails here, by name, rather than three steps later as an empty picker.
+    //
+    // `name` and `description` are **seed data** — a `draw_types` row a migration inserts
+    // — so this asks the server what it is serving. The sentence itself is not retyped:
+    // pinning that copy in a spec as well as in the migration is how a wording change
+    // reds a suite in a file nobody thought to look at. What is asserted is that both are
+    // real, director-facing strings and neither is the raw slug.
+    const catalogue = await getDrawTypeCatalogue(director, tournamentId)
+    const swiss = catalogue.find((row) => row.key === DRAW_TYPE_KEY)
+    if (!swiss) {
+      const keys = catalogue.map((row) => row.key).join(', ') || '(none)'
+      throw new Error(
+        `the served draw-type catalogue does not offer swiss — has: ${keys}`,
+      )
+    }
+    expect(swiss.name).toBe(DRAW_TYPE_LABEL)
+    expect(swiss.name).not.toBe(DRAW_TYPE_KEY)
+    expect(swiss.description.length).toBeGreaterThan(0)
+    expect(swiss.description).not.toBe(DRAW_TYPE_KEY)
+
+    // ----- author the swiss event, in the browser -----------------------------
+    // `chooseDrawType` picks the option by that same server-authored label, EXACTLY — so
+    // a picker rendering `swiss` (or nothing) finds no option and reds here. It is the
+    // browser's half of the assertion above.
+    const eventId = await authorSwissEvent(page, detail, director, tournamentId)
+
+    // ----- publish, then fill the field --------------------------------------
+    await detail.publishButton.click()
+    await expect(detail.startButton).toBeVisible()
+
+    const entrants = await seedEntrants(
+      director,
+      baseURL!,
+      tournamentId,
+      eventId,
+      EVEN_FIELD,
+    )
+    // How many entries landed is asked of the SERVER, not counted off the roster: the
+    // card lists eight chips and collapses the rest into "+N more", so a list-item count
+    // here would be counting the truncation rather than the field.
+    const filled = await findEventByName(director, tournamentId, EVENT_NAME)
+    expect(filled.entered).toBe(EVEN_FIELD)
+
+    await detail.reload(tournamentId)
+    await expect(detail.entrantsList(EVENT_NAME)).toContainText(entrants[0].username)
+
+    // ----- cut the draw: all R rounds, in one stroke --------------------------
+    const drawPost = page.waitForResponse(
+      (r) => r.url().endsWith('/draw') && r.request().method() === 'POST',
+    )
+    await detail.generateDrawButton(EVENT_NAME).click()
+    const drawResponse = await drawPost
+    expect(
+      drawResponse.status(),
+      `cutting the draw was refused: ${await drawResponse.text()}`,
+    ).toBe(201)
+
+    // ----- the rounds view, NOT the bracket ----------------------------------
+    // Both facts, because either alone passes against the view it is not about. Swiss and
+    // an `rr-then-ko` knockout stage share `pool_id IS NULL`, and routing on that null
+    // alone rendered a swiss draw through single-elimination's successor arithmetic —
+    // columns named back from a Final that a format eliminating nobody does not have.
+    await expect(detail.swissRounds(eventId)).toBeVisible()
+    await expect(detail.bracket(eventId)).toHaveCount(0)
+    // A swiss draw is pool-less: the whole field is ranked in one table.
+    await expect(detail.poolDraws(eventId)).toHaveCount(0)
+
+    // ----- round 1 is PAIRED, with real players ------------------------------
+    // One statement pinning the count, the order and the pairings: `⌊8/2⌋` = four
+    // fixtures, in position order, top half against bottom half of the draw order.
+    await expect(detail.swissRoundFixtures(eventId, 1)).toHaveText(
+      roundOneLines(entrants),
+    )
+    // An even field seats everybody, so nobody sits out — the half that makes the odd
+    // test's single absence mean something.
+    for (const entrant of entrants) {
+      await expect(
+        detail.swissRounds(eventId),
+        `${entrant.username} entered an even field and is in no round-1 fixture`,
+      ).toContainText(entrant.username)
+    }
+
+    // ----- …and rounds 2..R are CUT but not paired ---------------------------
+    // The ADR's whole shape: `R × ⌊n/2⌋` fixtures written at the cut, every side of the
+    // later rounds NULL. So each later round is a *forthcoming* announcement carrying its
+    // own match count — not a paired list, and not absent.
+    for (let round = 2; round <= ROUNDS; round += 1) {
+      await expect(detail.swissRound(eventId, round)).toHaveCount(0)
+      await expect(detail.swissRoundForthcoming(eventId, round)).toBeVisible()
+      // `⌊n/2⌋` per round, whatever the round. The client's sentence around it is not
+      // retyped — only the number the ADR fixes.
+      await expect(detail.swissRoundForthcoming(eventId, round)).toContainText(
+        `${EVEN_FIELD / 2} matches`,
+      )
+    }
+    // R rounds and no more: the round count is the director's setting, never derived from
+    // the field. A fourth round would mean the server had sized the draw off something
+    // else.
+    await expect(detail.swissRound(eventId, ROUNDS + 1)).toHaveCount(0)
+    await expect(detail.swissRoundForthcoming(eventId, ROUNDS + 1)).toHaveCount(0)
+
+    await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
+  })
+
+  test('a director cuts an odd swiss field, one entrant sits out round 1, and the tournament goes live', async ({
+    page,
+    baseURL,
+  }) => {
+    // Seven minted guests, seven director-entries, a real cut and a real go-live (which
+    // materializes round 1 into matches and enqueues the schedule solve on the stack's
+    // own worker), on top of the ordinary page work.
+    test.setTimeout(300_000)
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    const director = await guestFromContext(page.request)
+    grantBetaTester(director.username)
+
+    const name = `Swiss odd ${faker.string.alphanumeric(8)}`
+    const { tournamentId } = await createTournament(director, name)
+
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    const eventId = await authorSwissEvent(page, detail, director, tournamentId)
+
+    await detail.publishButton.click()
+    await expect(detail.startButton).toBeVisible()
+
+    const entrants = await seedEntrants(
+      director,
+      baseURL!,
+      tournamentId,
+      eventId,
+      ODD_FIELD,
+    )
+    const filled = await findEventByName(director, tournamentId, EVENT_NAME)
+    // Seven, off the server. The bye assertion below is "seven entered and six are
+    // named", so this number is half of it and cannot be counted off a roster that
+    // truncates.
+    expect(filled.entered).toBe(ODD_FIELD)
+
+    await detail.reload(tournamentId)
+
+    // ----- cut the draw ------------------------------------------------------
+    const drawPost = page.waitForResponse(
+      (r) => r.url().endsWith('/draw') && r.request().method() === 'POST',
+    )
+    await detail.generateDrawButton(EVENT_NAME).click()
+    const drawResponse = await drawPost
+    expect(
+      drawResponse.status(),
+      `cutting the draw was refused: ${await drawResponse.text()}`,
+    ).toBe(201)
+
+    await expect(detail.swissRounds(eventId)).toBeVisible()
+    await expect(detail.bracket(eventId)).toHaveCount(0)
+
+    // ----- exactly one entrant sits out round 1 ------------------------------
+    // `⌊7/2⌋` = three fixtures naming six of the seven, in position order.
+    await expect(detail.swissRoundFixtures(eventId, 1)).toHaveText(
+      roundOneLines(entrants),
+    )
+    // …and the seventh is nowhere in the draw at all. That absence IS the bye: the format
+    // byes the lowest-ranked entrant, who under registration draw order is the last one
+    // in, and a bye is the absence of a fixture rather than a row with an empty side.
+    const byed = entrants[entrants.length - 1]
+    await expect(
+      detail.swissRounds(eventId),
+      `${byed.username} should be round 1's bye — a bye is the absence of a fixture`,
+    ).not.toContainText(byed.username)
+
+    // Rounds 2..R are cut and forthcoming here too, at `⌊7/2⌋` matches apiece — the byed
+    // entrant costs the round a fixture, they do not get one of their own.
+    for (let round = 2; round <= ROUNDS; round += 1) {
+      await expect(detail.swissRound(eventId, round)).toHaveCount(0)
+      await expect(detail.swissRoundForthcoming(eventId, round)).toContainText(
+        `${Math.floor(ODD_FIELD / 2)} matches`,
+      )
+    }
+
+    // ----- GO LIVE — the assertion this test exists for -----------------------
+    // An odd swiss field's fixtures seat six of its seven entrants, and draw currency
+    // used to read that shortfall as an entry that landed after the cut: the draw was
+    // `stale`, and go-live answered 409 with a refusal no re-cut could clear. So the
+    // transition's own status is asserted, not merely that a button changed.
+    const transitionPost = page.waitForResponse(
+      (r) => r.url().endsWith('/transitions') && r.request().method() === 'POST',
+    )
+    await detail.startButton.click()
+    const transitionResponse = await transitionPost
+    expect(
+      transitionResponse.status(),
+      `going live was refused: ${await transitionResponse.text()}`,
+    ).toBe(201)
+    // Two more independent words on the same fact: the header now offers the only edge a
+    // live tournament has, and the inline refusal a rejected transition lands on is
+    // empty. Without the second, a 409 would surface as a button that never appeared.
+    await expect(detail.endButton).toBeVisible()
+    await expect(detail.lifecycleNotice).toBeHidden()
+
+    // ----- …and going live paired nothing new --------------------------------
+    // Materializing the draw turns *ready* fixtures into matches; it does not seat
+    // anybody. Round 1's lines now carry their match link and status, so they are no
+    // longer compared as text — but the later rounds must still be forthcoming, which is
+    // the statement that go-live did not quietly fill a round nothing has paired yet.
+    await expect(detail.swissRoundFixtures(eventId, 1)).toHaveCount(
+      Math.floor(ODD_FIELD / 2),
+    )
+    for (let round = 2; round <= ROUNDS; round += 1) {
+      await expect(detail.swissRound(eventId, round)).toHaveCount(0)
+      await expect(detail.swissRoundForthcoming(eventId, round)).toBeVisible()
+    }
+
+    await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
+  })
+})

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -4352,6 +4352,7 @@ internal enum Components {
             case singleElim = "single-elim"
             case roundRobin = "round-robin"
             case rrThenKo = "rr-then-ko"
+            case swiss = "swiss"
         }
         /// One selectable draw format, as the ``draw_types`` table holds it.
         ///
@@ -9953,6 +9954,62 @@ internal enum Components {
             case live = "live"
             case final = "final"
         }
+        /// The **pool-less standings** shape of an event's results — the swiss arm of the
+        /// ``results`` discriminated union, tagged ``kind: "swiss_standings"`` (ADR "swiss
+        /// pre-cuts every round and pairs each one on advance").
+        ///
+        /// One table over the whole field, because swiss has no pools: everybody is ranked
+        /// against everybody, which is what pairing by score is for. The rows are the *same*
+        /// :class:`StandingRowRead` a round-robin pool carries, so a client renders this with
+        /// the table it already has — the difference is that they arrive as one list rather
+        /// than grouped under a pool, which is a fact about the format and not a second row
+        /// shape.
+        ///
+        /// ``complete`` is every round decided, including the later rounds that are cut up
+        /// front with their sides still unknown. ``champion`` is the leader of a complete
+        /// event — a swiss ranks its whole field, so unlike the round-robin arm there is no
+        /// multi-pool carve-out — and ``null`` until then. Derived live from the fixtures'
+        /// completed matches like every other results shape.
+        ///
+        /// - Remark: Generated from `#/components/schemas/SwissStandingsResultsRead`.
+        internal struct SwissStandingsResultsRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/SwissStandingsResultsRead/kind`.
+            internal enum KindPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case swissStandings = "swiss_standings"
+            }
+            /// - Remark: Generated from `#/components/schemas/SwissStandingsResultsRead/kind`.
+            internal var kind: Components.Schemas.SwissStandingsResultsRead.KindPayload?
+            /// - Remark: Generated from `#/components/schemas/SwissStandingsResultsRead/rows`.
+            internal var rows: [Components.Schemas.StandingRowRead]
+            /// - Remark: Generated from `#/components/schemas/SwissStandingsResultsRead/complete`.
+            internal var complete: Swift.Bool
+            /// - Remark: Generated from `#/components/schemas/SwissStandingsResultsRead/champion`.
+            internal var champion: Swift.String?
+            /// Creates a new `SwissStandingsResultsRead`.
+            ///
+            /// - Parameters:
+            ///   - kind:
+            ///   - rows:
+            ///   - complete:
+            ///   - champion:
+            internal init(
+                kind: Components.Schemas.SwissStandingsResultsRead.KindPayload? = nil,
+                rows: [Components.Schemas.StandingRowRead],
+                complete: Swift.Bool,
+                champion: Swift.String? = nil
+            ) {
+                self.kind = kind
+                self.rows = rows
+                self.complete = complete
+                self.champion = champion
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case kind
+                case rows
+                case complete
+                case champion
+            }
+        }
         /// Two or more in-progress matches recorded on the *same table* at
         /// overlapping times — physically impossible (a table holds one match), so
         /// contradictory data from a soft manual placement PATCH. Resolved: the table's
@@ -10420,6 +10477,8 @@ internal enum Components {
             internal var drawType: Components.Schemas.DrawType
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/qualifiers_per_pool`.
             internal var qualifiersPerPool: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/rounds`.
+            internal var rounds: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/max_players`.
             internal var maxPlayers: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/entry_fee`.
@@ -10441,6 +10500,7 @@ internal enum Components {
             ///   - format:
             ///   - drawType:
             ///   - qualifiersPerPool:
+            ///   - rounds:
             ///   - maxPlayers:
             ///   - entryFee:
             ///   - timezone:
@@ -10453,6 +10513,7 @@ internal enum Components {
                 format: Components.Schemas.EventFormat,
                 drawType: Components.Schemas.DrawType,
                 qualifiersPerPool: Swift.Int? = nil,
+                rounds: Swift.Int? = nil,
                 maxPlayers: Swift.Int? = nil,
                 entryFee: Swift.Double,
                 timezone: Swift.String,
@@ -10465,6 +10526,7 @@ internal enum Components {
                 self.format = format
                 self.drawType = drawType
                 self.qualifiersPerPool = qualifiersPerPool
+                self.rounds = rounds
                 self.maxPlayers = maxPlayers
                 self.entryFee = entryFee
                 self.timezone = timezone
@@ -10478,6 +10540,7 @@ internal enum Components {
                 case format
                 case drawType = "draw_type"
                 case qualifiersPerPool = "qualifiers_per_pool"
+                case rounds
                 case maxPlayers = "max_players"
                 case entryFee = "entry_fee"
                 case timezone
@@ -10503,6 +10566,10 @@ internal enum Components {
                 self.qualifiersPerPool = try container.decodeIfPresent(
                     Swift.Int.self,
                     forKey: .qualifiersPerPool
+                )
+                self.rounds = try container.decodeIfPresent(
+                    Swift.Int.self,
+                    forKey: .rounds
                 )
                 self.maxPlayers = try container.decodeIfPresent(
                     Swift.Int.self,
@@ -10537,6 +10604,7 @@ internal enum Components {
                     "format",
                     "draw_type",
                     "qualifiers_per_pool",
+                    "rounds",
                     "max_players",
                     "entry_fee",
                     "timezone",
@@ -10561,6 +10629,8 @@ internal enum Components {
             internal var drawType: Components.Schemas.DrawType
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/qualifiers_per_pool`.
             internal var qualifiersPerPool: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/TournamentEventRead/rounds`.
+            internal var rounds: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/max_players`.
             internal var maxPlayers: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/entry_fee`.
@@ -10636,6 +10706,8 @@ internal enum Components {
                 case standings(Components.Schemas.StandingsResultsRead)
                 /// - Remark: Generated from `#/components/schemas/TournamentEventRead/results/StandingsThenFinishesResultsRead`.
                 case standingsThenFinishes(Components.Schemas.StandingsThenFinishesResultsRead)
+                /// - Remark: Generated from `#/components/schemas/TournamentEventRead/results/SwissStandingsResultsRead`.
+                case swissStandings(Components.Schemas.SwissStandingsResultsRead)
                 internal enum CodingKeys: String, CodingKey {
                     case kind
                 }
@@ -10652,6 +10724,8 @@ internal enum Components {
                         self = .standings(try .init(from: decoder))
                     case "standings_then_finishes":
                         self = .standingsThenFinishes(try .init(from: decoder))
+                    case "swiss_standings":
+                        self = .swissStandings(try .init(from: decoder))
                     default:
                         throw Swift.DecodingError.unknownOneOfDiscriminator(
                             discriminatorKey: CodingKeys.kind,
@@ -10667,6 +10741,8 @@ internal enum Components {
                     case let .standings(value):
                         try value.encode(to: encoder)
                     case let .standingsThenFinishes(value):
+                        try value.encode(to: encoder)
+                    case let .swissStandings(value):
                         try value.encode(to: encoder)
                     }
                 }
@@ -10690,6 +10766,7 @@ internal enum Components {
             ///   - format:
             ///   - drawType:
             ///   - qualifiersPerPool:
+            ///   - rounds:
             ///   - maxPlayers:
             ///   - entryFee:
             ///   - timezone:
@@ -10711,6 +10788,7 @@ internal enum Components {
                 format: Components.Schemas.EventFormat,
                 drawType: Components.Schemas.DrawType,
                 qualifiersPerPool: Swift.Int? = nil,
+                rounds: Swift.Int? = nil,
                 maxPlayers: Swift.Int? = nil,
                 entryFee: Swift.Double,
                 timezone: Swift.String,
@@ -10732,6 +10810,7 @@ internal enum Components {
                 self.format = format
                 self.drawType = drawType
                 self.qualifiersPerPool = qualifiersPerPool
+                self.rounds = rounds
                 self.maxPlayers = maxPlayers
                 self.entryFee = entryFee
                 self.timezone = timezone
@@ -10754,6 +10833,7 @@ internal enum Components {
                 case format
                 case drawType = "draw_type"
                 case qualifiersPerPool = "qualifiers_per_pool"
+                case rounds
                 case maxPlayers = "max_players"
                 case entryFee = "entry_fee"
                 case timezone
@@ -10836,6 +10916,8 @@ internal enum Components {
             internal var drawType: Components.Schemas.TournamentEventUpdate.DrawTypePayload?
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/qualifiers_per_pool`.
             internal var qualifiersPerPool: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/rounds`.
+            internal var rounds: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/max_players`.
             internal var maxPlayers: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/entry_fee`.
@@ -10893,6 +10975,7 @@ internal enum Components {
             ///   - format:
             ///   - drawType:
             ///   - qualifiersPerPool:
+            ///   - rounds:
             ///   - maxPlayers:
             ///   - entryFee:
             ///   - timezone:
@@ -10905,6 +10988,7 @@ internal enum Components {
                 format: Components.Schemas.TournamentEventUpdate.FormatPayload? = nil,
                 drawType: Components.Schemas.TournamentEventUpdate.DrawTypePayload? = nil,
                 qualifiersPerPool: Swift.Int? = nil,
+                rounds: Swift.Int? = nil,
                 maxPlayers: Swift.Int? = nil,
                 entryFee: Swift.Double? = nil,
                 timezone: Swift.String? = nil,
@@ -10917,6 +11001,7 @@ internal enum Components {
                 self.format = format
                 self.drawType = drawType
                 self.qualifiersPerPool = qualifiersPerPool
+                self.rounds = rounds
                 self.maxPlayers = maxPlayers
                 self.entryFee = entryFee
                 self.timezone = timezone
@@ -10930,6 +11015,7 @@ internal enum Components {
                 case format
                 case drawType = "draw_type"
                 case qualifiersPerPool = "qualifiers_per_pool"
+                case rounds
                 case maxPlayers = "max_players"
                 case entryFee = "entry_fee"
                 case timezone
@@ -10955,6 +11041,10 @@ internal enum Components {
                 self.qualifiersPerPool = try container.decodeIfPresent(
                     Swift.Int.self,
                     forKey: .qualifiersPerPool
+                )
+                self.rounds = try container.decodeIfPresent(
+                    Swift.Int.self,
+                    forKey: .rounds
                 )
                 self.maxPlayers = try container.decodeIfPresent(
                     Swift.Int.self,
@@ -10989,6 +11079,7 @@ internal enum Components {
                     "format",
                     "draw_type",
                     "qualifiers_per_pool",
+                    "rounds",
                     "max_players",
                     "entry_fee",
                     "timezone",

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -1031,6 +1031,13 @@ function planEventDraw(event: TournamentEventRead): DrawPlan {
     // reporting the substitution. `null` is the honest value for a count-less draw type,
     // and only the arm that never reads it can see it.
     event.qualifiers_per_pool,
+    // **The event's own R** (ADR "swiss pre-cuts every round and pairs each one on
+    // advance") — the round count the director configured and the PATCH stored, passed
+    // through unchanged and on exactly the same terms as the qualifier count above: it is
+    // what sizes a swiss draw (`R × ⌊n/2⌋` fixtures, all written at the cut), so a
+    // substitution here would deal a swiss of the wrong length with nothing reporting it.
+    // `null` is the honest value for the three draw types that choose no round count.
+    event.rounds,
   )
 }
 

--- a/web-client/e2e/tournaments/tournament-draw.spec.ts
+++ b/web-client/e2e/tournaments/tournament-draw.spec.ts
@@ -568,6 +568,7 @@ test.describe('Tournaments · the draw types a director is offered', () => {
     'Round robin',
     'Single elimination',
     'Round-robin then knockout',
+    'Swiss',
   ]
 
   test('offers exactly the seeded draw types, in the server’s words', async ({
@@ -581,14 +582,14 @@ test.describe('Tournaments · the draw types a director is offered', () => {
     await expect(pom.eventEditor).toBeVisible()
 
     // EXACTLY these, and in this order. `toEqual` is the assertion the claim needs, and
-    // it cuts both ways. "Double elimination" and "Swiss" were on this menu once, and
-    // each let a director author an event nothing could ever cut: they left the API's
-    // enum, so they are not seeded, so they are not here. **Round-robin then knockout
-    // went the other way** — it left with them in #1219 and came back in #1227 with a
-    // strategy behind it, and a client-side allowlist would have swallowed the served
-    // row without a word (ADR "rr-then-ko cuts both stages upfront…", Context). This is
-    // the browser end of that: the third row really crosses the wire, really survives
-    // the parse, and really reaches the listbox.
+    // it cuts both ways. "Double elimination" was on this menu once and let a director
+    // author an event nothing could ever cut: it left the API's enum, so it is not
+    // seeded, so it is not here. **Round-robin then knockout and Swiss went the other
+    // way** — both left in #1219 and each came back the moment a strategy stood behind
+    // it (#1227, then the swiss ADR), and a client-side allowlist would have swallowed
+    // the served row without a word (ADR "rr-then-ko cuts both stages upfront…",
+    // Context). This is the browser end of that: the third and fourth rows really cross
+    // the wire, really survive the parse, and really reach the listbox.
     expect(await pom.drawTypeOptions()).toEqual(SEEDED_LABELS)
 
     expect(store.unhandled).toEqual([])

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -2280,7 +2280,7 @@ export interface components {
          * DrawType
          * @enum {string}
          */
-        DrawType: "single-elim" | "round-robin" | "rr-then-ko";
+        DrawType: "single-elim" | "round-robin" | "rr-then-ko" | "swiss";
         /**
          * DrawTypeRead
          * @description One selectable draw format, as the ``draw_types`` table holds it.
@@ -4609,6 +4609,38 @@ export interface components {
          */
         Status: "scheduled" | "live" | "final";
         /**
+         * SwissStandingsResultsRead
+         * @description The **pool-less standings** shape of an event's results — the swiss arm of the
+         *     ``results`` discriminated union, tagged ``kind: "swiss_standings"`` (ADR "swiss
+         *     pre-cuts every round and pairs each one on advance").
+         *
+         *     One table over the whole field, because swiss has no pools: everybody is ranked
+         *     against everybody, which is what pairing by score is for. The rows are the *same*
+         *     :class:`StandingRowRead` a round-robin pool carries, so a client renders this with
+         *     the table it already has — the difference is that they arrive as one list rather
+         *     than grouped under a pool, which is a fact about the format and not a second row
+         *     shape.
+         *
+         *     ``complete`` is every round decided, including the later rounds that are cut up
+         *     front with their sides still unknown. ``champion`` is the leader of a complete
+         *     event — a swiss ranks its whole field, so unlike the round-robin arm there is no
+         *     multi-pool carve-out — and ``null`` until then. Derived live from the fixtures'
+         *     completed matches like every other results shape.
+         */
+        SwissStandingsResultsRead: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "swiss_standings";
+            /** Rows */
+            rows: components["schemas"]["StandingRowRead"][];
+            /** Complete */
+            complete: boolean;
+            /** Champion */
+            champion: string | null;
+        };
+        /**
          * TableConflictRead
          * @description Two or more in-progress matches recorded on the *same table* at
          *     overlapping times — physically impossible (a table holds one match), so
@@ -4804,6 +4836,8 @@ export interface components {
             draw_type: components["schemas"]["DrawType"];
             /** Qualifiers Per Pool */
             qualifiers_per_pool?: number | null;
+            /** Rounds */
+            rounds?: number | null;
             /** Max Players */
             max_players?: number | null;
             /** Entry Fee */
@@ -4835,6 +4869,8 @@ export interface components {
             draw_type: components["schemas"]["DrawType"];
             /** Qualifiers Per Pool */
             qualifiers_per_pool: number | null;
+            /** Rounds */
+            rounds: number | null;
             /** Max Players */
             max_players: number | null;
             /** Entry Fee */
@@ -4864,7 +4900,7 @@ export interface components {
             /** Fixtures */
             fixtures: components["schemas"]["TournamentFixtureRead"][];
             /** Results */
-            results: (components["schemas"]["StandingsResultsRead"] | components["schemas"]["FinishesResultsRead"] | components["schemas"]["StandingsThenFinishesResultsRead"]) | null;
+            results: (components["schemas"]["StandingsResultsRead"] | components["schemas"]["FinishesResultsRead"] | components["schemas"]["StandingsThenFinishesResultsRead"] | components["schemas"]["SwissStandingsResultsRead"]) | null;
             /**
              * Entered
              * @description The registration count. Derived — there is no stored counter (ADR-0016).
@@ -4904,6 +4940,8 @@ export interface components {
             draw_type?: components["schemas"]["DrawType"] | null;
             /** Qualifiers Per Pool */
             qualifiers_per_pool?: number | null;
+            /** Rounds */
+            rounds?: number | null;
             /** Max Players */
             max_players?: number | null;
             /** Entry Fee */

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -816,6 +816,10 @@ const event: TournamentEvent = {
   // write bodies below must OMIT the key entirely rather than send this `null`, because
   // that arm of the server's draw-settings union is `extra="forbid"`.
   qualifiersPerPool: null,
+  // …and its rounds come off the circle method rather than a setting, so it carries NO
+  // round count either (the swiss ADR). Same rule as the qualifier count above: the write
+  // bodies must OMIT the key, not send this `null`.
+  rounds: null,
   maxPlayers: 48,
   entryFee: 30,
   timezone: 'America/Chicago',
@@ -943,6 +947,9 @@ describe('eventToCreateBody', () => {
       // `event` — and the assertion below is therefore also the proof that the omission
       // and the `null` mean the same thing.
       qualifiers_per_pool: null,
+      // …and the round count the same way, for the same reason: omitted on the way out for
+      // a round-robin event, an explicit `null` on the way back.
+      rounds: null,
       id: event.id,
       tournament_id: 't-1',
       // The registrations are server-owned and absent from the create body;
@@ -1132,6 +1139,81 @@ describe('eventToUpdateBody', () => {
       })
 
       expect(apiToEvent(stored).qualifiersPerPool).toBe(2)
+    })
+  })
+
+  // The same claim for the same reason, one draw type over (ADR "swiss pre-cuts every round
+  // and pairs each one on advance"): the round count the director configured has to reach
+  // the API, because it is what sizes the whole draw (`R × ⌊n/2⌋` fixtures, cut up front).
+  // A dropped R is a swiss of the wrong length — silent, well-formed and wrong.
+  describe('the swiss round count on the wire', () => {
+    const swiss: TournamentEvent = { ...event, drawType: 'swiss', rounds: 5 }
+    const twoStage: TournamentEvent = {
+      ...event,
+      drawType: 'rr-then-ko',
+      qualifiersPerPool: 2,
+    }
+
+    it('SENDS the round count for swiss, on both verbs', () => {
+      expect(eventToCreateBody(asEditedEvent(swiss)).rounds).toBe(5)
+      expect(eventToUpdateBody(asEditedEvent(swiss)).rounds).toBe(5)
+    })
+
+    it('sends the DIRECTOR’s count, never a default', () => {
+      // `1` is the smallest legal R and the shape a dropped setting lands on, so a fixture
+      // of 1 could not tell "threaded through" from "fell back". Seven is neither.
+      const body = eventToUpdateBody(asEditedEvent({ ...swiss, rounds: 7 }))
+      expect(body.rounds).toBe(7)
+    })
+
+    // The three round-count-less arms of the server's draw-settings union are
+    // `extra="forbid"` and declare no `rounds` field at all, so the key is a **422** there —
+    // not a `null` politely ignored. Omission is the only correct spelling, and `toBeNull()`
+    // would pass against the payload that gets refused.
+    it.each(['round-robin', 'single-elim'] as const)(
+      'OMITS the key entirely for %s — where sending it is a 422, not a no-op',
+      (drawType) => {
+        const create = eventToCreateBody(asEditedEvent({ ...event, drawType }))
+        const update = eventToUpdateBody(asEditedEvent({ ...event, drawType }))
+
+        expect('rounds' in create).toBe(false)
+        expect('rounds' in update).toBe(false)
+      },
+    )
+
+    // The two settings are on OPPOSITE arms, so each body carries exactly one of them. A
+    // swiss body with a `qualifiers_per_pool` is a 422 naming the field, and vice versa —
+    // which a mapper that merely added a key rather than choosing an arm would author.
+    it('sends only its own arm’s setting, never both', () => {
+      const swissBody = eventToUpdateBody(asEditedEvent(swiss))
+      expect('qualifiers_per_pool' in swissBody).toBe(false)
+
+      const twoStageBody = eventToUpdateBody(asEditedEvent(twoStage))
+      expect('rounds' in twoStageBody).toBe(false)
+    })
+
+    it('reads the stored round count back off the wire', () => {
+      const read = apiToEvent(
+        buildTournamentEventRead({ draw_type: 'swiss', rounds: 4 }),
+      )
+
+      expect(read.rounds).toBe(4)
+    })
+
+    it('reads a round-count-less draw type back as null, never as a number', () => {
+      const read = apiToEvent(buildTournamentEventRead({ draw_type: 'round-robin' }))
+
+      expect(read.rounds).toBeNull()
+    })
+
+    it('round-trips a swiss event: configure 5, send 5, read 5 back', () => {
+      const sent = eventToUpdateBody(asEditedEvent(swiss))
+      const stored = buildTournamentEventRead({
+        draw_type: 'swiss',
+        rounds: sent.rounds,
+      })
+
+      expect(apiToEvent(stored).rounds).toBe(5)
     })
   })
 

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -145,6 +145,10 @@ export function apiToEvent(e: TournamentEventRead): TournamentEvent {
     // invent a qualifier count for a format that has no knockout stage — and, on the way
     // back out, author a body the server 422s.
     qualifiersPerPool: e.qualifiers_per_pool,
+    // **R**, carried across the same way and for the same reason (the swiss ADR): `null`
+    // is what the three round-count-less draw types store, not missing data, and inventing
+    // a `ceil(log2 n)` here would author a body the server 422s on the way back out.
+    rounds: e.rounds,
     maxPlayers: e.max_players,
     entryFee: e.entry_fee,
     timezone: e.timezone,
@@ -438,35 +442,49 @@ function poolEntriesToApi(
 }
 
 /**
- * The **draw configuration** as the write schemas take it: the draw type, and the
- * qualifier count *only* for the one draw type that has one (ADR 20260727).
+ * The **draw configuration** as the write schemas take it: the draw type, plus the ONE
+ * setting the chosen type actually has — a qualifier count for `rr-then-ko`
+ * (ADR 20260727), a round count for `swiss` (the swiss ADR), and nothing at all for the
+ * other two.
  *
- * The pair is flat on the wire and a **discriminated union tagged by `draw_type`** in
- * the server's interior. Two of its three arms — `round-robin` and `single-elim` — are
- * `extra="forbid"` and declare no `qualifiers_per_pool` field at all, so the key is a
- * **422 at the request boundary** on either of them. Not a value silently dropped: the
- * settings table's `CHECK` says `NULL` for every draw type but `rr-then-ko`, and a
- * director naming a qualifier count for a format with no knockout stage has
- * misunderstood something the server would rather say out loud.
+ * The fields are flat on the wire and a **discriminated union tagged by `draw_type`** in
+ * the server's interior. Every arm is `extra="forbid"` and declares only its own setting,
+ * so a key that belongs to another arm is a **422 at the request boundary**: a
+ * `qualifiers_per_pool` on a swiss body is refused exactly as a `rounds` on an
+ * `rr-then-ko` one is. Not a value silently dropped — a director naming a qualifier count
+ * for a pool-less format has misunderstood something the server would rather say out loud.
  *
- * So this omits the key rather than sending `null`, and it is the ONE place that
- * decision is made — shared by create and update, exactly as `toAddressInput` is,
- * because the alternative is two write surfaces putting different bytes on the wire for
- * one intent. (Absent and explicit `null` do mean the same thing to the server's
- * `_draw_settings_write`, which omits a `None` before validating; but only one of the
- * two survives `extra="forbid"`, so only one of them is safe to send.)
+ * So this sends **exactly one arm's worth of keys** and omits the rest rather than sending
+ * `null`, and it is the ONE place that decision is made — shared by create and update,
+ * exactly as `toAddressInput` is, because the alternative is two write surfaces putting
+ * different bytes on the wire for one intent. (Absent and explicit `null` do mean the same
+ * thing to the server's `_draw_settings_write`, which omits a `None` before validating; but
+ * only one of the two survives `extra="forbid"`, so only one of them is safe to send.)
  *
- * For `rr-then-ko` the count is **required** — the union arm has no default — so it is
- * sent as-is, `null` included. A `null` there is a 422 the form is meant to have caught
- * first (`qualifiersPerPoolSchema`, `data/event-validation`); sending it is honest, and
- * far better than inventing a `1` the director never chose.
+ * Each arm's own setting is **required** — the union arms carry no defaults — so it is sent
+ * as-is, `null` included. A `null` there is a 422 the form is meant to have caught first
+ * (`qualifiersPerPoolSchema` / `swissRoundsSchema`, `data/event-validation`); sending it is
+ * honest, and far better than inventing a number the director never chose.
+ *
+ * A `switch` with a `never` default rather than a chain of ternaries: a fifth draw type is a
+ * **compile error here** until somebody says which settings it puts on the wire.
  */
 function drawSettingsToApi(
-  ev: Pick<TournamentEvent, 'drawType' | 'qualifiersPerPool'>,
+  ev: Pick<TournamentEvent, 'drawType' | 'qualifiersPerPool' | 'rounds'>,
 ) {
-  return ev.drawType === 'rr-then-ko'
-    ? { draw_type: ev.drawType, qualifiers_per_pool: ev.qualifiersPerPool }
-    : { draw_type: ev.drawType }
+  switch (ev.drawType) {
+    case 'rr-then-ko':
+      return { draw_type: ev.drawType, qualifiers_per_pool: ev.qualifiersPerPool }
+    case 'swiss':
+      return { draw_type: ev.drawType, rounds: ev.rounds }
+    case 'round-robin':
+    case 'single-elim':
+      return { draw_type: ev.drawType }
+    default: {
+      const exhaustive: never = ev.drawType
+      return { draw_type: exhaustive }
+    }
+  }
 }
 
 /** The event fields shared by the create and update bodies — everything except the

--- a/web-client/src/components/tournaments/data/draw-types.test.ts
+++ b/web-client/src/components/tournaments/data/draw-types.test.ts
@@ -25,7 +25,8 @@ const row = (over: Partial<Record<string, unknown>> = {}) => ({
  * discover at the moment they cut the draw that it was never possible. The API's enum
  * now holds exactly what runs, and what does not is a **422 at the request boundary** —
  * a set that moves in both directions: `rr-then-ko` was removed with the other three and
- * came back in #1227 the moment its strategy landed.
+ * came back in #1227 the moment its strategy landed, and `swiss` came back the same way
+ * when `SwissStrategy` learned to cut a draw.
  *
  * What survives on the client is a *vocabulary*, not an offer, and it is declared
  * **once**: `DRAW_TYPES` in `./draw-types`, with `drawTypeSchema` (the event form's
@@ -48,9 +49,9 @@ describe('the draw-type vocabulary (a contract with the API, not a menu)', () =>
   })
 
   it('makes a draw type the server would 422 a compile error', () => {
-    // @ts-expect-error 'swiss' left the API's enum — it is not a draw type any more.
-    const drawType: DrawType = 'swiss'
-    expect(drawType).toBe('swiss')
+    // @ts-expect-error 'double-elim' is not in the API's enum — nothing can plan it.
+    const drawType: DrawType = 'double-elim'
+    expect(drawType).toBe('double-elim')
   })
 })
 
@@ -88,7 +89,7 @@ describe('parseDrawTypeCatalogue', () => {
   it('drops a draw type this build does not know, and keeps the rest', () => {
     const options = parseDrawTypeCatalogue([
       row({ key: 'round-robin', name: 'Round robin', display_order: 1 }),
-      row({ key: 'swiss', name: 'Swiss', display_order: 2 }),
+      row({ key: 'double-elim', name: 'Double elimination', display_order: 2 }),
     ])
 
     expect(options).toEqual([{ value: 'round-robin', label: 'Round robin' }])
@@ -115,6 +116,22 @@ describe('parseDrawTypeCatalogue', () => {
     expect(options).toEqual([
       { value: 'round-robin', label: 'Round robin' },
       { value: 'rr-then-ko', label: 'Round-robin then knockout' },
+    ])
+  })
+
+  /** The same pin for `swiss`, the second slug to make the trip from "a 422 at the
+   * request boundary" back to "a seeded row the picker must offer" (ADR "swiss pre-cuts
+   * every round and pairs each one on advance"). Written out rather than mapped from
+   * `DRAW_TYPES`, for the reason the rr-then-ko case gives above. */
+  it('keeps the swiss row the server seeds, rather than dropping it', () => {
+    const options = parseDrawTypeCatalogue([
+      row({ key: 'round-robin', name: 'Round robin', display_order: 1 }),
+      row({ key: 'swiss', name: 'Swiss', display_order: 4 }),
+    ])
+
+    expect(options).toEqual([
+      { value: 'round-robin', label: 'Round robin' },
+      { value: 'swiss', label: 'Swiss' },
     ])
   })
 

--- a/web-client/src/components/tournaments/data/draw-types.ts
+++ b/web-client/src/components/tournaments/data/draw-types.ts
@@ -33,11 +33,13 @@ import type { components } from '@/api/schema'
  * option simply is not on the menu. That is exactly how `rr-then-ko` was predicted to
  * need "no client change" and would instead have vanished (ADR "rr-then-ko cuts both
  * stages upfront and seeds qualifiers rematch-free", Context). Adding the slug here is
- * step one of adding a draw type to this client; the compiler will find the rest. */
+ * step one of adding a draw type to this client; the compiler will find the rest.
+ * `swiss` is the second slug to make that trip, and it made it the same way. */
 export const DRAW_TYPES = [
   'round-robin',
   'single-elim',
   'rr-then-ko',
+  'swiss',
 ] as const satisfies readonly components['schemas']['DrawType'][]
 
 /** The runtime parser for a single draw-type slug — what the event form validates
@@ -46,8 +48,9 @@ export const drawTypeSchema = z.enum(DRAW_TYPES)
 
 /** The draw types the API accepts — deliberately not a roadmap (ADR 20260726 "a draw
  * type is a seeded row"): a member exists iff the server has a strategy that can plan
- * it. `double-elim` and `swiss` were removed from the API's enum and are a 422 at the
- * boundary now; `rr-then-ko` came back in #1227 when its strategy landed.
+ * it. `double-elim` is still a 422 at the boundary; `rr-then-ko` came back in #1227
+ * when its strategy landed, and `swiss` came back the same way once `SwissStrategy`
+ * could cut a draw (ADR "swiss pre-cuts every round and pairs each one on advance").
  *
  * Inferred from `DRAW_TYPES` above rather than hand-written, and pinned to the
  * generated `components['schemas']['DrawType']` by a compile-time assertion in

--- a/web-client/src/components/tournaments/data/draw.test.ts
+++ b/web-client/src/components/tournaments/data/draw.test.ts
@@ -5,10 +5,13 @@ import {
   drawState,
   drawTypeFreeze,
   poolSetFreeze,
+  unpooledShape,
   type DrawState,
   type FixtureSide,
 } from './draw'
+import { DRAW_TYPES } from './draw-types'
 import {
+  buildBracketDrawnEvent,
   buildDrawnEvent,
   buildDrawTypes,
   buildEntrant,
@@ -16,6 +19,8 @@ import {
   buildEvent,
   buildFixture,
   buildPool,
+  buildSwissDrawnEvent,
+  buildTwoStageDrawnEvent,
 } from './seed.factory'
 
 /** The drawn arm, or a failed assertion — so the tests below can read `.pools`
@@ -47,6 +52,51 @@ function label(side: FixtureSide): string {
   }
 }
 
+/**
+ * **Which view an event's un-pooled fixtures get** — a fact about the DRAW TYPE, and the
+ * one this module exists to keep away from `poolId === null`.
+ *
+ * Three draw types put fixtures in `unpooled`, and nothing about the fixtures themselves
+ * tells them apart: single-elim's whole bracket, `rr-then-ko`'s knockout stage, and every
+ * fixture of a swiss draw all carry a null pool id. Routing on that null rendered a swiss
+ * draw as a knockout bracket, through the successor arithmetic the ADR says swiss does not
+ * have — silently, because a value check is not something a type checker can read.
+ */
+describe('unpooledShape', () => {
+  it('sends swiss to the ROUNDS view — never the bracket', () => {
+    expect(unpooledShape('swiss')).toBe('swiss-rounds')
+  })
+
+  // The regression pin, at the decision rather than at the DOM. `pool_id IS NULL` keeps
+  // meaning "the knockout stage" for `rr-then-ko`, and a single-elim draw is a bracket
+  // whole — neither may move because swiss now shares the null.
+  it.each(['single-elim', 'rr-then-ko'] as const)(
+    'keeps %s on the bracket',
+    (drawType) => {
+      expect(unpooledShape(drawType)).toBe('bracket')
+    },
+  )
+
+  /** A round-robin fixture with no pool is a payload the server cannot send — it names a
+   * pool the event does not list. `drawState` deliberately does not DROP it, and the
+   * bracket is the existing "show it anyway" fallback. Pinned so the arm is a decision
+   * somebody made rather than a default nobody noticed. */
+  it('keeps a round-robin’s orphaned fixtures on the same fallback they had', () => {
+    expect(unpooledShape('round-robin')).toBe('bracket')
+  })
+
+  /** Every draw type this client knows has an answer, and the `switch` has no catch-all —
+   * so a fifth member of the vocabulary is a compile error in `./draw` until somebody says
+   * how its draw reads. This asserts the runtime half: nothing falls through to
+   * `undefined`. Driven off `DRAW_TYPES` rather than a re-typed list, so adding a slug
+   * reaches this test without anybody remembering to. */
+  it('answers for every draw type in the vocabulary', () => {
+    for (const drawType of DRAW_TYPES) {
+      expect(['bracket', 'swiss-rounds']).toContain(unpooledShape(drawType))
+    }
+  })
+})
+
 describe('drawState', () => {
   it('reads an event with no fixtures as the designed UNDRAWN state', () => {
     expect(drawState(buildEvent({ fixtures: [] }))).toEqual({ kind: 'undrawn' })
@@ -57,6 +107,27 @@ describe('drawState', () => {
 
     expect(state.pools.map((p) => p.name)).toEqual(['Pool A', 'Pool B'])
     expect(state.unpooled).toEqual([])
+  })
+
+  /** The shape rides the read model, so the panel reads a tag rather than inferring a
+   * format from a null pool id. Asserted on all three un-pooled draw types, because the
+   * payloads they produce are indistinguishable at the fixture level. */
+  it('carries the un-pooled SHAPE, read off the event’s draw type', () => {
+    expect(drawn(drawState(buildSwissDrawnEvent())).unpooledShape).toBe(
+      'swiss-rounds',
+    )
+    expect(drawn(drawState(buildBracketDrawnEvent())).unpooledShape).toBe('bracket')
+    expect(drawn(drawState(buildTwoStageDrawnEvent())).unpooledShape).toBe('bracket')
+  })
+
+  /** A swiss draw's rounds all arrive un-pooled — every one of them, from the cut — so the
+   * pool list is empty and nothing is dropped. */
+  it('reads a swiss draw as un-pooled rounds, with every cut round present', () => {
+    const state = drawn(drawState(buildSwissDrawnEvent()))
+
+    expect(state.pools).toEqual([])
+    expect(state.unpooled.map((r) => r.round)).toEqual([1, 2, 3])
+    expect(state.unpooled.map((r) => r.fixtures.length)).toEqual([3, 3, 3])
   })
 
   it('lists each pool’s entrants — the members its own fixtures name, by NAME', () => {

--- a/web-client/src/components/tournaments/data/draw.ts
+++ b/web-client/src/components/tournaments/data/draw.ts
@@ -27,6 +27,7 @@ import { poolsInOrder } from './helpers'
 import { fallbackNotice, type Notice } from './notice'
 import { labelFor } from './options'
 import type {
+  DrawType,
   DrawTypeOption,
   Entrant,
   Fixture,
@@ -110,6 +111,61 @@ export interface PoolDraw {
 }
 
 /**
+ * How an event's **un-pooled fixtures read** — the one decision that says which view the
+ * draw panel gives them.
+ *
+ * ⚠️ **It is a fact about the DRAW TYPE, never about `poolId` being null**, and that
+ * distinction is the whole reason this type exists. `pool_id IS NULL` is the *stage*
+ * discriminator: for an `rr-then-ko` draw it means "the knockout stage" and will keep
+ * meaning exactly that. Swiss is a different **draw type** that happens to share the null,
+ * because it is pool-less end to end. Reading the null as "this is a bracket" conflated the
+ * two and rendered a swiss draw through single-elimination's successor arithmetic — the one
+ * thing the ADR says swiss does not have (ADR "swiss pre-cuts every round and pairs each
+ * one on advance": "swiss has no successor arithmetic").
+ */
+export type UnpooledShape =
+  /** Rounds-as-columns, named back from the final (`Bracket`). */
+  | 'bracket'
+  /** A flat list of rounds, the unpaired ones announced as forthcoming (`SwissRounds`). */
+  | 'swiss-rounds'
+
+/**
+ * Which view an event's un-pooled fixtures get — **exhaustive over `DrawType`, with no
+ * catch-all**, so a fifth draw type is a compile error here until somebody says how its
+ * draw reads.
+ *
+ * That exhaustiveness is the point. The routing this replaces was a value check
+ * (`unpooled.length > 0` → render a bracket), which no type checker can see through: swiss
+ * landed, shared the null, and silently rendered as a knockout bracket with nothing red.
+ */
+export function unpooledShape(drawType: DrawType): UnpooledShape {
+  switch (drawType) {
+    case 'single-elim':
+      return 'bracket'
+    case 'rr-then-ko':
+      // The knockout stage, which IS a bracket — `pool_id IS NULL` is the stage
+      // discriminator for this draw type, and the pool stage renders above it as pools.
+      return 'bracket'
+    case 'round-robin':
+      // A round-robin draw has no un-pooled fixtures the server can send: every fixture is
+      // dealt into a pool. One reaching here names a pool the event does not list, which is
+      // a payload that cannot legitimately arise — and `drawState` deliberately does not
+      // DROP it (see below). `'bracket'` is that existing "show it anyway" fallback and is
+      // preserved deliberately; it is not a claim that a round-robin has a bracket.
+      return 'bracket'
+    case 'swiss':
+      // Pool-less by design, and NOT a bracket: nobody is eliminated, `position` is a
+      // pairing rank rather than a topology, and rounds past the first are cut with both
+      // sides unknown until `advance()` pairs them.
+      return 'swiss-rounds'
+    default: {
+      const exhaustive: never = drawType
+      return exhaustive
+    }
+  }
+}
+
+/**
  * What an event's draw *is*, as a sum type — `undrawn` is a designed data state, not an
  * empty list to be rendered as a gap (`DEFINITION_OF_COMPLETE`: "Empty is a designed
  * data state, never a thrown one").
@@ -122,12 +178,16 @@ export type DrawState =
       kind: 'drawn'
       /** The pools the draw actually used, in the event's own pool order. */
       pools: PoolDraw[]
-      /** Fixtures belonging to **no pool** — an un-pooled draw (single-elim), or the
-       * knockout stage of a combined draw type (#787; ADR-0786: `pool_id` is `null` for
-       * both). A fixture that has no pool must not be *dropped*: it is rendered as a
-       * bracket (#785), and anything a bracket cannot place is still shown, honestly,
-       * outside the pools. */
+      /** Fixtures belonging to **no pool** — a pool-less draw (single-elim, swiss), or the
+       * knockout stage of a combined draw type (#787; ADR-0786: `pool_id` is `null` for all
+       * of them). A fixture that has no pool must not be *dropped*: it is rendered,
+       * honestly, outside the pools.
+       *
+       * **Which view it gets is `unpooledShape` below, not this list.** */
       unpooled: DrawRound[]
+      /** How `unpooled` reads — decided from the event's **draw type**, once, here, so no
+       * renderer has to infer a format from a null pool id. */
+      unpooledShape: UnpooledShape
     }
 
 /**
@@ -260,7 +320,14 @@ export function drawState(event: TournamentEvent): DrawState {
     ]
   })
 
-  return { kind: 'drawn', pools, unpooled: roundsOf(unpooled, byId) }
+  return {
+    kind: 'drawn',
+    pools,
+    unpooled: roundsOf(unpooled, byId),
+    // Read off the DRAW TYPE, never off the null pool id the fixtures above were bucketed
+    // by — see `unpooledShape`.
+    unpooledShape: unpooledShape(event.drawType),
+  }
 }
 
 /**

--- a/web-client/src/components/tournaments/data/event-validation.ts
+++ b/web-client/src/components/tournaments/data/event-validation.ts
@@ -22,7 +22,10 @@
 //   |               | whole cents                           | in whole cents              |
 //   | `qualifiers   | `QualifiersPerPool`: `ge=1`, `le=1000`,| required and 1 … 1,000 **for|
 //   |  _per_pool`   | required on the `rr-then-ko` union arm, | `rr-then-ko` only** — the   |
-//   |               | refused outright on the other two       | pair, not the field         |
+//   |               | refused outright on the other three     | pair, not the field         |
+//   | `rounds`      | `SwissRounds`: `ge=1`, `le=32`,       | required and 1 … 32 **for   |
+//   |               | required on the `swiss` union arm,      | `swiss` only** — again the  |
+//   |               | refused outright on the other three     | pair, not the field         |
 //   | `predicates`  | (permissive — see below)              | `predicate-validation.ts`   |
 //
 // ⚠️ **BLANK IS NOT ZERO — AND THE TWO NUMBER FIELDS DISAGREE ABOUT WHICH IS WHICH**
@@ -306,6 +309,58 @@ export const qualifiersPerPoolSchema = z
   // typed is the only thing they can change.
   .max(QUALIFIERS_PER_POOL_MAX, {
     error: `At most ${QUALIFIERS_PER_POOL_MAX.toLocaleString('en-US')} players can advance from each pool.`,
+  })
+
+/** The floor on **R** — the server's `SwissRounds = Annotated[int, Field(ge=1, …)]`,
+ * stated once there and mirrored once here. A swiss of zero rounds plays nothing, and a
+ * negative count is not a count. */
+export const SWISS_ROUNDS_MIN = 1
+
+/** The ceiling on **R** — the server's `MAX_SWISS_ROUNDS`, the same number, stated in both
+ * layers on purpose.
+ *
+ * The same kind of bound as `QUALIFIERS_PER_POOL_MAX`, and for the same reason: an
+ * `Integer` column behind an unbounded box is a **500** reported to the director as
+ * "something went wrong on our end", which is false — they typed a number. 32 is a bound
+ * with a reason: the largest field this API will hold (512) is conventionally paired out in
+ * nine rounds (`ceil(log2 n)`), so 32 is far above any event a table-tennis director will
+ * run and far below the column's 2,147,483,647.
+ *
+ * It is **not** the same kind of bound as the server's entrant-dependent one (`R <= N - 1`,
+ * because nobody has more than `N - 1` distinct opponents). That one moves with the field
+ * and is refused at the **cut** as a degenerate draw — a configuration that was legal when
+ * it was written must not become unwritable when a player withdraws — so it is deliberately
+ * NOT mirrored here. The cut's own refusal says which number to change, in the server's
+ * words (`drawRefusalNotice`, `data/draw`). */
+export const SWISS_ROUNDS_MAX = 32
+
+/**
+ * **R** — how many rounds a `swiss` event plays (ADR "swiss pre-cuts every round and pairs
+ * each one on advance").
+ *
+ * NOT `.nullable()`, exactly like `qualifiersPerPoolSchema` and for the identical reason: a
+ * blank round count on a swiss event is **missing**, not a state. The server's `swiss` arm
+ * requires the field with no default precisely because there is no defensible number to
+ * assume — `ceil(log2 n)` is the convention, and a derived default would move as entrants
+ * arrived, changing the length of a day the director has already booked a venue for. So
+ * `null` here is the *required* error and not a value to coalesce.
+ *
+ * It is applied **only when the draw type is `swiss`** — see `eventSchema`
+ * (`../tournament-detail-page/event-form`), which runs this parser from the object-level
+ * refinement rather than inlining it as a field rule. The bound belongs to the
+ * `(draw_type, R)` pair, exactly as it does on the server's tagged union, and a field rule
+ * that fired regardless would put a red under a control that is not on screen.
+ */
+export const swissRoundsSchema = z
+  .number({ error: 'Say how many rounds this event plays.' })
+  .int({ error: 'The number of rounds must be a whole number.' })
+  .min(SWISS_ROUNDS_MIN, {
+    error: `A swiss event plays at least ${SWISS_ROUNDS_MIN} round.`,
+  })
+  // The floor's sentence, turned over — one bound, two directions, one voice. Stated as a
+  // number the director can act on, not as "invalid".
+  .max(SWISS_ROUNDS_MAX, {
+    error: `A swiss event plays at most ${SWISS_ROUNDS_MAX} rounds.`,
   })
 
 /** The editor's four tabs, of which three can hold something invalid (Match settings

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -480,6 +480,11 @@ export function emptyEvent(t: Tournament): TournamentEvent {
     // 20260727). A new event that pre-filled a number here would be one whose create
     // body the API 422s the moment the director never touched the draw type.
     qualifiersPerPool: null,
+    // …and no round count either: a bracket's depth follows from the field rather than from
+    // a setting, and `null` is the only value the server's `single-elim` arm admits (the
+    // swiss ADR). A new event that pre-filled a number here would be one whose create body
+    // the API 422s the moment the director never touched the draw type.
+    rounds: null,
     maxPlayers: 32,
     entryFee: 30,
     // Anchor the wall-clock windows in the director's own timezone (ADR 20260719):

--- a/web-client/src/components/tournaments/data/results.test.ts
+++ b/web-client/src/components/tournaments/data/results.test.ts
@@ -6,6 +6,7 @@ type StandingsResultsRead = components['schemas']['StandingsResultsRead']
 type FinishesResultsRead = components['schemas']['FinishesResultsRead']
 type StandingsThenFinishesResultsRead =
   components['schemas']['StandingsThenFinishesResultsRead']
+type SwissStandingsResultsRead = components['schemas']['SwissStandingsResultsRead']
 type StandingRowRead = components['schemas']['StandingRowRead']
 type FinishRowRead = components['schemas']['FinishRowRead']
 
@@ -88,6 +89,20 @@ function wireTwoStage(
     ],
     complete: true,
     champion: 'entry-2',
+    ...overrides,
+  }
+}
+
+/** A complete `swiss_standings` results block off the wire (the swiss ADR) — **one list of
+ * rows, no pools**, because swiss ranks the whole field in one table. */
+function wireSwiss(
+  overrides: Partial<SwissStandingsResultsRead> = {},
+): SwissStandingsResultsRead {
+  return {
+    kind: 'swiss_standings',
+    rows: [wireRow(), wireRow({ entry_id: 'entry-2', rank: 2 })],
+    complete: true,
+    champion: 'entry-1',
     ...overrides,
   }
 }
@@ -201,6 +216,67 @@ describe('parseResults', () => {
         ? parsed.finishes.map((f) => f.position)
         : null,
     ).toEqual([3, 3])
+  })
+
+  it('maps a wire swiss block to the camelCase domain shape', () => {
+    // The fourth arm (the swiss ADR): ONE list of rows, no `pools` key at all, and the tag
+    // preserved so `ResultsPanel` can narrow to it. Without this arm the parse THROWS — and
+    // since the tournaments list maps every event through it, that takes the whole page
+    // down, not one panel.
+    expect(parseResults(wireSwiss())).toEqual({
+      kind: 'swiss_standings',
+      rows: [
+        {
+          entryId: 'entry-1',
+          rank: 1,
+          played: 2,
+          wins: 2,
+          losses: 0,
+          gamesWon: 4,
+          gamesLost: 1,
+          gameDifference: 3,
+        },
+        {
+          entryId: 'entry-2',
+          rank: 2,
+          played: 2,
+          wins: 2,
+          losses: 0,
+          gamesWon: 4,
+          gamesLost: 1,
+          gameDifference: 3,
+        },
+      ],
+      complete: true,
+      champion: 'entry-1',
+    })
+  })
+
+  it('keeps a LIVE swiss block incomplete, with no champion', () => {
+    // Rounds 2 and 3 are cut up front with their sides unknown, so a swiss event spends
+    // most of its life here: rows that are already ranked, and nobody crowned.
+    const parsed = parseResults(wireSwiss({ complete: false, champion: null }))
+
+    expect(parsed?.complete).toBe(false)
+    expect(parsed?.champion).toBeNull()
+  })
+
+  it('carries the server’s swiss row order through — it does not sort', () => {
+    // The order IS the result (ADR-0788), and it matters more in swiss than anywhere: the
+    // format pairs by score, so level rows are the ordinary state of the table and the
+    // tiebreak that separated them is one the client cannot see.
+    const parsed = parseResults(
+      wireSwiss({
+        rows: [
+          wireRow({ entry_id: 'entry-5', rank: 3 }),
+          wireRow({ entry_id: 'entry-1', rank: 1 }),
+        ],
+      }),
+    )
+
+    expect(
+      parsed?.kind === 'swiss_standings' ? parsed.rows.map((r) => r.entryId) : null,
+    ).toEqual(['entry-5', 'entry-1'])
   })
 
   it('carries the server’s row order through — it does not sort', () => {

--- a/web-client/src/components/tournaments/data/results.ts
+++ b/web-client/src/components/tournaments/data/results.ts
@@ -2,8 +2,9 @@
 // being bytes off the wire and become a typed domain value.
 //
 // An event's results are a **discriminated union tagged by shape** — `standings` (a table
-// per pool) for round-robin, `finishes` (a placement list) for single-elimination, and
-// `standings_then_finishes` (one of each, ADR 20260727) for round-robin-then-knockout —
+// per pool) for round-robin, `finishes` (a placement list) for single-elimination,
+// `standings_then_finishes` (one of each, ADR 20260727) for round-robin-then-knockout, and
+// `swiss_standings` (one table over the whole field, no pools) for swiss —
 // plus whether the whole event is decided and its champion, all derived *live* on the server
 // from the fixtures' currently-completed matches (never a snapshot). This is the runtime
 // parse that guards them, the twin of `./fixtures` for the draw. The parse switches on
@@ -147,12 +148,29 @@ const standingsThenFinishesResultsWireSchema = z.object({
   champion: z.string().nullable(),
 })
 
+/** The wire shape (`SwissStandingsResultsRead`): the swiss arm, tagged
+ * `kind: "swiss_standings"` — **one list of rows over the whole field**, whether every round
+ * is decided, and the leader once it is.
+ *
+ * The rows are parsed by `standingRowSchema`, the very parser a pool's standings use, so the
+ * swiss table cannot drift from the round-robin one and a malformed row fails at the same
+ * boundary whichever arm carried it. The only structural difference is the absence of a pool
+ * to group under — swiss ranks the whole field in one table (ADR "swiss pre-cuts every round
+ * and pairs each one on advance"). */
+const swissStandingsResultsWireSchema = z.object({
+  kind: z.literal('swiss_standings'),
+  rows: z.array(standingRowSchema),
+  complete: z.boolean(),
+  champion: z.string().nullable(),
+})
+
 /** The parsed wire union — the input to the transform below, named so the transform can
  * switch on it exhaustively. */
 type EventResultsWire = z.output<
   | typeof standingsResultsWireSchema
   | typeof finishesResultsWireSchema
   | typeof standingsThenFinishesResultsWireSchema
+  | typeof swissStandingsResultsWireSchema
 >
 
 /** Wire → domain, arm by arm. A `switch` with a `never` default rather than a chain of
@@ -183,6 +201,13 @@ function toDomain(r: EventResultsWire): EventResults {
         complete: r.complete,
         champion: r.champion,
       }
+    case 'swiss_standings':
+      return {
+        kind: 'swiss_standings',
+        rows: r.rows,
+        complete: r.complete,
+        champion: r.champion,
+      }
     default: {
       const exhaustive: never = r
       return exhaustive
@@ -205,6 +230,7 @@ export const eventResultsSchema = z
     standingsResultsWireSchema,
     finishesResultsWireSchema,
     standingsThenFinishesResultsWireSchema,
+    swissStandingsResultsWireSchema,
   ])
   .transform(toDomain)
 

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -617,6 +617,215 @@ export function buildDrawnEvent(
   })
 }
 
+/**
+ * A **swiss** event whose draw is cut: six entrants over three rounds, so `3 × ⌊6/2⌋ = 9`
+ * fixtures — **all of them written at the cut**, which is the format (ADR "swiss pre-cuts
+ * every round and pairs each one on advance").
+ *
+ * Round 1 is paired top-half-against-bottom-half from the draw order, exactly as
+ * `SwissStrategy.plan_initial` seeds it (`entry-1 v entry-4`, `entry-2 v entry-5`,
+ * `entry-3 v entry-6`). Rounds 2 and 3 carry **both sides null** — TBD, waiting on
+ * `advance()`, and *not* byes.
+ *
+ * Every fixture is `poolId: null`, and that is the trap this fixture exists to catch: it is
+ * byte-identical in shape to a single-elimination bracket, so a panel routing on the null
+ * renders this as one. Only the DRAW TYPE tells them apart.
+ *
+ * `rounds: 3` over six entrants is legal at the cut (`R <= n - 1`), so nothing here is a
+ * shape the server would have refused.
+ */
+export function buildSwissDrawnEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  const pairing = (round: number, position: number, a: string | null, b: string | null) =>
+    buildFixture({
+      id: `fx-sw-r${round}-p${position}`,
+      poolId: null,
+      round,
+      position,
+      entryAId: a,
+      entryBId: b,
+    })
+  return buildSwissEvent({
+    entrants: buildEntrants(6),
+    rounds: 3,
+    fixtures: [
+      pairing(1, 1, 'entry-1', 'entry-4'),
+      pairing(1, 2, 'entry-2', 'entry-5'),
+      pairing(1, 3, 'entry-3', 'entry-6'),
+      pairing(2, 1, null, null),
+      pairing(2, 2, null, null),
+      pairing(2, 3, null, null),
+      pairing(3, 1, null, null),
+      pairing(3, 2, null, null),
+      pairing(3, 3, null, null),
+    ],
+    ...overrides,
+  })
+}
+
+/**
+ * The same swiss event **one round in**: round 1 played out and round 2 paired by
+ * `advance()` from the standings, round 3 still waiting.
+ *
+ * The discriminating fixture for "is this round forthcoming?". On the cut-fresh event above
+ * the answer tracks the round number exactly — round 1 paired, 2 and 3 not — so a renderer
+ * that asked `round > 1` instead of asking the *sides* would pass on it and be wrong for
+ * the rest of the tournament. Here the two disagree: **round 2 is paired**, and it is what
+ * the ordinary state of a running swiss event looks like.
+ *
+ * Round 2's pairings are by score, not by the round-1 bracket: the round-1 winners
+ * (`entry-1`, `entry-2`, `entry-3`) meet each other, as swiss pairs like with like.
+ */
+export function buildSwissMidEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  const cut = buildSwissDrawnEvent()
+  return buildSwissDrawnEvent({
+    fixtures: [
+      ...cut.fixtures.slice(0, 3),
+      buildFixture({
+        id: 'fx-sw-r2-p1',
+        poolId: null,
+        round: 2,
+        position: 1,
+        entryAId: 'entry-1',
+        entryBId: 'entry-2',
+      }),
+      buildFixture({
+        id: 'fx-sw-r2-p2',
+        poolId: null,
+        round: 2,
+        position: 2,
+        entryAId: 'entry-3',
+        entryBId: 'entry-4',
+      }),
+      buildFixture({
+        id: 'fx-sw-r2-p3',
+        poolId: null,
+        round: 2,
+        position: 3,
+        entryAId: 'entry-5',
+        entryBId: 'entry-6',
+      }),
+      ...cut.fixtures.slice(6),
+    ],
+    ...overrides,
+  })
+}
+
+/**
+ * An **rr-then-ko** event whose draw is cut: both pools' round-robin fixtures **and** the
+ * knockout bracket, all in one stroke (ADR 20260727) — the bracket entirely TBD-sided,
+ * because nobody has qualified yet.
+ *
+ * The regression pin for the routing. Its knockout fixtures are `poolId: null`, exactly as
+ * a swiss draw's are, and they must keep rendering as a **bracket**: for this draw type the
+ * null really is the stage discriminator, which is the meaning the swiss fix must not
+ * disturb.
+ */
+export function buildTwoStageDrawnEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  return buildRrThenKoEvent({
+    entrants: buildEntrants(8),
+    fixtures: [
+      // The pool stage — one fixture per pool is enough to prove the pools still render
+      // above the bracket; the snake's full circle is `buildDrawnEvent`'s business.
+      buildFixture({
+        id: 'fx-pa-1',
+        poolId: 'p-a',
+        round: 1,
+        position: 1,
+        entryAId: 'entry-1',
+        entryBId: 'entry-3',
+      }),
+      buildFixture({
+        id: 'fx-pb-1',
+        poolId: 'p-b',
+        round: 1,
+        position: 1,
+        entryAId: 'entry-2',
+        entryBId: 'entry-4',
+      }),
+      // The knockout stage: `P × K` = 2 × 2 = 4 slots, so two semifinals and a final, every
+      // side TBD until the pools decide their qualifiers.
+      buildFixture({
+        id: 'fx-ko-r1-p1',
+        poolId: null,
+        round: 1,
+        position: 1,
+        entryAId: null,
+        entryBId: null,
+      }),
+      buildFixture({
+        id: 'fx-ko-r1-p2',
+        poolId: null,
+        round: 1,
+        position: 2,
+        entryAId: null,
+        entryBId: null,
+      }),
+      buildFixture({
+        id: 'fx-ko-r2-p1',
+        poolId: null,
+        round: 2,
+        position: 1,
+        entryAId: null,
+        entryBId: null,
+      }),
+    ],
+    ...overrides,
+  })
+}
+
+/**
+ * A **single-elimination** event whose draw is cut: four entrants, two semifinals with
+ * their seeds named and a TBD final.
+ *
+ * The other regression pin. Un-pooled like a swiss draw and like the knockout stage above,
+ * and it must keep rendering as a bracket.
+ */
+export function buildBracketDrawnEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  return buildEvent({
+    id: 'ev-bracket',
+    name: 'Championship Singles',
+    drawType: 'single-elim',
+    entrants: buildEntrants(4),
+    // A bracket is un-pooled — the event's pools are not consulted at all (ADR-0786).
+    pools: [],
+    fixtures: [
+      buildFixture({
+        id: 'fx-se-r1-p1',
+        poolId: null,
+        round: 1,
+        position: 1,
+        entryAId: 'entry-1',
+        entryBId: 'entry-4',
+      }),
+      buildFixture({
+        id: 'fx-se-r1-p2',
+        poolId: null,
+        round: 1,
+        position: 2,
+        entryAId: 'entry-3',
+        entryBId: 'entry-2',
+      }),
+      buildFixture({
+        id: 'fx-se-r2-p1',
+        poolId: null,
+        round: 2,
+        position: 1,
+        entryAId: null,
+        entryBId: null,
+      }),
+    ],
+    ...overrides,
+  })
+}
+
 /** How many pools `buildTenPools` builds — ten, because ten is the smallest count at
  * which a legacy client-minted id (`p-10-…`) sorts into the middle of the single digits.
  * Nine pools would order identically by id and by position, and prove nothing. */

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -25,6 +25,7 @@ import type {
   StandingRow,
   StandingsResults,
   StandingsThenFinishesResults,
+  SwissStandingsResults,
   Tournament,
   TournamentEvent,
   TournamentTable,
@@ -180,6 +181,12 @@ export function buildEvent(
     // explicit `undefined` while the field is required-and-nullable (`number | null`) —
     // the same reason `entryState` is computed below rather than spread.
     qualifiersPerPool: overrides.qualifiersPerPool ?? null,
+    // **No chosen round count** either (the swiss ADR) — a round-robin's rounds are dealt by
+    // the circle method and a bracket's depth follows from the field, so `null` is the only
+    // value those draw types' settings admit. Stated AFTER the spread for the same reason
+    // the qualifier count is: `Partial<…>` admits an explicit `undefined` while the field is
+    // required-and-nullable (`number | null`).
+    rounds: overrides.rounds ?? null,
   } satisfies Omit<TournamentEvent, 'entered'>
   // An **uncapped** event (`maxPlayers: null`, ADR-0935) is never `event_full` —
   // the server guarantees it, and so does the fixture. The null check is the whole
@@ -295,6 +302,34 @@ export function buildRrThenKoEvent(
         position: 1,
       }),
     ],
+    ...overrides,
+  })
+}
+
+/**
+ * A **swiss** event (ADR "swiss pre-cuts every round and pairs each one on advance"): eight
+ * entrants over **three** rounds, and **no pools at all**.
+ *
+ * `rounds: 3` rather than the smallest legal `1`, deliberately, and for the reason
+ * `buildRrThenKoEvent` gives about its qualifier count: `1` is where any dropped-setting
+ * bug lands, so a fixture built on it could not tell "the director's R was threaded
+ * through" from "something substituted the minimum". It is also a legal R for this field —
+ * the cut refuses `R > n - 1`, and 3 is comfortably under 7.
+ *
+ * `pools: []` is the format, not an omission: swiss ranks the whole field in one table, so
+ * an event carrying pools would be describing a shape the draw does not have.
+ */
+export function buildSwissEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  return buildEvent({
+    id: 'ev-swiss',
+    name: 'Swiss Singles',
+    drawType: 'swiss',
+    rounds: 3,
+    maxPlayers: 32,
+    entrants: buildEntrants(8),
+    pools: [],
     ...overrides,
   })
 }
@@ -945,6 +980,96 @@ export function buildTwoStageEvent(
 ): TournamentEvent {
   return buildRrThenKoEvent({
     results: buildTwoStageResults(),
+    ...overrides,
+  })
+}
+
+/**
+ * A fixture event's own **swiss standings block**, narrowed — the `swiss_standings` twin
+ * of the three above, and throwing for the same reason.
+ */
+export function swissStandingsResultsOf(
+  event: TournamentEvent,
+): SwissStandingsResults {
+  const results = event.results
+  if (results === null || results.kind !== 'swiss_standings') {
+    throw new Error(
+      `Fixture event '${event.id}' has no swiss standings block (results: ${results?.kind ?? 'null'}). Build it with buildSwissStandingsEvent().`,
+    )
+  }
+  return results
+}
+
+/**
+ * A **swiss** event's results (the swiss ADR): **one complete table over the whole field**,
+ * four entrants deep, with `entry-1` on top and crowned.
+ *
+ * No pools, which is the whole shape: a swiss ranks everybody against everybody. The ranks
+ * are distinct and the numbers descend with them, so a panel that re-sorted — or a selector
+ * that lost the order — would show a visibly different table. The live state (rounds still
+ * to play) is `buildSwissStandingsResults({ complete: false, champion: null })`.
+ */
+export function buildSwissStandingsResults(
+  overrides: Partial<SwissStandingsResults> = {},
+): SwissStandingsResults {
+  return {
+    kind: 'swiss_standings',
+    rows: [
+      buildStandingRow({
+        entryId: 'entry-1',
+        rank: 1,
+        played: 3,
+        wins: 3,
+        losses: 0,
+        gamesWon: 9,
+        gamesLost: 2,
+        gameDifference: 7,
+      }),
+      buildStandingRow({
+        entryId: 'entry-2',
+        rank: 2,
+        played: 3,
+        wins: 2,
+        losses: 1,
+        gamesWon: 7,
+        gamesLost: 5,
+        gameDifference: 2,
+      }),
+      buildStandingRow({
+        entryId: 'entry-3',
+        rank: 3,
+        played: 3,
+        wins: 1,
+        losses: 2,
+        gamesWon: 5,
+        gamesLost: 7,
+        gameDifference: -2,
+      }),
+      buildStandingRow({
+        entryId: 'entry-4',
+        rank: 4,
+        played: 3,
+        wins: 0,
+        losses: 3,
+        gamesWon: 2,
+        gamesLost: 9,
+        gameDifference: -7,
+      }),
+    ],
+    complete: true,
+    champion: 'entry-1',
+    ...overrides,
+  }
+}
+
+/** A **swiss** event **with results**: the pool-less swiss event `buildSwissEvent` seeds,
+ * played out to a champion. Its entrants (`entry-1`…`entry-8`) include every id the table
+ * names, so every row joins to a username. */
+export function buildSwissStandingsEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  return buildSwissEvent({
+    results: buildSwissStandingsResults(),
     ...overrides,
   })
 }

--- a/web-client/src/components/tournaments/data/swiss-standings.test.ts
+++ b/web-client/src/components/tournaments/data/swiss-standings.test.ts
@@ -1,0 +1,85 @@
+import { WITHDRAWN_LABEL } from './draw'
+import {
+  buildEntrants,
+  buildStandingRow,
+  buildSwissStandingsEvent,
+  buildSwissStandingsResults,
+  swissStandingsResultsOf,
+} from './seed.factory'
+import { eventSwissStandings } from './swiss-standings'
+import type { TournamentEvent } from './types'
+
+/** The view for an event's own swiss block — the pairing `ResultsPanel` makes at runtime,
+ * since the selector is handed the block rather than finding one. */
+const viewOf = (event: TournamentEvent) =>
+  eventSwissStandings(event, swissStandingsResultsOf(event))
+
+describe('eventSwissStandings', () => {
+  it('joins every row’s entry id to a username, in one table', () => {
+    const view = viewOf(buildSwissStandingsEvent())
+
+    expect(view.rows.map((r) => r.name)).toEqual([
+      'player.1',
+      'player.2',
+      'player.3',
+      'player.4',
+    ])
+  })
+
+  it('carries every server number and order through untouched', () => {
+    // The client shows the figures, it does not compute them (ADR-0788). Feed rows out of
+    // rank order and expect them back in that same order, numbers intact — which is what a
+    // selector that quietly sorted by rank or by wins would fail.
+    const view = viewOf(
+      buildSwissStandingsEvent({
+        results: buildSwissStandingsResults({
+          rows: [
+            buildStandingRow({ entryId: 'entry-3', rank: 3, gameDifference: -2 }),
+            buildStandingRow({ entryId: 'entry-1', rank: 1, gameDifference: 7 }),
+          ],
+        }),
+      }),
+    )
+
+    expect(view.rows.map((r) => r.entryId)).toEqual(['entry-3', 'entry-1'])
+    expect(view.rows.map((r) => r.gameDifference)).toEqual([-2, 7])
+    expect(view.rows.map((r) => r.rank)).toEqual([3, 1])
+  })
+
+  it('joins the champion to a name', () => {
+    const view = viewOf(buildSwissStandingsEvent())
+
+    expect(view.complete).toBe(true)
+    expect(view.champion).toBe('player.1')
+  })
+
+  // A swiss event with rounds still to play — the state it spends most of its life in,
+  // since every round is cut up front and paired only as the one before it is decided.
+  it('keeps a null champion null while rounds are still unplayed', () => {
+    const view = viewOf(
+      buildSwissStandingsEvent({
+        results: buildSwissStandingsResults({ complete: false, champion: null }),
+      }),
+    )
+
+    expect(view.complete).toBe(false)
+    expect(view.champion).toBeNull()
+  })
+
+  it('shows a row naming a no-longer-listed entry as Withdrawn', () => {
+    // A player who withdrew after playing: their completed matches still count toward the
+    // numbers, but they are no longer an entrant, so the join has no username. It is the
+    // withdrawn word, never a blank and never the raw id — the SAME join the pool table
+    // makes, which is why this selector reuses `nameOf` rather than forking it.
+    const view = viewOf(
+      buildSwissStandingsEvent({
+        entrants: buildEntrants(2), // entry-3 and entry-4 are gone
+        results: buildSwissStandingsResults({
+          rows: [buildStandingRow({ entryId: 'entry-4', rank: 1 })],
+        }),
+      }),
+    )
+
+    expect(view.rows[0].name).toBe(WITHDRAWN_LABEL)
+  })
+})

--- a/web-client/src/components/tournaments/data/swiss-standings.ts
+++ b/web-client/src/components/tournaments/data/swiss-standings.ts
@@ -1,0 +1,73 @@
+// What a **swiss** event's results look like to a reader (ADR "swiss pre-cuts every round
+// and pairs each one on advance") — the pure derivation behind the Events tab's swiss
+// standings block, and the pool-less sibling of `./standings`.
+//
+// The wire gives us the `swiss_standings` arm of `EventResults` (parsed at the boundary by
+// `./results`): **one list of rows over the whole field**, keyed by entry id, plus whether
+// every round is decided and a champion that is an entry id. A director reads that as a
+// **named** table with a **named** leader, and nothing on the wire is shaped that way —
+// deliberately, and for the reason `./standings` gives: a row carries an entry *id*, the
+// username behind it is already on the event (`entrants` is keyed by that id), so the join
+// happens here, once. Copying the username onto the row would carry a field and its own
+// derivation, and the two would drift the moment a player is renamed.
+//
+// **It makes ONE join, not two.** A pool's standings also resolve a `poolId` to a pool
+// name; swiss has no pool to resolve, because it ranks the whole field in one table. That
+// absence is the only thing that distinguishes this module from `./standings` — the rows
+// themselves are the very `StandingRow`s a pool carries, joined by the very same
+// `nameOf`, so the withdrawn-entrant label and every number cannot fork into a second
+// implementation.
+//
+// What it deliberately does **not** do is re-order or recompute anything: the server owns
+// the finishing order and every figure (ADR-0788 — "the order *is* the result"), so the
+// rows are mapped **in the order they arrive**, untouched.
+//
+// A pure function of one event, so it is unit-tested (`./swiss-standings.test.ts`) rather
+// than asserted through a DOM.
+
+import { nameByEntryId, nameOf } from './entrant-names'
+import type { StandingLine } from './standings'
+import type { SwissStandingsResults, TournamentEvent } from './types'
+
+/** A swiss event's standings, shaped for the reader: the whole field as one named table,
+ * whether every round is decided, and the leader's *name* (joined) once it is. */
+export interface SwissStandingsView {
+  /** Every entrant, in the server's finishing order — **one list, no pools**, rendered
+   * untouched. */
+  rows: StandingLine[]
+  /** True when **every round** is decided, the later ones included. */
+  complete: boolean
+  /** The leader's username once the event is complete, else `null` — the server's own
+   * `champion`, joined to a name. A swiss ranks its whole field, so unlike the round-robin
+   * block there is no multi-pool carve-out that leaves a complete event uncrowned. */
+  champion: string | null
+}
+
+/**
+ * A **swiss standings block**, shaped for the reader — always a view, never `null`.
+ *
+ * Like `eventStandings` it is handed the block rather than digging one out of the event, so
+ * it does not decide whether it applies: **the caller that switches on `results.kind` does**
+ * (`ResultsPanel`), and it is the only place that knows an event may have no results at all.
+ *
+ * The rows are mapped **in the order the server sent them**. Re-sorting them here — even by
+ * the same visible keys — would be the client second-guessing a result it does not own, and
+ * would silently disagree the day a tiebreaker the client cannot see (head-to-head, and
+ * Buchholz once it lands) decides two level rows. In swiss that is not a corner case: the
+ * format pairs by score, so level rows are the ordinary state of the table.
+ */
+export function eventSwissStandings(
+  event: TournamentEvent,
+  results: SwissStandingsResults,
+): SwissStandingsView {
+  const names = nameByEntryId(event)
+
+  return {
+    rows: results.rows.map(
+      (row): StandingLine => ({ ...row, name: nameOf(row.entryId, names) }),
+    ),
+    complete: results.complete,
+    champion:
+      results.champion === null ? null : nameOf(results.champion, names),
+  }
+}

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -425,11 +425,40 @@ export interface StandingsThenFinishesResults {
 }
 
 /**
+ * A **swiss** event's results (ADR "swiss pre-cuts every round and pairs each one on
+ * advance"): **one standings table over the whole field**, whether every round is decided,
+ * and the leader once it is. The `swiss_standings` arm of the `EventResults` union.
+ *
+ * The rows are the very `StandingRow`s a round-robin pool carries — not a swiss-flavoured
+ * near-copy — so the same table renders them and the two shapes cannot drift apart. The
+ * one difference is that they arrive as **one list rather than grouped under a pool**, and
+ * that is a fact about the format: swiss is pool-less, everybody is ranked against
+ * everybody, which is what pairing by score is for.
+ *
+ * Live and partial like every other results shape: the table fills in as matches land, and
+ * the later rounds — cut up front with their sides still unknown — contribute nothing until
+ * they are paired and played.
+ */
+export interface SwissStandingsResults {
+  kind: 'swiss_standings'
+  /** The whole field in the server's finishing order, **never re-sorted here** (the order
+   * *is* the result — ADR-0788). One list, because there is no pool to group by. */
+  rows: StandingRow[]
+  /** True when **every round** is decided, the later ones included. */
+  complete: boolean
+  /** The leader's **entry id** once the event is complete, else `null`. A swiss ranks its
+   * whole field, so unlike the round-robin arm there is no multi-pool carve-out: a complete
+   * swiss always has one. Joined to a username at render, like a row's `entryId`. */
+  champion: string | null
+}
+
+/**
  * An event's **results**, a discriminated union tagged by shape (ADR-0785, widened by ADR
- * 20260727): `standings` for round-robin, `finishes` for single-elimination,
- * `standings_then_finishes` for round-robin-then-knockout. Each draw type's results
- * strategy returns its own shape; the BFF emits the `kind` tag; the client switches on it.
- * A future draw type is a type error until it declares its shape.
+ * 20260727 and by the swiss ADR): `standings` for round-robin, `finishes` for
+ * single-elimination, `standings_then_finishes` for round-robin-then-knockout, and
+ * `swiss_standings` for swiss. Each draw type's results strategy returns its own shape; the
+ * BFF emits the `kind` tag; the client switches on it. A future draw type is a type error
+ * until it declares its shape.
  *
  * On the event it is `null` for an event with **no draw** — nothing to stand — an honest
  * "no results", never an empty table that would read as a played event with nobody in it.
@@ -440,6 +469,7 @@ export type EventResults =
   | StandingsResults
   | FinishesResults
   | StandingsThenFinishesResults
+  | SwissStandingsResults
 
 /** One *active* entry in an event. Withdrawn entries are not entrants — they
  * appear in neither this list nor the `entered` count (ADR-0016).
@@ -536,6 +566,25 @@ export interface TournamentEvent {
    * the mock planner and every reader take the director's real value rather than a
    * default. */
   qualifiersPerPool: number | null
+  /** **R** — how many rounds a `swiss` event plays, or `null` for a draw type whose round
+   * count is not a thing anybody chooses (ADR "swiss pre-cuts every round and pairs each
+   * one on advance").
+   *
+   * ⚠️ `null` is not "unset" — it is the **only** legal value for the other three draw
+   * types, and the server says so at the request boundary the same way it does for the
+   * qualifier count: the draw configuration is a union tagged by the draw type, and the
+   * three round-count-less arms are `extra="forbid"`, so a `rounds` sent alongside any of
+   * them is a 422 rather than a value quietly dropped. That is why `eventToApiFields`
+   * (`./api`) **omits** the key for those three instead of sending `null` — and why the
+   * editor's control for it is rendered only for `swiss`.
+   *
+   * For `swiss` it is **required**, and it is not a number this client may assume:
+   * `ceil(log2 n)` is the convention, and deliberately not a derived default — a director
+   * books tables and a venue window before registration opens, so a round count that moved
+   * as entrants arrived would change the length of a day that is already booked. It is also
+   * what sizes the draw (`R × ⌊n/2⌋` fixtures, all cut up front), which is why it is
+   * carried on the read model at all. */
+  rounds: number | null
   /** The entrant cap, or `null` for an uncapped event. `null` means "no cap",
    * never zero (ADR-0935): a blank player-limit field submits `null`, and every
    * reader must handle the no-cap branch rather than dividing by it. */

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -215,6 +215,10 @@ export const EventEditor = ({
     // (ADR 20260727): a draw type set without its count would be validated against a
     // stale K, and a count without its type against a stale arm.
     form.setValue('qualifiersPerPool', next.qualifiersPerPool, opts)
+    // …and the round count with them, for the identical reason (the swiss ADR): the
+    // resolver judges `(drawType, rounds)` as one pair too, so a draw type set without its
+    // round count would be validated against a stale R.
+    form.setValue('rounds', next.rounds, opts)
     form.setValue('maxPlayers', next.maxPlayers, opts)
     form.setValue('entryFee', next.entryFee, opts)
     form.setValue('timezone', next.timezone, opts)
@@ -256,6 +260,7 @@ export const EventEditor = ({
   const basicsErrors = {
     name: errors.name?.message,
     qualifiersPerPool: errors.qualifiersPerPool?.message,
+    rounds: errors.rounds?.message,
     maxPlayers: errors.maxPlayers?.message,
     entryFee: errors.entryFee?.message,
     timezone: errors.timezone?.message,

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
@@ -39,6 +39,24 @@ const scoped = (container: Container) => ({
   getQualifiersValue() {
     return fieldPage.within(container).getFieldValue('Qualifiers per pool')
   },
+  /** **R** — the round-count box, which exists only for a `swiss` event (the swiss ADR).
+   * `get` for the case that expects it. */
+  getRoundsInput() {
+    return container.getByLabelText(/^Rounds/)
+  },
+  /** …and the `query` twin, because "this control is NOT on screen" is the claim for
+   * every other draw type: a round count is not a blank field a round-robin event has,
+   * it is a question that format does not ask. Asked by LABEL rather than by
+   * `getFormElements().length`, so it discriminates "the row is absent" from "some other
+   * row went missing too". */
+  queryRoundsInput() {
+    return container.queryByLabelText(/^Rounds/)
+  },
+  /** The round count as a **reader** sees it — the `Field` read-only branch's value under
+   * its label (ADR 0015). Use `queryRoundsInput` for the "row absent" claim. */
+  getRoundsValue() {
+    return fieldPage.within(container).getFieldValue('Rounds')
+  },
   /** The red message under a field — the `Field` row's `hint`, rendered as an error.
    * Queried by its TEXT because that is what the organizer reads; a test that asked
    * for "the hint node" would pass on a message rendered in the wrong colour under

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
@@ -7,6 +7,7 @@ import {
   buildDrawnEvent,
   buildEvent,
   buildRrThenKoEvent,
+  buildSwissEvent,
 } from '../../data/seed.factory'
 import { basicsSectionPage } from './basics-section.page'
 
@@ -380,6 +381,146 @@ describe('BasicsSection', () => {
     })
   })
 
+  /**
+   * **R** — the round count (ADR "swiss pre-cuts every round and pairs each one on
+   * advance"). Its design is the qualifier count's, one draw type over: it belongs to the
+   * `(draw_type, R)` PAIR and not to the event, because the server parses the two into a
+   * union tagged by the draw type, whose `swiss` arm requires a count and whose other three
+   * arms are `extra="forbid"` and refuse the key outright.
+   *
+   * So the claim worth pinning is not "there is a number box" — it is that the box is **on
+   * screen for exactly one draw type**, and absent (not disabled, not em-dashed) for the
+   * rest. A control rendered unconditionally would invite a director to say how many rounds
+   * a knockout bracket plays, and would author a 422.
+   */
+  describe('the round count (swiss only)', () => {
+    it('renders the control for a swiss event', () => {
+      basicsSectionPage.render({ event: buildSwissEvent({ rounds: 5 }) })
+
+      expect(basicsSectionPage.getRoundsInput()).toHaveValue(5)
+    })
+
+    // The falsification for the conditional: render it unconditionally and these red.
+    it.each(['round-robin', 'single-elim', 'rr-then-ko'] as const)(
+      'does not render it at all for %s — a format whose rounds nobody chooses',
+      (drawType) => {
+        basicsSectionPage.render({
+          event: buildEvent({
+            drawType,
+            rounds: null,
+            qualifiersPerPool: drawType === 'rr-then-ko' ? 2 : null,
+          }),
+        })
+
+        expect(basicsSectionPage.queryRoundsInput()).toBeNull()
+        // …and the rest of the tab is untouched, so this is "one row is absent" rather
+        // than "the section failed to render".
+        expect(basicsSectionPage.getNameInput()).toBeInTheDocument()
+        expect(basicsSectionPage.getDrawTypeTrigger()).toBeInTheDocument()
+      },
+    )
+
+    // ⚠️ `rerenderWith`, never a second `render` — see the qualifier count's twin of this
+    // test for the measurement behind that.
+    it('appears and disappears with the draw type the director picks', () => {
+      const { rerenderWith } = basicsSectionPage.render({
+        event: buildSwissEvent({ rounds: 5 }),
+      })
+      expect(basicsSectionPage.getRoundsInput()).toBeInTheDocument()
+
+      rerenderWith({
+        event: buildSwissEvent({ drawType: 'round-robin', rounds: null }),
+      })
+
+      expect(basicsSectionPage.queryRoundsInput()).toBeNull()
+      // One tree, so the absence above is a real unmount and not a query that missed.
+      expect(screen.getAllByTestId('basics-section')).toHaveLength(1)
+    })
+
+    it('emits the typed round count', () => {
+      const onChange = vi.fn()
+      basicsSectionPage.render({ event: buildSwissEvent({ rounds: 5 }), onChange })
+
+      fireEvent.change(basicsSectionPage.getRoundsInput(), {
+        target: { value: '7' },
+      })
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ rounds: 7 }),
+      )
+    })
+
+    // Blank is **missing**, not zero — `Number('')` is `0`, and a swiss that plays no
+    // rounds is not what an emptied box means. The resolver turns the `null` into the
+    // required error; a `0` would sail past a "did they answer?" check and be refused
+    // later, by the server, in Pydantic's words.
+    it('emits null — never 0 — when the box is cleared', () => {
+      const onChange = vi.fn()
+      basicsSectionPage.render({ event: buildSwissEvent({ rounds: 5 }), onChange })
+
+      fireEvent.change(basicsSectionPage.getRoundsInput(), {
+        target: { value: '' },
+      })
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ rounds: null }),
+      )
+    })
+
+    it('prints the form’s message under the box, and marks it invalid', () => {
+      basicsSectionPage.render({
+        event: buildSwissEvent({ rounds: null }),
+        errors: { rounds: 'Say how many rounds this event plays.' },
+      })
+
+      expect(basicsSectionPage.getRoundsInput()).toHaveAttribute(
+        'aria-invalid',
+        'true',
+      )
+      expect(
+        basicsSectionPage.queryFieldError('Say how many rounds this event plays.'),
+      ).toBeInTheDocument()
+    })
+
+    // The round count rides the SAME freeze as the draw type, because on the server it is
+    // the same guard: `_enforce_draw_settings_frozen` compares the whole configuration,
+    // since a draw cut as `R × ⌊n/2⌋` fixtures is exactly as contradicted by a changed R as
+    // by a changed type. A live box here would author a 409.
+    it('freezes with the draw type once the draw is cut, pointing at the reason', () => {
+      basicsSectionPage.render({
+        event: buildSwissEvent({ fixtures: buildDrawnEvent().fixtures }),
+      })
+
+      const input = basicsSectionPage.getRoundsInput()
+      expect(input).toBeDisabled()
+      const describedBy = input.getAttribute('aria-describedby')
+      expect(describedBy).toBeTruthy()
+      expect(document.getElementById(describedBy!)).toHaveTextContent(
+        /Delete the draw/i,
+      )
+    })
+
+    it('leaves it live, with its hint, when no draw is cut', () => {
+      basicsSectionPage.render({ event: buildSwissEvent() })
+
+      expect(basicsSectionPage.getRoundsInput()).toBeEnabled()
+      expect(
+        basicsSectionPage.queryFieldError(/Nobody is eliminated/i),
+      ).toBeInTheDocument()
+    })
+
+    // A reader gets the number as TEXT, never a disabled spinner (ADR-0015).
+    it('reads a viewer the stored round count, with no control at all', () => {
+      basicsSectionPage.render({
+        event: buildSwissEvent({ rounds: 5 }),
+        canEdit: false,
+      })
+
+      expect(basicsSectionPage.getRoundsValue()).toHaveTextContent('5')
+      expect(basicsSectionPage.queryRoundsInput()).toBeNull()
+    })
+  })
+
   it('shows the event name and format', () => {
     basicsSectionPage.render({
       event: buildEvent({ name: 'Open Singles', format: 'singles' }),
@@ -600,6 +741,25 @@ describe('BasicsSection', () => {
       // (`Field` requires a `value` beside `readOnly` precisely so a row cannot vanish
       // into an em-dash and be mistaken for one the organizer left blank.)
       expect(basicsSectionPage.getQualifiersValue()).toHaveTextContent('2')
+    })
+
+    // …and the same sweep over the OTHER draw type that renders an extra row. The two
+    // guards above are both blind to it: the default fixture is round-robin and the
+    // two-stage one renders the qualifier count, so neither ever mounts the swiss branch —
+    // and a live `<input type=number>` there is a `spinbutton`, which a role-only sweep
+    // does not see at all (`web-client/CLAUDE.md`). The DOM sweep over a swiss event is
+    // what actually covers it.
+    it('renders no interactive controls for a swiss event either', () => {
+      basicsSectionPage.render({
+        event: buildSwissEvent({ rounds: 5 }),
+        canEdit: false,
+      })
+
+      expect(basicsSectionPage.getFormElements()).toHaveLength(0)
+      expect(basicsSectionPage.queryRoundsInput()).toBeNull()
+      // The value is still THERE — a viewer reads the round count, they just cannot type
+      // it.
+      expect(basicsSectionPage.getRoundsValue()).toHaveTextContent('5')
     })
 
     it('renders every field as a value', () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
@@ -6,6 +6,8 @@ import {
   PLAYERS_MAX,
   QUALIFIERS_PER_POOL_MAX,
   QUALIFIERS_PER_POOL_MIN,
+  SWISS_ROUNDS_MAX,
+  SWISS_ROUNDS_MIN,
 } from '../../data/event-validation'
 import { fmtDate } from '../../data/helpers'
 import { FORMAT_OPTIONS, labelFor } from '../../data/options'
@@ -30,6 +32,10 @@ export interface BasicsFieldErrors {
    * since that is the only draw type the resolver asks the question of (and the only one
    * whose control is on screen). */
   qualifiersPerPool?: string
+  /** The round count's inline red — only ever present for a `swiss` event, since that is
+   * the only draw type the resolver asks the question of (and the only one whose control
+   * is on screen). */
+  rounds?: string
   maxPlayers?: string
   entryFee?: string
   /** The timezone is chosen from a picker that only ever offers real IANA zones, so
@@ -259,6 +265,60 @@ export const BasicsSection = ({
                   set({
                     qualifiersPerPool:
                       e.target.value === '' ? null : Number(e.target.value),
+                  })
+                }
+              />
+            )}
+          </Field>
+        )}
+        {/* **R**, and only for the one draw type whose round count anybody chooses (ADR
+            "swiss pre-cuts every round and pairs each one on advance"). Absent for the
+            other three, exactly as the qualifier count above is absent for theirs, and for
+            the same reason: a round-robin's rounds are dealt by the circle method and a
+            bracket's depth follows from the field, so this is not a box those formats leave
+            blank — it is a question they do not ask. The server says the same thing by
+            refusing the key outright on their arms of the draw-settings union
+            (`extra="forbid"` — a 422, not a silently dropped value).
+
+            It rides the SAME freeze as the draw type, because on the server it is the same
+            guard: `_enforce_draw_settings_frozen` compares the whole configuration, and a
+            5-round swiss cut for R=5 is exactly as contradicted by a changed R as by a
+            changed type. One freeze, one sentence, one way out (delete the draw, cut
+            again). */}
+        {event.drawType === 'swiss' && (
+          <Field
+            label="Rounds"
+            required
+            readOnly={readOnly}
+            value={numericValue(event.rounds)}
+            error={!!errors.rounds}
+            hint={
+              errors.rounds ??
+              (drawTypeFreeze.kind === 'frozen'
+                ? drawTypeFreeze.reason
+                : 'How many rounds every entrant plays. Nobody is eliminated.')
+            }
+          >
+            {(id, hintId) => (
+              <Input
+                id={id}
+                type="number"
+                min={SWISS_ROUNDS_MIN}
+                // Advisory, exactly like every other `max` on this tab: it steers the
+                // spinner and stops nothing that is typed or pasted. The bound that BINDS is
+                // `swissRoundsSchema`'s. Both are stated from the same constants so the
+                // browser control and the resolver agree about the same number.
+                max={SWISS_ROUNDS_MAX}
+                aria-invalid={!!errors.rounds}
+                aria-describedby={hintId}
+                disabled={drawTypeFreeze.kind === 'frozen'}
+                // Hold empty as empty. A blank round count is a MISSING answer to a question
+                // this draw type does ask — never `Number('')`, which is `0`, which is a
+                // swiss that plays nothing.
+                value={event.rounds ?? ''}
+                onChange={(e) =>
+                  set({
+                    rounds: e.target.value === '' ? null : Number(e.target.value),
                   })
                 }
               />

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
@@ -109,6 +109,104 @@ describe('eventSchema', () => {
     })
   })
 
+  /**
+   * **R is judged with its draw type, never alone** (ADR "swiss pre-cuts every round and
+   * pairs each one on advance") — the resolver's half of the server's tagged union, one
+   * draw type over from the qualifier count above and for the identical reason.
+   *
+   * A field-level rule would have to answer "is a null round count wrong?" without knowing
+   * the draw type, and both answers are wrong three-quarters of the time: for `swiss`,
+   * `null` is a missing answer; for the other three it is the only legal value — and a red
+   * raised there would refuse the save with a message under a control that is not rendered.
+   */
+  describe('the round count', () => {
+    const swiss = (rounds: number | null) => formFor({ drawType: 'swiss', rounds })
+
+    it('requires a round count for swiss, and blames the field by name', () => {
+      expect(rejectedFields(swiss(null))).toEqual(['rounds'])
+    })
+
+    it('speaks the schema’s own sentence about the missing answer', () => {
+      const result = eventSchema.safeParse(swiss(null))
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe(
+        'Say how many rounds this event plays.',
+      )
+    })
+
+    // `ge=1` on the server (`SwissRounds`). A swiss of zero rounds plays nothing, a
+    // negative count is not a count, and half a round is not a round.
+    it.each([0, -1, 2.5])('refuses %s', (bad) => {
+      expect(rejectedFields(swiss(bad))).toEqual(['rounds'])
+    })
+
+    it('accepts the smallest legal count, and a larger one', () => {
+      expect(rejectedFields(swiss(1))).toEqual([])
+      expect(rejectedFields(swiss(5))).toEqual([])
+    })
+
+    /**
+     * ⚠️ **`le=32` on the server, and the resolver has to know it too** — the qualifier
+     * count's #1231 bug, one field over: an unbounded box sends a number that overflows the
+     * `Integer` column, and the director is told "something went wrong on our end", which is
+     * false. Refused HERE, so it is never sent, with the ceiling named because the number is
+     * the only thing they can change.
+     */
+    it.each([33, 999_999_999, 2_147_483_648])('refuses %s', (tooMany) => {
+      expect(rejectedFields(swiss(tooMany))).toEqual(['rounds'])
+    })
+
+    it('speaks the schema’s own sentence about the ceiling', () => {
+      const result = eventSchema.safeParse(swiss(33))
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe(
+        'A swiss event plays at most 32 rounds.',
+      )
+    })
+
+    // The server's bound is INCLUSIVE, so the boundary itself must save — a form that
+    // refused 32 would refuse a save the API accepts.
+    it('accepts the ceiling itself', () => {
+      expect(rejectedFields(swiss(32))).toEqual([])
+    })
+
+    // ⚠️ The inverse, and the one a field-level rule would get wrong: the other three draw
+    // types carry `null` and must SAVE. A schema that demanded a round count regardless
+    // would dead-end every non-swiss event, with a red nobody could see or fix.
+    it.each(['round-robin', 'single-elim'] as const)(
+      'asks nothing of %s, whose round count is null',
+      (drawType) => {
+        expect(rejectedFields(formFor({ drawType, rounds: null }))).toEqual([])
+      },
+    )
+
+    // …and does not complain about a STALE count left behind by a draw-type switch: the
+    // control unmounted, but React-Hook-Form keeps the value, and the write body omits it
+    // anyway (`drawSettingsToApi`). A rule that fired here would block the save over a
+    // number that is never sent.
+    it('ignores a leftover round count once the draw type no longer plays rounds', () => {
+      expect(rejectedFields(formFor({ drawType: 'round-robin', rounds: 5 }))).toEqual(
+        [],
+      )
+    })
+
+    // The two halves of the draw configuration are judged INDEPENDENTLY: a swiss event is
+    // never asked for a qualifier count, and a two-stage event is never asked for a round
+    // count. A refinement that shared one branch would blame both fields at once.
+    it('asks a swiss event for no qualifier count, and a two-stage one for no rounds', () => {
+      expect(
+        rejectedFields(
+          formFor({ drawType: 'swiss', rounds: 3, qualifiersPerPool: null }),
+        ),
+      ).toEqual([])
+      expect(
+        rejectedFields(
+          formFor({ drawType: 'rr-then-ko', qualifiersPerPool: 2, rounds: null }),
+        ),
+      ).toEqual([])
+    })
+  })
+
   it('requires an entry fee, and takes zero for a free event', () => {
     expect(rejectedFields(formFor({ entryFee: Number.NaN }))).toEqual(['entryFee'])
     expect(rejectedFields(formFor({ entryFee: 0 }))).toEqual([])
@@ -222,6 +320,13 @@ describe('firstInvalidSection', () => {
     expect(
       firstInvalidSection({ qualifiersPerPool: { type: 'custom', message: 'x' } }),
     ).toBe('basics')
+  })
+
+  // …and the round count, which lives on the same tab beside the same picker.
+  it('sends a broken round count to Basics', () => {
+    expect(firstInvalidSection({ rounds: { type: 'custom', message: 'x' } })).toBe(
+      'basics',
+    )
   })
 
   it('sends a broken timezone to Basics', () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
@@ -8,6 +8,7 @@ import {
   nameSchema,
   poolNameSchema,
   qualifiersPerPoolSchema,
+  swissRoundsSchema,
   type EventSection,
 } from '../data/event-validation'
 import { browserTimezone, poolsInOrder } from '../data/helpers'
@@ -150,6 +151,11 @@ export const eventSchema = z.object({
   // see. See `qualifiersPerPoolSchema` (`data/event-validation`) for why the pair, and
   // not the field, carries the bound.
   qualifiersPerPool: z.number().nullable(),
+  // **R**, held the same way and judged in the same place, beside the draw type that
+  // decides whether it is asked at all (the swiss ADR). `null` is the honest value for the
+  // three draw types whose round count nobody chooses, and it is the *blank box* for the
+  // one whose director does.
+  rounds: z.number().nullable(),
   maxPlayers: maxPlayersSchema,
   entryFee: entryFeeSchema,
   // The IANA timezone anchoring the wall-clock windows (ADR 20260719). `NOT NULL`
@@ -211,6 +217,27 @@ export const eventSchema = z.object({
       message: result.error.issues[0].message,
     })
   })
+  // **R** is judged as half of the same pair, for the same reason and by the same shape
+  // (ADR "swiss pre-cuts every round and pairs each one on advance"): the server parses
+  // `(draw_type, rounds)` into a union tagged by the draw type, one arm of which requires a
+  // round count and three of which forbid the key outright.
+  //
+  // Only the `swiss` arm is asked at all: for the other three, `rounds` is `null`, there is
+  // no control on screen (the Basics tab renders it only for swiss), and the write body
+  // omits the key entirely (`drawSettingsToApi`, `data/api`) — so a rule that fired there
+  // would refuse a save for a reason the director cannot see, let alone fix. The issue is
+  // raised **at the field's own path**, so React-Hook-Form reports it as `errors.rounds`
+  // and the red lands under the box.
+  .superRefine((values, ctx) => {
+    if (values.drawType !== 'swiss') return
+    const result = swissRoundsSchema.safeParse(values.rounds)
+    if (result.success) return
+    ctx.addIssue({
+      code: 'custom',
+      path: ['rounds'],
+      message: result.error.issues[0].message,
+    })
+  })
 
 // The schema mirrors the domain types (`Predicate`, `PoolEntry`) so the nested-array
 // sub-forms are validated by this one resolver; the section code that rebuilds a
@@ -225,6 +252,10 @@ const EMPTY_FORM_VALUES: EventFormValues = {
   // …and a bracket has no pools to qualify out of, so no qualifier count (ADR 20260727).
   // `null` is the only value the server's `single-elim` arm admits.
   qualifiersPerPool: null,
+  // …and a bracket's depth follows from the field rather than from a setting, so no round
+  // count either (the swiss ADR). `null` is the only value the server's `single-elim` arm
+  // admits.
+  rounds: null,
   // A new event starts **uncapped**, not at an invented number: `null` is a valid,
   // saveable answer (ADR-0935), so an organizer who never touches the box gets an
   // event with no cap — rather than a form that silently refuses to submit.
@@ -255,6 +286,9 @@ export function eventToFormValues(event: TournamentEvent | null): EventFormValue
     // The count the SERVER sent back, straight onto the control — this projection is the
     // near half of the round trip the read shape's `qualifiers_per_pool` exists for.
     qualifiersPerPool: event.qualifiersPerPool,
+    // …and the round count the same way, the near half of the round trip the read shape's
+    // `rounds` exists for.
+    rounds: event.rounds,
     maxPlayers: event.maxPlayers,
     entryFee: event.entryFee,
     timezone: event.timezone,
@@ -298,11 +332,13 @@ export function eventToFormValues(event: TournamentEvent | null): EventFormValue
 export function firstInvalidSection(
   errors: FieldErrors<EventFormValues>,
 ): EventSection | null {
-  // `qualifiersPerPool` lives on Basics beside the draw type that decides whether it is
-  // asked at all, so a refused two-stage save opens the tab holding the empty box.
+  // `qualifiersPerPool` and `rounds` both live on Basics beside the draw type that decides
+  // whether either is asked at all, so a refused two-stage or swiss save opens the tab
+  // holding the empty box.
   if (
     errors.name ||
     errors.qualifiersPerPool ||
+    errors.rounds ||
     errors.maxPlayers ||
     errors.entryFee ||
     errors.timezone

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.page.tsx
@@ -4,6 +4,7 @@ import { render, screen, type Container } from '@/test/utilities'
 import { DrawPanel, type DrawPanelProps } from './draw-panel'
 import { buildDrawPanelProps } from './draw-panel.factory'
 import { poolDrawPage } from './draw-panel/pool-draw.page'
+import { swissRoundsPage } from './draw-panel/swiss-rounds.page'
 
 const scoped = (container: Container) => ({
   /** The whole panel for one event — the scope a read-only guard sweeps, and the one an
@@ -75,14 +76,27 @@ const scoped = (container: Container) => ({
     return interactiveElementsIn(container.getByTestId(`draw-panel-${eventId}`))
   },
 
-  /** The un-pooled group — fixtures belonging to no pool. Empty today (round-robin is
-   * the only draw type with a generator), but never *dropped*. */
+  /** The un-pooled group **as a bracket** — a single-elim draw, or the knockout stage of an
+   * `rr-then-ko` one. `query…` because "this draw did NOT get the bracket" is half of the
+   * routing claim. */
   queryUnpooled() {
     return container.queryByTestId('draw-unpooled')
   },
 
-  // Pools, rounds and fixture lines come from the child page objects.
+  /** The un-pooled group **as swiss rounds**. The other half of the same claim: a swiss draw
+   * is un-pooled exactly as a bracket is, so the two hooks are what tell "routed on the draw
+   * type" from "routed on the null pool id" (`unpooledShape`, `../../data/draw`). */
+  querySwissRounds() {
+    return container.queryByTestId('draw-swiss-rounds')
+  },
+  getSwissRounds() {
+    return container.getByTestId('draw-swiss-rounds')
+  },
+
+  // Pools, rounds and fixture lines come from the child page objects; the swiss rounds'
+  // own accessors (a paired round's lines, a forthcoming round's copy) from theirs.
   ...poolDrawPage.within(container),
+  swiss: swissRoundsPage.within(container),
 })
 
 /**

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
@@ -10,12 +10,15 @@ import { server } from '@/mocks/server'
 import { waitFor } from '@/test/utilities'
 
 import {
+  buildBracketDrawnEvent,
   buildDrawnEvent,
   buildEntrants,
   buildEvent,
   buildFixture,
   buildPool,
+  buildSwissDrawnEvent,
   buildTenPoolDrawnEvent,
+  buildTwoStageDrawnEvent,
   TEN_POOLS_BY_ID,
   TEN_POOLS_BY_POSITION,
 } from '../../data/seed.factory'
@@ -151,6 +154,77 @@ describe('DrawPanel', () => {
 
       expect(page.queryUnpooled()).toBeInTheDocument()
       expect(page.getLineTexts()).toEqual(['player.1 vs TBD'])
+    })
+  })
+
+  /**
+   * **Which view the un-pooled fixtures get is the DRAW TYPE's answer** (`unpooledShape`,
+   * `../../data/draw`) — the bug this suite exists to hold shut.
+   *
+   * Three draw types put fixtures in `unpooled`, and their payloads are indistinguishable
+   * there: single-elim's whole bracket, `rr-then-ko`'s knockout stage, and every fixture of
+   * a swiss draw all carry `pool_id: null`. The panel routed on that null, so swiss — a
+   * pool-less draw *type* that merely shares it — rendered through single-elimination's
+   * successor arithmetic, the one thing the ADR says swiss does not have.
+   *
+   * The type checker could never have caught it: the routing was a value check on a list's
+   * length, not an exhaustive switch. It is one now, at both ends, and these are the tests
+   * that say the switch sends each type somewhere different.
+   */
+  describe('which view the un-pooled fixtures get', () => {
+    it('gives a SWISS draw the rounds view, and not the bracket', () => {
+      page.render({ event: buildSwissDrawnEvent() })
+
+      expect(page.querySwissRounds()).toBeInTheDocument()
+      // The discriminating half: a swiss draw must not reach the bracket at all.
+      expect(page.queryUnpooled()).toBeNull()
+    })
+
+    it('shows a swiss draw’s round 1 paired and its later rounds as forthcoming', () => {
+      // Slice 2's demoable outcome, through the panel: the pairings a director reviews, and
+      // the rounds that exist but have nobody in them yet — announced, not blank, not
+      // hidden.
+      page.render({ event: buildSwissDrawnEvent() })
+
+      expect(page.swiss.getRoundHeadings()).toEqual([
+        'Round 1',
+        'Round 2',
+        'Round 3',
+      ])
+      expect(page.swiss.getRoundLines(1)).toEqual([
+        'player.1 vs player.4',
+        'player.2 vs player.5',
+        'player.3 vs player.6',
+      ])
+      expect(page.swiss.getForthcomingText(2)).toBe(
+        '3 matches, paired once round 1 is decided.',
+      )
+    })
+
+    // The regression pins. Both of these are un-pooled exactly as the swiss draw above is,
+    // and both must still be brackets — for `rr-then-ko` the null genuinely IS the stage
+    // discriminator, and that meaning is what the swiss fix must not disturb.
+    it('still gives a SINGLE-ELIM draw the bracket', () => {
+      page.render({ event: buildBracketDrawnEvent() })
+
+      expect(page.queryUnpooled()).toBeInTheDocument()
+      expect(page.querySwissRounds()).toBeNull()
+      expect(page.getLineTexts()).toEqual([
+        'player.1 vs player.4',
+        'player.3 vs player.2',
+        'TBD vs TBD',
+      ])
+    })
+
+    it('still gives an RR-THEN-KO knockout stage the bracket, with its pools above it', () => {
+      page.render({ event: buildTwoStageDrawnEvent() })
+
+      expect(page.queryUnpooled()).toBeInTheDocument()
+      expect(page.querySwissRounds()).toBeNull()
+      // The pool stage is untouched by the routing change — it never went through
+      // `unpooled` at all.
+      expect(page.getPoolLines('p-a')).toEqual(['player.1 vs player.3'])
+      expect(page.getPoolLines('p-b')).toEqual(['player.2 vs player.4'])
     })
   })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
@@ -5,12 +5,19 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 
 import { useCutDraw, useUncutDraw } from '../../data/api'
-import { drawRefusalNotice, drawState, type DrawNotice } from '../../data/draw'
+import {
+  drawRefusalNotice,
+  drawState,
+  type DrawNotice,
+  type DrawRound,
+  type UnpooledShape,
+} from '../../data/draw'
 import type { TournamentEvent } from '../../data/types'
 import { LeadReason } from './lead-reason'
 import { Bracket } from './draw-panel/bracket'
 import { PoolDraw } from './draw-panel/pool-draw'
 import { ResultsPanel } from './draw-panel/results-panel'
+import { SwissRounds } from './draw-panel/swiss-rounds'
 
 export interface DrawPanelProps {
   tournamentId: string
@@ -215,22 +222,15 @@ const DrawBody = ({
           {state.pools.map((pool) => (
             <PoolDraw key={pool.id} pool={pool} />
           ))}
-          {/* Fixtures belonging to no pool — a single-elim bracket (or the knockout stage
-              of a combined draw type, #787). Rendered as rounds-as-columns by `Bracket` (ADR-0785), which
-              replaces the flat `RoundList` here; pools above keep `RoundList`. Shown both
-              pre-live (the director reviews the seeded round-1 pairings and byes) and
-              live. */}
+          {/* Fixtures belonging to no pool. **Which view they get is the DRAW TYPE's
+              answer, not this list's** (`unpooledShape`, `../../data/draw`): `pool_id IS
+              NULL` is the *stage* discriminator for an `rr-then-ko` knockout stage and
+              will keep meaning that, while swiss is a pool-less draw *type* that happens
+              to share the null. Routing on the null alone is what rendered a swiss draw
+              through single-elimination's successor arithmetic. Shown both pre-live (the
+              director reviews the seeded round-1 pairings and byes) and live. */}
           {state.unpooled.length > 0 && (
-            <section
-              data-testid="draw-unpooled"
-              aria-label="Bracket"
-              className="rounded-[10px] border border-[color:var(--border-subtle)] p-3"
-            >
-              <h4 className="text-[13px] font-semibold text-[color:var(--fg-1)]">
-                Bracket
-              </h4>
-              <Bracket rounds={state.unpooled} />
-            </section>
+            <UnpooledDraw shape={state.unpooledShape} rounds={state.unpooled} />
           )}
         </div>
       )
@@ -238,6 +238,68 @@ const DrawBody = ({
     default: {
       // A third draw state without copy is a TYPE error here, not a blank card section.
       const exhaustive: never = state
+      return exhaustive
+    }
+  }
+}
+
+/**
+ * The un-pooled block, in the view its **draw type** calls for — the second half of the
+ * routing decision `unpooledShape` (`../../data/draw`) makes.
+ *
+ * A `switch` with a `never` default, so the two halves are checked at both ends: adding a
+ * draw type is a compile error in `unpooledShape` until it names a shape, and adding a
+ * shape is a compile error *here* until it has a view. Neither is something a value check
+ * on `pool_id` could ever have given us — which is precisely how a swiss draw came to
+ * render as a knockout bracket with nothing red.
+ *
+ * The block keeps its `draw-unpooled` test hook in the bracket arm: it is the same block
+ * the existing bracket tests address, and renaming it would churn them for nothing. The
+ * swiss arm gets a hook of its own, so "this event got the rounds view and NOT the bracket"
+ * is one assertion rather than an inference.
+ */
+const UnpooledDraw = ({
+  shape,
+  rounds,
+}: {
+  shape: UnpooledShape
+  rounds: DrawRound[]
+}) => {
+  switch (shape) {
+    case 'bracket':
+      return (
+        <section
+          data-testid="draw-unpooled"
+          aria-label="Bracket"
+          className="rounded-[10px] border border-[color:var(--border-subtle)] p-3"
+        >
+          <h4 className="text-[13px] font-semibold text-[color:var(--fg-1)]">
+            Bracket
+          </h4>
+          <Bracket rounds={rounds} />
+        </section>
+      )
+
+    case 'swiss-rounds':
+      // Titled "Rounds", not "Bracket": swiss eliminates nobody and has no final, so the
+      // bracket's own vocabulary would be a lie in the heading before it was one in the
+      // layout.
+      return (
+        <section
+          data-testid="draw-swiss-rounds"
+          aria-label="Rounds"
+          className="rounded-[10px] border border-[color:var(--border-subtle)] p-3"
+        >
+          <h4 className="text-[13px] font-semibold text-[color:var(--fg-1)]">
+            Rounds
+          </h4>
+          <SwissRounds rounds={rounds} />
+        </section>
+      )
+
+    default: {
+      // A shape without a view is a TYPE error here, not a dropped draw.
+      const exhaustive: never = shape
       return exhaustive
     }
   }

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/bracket.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/bracket.factory.tsx
@@ -226,6 +226,10 @@ export function buildSingleElimDrawState(
   return {
     kind: 'drawn',
     pools: [],
+    // A single-elim draw's un-pooled fixtures ARE its bracket (`unpooledShape`,
+    // `../../../data/draw`) — stated, because since swiss landed "un-pooled" no longer
+    // implies it.
+    unpooledShape: 'bracket',
     unpooled: buildEightEntrantRounds(),
     ...overrides,
   }

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.page.tsx
@@ -23,6 +23,12 @@ const scoped = (container: Container) => ({
     return container.queryByTestId(`two-stage-panel-${eventId}`)
   },
 
+  /** The **swiss** block, by event id — present only when the results are the
+   * `swiss_standings` arm. `query…` for the same reason as the rest. */
+  querySwissPanel(eventId: string) {
+    return container.queryByTestId(`swiss-standings-panel-${eventId}`)
+  },
+
   /** Each block's own champion callout, by event id. The two-stage arm asserts the STAGE
    * callouts are absent (it crowns once, itself), so all three need a `query…`. */
   queryStandingsChampion(eventId: string) {
@@ -33,6 +39,9 @@ const scoped = (container: Container) => ({
   },
   queryTwoStageChampion(eventId: string) {
     return container.queryByTestId(`two-stage-champion-${eventId}`)
+  },
+  querySwissChampion(eventId: string) {
+    return container.queryByTestId(`swiss-champion-${eventId}`)
   },
 
   /** A block's champion callout, by its full test id. The panels are handed their view now,

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.test.tsx
@@ -2,6 +2,8 @@ import {
   buildEvent,
   buildFinishesEvent,
   buildMidFlightTwoStageResults,
+  buildSwissStandingsEvent,
+  buildSwissStandingsResults,
   buildTwoStageEvent,
 } from '../../../data/seed.factory'
 import { resultsPanelPage as page } from './results-panel.page'
@@ -62,10 +64,39 @@ describe('ResultsPanel', () => {
     expect(page.queryTwoStageChampion('ev-two-stage')).toBeNull()
   })
 
+  it('renders ONE pool-less table for a swiss event (kind: swiss_standings)', () => {
+    // The fourth arm (the swiss ADR) routes to the pool-less panel. It is neither of the
+    // pooled blocks — a `standings-panel-…` here would mean a swiss event was routed into
+    // the arm that groups by pool, which for a format with no pools renders nothing at all.
+    page.render({ event: buildSwissStandingsEvent() })
+
+    expect(page.querySwissPanel('ev-swiss')).not.toBeNull()
+    expect(page.queryStandingsPanel('ev-swiss')).toBeNull()
+    expect(page.queryFinishesPanel('ev-swiss')).toBeNull()
+    // The wiring check: the event's OWN standings (champion `entry-1`, joined to a name)
+    // reached the panel, and the table's accessible name is the only proof that the event's
+    // NAME was threaded through to a panel that does not read the event.
+    expect(page.getChampion('swiss-champion-ev-swiss')).toHaveTextContent('player.1')
+    expect(page.getTableName()).toBe('Standings for Swiss Singles')
+  })
+
+  it('renders a live swiss event with no champion at all', () => {
+    // Rounds still to play: the table renders and nobody is crowned.
+    page.render({
+      event: buildSwissStandingsEvent({
+        results: buildSwissStandingsResults({ complete: false, champion: null }),
+      }),
+    })
+
+    expect(page.querySwissPanel('ev-swiss')).not.toBeNull()
+    expect(page.querySwissChampion('ev-swiss')).toBeNull()
+  })
+
   it('renders nothing for an event with no results', () => {
     page.render({ event: buildEvent() })
 
     expect(page.queryStandingsPanel('ev-open-singles')).toBeNull()
     expect(page.queryFinishesPanel('ev-open-singles')).toBeNull()
+    expect(page.querySwissPanel('ev-open-singles')).toBeNull()
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/results-panel.tsx
@@ -1,9 +1,11 @@
 import { eventFinishes } from '../../../data/finishes'
 import { eventStandings } from '../../../data/standings'
+import { eventSwissStandings } from '../../../data/swiss-standings'
 import { eventStandingsThenFinishes } from '../../../data/two-stage'
 import type { TournamentEvent } from '../../../data/types'
 import { FinishesPanel } from './finishes/finishes-panel'
 import { StandingsPanel } from './standings/standings-panel'
+import { SwissStandingsPanel } from './standings/swiss-standings-panel'
 import { TwoStagePanel } from './two-stage/two-stage-panel'
 
 export interface ResultsPanelProps {
@@ -12,9 +14,10 @@ export interface ResultsPanelProps {
 
 /**
  * An event's **results** on its card in the Events tab — the one render path that switches on
- * the results shape (ADR-0785, widened by ADR 20260727): a **standings** table for
- * round-robin, a **finishes** placement list for single-elimination, and **both** — pools
- * above bracket, one champion — for round-robin-then-knockout. The results are a
+ * the results shape (ADR-0785, widened by ADR 20260727 and by the swiss ADR): a **standings**
+ * table for round-robin, a **finishes** placement list for single-elimination, **both** —
+ * pools above bracket, one champion — for round-robin-then-knockout, and **one pool-less
+ * table over the whole field** for swiss. The results are a
  * discriminated union tagged by `kind`, parsed at the boundary (`../../../data/results`), so
  * this switch is exhaustive: a future draw type's shape is a **type error here** until it is
  * given a render arm.
@@ -61,6 +64,17 @@ export const ResultsPanel = ({ event }: ResultsPanelProps) => {
           eventId={event.id}
           eventName={event.name}
           twoStage={eventStandingsThenFinishes(event, results)}
+        />
+      )
+    case 'swiss_standings':
+      // One table over the whole field (the swiss ADR): swiss has no pools, so there is
+      // nothing to group by and nothing to title each block with. The table itself is the
+      // one a pool renders.
+      return (
+        <SwissStandingsPanel
+          eventId={event.id}
+          eventName={event.name}
+          standings={eventSwissStandings(event, results)}
         />
       )
     default: {

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.tsx
@@ -1,44 +1,19 @@
 import { useId } from 'react'
 
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
-
 import type { PoolStandingsView } from '../../../../data/standings'
+import { StandingsTable } from './standings-table'
 
 export interface PoolStandingsTableProps {
   pool: PoolStandingsView
 }
 
-/** One numeric column's header: a terse glyph on screen (`W`, `L`) and the full word for a
- * screen reader, which cannot guess what `W` abbreviates. Both channels carry the meaning;
- * neither is left to infer it. */
-const NumHead = ({ short, full }: { short: string; full: string }) => (
-  <TableHead className="text-right font-mono tabular-nums">
-    <span aria-hidden="true">{short}</span>
-    <span className="sr-only">{full}</span>
-  </TableHead>
-)
-
 /**
- * One **pool's standings** as a table (ADR-0788): the entrants in the server's finishing
- * order, one row each, with wins, losses, game difference and games won.
+ * One **pool's standings** (ADR-0788): the pool's name over the table that ranks it.
  *
- * **Nothing here re-sorts or recomputes.** The rows arrive in the pool's total order (wins
- * → two-way head-to-head → game difference → games won, decided on the server) and are
- * rendered in exactly that order — the order *is* the result. `game_difference` is the
- * server's own figure, shown, not derived from the two counts beside it (which would be a
- * second copy that could disagree). The view-model (`data/standings`) has already joined
- * each row's entry id to a username; a row is never a raw uuid.
- *
- * A real `<table>`, not a grid of divs: standings are tabular data, and a screen reader
- * reads a `<th scope>`-headed table by column ("player.1, Wins 2, Losses 0") rather than
- * as a wall of numbers. The numeric headers say their full word to it (`NumHead`).
+ * The table itself is `StandingsTable` — shared with the pool-less swiss block, so the two
+ * cannot drift on a column, an order or a sign. What this adds is the two things that are
+ * about the *pool*: the heading that names it, and the test hook that scopes it, so a card
+ * showing several pools still names each one.
  */
 export const PoolStandingsTable = ({ pool }: PoolStandingsTableProps) => {
   const captionId = useId()
@@ -56,54 +31,11 @@ export const PoolStandingsTable = ({ pool }: PoolStandingsTableProps) => {
         {pool.name}
       </h4>
 
-      <Table
-        aria-label={`Standings for ${pool.name}`}
-        className="mt-2 text-[13px]"
-      >
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-8 text-right font-mono tabular-nums">
-              <span aria-hidden="true">#</span>
-              <span className="sr-only">Rank</span>
-            </TableHead>
-            <TableHead>Player</TableHead>
-            <NumHead short="W" full="Wins" />
-            <NumHead short="L" full="Losses" />
-            <NumHead short="Diff" full="Game difference" />
-            <NumHead short="GW" full="Games won" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {pool.rows.map((row) => (
-            <TableRow
-              key={row.entryId}
-              data-testid={`standing-row-${row.entryId}`}
-            >
-              <TableCell className="text-right font-mono tabular-nums text-[color:var(--fg-3)]">
-                {row.rank}
-              </TableCell>
-              <TableCell className="text-[color:var(--fg-1)]">
-                {row.name}
-              </TableCell>
-              <TableCell className="text-right font-mono tabular-nums">
-                {row.wins}
-              </TableCell>
-              <TableCell className="text-right font-mono tabular-nums">
-                {row.losses}
-              </TableCell>
-              {/* The sign is load-bearing — `+2` and `-2` are different standings, and a
-                  bare `2` would read as both. A screen reader hears "plus 2" / "minus 2"
-                  from the same glyph. */}
-              <TableCell className="text-right font-mono tabular-nums text-[color:var(--fg-2)]">
-                {row.gameDifference > 0 ? `+${row.gameDifference}` : row.gameDifference}
-              </TableCell>
-              <TableCell className="text-right font-mono tabular-nums">
-                {row.gamesWon}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      <StandingsTable
+        ariaLabel={`Standings for ${pool.name}`}
+        rows={pool.rows}
+        className="mt-2"
+      />
     </section>
   )
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.factory.tsx
@@ -1,0 +1,56 @@
+import { buildStandingRow } from '../../../../data/seed.factory'
+import type { StandingLine } from '../../../../data/standings'
+import type { StandingsTableProps } from './standings-table'
+
+/** One standings line, ready to render — a `StandingRow` with the username already joined
+ * on (`data/standings`, `data/swiss-standings`). Defaults to `entry-1`, 1st, a clean 2–0. */
+export function buildStandingLine(
+  overrides: Partial<StandingLine> = {},
+): StandingLine {
+  return { ...buildStandingRow(), name: 'player.1', ...overrides }
+}
+
+/** Props for `StandingsTable`: a three-deep table whose ranks, wins and game differences
+ * all descend together, so a component that dropped a column or re-sorted a row shows a
+ * visibly different table. The **negative** difference on the last row is deliberate — the
+ * sign is load-bearing, and a row of all-positive figures could not prove it is rendered. */
+export function buildStandingsTableProps(
+  overrides: Partial<StandingsTableProps> = {},
+): StandingsTableProps {
+  return {
+    ariaLabel: 'Standings for Pool A',
+    rows: [
+      buildStandingLine({
+        entryId: 'entry-1',
+        name: 'player.1',
+        rank: 1,
+        wins: 2,
+        losses: 0,
+        gamesWon: 4,
+        gamesLost: 1,
+        gameDifference: 3,
+      }),
+      buildStandingLine({
+        entryId: 'entry-4',
+        name: 'player.4',
+        rank: 2,
+        wins: 1,
+        losses: 1,
+        gamesWon: 3,
+        gamesLost: 3,
+        gameDifference: 0,
+      }),
+      buildStandingLine({
+        entryId: 'entry-5',
+        name: 'player.5',
+        rank: 3,
+        wins: 0,
+        losses: 2,
+        gamesWon: 1,
+        gamesLost: 4,
+        gameDifference: -3,
+      }),
+    ],
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.page.tsx
@@ -1,0 +1,50 @@
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import { StandingsTable, type StandingsTableProps } from './standings-table'
+import { buildStandingsTableProps } from './standings-table.factory'
+
+const scoped = (container: Container) => ({
+  /** The table itself, by its accessible name — the one thing the caller supplies, so a
+   * table found this way is a table whose `aria-label` was really wired through. */
+  getTable(ariaLabel: string) {
+    return container.getByRole('table', { name: ariaLabel })
+  },
+
+  /** Every column header's visible glyph, left to right — the terse on-screen row. */
+  getHeaderGlyphs(ariaLabel: string) {
+    return within(this.getTable(ariaLabel))
+      .getAllByRole('columnheader')
+      .map((h) => (h.textContent ?? '').trim())
+  },
+
+  /** One column of body cells, top to bottom, by its **index** in the header order
+   * (`#`, Player, W, L, Diff, GW). */
+  getColumn(ariaLabel: string, index: number) {
+    return within(this.getTable(ariaLabel))
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => (within(row).getAllByRole('cell')[index].textContent ?? '').trim())
+  },
+
+  /** One entry's row, by the entry id it is keyed on — for scoping a per-row assertion. */
+  getRow(entryId: string) {
+    return container.getByTestId(`standing-row-${entryId}`)
+  },
+  queryRow(entryId: string) {
+    return container.queryByTestId(`standing-row-${entryId}`)
+  },
+})
+
+/** Test page-object for `StandingsTable` — the table body shared by the pooled and the
+ * pool-less standings blocks. */
+export const standingsTablePage = {
+  render(overrides: Partial<StandingsTableProps> = {}) {
+    render(<StandingsTable {...buildStandingsTableProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.test.tsx
@@ -1,0 +1,114 @@
+import { screen, within } from '@/test/utilities'
+
+import { buildStandingLine } from './standings-table.factory'
+import { standingsTablePage } from './standings-table.page'
+
+describe('StandingsTable', () => {
+  it('takes its accessible name from the caller', () => {
+    // The one thing that varies between a pool's table and a swiss event's, so it is a prop
+    // rather than something derived here — and asserted with a name neither caller uses.
+    standingsTablePage.render({ ariaLabel: 'Standings for the whole field' })
+
+    expect(
+      standingsTablePage.getTable('Standings for the whole field'),
+    ).toBeInTheDocument()
+  })
+
+  it('heads the columns with rank, player and the four figures', () => {
+    standingsTablePage.render()
+
+    // The glyphs a sighted reader sees. The `sr-only` full words ride in the same node, so
+    // the trimmed text carries both — which is the point: neither channel is left to infer.
+    expect(standingsTablePage.getHeaderGlyphs('Standings for Pool A')).toEqual([
+      '#Rank',
+      'Player',
+      'WWins',
+      'LLosses',
+      'DiffGame difference',
+      'GWGames won',
+    ])
+  })
+
+  it('renders the rows in the order it is handed, with the server’s figures', () => {
+    standingsTablePage.render()
+
+    expect(standingsTablePage.getColumn('Standings for Pool A', 0)).toEqual([
+      '1',
+      '2',
+      '3',
+    ])
+    expect(standingsTablePage.getColumn('Standings for Pool A', 1)).toEqual([
+      'player.1',
+      'player.4',
+      'player.5',
+    ])
+    expect(standingsTablePage.getColumn('Standings for Pool A', 2)).toEqual([
+      '2',
+      '1',
+      '0',
+    ])
+    expect(standingsTablePage.getColumn('Standings for Pool A', 3)).toEqual([
+      '0',
+      '1',
+      '2',
+    ])
+    expect(standingsTablePage.getColumn('Standings for Pool A', 5)).toEqual([
+      '4',
+      '3',
+      '1',
+    ])
+  })
+
+  /** The sign is load-bearing: `+2` and `-2` are different standings, and a bare `2` would
+   * read as both. Zero carries no sign — a `+0` would claim a margin nobody has. */
+  it('signs a positive game difference, leaves a negative one, and bares a zero', () => {
+    standingsTablePage.render()
+
+    expect(standingsTablePage.getColumn('Standings for Pool A', 4)).toEqual([
+      '+3',
+      '0',
+      '-3',
+    ])
+  })
+
+  it('does not re-sort or recompute what it is given', () => {
+    // Rows out of rank order, and a game difference that does NOT equal `gamesWon -
+    // gamesLost`: the server's figure is shown, never re-derived from the two counts beside
+    // it (which would be a second copy that could disagree).
+    standingsTablePage.render({
+      rows: [
+        buildStandingLine({
+          entryId: 'entry-9',
+          name: 'player.9',
+          rank: 4,
+          gamesWon: 1,
+          gamesLost: 1,
+          gameDifference: 5,
+        }),
+        buildStandingLine({ entryId: 'entry-1', name: 'player.1', rank: 1 }),
+      ],
+    })
+
+    expect(standingsTablePage.getColumn('Standings for Pool A', 0)).toEqual(['4', '1'])
+    expect(standingsTablePage.getColumn('Standings for Pool A', 4)).toEqual(['+5', '+3'])
+  })
+
+  it('keys each row on its entry id, so a row can be addressed', () => {
+    standingsTablePage.render()
+
+    expect(
+      within(standingsTablePage.getRow('entry-5')).getAllByRole('cell')[1],
+    ).toHaveTextContent('player.5')
+    expect(standingsTablePage.queryRow('entry-nobody')).toBeNull()
+  })
+
+  it('renders a header and no body rows for an empty table', () => {
+    // The designed state of a cut-but-unplayed event, not an error: the columns still say
+    // what is coming.
+    standingsTablePage.render({ rows: [] })
+
+    expect(
+      within(screen.getByRole('table')).getAllByRole('row'),
+    ).toHaveLength(1)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.tsx
@@ -1,0 +1,110 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+import { cn } from '@/lib/utils'
+
+import type { StandingLine } from '../../../../data/standings'
+
+export interface StandingsTableProps {
+  /** The table's accessible name — what a screen reader is told this table ranks. The
+   * caller owns the wording because it owns the scope: a pool names itself ("Standings for
+   * Pool A"), a swiss event names the event, and neither fact is knowable here. */
+  ariaLabel: string
+  /** The rows in the **server's finishing order**, already joined to usernames. Rendered in
+   * exactly that order — see below. */
+  rows: StandingLine[]
+  /** Spacing from whatever sits above, which is the caller's to decide: a pool's table
+   * follows an `<h4>` naming the pool and wants a gap, a swiss event's is the first thing
+   * in its box and does not. The table owns no margin of its own for that reason. */
+  className?: string
+}
+
+/** One numeric column's header: a terse glyph on screen (`W`, `L`) and the full word for a
+ * screen reader, which cannot guess what `W` abbreviates. Both channels carry the meaning;
+ * neither is left to infer it. */
+const NumHead = ({ short, full }: { short: string; full: string }) => (
+  <TableHead className="text-right font-mono tabular-nums">
+    <span aria-hidden="true">{short}</span>
+    <span className="sr-only">{full}</span>
+  </TableHead>
+)
+
+/**
+ * A **standings table** (ADR-0788): entrants in the server's finishing order, one row each,
+ * with wins, losses, game difference and games won.
+ *
+ * **One table for every results shape that ranks players.** A round-robin pool
+ * (`PoolStandingsTable`) and a pool-less swiss event (`SwissStandingsPanel`) show the same
+ * columns computed the same way, so they render through this one component rather than two
+ * that agree today. What differs between them is what *titles* the table and what scopes its
+ * test hooks — both of which belong to the caller, which is why this takes only an accessible
+ * name and rows.
+ *
+ * **Nothing here re-sorts or recomputes.** The rows arrive in a total order decided on the
+ * server (wins → head-to-head → game difference → games won) and are rendered in exactly
+ * that order — the order *is* the result. `gameDifference` is the server's own figure,
+ * shown, not derived from the two counts beside it (which would be a second copy that could
+ * disagree). The view-model (`data/standings`, `data/swiss-standings`) has already joined
+ * each row's entry id to a username; a row is never a raw uuid.
+ *
+ * A real `<table>`, not a grid of divs: standings are tabular data, and a screen reader reads
+ * a `<th scope>`-headed table by column ("player.1, Wins 2, Losses 0") rather than as a wall
+ * of numbers. The numeric headers say their full word to it (`NumHead`).
+ */
+export const StandingsTable = ({
+  ariaLabel,
+  rows,
+  className,
+}: StandingsTableProps) => (
+  // `className` FIRST, unusually — it is spacing from whatever sits above, and putting it
+  // ahead of the table's own type scale keeps the emitted class string byte-identical to
+  // the one `PoolStandingsTable` rendered before this component was extracted. The
+  // standings panel carries a whole-DOM inline snapshot guard, which is what makes "this
+  // extraction is DOM-preserving" a measured fact rather than an intention.
+  <Table aria-label={ariaLabel} className={cn(className, 'text-[13px]')}>
+    <TableHeader>
+      <TableRow>
+        <TableHead className="w-8 text-right font-mono tabular-nums">
+          <span aria-hidden="true">#</span>
+          <span className="sr-only">Rank</span>
+        </TableHead>
+        <TableHead>Player</TableHead>
+        <NumHead short="W" full="Wins" />
+        <NumHead short="L" full="Losses" />
+        <NumHead short="Diff" full="Game difference" />
+        <NumHead short="GW" full="Games won" />
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {rows.map((row) => (
+        <TableRow key={row.entryId} data-testid={`standing-row-${row.entryId}`}>
+          <TableCell className="text-right font-mono tabular-nums text-[color:var(--fg-3)]">
+            {row.rank}
+          </TableCell>
+          <TableCell className="text-[color:var(--fg-1)]">{row.name}</TableCell>
+          <TableCell className="text-right font-mono tabular-nums">
+            {row.wins}
+          </TableCell>
+          <TableCell className="text-right font-mono tabular-nums">
+            {row.losses}
+          </TableCell>
+          {/* The sign is load-bearing — `+2` and `-2` are different standings, and a bare
+              `2` would read as both. A screen reader hears "plus 2" / "minus 2" from the
+              same glyph. */}
+          <TableCell className="text-right font-mono tabular-nums text-[color:var(--fg-2)]">
+            {row.gameDifference > 0 ? `+${row.gameDifference}` : row.gameDifference}
+          </TableCell>
+          <TableCell className="text-right font-mono tabular-nums">
+            {row.gamesWon}
+          </TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+)

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.factory.tsx
@@ -1,0 +1,36 @@
+import {
+  buildSwissStandingsEvent,
+  swissStandingsResultsOf,
+} from '../../../../data/seed.factory'
+import { eventSwissStandings } from '../../../../data/swiss-standings'
+import type { TournamentEvent } from '../../../../data/types'
+import type { SwissStandingsPanelProps } from './swiss-standings-panel'
+
+/** What a test varies: the whole **event** whose standings the panel is handed (the natural
+ * unit — the results and the entrants they join against travel together), or a prop
+ * directly. */
+export type SwissStandingsPanelScenario = Partial<SwissStandingsPanelProps> & {
+  event?: TournamentEvent
+}
+
+/**
+ * Props for `SwissStandingsPanel`: by default a **swiss** event with results — one complete
+ * four-deep table over the whole field, and a champion (`buildSwissStandingsEvent`).
+ *
+ * The panel takes a view, not an event, but a test still reasons in events — so this derives
+ * the props from one **the same way `ResultsPanel` does at runtime**: `eventSwissStandings`
+ * over the event's own `swiss_standings` block. A test that hands over a differently-built
+ * event therefore exercises the real selection path, not a hand-written view-model that
+ * could drift from it.
+ */
+export function buildSwissStandingsPanelProps({
+  event = buildSwissStandingsEvent(),
+  ...overrides
+}: SwissStandingsPanelScenario = {}): SwissStandingsPanelProps {
+  return {
+    eventId: event.id,
+    eventName: event.name,
+    standings: eventSwissStandings(event, swissStandingsResultsOf(event)),
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.page.tsx
@@ -1,0 +1,73 @@
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import { SwissStandingsPanel } from './swiss-standings-panel'
+import {
+  buildSwissStandingsPanelProps,
+  type SwissStandingsPanelScenario,
+} from './swiss-standings-panel.factory'
+
+const scoped = (container: Container) => ({
+  /** The whole swiss results block, by event id. */
+  getPanel(eventId: string) {
+    return container.getByTestId(`swiss-standings-panel-${eventId}`)
+  },
+  queryPanel(eventId: string) {
+    return container.queryByTestId(`swiss-standings-panel-${eventId}`)
+  },
+
+  /** The panel's landmark by its accessible name — a `<section>` with `aria-labelledby` is
+   * a `region`, so this only resolves while the heading is still wired to the section. */
+  getRegion() {
+    return container.getByRole('region', { name: 'Standings' })
+  },
+
+  /** The champion callout, by event id — shown only once every round is decided. `query…`
+   * because its absence is half of what the tests assert. */
+  queryChampion(eventId: string) {
+    return container.queryByTestId(`swiss-champion-${eventId}`)
+  },
+
+  /** Every table in the panel, by accessible name. Swiss has **one** — the claim that
+   * distinguishes it from the pooled block, so the count is part of the assertion. */
+  getTableNames() {
+    return container
+      .getAllByRole('table')
+      .map((t: HTMLElement) => t.getAttribute('aria-label') ?? '')
+  },
+
+  /** The table's player names, top to bottom (the rendered order). */
+  getRowNames(eventName: string) {
+    return within(container.getByRole('table', { name: `Standings for ${eventName}` }))
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => (within(row).getAllByRole('cell')[1].textContent ?? '').trim())
+  },
+
+  /** One numeric column of the table, read top to bottom by its **column index** — the same
+   * order the header row declares (`#`, Player, W, L, Diff, GW). */
+  getColumn(eventName: string, index: number) {
+    return within(container.getByRole('table', { name: `Standings for ${eventName}` }))
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => (within(row).getAllByRole('cell')[index].textContent ?? '').trim())
+  },
+
+  /** A pool table's test hook, which must NEVER appear here: swiss has no pools, so a
+   * `pool-standings-…` node in this panel would mean a forged pool id reached the DOM. */
+  queryPoolTables() {
+    return container.queryAllByTestId(/^pool-standings-/)
+  },
+})
+
+/** Test page-object for `SwissStandingsPanel`. */
+export const swissStandingsPanelPage = {
+  render(overrides: SwissStandingsPanelScenario = {}) {
+    render(<SwissStandingsPanel {...buildSwissStandingsPanelProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.test.tsx
@@ -1,0 +1,122 @@
+import {
+  buildStandingRow,
+  buildSwissStandingsEvent,
+  buildSwissStandingsResults,
+} from '../../../../data/seed.factory'
+import { swissStandingsPanelPage } from './swiss-standings-panel.page'
+
+describe('SwissStandingsPanel', () => {
+  /**
+   * The claim that separates this panel from the pooled one (the swiss ADR): **one table
+   * over the whole field**. A swiss event has no pools, so a panel that grouped — or that
+   * forged a pool to reuse `PoolStandingsTable` — would put an id nobody can read into the
+   * DOM and name a pool that does not exist.
+   */
+  it('renders ONE table over the whole field, and no pool at all', () => {
+    swissStandingsPanelPage.render()
+
+    expect(swissStandingsPanelPage.getTableNames()).toEqual([
+      'Standings for Swiss Singles',
+    ])
+    expect(swissStandingsPanelPage.queryPoolTables()).toHaveLength(0)
+  })
+
+  it('names the panel’s region from its heading', () => {
+    swissStandingsPanelPage.render()
+
+    expect(swissStandingsPanelPage.getRegion()).toBeInTheDocument()
+    expect(swissStandingsPanelPage.getPanel('ev-swiss')).toBeInTheDocument()
+  })
+
+  it('lists every entrant in the server’s order, joined to a username', () => {
+    swissStandingsPanelPage.render()
+
+    expect(
+      swissStandingsPanelPage.getRowNames('Swiss Singles'),
+    ).toEqual(['player.1', 'player.2', 'player.3', 'player.4'])
+  })
+
+  // The order IS the result (ADR-0788), and swiss is where a client that re-sorted would go
+  // wrong most often: the format pairs by score, so level rows are ordinary and the tiebreak
+  // that separated them (head-to-head, and Buchholz once it lands) is one the client cannot
+  // see. Feed the rows out of rank order and expect them back untouched.
+  it('does not re-sort the rows it is handed', () => {
+    swissStandingsPanelPage.render({
+      event: buildSwissStandingsEvent({
+        results: buildSwissStandingsResults({
+          rows: [
+            buildStandingRow({ entryId: 'entry-3', rank: 3, wins: 1 }),
+            buildStandingRow({ entryId: 'entry-1', rank: 1, wins: 3 }),
+          ],
+        }),
+      }),
+    })
+
+    expect(swissStandingsPanelPage.getRowNames('Swiss Singles')).toEqual([
+      'player.3',
+      'player.1',
+    ])
+    // The rank column follows the rows, so a panel that sorted by rank would show 1 then 3.
+    expect(swissStandingsPanelPage.getColumn('Swiss Singles', 0)).toEqual(['3', '1'])
+  })
+
+  // The columns are the pool table's, because they ARE the pool table's — one
+  // `StandingsTable`, not two that agree today. `+7` and `-7` are different standings, so
+  // the sign is asserted, not just the digit.
+  it('shows the server’s wins, losses, game difference and games won', () => {
+    swissStandingsPanelPage.render()
+
+    expect(swissStandingsPanelPage.getColumn('Swiss Singles', 2)).toEqual([
+      '3',
+      '2',
+      '1',
+      '0',
+    ])
+    expect(swissStandingsPanelPage.getColumn('Swiss Singles', 4)).toEqual([
+      '+7',
+      '+2',
+      '-2',
+      '-7',
+    ])
+    expect(swissStandingsPanelPage.getColumn('Swiss Singles', 5)).toEqual([
+      '9',
+      '7',
+      '5',
+      '2',
+    ])
+  })
+
+  it('crowns the champion once every round is decided', () => {
+    swissStandingsPanelPage.render()
+
+    expect(swissStandingsPanelPage.queryChampion('ev-swiss')).toHaveTextContent(
+      'player.1',
+    )
+  })
+
+  // The state a swiss event spends most of its life in: every round cut up front, and the
+  // later ones not yet paired. The table is already worth reading; nobody has won yet.
+  it('shows the table but crowns nobody while rounds are still unplayed', () => {
+    swissStandingsPanelPage.render({
+      event: buildSwissStandingsEvent({
+        results: buildSwissStandingsResults({ complete: false, champion: null }),
+      }),
+    })
+
+    expect(swissStandingsPanelPage.queryChampion('ev-swiss')).toBeNull()
+    expect(swissStandingsPanelPage.getRowNames('Swiss Singles')).toHaveLength(4)
+  })
+
+  // `complete` alone is not the condition, and neither is `champion` alone. A complete
+  // event whose champion the server has not named must not be crowned by the client reading
+  // the top row — which is exactly what a panel that dropped the null check would do.
+  it('crowns nobody when the server named no champion, complete or not', () => {
+    swissStandingsPanelPage.render({
+      event: buildSwissStandingsEvent({
+        results: buildSwissStandingsResults({ complete: true, champion: null }),
+      }),
+    })
+
+    expect(swissStandingsPanelPage.queryChampion('ev-swiss')).toBeNull()
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.tsx
@@ -1,0 +1,92 @@
+import { useId } from 'react'
+
+import type { SwissStandingsView } from '../../../../data/swiss-standings'
+import { ChampionBanner } from '../champion-banner'
+import { StandingsTable } from './standings-table'
+
+export interface SwissStandingsPanelProps {
+  /** The event the standings belong to — its id is what the panel's test hooks hang off
+   * (`swiss-standings-panel-…`, `swiss-champion-…`), so a card showing more than one results
+   * block still names each one. */
+  eventId: string
+  /** The event's name, used as the table's accessible name. A swiss table ranks the whole
+   * field, so the event is what it is "standings for" — there is no pool to name. */
+  eventName: string
+  /** The standings to render, already selected and joined to names (`eventSwissStandings`).
+   * **Never null**: whether an event *has* standings is the caller's decision, not this
+   * panel's. */
+  standings: SwissStandingsView
+}
+
+/**
+ * A **swiss event's standings** on its card in the Events tab (ADR "swiss pre-cuts every
+ * round and pairs each one on advance"): **one table over the whole field**, and — once
+ * every round is decided — the leader.
+ *
+ * ## One table, because swiss has no pools
+ *
+ * That is the only thing separating this from `StandingsPanel`: everybody is ranked against
+ * everybody, which is what pairing by score is for. The table is the very `StandingsTable` a
+ * pool renders, so the columns, the order and the withdrawn-entrant label are structurally
+ * the same and not two implementations agreeing.
+ *
+ * ## It renders what it is handed
+ *
+ * It takes its standings as a prop instead of reading them off an event and deciding whether
+ * they apply. The switch on the results shape lives in exactly one place (`ResultsPanel`). A
+ * panel that re-checked `results.kind` would silently render nothing the moment it met a
+ * shape it did not recognise.
+ *
+ * ## Live, with no machinery of its own
+ *
+ * The standings are just BFF data, derived live on the server from the fixtures' completed
+ * matches. As matches land, the mutations that drive play invalidate the tournament and the
+ * table fills in on the next read — **no polling and no client recompute** here. In swiss
+ * that also covers the rounds that were cut up front with their sides unknown: they
+ * contribute nothing until they are paired and played, which needs no special case.
+ */
+export const SwissStandingsPanel = ({
+  eventId,
+  eventName,
+  standings,
+}: SwissStandingsPanelProps) => {
+  const headingId = useId()
+
+  return (
+    <section
+      data-testid={`swiss-standings-panel-${eventId}`}
+      aria-labelledby={headingId}
+      className="mt-2.5"
+    >
+      <h3
+        id={headingId}
+        className="text-[11px] font-semibold tracking-[0.12em] text-[color:var(--fg-3)] uppercase"
+      >
+        Standings
+      </h3>
+
+      {/* The leader of a decided event, in the app's "featured" voice (`web-client/CLAUDE.md`,
+          design system). Not an Alert: it is not the app talking back to an action and it does
+          not dismiss, it is a fact about the finished event. A swiss ranks its whole field, so
+          a complete event always has one — but the `null` check stays, because `champion` is
+          the SERVER's answer and this panel does not crown anybody by reading the top row. */}
+      {standings.complete && standings.champion !== null && (
+        <ChampionBanner
+          name={standings.champion}
+          testId={`swiss-champion-${eventId}`}
+        />
+      )}
+
+      {/* The bordered box a pool's table sits in, minus the `<h4>` — there is no pool to
+          name, and the section's own heading already says "Standings". The table therefore
+          takes no top margin here: it is the first thing in the box, not something
+          following a heading. */}
+      <div className="mt-2 rounded-[10px] border border-[color:var(--border-subtle)] p-3">
+        <StandingsTable
+          ariaLabel={`Standings for ${eventName}`}
+          rows={standings.rows}
+        />
+      </div>
+    </section>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/swiss-rounds.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/swiss-rounds.factory.tsx
@@ -1,0 +1,51 @@
+import { drawState, type DrawRound } from '../../../data/draw'
+import {
+  buildSwissDrawnEvent,
+  buildSwissMidEvent,
+} from '../../../data/seed.factory'
+import type { SwissRoundsProps } from './swiss-rounds'
+
+/**
+ * The rounds of an event's draw as the panel hands them over — **`drawState`'s own output**,
+ * never a hand-written `DrawRound[]`.
+ *
+ * Derived from a whole event on purpose: `unpooled` is what the real routing feeds this
+ * component, so a fixture built any other way could drift from the shape the panel actually
+ * produces (round grouping, position order, the TBD/withdrawn side join). It throws on an
+ * undrawn event rather than yielding `[]`, so a mis-built test says so at the call site.
+ */
+function unpooledRoundsOf(event: Parameters<typeof drawState>[0]): DrawRound[] {
+  const state = drawState(event)
+  if (state.kind !== 'drawn') {
+    throw new Error(
+      `Fixture event '${event.id}' has no draw cut, so it has no rounds to render.`,
+    )
+  }
+  return state.unpooled
+}
+
+/** A **freshly cut** swiss draw: round 1 paired from the draw order, rounds 2 and 3 written
+ * with both sides null. The state a director reviews the moment they cut. */
+export function buildCutSwissRounds(): DrawRound[] {
+  return unpooledRoundsOf(buildSwissDrawnEvent())
+}
+
+/**
+ * The same draw **one round in**: round 1 played, round 2 paired by the standings, round 3
+ * still waiting.
+ *
+ * The discriminating fixture. On the cut-fresh rounds above, "is this round paired?" and
+ * "is this round 1?" give the same answer for every round — so a component keyed off the
+ * round *number* passes on that fixture alone. Here they disagree.
+ */
+export function buildMidSwissRounds(): DrawRound[] {
+  return unpooledRoundsOf(buildSwissMidEvent())
+}
+
+/** Props for `SwissRounds` — the freshly-cut three-round draw by default, which is the
+ * state that shows both a paired round and forthcoming ones at once. */
+export function buildSwissRoundsProps(
+  overrides: Partial<SwissRoundsProps> = {},
+): SwissRoundsProps {
+  return { rounds: buildCutSwissRounds(), ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/swiss-rounds.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/swiss-rounds.page.tsx
@@ -1,0 +1,83 @@
+import { renderWithRoutes } from '@/test/router'
+import { screen, type Container } from '@/test/utilities'
+
+import { SwissRounds, type SwissRoundsProps } from './swiss-rounds'
+import { buildSwissRoundsProps } from './swiss-rounds.factory'
+import {
+  fixtureLinePage,
+  fixtureLineTexts,
+} from './round-list/fixture-line.page'
+
+const scoped = (container: Container) => ({
+  /** One **paired** round's list of fixtures, by round number. `query…` because its absence
+   * is exactly what a forthcoming round asserts. */
+  getRound(round: number) {
+    return container.getByTestId(`swiss-round-${round}`)
+  },
+  queryRound(round: number) {
+    return container.queryByTestId(`swiss-round-${round}`)
+  },
+
+  /** One **forthcoming** round's line — the round that exists, is cut, and has nobody in it
+   * yet. `query…` for the same reason, from the other side. */
+  queryForthcoming(round: number) {
+    return container.queryByTestId(`swiss-round-forthcoming-${round}`)
+  },
+  getForthcoming(round: number) {
+    return container.getByTestId(`swiss-round-forthcoming-${round}`)
+  },
+  /** That line as one normalised string — the copy is the whole content of a forthcoming
+   * round, so it is read as text rather than as a node. */
+  getForthcomingText(round: number) {
+    return (
+      container.getByTestId(`swiss-round-forthcoming-${round}`).textContent ?? ''
+    )
+      .replace(/\s+/g, ' ')
+      .trim()
+  },
+
+  /** Every round heading in DOM order (`['Round 1', 'Round 2', …]`) — the assertion that
+   * **every** cut round is on screen, forthcoming ones included, in order. Read off the
+   * headings rather than the lists, because a forthcoming round has no list. */
+  getRoundHeadings(): string[] {
+    return container
+      .queryAllByText(/^Round \d+$/)
+      .map((el: HTMLElement) => (el.textContent ?? '').trim())
+  },
+
+  /** One paired round's fixture lines, as text (`player.1 vs player.4`), in render order. */
+  getRoundLines(round: number): string[] {
+    return fixtureLineTexts(container.getByTestId(`swiss-round-${round}`))
+  },
+
+  // Every fixture line in scope, plus each line's per-side text and match link, straight
+  // from the reused FixtureLine page object.
+  ...fixtureLinePage.within(container),
+})
+
+/**
+ * Test page-object for `SwissRounds`.
+ *
+ * A materialized fixture renders a typed `<Link>` to its match (reused `FixtureLine`),
+ * which needs a `RouterProvider` registering `/matches/$matchId` — so `render` mounts under
+ * `renderWithRoutes`. That router resolves asynchronously, so tests start with an
+ * `await swissRoundsPage.findRound(n)` before reading the synchronous accessors.
+ */
+export const swissRoundsPage = {
+  render(overrides: Partial<SwissRoundsProps> = {}) {
+    renderWithRoutes(<SwissRounds {...buildSwissRoundsProps(overrides)} />, {
+      linkTargets: ['/matches/$matchId'],
+    })
+  },
+
+  /** Async-first: the router resolves the route tree on the first paint. */
+  findRound(round: number) {
+    return screen.findByTestId(`swiss-round-${round}`)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/swiss-rounds.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/swiss-rounds.test.tsx
@@ -1,0 +1,139 @@
+import { buildFixtureLineView } from './round-list/fixture-line.factory'
+import { buildMidSwissRounds } from './swiss-rounds.factory'
+import { swissRoundsPage as page } from './swiss-rounds.page'
+
+describe('SwissRounds', () => {
+  it('shows every cut round, in order — the forthcoming ones included', async () => {
+    // All `R` rounds exist from the cut (ADR "swiss pre-cuts every round and pairs each one
+    // on advance"), and the round count is the setting the director chose, so hiding the
+    // unpaired ones would hide the length of the day they booked a venue for.
+    page.render()
+    await page.findRound(1)
+
+    expect(page.getRoundHeadings()).toEqual(['Round 1', 'Round 2', 'Round 3'])
+  })
+
+  it('renders round 1’s pairings, seeded from the draw order', async () => {
+    page.render()
+    await page.findRound(1)
+
+    expect(page.getRoundLines(1)).toEqual([
+      'player.1 vs player.4',
+      'player.2 vs player.5',
+      'player.3 vs player.6',
+    ])
+  })
+
+  /**
+   * The claim the whole component is for: an unpaired round is announced, not drawn as
+   * `⌊n/2⌋` identical "TBD vs TBD" rows — which is honest, unreadable, and reads as a bug —
+   * and not hidden either.
+   */
+  it('announces an unpaired round instead of listing TBD against TBD', async () => {
+    page.render()
+    await page.findRound(1)
+
+    expect(page.queryRound(2)).toBeNull()
+    expect(page.getForthcomingText(2)).toBe(
+      '3 matches, paired once round 1 is decided.',
+    )
+    expect(page.getForthcomingText(3)).toBe(
+      '3 matches, paired once round 2 is decided.',
+    )
+  })
+
+  it('says which round each forthcoming one waits on — never all on round 1', async () => {
+    // Round 3 waits on round 2, not on round 1. A component that hardcoded "round 1", or
+    // that read the FIRST round rather than the previous one, passes the round-2 case and
+    // fails here.
+    page.render()
+    await page.findRound(1)
+
+    expect(page.getForthcomingText(3)).toContain('round 2')
+    expect(page.getForthcomingText(3)).not.toContain('round 1')
+  })
+
+  /**
+   * ⚠️ **The discriminating case.** On a freshly-cut draw "is this round paired?" and "is
+   * this round 1?" give the same answer for every round, so a component keyed off the round
+   * NUMBER passes every test above. Here they disagree: round 2 has been paired by
+   * `advance()` from the standings and must render its real fixtures, while round 3 is
+   * still forthcoming.
+   *
+   * This is not a contrived state — it is what a running swiss event looks like for most of
+   * its life. A number-keyed renderer would show a live, playable round 2 as "not paired
+   * yet" for the rest of the tournament.
+   */
+  it('renders a LATER round that advance() has paired, and still waits on the rest', async () => {
+    page.render({ rounds: buildMidSwissRounds() })
+    await page.findRound(1)
+
+    expect(page.getRoundLines(2)).toEqual([
+      'player.1 vs player.2',
+      'player.3 vs player.4',
+      'player.5 vs player.6',
+    ])
+    // …and the round after it is still forthcoming, so this is "the predicate follows the
+    // sides" rather than "everything renders as paired now".
+    expect(page.queryRound(3)).toBeNull()
+    expect(page.queryForthcoming(3)).not.toBeNull()
+    // Round 2 is paired, so it is NOT also announced as forthcoming.
+    expect(page.queryForthcoming(2)).toBeNull()
+  })
+
+  it('inflects a one-match round', async () => {
+    // A two-entrant swiss: one pairing a round, so the noun is singular. The count comes
+    // off the fixtures, so a hardcoded plural is wrong for the smallest real field.
+    page.render({
+      rounds: [
+        {
+          round: 1,
+          fixtures: [
+            buildFixtureLineView({ id: 'fx-r1', position: 1 }),
+          ],
+        },
+        {
+          round: 2,
+          fixtures: [
+            buildFixtureLineView({
+              id: 'fx-r2',
+              position: 1,
+              a: { kind: 'tbd' },
+              b: { kind: 'tbd' },
+            }),
+          ],
+        },
+      ],
+    })
+    await page.findRound(1)
+
+    expect(page.getForthcomingText(2)).toBe(
+      '1 match, paired once round 1 is decided.',
+    )
+  })
+
+  /** A withdrawn side means the entry was *seated* and has since left — the draw is stale,
+   * which is a thing to show. Treating it as unpaired would replace a real pairing with
+   * "forthcoming" and hide the staleness. */
+  it('treats a round with a withdrawn side as paired, not forthcoming', async () => {
+    page.render({
+      rounds: [
+        {
+          round: 1,
+          fixtures: [
+            buildFixtureLineView({
+              id: 'fx-stale',
+              position: 1,
+              a: { kind: 'withdrawn' },
+              b: { kind: 'tbd' },
+            }),
+          ],
+        },
+      ],
+    })
+    await page.findRound(1)
+
+    expect(page.getRoundLines(1)).toEqual(['Withdrawn vs TBD'])
+    expect(page.queryForthcoming(1)).toBeNull()
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/swiss-rounds.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/swiss-rounds.tsx
@@ -1,0 +1,99 @@
+import type { DrawRound, FixtureLine as FixtureLineView } from '../../../data/draw'
+// `FixtureLine` is shared with `RoundList` (the pooled renderer) and `Bracket`; its owner
+// is the `round-list/` subtree today. Reached across rather than duplicating the three-way
+// `FixtureSide` switch — the same call `Bracket` makes, and for the same reason. It is now
+// the third importer, so per the supremum rule it wants floating up to `draw-panel/`; left
+// in place to keep this change to the routing it is about.
+import { FixtureLine } from './round-list/fixture-line'
+
+export interface SwissRoundsProps {
+  /** The event's un-pooled fixtures, already grouped and ordered into rounds by
+   * `drawState` (`../../../data/draw`) — round 1 first. A swiss draw's rounds are **all**
+   * of them: the cut writes `R × ⌊n/2⌋` fixtures up front. */
+  rounds: DrawRound[]
+}
+
+/**
+ * Whether a round has been **paired** — anybody at all is seated in it.
+ *
+ * Asked of the SIDES, never of the round number. `round > 1` gives the same answer on a
+ * freshly-cut draw and a different one the moment `advance()` pairs round 2, which is the
+ * ordinary state of a running event — so a renderer keyed off the number would show a live,
+ * paired round 2 as "not paired yet" for the rest of the tournament.
+ *
+ * A withdrawn side counts as paired: the entry was seated, and the round is a real pairing
+ * whose draw has gone stale — which is a thing to show, not to hide behind "forthcoming".
+ */
+const isPaired = (fixtures: FixtureLineView[]): boolean =>
+  fixtures.some((f) => f.a.kind !== 'tbd' || f.b.kind !== 'tbd')
+
+/** A round nobody is seated in yet, announced as **forthcoming** rather than drawn as a
+ * column of "TBD vs TBD" lines.
+ *
+ * Those lines would be honest and unreadable: `⌊n/2⌋` identical rows saying nothing, which
+ * a director reads as a bug rather than as a format. Hiding the round would be worse — it
+ * exists, it is already cut, and how many rounds the event plays is the setting the
+ * director chose. So the round keeps its heading and says the two facts it has: how many
+ * matches it holds, and what has to happen before it has players in it. */
+const ForthcomingRound = ({ round }: { round: DrawRound }) => (
+  <p
+    data-testid={`swiss-round-forthcoming-${round.round}`}
+    className="mt-0.5 text-[13px] text-[color:var(--fg-3)] italic"
+  >
+    {round.fixtures.length} {round.fixtures.length === 1 ? 'match' : 'matches'},
+    paired once round {round.round - 1} is decided.
+  </p>
+)
+
+/**
+ * A **swiss** draw's fixtures, round by round (ADR "swiss pre-cuts every round and pairs
+ * each one on advance").
+ *
+ * ## Why not the bracket
+ *
+ * A swiss draw is un-pooled, exactly as a single-elimination bracket is, and until this
+ * component existed it was routed to `Bracket` on that resemblance alone. It is the wrong
+ * view, not merely a plain one: a bracket's columns are named back from the **Final**
+ * ("Semifinals", "Quarterfinals") and its whole read is that a winner reappears one column
+ * along. Swiss eliminates nobody, has no final, and pairs each round from the standings —
+ * "no successor arithmetic", as the ADR puts it. A flat, numbered list of rounds is what
+ * the format actually is.
+ *
+ * ## Every round is here from the cut
+ *
+ * The cut writes all `R` rounds at once, so rounds 2…R exist as fixtures with **both sides
+ * null** from the moment the draw is dealt. They are shown as *forthcoming* — the round,
+ * its match count, and what has to finish first — rather than as rows of `TBD vs TBD`
+ * (which reads as a bug) or hidden (which loses the length of the day the director booked).
+ *
+ * The distinction is drawn from the **sides**, not the round number (`isPaired`), so a
+ * round that `advance()` has paired renders its real fixtures whatever its number is.
+ *
+ * Each paired round is its own `<ul>` so a fixture stays an `<li>` a screen reader can
+ * count, named by its round so the rotor tells one from the next — the same shape
+ * `RoundList` and `Bracket` use.
+ */
+export const SwissRounds = ({ rounds }: SwissRoundsProps) => (
+  <div className="mt-2 flex flex-col gap-2">
+    {rounds.map((round) => (
+      <div key={round.round}>
+        <div className="text-[11px] font-semibold tracking-[0.08em] text-[color:var(--fg-3)] uppercase">
+          Round {round.round}
+        </div>
+        {isPaired(round.fixtures) ? (
+          <ul
+            data-testid={`swiss-round-${round.round}`}
+            aria-label={`Round ${round.round} fixtures`}
+            className="mt-0.5"
+          >
+            {round.fixtures.map((fixture) => (
+              <FixtureLine key={fixture.id} fixture={fixture} />
+            ))}
+          </ul>
+        ) : (
+          <ForthcomingRound round={round} />
+        )}
+      </div>
+    ))}
+  </div>
+)

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -651,6 +651,53 @@ export function planSingleElimFixtures(
   )
 }
 
+/**
+ * Plan a **swiss** draw the way the API plans one (`SwissStrategy.plan_initial`,
+ * `api/app/draws.py`): all `R` rounds up front, `⌊n/2⌋` fixtures each, round 1 seeded
+ * top-half-against-bottom-half from the draw order and every later round written with both
+ * sides TBD.
+ *
+ * That "later rounds with no players" shape is not a stub — it is the format (ADR "swiss
+ * pre-cuts every round and pairs each one on advance"): with the field frozen at the cut
+ * and `R` an explicit setting, the *number* of fixtures is fully determined and only the
+ * *sides* are unknown, which is the one thing `advance()` has always handled. So the mock
+ * cuts exactly what the server cuts, including the empty rounds a director will see.
+ *
+ * Fixtures are **un-pooled** (`pool_id: null`): swiss ranks the whole field in one table.
+ * An odd field byes the **lowest**-ranked entrant, who simply has no fixture — a bye is the
+ * absence of a row (ADR-0786), never a row with a null side.
+ *
+ * `entryIds` arrive in **draw order** (seed ascending, then registration order). Like the
+ * other planners it does **not** enforce the API's refusals; those are `planDraw`'s.
+ */
+export function planSwissFixtures(
+  entryIds: readonly string[],
+  rounds: number,
+): TournamentFixtureRead[] {
+  // The odd entrant out sits the round, so every round holds ⌊n/2⌋ fixtures whatever the
+  // parity.
+  const pairsPerRound = Math.floor(entryIds.length / 2)
+  const fixtures: TournamentFixtureRead[] = []
+  for (let round = 1; round <= rounds; round += 1) {
+    for (let position = 1; position <= pairsPerRound; position += 1) {
+      fixtures.push(
+        buildTournamentFixtureRead({
+          id: `fx-sw-r${round}-p${position}`,
+          pool_id: null,
+          round,
+          position,
+          // Round 1 alone is paired at the cut: draw-order index `i` meets index
+          // `i + pairsPerRound`, so the top seed meets the best of the bottom half. Every
+          // later round is genuinely TBD until `advance()` pairs it from the standings.
+          entry_a_id: round === 1 ? entryIds[position - 1] : null,
+          entry_b_id: round === 1 ? entryIds[position - 1 + pairsPerRound] : null,
+        }),
+      )
+    }
+  }
+  return fixtures
+}
+
 /** A planned draw, or the server's sentence for why this event cannot be cut as it
  * stands. ONE value for both, because they are the same decision: split in two, a
  * refusal check could answer "nothing wrong here" for a shape the planner then has
@@ -725,6 +772,11 @@ export function planDraw(
    * knockout stage. `null` for the two draw types that have no knockout stage to qualify
    * for, which is what their settings row holds and what their callers pass out loud. */
   qualifiersPerPool: number | null,
+  /** **R** — how many rounds a `swiss` draw plays. `null` for the three draw types whose
+   * round count nobody chooses, which is what their settings row holds and what their
+   * callers pass out loud. Same discipline as `qualifiersPerPool` above: no default, so
+   * every caller has to answer where R comes from. */
+  rounds: number | null,
 ): DrawPlan {
   switch (drawType) {
     case 'round-robin': {
@@ -815,6 +867,49 @@ export function planDraw(
           ),
         ],
       }
+    }
+    case 'swiss': {
+      if (rounds === null) {
+        // NOT a refusal, and NOT a default: a `swiss` event without a round count is not a
+        // state the server can be in — the write boundary requires one with no default
+        // (`SwissDrawSettingsWrite`), so the column is never NULL for this draw type. A
+        // stub reaching here has been seeded or patched into a shape the API cannot hold,
+        // and says so instead of quietly cutting a one-round event.
+        throw new Error(
+          'planDraw: a “swiss” draw has no rounds. The count is required at the write ' +
+            'boundary, so a stored event always has one — pass the event’s own value, ' +
+            'never a fallback.',
+        )
+      }
+      // Round-robin's per-pool floor, one level up and pool-less, exactly as single-elim's
+      // is. The event's POOLS are not consulted at all: swiss ranks the whole field in one
+      // table, so a swiss event with pools cuts perfectly well and one with none is not
+      // refused. The two sentences below are the SERVER's, verbatim
+      // (`SwissStrategy.plan_initial`), because for a refusal the sentence *is* the answer.
+      if (entryIds.length < 2) {
+        return {
+          ok: false,
+          detail:
+            'A swiss draw needs at least 2 entrants — a field of one has nobody to play.',
+        }
+      }
+      if (rounds > entryIds.length - 1) {
+        // `n - 1` is the number of distinct opponents an entrant can have, so past it a
+        // rematch-free swiss cannot exist. Refused at the CUT and not at configure time,
+        // because `n` is not known when the setting is written (ADR "swiss pre-cuts every
+        // round and pairs each one on advance") — which is exactly why the form's own bound
+        // (`swissRoundsSchema`) stops at 32 and says nothing about the field.
+        const roundNoun = rounds === 1 ? 'round' : 'rounds'
+        const opponentNoun = entryIds.length - 1 === 1 ? 'opponent' : 'opponents'
+        return {
+          ok: false,
+          detail:
+            `${rounds} ${roundNoun} is more than the ${entryIds.length - 1} ` +
+            `${opponentNoun} each of ${entryIds.length} entrants can have — play fewer ` +
+            'rounds, or add entrants.',
+        }
+      }
+      return { ok: true, fixtures: planSwissFixtures(entryIds, rounds) }
     }
   }
 }
@@ -1087,6 +1182,11 @@ export function buildTournamentEventRead(
     // null`, no `?`) while `Partial<…>` admits an explicit `undefined` — so the spread
     // alone would widen it to a type the wire cannot hold.
     qualifiers_per_pool: overrides.qualifiers_per_pool ?? null,
+    // **No chosen round count** (the swiss ADR): a round-robin's rounds come off the circle
+    // method, so `null` is the only value its settings arm admits. Stated AFTER the spread
+    // for the reason the qualifier count is — the field is required-and-nullable on the read
+    // shape while `Partial<…>` admits an explicit `undefined`.
+    rounds: overrides.rounds ?? null,
   } satisfies Omit<TournamentEventRead, 'entered'>
   return {
     ...event,
@@ -1147,6 +1247,20 @@ export const DRAW_TYPE_CATALOGUE: DrawTypeRead[] = [
       'Pools play all-play-all, then the top finishers from each pool meet in a ' +
       'knockout bracket.',
     display_order: 3,
+  },
+  {
+    key: 'swiss',
+    // Pinned by the ADR "swiss pre-cuts every round and pairs each one on advance" —
+    // seed data (migration `0010`'s `DRAW_TYPE_SEED`), so changing either string is a
+    // migration there and a re-copy here.
+    name: 'Swiss',
+    description:
+      'A fixed number of rounds, each pairing entrants who are on similar ' +
+      'scores. Nobody is eliminated and everybody plays every round, so a ' +
+      'large field is ranked in far fewer matches than a round robin — but a ' +
+      "round's pairings are only known once the round before it has finished, " +
+      'and a long event may repeat a pairing.',
+    display_order: 4,
   },
 ]
 

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -1657,7 +1657,7 @@ describe('planDraw, rr-then-ko, with a qualifier count', () => {
     // 8 entrants across 2 pools of 4, K = 1, so 2 qualifiers meet in a one-fixture
     // bracket. The count is passed explicitly like every other: the planner has no
     // default, so "pool winners only" is a configuration, never an omission.
-    const plan = planDraw('rr-then-ko', entrants(8), pools(2), 1)
+    const plan = planDraw('rr-then-ko', entrants(8), pools(2), 1, null)
 
     if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
     expect(plan.fixtures.filter((f) => f.pool_id === null)).toHaveLength(1)
@@ -1666,7 +1666,7 @@ describe('planDraw, rr-then-ko, with a qualifier count', () => {
   it('sizes the bracket from P × K — derived, never configured', () => {
     // 2 pools × 3 qualifiers = 6, padded to an 8-slot bracket: 7 slots, of which the two
     // byed seeds' round-1 rows are absent → 2 round-1 + 2 semis + 1 final.
-    const plan = planDraw('rr-then-ko', entrants(12), pools(2), 3)
+    const plan = planDraw('rr-then-ko', entrants(12), pools(2), 3, null)
 
     if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
     expect(plan.fixtures.filter((f) => f.pool_id === null)).toHaveLength(5)
@@ -1675,7 +1675,7 @@ describe('planDraw, rr-then-ko, with a qualifier count', () => {
   it('refuses taking more qualifiers than the smallest pool holds', () => {
     // 9 entrants across 2 pools → 5 and 4; taking 5 from each is more than the 4 the
     // smaller pool has, and the sentence names both numbers.
-    const plan = planDraw('rr-then-ko', entrants(9), pools(2), 5)
+    const plan = planDraw('rr-then-ko', entrants(9), pools(2), 5, null)
 
     expect(plan.ok).toBe(false)
     if (plan.ok) return
@@ -1688,10 +1688,154 @@ describe('planDraw, rr-then-ko, with a qualifier count', () => {
   it('allows a ONE-POOL draw once more than one player qualifies', () => {
     // "League, then a playoff" is a real format (ADR), and so is K = ⌊N/P⌋, where
     // everyone qualifies and the pool stage exists purely to seed.
-    const plan = planDraw('rr-then-ko', entrants(4), pools(1), 4)
+    const plan = planDraw('rr-then-ko', entrants(4), pools(1), 4, null)
 
     if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
     expect(plan.fixtures.filter((f) => f.pool_id === null)).toHaveLength(3)
+  })
+})
+
+/**
+ * The **swiss** arm of the planner (ADR "swiss pre-cuts every round and pairs each one on
+ * advance"). What it has to get right is the shape the ADR chose, and it is a shape that
+ * looks broken until you know the reason: **all `R` rounds are written at the cut**, and
+ * every round past the first has both sides `null`. That is not a stub — with the field
+ * frozen at the cut and `R` an explicit setting, the number of fixtures is fully
+ * determined and only the sides are unknown, which is the one state `advance()` has always
+ * handled.
+ *
+ * The mock's job is to cut exactly what the server cuts, empty rounds included, so a
+ * director in `npm run dev` sees the same draw a director on the real API does.
+ */
+describe('planDraw, swiss', () => {
+  const entrants = (n: number) => Array.from({ length: n }, (_, i) => `entry-${i + 1}`)
+
+  it('writes every round up front — R × ⌊n/2⌋ fixtures', () => {
+    // 8 entrants, 3 rounds → 4 pairings per round, 12 fixtures. A planner that wrote only
+    // round 1 (the "we will create them as we go" reading the ADR rejects) gives 4.
+    const plan = planDraw('swiss', entrants(8), [], null, 3)
+
+    if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
+    expect(plan.fixtures).toHaveLength(12)
+    expect(plan.fixtures.map((f) => f.round)).toEqual([
+      1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,
+    ])
+  })
+
+  it('pairs ONLY round 1, top half against bottom half, and leaves the rest TBD', () => {
+    const plan = planDraw('swiss', entrants(8), [], null, 3)
+
+    if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
+    // Draw-order index `i` meets index `i + ⌊n/2⌋`: seed 1 meets seed 5, not seed 2 (a
+    // consecutive pairing) and not seed 8 (a bracket's 1-v-N).
+    expect(
+      plan.fixtures
+        .filter((f) => f.round === 1)
+        .map((f) => [f.entry_a_id, f.entry_b_id]),
+    ).toEqual([
+      ['entry-1', 'entry-5'],
+      ['entry-2', 'entry-6'],
+      ['entry-3', 'entry-7'],
+      ['entry-4', 'entry-8'],
+    ])
+    // Every later round is genuinely unpaired — `advance()` fills it once the round before
+    // it is decided. A planner that seeded them all the same way would look identical on
+    // round 1 and be wrong everywhere else.
+    expect(
+      plan.fixtures
+        .filter((f) => f.round > 1)
+        .every((f) => f.entry_a_id === null && f.entry_b_id === null),
+    ).toBe(true)
+  })
+
+  it('cuts un-pooled fixtures, whatever pools the event carries', () => {
+    // Swiss ranks the whole field in one table, so `pool_id` is null throughout — and the
+    // event's pools are not consulted at all, exactly as on the server.
+    const plan = planDraw('swiss', entrants(8), ['p-1', 'p-2'], null, 2)
+
+    if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
+    expect(plan.fixtures.every((f) => f.pool_id === null)).toBe(true)
+  })
+
+  it('byes the LOWEST-ranked entrant on an odd field, by leaving them out of every round', () => {
+    // 7 entrants → 3 pairings per round, and `entry-7` sits in no fixture. A bye is the
+    // ABSENCE of a row (ADR-0786), never a row with a null side — which here would be
+    // indistinguishable from a later round awaiting its pairing.
+    const plan = planDraw('swiss', entrants(7), [], null, 2)
+
+    if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
+    expect(plan.fixtures).toHaveLength(6)
+    const seated = plan.fixtures
+      .filter((f) => f.round === 1)
+      .flatMap((f) => [f.entry_a_id, f.entry_b_id])
+    expect(seated).toEqual([
+      'entry-1',
+      'entry-4',
+      'entry-2',
+      'entry-5',
+      'entry-3',
+      'entry-6',
+    ])
+    expect(seated).not.toContain('entry-7')
+  })
+
+  it('refuses a field of one, in the server’s own words', () => {
+    const plan = planDraw('swiss', entrants(1), [], null, 1)
+
+    expect(plan.ok).toBe(false)
+    if (plan.ok) return
+    expect(plan.detail).toBe(
+      'A swiss draw needs at least 2 entrants — a field of one has nobody to play.',
+    )
+  })
+
+  /**
+   * `R > n - 1` is refused at the **cut**, not at configure time: `n` is not known when the
+   * setting is written, so a round count that was legal when the director typed it must not
+   * become unwritable when somebody withdraws. This is the sentence the API raises
+   * (`SwissStrategy.plan_initial`), copied verbatim — a paraphrase here would go green
+   * against words the server never says.
+   */
+  it('refuses more rounds than there are distinct opponents, naming both numbers', () => {
+    const plan = planDraw('swiss', entrants(5), [], null, 9)
+
+    expect(plan.ok).toBe(false)
+    if (plan.ok) return
+    expect(plan.detail).toBe(
+      '9 rounds is more than the 4 opponents each of 5 entrants can have — play ' +
+        'fewer rounds, or add entrants.',
+    )
+  })
+
+  // The boundary itself is legal: with `n` entrants everybody CAN meet all `n - 1` others.
+  it('accepts exactly n − 1 rounds', () => {
+    const plan = planDraw('swiss', entrants(5), [], null, 4)
+
+    if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
+    expect(plan.fixtures).toHaveLength(8)
+  })
+
+  // Singular/plural, because the message is read by a person. One round against a field of
+  // two is the only shape that reaches both nouns at once.
+  it('inflects the sentence for a single round and a single opponent', () => {
+    const plan = planDraw('swiss', entrants(2), [], null, 2)
+
+    expect(plan.ok).toBe(false)
+    if (plan.ok) return
+    expect(plan.detail).toBe(
+      '2 rounds is more than the 1 opponent each of 2 entrants can have — play ' +
+        'fewer rounds, or add entrants.',
+    )
+  })
+
+  /** NOT a refusal and NOT a default: the write boundary requires `rounds` with no default
+   * on the swiss arm, so the column is never NULL for this draw type. A stub that arrived
+   * here has been seeded into a shape the API cannot hold, and it says so rather than
+   * quietly cutting a one-round event. */
+  it('throws — never substitutes — when a swiss event has no round count', () => {
+    expect(() => planDraw('swiss', entrants(8), [], null, null)).toThrow(
+      /has no rounds/,
+    )
   })
 })
 
@@ -1712,8 +1856,9 @@ describe('the draw-type catalogue', () => {
       'round-robin',
       'single-elim',
       'rr-then-ko',
+      'swiss',
     ])
-    expect(catalogue!.map((d) => d.display_order)).toEqual([1, 2, 3])
+    expect(catalogue!.map((d) => d.display_order)).toEqual([1, 2, 3, 4])
     // The copy is what a director reads while choosing; neither field is ever empty.
     for (const drawType of catalogue!) {
       expect(drawType.name.length).toBeGreaterThan(0)
@@ -2261,6 +2406,8 @@ describe('the seeded two-stage (rr-then-ko) events', () => {
         // The event's own count, unasserted: the planner takes `number | null` and
         // refuses the impossible pair loudly, so there is nothing here to talk past.
         event.qualifiers_per_pool,
+        // No round count: this draw type has none, and only the swiss arm reads it.
+        null,
       )
       if (!plan.ok) throw new Error(`expected a plan, got: ${plan.detail}`)
 

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -105,7 +105,13 @@ type ScheduleSolveRead = components['schemas']['ScheduleSolveRead']
  * **It is `null` for every draw type but `rr-then-ko`** (ADR 20260727), which is why the
  * seed below states the bare literal and says no more: no knockout stage to qualify for,
  * so no qualifier count — `null` is the only value those draw types' settings row admits,
- * and it is not "unset". */
+ * and it is not "unset".
+ *
+ * `rounds` is stored on exactly the same terms (the swiss ADR): it is what sizes a swiss
+ * draw at the cut (`R × ⌊n/2⌋` fixtures, all of them written up front), it is `null` for
+ * every draw type but `swiss`, and `null` is not "unset" there either — a round-robin's
+ * rounds come off the circle method and a bracket's depth follows from the field, so
+ * neither is a number anybody chooses. */
 type StoredEvent = Omit<TournamentEventRead, 'entered' | 'entry_state'> & {
   /** Seeded: the dev user is refused by this rule, at this rating. */
   ineligible?: { predicate_id: string; rating: number }
@@ -566,6 +572,7 @@ function seed(): StoredTournament[] {
           format: 'singles',
           draw_type: 'round-robin',
           qualifiers_per_pool: null,
+          rounds: null,
           max_players: 64,
           entry_fee: 45,
           timezone: 'America/Chicago',
@@ -613,6 +620,7 @@ function seed(): StoredTournament[] {
           format: 'singles',
           draw_type: 'round-robin',
           qualifiers_per_pool: null,
+          rounds: null,
           max_players: 48,
           entry_fee: 30,
           timezone: 'America/Los_Angeles',
@@ -637,6 +645,7 @@ function seed(): StoredTournament[] {
           format: 'singles',
           draw_type: 'single-elim',
           qualifiers_per_pool: null,
+          rounds: null,
           max_players: 16,
           entry_fee: 60,
           timezone: 'America/Los_Angeles',
@@ -672,6 +681,7 @@ function seed(): StoredTournament[] {
           format: 'singles',
           draw_type: 'round-robin',
           qualifiers_per_pool: null,
+          rounds: null,
           max_players: 24,
           entry_fee: 20,
           timezone: 'America/Los_Angeles',
@@ -736,6 +746,7 @@ function seed(): StoredTournament[] {
           format: 'doubles',
           draw_type: 'single-elim',
           qualifiers_per_pool: null,
+          rounds: null,
           max_players: 32,
           entry_fee: 25,
           timezone: 'America/Los_Angeles',
@@ -795,6 +806,7 @@ function seed(): StoredTournament[] {
           format: 'singles',
           draw_type: 'round-robin',
           qualifiers_per_pool: null,
+          rounds: null,
           max_players: 16,
           entry_fee: 20,
           timezone: 'America/New_York',
@@ -857,6 +869,7 @@ function seed(): StoredTournament[] {
           format: 'singles',
           draw_type: 'single-elim',
           qualifiers_per_pool: null,
+          rounds: null,
           max_players: 32,
           entry_fee: 40,
           timezone: 'America/Los_Angeles',
@@ -954,6 +967,7 @@ function seed(): StoredTournament[] {
           format: 'singles',
           draw_type: 'round-robin',
           qualifiers_per_pool: null,
+          rounds: null,
           max_players: 8,
           entry_fee: 0,
           timezone: 'America/Los_Angeles',
@@ -1023,6 +1037,7 @@ function seed(): StoredTournament[] {
           // every other event in this seed it is NOT null: a knockout stage to qualify
           // for is exactly what this draw type has.
           qualifiers_per_pool: 2,
+          rounds: null,
           max_players: 8,
           entry_fee: 35,
           timezone: 'America/Los_Angeles',
@@ -1112,6 +1127,7 @@ function seed(): StoredTournament[] {
           // maximum, where everyone but the pool's last qualifies and the pool stage
           // exists purely to seed (ADR 20260727).
           qualifiers_per_pool: 2,
+          rounds: null,
           max_players: 6,
           entry_fee: 25,
           timezone: 'America/Los_Angeles',
@@ -2215,6 +2231,11 @@ export function createEvent(
     // (`planEventDraw` below), so a fallback here would deal a bracket for a K the
     // director never chose.
     qualifiers_per_pool: body.qualifiers_per_pool ?? null,
+    // **R**, stored beside the draw type it belongs to (the swiss ADR), on exactly the same
+    // terms as the qualifier count above: absent means the draw type has no round count to
+    // choose, which is `null`, never `undefined` and never an invented number — the day
+    // this event's draw is cut, this is how many rounds get written.
+    rounds: body.rounds ?? null,
     // A missing cap is "no cap" (ADR-0935), stored as null — never undefined.
     max_players: body.max_players ?? null,
     entry_fee: body.entry_fee,
@@ -2302,6 +2323,13 @@ export function updateEvent(
       patch.draw_type === undefined || patch.draw_type === null
         ? event.qualifiers_per_pool
         : (patch.qualifiers_per_pool ?? null),
+    // …and **R** moves with the very same unit, for the very same reason (the swiss ADR).
+    // Reading it with `??` would strand a swiss event's round count on a round-robin it was
+    // just re-typed as — the contradiction the union exists to make unrepresentable.
+    rounds:
+      patch.draw_type === undefined || patch.draw_type === null
+        ? event.rounds
+        : (patch.rounds ?? null),
     // An explicit `null` clears the cap (ADR-0935); only an *absent* key leaves
     // the stored cap untouched. `??` would conflate the two, silently keeping a
     // cap the editor meant to remove.
@@ -2501,6 +2529,10 @@ function planEventDraw(event: StoredEvent): DrawPlan {
     // SILENT one: an event configured at K=2 would be cut into a `P × 1` bracket — a
     // perfectly well-formed draw of the wrong size, with nothing anywhere reporting it.
     event.qualifiers_per_pool,
+    // **The event's own R** (the swiss ADR) — the stored number, passed through unchanged,
+    // for exactly the reasons the qualifier count above is. Only the `swiss` arm reads it,
+    // and a swiss event always has one, so that arm never meets the null.
+    event.rounds,
   )
 }
 


### PR DESCRIPTION
Slice 2 of the swiss stack (#1276). **Stacked on #1279** — review that first; this PR's base is `…-s1`, so the diff here is slice 2 only.

Swiss is now a draw type a director can pick, configure, cut and run round 1 of. Pairing later rounds, byes scoring, and Buchholz are slices 3 and 4.

## What changes

**API.** `swiss` joins the `DrawType` enum with its `draw_types` seed row, a settings arm carrying a required round count, the cut, and all six exhaustive dispatch sites.

The cut pre-writes **every** round: `R × floor(n/2)` un-pooled fixtures, round 1 seeded from the draw order and later rounds with both sides `NULL` — which already means "TBD, `advance()` will fill it". `advance()` pairs nothing yet; it only reports round 1 ready. `DegenerateDraw` when `R > n-1`, since `n` entrants give nobody more than `n-1` distinct opponents.

`reads_fixture_games` is `True` for swiss. The schedule preview **refuses** swiss exactly as it refuses single-elim, swiss being pool-less.

**Web.** The `DrawType` union, a round-count field in the event editor, the mock draw planner, the seed row, and a new `swiss_standings` results arm. Swiss has no pools, so it gets its own results arm rather than a fabricated pool id.

## Two bugs found while building this, neither in the original plan

**An odd swiss field could not go live.** Draw currency compared the fixture-seated set to the active set for equality. A swiss round emits `floor(n/2)` fixtures and a bye is the absence of a row, so a 7-player draw cut from exactly those 7 entrants read `stale` and 409'd at go-live. `unseated_entrant_allowance` is now an exhaustive match beside `reads_fixture_games`: `0` for the other three draw types — not because they have no byes, but because their byed entrants are seated somewhere else — and `field_size % 2` for swiss. For an allowance of `0` the new check is *exactly* the old equality, so no other draw type's protection moved. Falsified by setting round-robin's allowance to `1`, which reds the two existing round-robin staleness guards.

**Swiss rendered as a knockout bracket.** The draw panel routed on `pool_id IS NULL`, which is the *stage* discriminator for rr-then-ko's knockout stage. Swiss is un-pooled and shares that null. Worse than it sounds: the bracket's `roundLabel` names rounds back from the final, so a swiss event was labelling its rounds **"Quarterfinals / Semifinals / Final"** in a format where nobody is eliminated and there is no final. Routing now reads the draw type through an exhaustive `unpooledShape`, and both directions are compile-checked — a fifth draw type is an error until it names a shape, a fifth shape is an error until it has a view.

## Known limit, pinned rather than hidden

A swiss draw cut for **8** and joined by a **9th** holds byte-for-byte the rows a draw cut for 9 holds — `floor(8/2)` and `floor(9/2)` are the same four fixtures — and the parity of the field the draw was cut for is stored nowhere. That one case reads `current` and the latecomer becomes round 1's bye. It is pinned as a test with the reasoning in the docstring. Two latecomers, a latecomer leaving the field even, and any withdrawal of a seated entry all still read `stale`.

## Verification

- api: `ruff`, `mypy --strict` (170 files, no new ignores), **2190 pytest passing**, and `alembic upgrade head` against a fresh Postgres confirming the fourth seed row
- web: `tsc -b` at **zero** (the regen broke 17 sites), **3509 vitest passing**, `eslint` clean, 321 Playwright
- root e2e: **exit 0, 26 passed against `--list`'s 26 collected** — the numbers agree, so nothing silently skipped
- Falsifications run on the cut refusal, the round-1 seeding, the draw-panel routing, the round-count field, and the go-live. The go-live one reverts the allowance and confirms **only the odd-field test** reds, isolating parity rather than leaving an undiscriminated failure.

Chores: `2abcd`, `2h`, `2e`, `2f`, `2f3`, `2g`. Several folded — this codebase's exhaustiveness discipline means an enum member breaks six `match` statements at once and a regen broke 17 typecheck sites, so partial states are not green.

Part of #1276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
