### PR TITLE
Slice 3: completing a round pairs the next one from the standings

### DIFF
--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -50,12 +50,7 @@ from datetime import datetime
 from typing import NewType, Protocol
 
 from app.models.tournament import DrawType, EventFormat
-from app.pool_finishing_order import (
-    EntryTally,
-    MatchOutcome,
-    entry_id_order,
-    finishing_order,
-)
+from app.pool_finishing_order import EntryTally, MatchOutcome, finishing_order
 from app.schemas.tournament import (
     DrawSettingsWriteArm,
     RoundRobinDrawSettingsWrite,
@@ -408,6 +403,29 @@ class FixtureState:
         """Some side is still unknown."""
         return self.entry_a_id is None or self.entry_b_id is None
 
+    @property
+    def is_decided(self) -> bool:
+        """This fixture has produced all the result it ever will — a live score, or a
+        **void** that means there will never be one.
+
+        The two facts, in one place, because two readers ask this same question of this
+        same type within one advance: :func:`_swiss_round_is_decided` (may the next
+        round be paired?) and :attr:`SeatedPairing.decided` (may this round's bye be
+        scored?). Spelled twice they could gain a third condition — a forfeit status —
+        one at a time, and a bye scored in the standings but not in the pairing is the
+        result.
+
+        The **live-outcome** view (:attr:`games`), not the written-back
+        ``winner_entry_id``: a result under correction leaves its match un-``completed``
+        while the winner id stays put, so a correction genuinely un-decides its fixture.
+
+        Says nothing about the sides being known — an unpaired fixture is not decided in
+        any useful sense, but it is not this property's question either. A caller that
+        needs both asks for both (``not f.is_pending and f.is_decided``); the callers
+        that already hold a seated fixture do not re-ask.
+        """
+        return self.match_voided or self.games is not None
+
 
 @dataclass(frozen=True, slots=True)
 class SeatedPairing:
@@ -435,8 +453,9 @@ class SeatedPairing:
     #: match, or a **voided** one, which never will. It is here because a bye is scored
     #: with its round (:func:`swiss_byes`), and a round is only over when every pairing
     #: in it is: a fixture still being played leaves the round open, and a voided one
-    #: does not, exactly as :func:`_swiss_round_is_decided` reads the same two facts for
-    #: the pairing.
+    #: does not. The draw layer fills it straight from
+    #: :attr:`FixtureState.is_decided` — the one place those two facts are spelled —
+    #: which is the same property :func:`_swiss_round_is_decided` asks.
     #:
     #: **No default**, deliberately. Either default is a lie a caller can tell by
     #: omission, and both fail quietly: ``False`` credits nobody for a bye they took,
@@ -515,6 +534,15 @@ class DrawStrategy(Protocol):
         case. A caller may hand those three an **empty** sequence rather than paying for
         a load they discard — :func:`reads_entrants` is where each draw type says which
         it is.
+
+        **Required, with no default**, and that is a fact about this being a
+        :class:`Protocol` with four implementations rather than a rule about optional
+        parameters. A default here would let one implementation quietly leave the
+        parameter off its signature and still satisfy the checker, and the one that did
+        would be the one that needed it. The mirror case is
+        :func:`~app.pool_finishing_order.finishing_order`, a single free function whose
+        ``byes`` **is** defaulted: nothing implements it, so an omission there is a
+        caller's choice at one call site rather than a hole in a seam.
         """
         ...
 
@@ -1192,10 +1220,16 @@ def swiss_byes(
     round does. It costs the pairing nothing, because a round is paired only after the
     round before it is decided.
 
-    One definition, two readers (see :class:`SeatedPairing`): the draw layer picks the
+    One definition, two layers (see :class:`SeatedPairing`): the draw layer picks the
     next bye by preferring an entrant with none of these, and the results layer scores
-    each one as a win worth zero games. Ordered by round then by entry id so the value
-    is reproducible, though only its *multiset* is ever read.
+    each one as a win worth zero games.
+
+    Grouped by **round, in round order** — the one ordering that is read, since a round
+    is what a bye is scored with. Within a round the ids arrive in whatever order the
+    caller's ``field`` iterates, and that is deliberate: every consumer takes the
+    *multiset* and nothing else (``Counter(...)`` for the selection rule,
+    ``for entry_id in byes`` for the scoring), so sorting the field here would be an
+    ``O(n log n)`` pass per call buying a total order nobody asks for.
     """
     seated: dict[int, set[EntryId]] = defaultdict(set)
     undecided: set[int] = set()
@@ -1203,12 +1237,15 @@ def swiss_byes(
         seated[pairing.round].update({pairing.entry_a_id, pairing.entry_b_id})
         if not pairing.decided:
             undecided.add(pairing.round)
-    ordered_field = sorted(field, key=entry_id_order)
+    # Materialized, because ``field`` is an ``Iterable`` and the comprehension below
+    # walks it once **per decided round**: a generator would yield the first round's
+    # byes and then silently nothing.
+    entrants = list(field)
     return tuple(
         entry_id
         for round_number in sorted(seated)
         if round_number not in undecided
-        for entry_id in ordered_field
+        for entry_id in entrants
         if entry_id not in seated[round_number]
     )
 
@@ -1226,11 +1263,15 @@ def _swiss_pairing_fills(
     if round_fixtures is None:
         return []
     field = [entrant.entry_id for entrant in ordered_entrants]
-    # Projected once and handed to all three readers, so "who has played whom" and "who
-    # has sat out" are two questions asked of one set of pairings.
+    # Projected once and handed to both readers, so "who has played whom" and "who has
+    # sat out" are two questions asked of one set of pairings.
     pairings = _swiss_seated_pairings(fixtures)
-    order = _swiss_standings_order(field, fixtures, pairings)
-    bye = _swiss_bye(order, pairings)
+    # Derived once, here, and handed to both the scoring and the selection below. Two
+    # calls would be two chances to disagree — and the shape of that disagreement is an
+    # entrant sitting out twice while the table says they never did.
+    byes = swiss_byes(field, pairings)
+    order = _swiss_standings_order(field, fixtures, byes)
+    bye = _swiss_bye(order, byes)
     pairs = swiss_pairings(
         [entry_id for entry_id in order if entry_id != bye], _swiss_met(pairings)
     )
@@ -1294,30 +1335,26 @@ def _swiss_round_to_pair(
 def _swiss_round_is_decided(round_fixtures: Sequence[FixtureState]) -> bool:
     """Whether every fixture in one round has produced all the result it ever will.
 
-    The **live-outcome** view (:attr:`FixtureState.games`), not the written-back
-    ``winner_entry_id``, for the reason :func:`_finished_pool_order` reads the same
-    field: a result under correction leaves its match un-``completed`` while the winner
-    id stays put, and the standings the next round is paired from are projected from the
-    games. So a correction un-decides its round rather than letting the next one be
-    paired off a table nobody can see.
+    Per fixture that is :attr:`FixtureState.is_decided` — the shared spelling, which is
+    also what :attr:`SeatedPairing.decided` carries, so "this round is over" is one
+    answer whether it is being asked in order to pair the next round or in order to
+    score a bye. Read that property for why it is the **live-outcome** view
+    (:attr:`FixtureState.games`) and why a **voided** fixture counts as decided.
 
-    A **voided** fixture never will produce a result (the match is terminal, and
-    ``ready_fixtures`` will not re-materialize a fixture that has a ``match_id``), so it
-    is excluded rather than counted-but-missing. Counting it would stall the event
-    permanently one score short, with no move a director could make.
+    The extra half — both sides known — stays here rather than on the property. It is a
+    question about a *round* being playable at all, not about one fixture's result, and
+    a round with an unpaired fixture in it has not been played whatever its other rows
+    say.
     """
     return all(
-        fixture.entry_a_id is not None
-        and fixture.entry_b_id is not None
-        and (fixture.match_voided or fixture.games is not None)
-        for fixture in round_fixtures
+        not fixture.is_pending and fixture.is_decided for fixture in round_fixtures
     )
 
 
 def _swiss_standings_order(
     field: Sequence[EntryId],
     fixtures: Sequence[FixtureState],
-    pairings: Sequence[SeatedPairing],
+    byes: Sequence[EntryId],
 ) -> list[EntryId]:
     """The field ordered by the current standings — the order the next round is paired
     down.
@@ -1327,6 +1364,10 @@ def _swiss_standings_order(
     Buchholz"). Leaving them out would rank a byed entrant below everybody who played
     while the director's table ranked them above — the two layers disagreeing about the
     standings, which is precisely what one shared chain exists to prevent.
+
+    ``byes`` arrives already derived (:func:`swiss_byes`, called once by
+    :func:`_swiss_pairing_fills`) rather than being derived here, so that this and
+    :func:`_swiss_bye` read one value instead of two derivations of it.
 
     :func:`~app.pool_finishing_order.finishing_order` is the *shared* definition of that
     table, the same call the standings on screen are projected through, so the order a
@@ -1362,22 +1403,25 @@ def _swiss_standings_order(
                 entry_b_games=games.entry_b_games,
             )
         )
-    return [
-        tally.entry_id
-        for tally in finishing_order(field, outcomes, swiss_byes(field, pairings))
-    ]
+    return [tally.entry_id for tally in finishing_order(field, outcomes, byes)]
 
 
-def _swiss_bye(
-    order: Sequence[EntryId], pairings: Sequence[SeatedPairing]
-) -> EntryId | None:
+def _swiss_bye(order: Sequence[EntryId], byes: Sequence[EntryId]) -> EntryId | None:
     """Who sits out this round: the **lowest-ranked entrant who has not had a bye yet**,
     or ``None`` when the field is even.
 
-    Selection and scoring read the *same* derivation (:func:`swiss_byes`), so the
-    entrant this passes over for having had one is exactly the entrant the standings
-    credited with a win for it. Two derivations could disagree, and the shape of that
+    Selection and scoring read the same **value**, not two derivations of it:
+    :func:`_swiss_pairing_fills` calls :func:`swiss_byes` once and hands the one tuple
+    to this and to :func:`_swiss_standings_order`. So the entrant this passes over for
+    having had one is exactly the entrant the standings credited with a win for it, by
+    construction — where two calls would agree only as long as nobody changed what
+    :func:`swiss_byes` returns for one caller's argument shape. The shape of that
     disagreement is somebody sitting out twice while the table says they never did.
+
+    (Within *this* layer, that is. The results layer derives its own byes from its own
+    row shape, because the two hold different rows — see :class:`SeatedPairing` — and
+    that the two spellings of "decided" underneath them still agree is pinned by a
+    test, not by a shared call.)
 
     The fallback for a field in which everybody has had one (the lowest-ranked overall)
     is written for completeness rather than because it runs. The cut refuses ``R > n −
@@ -1386,9 +1430,9 @@ def _swiss_bye(
     """
     if len(order) % 2 == 0:
         return None
-    byes = Counter(swiss_byes(order, pairings))
+    taken = Counter(byes)
     for entry_id in reversed(order):
-        if not byes[entry_id]:
+        if not taken[entry_id]:
             return entry_id
     return order[-1]
 
@@ -1410,16 +1454,17 @@ def _swiss_seated_pairings(
     derivations read. A fixture with an empty side is a round waiting to be paired, not
     a pairing.
 
-    ``decided`` reads the same two facts :func:`_swiss_round_is_decided` reads — a live
-    score, or a void that means there will never be one — so "this round is over" is one
-    answer here, whether it is being asked in order to pair the next round or in order
-    to score a bye."""
+    ``decided`` is :attr:`FixtureState.is_decided` itself — a live score, or a void that
+    means there will never be one — which is the same property
+    :func:`_swiss_round_is_decided` asks, so "this round is over" is one answer here,
+    whether it is being asked in order to pair the next round or in order to score a
+    bye."""
     return [
         SeatedPairing(
             round=fixture.round,
             entry_a_id=fixture.entry_a_id,
             entry_b_id=fixture.entry_b_id,
-            decided=fixture.match_voided or fixture.games is not None,
+            decided=fixture.is_decided,
         )
         for fixture in fixtures
         if fixture.entry_a_id is not None and fixture.entry_b_id is not None

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -43,14 +43,19 @@ from __future__ import annotations
 
 import enum
 import uuid
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import NewType, Protocol
 
 from app.models.tournament import DrawType, EventFormat
-from app.pool_finishing_order import EntryTally, MatchOutcome, finishing_order
+from app.pool_finishing_order import (
+    EntryTally,
+    MatchOutcome,
+    entry_id_order,
+    finishing_order,
+)
 from app.schemas.tournament import (
     DrawSettingsWriteArm,
     RoundRobinDrawSettingsWrite,
@@ -402,6 +407,42 @@ class FixtureState:
     def is_pending(self) -> bool:
         """Some side is still unknown."""
         return self.entry_a_id is None or self.entry_b_id is None
+
+
+@dataclass(frozen=True, slots=True)
+class SeatedPairing:
+    """A fixture that seats **both** sides, in the one round it belongs to — the whole
+    input to :func:`swiss_byes`, and deliberately nothing more.
+
+    Both sides are non-optional, which is the type doing the work: a bye is derived by
+    asking who is *absent* from a round that was paired, so a fixture with an empty side
+    (a round nobody has been paired into yet) must not be able to enter that derivation
+    at all. Filtering happens where these are built, once, rather than being re-asserted
+    inside every reader.
+
+    It exists because **two layers derive byes and must not disagree** — the draw layer
+    pairs the next round down the standings (:class:`SwissStrategy`), and the results
+    layer reads those standings out to a director (:mod:`app.results`) — and the two
+    hold entirely different row shapes (:class:`FixtureState` and a
+    ``TournamentFixtureRead``). This is the small common shape both can project into, so
+    the *rule* has one implementation while the projections stay each caller's own.
+    """
+
+    round: int
+    entry_a_id: EntryId
+    entry_b_id: EntryId
+    #: Whether this pairing has produced all the result it ever will — a completed
+    #: match, or a **voided** one, which never will. It is here because a bye is scored
+    #: with its round (:func:`swiss_byes`), and a round is only over when every pairing
+    #: in it is: a fixture still being played leaves the round open, and a voided one
+    #: does not, exactly as :func:`_swiss_round_is_decided` reads the same two facts for
+    #: the pairing.
+    #:
+    #: **No default**, deliberately. Either default is a lie a caller can tell by
+    #: omission, and both fail quietly: ``False`` credits nobody for a bye they took,
+    #: and ``True`` credits a round still being played. Every construction site holds
+    #: the fact already, so it states it.
+    decided: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -1120,6 +1161,58 @@ def swiss_pairings(
     return pairs
 
 
+def swiss_byes(
+    field: Iterable[EntryId], pairings: Iterable[SeatedPairing]
+) -> tuple[EntryId, ...]:
+    """Every bye this draw has handed out: one entry id **per bye taken**, so an entrant
+    who has sat out twice appears twice.
+
+    A bye is the absence of a fixture row (CONTEXT.md, "Bye"), never a row with a
+    ``NULL`` side and never a stored flag — so it is *derived*, here, by asking who is
+    missing from a round that was paired. Nothing else can answer it: the rows are the
+    only record there is, and the absence of one is the record of a bye.
+
+    **The field comes from the event's entrants**, not from the entries the fixtures
+    seat, for the reason that runs through the whole format: the byed entrant is by
+    definition in no row that round, and a swiss draw cut for eight that a ninth player
+    joined is seated nowhere at all. Derive the field from the rows and the very
+    entrants this function exists to find would be the ones it could not see.
+
+    A round with no seated pairing is **not** a round everybody was byed in — it is a
+    round nobody has been paired into yet, which is the ordinary state of every later
+    round of a freshly cut draw. Only rounds present in ``pairings`` are counted, which
+    is why the input is pairings rather than a round count.
+
+    **A bye is scored with its round**, so a round counts only once every pairing in it
+    is :attr:`~SeatedPairing.decided`. The alternative — crediting it the moment the
+    round is *paired* — puts a win on the table for a round nobody has played: a
+    seven-player draw would be cut and immediately show its byed entrant top of the
+    standings, ahead of six players who have not been given the chance to hit a ball.
+    Gating on the round makes the bye land at the same moment every real result in that
+    round does. It costs the pairing nothing, because a round is paired only after the
+    round before it is decided.
+
+    One definition, two readers (see :class:`SeatedPairing`): the draw layer picks the
+    next bye by preferring an entrant with none of these, and the results layer scores
+    each one as a win worth zero games. Ordered by round then by entry id so the value
+    is reproducible, though only its *multiset* is ever read.
+    """
+    seated: dict[int, set[EntryId]] = defaultdict(set)
+    undecided: set[int] = set()
+    for pairing in pairings:
+        seated[pairing.round].update({pairing.entry_a_id, pairing.entry_b_id})
+        if not pairing.decided:
+            undecided.add(pairing.round)
+    ordered_field = sorted(field, key=entry_id_order)
+    return tuple(
+        entry_id
+        for round_number in sorted(seated)
+        if round_number not in undecided
+        for entry_id in ordered_field
+        if entry_id not in seated[round_number]
+    )
+
+
 def _swiss_pairing_fills(
     fixtures: Sequence[FixtureState], ordered_entrants: Sequence[OrderedEntrant]
 ) -> list[SideFill]:
@@ -1133,10 +1226,13 @@ def _swiss_pairing_fills(
     if round_fixtures is None:
         return []
     field = [entrant.entry_id for entrant in ordered_entrants]
-    order = _swiss_standings_order(field, fixtures)
-    bye = _swiss_bye(order, fixtures)
+    # Projected once and handed to all three readers, so "who has played whom" and "who
+    # has sat out" are two questions asked of one set of pairings.
+    pairings = _swiss_seated_pairings(fixtures)
+    order = _swiss_standings_order(field, fixtures, pairings)
+    bye = _swiss_bye(order, pairings)
     pairs = swiss_pairings(
-        [entry_id for entry_id in order if entry_id != bye], _swiss_met(fixtures)
+        [entry_id for entry_id in order if entry_id != bye], _swiss_met(pairings)
     )
     fills: list[SideFill] = []
     # ``position`` is the pairing's rank (ADR), so the round's rows are filled in
@@ -1219,10 +1315,18 @@ def _swiss_round_is_decided(round_fixtures: Sequence[FixtureState]) -> bool:
 
 
 def _swiss_standings_order(
-    field: Sequence[EntryId], fixtures: Sequence[FixtureState]
+    field: Sequence[EntryId],
+    fixtures: Sequence[FixtureState],
+    pairings: Sequence[SeatedPairing],
 ) -> list[EntryId]:
     """The field ordered by the current standings — the order the next round is paired
     down.
+
+    **Byes are scored here too**, as a win worth zero games, by the same
+    :func:`finishing_order` the table on screen is built by (ADR "swiss standings add
+    Buchholz"). Leaving them out would rank a byed entrant below everybody who played
+    while the director's table ranked them above — the two layers disagreeing about the
+    standings, which is precisely what one shared chain exists to prevent.
 
     :func:`~app.pool_finishing_order.finishing_order` is the *shared* definition of that
     table, the same call the standings on screen are projected through, so the order a
@@ -1258,65 +1362,68 @@ def _swiss_standings_order(
                 entry_b_games=games.entry_b_games,
             )
         )
-    return [tally.entry_id for tally in finishing_order(field, outcomes)]
+    return [
+        tally.entry_id
+        for tally in finishing_order(field, outcomes, swiss_byes(field, pairings))
+    ]
 
 
 def _swiss_bye(
-    order: Sequence[EntryId], fixtures: Sequence[FixtureState]
+    order: Sequence[EntryId], pairings: Sequence[SeatedPairing]
 ) -> EntryId | None:
     """Who sits out this round: the **lowest-ranked entrant who has not had a bye yet**,
     or ``None`` when the field is even.
 
-    A bye is the absence of a fixture row, so who has already had one is *derived* —
-    an entrant seated in no fixture of a round that was paired (:func:`_swiss_seated`).
-    Nothing is stored, and nothing needs to be: the rows are the record.
+    Selection and scoring read the *same* derivation (:func:`swiss_byes`), so the
+    entrant this passes over for having had one is exactly the entrant the standings
+    credited with a win for it. Two derivations could disagree, and the shape of that
+    disagreement is somebody sitting out twice while the table says they never did.
 
     The fallback for a field in which everybody has had one (the lowest-ranked overall)
     is written for completeness rather than because it runs. The cut refuses ``R > n −
     1``, so there are always fewer rounds than entrants and the byeless set cannot
     empty.
-
-    Bye **scoring** — a win worth zero games — is not here. It is a standings question,
-    and it lands with the standings (ADR "swiss standings add Buchholz").
     """
     if len(order) % 2 == 0:
         return None
-    byes: dict[EntryId, int] = dict.fromkeys(order, 0)
-    for seated in _swiss_seated(fixtures).values():
-        for entry_id in order:
-            if entry_id not in seated:
-                byes[entry_id] += 1
+    byes = Counter(swiss_byes(order, pairings))
     for entry_id in reversed(order):
-        if byes[entry_id] == 0:
+        if not byes[entry_id]:
             return entry_id
     return order[-1]
 
 
-def _swiss_seated(fixtures: Sequence[FixtureState]) -> dict[int, set[EntryId]]:
-    """Who is seated in each **paired** round — a round with no seated fixture at all is
-    absent from the map, so an unpaired round does not read as a round everybody was
-    byed in."""
-    seated: dict[int, set[EntryId]] = defaultdict(set)
-    for fixture in fixtures:
-        if fixture.entry_a_id is None or fixture.entry_b_id is None:
-            continue
-        seated[fixture.round].update({fixture.entry_a_id, fixture.entry_b_id})
-    return seated
-
-
-def _swiss_met(fixtures: Sequence[FixtureState]) -> set[frozenset[EntryId]]:
+def _swiss_met(pairings: Iterable[SeatedPairing]) -> set[frozenset[EntryId]]:
     """Every pair this draw has already put in a fixture together.
 
     Read off the *pairings*, not the results: a voided match and a result still being
     corrected are both pairings that happened, and pairing them again would be the
     rematch the walk exists to avoid.
     """
-    met: set[frozenset[EntryId]] = set()
-    for fixture in fixtures:
-        if fixture.entry_a_id is None or fixture.entry_b_id is None:
-            continue
-        met.add(frozenset({fixture.entry_a_id, fixture.entry_b_id}))
-    return met
+    return {frozenset({pairing.entry_a_id, pairing.entry_b_id}) for pairing in pairings}
+
+
+def _swiss_seated_pairings(
+    fixtures: Sequence[FixtureState],
+) -> list[SeatedPairing]:
+    """This draw's fixtures that seat **both** sides, as the shape the bye and rematch
+    derivations read. A fixture with an empty side is a round waiting to be paired, not
+    a pairing.
+
+    ``decided`` reads the same two facts :func:`_swiss_round_is_decided` reads — a live
+    score, or a void that means there will never be one — so "this round is over" is one
+    answer here, whether it is being asked in order to pair the next round or in order
+    to score a bye."""
+    return [
+        SeatedPairing(
+            round=fixture.round,
+            entry_a_id=fixture.entry_a_id,
+            entry_b_id=fixture.entry_b_id,
+            decided=fixture.match_voided or fixture.games is not None,
+        )
+        for fixture in fixtures
+        if fixture.entry_a_id is not None and fixture.entry_b_id is not None
+    ]
 
 
 def _finished_pool_order(

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -1250,6 +1250,45 @@ def swiss_byes(
     )
 
 
+def swiss_pairable_rows(row_count: int, seated_count: int, field_size: int) -> int:
+    """How many of one swiss round's pre-cut rows can ever carry a pairing.
+
+    The cut writes ``⌊n/2⌋`` rows a round from the field it saw, and **the field moves
+    under that number in both directions**. The rule that survives both is: a round's
+    *capacity* is ``⌊(current field)/2⌋``, capped by the rows that exist and floored by
+    the rows already seated.
+
+    - ``min(row_count, …)`` is the **grown** field. A draw cut for eight that a ninth
+      joined has one pairing more than there are rows for, and the lowest-ranked
+      pairing is simply not written — the same outcome that entrant would have had as
+      the round's bye. Without the cap a fully-written round would read as still having
+      room, and would be re-paired over rows that are already being played.
+    - ``max(seated_count, …)`` is the **shrunk** field, one round late. A round paired
+      when the field was eight holds four real pairings; if somebody then leaves, those
+      four are still four fixtures that will produce four results, whatever ``⌊7/2⌋``
+      says. Only rows that were never seated are lost to a shrink.
+
+    What is left over — ``row_count`` minus this — is **permanently unpairable**: rows
+    the cut wrote for a field that no longer exists. They are not pending. Three
+    readings depend on saying so once, here, rather than three times:
+
+    - a round with this many rows filled is fully paired, so the walk moves past it
+      instead of stalling on a round that is neither wholly unpaired nor decided
+      (:func:`_swiss_round_to_pair`);
+    - a round is decided when every row that *could* be filled is
+      (:func:`_swiss_round_is_decided`), so a dead row does not hold its round — and the
+      bye scored against it — open forever;
+    - the event's fixture count is this, not the row count
+      (:func:`app.tournament_serialization._field_input`), so a shrunk field can still
+      read ``complete``.
+
+    ``field_size`` is the **active** field in both layers, which is the same field
+    :func:`swiss_byes` is derived over. A shrunk field that shrank the capacity but not
+    the byes would credit a departed entrant with a bye per round.
+    """
+    return max(seated_count, min(row_count, field_size // 2))
+
+
 def _swiss_pairing_fills(
     fixtures: Sequence[FixtureState], ordered_entrants: Sequence[OrderedEntrant]
 ) -> list[SideFill]:
@@ -1259,10 +1298,10 @@ def _swiss_pairing_fills(
     The four steps are the ADR's own sentence: find the round to pair, order the field
     by the current standings, take the bye out of an odd field, and walk the rest.
     """
-    round_fixtures = _swiss_round_to_pair(fixtures)
+    field = [entrant.entry_id for entrant in ordered_entrants]
+    round_fixtures = _swiss_round_to_pair(fixtures, len(field))
     if round_fixtures is None:
         return []
-    field = [entrant.entry_id for entrant in ordered_entrants]
     # Projected once and handed to both readers, so "who has played whom" and "who has
     # sat out" are two questions asked of one set of pairings.
     pairings = _swiss_seated_pairings(fixtures)
@@ -1278,11 +1317,15 @@ def _swiss_pairing_fills(
     fills: list[SideFill] = []
     # ``position`` is the pairing's rank (ADR), so the round's rows are filled in
     # position order with the pairings in standings order. ``strict=False`` because the
-    # two can legitimately differ in length: a field that grew by one after the cut has
-    # a pairing more than there are rows for, and its lowest-ranked pairing simply is
-    # not written — the same outcome the entrant would have had as that round's bye. A
-    # field that grew by *more* than one is a stale draw, which go-live refuses
-    # (:func:`unseated_entrant_allowance`) before this is ever reached.
+    # two can legitimately differ in length, in **either** direction
+    # (:func:`swiss_pairable_rows`). A field that grew by one after the cut has a
+    # pairing more than there are rows for, and its lowest-ranked pairing simply is not
+    # written — the same outcome the entrant would have had as that round's bye. (A
+    # field that grew by *more* than one is a stale draw, which go-live refuses —
+    # :func:`unseated_entrant_allowance` — before this is ever reached.) A field that
+    # SHRANK has fewer pairings than rows, and the surplus rows stay ``NULL`` for good:
+    # the round is fully paired all the same, which is what stops the walk stalling on
+    # it forever.
     for (higher, lower), fixture in zip(
         pairs, sorted(round_fixtures, key=lambda f: f.position), strict=False
     ):
@@ -1296,7 +1339,7 @@ def _swiss_pairing_fills(
 
 
 def _swiss_round_to_pair(
-    fixtures: Sequence[FixtureState],
+    fixtures: Sequence[FixtureState], field_size: int
 ) -> list[FixtureState] | None:
     """The fixtures of the round this advance may pair — the **earliest wholly unpaired
     round, and only if every round before it is decided** — or ``None``.
@@ -1312,28 +1355,52 @@ def _swiss_round_to_pair(
     one risks seating an entrant in two fixtures of the same round. So a half-paired
     round stalls the walk instead, visibly, rather than being papered over.
 
-    It is also what makes the whole advance idempotent: once a round's rows are filled
-    it is no longer wholly unpaired, so no later run re-pairs it — which is the same
-    mechanism that keeps a correction to an earlier result from re-pairing a round that
-    is already being played.
+    **A round is over when it is full, and full is not the row count.** An earlier
+    version asked whether every row was seated, which is the same question only while
+    the field is the one the cut saw. A field that **shrinks** afterwards — the account
+    merge withdraws a guest whose entry seats played fixtures, and that is not
+    window-gated — leaves ``⌊n/2⌋`` pairings for a round of more rows than that, so the
+    surplus rows stay ``NULL`` for good. Read as "not yet fully seated" they made the
+    round neither wholly unpaired nor decided, which returned ``None`` here on that call
+    and on every call after: rounds ``r+1…R`` were never paired, and a played draw
+    cannot be un-cut. One withdrawal deadlocked an eight-entrant, four-round event.
+    :func:`swiss_pairable_rows` is the count that is actually full, and it holds for a
+    field that grew too.
+
+    It is still what makes the whole advance idempotent: once a round's pairable rows
+    are filled it is no longer wholly unpaired, so no later run re-pairs it — which is
+    the same mechanism that keeps a correction to an earlier result from re-pairing a
+    round that is already being played.
     """
     by_round: dict[int, list[FixtureState]] = defaultdict(list)
     for fixture in fixtures:
         by_round[fixture.round].append(fixture)
     for round_number in sorted(by_round):
         round_fixtures = by_round[round_number]
-        if all(
+        seated = [fixture for fixture in round_fixtures if not fixture.is_pending]
+        pairable = swiss_pairable_rows(len(round_fixtures), len(seated), field_size)
+        # Wholly unpaired — every row's BOTH sides empty, which is stricter than "none
+        # is seated" and deliberately so: a row with one side filled is a state nothing
+        # can produce, and pairing around it could seat somebody twice in one round.
+        # ``pairable > 0`` excludes a field of one (or none), which has nobody to play:
+        # not a round to pair, and not a round to stall on either.
+        if pairable > 0 and all(
             fixture.entry_a_id is None and fixture.entry_b_id is None
             for fixture in round_fixtures
         ):
             return round_fixtures
-        if not _swiss_round_is_decided(round_fixtures):
+        if not _swiss_round_is_decided(seated, pairable):
             return None
     return None
 
 
-def _swiss_round_is_decided(round_fixtures: Sequence[FixtureState]) -> bool:
-    """Whether every fixture in one round has produced all the result it ever will.
+def _swiss_round_is_decided(seated: Sequence[FixtureState], pairable: int) -> bool:
+    """Whether every row of one round that could **ever** carry a pairing has produced
+    all the result it ever will.
+
+    Takes the round's *seated* fixtures and how many rows it can fill
+    (:func:`swiss_pairable_rows`), rather than the round's rows, because those are the
+    two facts the answer is made of and the caller has already derived both.
 
     Per fixture that is :attr:`FixtureState.is_decided` — the shared spelling, which is
     also what :attr:`SeatedPairing.decided` carries, so "this round is over" is one
@@ -1341,14 +1408,14 @@ def _swiss_round_is_decided(round_fixtures: Sequence[FixtureState]) -> bool:
     score a bye. Read that property for why it is the **live-outcome** view
     (:attr:`FixtureState.games`) and why a **voided** fixture counts as decided.
 
-    The extra half — both sides known — stays here rather than on the property. It is a
-    question about a *round* being playable at all, not about one fixture's result, and
-    a round with an unpaired fixture in it has not been played whatever its other rows
-    say.
+    The extra half — that the round has no row left to seat — stays here rather than on
+    the property. It is a question about a *round* being playable at all, not about one
+    fixture's result, and a round still owing a pairing has not been played whatever
+    its other rows say. What it is **not** is "no row is still ``NULL``": a round whose
+    field shrank under it keeps rows that can never be seated, and holding the round
+    open for them would hold the bye scored against it open too, and the event with it.
     """
-    return all(
-        not fixture.is_pending and fixture.is_decided for fixture in round_fixtures
-    )
+    return len(seated) >= pairable and all(fixture.is_decided for fixture in seated)
 
 
 def _swiss_standings_order(
@@ -1423,10 +1490,21 @@ def _swiss_bye(order: Sequence[EntryId], byes: Sequence[EntryId]) -> EntryId | N
     that the two spellings of "decided" underneath them still agree is pinned by a
     test, not by a shared call.)
 
-    The fallback for a field in which everybody has had one (the lowest-ranked overall)
-    is written for completeness rather than because it runs. The cut refuses ``R > n −
-    1``, so there are always fewer rounds than entrants and the byeless set cannot
-    empty.
+    The fallback for a field in which everybody has had one takes the lowest-ranked
+    entrant overall — a second bye, which is worse than the rule but is a bye somebody
+    has to take.
+
+    **It runs**, and an earlier version of this docstring argued it could not: it read
+    the ceiling as ``R ≤ n − 1``, so byes taken (``r − 1`` when pairing round ``r``)
+    could never reach ``n``. The ceiling is ``R ≤ n − 1 + n % 2``
+    (:func:`_max_rematch_free_rounds`) — an odd field legally plays ``R = n`` — and,
+    more to the point, ``n`` is the field **at the cut**. A field that shrinks
+    afterwards (the account merge withdraws a guest whose entry seats played fixtures)
+    can hand out a bye to every remaining entrant and still owe rounds: six cut for five
+    rounds, then three left, and by round 5 all three have sat out
+    (``test_a_shrunk_field_runs_out_of_byeless_entrants``). The *conclusion* of the old
+    argument still holds for a field that only grows, which is why the branch was never
+    reached before.
     """
     if len(order) % 2 == 0:
         return None
@@ -1750,8 +1828,8 @@ def unseated_entrant_allowance(draw_type: DrawType, field_size: int) -> int:
     says so. Hence ``field_size % 2``: one for an odd field, none for an even one.
 
     It is an **allowance**, i.e. an upper bound, not a required count. Once a later
-    round is paired (the next slice) the round-1 bye is seated in it, and a draw that
-    seats its whole field must stay current.
+    round is paired the round-1 bye is seated in it, and a draw that seats its whole
+    field must stay current.
 
     What the allowance **cannot** do is tell a byed entrant from a single latecomer who
     leaves the field odd: a swiss draw cut for eight and joined by a ninth holds exactly

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -14,13 +14,19 @@ Each :class:`~app.models.tournament.DrawType` is a strategy behind
 ``plan_initial(config, ordered_entrants)``
     Cuts the draw — the fixtures as they stand the moment they are first written.
 
-``advance(fixtures)``
+``advance(fixtures, ordered_entrants)``
     Reads the persisted fixtures *as they currently stand* and returns the
     side-fills that the decided fixtures now imply, plus the fixtures that have
     become **ready** (both sides known, no match yet). It is re-run after *every*
     result and at go-live rather than fired by carefully-chosen events, which only
     works because it is **idempotent**: apply its plan, feed the resulting state
     back in, and the second plan is empty (:attr:`AdvancePlan.is_empty`).
+
+    It takes the **field** as well as the fixtures because the fixtures are not always
+    a complete description of it. A swiss bye is the absence of a fixture row, so a
+    byed entrant sits in no row at all, and pairing the next round from the seated set
+    alone would drop them from the event permanently. Three of the four strategies
+    ignore the argument — their fixtures do seat their whole field — and say so.
 
 Two things the schema deliberately does not store, and this module therefore owns:
 
@@ -38,7 +44,7 @@ from __future__ import annotations
 import enum
 import uuid
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import NewType, Protocol
@@ -453,9 +459,22 @@ class DrawStrategy(Protocol):
         """
         ...
 
-    def advance(self, fixtures: Sequence[FixtureState]) -> AdvancePlan:
-        """What the current state of these fixtures implies. Idempotent: run against a
-        state its own last plan was applied to, it returns an empty plan."""
+    def advance(
+        self,
+        fixtures: Sequence[FixtureState],
+        ordered_entrants: Sequence[OrderedEntrant],
+    ) -> AdvancePlan:
+        """What the current state of these fixtures implies, for this field. Idempotent:
+        run against a state its own last plan was applied to, it returns an empty plan.
+
+        ``ordered_entrants`` is the event's **active** field in draw order — the same
+        value :meth:`plan_initial` was cut from, not a set recovered from the fixtures.
+        Only :class:`SwissStrategy` reads it (see the module docstring); the other three
+        take it and ignore it, so that the seam has one shape rather than a special
+        case. A caller may hand those three an **empty** sequence rather than paying for
+        a load they discard — :func:`reads_entrants` is where each draw type says which
+        it is.
+        """
         ...
 
 
@@ -608,11 +627,19 @@ class RoundRobinStrategy:
             for fixture in _circle_method(pool_id, members)
         ]
 
-    def advance(self, fixtures: Sequence[FixtureState]) -> AdvancePlan:
+    def advance(
+        self,
+        fixtures: Sequence[FixtureState],
+        ordered_entrants: Sequence[OrderedEntrant],
+    ) -> AdvancePlan:
         """Round-robin fixtures are fully determined at the cut, so there is never a
         side to fill: every pairing was known the moment the draw existed. All this can
         report is which fixtures are ready to become matches — which, on a freshly cut
-        draw, is all of them, and on an already-materialized one is none of them."""
+        draw, is all of them, and on an already-materialized one is none of them.
+
+        ``ordered_entrants`` is ignored: an odd pool's bye is a round this pool's own
+        fixtures seat its holder in every *other* round of, so the seated set already is
+        the field and nothing here needs to be told it a second time."""
         return AdvancePlan(side_fills=(), ready_fixture_ids=ready_fixtures(fixtures))
 
 
@@ -656,9 +683,17 @@ class SingleElimStrategy:
         seed_entry = {entrant.position: entrant.entry_id for entrant in entrants}
         return _knockout_fixtures(size, seed_entry)
 
-    def advance(self, fixtures: Sequence[FixtureState]) -> AdvancePlan:
+    def advance(
+        self,
+        fixtures: Sequence[FixtureState],
+        ordered_entrants: Sequence[OrderedEntrant],
+    ) -> AdvancePlan:
         """Seat every decided fixture's winner into its successor slot, plus report the
         fixtures now ready to materialize.
+
+        ``ordered_entrants`` is ignored: a bracket's byed seeds are seated onto their
+        round-2 sides at cut time, so every entrant is already in a row and the
+        successor arithmetic needs nothing the fixtures do not carry.
 
         Idempotent: it seats only sides that are still empty, so re-running it over a
         state its own last plan was applied to fills nothing. The final round has no
@@ -791,13 +826,21 @@ class RrThenKoStrategy:
         fixtures.extend(_knockout_fixtures(qualifier_count, {}))
         return fixtures
 
-    def advance(self, fixtures: Sequence[FixtureState]) -> AdvancePlan:
+    def advance(
+        self,
+        fixtures: Sequence[FixtureState],
+        ordered_entrants: Sequence[OrderedEntrant],
+    ) -> AdvancePlan:
         """Seat the qualifiers of every **finished** pool into their predetermined
         bracket slots, then seat the knockout's own decided winners forward.
 
         Idempotent, twice over: a qualifier is seated only into a still-empty side,
         and the knockout half is :meth:`SingleElimStrategy.advance`, which already is.
         Run it against a state its own last plan was applied to and it plans nothing.
+
+        ``ordered_entrants`` is ignored for both halves, for the two reasons the halves
+        give themselves: the pools seat their whole field, and the bracket is seeded
+        from *results*, never from the field directly.
         """
         knockout = [fixture for fixture in fixtures if fixture.pool_id is None]
         return AdvancePlan(
@@ -808,7 +851,7 @@ class RrThenKoStrategy:
                 # the un-pooled fixtures alone. Passing the pool fixtures too would let
                 # a pool's ``(round, position)`` collide with the bracket's and seat a
                 # pool winner into a knockout slot.
-                *SingleElimStrategy().advance(knockout).side_fills,
+                *SingleElimStrategy().advance(knockout, ordered_entrants).side_fills,
             ),
             ready_fixture_ids=ready_fixtures(fixtures),
         )
@@ -918,10 +961,12 @@ class SwissStrategy:
     no fixture — a bye is the absence of a row (ADR-0786), never a row with a ``NULL``
     side, which here would be indistinguishable from a later round awaiting its pairing.
 
-    **This strategy does not pair anything past round 1 yet.** :meth:`advance` fills no
-    sides; it reports readiness exactly as :class:`RoundRobinStrategy`'s does. Pairing
-    round ``r + 1`` from the standings once round ``r`` is decided is its own slice, and
-    stubbing it would mean writing pairings nobody computed.
+    **Every later round is paired by :meth:`advance`**, once the round before it is
+    fully decided: the field is ordered by the current standings, walked, and each
+    still-unpaired entrant given the nearest following entrant they have not already met
+    (:func:`swiss_pairings`). The pairings are written into that round's
+    already-existing rows in rank order, so a fixture's ``position`` *is* its pairing
+    rank.
 
     Fixtures are **un-pooled** (``pool_id=None``): swiss ranks the whole field in one
     table, which is why the schedule preview refuses it exactly as it refuses a bracket.
@@ -989,19 +1034,289 @@ class SwissStrategy:
         )
         return fixtures
 
-    def advance(self, fixtures: Sequence[FixtureState]) -> AdvancePlan:
-        """Report which fixtures are ready to become matches, and fill nothing.
+    def advance(
+        self,
+        fixtures: Sequence[FixtureState],
+        ordered_entrants: Sequence[OrderedEntrant],
+    ) -> AdvancePlan:
+        """Pair the next round, if the round before it is decided, and report which
+        fixtures are ready to become matches.
 
-        Round 1 was paired at the cut, so on a freshly cut draw this is round 1's
-        fixtures and nothing else: the later rounds are ``is_pending`` (both sides
-        unknown) and :func:`ready_fixtures` already leaves those out.
+        On a freshly cut draw there is nothing to pair — round 1 is seeded and undecided
+        — so this is round 1's fixtures and nothing else: the later rounds are
+        ``is_pending`` (both sides unknown) and :func:`ready_fixtures` leaves those out.
+        Once every round-1 fixture carries a result, the same call pairs round 2 into
+        the rows the cut already wrote (:func:`_swiss_pairing_fills`).
 
-        Pairing round ``r + 1`` from round ``r``'s standings is the next slice's work,
-        deliberately absent rather than stubbed — a stub here would either write
-        pairings nothing computed or quietly report a round ready that has no players in
-        it.
+        **The field comes from** ``ordered_entrants``, **never from the seated set.** A
+        bye is the absence of a row, so the round-1 bye holder appears in no fixture at
+        all; pairing from the fixtures would drop them out of the event from round 2 on.
+        The same is true of a latecomer, for whom the draw is *not* stale
+        (:func:`unseated_entrant_allowance`) precisely because a later round will seat
+        them.
+
+        Idempotent, and by a stronger mechanism than "do not overwrite": a round is
+        pairable only while **every** one of its fixtures is still unpaired, so a fill
+        this plans can only ever land on a ``NULL`` side. Run it again over the state
+        its own fills were applied to and that round no longer qualifies — which is also
+        what stops a *corrected* earlier result from re-pairing a round that is already
+        being played. (The just-paired round is then genuinely ``ready``, so the second
+        plan names it; the third, once those rows carry matches, is empty.)
+
+        ``ready_fixture_ids`` is computed over the state as handed in, exactly as every
+        other strategy computes it — the caller applies the fills and recomputes
+        readiness itself (:func:`app.tournament_materialization.materialize_event`), so
+        a round paired here still materializes in the same transaction.
         """
-        return AdvancePlan(side_fills=(), ready_fixture_ids=ready_fixtures(fixtures))
+        return AdvancePlan(
+            side_fills=tuple(_swiss_pairing_fills(fixtures, ordered_entrants)),
+            ready_fixture_ids=ready_fixtures(fixtures),
+        )
+
+
+def swiss_pairings(
+    order: Sequence[EntryId], met: Collection[frozenset[EntryId]]
+) -> list[tuple[EntryId, EntryId]]:
+    """Pair a swiss round: walk the standings ``order`` and give each still-unpaired
+    entrant the **nearest following entrant they have not already met** (ADR "swiss
+    pre-cuts every round and pairs each one on advance").
+
+    Returns the pairings in **rank order** — pairing 1 contains the highest-ranked
+    entrant — which is what a fixture's ``position`` is assigned from, and each pairing
+    ``(higher, lower)`` in that same order.
+
+    **A rematch is the last resort and never a refusal.** When an entrant has met
+    everybody left below them, they are paired with the nearest one they *have* met: the
+    ``next(...)`` below falls back to index ``0``, the nearest following entrant, full
+    stop. Refusing to pair would strand a live tournament mid-event with no move a
+    director could make, which is far worse than a repeated fixture. (The cut already
+    refuses ``R > n − 1``, so a rematch-free swiss *exists* for every draw that was
+    written; this greedy walk does not always find one, and knowingly does not try — a
+    maximum matching over "has not met" would pair strangers further apart in the
+    standings, which is a worse swiss than one repeat.)
+
+    An **odd** ``order`` leaves its last entrant unpaired rather than raising: the
+    caller removes the bye before calling, and this stays a total function so a miscount
+    can only cost a fixture, not a 500 in the middle of an event.
+
+    Pure, and takes only what the rule needs — an order and a set of pairs — so the rule
+    is testable without a fixture, a draw or a database, which is how the last-resort
+    branch is pinned directly rather than through a contrived tournament.
+    """
+    remaining = list(order)
+    pairs: list[tuple[EntryId, EntryId]] = []
+    while len(remaining) >= 2:
+        first = remaining.pop(0)
+        index = next(
+            (
+                index
+                for index, other in enumerate(remaining)
+                if frozenset({first, other}) not in met
+            ),
+            # The last resort: nobody below is fresh, so take the nearest all the same.
+            0,
+        )
+        pairs.append((first, remaining.pop(index)))
+    return pairs
+
+
+def _swiss_pairing_fills(
+    fixtures: Sequence[FixtureState], ordered_entrants: Sequence[OrderedEntrant]
+) -> list[SideFill]:
+    """The side-fills that pair the next swiss round, or nothing when no round is
+    pairable yet.
+
+    The four steps are the ADR's own sentence: find the round to pair, order the field
+    by the current standings, take the bye out of an odd field, and walk the rest.
+    """
+    round_fixtures = _swiss_round_to_pair(fixtures)
+    if round_fixtures is None:
+        return []
+    field = [entrant.entry_id for entrant in ordered_entrants]
+    order = _swiss_standings_order(field, fixtures)
+    bye = _swiss_bye(order, fixtures)
+    pairs = swiss_pairings(
+        [entry_id for entry_id in order if entry_id != bye], _swiss_met(fixtures)
+    )
+    fills: list[SideFill] = []
+    # ``position`` is the pairing's rank (ADR), so the round's rows are filled in
+    # position order with the pairings in standings order. ``strict=False`` because the
+    # two can legitimately differ in length: a field that grew by one after the cut has
+    # a pairing more than there are rows for, and its lowest-ranked pairing simply is
+    # not written — the same outcome the entrant would have had as that round's bye. A
+    # field that grew by *more* than one is a stale draw, which go-live refuses
+    # (:func:`unseated_entrant_allowance`) before this is ever reached.
+    for (higher, lower), fixture in zip(
+        pairs, sorted(round_fixtures, key=lambda f: f.position), strict=False
+    ):
+        fills.append(
+            SideFill(fixture_id=fixture.fixture_id, side=Side.a, entry_id=higher)
+        )
+        fills.append(
+            SideFill(fixture_id=fixture.fixture_id, side=Side.b, entry_id=lower)
+        )
+    return fills
+
+
+def _swiss_round_to_pair(
+    fixtures: Sequence[FixtureState],
+) -> list[FixtureState] | None:
+    """The fixtures of the round this advance may pair — the **earliest wholly unpaired
+    round, and only if every round before it is decided** — or ``None``.
+
+    Walking from round 1 is what enforces "a round is paired once the round before it is
+    fully decided": the first round that is not decided ends the walk, and it is paired
+    only if it is the one that has not been paired yet.
+
+    **Wholly unpaired**, not "has an empty side", on purpose. A half-paired round is a
+    state neither the cut (which writes both sides or neither) nor this function (whose
+    fills are applied in one transaction) can produce, and pairing "around" the seated
+    half would need a rule for who the already-seated player's opponent is — inventing
+    one risks seating an entrant in two fixtures of the same round. So a half-paired
+    round stalls the walk instead, visibly, rather than being papered over.
+
+    It is also what makes the whole advance idempotent: once a round's rows are filled
+    it is no longer wholly unpaired, so no later run re-pairs it — which is the same
+    mechanism that keeps a correction to an earlier result from re-pairing a round that
+    is already being played.
+    """
+    by_round: dict[int, list[FixtureState]] = defaultdict(list)
+    for fixture in fixtures:
+        by_round[fixture.round].append(fixture)
+    for round_number in sorted(by_round):
+        round_fixtures = by_round[round_number]
+        if all(
+            fixture.entry_a_id is None and fixture.entry_b_id is None
+            for fixture in round_fixtures
+        ):
+            return round_fixtures
+        if not _swiss_round_is_decided(round_fixtures):
+            return None
+    return None
+
+
+def _swiss_round_is_decided(round_fixtures: Sequence[FixtureState]) -> bool:
+    """Whether every fixture in one round has produced all the result it ever will.
+
+    The **live-outcome** view (:attr:`FixtureState.games`), not the written-back
+    ``winner_entry_id``, for the reason :func:`_finished_pool_order` reads the same
+    field: a result under correction leaves its match un-``completed`` while the winner
+    id stays put, and the standings the next round is paired from are projected from the
+    games. So a correction un-decides its round rather than letting the next one be
+    paired off a table nobody can see.
+
+    A **voided** fixture never will produce a result (the match is terminal, and
+    ``ready_fixtures`` will not re-materialize a fixture that has a ``match_id``), so it
+    is excluded rather than counted-but-missing. Counting it would stall the event
+    permanently one score short, with no move a director could make.
+    """
+    return all(
+        fixture.entry_a_id is not None
+        and fixture.entry_b_id is not None
+        and (fixture.match_voided or fixture.games is not None)
+        for fixture in round_fixtures
+    )
+
+
+def _swiss_standings_order(
+    field: Sequence[EntryId], fixtures: Sequence[FixtureState]
+) -> list[EntryId]:
+    """The field ordered by the current standings — the order the next round is paired
+    down.
+
+    :func:`~app.pool_finishing_order.finishing_order` is the *shared* definition of that
+    table, the same call the standings on screen are projected through, so the order a
+    director reads and the order the pairing walks cannot disagree. (Swiss gets its own
+    chain — Buchholz above game difference — in its own slice; until then this is the
+    one that exists, and it is one call to change.)
+
+    An outcome naming an entry that is not in the field is left out: a withdrawal
+    between the cut and this advance would otherwise be a ``KeyError`` deep inside the
+    tally. Filtering the *outcomes* rather than widening the tallied set is deliberate —
+    a stranger in the tallies would turn a two-way tie into a three-way one and silently
+    cost the pair its head-to-head.
+    """
+    in_field = set(field)
+    outcomes: list[MatchOutcome] = []
+    for fixture in fixtures:
+        entry_a_id, entry_b_id, games = (
+            fixture.entry_a_id,
+            fixture.entry_b_id,
+            fixture.games,
+        )
+        if entry_a_id is None or entry_b_id is None or games is None:
+            continue
+        if fixture.match_voided:
+            continue
+        if entry_a_id not in in_field or entry_b_id not in in_field:
+            continue
+        outcomes.append(
+            MatchOutcome(
+                entry_a_id=entry_a_id,
+                entry_b_id=entry_b_id,
+                entry_a_games=games.entry_a_games,
+                entry_b_games=games.entry_b_games,
+            )
+        )
+    return [tally.entry_id for tally in finishing_order(field, outcomes)]
+
+
+def _swiss_bye(
+    order: Sequence[EntryId], fixtures: Sequence[FixtureState]
+) -> EntryId | None:
+    """Who sits out this round: the **lowest-ranked entrant who has not had a bye yet**,
+    or ``None`` when the field is even.
+
+    A bye is the absence of a fixture row, so who has already had one is *derived* —
+    an entrant seated in no fixture of a round that was paired (:func:`_swiss_seated`).
+    Nothing is stored, and nothing needs to be: the rows are the record.
+
+    The fallback for a field in which everybody has had one (the lowest-ranked overall)
+    is written for completeness rather than because it runs. The cut refuses ``R > n −
+    1``, so there are always fewer rounds than entrants and the byeless set cannot
+    empty.
+
+    Bye **scoring** — a win worth zero games — is not here. It is a standings question,
+    and it lands with the standings (ADR "swiss standings add Buchholz").
+    """
+    if len(order) % 2 == 0:
+        return None
+    byes: dict[EntryId, int] = dict.fromkeys(order, 0)
+    for seated in _swiss_seated(fixtures).values():
+        for entry_id in order:
+            if entry_id not in seated:
+                byes[entry_id] += 1
+    for entry_id in reversed(order):
+        if byes[entry_id] == 0:
+            return entry_id
+    return order[-1]
+
+
+def _swiss_seated(fixtures: Sequence[FixtureState]) -> dict[int, set[EntryId]]:
+    """Who is seated in each **paired** round — a round with no seated fixture at all is
+    absent from the map, so an unpaired round does not read as a round everybody was
+    byed in."""
+    seated: dict[int, set[EntryId]] = defaultdict(set)
+    for fixture in fixtures:
+        if fixture.entry_a_id is None or fixture.entry_b_id is None:
+            continue
+        seated[fixture.round].update({fixture.entry_a_id, fixture.entry_b_id})
+    return seated
+
+
+def _swiss_met(fixtures: Sequence[FixtureState]) -> set[frozenset[EntryId]]:
+    """Every pair this draw has already put in a fixture together.
+
+    Read off the *pairings*, not the results: a voided match and a result still being
+    corrected are both pairings that happened, and pairing them again would be the
+    rematch the walk exists to avoid.
+    """
+    met: set[frozenset[EntryId]] = set()
+    for fixture in fixtures:
+        if fixture.entry_a_id is None or fixture.entry_b_id is None:
+            continue
+        met.add(frozenset({fixture.entry_a_id, fixture.entry_b_id}))
+    return met
 
 
 def _finished_pool_order(
@@ -1224,6 +1539,40 @@ def reads_fixture_games(draw_type: DrawType) -> bool:
             return False
         case DrawType.rr_then_ko:
             return True
+        case DrawType.swiss:
+            return True
+
+
+def reads_entrants(draw_type: DrawType) -> bool:
+    """Whether this draw type's ``advance()`` reads the **field** — i.e. whether a
+    caller advancing it has to load the event's entrants first.
+
+    :func:`reads_fixture_games`' sibling, for the same seam and the same reason. The
+    advance runs inside the score-accept transaction on every result, so a load nothing
+    reads is a round trip per submission, and the gate is what keeps three of the four
+    draw types costing exactly the fixture load they always cost.
+
+    Only ``swiss`` declares **true**. Its bye is the absence of a fixture row, so the
+    seated set is *not* the field: pairing the next round from the rows alone would drop
+    the byed entrant — and a latecomer the currency check deliberately tolerates — out
+    of the event for good. The other three seat every entrant they have in a row
+    (a round-robin bye sits out one round of a schedule that seats it in the others, a
+    byed knockout seed is seated onto its round-2 side at the cut), so for them the
+    field is already in the fixtures and the load would be discarded.
+
+    An exhaustive ``match`` with **no catch-all**, exactly like its sibling: a new
+    :class:`DrawType` has to declare its own answer, and until it does this fails to
+    type-check. The failure a default of ``False`` would cause is the silent one — a
+    strategy handed an empty field pairs nobody and the event simply stops — which is
+    why the declaration is compulsory rather than inferred.
+    """
+    match draw_type:
+        case DrawType.round_robin:
+            return False
+        case DrawType.single_elim:
+            return False
+        case DrawType.rr_then_ko:
+            return False
         case DrawType.swiss:
             return True
 

--- a/api/app/pool_finishing_order.py
+++ b/api/app/pool_finishing_order.py
@@ -25,7 +25,7 @@ a snapshot — a corrected or voided match re-derives the order the instant it l
 
 The chain, in order:
 
-1. **wins** — most match wins first;
+1. **wins** — most match wins first, and a **bye counts as one of them**;
 2. **head-to-head**, *only when exactly two entries are tied* on wins — the one that
    beat the other ranks above it. A three-or-more-way tie can cycle (A beat B beat C
    beat A), so it is **not** broken head-to-head; it falls straight through to the game
@@ -34,6 +34,21 @@ The chain, in order:
 4. **games won**;
 5. the **entry id** — a total, deterministic fallback, so a pool in which two entries
    are genuinely level on every count still orders the same way on every read.
+
+**A bye is a win worth zero games** (ADR "swiss standings add Buchholz, and
+head-to-head is guarded on having met"). The win, because a player must not be punished
+for a scheduling artifact they did not cause. Zero games, because steps 3 and 4 are the
+ones a nominal 3-0 would corrupt: it would hand the byed entrant a game difference
+nobody earned, which can lift them above somebody who went out and beat a real
+opponent. So a bye moves step 1 and is neutral on everything below it, and it is
+slightly *under*-credited — the deliberate direction to err on a result nobody played.
+
+Byes reach here as a **flat sequence of entry ids, one per bye taken**, because they are
+derived rather than stored: a bye is the absence of a fixture row (CONTEXT.md, "Bye"),
+so the byed entrant is the one with no fixture that round. :func:`app.draws.swiss_byes`
+is where that derivation lives, once, for both callers. Round-robin passes none — its
+byed entrant sits out one round of a schedule that seats them in every other, which is
+not a result and is not scored as one.
 """
 
 from __future__ import annotations
@@ -134,13 +149,21 @@ _TIEBREAKERS: tuple[Callable[[EntryTally], int], ...] = (
 
 
 def finishing_order(
-    entrants: Iterable[EntryId], outcomes: Sequence[MatchOutcome]
+    entrants: Iterable[EntryId],
+    outcomes: Sequence[MatchOutcome],
+    byes: Iterable[EntryId] = (),
 ) -> list[EntryTally]:
-    """The pool's finishing order: its ``entrants`` tallied from ``outcomes``, then
-    ordered by the chain in this module's docstring.
+    """The pool's finishing order: its ``entrants`` tallied from ``outcomes`` and
+    ``byes``, then ordered by the chain in this module's docstring.
 
     ``entrants`` is the full seated field — not just the entries that have played — so
     the returned list always covers the whole pool. First place is index ``0``.
+
+    ``byes`` names one entry id **per bye taken**, so an entrant who has sat out twice
+    appears twice. Empty for every format but swiss, and empty for an even swiss field.
+    Both it and ``outcomes`` may only name entries that are in ``entrants``: the tallies
+    are keyed by entrant, so a stranger is a ``KeyError`` rather than a row appearing
+    from nowhere.
     """
     tallies: dict[EntryId, EntryTally] = {
         entry_id: EntryTally(entry_id=entry_id) for entry_id in entrants
@@ -149,6 +172,8 @@ def finishing_order(
         _record_outcome(
             tallies[outcome.entry_a_id], tallies[outcome.entry_b_id], outcome
         )
+    for entry_id in byes:
+        _record_bye(tallies[entry_id])
     return _order(list(tallies.values()), outcomes)
 
 
@@ -174,6 +199,23 @@ def _record_outcome(a: EntryTally, b: EntryTally, outcome: MatchOutcome) -> None
     else:
         b.wins += 1
         a.losses += 1
+
+
+def _record_bye(tally: EntryTally) -> None:
+    """Fold one bye into its holder's tally: a **win worth zero games**.
+
+    The three lines this function does *not* have are the point. No ``games_won``,
+    because awarding a nominal 3-0 would give the byed entrant a game difference nobody
+    earned and float them above a player who beat a real opponent. No ``games_lost``,
+    for the mirror reason. No ``losses``, obviously — this is a win.
+
+    ``played`` does move, and it is the one judgement call the ADR leaves open: the
+    entrant has a result for that round, and the invariant every other row on the table
+    satisfies is ``played == wins + losses``. A row reading "played 0, won 1" would look
+    to a director exactly like an arithmetic bug in the standings.
+    """
+    tally.played += 1
+    tally.wins += 1
 
 
 def entry_id_order(entry_id: EntryId) -> int:

--- a/api/app/pool_finishing_order.py
+++ b/api/app/pool_finishing_order.py
@@ -164,6 +164,14 @@ def finishing_order(
     Both it and ``outcomes`` may only name entries that are in ``entrants``: the tallies
     are keyed by entrant, so a stranger is a ``KeyError`` rather than a row appearing
     from nowhere.
+
+    ``byes`` **defaults to empty**, which is safe here for a reason that does not
+    travel: this is one free function, so an omission is a caller declining to pass a
+    value at one call site — visible in the diff, and "no byes" is the truth for every
+    format but swiss. Contrast :meth:`app.draws.DrawStrategy.advance`, where the field
+    is a **required** parameter precisely because that is a ``Protocol`` with four
+    implementations: there, a default would let an implementation omit the parameter
+    from its own signature and still type-check.
     """
     tallies: dict[EntryId, EntryTally] = {
         entry_id: EntryTally(entry_id=entry_id) for entry_id in entrants

--- a/api/app/results.py
+++ b/api/app/results.py
@@ -461,8 +461,11 @@ class SwissResults:
     player did not cause. Zero games, because a nominal 3-0 would hand them a game
     difference nobody earned and lift them over somebody who beat a real opponent. The
     byes themselves are derived from the fixtures by :func:`app.draws.swiss_byes` and
-    arrive on :attr:`FieldInput.byes` — the same derivation the draw layer pairs by, so
-    the rank a director reads and the rank the next round is paired down are one number.
+    arrive on :attr:`FieldInput.byes` — one derivation over one field (the **active**
+    entrants), which is what the draw layer pairs by, so a bye credited here is a bye
+    the next round's pairing passes over. The claim is about the byes and stops there:
+    a departed entrant's real results are still tallied here and are dropped by the
+    pairing, so the two tables can differ by exactly that after a withdrawal.
 
     Live and partial like every other shape: an entrant appears from the moment they are
     seated, and a correction re-orders the table the instant it lands.

--- a/api/app/results.py
+++ b/api/app/results.py
@@ -101,15 +101,25 @@ class FieldInput:
     a row of zeros, and ``fixture_count`` counts the pairings that can still yield a
     result, which for swiss includes the later rounds that are cut but not yet paired.
 
+    ``byes`` is the fourth field and the one :class:`PoolInput` will never have: one
+    entry id **per bye taken**, derived by :func:`app.draws.swiss_byes` from the rows
+    the caller is already holding. It is a *result* the table has to score — a win worth
+    zero games (ADR "swiss standings add Buchholz") — and it cannot come from
+    ``outcomes``, because a bye has no opponent to name. Empty for an even field, and
+    empty for a round-robin pool, whose byed entrant is seated in every other round and
+    is not credited with anything for the one they sat out.
+
     It is deliberately not a shared base class with :class:`PoolInput`. One is keyed by
-    a pool and one is not, which is the only difference there will ever be, and a base
-    would buy a name for three fields at the cost of a hierarchy in a module that is
-    otherwise flat value objects.
+    a pool and one is not, and one scores byes, and a base would buy a name for three
+    fields at the cost of a hierarchy in a module that is otherwise flat value objects.
     """
 
     entrants: tuple[EntryId, ...]
     fixture_count: int
     outcomes: tuple[MatchOutcome, ...]
+    #: Only ids that are in ``entrants`` — the tallies are keyed by entrant, so a
+    #: stranger here is a ``KeyError``. Empty when nobody has sat out.
+    byes: tuple[EntryId, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -445,12 +455,21 @@ class SwissResults:
     head-to-head is guarded on having met"). Until then this reads out the chain that
     exists rather than a swiss-shaped approximation of the one that does not.
 
+    **A bye scores as a win worth zero games** (ADR "swiss standings add Buchholz, and
+    head-to-head is guarded on having met"), which is the one thing this table counts
+    that a pool's does not. The win, because sitting out is a scheduling artifact the
+    player did not cause. Zero games, because a nominal 3-0 would hand them a game
+    difference nobody earned and lift them over somebody who beat a real opponent. The
+    byes themselves are derived from the fixtures by :func:`app.draws.swiss_byes` and
+    arrive on :attr:`FieldInput.byes` — the same derivation the draw layer pairs by, so
+    the rank a director reads and the rank the next round is paired down are one number.
+
     Live and partial like every other shape: an entrant appears from the moment they are
     seated, and a correction re-orders the table the instant it lands.
     """
 
     def tabulate(self, field: FieldInput) -> SwissStandings:
-        rows = _standing_rows(field.entrants, field.outcomes)
+        rows = _standing_rows(field.entrants, field.outcomes, field.byes)
         # Every round decided — which, since the later rounds are cut up front with
         # their sides unknown, includes the ones nobody has been paired into yet. An
         # event with no fixtures that can still yield a result is deliberately NOT
@@ -471,7 +490,9 @@ def _pool_standings(pool: PoolInput) -> PoolStandings:
 
 
 def _standing_rows(
-    entrants: Sequence[EntryId], outcomes: Sequence[MatchOutcome]
+    entrants: Sequence[EntryId],
+    outcomes: Sequence[MatchOutcome],
+    byes: Sequence[EntryId] = (),
 ) -> tuple[StandingRow, ...]:
     """These entrants' rows, at their settled ranks — the one place a table is built,
     for the two shapes that carry one (a pool's, and a swiss field's).
@@ -479,7 +500,11 @@ def _standing_rows(
     Shared so that "a standings row means the same thing whichever event it is read
     off" is true structurally: the ordering is
     :func:`~app.pool_finishing_order.finishing_order` and the counts come off the
-    tallies it returns, in one function rather than two that agree today."""
+    tallies it returns, in one function rather than two that agree today.
+
+    ``byes`` defaults to none, which is a **fact about a pool** rather than a
+    convenience: a round-robin bye is a round sat out inside a schedule that seats its
+    holder in every other one, so there is nothing to score. Only swiss passes any."""
     return tuple(
         StandingRow(
             entry_id=tally.entry_id,
@@ -490,5 +515,5 @@ def _standing_rows(
             games_won=tally.games_won,
             games_lost=tally.games_lost,
         )
-        for rank, tally in enumerate(finishing_order(entrants, outcomes), start=1)
+        for rank, tally in enumerate(finishing_order(entrants, outcomes, byes), start=1)
     )

--- a/api/app/tournament_materialization.py
+++ b/api/app/tournament_materialization.py
@@ -22,7 +22,15 @@ from collections.abc import Sequence
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.draws import Side, SideFill, reads_fixture_games, ready_fixtures
+from app.draws import (
+    OrderedEntrant,
+    Side,
+    SideFill,
+    order_entrants,
+    reads_entrants,
+    reads_fixture_games,
+    ready_fixtures,
+)
 from app.models import (
     Match,
     MatchSettings,
@@ -35,7 +43,12 @@ from app.models import (
     TournamentFixture,
 )
 from app.schemas.tournament import MatchSettings as EventMatchSettings
-from app.tournament_draws import fixture_state, pool_order, strategy_for_event
+from app.tournament_draws import (
+    active_draw_entrants,
+    fixture_state,
+    pool_order,
+    strategy_for_event,
+)
 from app.tournament_queries import game_counts_by_match
 
 
@@ -112,6 +125,14 @@ async def materialize_event(
     score-accept transaction under the match row lock. The gate is an exhaustive
     ``match`` over the draw type with no catch-all, so a new one cannot arrive here
     having quietly opted out of a load its strategy needs.
+
+    **The event's entrants are loaded the same way, behind the same kind of gate**
+    (``app.draws.reads_entrants``). ``advance()`` takes the field as well as the
+    fixtures because for swiss the two are not the same thing: a bye is the absence of a
+    fixture row, so its byed entrant — and a latecomer the currency check tolerates —
+    is in no row at all, and a next round paired from the rows would leave them out of
+    the event permanently. Only swiss declares it, so the other three still cost exactly
+    the one fixture statement they always cost.
     """
     (
         fixtures,
@@ -133,8 +154,23 @@ async def materialize_event(
     # fills ``FixtureState.pool_position``, and so what makes an ``advance()`` plan's
     # ready list run pool 1, 2, … 10 rather than the ids' 1, 10, 2 (ADR 20260801).
     pools = pool_order(event)
+    # The **field**, beside the fixtures, for the one draw type that cannot recover it
+    # from them: a swiss bye is the absence of a fixture row, so pairing the next round
+    # from the seated set alone would drop the byed entrant out of the event. Read
+    # through the same pair the cut reads it through — ``active_draw_entrants`` then
+    # ``order_entrants`` — so the field a draw is advanced against is the field it was
+    # cut from, by construction rather than by two loaders agreeing. Gated exactly as
+    # the game counts are, and for the same reason: on the completion seam this is a
+    # round trip per result submission, and three of the four draw types would discard
+    # it (``app.draws.reads_entrants``).
+    entrants: Sequence[OrderedEntrant] = (
+        order_entrants(await active_draw_entrants(db, event.id))
+        if reads_entrants(event.draw_settings.draw_type)
+        else ()
+    )
     plan = strategy.advance(
-        [fixture_state(f, game_counts, voided_match_ids, pools) for f in fixtures]
+        [fixture_state(f, game_counts, voided_match_ids, pools) for f in fixtures],
+        entrants,
     )
     # Apply the side-fills a decided fixture implies BEFORE the readiness pass, so a
     # fixture made whole by them seats its match in this same transaction. A fill only

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -379,13 +379,12 @@ def _field_input(
             1 for f in fixtures if f.match_status is not MatchStatus.voided
         ),
         outcomes=tuple(outcomes),
-        byes=swiss_byes(field, _seated_pairings(fixtures, game_counts)),
+        byes=swiss_byes(field, _seated_pairings(fixtures)),
     )
 
 
 def _seated_pairings(
     fixtures: list[TournamentFixtureRead],
-    game_counts: dict[uuid.UUID, tuple[int, int]],
 ) -> list[SeatedPairing]:
     """The read rows that seat **both** sides, in the shape
     :func:`~app.draws.swiss_byes` reads them.
@@ -398,16 +397,31 @@ def _seated_pairings(
     ``fixture_count``: it will never produce a result, so it must not hold its round —
     and the bye scored against that round — open forever.
 
-    ``decided`` is read through :func:`_fixture_outcome`, the same projection the
-    standings themselves are built from, so a result under correction un-decides its
-    round here exactly as it un-scores its match there."""
+    ``decided`` is the match's **terminal status** — completed, or voided — read live
+    off the row, which is the same live fact :func:`_fixture_outcome` gates the
+    standings on. So a result under correction un-decides its round here exactly as it
+    un-scores its match there.
+
+    It asks the status directly rather than building the outcome and testing it for
+    ``None``, which is what this did and what cost a discarded ``MatchOutcome`` per
+    completed fixture on every detail render. The other two things that projection
+    checks are already true of every row that reaches here: the comprehension filters
+    both entries, and ``match_status`` is read off an outer join onto the fixture's own
+    ``match_id`` (:func:`~app.tournament_queries.fixtures_by_event`), so a status of
+    any kind means there is a match behind it.
+
+    The draw layer spells the same question over its own row shape
+    (:attr:`app.draws.FixtureState.is_decided`, a live score or a void). The row shapes
+    genuinely differ, so the two are not one predicate — that the two agree, including
+    on a status neither of them names, is pinned by a test in ``tests/test_swiss.py``.
+    """
     return [
         SeatedPairing(
             round=f.round,
             entry_a_id=EntryId(f.entry_a_id),
             entry_b_id=EntryId(f.entry_b_id),
             decided=f.match_status is MatchStatus.voided
-            or _fixture_outcome(f, game_counts) is not None,
+            or f.match_status is MatchStatus.completed,
         )
         for f in fixtures
         if f.entry_a_id is not None and f.entry_b_id is not None

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -18,7 +18,13 @@ from typing import Any, assert_never
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.draws import EntryId, PoolId, SeatedPairing, swiss_byes
+from app.draws import (
+    EntryId,
+    PoolId,
+    SeatedPairing,
+    swiss_byes,
+    swiss_pairable_rows,
+)
 from app.models import (
     MatchStatus,
     ScheduleSolve,
@@ -346,23 +352,38 @@ def _field_input(
     seven-player draw derived from fixtures alone would stand a six-player table.
 
     The entries seated in fixtures are **unioned in** rather than assumed to be a
-    subset. A player who withdraws after the draw is cut leaves the active list while
-    their played fixtures stay, and :func:`~app.pool_finishing_order.finishing_order`
-    indexes its tallies by entrant — so dropping them would be a ``KeyError`` on the
-    first outcome that names them, on the detail page of any event that had a
-    withdrawal.
+    subset, for the **rows** only. A player who withdraws after the draw is cut leaves
+    the active list while their played fixtures stay, and
+    :func:`~app.pool_finishing_order.finishing_order` indexes its tallies by entrant —
+    so dropping them would be a ``KeyError`` on the first outcome that names them, on
+    the detail page of any event that had a withdrawal. Somebody who played real
+    matches belongs in the table.
 
-    A round nobody has been paired into yet is still **counted**: it can very much still
-    yield a result. Only a **voided** pairing is left out of the count, exactly as it is
-    for a pool — it never will produce one, and counting it would hold the event one
-    outcome short of complete forever.
+    The **byes** are derived here rather than stored, because there is nothing to
+    store: a bye is the absence of a fixture row, so it is read off the rounds that
+    *are* paired (:func:`~app.draws.swiss_byes`). They are scored as a win worth zero
+    games one layer down, in the standings themselves.
 
-    The **byes** are derived here rather than stored, because there is nothing to store:
-    a bye is the absence of a fixture row, so it is read off the rounds that *are*
-    paired (:func:`~app.draws.swiss_byes`, the same call the draw layer's pairing makes,
-    so the table and the next round's seedings cannot rank the field differently). They
-    are scored as a win worth zero games one layer down, in the standings themselves."""
-    field = {EntryId(entrant.id) for entrant in entrants} | {
+    **Over the active entrants, not that union** — the one field the draw layer pairs
+    from. Handed the union, this layer asked who was missing from each round and got
+    the departed entrant back every time, because nobody seats them again: a
+    withdrawn-but-seated player collected a phantom bye win per remaining round, up to
+    ``R − 1`` of them, on a table that otherwise looked right. The two layers now derive
+    byes from one field, which is the whole of what they share: the tallies are still
+    the union's, so a departed entrant's results count here and are dropped by
+    :func:`~app.draws._swiss_standings_order` (a stranger in its tallies would turn a
+    two-way tie into a three-way one). For a field that never shrank the two sets are
+    the same set and the two tables are the same table.
+
+    ``fixture_count`` is **what can still be paired**, not the row count. Every round
+    is cut with ``⌊n/2⌋`` rows from the field at the cut, and a round nobody has been
+    paired into yet is very much still countable — but a field that shrank leaves rows
+    nothing will ever seat, and counting those holds the event one outcome short of
+    complete forever. :func:`~app.draws.swiss_pairable_rows` is that count, per round,
+    over the same active field; a **voided** pairing comes off it exactly as it does
+    for a pool, for the same reason."""
+    active = tuple(EntryId(entrant.id) for entrant in entrants)
+    field = set(active) | {
         EntryId(entry_id)
         for f in fixtures
         for entry_id in (f.entry_a_id, f.entry_b_id)
@@ -375,12 +396,35 @@ def _field_input(
     ]
     return FieldInput(
         entrants=tuple(field),
-        fixture_count=sum(
-            1 for f in fixtures if f.match_status is not MatchStatus.voided
-        ),
+        fixture_count=_swiss_fixture_count(fixtures, len(active)),
         outcomes=tuple(outcomes),
-        byes=swiss_byes(field, _seated_pairings(fixtures)),
+        byes=swiss_byes(active, _seated_pairings(fixtures)),
     )
+
+
+def _swiss_fixture_count(fixtures: list[TournamentFixtureRead], field_size: int) -> int:
+    """How many of a swiss draw's rows can still yield a result — the denominator
+    ``complete`` is measured against.
+
+    Per round, because that is the grain the cut wrote and the grain a field change
+    moves: :func:`~app.draws.swiss_pairable_rows` says how many of a round's rows can
+    ever carry a pairing, and the ones already seated into a **voided** match are taken
+    back off, since that match is terminal and will never produce the outcome the count
+    is promising."""
+    by_round: dict[int, list[TournamentFixtureRead]] = defaultdict(list)
+    for f in fixtures:
+        by_round[f.round].append(f)
+    total = 0
+    for round_fixtures in by_round.values():
+        seated = [
+            f
+            for f in round_fixtures
+            if f.entry_a_id is not None and f.entry_b_id is not None
+        ]
+        total += swiss_pairable_rows(
+            len(round_fixtures), len(seated), field_size
+        ) - sum(1 for f in seated if f.match_status is MatchStatus.voided)
+    return total
 
 
 def _seated_pairings(

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -18,7 +18,7 @@ from typing import Any, assert_never
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.draws import EntryId, PoolId
+from app.draws import EntryId, PoolId, SeatedPairing, swiss_byes
 from app.models import (
     MatchStatus,
     ScheduleSolve,
@@ -355,7 +355,13 @@ def _field_input(
     A round nobody has been paired into yet is still **counted**: it can very much still
     yield a result. Only a **voided** pairing is left out of the count, exactly as it is
     for a pool — it never will produce one, and counting it would hold the event one
-    outcome short of complete forever."""
+    outcome short of complete forever.
+
+    The **byes** are derived here rather than stored, because there is nothing to store:
+    a bye is the absence of a fixture row, so it is read off the rounds that *are*
+    paired (:func:`~app.draws.swiss_byes`, the same call the draw layer's pairing makes,
+    so the table and the next round's seedings cannot rank the field differently). They
+    are scored as a win worth zero games one layer down, in the standings themselves."""
     field = {EntryId(entrant.id) for entrant in entrants} | {
         EntryId(entry_id)
         for f in fixtures
@@ -373,7 +379,39 @@ def _field_input(
             1 for f in fixtures if f.match_status is not MatchStatus.voided
         ),
         outcomes=tuple(outcomes),
+        byes=swiss_byes(field, _seated_pairings(fixtures, game_counts)),
     )
+
+
+def _seated_pairings(
+    fixtures: list[TournamentFixtureRead],
+    game_counts: dict[uuid.UUID, tuple[int, int]],
+) -> list[SeatedPairing]:
+    """The read rows that seat **both** sides, in the shape
+    :func:`~app.draws.swiss_byes` reads them.
+
+    A **voided** pairing is deliberately still a pairing here. It happened — those two
+    were drawn against each other and neither sat out — so counting its round as one
+    nobody was paired into would invent a bye for every other entrant in it. Voiding
+    takes away the *result*, which ``outcomes`` above already reflects, not the fact of
+    the pairing. It counts as ``decided`` for the same reason it is left out of
+    ``fixture_count``: it will never produce a result, so it must not hold its round —
+    and the bye scored against that round — open forever.
+
+    ``decided`` is read through :func:`_fixture_outcome`, the same projection the
+    standings themselves are built from, so a result under correction un-decides its
+    round here exactly as it un-scores its match there."""
+    return [
+        SeatedPairing(
+            round=f.round,
+            entry_a_id=EntryId(f.entry_a_id),
+            entry_b_id=EntryId(f.entry_b_id),
+            decided=f.match_status is MatchStatus.voided
+            or _fixture_outcome(f, game_counts) is not None,
+        )
+        for f in fixtures
+        if f.entry_a_id is not None and f.entry_b_id is not None
+    ]
 
 
 def _bracket_fixtures(

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -33,6 +33,7 @@ from app.draws import (
     QualifierSeat,
     RoundRobinStrategy,
     RrThenKoStrategy,
+    SeatedPairing,
     Side,
     SideFill,
     SingleElimStrategy,
@@ -43,6 +44,7 @@ from app.draws import (
     reads_fixture_games,
     ready_fixtures,
     strategy_for,
+    swiss_byes,
     swiss_pairings,
     unseated_entrant_allowance,
 )
@@ -2594,6 +2596,51 @@ class TestSwissAdvance:
 
         assert byes == [{5}, {4}, {3}]
 
+    def test_the_pairing_counts_a_bye_as_a_win_when_it_ranks_the_field(self) -> None:
+        """**The two layers rank one table.** A bye is a win worth zero games in the
+        standings (ADR "swiss standings add Buchholz"), and the next round is paired by
+        walking those standings — so the win has to count *here* too, or the draw would
+        pair the field in an order that contradicts the table on screen.
+
+        Seven entrants, three rounds, driven through two rounds of real results. By
+        round 3 the two byed entrants are seed 7 (round 1) and seed 5 (round 2), and
+        their bye wins move both of them up the table: 7 into the two-win group above
+        every one-win player, and 5 above seeds 1 and 3. Score the byes as nothing and
+        the walk sees a different order and emits three different pairings —
+        2v4, 7v1, 6v5 — including one the rematch rule then has to work around.
+        """
+        cut = _persisted(
+            SwissStrategy(rounds=3).plan_initial(DrawConfig(), _ordered(7))
+        )
+        round_one = _played(
+            cut,
+            {
+                frozenset({1, 4}): (1, 3, 2),
+                frozenset({2, 5}): (2, 3, 2),
+                frozenset({3, 6}): (6, 3, 2),
+            },
+        )
+        round_two = _played(
+            _apply(round_one, SwissStrategy(rounds=3).advance(round_one, _ordered(7))),
+            {
+                frozenset({1, 2}): (2, 3, 0),
+                frozenset({6, 7}): (7, 3, 2),
+                frozenset({3, 4}): (4, 3, 0),
+            },
+        )
+
+        plan = SwissStrategy(rounds=3).advance(round_two, _ordered(7))
+
+        assert _seed_pairs(round_two, 2) == [(1, 1, 2), (2, 6, 7), (3, 3, 4)]
+        assert _seed_pairs(_apply(round_two, plan), 3) == [
+            (1, 2, 7),
+            (2, 4, 6),
+            (3, 5, 1),
+        ]
+        assert _seated(_apply(round_two, plan), 3) == {1, 2, 4, 5, 6, 7}, (
+            "seed 3 takes round 3's bye, being the lowest-ranked entrant without one"
+        )
+
     def test_a_forced_rematch_is_paired_rather_than_refused(self) -> None:
         """**The last resort, reached by a draw the cut itself writes.** Five entrants,
         three rounds in: by round 3 the standings put seeds 2 and 4 last among those
@@ -2662,6 +2709,81 @@ class TestSwissAdvance:
 
     def test_an_empty_draw_advances_to_nothing(self) -> None:
         assert self._advance([], _ordered(8)) == AdvancePlan()
+
+
+class TestSwissByes:
+    """Who has sat out, derived from the rows — because a bye is the *absence* of a
+    row (CONTEXT.md, "Bye") and there is nothing else to read it off."""
+
+    def _byes(
+        self,
+        field: Sequence[int],
+        pairings: Sequence[tuple[int, int, int]],
+        *,
+        undecided: Collection[tuple[int, int, int]] = (),
+    ) -> list[int]:
+        """The byes of a field whose ``pairings`` are ``(round, seed a, seed b)``. Every
+        pairing is decided unless it is named in ``undecided`` — a bye is scored with
+        its round, so the flag is what a round being over means here."""
+        return [
+            entry_id.int
+            for entry_id in swiss_byes(
+                [_entry_id(seed) for seed in field],
+                [
+                    SeatedPairing(
+                        round=round_number,
+                        entry_a_id=_entry_id(a),
+                        entry_b_id=_entry_id(b),
+                        decided=(round_number, a, b) not in undecided,
+                    )
+                    for round_number, a, b in pairings
+                ],
+            )
+        ]
+
+    def test_the_entrant_missing_from_a_paired_round_took_its_bye(self) -> None:
+        assert self._byes([1, 2, 3], [(1, 1, 2)]) == [3]
+
+    def test_an_even_field_byes_nobody(self) -> None:
+        assert self._byes([1, 2, 3, 4], [(1, 1, 2), (1, 3, 4)]) == []
+
+    def test_each_paired_round_yields_its_own_bye(self) -> None:
+        """One id per bye taken, so the multiset carries how many each entrant has —
+        which is what the selection rule ("who has not had one") reads."""
+        assert self._byes([1, 2, 3], [(1, 1, 2), (2, 1, 3)]) == [3, 2]
+
+    def test_the_same_entrant_byed_twice_appears_twice(self) -> None:
+        assert self._byes([1, 2, 3], [(1, 1, 2), (2, 2, 1)]) == [3, 3]
+
+    def test_a_round_nobody_is_paired_into_yields_no_byes(self) -> None:
+        """**The one that stops a freshly cut draw handing everybody a bye.** Rounds 2
+        and 3 of a swiss draw exist as rows with both sides unknown from the moment it
+        is cut, so they contribute no pairings — and a round with no pairing is a round
+        waiting to be paired, not a round the whole field sat out."""
+        assert self._byes([1, 2, 3], [(1, 1, 2)]) == [3]
+
+    def test_a_round_still_being_played_scores_no_bye_yet(self) -> None:
+        """**A bye is scored with its round.** Round 2 is paired but one of its matches
+        is still on, so nobody has a result for that round — and the entrant sitting it
+        out does not get one either. Credit it early and a freshly cut seven-player draw
+        would show its byed entrant top of the table before a ball was hit."""
+        pairings = [(1, 1, 2), (1, 3, 4), (2, 1, 3), (2, 2, 4)]
+
+        assert self._byes([1, 2, 3, 4, 5], pairings, undecided=[(2, 2, 4)]) == [5]
+
+    def test_a_round_of_one_undecided_match_scores_no_bye_at_all(self) -> None:
+        """The same rule at the start of an event: round 1 is paired at the cut, so its
+        pairings exist from day one, and none of them has been played."""
+        assert self._byes([1, 2, 3], [(1, 1, 2)], undecided=[(1, 1, 2)]) == []
+
+    def test_an_entrant_seated_nowhere_is_byed_in_every_paired_round(self) -> None:
+        """The latecomer: a draw cut for four that a fifth player joined seats them in
+        no round at all. They are in the field, so they collect a bye for every round
+        that has been paired — which is what stops the selection rule handing them yet
+        another one."""
+        pairings = [(1, 1, 2), (1, 3, 4), (2, 1, 3), (2, 2, 4)]
+
+        assert self._byes([1, 2, 3, 4, 5], pairings) == [5, 5]
 
 
 class TestSwissPairings:

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -39,9 +39,11 @@ from app.draws import (
     SwissStrategy,
     order_entrants,
     qualifier_seed_assignment,
+    reads_entrants,
     reads_fixture_games,
     ready_fixtures,
     strategy_for,
+    swiss_pairings,
     unseated_entrant_allowance,
 )
 from app.models.tournament import DrawType
@@ -91,6 +93,14 @@ def _ordered(count: int) -> list[OrderedEntrant]:
     return [
         OrderedEntrant(entry_id=_entry_id(i), position=i) for i in range(1, count + 1)
     ]
+
+
+#: The field argument for the three strategies that **do not read it**. ``advance``
+#: takes the event's entrants as well as its fixtures because a swiss bye is the
+#: absence of a fixture row, so swiss cannot recover its field from the rows.
+#: Round-robin seats its whole field in every pool, and a bracket seats even its byed
+#: seeds at cut time. Passing an empty field to those three asserts they never look.
+NO_FIELD: tuple[OrderedEntrant, ...] = ()
 
 
 def _seed_of(entry_id: EntryId | None) -> int:
@@ -343,6 +353,62 @@ class TestStrategyRegistry:
             DrawType.swiss: True,
         }
 
+    def test_the_field_gate_names_every_draw_type_and_only_the_one_that_reads_it(
+        self,
+    ) -> None:
+        """``reads_entrants`` is the games gate's sibling: it lets the same seam skip
+        loading a field nothing will read, on every result submission.
+
+        A whole-enum equality, so a new ``DrawType`` reds here as well as failing to
+        type-check. The three ``False``\\ s are not "these formats have no byes" — they
+        are "their byed entrants are seated in some other row", which is what makes the
+        fixtures a complete description of their field and leaves swiss the only one
+        that has to be told."""
+        assert {draw_type: reads_entrants(draw_type) for draw_type in DrawType} == {
+            DrawType.round_robin: False,
+            DrawType.single_elim: False,
+            DrawType.rr_then_ko: False,
+            # A swiss bye is the absence of a row, so the seated set is not the field.
+            DrawType.swiss: True,
+        }
+
+    def test_a_draw_type_the_field_gate_clears_advances_the_same_without_a_field(
+        self,
+    ) -> None:
+        """And *true of the strategies*, not merely asserted about them: for every draw
+        type the gate clears, a played-out draw advances byte-identically whether it is
+        handed the field or an empty sequence.
+
+        The falsifiable half. A strategy that started reading the field would part
+        company here, rather than silently pairing nobody at the one seam that skips the
+        load."""
+        for draw_type in DrawType:
+            if reads_entrants(draw_type):
+                continue
+            strategy = strategy_for(_settings(draw_type))
+            ordered = _ordered(8)
+            cut = _persisted(strategy.plan_initial(_config(2), ordered))
+            played = _played(
+                cut,
+                {
+                    frozenset({f.entry_a_id.int, f.entry_b_id.int}): (
+                        min(f.entry_a_id.int, f.entry_b_id.int),
+                        3,
+                        1,
+                    )
+                    for f in cut
+                    if f.entry_a_id is not None and f.entry_b_id is not None
+                },
+            )
+            assert not strategy.advance(cut, ordered).is_empty, (
+                f"{draw_type.value}: two empty plans would compare equal for free"
+            )
+
+            for state in (cut, played):
+                assert strategy.advance(state, ordered) == strategy.advance(
+                    state, NO_FIELD
+                )
+
     @pytest.mark.parametrize("field_size", [6, 7])
     def test_the_bye_allowance_names_every_draw_type_and_only_swiss_byes_absently(
         self, field_size: int
@@ -427,7 +493,9 @@ class TestStrategyRegistry:
                 f"{draw_type.value}: the two states must actually differ"
             )
 
-            assert strategy.advance(with_games) == strategy.advance(without_games)
+            assert strategy.advance(with_games, NO_FIELD) == strategy.advance(
+                without_games, NO_FIELD
+            )
 
     def test_the_draw_type_lives_in_exactly_one_place_and_it_is_not_the_config(
         self,
@@ -716,7 +784,7 @@ class TestRoundRobinAdvance:
         planned = RoundRobinStrategy().plan_initial(_config(2), _ordered(7))
         fixtures = _persisted(planned)
 
-        plan = RoundRobinStrategy().advance(fixtures)
+        plan = RoundRobinStrategy().advance(fixtures, NO_FIELD)
 
         assert plan.side_fills == ()
         assert set(plan.ready_fixture_ids) == {f.fixture_id for f in fixtures}
@@ -729,7 +797,7 @@ class TestRoundRobinAdvance:
         by_id = {f.fixture_id: f for f in fixtures}
 
         # Feed them in deliberately scrambled — the plan must not inherit input order.
-        plan = RoundRobinStrategy().advance(list(reversed(fixtures)))
+        plan = RoundRobinStrategy().advance(list(reversed(fixtures)), NO_FIELD)
 
         keys = [
             (by_id[fid].pool_id or "", by_id[fid].round, by_id[fid].position)
@@ -742,7 +810,9 @@ class TestRoundRobinAdvance:
         # it proposes nothing. That is what lets advance() run after every result.
         planned = RoundRobinStrategy().plan_initial(_config(2), _ordered(6))
 
-        plan = RoundRobinStrategy().advance(_persisted(planned, materialized=True))
+        plan = RoundRobinStrategy().advance(
+            _persisted(planned, materialized=True), NO_FIELD
+        )
 
         assert plan == AdvancePlan()
         assert plan.is_empty
@@ -753,7 +823,9 @@ class TestRoundRobinAdvance:
         )
         strategy = RoundRobinStrategy()
 
-        assert strategy.advance(fixtures) == strategy.advance(fixtures)
+        assert strategy.advance(fixtures, NO_FIELD) == strategy.advance(
+            fixtures, NO_FIELD
+        )
 
     def test_a_decided_fixture_is_not_ready_again(self) -> None:
         # match_id is ON DELETE SET NULL, so a decided fixture can lose its match link.
@@ -769,7 +841,7 @@ class TestRoundRobinAdvance:
             match_id=None,
         )
 
-        assert RoundRobinStrategy().advance([decided]).is_empty
+        assert RoundRobinStrategy().advance([decided], NO_FIELD).is_empty
 
     def test_a_fixture_with_an_unknown_side_is_never_ready(self) -> None:
         pending = FixtureState(
@@ -782,10 +854,10 @@ class TestRoundRobinAdvance:
         )
 
         assert pending.is_pending
-        assert RoundRobinStrategy().advance([pending]).is_empty
+        assert RoundRobinStrategy().advance([pending], NO_FIELD).is_empty
 
     def test_an_empty_draw_advances_to_an_empty_plan(self) -> None:
-        assert RoundRobinStrategy().advance([]) == AdvancePlan()
+        assert RoundRobinStrategy().advance([], NO_FIELD) == AdvancePlan()
 
 
 class TestReadyFixtures:
@@ -931,7 +1003,7 @@ class TestReadyFixtures:
         fixtures = [ready, materialized, pending]
 
         assert ready_fixtures(fixtures) == (ready.fixture_id,)
-        assert RoundRobinStrategy().advance(fixtures) == AdvancePlan(
+        assert RoundRobinStrategy().advance(fixtures, NO_FIELD) == AdvancePlan(
             side_fills=(), ready_fixture_ids=(ready.fixture_id,)
         )
 
@@ -1196,7 +1268,7 @@ class TestSingleElimAdvance:
         assert winner is not None
 
         plan = SingleElimStrategy().advance(
-            self._decide(fixtures, round=1, position=1, winner=winner)
+            self._decide(fixtures, round=1, position=1, winner=winner), NO_FIELD
         )
 
         # position 1 is odd → side a of round 2, position ceil(1/2) = 1.
@@ -1211,7 +1283,7 @@ class TestSingleElimAdvance:
         assert winner is not None
 
         plan = SingleElimStrategy().advance(
-            self._decide(fixtures, round=1, position=2, winner=winner)
+            self._decide(fixtures, round=1, position=2, winner=winner), NO_FIELD
         )
 
         # position 2 is even → side b of round 2, position ceil(2/2) = 1.
@@ -1235,7 +1307,7 @@ class TestSingleElimAdvance:
             for f in decided
         ]
 
-        assert SingleElimStrategy().advance(applied).side_fills == ()
+        assert SingleElimStrategy().advance(applied, NO_FIELD).side_fills == ()
 
     def test_a_champion_is_seated_nowhere_the_final_has_no_successor(self) -> None:
         # A decided final must not seat its winner into a non-existent round after
@@ -1253,7 +1325,7 @@ class TestSingleElimAdvance:
         )
         state = [decided_final if f is final else f for f in fixtures]
 
-        assert SingleElimStrategy().advance(state).side_fills == ()
+        assert SingleElimStrategy().advance(state, NO_FIELD).side_fills == ()
 
     def test_a_freshly_cut_bracket_is_ready_exactly_where_both_sides_are_known(
         self,
@@ -1264,7 +1336,7 @@ class TestSingleElimAdvance:
         fixtures = self._persisted_bracket(5)
         by_rp = {(f.round, f.position): f for f in fixtures}
 
-        plan = SingleElimStrategy().advance(fixtures)
+        plan = SingleElimStrategy().advance(fixtures, NO_FIELD)
 
         assert plan.side_fills == ()
         ready = set(plan.ready_fixture_ids)
@@ -1791,7 +1863,7 @@ class TestRrThenKoAdvance:
         fixtures = _played(self._cut(), POOL_A_RESULTS)
         by_slot = {(f.round, f.position): f for f in fixtures if f.pool_id is None}
 
-        plan = _rr_then_ko(2).advance(fixtures)
+        plan = _rr_then_ko(2).advance(fixtures, NO_FIELD)
 
         assert plan.side_fills == (
             SideFill(
@@ -1830,7 +1902,7 @@ class TestRrThenKoAdvance:
         cut = _persisted(_rr_then_ko(2).plan_initial(_config(1), _ordered(4)))
         fixtures = _played(cut, CYCLIC_POOL_RESULTS)
 
-        plan = _rr_then_ko(2).advance(fixtures)
+        plan = _rr_then_ko(2).advance(fixtures, NO_FIELD)
 
         assert _knockout_sides(_apply(fixtures, plan)) == {
             (1, 1, "a"): CYCLIC_POOL_FINISHING_ORDER[0],
@@ -1843,15 +1915,17 @@ class TestRrThenKoAdvance:
         cut = self._cut()
         partial = dict(list(POOL_A_RESULTS.items())[:-1])
 
-        assert _rr_then_ko(2).advance(_played(cut, partial)).side_fills == ()
+        assert _rr_then_ko(2).advance(_played(cut, partial), NO_FIELD).side_fills == ()
 
     def test_rr_then_ko_is_idempotent_once_the_qualifiers_are_seated(self) -> None:
         # THE idempotence claim: apply the plan, feed the result back, and the second
         # advance seats nobody — a SideFill only ever fills an *empty* side.
         fixtures = _played(self._cut(), POOL_A_RESULTS)
-        first = _rr_then_ko(2).advance(fixtures)
+        first = _rr_then_ko(2).advance(fixtures, NO_FIELD)
 
-        assert _rr_then_ko(2).advance(_apply(fixtures, first)).side_fills == ()
+        assert (
+            _rr_then_ko(2).advance(_apply(fixtures, first), NO_FIELD).side_fills == ()
+        )
 
     def test_rr_then_ko_plans_nothing_at_all_over_its_own_fully_applied_plan(
         self,
@@ -1860,7 +1934,7 @@ class TestRrThenKoAdvance:
         # materialized (what ``materialize_event`` does in the same transaction), the
         # whole plan is empty — which is what makes re-running after every result safe.
         fixtures = _played(self._cut(), POOL_A_RESULTS)
-        applied = _apply(fixtures, _rr_then_ko(2).advance(fixtures))
+        applied = _apply(fixtures, _rr_then_ko(2).advance(fixtures, NO_FIELD))
         materialized = [
             dataclasses.replace(f, match_id=MatchId(uuid.UUID(int=4000 + i)))
             if f.match_id is None
@@ -1868,7 +1942,7 @@ class TestRrThenKoAdvance:
             for i, f in enumerate(applied)
         ]
 
-        assert _rr_then_ko(2).advance(materialized) == AdvancePlan()
+        assert _rr_then_ko(2).advance(materialized, NO_FIELD) == AdvancePlan()
 
     def test_rr_then_ko_advances_the_knockout_as_a_single_elim_bracket_does(
         self,
@@ -1889,7 +1963,7 @@ class TestRrThenKoAdvance:
         ]
         by_slot = {(f.round, f.position): f for f in seeded if f.pool_id is None}
 
-        plan = _rr_then_ko(2).advance(seeded)
+        plan = _rr_then_ko(2).advance(seeded, NO_FIELD)
 
         # Round 1 position 3 is odd → side a of round 2, position 2.
         assert (
@@ -1912,7 +1986,7 @@ class TestRrThenKoAdvance:
         cut = self._cut()
         partial = dict(list(POOL_A_RESULTS.items())[:2])
 
-        assert _rr_then_ko(2).advance(_played(cut, partial)).side_fills == ()
+        assert _rr_then_ko(2).advance(_played(cut, partial), NO_FIELD).side_fills == ()
 
     def test_rr_then_ko_round_one_never_pairs_two_qualifiers_out_of_one_pool(
         self,
@@ -1928,7 +2002,7 @@ class TestRrThenKoAdvance:
         cut = _persisted(planned)
         fixtures = _played(cut, _lower_seed_wins(cut))
 
-        seeded = _apply(fixtures, _rr_then_ko(2).advance(fixtures))
+        seeded = _apply(fixtures, _rr_then_ko(2).advance(fixtures, NO_FIELD))
 
         round_one = [
             (f.entry_a_id, f.entry_b_id)
@@ -1945,7 +2019,7 @@ class TestRrThenKoAdvance:
         # pool stage materializes at go-live and the bracket waits.
         cut = self._cut()
 
-        plan = _rr_then_ko(2).advance(cut)
+        plan = _rr_then_ko(2).advance(cut, NO_FIELD)
 
         assert plan.side_fills == ()
         assert set(plan.ready_fixture_ids) == {
@@ -1969,7 +2043,7 @@ class TestRrThenKoAdvance:
         ]
 
         with pytest.raises(MissingFixtureGames) as excinfo:
-            _rr_then_ko(2).advance(gameless)
+            _rr_then_ko(2).advance(gameless, NO_FIELD)
 
         assert "no game counts" in str(excinfo.value)
         assert "18 decided pool fixtures" in str(excinfo.value)
@@ -1988,7 +2062,7 @@ class TestRrThenKoAdvance:
         fixtures = _played(cut, _lower_seed_wins(cut))
 
         with pytest.raises(MissingBracketSlot) as excinfo:
-            _rr_then_ko(2).advance(fixtures)
+            _rr_then_ko(2).advance(fixtures, NO_FIELD)
 
         assert "cut for a different number of qualifiers" in str(excinfo.value)
         # Not a DrawError: a frozen K means nothing a director can type reaches this, so
@@ -2010,7 +2084,7 @@ class TestRrThenKoAdvance:
             for f in fixtures
         ]
 
-        plan = _rr_then_ko(2).advance(in_flux)
+        plan = _rr_then_ko(2).advance(in_flux, NO_FIELD)
 
         assert plan.side_fills == ()
 
@@ -2041,7 +2115,7 @@ class TestRrThenKoAdvance:
         )
         fixtures = _voided(played, {voided_pair})
 
-        plan = _rr_then_ko(2).advance(fixtures)
+        plan = _rr_then_ko(2).advance(fixtures, NO_FIELD)
 
         assert _knockout_sides(_apply(fixtures, plan)) == {
             (1, 1, "a"): 2,
@@ -2060,7 +2134,7 @@ class TestRrThenKoAdvance:
         cut = _persisted(_rr_then_ko(2).plan_initial(_config(1), _ordered(4)))
         fixtures = _voided(cut, set(CYCLIC_POOL_RESULTS))
 
-        plan = _rr_then_ko(2).advance(fixtures)
+        plan = _rr_then_ko(2).advance(fixtures, NO_FIELD)
 
         assert plan.side_fills == ()
 
@@ -2075,7 +2149,7 @@ class TestRrThenKoAdvance:
         cut = self._cut()
         fixtures = _voided(cut, {frozenset({1, 6})})
 
-        plan = _rr_then_ko(2).advance(fixtures)
+        plan = _rr_then_ko(2).advance(fixtures, NO_FIELD)
 
         assert plan.side_fills == (), "pool A has five pairings still to play"
 
@@ -2094,7 +2168,7 @@ class TestRrThenKoAdvance:
         fixtures = _voided(gameless, {frozenset({1, 6})})
 
         with pytest.raises(MissingFixtureGames) as excinfo:
-            _rr_then_ko(2).advance(fixtures)
+            _rr_then_ko(2).advance(fixtures, NO_FIELD)
 
         assert "5 decided pool fixtures" in str(excinfo.value)
 
@@ -2281,22 +2355,90 @@ class TestSwissCut:
             SwissStrategy(rounds=0)
 
 
+#: Round 1 of an 8-entrant cut (1v5, 2v6, 3v7, 4v8), played so that the standings it
+#: produces are a **permutation** of the draw order rather than the draw order itself:
+#: seed 5 beats 1 and seed 7 beats 3, and the margins separate the two winners left
+#: level on wins. A round-2 pairing computed off the seeds instead of the table cannot
+#: agree with the expectation below by luck.
+_ROUND_ONE_UPSETS: dict[frozenset[int], tuple[int, int, int]] = {
+    frozenset({1, 5}): (5, 3, 0),
+    frozenset({2, 6}): (2, 3, 1),
+    frozenset({3, 7}): (7, 3, 2),
+    frozenset({4, 8}): (4, 3, 0),
+}
+
+
+def _seed_pairs(
+    fixtures: Sequence[FixtureState], round_number: int
+) -> list[tuple[int, int, int]]:
+    """``(position, seed a, seed b)`` for one round, in position order."""
+    return [
+        (f.position, _seed_of(f.entry_a_id), _seed_of(f.entry_b_id))
+        for f in sorted(fixtures, key=lambda f: f.position)
+        if f.round == round_number
+    ]
+
+
+def _seated(fixtures: Sequence[FixtureState], round_number: int) -> set[int]:
+    """The seeds seated in one round — everybody but that round's bye."""
+    return {
+        entry_id.int
+        for f in fixtures
+        if f.round == round_number
+        for entry_id in (f.entry_a_id, f.entry_b_id)
+        if entry_id is not None
+    }
+
+
+#: The five-entrant, four-round chain the bye and forced-rematch tests drive. Round 1 is
+#: the cut's own (1v3, 2v4, seed 5 byed); rounds 2 and 3 are whatever ``advance`` pairs,
+#: written out here so a change to the pairing rule shows up as a ``_played`` call that
+#: matches no fixture rather than as a quietly different tournament.
+_FIVE_ENTRANT_RESULTS: list[dict[frozenset[int], tuple[int, int, int]]] = [
+    {frozenset({1, 3}): (1, 3, 0), frozenset({2, 4}): (2, 3, 0)},
+    {frozenset({1, 2}): (1, 3, 0), frozenset({5, 3}): (5, 3, 0)},
+    {frozenset({1, 5}): (1, 3, 0), frozenset({2, 4}): (2, 3, 0)},
+]
+
+
+def _five_entrant_rounds(
+    cut: Sequence[FixtureState], rounds: int
+) -> list[FixtureState]:
+    """A five-entrant swiss driven ``rounds`` rounds forward — every round after the
+    first paired by ``advance`` itself, then played out."""
+    played = _played(cut, _FIVE_ENTRANT_RESULTS[0])
+    for results in _FIVE_ENTRANT_RESULTS[1:rounds]:
+        played = _played(
+            _apply(played, SwissStrategy(rounds=4).advance(played, _ordered(5))),
+            results,
+        )
+    return played
+
+
 class TestSwissAdvance:
-    """Round 1 was paired at the cut, so all ``advance`` has to report today is
-    readiness. Pairing rounds 2..R off the standings is its own slice, and its absence
-    is asserted here rather than stubbed."""
+    """Once every fixture in a round carries a result, ``advance`` pairs the next round
+    into the rows the cut already wrote: the field ordered by the standings, walked, and
+    each entrant given the nearest one below they have not met (ADR "swiss pre-cuts
+    every round and pairs each one on advance")."""
 
     def _cut(self, *, rounds: int = 3, entrants: int = 8) -> list[FixtureState]:
         return _persisted(
             SwissStrategy(rounds=rounds).plan_initial(DrawConfig(), _ordered(entrants))
         )
 
+    def _advance(
+        self, fixtures: Sequence[FixtureState], field: Sequence[OrderedEntrant]
+    ) -> AdvancePlan:
+        return SwissStrategy(rounds=3).advance(fixtures, field)
+
     def test_a_freshly_cut_draw_is_ready_in_round_one_only_and_fills_nothing(
         self,
     ) -> None:
+        """Nothing is decided, so there is nothing to pair: round 1 was seeded at the
+        cut and rounds 2..R wait for it."""
         fixtures = self._cut()
 
-        plan = SwissStrategy(rounds=3).advance(fixtures)
+        plan = self._advance(fixtures, _ordered(8))
 
         assert plan.side_fills == ()
         assert set(plan.ready_fixture_ids) == {
@@ -2305,9 +2447,9 @@ class TestSwissAdvance:
         assert not plan.is_empty
 
     def test_a_materialized_round_one_leaves_an_empty_plan(self) -> None:
-        """Idempotence: apply the plan (the fixtures now carry matches) and re-running
-        it proposes nothing — the later rounds are still pending, so they are not
-        ready, and round 1 is no longer."""
+        """Round 1 is being *played*, not decided: its fixtures carry matches, so they
+        are no longer ready, and round 2 must not be paired off a table that is still
+        moving."""
         fixtures = [
             dataclasses.replace(f, match_id=MatchId(uuid.UUID(int=4000 + i)))
             if f.round == 1
@@ -2315,32 +2457,255 @@ class TestSwissAdvance:
             for i, f in enumerate(self._cut())
         ]
 
-        plan = SwissStrategy(rounds=3).advance(fixtures)
+        plan = self._advance(fixtures, _ordered(8))
 
         assert plan.is_empty
 
-    def test_a_decided_round_one_pairs_nothing_yet(self) -> None:
-        """**The honest limit of this slice.** Round 1 played out in full still fills no
-        side of round 2: pairing by standings is the next chore, and a stub that seated
-        somebody here would be writing pairings nothing computed.
+    def test_a_decided_round_one_pairs_round_two_in_standings_order(self) -> None:
+        """The claim in one assertion: **who** meets whom, and **where**.
 
-        It is asserted rather than left unsaid so that the chore landing the pairing has
-        a test to *change*, and so nothing quietly reports a round ready that has no
-        players in it."""
-        played = _played(
-            self._cut(),
-            {
-                frozenset({1, 5}): (1, 3, 0),
-                frozenset({2, 6}): (2, 3, 1),
-                frozenset({3, 7}): (7, 3, 2),
-                frozenset({4, 8}): (4, 3, 0),
-            },
+        Round 1 upsets the seeding — 5 beats 1, 7 beats 3 — so the table reads
+        4, 5, 2, 7, 3, 6, 1, 8 (seed 4 above seed 5 on the entry-id fallback, the two
+        being level on wins, game difference and games won). Pairing that order down the
+        list gives 4v5, 2v7, 3v6, 1v8, and a fixture's ``position`` is its **pairing
+        rank**, so the pairing holding the top-ranked entrant is position 1.
+
+        Pairing by the draw order instead would give 1v2, 3v4, 5v6, 7v8 — a different
+        answer in every position, which is what makes this test discriminating."""
+        played = _played(self._cut(), _ROUND_ONE_UPSETS)
+
+        plan = self._advance(played, _ordered(8))
+
+        assert _seed_pairs(_apply(played, plan), 2) == [
+            (1, 4, 5),
+            (2, 2, 7),
+            (3, 3, 6),
+            (4, 1, 8),
+        ]
+
+    def test_the_walk_takes_the_nearest_opponent_it_has_not_already_met(self) -> None:
+        """**The rematch-avoidance test, built so that the naive answer is wrong.**
+
+        Four entrants, three rounds, driven all the way through. Round 1 is 1v3, 2v4;
+        the standings stay 1, 2, 3, 4 throughout, so round 2 pairs 1v2 and 3v4 —
+        indistinguishable from pairing adjacent entrants. Round 3 is where they part:
+        every adjacent pair has now met, so pairing down the standings unchecked would
+        emit 1v2 and 3v4 again, both repeats. Skipping to the nearest **unmet** opponent
+        gives 1v4 and 2v3 — the only rematch-free round left."""
+        round_one = _played(
+            self._cut(rounds=3, entrants=4),
+            {frozenset({1, 3}): (1, 3, 0), frozenset({2, 4}): (2, 3, 0)},
+        )
+        round_two = _played(
+            _apply(round_one, self._advance(round_one, _ordered(4))),
+            {frozenset({1, 2}): (1, 3, 0), frozenset({3, 4}): (3, 3, 0)},
         )
 
-        plan = SwissStrategy(rounds=3).advance(played)
+        plan = self._advance(round_two, _ordered(4))
+
+        assert _seed_pairs(round_two, 2) == [(1, 1, 2), (2, 3, 4)]
+        assert _seed_pairs(_apply(round_two, plan), 3) == [(1, 1, 4), (2, 2, 3)]
+
+    def test_only_the_next_round_is_paired(self) -> None:
+        """Round 3 cannot be paired off round 1's table — it is paired off round 2's,
+        which has not been played. So a decided round 1 fills round 2 and nothing
+        else."""
+        played = _played(self._cut(), _ROUND_ONE_UPSETS)
+
+        applied = _apply(played, self._advance(played, _ordered(8)))
+
+        assert all(
+            f.entry_a_id is None and f.entry_b_id is None
+            for f in applied
+            if f.round == 3
+        )
+
+    def test_a_round_with_one_result_outstanding_pairs_nothing(self) -> None:
+        """A swiss round pairs off the whole table, so one unreported result blocks the
+        next round for the entire field (ADR, "a stalled round stalls the whole
+        event"). Three of round 1's four fixtures decided is not a table."""
+        partial = dict(_ROUND_ONE_UPSETS)
+        del partial[frozenset({4, 8})]
+        played = _played(self._cut(), partial)
+
+        plan = self._advance(played, _ordered(8))
 
         assert plan.side_fills == ()
-        assert plan.ready_fixture_ids == ()
-        assert all(
-            f.entry_a_id is None and f.entry_b_id is None for f in played if f.round > 1
+
+    def test_a_voided_pairing_does_not_stall_the_round(self) -> None:
+        """A voided match will never produce a result, so requiring one would leave the
+        event one score short forever, with no move a director could make. The round
+        counts as decided without it — the same exception the pool-finished test
+        makes."""
+        cut = self._cut(rounds=3, entrants=4)
+        played = _played(cut, {frozenset({2, 4}): (2, 3, 0)})
+        voided = [
+            dataclasses.replace(
+                f, match_id=MatchId(uuid.UUID(int=5000)), match_voided=True
+            )
+            if f.round == 1 and _seed_of(f.entry_a_id) == 1
+            else f
+            for f in played
+        ]
+
+        plan = self._advance(voided, _ordered(4))
+
+        assert _seed_pairs(_apply(voided, plan), 2) == [(1, 2, 1), (2, 3, 4)]
+
+    def test_the_field_is_the_entrants_so_round_ones_bye_is_paired_next(self) -> None:
+        """**The field comes from the entrants, never from the seated set.** Seed 5 has
+        no round-1 fixture at all — a bye is the absence of a row — so a pairing built
+        from the rows would drop them out of the event from here on. They are paired in
+        round 2, and the bye passes to the lowest-ranked entrant who has not had one."""
+        played = _played(
+            self._cut(rounds=4, entrants=5),
+            {frozenset({1, 3}): (1, 3, 0), frozenset({2, 4}): (2, 3, 0)},
         )
+
+        applied = _apply(played, SwissStrategy(rounds=4).advance(played, _ordered(5)))
+
+        assert _seed_pairs(applied, 2) == [(1, 1, 2), (2, 5, 3)]
+        assert _seated(applied, 2) == {1, 2, 3, 5}
+
+    def test_a_latecomer_seated_nowhere_is_paired_into_the_next_round(self) -> None:
+        """A draw cut for eight that a ninth entrant joined holds exactly the rows a
+        draw cut for nine holds (``unseated_entrant_allowance``), so the latecomer is an
+        entrant with no fixture anywhere. Pairing from the entrants is what gets them a
+        match; pairing from the rows would leave them entered and unplayable."""
+        played = _played(self._cut(), _ROUND_ONE_UPSETS)
+
+        applied = _apply(played, self._advance(played, _ordered(9)))
+
+        assert 9 in _seated(applied, 2)
+        assert len(_seated(applied, 2)) == 8
+
+    def test_the_bye_goes_to_the_lowest_ranked_entrant_who_has_not_had_one(
+        self,
+    ) -> None:
+        """Nobody sits out twice before everybody has sat out once (CONTEXT.md, "Bye").
+        Five entrants over three played rounds bye a different entrant each time, and
+        the one taking it is always the lowest-ranked entrant still without one."""
+        played = _five_entrant_rounds(self._cut(rounds=4, entrants=5), 3)
+
+        byes = [
+            {1, 2, 3, 4, 5} - _seated(played, round_number)
+            for round_number in (1, 2, 3)
+        ]
+
+        assert byes == [{5}, {4}, {3}]
+
+    def test_a_forced_rematch_is_paired_rather_than_refused(self) -> None:
+        """**The last resort, reached by a draw the cut itself writes.** Five entrants,
+        three rounds in: by round 3 the standings put seeds 2 and 4 last among those
+        still to be paired, and they met in round 1. No rematch-free pairing is left for
+        them, and the round is paired anyway — 2v4 again — because refusing would strand
+        a live event with a round nobody can play.
+
+        The pairing above it, 1v5, is fresh: the fallback is taken only by the pair that
+        has no alternative, not by the whole round."""
+        round_two = _five_entrant_rounds(self._cut(rounds=4, entrants=5), 2)
+
+        plan = SwissStrategy(rounds=4).advance(round_two, _ordered(5))
+
+        assert _seed_pairs(_apply(round_two, plan), 3) == [(1, 1, 5), (2, 2, 4)]
+        assert (2, 2, 4) in _seed_pairs(round_two, 1)  # the repeat, round 1's own
+
+    def test_re_running_the_advance_pairs_the_round_again_no_differently(self) -> None:
+        """**Idempotence, in the two steps the seam takes.** Apply the fills and the
+        round is no longer *wholly* unpaired, so it is no longer pairable and a second
+        run plans no fill.
+
+        The second plan is not *empty*, and must not be: the round it just paired is
+        genuinely ready to become matches, which is what the caller does with it next
+        (``materialize_event`` re-derives readiness over the filled state). Materialize
+        those rows and the third run is the empty plan the contract asks for."""
+        played = _played(self._cut(), _ROUND_ONE_UPSETS)
+        applied = _apply(played, self._advance(played, _ordered(8)))
+
+        second = self._advance(applied, _ordered(8))
+
+        assert second.side_fills == ()
+        assert set(second.ready_fixture_ids) == {
+            f.fixture_id for f in applied if f.round == 2
+        }
+        materialized = [
+            dataclasses.replace(f, match_id=MatchId(uuid.UUID(int=6000 + i)))
+            if f.fixture_id in second.ready_fixture_ids
+            else f
+            for i, f in enumerate(applied)
+        ]
+        assert self._advance(materialized, _ordered(8)) == AdvancePlan()
+
+    def test_a_corrected_earlier_result_does_not_re_pair_a_paired_round(self) -> None:
+        """A round-1 result taken back into correction un-decides round 1 — but round 2
+        is already paired and possibly being played, and a fill only ever lands on a
+        wholly unpaired round. So the pairings stand, exactly as single-elim never
+        un-seats a winner."""
+        played = _played(self._cut(), _ROUND_ONE_UPSETS)
+        applied = _apply(played, self._advance(played, _ordered(8)))
+        in_correction = [
+            dataclasses.replace(f, games=None)
+            if f.round == 1 and _seed_of(f.entry_a_id) == 1
+            else f
+            for f in applied
+        ]
+
+        plan = self._advance(in_correction, _ordered(8))
+
+        assert plan.side_fills == ()
+        assert _seed_pairs(in_correction, 2) == [
+            (1, 4, 5),
+            (2, 2, 7),
+            (3, 3, 6),
+            (4, 1, 8),
+        ]
+
+    def test_an_empty_draw_advances_to_nothing(self) -> None:
+        assert self._advance([], _ordered(8)) == AdvancePlan()
+
+
+class TestSwissPairings:
+    """The pairing rule on its own: an order in, pairs out. Pure, so the branch that
+    matters most — the forced rematch — is pinned directly rather than through a
+    tournament contrived to reach it."""
+
+    def _pairs(
+        self, order: Sequence[int], met: Collection[frozenset[int]] = ()
+    ) -> list[tuple[int, int]]:
+        pairings = swiss_pairings(
+            [_entry_id(seed) for seed in order],
+            {frozenset(_entry_id(seed) for seed in pair) for pair in met},
+        )
+        return [(a.int, b.int) for a, b in pairings]
+
+    def test_a_field_that_has_met_nobody_pairs_straight_down_the_order(self) -> None:
+        assert self._pairs([4, 1, 3, 2]) == [(4, 1), (3, 2)]
+
+    def test_an_entrant_already_met_is_skipped_for_the_next_one_down(self) -> None:
+        """The whole rule in one line: 1 has met 2, so 1 takes 3 — and 2, still
+        unpaired, takes the nearest entrant left."""
+        assert self._pairs([1, 2, 3, 4], {frozenset({1, 2})}) == [(1, 3), (2, 4)]
+
+    def test_a_rematch_is_the_last_resort_rather_than_a_refusal(self) -> None:
+        """**Never a refusal.** With 1 having met everybody below them, no rematch-free
+        pairing for 1 exists — and the walk pairs them anyway, with the nearest, rather
+        than returning a short list that would leave a live event with fixtures nobody
+        can play. The repeat is 1v2, and 3v4 is untouched by it."""
+        met = {frozenset({1, 2}), frozenset({1, 3}), frozenset({1, 4})}
+
+        assert self._pairs([1, 2, 3, 4], met) == [(1, 2), (3, 4)]
+
+    def test_a_field_in_which_everyone_has_met_everyone_still_pairs(self) -> None:
+        """The extreme of the same rule — every pair is a repeat, so every pairing is a
+        rematch, and the round still happens."""
+        met = {frozenset(pair) for pair in combinations([1, 2, 3, 4], 2)}
+
+        assert self._pairs([1, 2, 3, 4], met) == [(1, 2), (3, 4)]
+
+    def test_an_odd_order_leaves_its_last_entrant_unpaired(self) -> None:
+        """Total, not raising: the caller takes the bye out before calling, and a
+        miscount that got past it costs a fixture rather than a 500 mid-event."""
+        assert self._pairs([1, 2, 3]) == [(1, 2)]
+
+    def test_an_empty_order_pairs_nothing(self) -> None:
+        assert self._pairs([]) == []

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -2586,7 +2586,13 @@ class TestSwissAdvance:
     ) -> None:
         """Nobody sits out twice before everybody has sat out once (CONTEXT.md, "Bye").
         Five entrants over three played rounds bye a different entrant each time, and
-        the one taking it is always the lowest-ranked entrant still without one."""
+        the one taking it is always the lowest-ranked entrant still without one.
+
+        This chain pins the *sequence*, not the byeless preference: its bye holders bank
+        a win and float up the table, so "lowest-ranked byeless" and "lowest-ranked"
+        happen to agree every round and it would pass against an implementation that
+        never checked. ``test_the_bye_skips_an_entrant_who_has_had_one_even_when_they
+        _rank_last`` is the one that tells them apart."""
         played = _five_entrant_rounds(self._cut(rounds=4, entrants=5), 3)
 
         byes = [
@@ -2640,6 +2646,116 @@ class TestSwissAdvance:
         assert _seated(_apply(round_two, plan), 3) == {1, 2, 4, 5, 6, 7}, (
             "seed 3 takes round 3's bye, being the lowest-ranked entrant without one"
         )
+
+    def test_the_bye_skips_an_entrant_who_has_had_one_even_when_they_rank_last(
+        self,
+    ) -> None:
+        """**The byeless preference, in the only case that tests it.**
+
+        "The lowest-ranked entrant who has not yet had a bye" and "the lowest-ranked
+        entrant" are the same answer in most fields, because a bye banks a win and
+        floats its holder *up* the table, leaving somebody byeless at the bottom. A test
+        built on such a field passes against an implementation that never looks at who
+        has already sat out.
+
+        So this one sinks the bye holder instead. Seed 5 sits out round 1, then loses
+        round 2, and comes into round 3 **last**: five entrants, and the table reads
+        1, 2, 3, 4, 5 (seed 4 and seed 5 both on one win and a game difference of −3,
+        separated by the entry-id fallback).
+
+            round 1   1 beat 3, 2 beat 4          5 byed
+            round 2   1 beat 2, 3 beat 5          4 byed
+            round 3   the bye is seed 3's — the lowest-ranked of 1, 2 and 3, the
+                      entrants who have not had one
+
+        Ignore the preference and the bye goes to seed 5 for the **second** time, while
+        three players have never sat out at all. That is what this reds on.
+        """
+        round_one = _played(
+            self._cut(rounds=3, entrants=5),
+            {frozenset({1, 3}): (1, 3, 0), frozenset({2, 4}): (2, 3, 0)},
+        )
+        round_two = _played(
+            _apply(round_one, SwissStrategy(rounds=3).advance(round_one, _ordered(5))),
+            {frozenset({1, 2}): (1, 3, 0), frozenset({3, 5}): (3, 3, 0)},
+        )
+
+        plan = SwissStrategy(rounds=3).advance(round_two, _ordered(5))
+
+        applied = _apply(round_two, plan)
+        assert _seed_pairs(applied, 2) == [(1, 1, 2), (2, 5, 3)]
+        assert _seated(applied, 3) == {1, 2, 4, 5}, (
+            "seed 3 takes round 3's bye. Seed 5 is ranked below them and would take it "
+            "again under a rule that only reads the standings — a second bye for the "
+            "one entrant who has already had one"
+        )
+        assert [
+            {1, 2, 3, 4, 5} - _seated(applied, round_number)
+            for round_number in (1, 2, 3)
+        ] == [{5}, {4}, {3}], "three rounds, three different entrants sitting out"
+
+    def test_once_everybody_has_had_a_bye_it_falls_back_to_the_lowest_ranked(
+        self,
+    ) -> None:
+        """The other half of the rule: with the byeless set empty, selection takes the
+        lowest-ranked entrant overall rather than refusing or looking forever.
+
+        The state is **one the cut refuses** — three entrants cannot be given four
+        rounds (``R > n − 1``), and byes are handed out at most one per round, so a
+        field in which everybody has had one is unreachable through
+        ``plan_initial``. It is built by hand precisely because of that: the branch
+        exists to keep the function total, and an unreachable branch that raises or
+        loops is still a live event stopped dead if anything ever reaches it.
+
+            round 1   1 beat 2    3 byed
+            round 2   1 beat 3    2 byed
+            round 3   2 beat 3    1 byed
+            round 4   everybody has sat out once, so the bye is seed 3's, last on the
+                      table — and the round is paired, as a rematch, because after
+                      three rounds these three have met everybody
+        """
+        played = _played(
+            _persisted(
+                [
+                    PlannedFixture(
+                        pool_id=None,
+                        round=1,
+                        position=1,
+                        entry_a_id=_entry_id(1),
+                        entry_b_id=_entry_id(2),
+                    ),
+                    PlannedFixture(
+                        pool_id=None,
+                        round=2,
+                        position=1,
+                        entry_a_id=_entry_id(1),
+                        entry_b_id=_entry_id(3),
+                    ),
+                    PlannedFixture(
+                        pool_id=None,
+                        round=3,
+                        position=1,
+                        entry_a_id=_entry_id(2),
+                        entry_b_id=_entry_id(3),
+                    ),
+                    PlannedFixture(pool_id=None, round=4, position=1),
+                ]
+            ),
+            {
+                frozenset({1, 2}): (1, 3, 0),
+                frozenset({1, 3}): (1, 3, 0),
+                frozenset({2, 3}): (2, 3, 0),
+            },
+        )
+
+        plan = SwissStrategy(rounds=4).advance(played, _ordered(3))
+
+        assert not plan.is_empty, (
+            "a field that has run out of byeless entrants is still paired — the "
+            "fallback is a choice, not a refusal"
+        )
+        assert _seed_pairs(_apply(played, plan), 4) == [(1, 1, 2)]
+        assert _seated(_apply(played, plan), 4) == {1, 2}, "seed 3 sits out again"
 
     def test_a_forced_rematch_is_paired_rather_than_refused(self) -> None:
         """**The last resort, reached by a draw the cut itself writes.** Five entrants,

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -2381,6 +2381,24 @@ def _seed_pairs(
     ]
 
 
+def _paired_rows(
+    fixtures: Sequence[FixtureState], round_number: int
+) -> list[tuple[int, int, int]]:
+    """:func:`_seed_pairs` for a round some of whose rows can never be paired.
+
+    A field that shrinks after the cut leaves a round with more rows than pairings, and
+    ``_seed_pairs`` reads every row (its ``_seed_of`` asserts a seat). This one reports
+    the rows that carry a pairing and says nothing about the rest, so a test can assert
+    both the pairings and how many rows were left."""
+    return [
+        (f.position, f.entry_a_id.int, f.entry_b_id.int)
+        for f in sorted(fixtures, key=lambda f: f.position)
+        if f.round == round_number
+        and f.entry_a_id is not None
+        and f.entry_b_id is not None
+    ]
+
+
 def _seated(fixtures: Sequence[FixtureState], round_number: int) -> set[int]:
     """The seeds seated in one round — everybody but that round's bye."""
     return {
@@ -2700,12 +2718,13 @@ class TestSwissAdvance:
         """The other half of the rule: with the byeless set empty, selection takes the
         lowest-ranked entrant overall rather than refusing or looking forever.
 
-        The state is **one the cut refuses** — three entrants cannot be given four
-        rounds (``R > n − 1``), and byes are handed out at most one per round, so a
-        field in which everybody has had one is unreachable through
-        ``plan_initial``. It is built by hand precisely because of that: the branch
-        exists to keep the function total, and an unreachable branch that raises or
-        loops is still a live event stopped dead if anything ever reaches it.
+        The state is one **the cut refuses to write** — three entrants cannot be given
+        four rounds — so it is built by hand here rather than driven through
+        ``plan_initial``. It is not unreachable: the cut compares ``R`` against the
+        field it sees, and a field that **shrinks** afterwards (an account merge
+        withdraws a guest whose entry seats played fixtures) carries the old ``R`` into
+        a smaller field, which is exactly this. A branch that raised or looped would be
+        a live event stopped dead.
 
             round 1   1 beat 2    3 byed
             round 2   1 beat 3    2 byed
@@ -2772,6 +2791,114 @@ class TestSwissAdvance:
 
         assert _seed_pairs(_apply(round_two, plan), 3) == [(1, 1, 5), (2, 2, 4)]
         assert (2, 2, 4) in _seed_pairs(round_two, 1)  # the repeat, round 1's own
+
+    def test_a_field_that_shrinks_after_the_cut_keeps_pairing_its_later_rounds(
+        self,
+    ) -> None:
+        """**The deadlock, and the one withdrawal that caused it.**
+
+        Eight entrants are cut for four rounds — four rows a round — and round 1 is
+        played by all eight. Seed 8 then leaves, which the ordinary withdrawal endpoint
+        cannot do to a live event but the account merge can: it flips a colliding
+        guest's entry to ``withdrawn`` rather than deleting it, *because* the row seats
+        played fixtures. Seven entrants make three pairings, so round 2 is paired into
+        three of its four rows and the fourth stays ``NULL`` for good.
+
+        That fourth row is what has to be understood as **permanently unpairable**
+        rather than pending. Read as pending it made round 2 neither wholly unpaired nor
+        decided, and the walk answered "no round is pairable" on that call and on every
+        call after: rounds 3 and 4 were never paired, the event never read complete, and
+        a played draw cannot be un-cut — no move a director could make.
+
+        The pairings are asserted exactly, in both rounds, so this cannot pass by
+        pairing *something*. Round 2's table is the seven survivors' (5, 2, 7, 4, 3, 6,
+        1 — seed 8's win over seed 4 is not theirs to count), seed 1 takes the bye, and
+        round 3 is paired off round 2's table in turn.
+        """
+        played = _played(self._cut(rounds=4, entrants=8), _ROUND_ONE_UPSETS)
+
+        round_two = _apply(played, SwissStrategy(rounds=4).advance(played, _ordered(7)))
+
+        assert _paired_rows(round_two, 2) == [(1, 5, 2), (2, 7, 4), (3, 3, 6)]
+        assert _seated(round_two, 2) == {2, 3, 4, 5, 6, 7}, "seed 1 sits round 2 out"
+        assert len([f for f in round_two if f.round == 2]) == 4, (
+            "the cut's fourth row is still there — it is unpairable, not deleted"
+        )
+
+        decided = _played(
+            round_two,
+            {
+                frozenset({5, 2}): (5, 3, 0),
+                frozenset({7, 4}): (7, 3, 0),
+                frozenset({3, 6}): (3, 3, 0),
+            },
+        )
+        round_three = _apply(
+            decided, SwissStrategy(rounds=4).advance(decided, _ordered(7))
+        )
+
+        assert _paired_rows(round_three, 3) == [(1, 5, 7), (2, 3, 2), (3, 1, 4)], (
+            "round 3 is paired off round 2's table — the round that was neither "
+            "wholly unpaired nor decided, and stalled the walk forever"
+        )
+        assert _seated(round_three, 3) == {1, 2, 3, 4, 5, 7}, "seed 6 sits round 3 out"
+
+    def test_a_shrunk_round_is_not_paired_a_second_time(self) -> None:
+        """The idempotence the fix must not cost. A round paired down to a shrunk field
+        has a ``NULL`` row left in it, and "has a ``NULL`` row" is exactly what the
+        pairable check no longer means — so the guard has to be that the round is
+        **full**, not that it is untouched. Re-run over the applied state and it plans
+        no fill, and the rows it filled keep the entrants they were given."""
+        played = _played(self._cut(rounds=4, entrants=8), _ROUND_ONE_UPSETS)
+        applied = _apply(played, SwissStrategy(rounds=4).advance(played, _ordered(7)))
+
+        second = SwissStrategy(rounds=4).advance(applied, _ordered(7))
+
+        assert second.side_fills == ()
+        assert _paired_rows(applied, 2) == [(1, 5, 2), (2, 7, 4), (3, 3, 6)]
+
+    def test_a_shrunk_field_runs_out_of_byeless_entrants(self) -> None:
+        """**The byeless fallback is reachable through the real cut**, and the docstring
+        beside it used to argue it was not.
+
+        That argument read the ceiling as ``R ≤ n − 1``, so the byes handed out (one a
+        round) could never cover the field. It reasoned about ``n`` at the cut. Six
+        entrants are cut for five rounds here — legal — and three of them are left after
+        round 1, so rounds 2, 3 and 4 bye one survivor each and round 5 has nobody
+        byeless to pick. It hands the bye to the lowest-ranked entrant overall, a second
+        one for seed 3, rather than raising or looping in the middle of a live event.
+
+        Every round after the first is paired by ``advance`` itself, which is what makes
+        this a statement about a draw the system can actually be in."""
+        played = _played(
+            self._cut(rounds=5, entrants=6),
+            {
+                frozenset({1, 4}): (1, 3, 0),
+                frozenset({2, 5}): (2, 3, 0),
+                frozenset({3, 6}): (3, 3, 0),
+                # Every pairing the three survivors can be given, so each round is
+                # played out whichever two of them meet.
+                frozenset({1, 2}): (1, 3, 0),
+                frozenset({1, 3}): (1, 3, 0),
+                frozenset({2, 3}): (2, 3, 0),
+            },
+        )
+        for _ in range(4):
+            played = _played(
+                _apply(played, SwissStrategy(rounds=5).advance(played, _ordered(3))),
+                {
+                    frozenset({1, 2}): (1, 3, 0),
+                    frozenset({1, 3}): (1, 3, 0),
+                    frozenset({2, 3}): (2, 3, 0),
+                },
+            )
+
+        assert [
+            {1, 2, 3} - _seated(played, round_number) for round_number in (2, 3, 4, 5)
+        ] == [{3}, {2}, {1}, {3}], (
+            "three byeless entrants last three rounds; the fourth falls back to the "
+            "lowest-ranked, who has already had one"
+        )
 
     def test_re_running_the_advance_pairs_the_round_again_no_differently(self) -> None:
         """**Idempotence, in the two steps the seam takes.** Apply the fills and the

--- a/api/tests/test_pool_finishing_order.py
+++ b/api/tests/test_pool_finishing_order.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import app.pool_finishing_order
 from app.draws import EntryId, PoolId
-from app.pool_finishing_order import MatchOutcome, finishing_order
+from app.pool_finishing_order import EntryTally, MatchOutcome, finishing_order
 from app.results import PoolInput, RoundRobinResults
 
 _API_ROOT = Path(__file__).resolve().parent.parent
@@ -61,8 +61,25 @@ def _outcome(
     )
 
 
-def _order(entrants: list[EntryId], outcomes: list[MatchOutcome]) -> list[EntryId]:
-    return [tally.entry_id for tally in finishing_order(entrants, outcomes)]
+def _order(
+    entrants: list[EntryId],
+    outcomes: list[MatchOutcome],
+    byes: list[EntryId] | None = None,
+) -> list[EntryId]:
+    return [tally.entry_id for tally in finishing_order(entrants, outcomes, byes or ())]
+
+
+def _tally(
+    entrants: list[EntryId],
+    outcomes: list[MatchOutcome],
+    byes: list[EntryId],
+    of: EntryId,
+) -> EntryTally:
+    return next(
+        tally
+        for tally in finishing_order(entrants, outcomes, byes)
+        if tally.entry_id == of
+    )
 
 
 def test_the_shared_module_imports_no_layer_that_imports_it() -> None:
@@ -160,6 +177,89 @@ def test_the_entry_id_is_the_final_deterministic_tiebreak() -> None:
 
     fed_in = [c, b, a]
     assert _order(fed_in, outcomes) == list(reversed(fed_in))
+
+
+def test_a_bye_counts_as_a_win() -> None:
+    """A bye is a **win** in the first link of the chain (ADR "swiss standings add
+    Buchholz"), because a player must not be punished for a scheduling artifact they
+    did not cause.
+
+    Built so the win alone moves B, and moves them *past somebody*. C has a real win
+    and a game difference of −2; B has a bye and a game difference of 0. Counting the
+    bye puts B and C in the same wins group, where B's better difference ranks them
+    above. Not counting it drops B into the group below C entirely — second place to
+    third, overtaken by the player they are level with.
+
+        A beat C 3-0, A beat D 3-0  → A: 2-0
+        C beat D 3-2                → C: 1-1, GW 3, GL 5, GD -2
+                                      D: 0-2, GW 2, GL 6, GD -4
+        B sat out                   → B: 1-0 by bye, GW 0, GL 0, GD 0
+    """
+    a, b, c, d = _eid(1), _eid(2), _eid(3), _eid(4)
+    outcomes = [_outcome(a, c, 3, 0), _outcome(a, d, 3, 0), _outcome(c, d, 3, 2)]
+
+    assert _order([a, b, c, d], outcomes, byes=[b]) == [a, b, c, d]
+    # And the same field with the bye unscored, which is what the assertion above is
+    # worth: B falls behind the entrant they outrank on every count but the win.
+    assert _order([a, b, c, d], outcomes) == [a, c, b, d]
+
+
+def test_a_bye_is_worth_zero_games_not_a_nominal_win() -> None:
+    """**The half of the rule that a passing test can easily miss.** A bye adds a win
+    and *no games*, so it stays neutral on game difference and games won — the links
+    below it.
+
+    Awarding a nominal 3-0 instead would be invisible in the wins column and decisive
+    here: A and B are level on wins, have never met (B was byed, so head-to-head has
+    nothing to read), and A's real 3-1 win gives them a difference of +2. A phantom
+    3-0 would give B +3 and put the player who sat out above the player who went and
+    won a match.
+
+        A beat C 3-1  → A: 1-0, GW 3, GL 1, GD +2
+                        C: 0-1, GW 1, GL 3, GD -2
+        B sat out     → B: 1-0 by bye, GW 0, GL 0, GD 0  (a nominal 3-0 would be +3)
+    """
+    a, b, c = _eid(1), _eid(2), _eid(3)
+    outcomes = [_outcome(a, c, 3, 1)]
+
+    assert _order([a, b, c], outcomes, byes=[b]) == [a, b, c]
+
+    tally = _tally([a, b, c], outcomes, [b], of=b)
+    assert (tally.wins, tally.games_won, tally.games_lost) == (1, 0, 0)
+    assert tally.game_difference == 0, "the bye moves neither game counter"
+
+
+def test_a_bye_leaves_the_row_reading_played_once_and_won_once() -> None:
+    """``played`` moves with the win, so the row still satisfies the arithmetic every
+    other row on the table does: played equals wins plus losses. A row reading "played
+    0, won 1" is what a director would report as a bug in the standings."""
+    a, b = _eid(1), _eid(2)
+
+    tally = _tally([a, b], [], [b], of=b)
+
+    assert (tally.played, tally.wins, tally.losses) == (1, 1, 0)
+
+
+def test_two_byes_count_twice() -> None:
+    """Byes arrive one id per bye taken, so an entrant who has sat out twice is
+    credited twice — the multiset is the whole meaning of that argument."""
+    a, b = _eid(1), _eid(2)
+
+    tally = _tally([a, b], [], [b, b], of=b)
+
+    assert (tally.played, tally.wins) == (2, 2)
+
+
+def test_a_bye_does_not_reach_the_head_to_head_link() -> None:
+    """A bye has no opponent, so it cannot be read as a result *against* anybody. B
+    and C are tied on wins — C's from a real match, B's from a bye — and the pair have
+    never met, so the head-to-head link falls through to the game tiebreakers, where
+    C's +1 outranks B's 0. A bye that leaked into head-to-head could only invent a
+    result nobody played."""
+    b, c, d = _eid(1), _eid(2), _eid(3)
+    outcomes = [_outcome(c, d, 3, 2)]
+
+    assert _order([b, c, d], outcomes, byes=[b]) == [c, b, d]
 
 
 def test_the_standings_table_is_this_order() -> None:

--- a/api/tests/test_results.py
+++ b/api/tests/test_results.py
@@ -129,6 +129,44 @@ def test_a_swiss_field_stands_in_one_table_ordered_by_the_shared_chain() -> None
     assert [row.rank for row in standings.rows] == [1, 2, 3, 4]
 
 
+def test_a_byed_entrant_is_credited_with_a_win_and_no_games() -> None:
+    """The bye reaches the table as a **win worth zero games** (ADR "swiss standings
+    add Buchholz"): C sat out round 1 and reads 1-0 with a game difference of zero.
+
+    The rule is pinned link by link in ``tests/test_pool_finishing_order.py``; what
+    this asserts is that the swiss table actually *passes its byes through*, which is
+    the half a test of the chain alone cannot see.
+    """
+    field = FieldInput(
+        entrants=(A, B, C),
+        fixture_count=3,
+        outcomes=(_outcome(A, B, 3, 1),),
+        byes=(C,),
+    )
+
+    standings = SwissResults().tabulate(field)
+
+    by_entry = {row.entry_id: row for row in standings.rows}
+    assert (by_entry[C].played, by_entry[C].wins, by_entry[C].losses) == (1, 1, 0)
+    assert (by_entry[C].games_won, by_entry[C].games_lost) == (0, 0)
+    assert by_entry[C].game_difference == 0
+    # A won a real match 3-1, so A's +2 outranks the bye's 0 — the two are level on
+    # wins and have never met. A nominal 3-0 for the bye would put C first.
+    assert [row.entry_id for row in standings.rows] == [A, C, B]
+
+
+def test_a_pool_scores_no_byes() -> None:
+    """A round-robin pool passes none, and that is a fact about the format rather than
+    an omission: its byed entrant sits out one round of a schedule that seats them in
+    every other, so there is no result to credit. B has played nobody and reads a row
+    of zeros."""
+    pool = _single_pool(entrants=(A, B), fixture_count=1, outcomes=[])
+
+    (standings,) = RoundRobinResults().tabulate([pool]).pools
+
+    assert all((row.played, row.wins) == (0, 0) for row in standings.rows)
+
+
 def test_a_swiss_event_is_complete_and_crowned_when_every_round_is_decided() -> None:
     """A swiss ranks the whole field, so its complete table's top row is the champion —
     no single-pool carve-out, because there are no pools to have more than one of."""

--- a/api/tests/test_swiss.py
+++ b/api/tests/test_swiss.py
@@ -5,12 +5,15 @@ The strategy itself is pure and is tested from literals in ``test_draws.py``; th
 standings shape is tested the same way in ``test_results.py``. What this file tests is
 everything *between* them and a director: the request boundary that requires a round
 count for exactly one draw type, the settings row it lands on, the wire it reads back
-on, and the cut that writes every round at once.
+on, the cut that writes every round at once, and the completion seam that pairs the
+next round when the current one is done.
 
-**What is deliberately absent.** ``advance()`` does not pair rounds 2..R yet — that is
-the next slice — so there is no test here of a decided round producing pairings. The
-absence is asserted in ``test_draws.py`` rather than papered over, because a stub would
-write pairings nothing computed.
+That last one is here rather than only in ``test_draws.py`` because a pure strategy
+that pairs perfectly is **inert** unless the seam hands it the two things it needs: the
+fixtures' game counts, and the event's **entrants** (a byed entrant sits in no fixture,
+so the seated set is not the field). Both are loaded in
+``app.tournament_materialization``, neither is visible to a unit test, and getting
+either wrong stalls a live event silently rather than failing.
 """
 
 import uuid
@@ -37,11 +40,24 @@ from app.schemas.tournament import MAX_SWISS_ROUNDS
 from app.tournament_draw_settings import draw_settings_of
 from app.tournament_draws import DrawCurrency, draw_currency_by_event
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
-from tests._helpers import grant_permissions, make_user, start_session
+from tests._helpers import (
+    grant_permissions,
+    make_user,
+    opponent_session,
+    start_session,
+)
 
 # The tournament suite's own lifecycle helpers, imported rather than re-declared so a
-# change to how a tournament is started (or a status is staged) reaches this file too.
-from tests.test_tournaments import _go_live, _set_status, _withdraw
+# change to how a tournament is started (or a status is staged) reaches this file too —
+# including how a materialized fixture is called to a table and played out, so a swiss
+# match completes by exactly the route a round-robin or knockout one does.
+from tests.test_tournaments import (
+    _call_fixtures,
+    _go_live,
+    _set_status,
+    _win_fixture_match,
+    _withdraw,
+)
 
 SWISS = DrawType.swiss.value
 
@@ -676,6 +692,122 @@ async def test_a_lone_latecomer_leaving_an_odd_field_reads_as_that_rounds_bye(
 
     assert await _currency(db_session, event_id) is DrawCurrency.current
     assert (await _go_live(client, tournament_id)).status_code == 201
+
+
+# ----- the completion seam: a decided round pairs the next one -----------------------
+
+
+async def test_completing_every_round_one_match_pairs_and_materializes_round_two(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """**The whole slice, through the real endpoints.** Four entrants, three rounds. The
+    cut seats round 1 (1v3, 2v4) and leaves rounds 2 and 3 empty; go-live materializes
+    round 1 and nothing else. One result is not a table, so it pairs nothing. The
+    *second* result completes the round, and round 2 pairs the two winners against each
+    other and the two losers against each other — becoming matches in the same
+    transaction.
+
+    Round 1 is played as an **upset** (seed 3 beats seed 1) so that the answer is one
+    only the standings give: pairing by the draw order would meet 1v2 and 3v4, and
+    re-pairing round 1 would meet 1v3 and 2v4. Neither is what this asserts.
+
+    Pairs are compared **unordered**, and that is the honest thing rather than a
+    weakening. The two winners are level on wins, game difference and games won, so the
+    order between them — and therefore which pairing takes position 1, and which entrant
+    lands on side ``a`` — falls to the entry-id tiebreak, and an entry id here is a
+    server-minted uuid. The rank-ordered ``position`` claim is pinned in
+    ``test_draws.py``, where the ids are literals and the order is a fact.
+
+    What only this test can catch: the seam
+    (``app.tournament_materialization.materialize_event``) loading the game counts and
+    the **entrants** the strategy needs. A unit test cannot see either, and either one
+    missing leaves a live swiss event stalled after round 1 with nothing in the logs.
+    """
+    client, owner = authed_client
+    async with (
+        opponent_session(db_session, "swiss-two") as (client_2, user_2),
+        opponent_session(db_session, "swiss-three") as (client_3, user_3),
+        opponent_session(db_session, "swiss-four") as (client_4, user_4),
+    ):
+        tournament_id = await _tournament(client)
+        event_id = (await _create_event(client, tournament_id)).json()["id"]
+        entries = [
+            await _enter(db_session, event_id, user, seed=seed, minutes=seed)
+            for seed, user in enumerate((owner, user_2, user_3, user_4), start=1)
+        ]
+        assert (await _cut(client, tournament_id, event_id)).status_code == 201
+        await _set_status(db_session, tournament_id, TournamentStatus.published)
+        assert (await _go_live(client, tournament_id)).status_code == 201
+        # The ids as plain values, taken once: the ORM entries are expired by the
+        # ``expire_all`` below (and by the seam's own commits), and re-reading an
+        # attribute off an expired instance in async context is a ``MissingGreenlet``,
+        # not a lazy load.
+        entry_ids = [entry.id for entry in entries]
+        clients = dict(
+            zip(entry_ids, [client, client_2, client_3, client_4], strict=True)
+        )
+        seed_of = {entry_id: seed for seed, entry_id in enumerate(entry_ids, start=1)}
+
+        def pairs(
+            fixtures: list[TournamentFixture], round_number: int
+        ) -> set[frozenset[int]]:
+            """Each of the round's pairings as a set of seeds, unordered."""
+            return {
+                frozenset(
+                    seed
+                    for entry_id in (f.entry_a_id, f.entry_b_id)
+                    if (seed := seed_of.get(entry_id)) is not None
+                )
+                for f in fixtures
+                if f.round == round_number
+            }
+
+        def is_unpaired(fixtures: list[TournamentFixture], round_number: int) -> bool:
+            return all(
+                f.entry_a_id is None and f.entry_b_id is None
+                for f in fixtures
+                if f.round == round_number
+            )
+
+        rows = await _fixtures(db_session, event_id)
+        round_one = [f for f in rows if f.round == 1]
+        assert pairs(rows, 1) == {frozenset({1, 3}), frozenset({2, 4})}, "the cut's own"
+        assert all(f.match_id is not None for f in round_one), "round 1 materialized"
+        assert is_unpaired(rows, 2), "round 2 is TBD until round 1 is decided"
+
+        await _call_fixtures(db_session, tournament_id, round_one)
+        # The upset: seed 3 takes the first fixture, so the winners are seeds 3 and 2.
+        await _win_fixture_match(
+            round_one[0],
+            clients_by_entry=clients,
+            winner_entry_id=entry_ids[2],
+            rated=False,
+        )
+
+        db_session.expire_all()
+        rows = await _fixtures(db_session, event_id)
+        assert is_unpaired(rows, 2), (
+            "one result is not a table — the round is paired off all of them or none"
+        )
+
+        await _win_fixture_match(
+            round_one[1],
+            clients_by_entry=clients,
+            winner_entry_id=entry_ids[1],
+            rated=False,
+        )
+
+        db_session.expire_all()
+        rows = await _fixtures(db_session, event_id)
+        assert pairs(rows, 2) == {frozenset({2, 3}), frozenset({1, 4})}, (
+            "the two winners meet and the two losers meet — which is the standings' "
+            "answer, and neither the draw order's (1v2, 3v4) nor round 1's own (1v3, "
+            "2v4)"
+        )
+        assert all(f.match_id is not None for f in rows if f.round == 2), (
+            "and the paired round materializes in the same transaction"
+        )
+        assert is_unpaired(rows, 3), "round 3 waits for round 2's table"
 
 
 async def test_a_swiss_event_has_no_schedule_preview(

--- a/api/tests/test_swiss.py
+++ b/api/tests/test_swiss.py
@@ -25,10 +25,14 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
+from app.draws import _swiss_seated_pairings
 from app.models import (
     DrawType,
+    Match,
+    MatchStatus,
+    Tournament,
     TournamentEntry,
     TournamentEntryStatus,
     TournamentEvent,
@@ -36,11 +40,14 @@ from app.models import (
     TournamentStatus,
     User,
 )
-from app.schemas.tournament import MAX_SWISS_ROUNDS
+from app.schemas.tournament import MAX_SWISS_ROUNDS, TournamentFixtureRead
 from app.tournament_draw_settings import draw_settings_of
-from app.tournament_draws import DrawCurrency, draw_currency_by_event
+from app.tournament_draws import DrawCurrency, draw_currency_by_event, fixture_state
+from app.tournament_materialization import materialize_event
+from app.tournament_serialization import _seated_pairings
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import (
+    counted_statements,
     grant_permissions,
     make_user,
     opponent_session,
@@ -875,6 +882,185 @@ async def test_a_byed_entrant_is_credited_with_a_win_worth_zero_games(
             entry_ids[1],
             entry_ids[2],
         }, "round 2 seats the byed entrant, and the bye passes to the seed without one"
+
+
+async def test_advancing_a_swiss_event_costs_three_statements(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+) -> None:
+    """``materialize_event`` runs on the **completion seam** — every result submission
+    re-runs it, inside the score-accept transaction, under the match row lock — so what
+    the swiss advance costs there is not a micro-optimization.
+
+    Swiss is the draw type that loads the most: the fixtures, the fixtures' **game
+    counts** (it pairs down the standings) and the event's **entrants** (a bye is the
+    absence of a row, so the seated set is not the field). Three, and **three is the
+    whole of it** — one statement each, all of them batched over the event. Nothing in
+    the resulting fixtures shows the difference between that and a load moved inside the
+    round loop, or a field projected per fixture: both pair the identical round, and
+    both turn one round trip into one per round or one per pairing on a seam that runs
+    on every score. The round-robin twin of this pin
+    (``tests/test_tournaments.py``) is the other half of the same claim — that the three
+    draw types which read neither counts nor field still pay for neither.
+
+    Each of the three is asserted **by name** as well as by the count, so a load that
+    moved to a different table (or folded into the fixture statement) reds too rather
+    than quietly keeping the total at three.
+
+    Run against a round that is **partially** decided — one of round 1's two matches
+    completed, the other still on — which is exactly what the seam sees on the first of
+    a round's results. Nothing is pairable and nothing is newly ready, so the whole call
+    *is* the three loads. The completed match is load-bearing rather than scene-setting:
+    ``game_counts_by_match`` returns without a statement when no match has completed
+    (``if not counts``), so without it the game-count third of this pin would be
+    vacuous.
+    """
+    client, _ = authed_client
+    tournament_id, event_id, _ = await _field(client, db_session, 4)
+    assert (await _cut(client, tournament_id, event_id)).status_code == 201
+    await _set_status(db_session, tournament_id, TournamentStatus.published)
+    assert (await _go_live(client, tournament_id)).status_code == 201
+    # One of round 1's two matches completed, the other untouched: the round is not
+    # decided, so no round is pairable and no fixture is newly ready.
+    played, _still_on = [
+        f for f in await _fixtures(db_session, event_id) if f.round == 1
+    ]
+    assert played.match_id is not None
+    match = await db_session.get(Match, played.match_id)
+    assert match is not None
+    match.status = MatchStatus.completed
+    await db_session.commit()
+
+    async with counted_statements(engine) as (session, statements):
+        tournament = (
+            await session.execute(
+                select(Tournament).where(Tournament.id == uuid.UUID(tournament_id))
+            )
+        ).scalar_one()
+        event_row = (
+            await session.execute(
+                select(TournamentEvent).where(TournamentEvent.id == uuid.UUID(event_id))
+            )
+        ).scalar_one()
+        # Only the seam's own statements are counted, not the two loads that stand in
+        # for the caller already holding these rows.
+        statements.clear()
+        await materialize_event(session, tournament, event_row)
+
+    assert len(statements) == 3, statements
+    assert [s for s in statements if "tournament_fixtures" in s], (
+        "the fixtures, with their matches' statuses riding along on the same join"
+    )
+    assert [s for s in statements if "match_game_scores" in s], (
+        "the game counts, batched over the event — swiss pairs down the standings"
+    )
+    assert [s for s in statements if "tournament_entries" in s], (
+        "and the field, which the fixtures cannot yield: a byed entrant is in no row"
+    )
+
+
+# ----- the two layers' spellings of "a pairing is decided" ---------------------------
+
+
+#: What "decided" means, as a function of the linked match's **live status** — ``None``
+#: being a fixture that has not materialized into a match at all.
+#:
+#: Written out as a literal mapping rather than derived from either layer, so the test
+#: below pins the answer itself. Asserting only that the two layers agree would pass
+#: vacuously the day both of them start returning ``False`` for everything.
+_DECIDED_BY_MATCH_STATUS: dict[MatchStatus | None, bool] = {
+    None: False,
+    MatchStatus.pending: False,
+    MatchStatus.in_progress: False,
+    MatchStatus.completed: True,
+    MatchStatus.voided: True,
+}
+
+
+def test_the_draw_layer_and_the_read_layer_decide_a_pairing_alike() -> None:
+    """**One rule, two row shapes, and nothing but this test holding them together.**
+
+    ``app.draws`` reads a pairing's decidedness off a
+    :class:`~app.draws.FixtureState` (a live score, or a void that means there will
+    never be one); ``app.tournament_serialization`` reads it off a
+    ``TournamentFixtureRead`` (the match's terminal status). Both fill the same
+    :attr:`~app.draws.SeatedPairing.decided`, which is what gates a **bye** being
+    scored — so the two disagreeing means a bye credited in the director's standings
+    but not in the pairing of the next round, or the reverse.
+
+    They are deliberately **not** one shared predicate: the two hold genuinely
+    different rows, one an ORM projection and one a wire model, and forcing a common
+    shape on them would be a worse coupling than this. What is shared is the *answer*,
+    and this is where that is asserted — over the whole status domain, so a third
+    condition (a forfeit status, say) added on one side alone reds here rather than in
+    a live event.
+
+    Both inputs are built from **one** status literal per case, through the same gates
+    the two production loaders apply — game counts are keyed only for a completed match
+    (``app.tournament_queries.game_counts_by_match``), a match id is in the voided set
+    only for a voided one — so the case cannot be set up as agreeing.
+    """
+    assert set(_DECIDED_BY_MATCH_STATUS) == {None, *MatchStatus}, (
+        "every match status is named, so a new one has to be answered here rather "
+        "than falling through to whatever the two layers happen to do with it"
+    )
+    entry_a_id, entry_b_id = uuid.uuid4(), uuid.uuid4()
+
+    for match_status, decided in _DECIDED_BY_MATCH_STATUS.items():
+        match_id = uuid.uuid4() if match_status is not None else None
+        # The read layer's row, exactly as ``fixtures_by_event`` composes it: the status
+        # comes off an outer join on this same ``match_id``.
+        (from_the_read,) = _seated_pairings(
+            [
+                TournamentFixtureRead(
+                    id=uuid.uuid4(),
+                    pool_id=None,
+                    round=1,
+                    position=1,
+                    entry_a_id=entry_a_id,
+                    entry_b_id=entry_b_id,
+                    winner_entry_id=None,
+                    match_id=match_id,
+                    match_status=match_status,
+                    table_id=None,
+                    scheduled_start=None,
+                    pinned_at=None,
+                    call_notified_count=0,
+                    completed_at=None,
+                )
+            ]
+        )
+        # The draw layer's row, through the same bridge the completion seam projects
+        # with — and through the same two gates that seam loads its inputs behind.
+        (from_the_row,) = _swiss_seated_pairings(
+            [
+                fixture_state(
+                    TournamentFixture(
+                        id=uuid.uuid4(),
+                        event_id=uuid.uuid4(),
+                        pool_id=None,
+                        round=1,
+                        position=1,
+                        entry_a_id=entry_a_id,
+                        entry_b_id=entry_b_id,
+                        match_id=match_id,
+                    ),
+                    {match_id: (3, 1)}
+                    if match_id is not None and match_status is MatchStatus.completed
+                    else {},
+                    frozenset({match_id})
+                    if match_id is not None and match_status is MatchStatus.voided
+                    else frozenset(),
+                    None,
+                )
+            ]
+        )
+
+        assert (from_the_read.decided, from_the_row.decided) == (decided, decided), (
+            f"the read layer and the draw layer must both call a {match_status} "
+            f"pairing {'decided' if decided else 'undecided'}"
+        )
 
 
 async def test_a_swiss_event_has_no_schedule_preview(

--- a/api/tests/test_swiss.py
+++ b/api/tests/test_swiss.py
@@ -810,6 +810,73 @@ async def test_completing_every_round_one_match_pairs_and_materializes_round_two
         assert is_unpaired(rows, 3), "round 3 waits for round 2's table"
 
 
+async def test_a_byed_entrant_is_credited_with_a_win_worth_zero_games(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """**The bye scores, end to end.** Three entrants over two rounds: round 1 pairs
+    seeds 1 and 2 and seed 3 sits out. Seed 2 wins it, and the table then reads
+    2, 3, 1 — the byed entrant credited with a win and placed above the player who lost
+    a real match, but below the player who won one.
+
+    The row is the assertion that matters: **played 1, won 1, and no games either way**.
+    A nominal 3-0 for the bye would be invisible in the wins column and would show up
+    here as game counts nobody played, which is exactly the game difference that would
+    float a byed entrant over somebody who beat a real opponent.
+
+    Round 2 is paired in the same breath, seating the byed entrant and passing the bye
+    to seed 1 — the entrant who has not had one.
+    """
+    client, owner = authed_client
+    async with (
+        opponent_session(db_session, "swiss-bye-two") as (client_2, user_2),
+        opponent_session(db_session, "swiss-bye-three") as (client_3, user_3),
+    ):
+        tournament_id = await _tournament(client)
+        event_id = (await _create_event(client, tournament_id, rounds=2)).json()["id"]
+        entries = [
+            await _enter(db_session, event_id, user, seed=seed, minutes=seed)
+            for seed, user in enumerate((owner, user_2, user_3), start=1)
+        ]
+        assert (await _cut(client, tournament_id, event_id)).status_code == 201
+        await _set_status(db_session, tournament_id, TournamentStatus.published)
+        assert (await _go_live(client, tournament_id)).status_code == 201
+        entry_ids = [entry.id for entry in entries]
+        clients = dict(zip(entry_ids, [client, client_2, client_3], strict=True))
+
+        rows = await _fixtures(db_session, event_id)
+        round_one = [f for f in rows if f.round == 1]
+        await _call_fixtures(db_session, tournament_id, round_one)
+        await _win_fixture_match(
+            round_one[0],
+            clients_by_entry=clients,
+            winner_entry_id=entry_ids[1],
+            rated=False,
+        )
+
+        db_session.expire_all()
+        results = (await _event_read(client, tournament_id))["results"]
+
+        by_entry = {row["entry_id"]: row for row in results["rows"]}
+        byed = by_entry[str(entry_ids[2])]
+        assert (byed["played"], byed["wins"], byed["losses"]) == (1, 1, 0)
+        assert (byed["games_won"], byed["games_lost"]) == (0, 0), (
+            "a bye is worth zero games — a nominal score would be a game difference "
+            "nobody played for"
+        )
+        assert [row["entry_id"] for row in results["rows"]] == [
+            str(entry_ids[1]),
+            str(entry_ids[2]),
+            str(entry_ids[0]),
+        ], "the winner, then the bye, then the loser"
+
+        fixtures = await _fixtures(db_session, event_id)
+        (round_two,) = [f for f in fixtures if f.round == 2]
+        assert {round_two.entry_a_id, round_two.entry_b_id} == {
+            entry_ids[1],
+            entry_ids[2],
+        }, "round 2 seats the byed entrant, and the bye passes to the seed without one"
+
+
 async def test_a_swiss_event_has_no_schedule_preview(
     authed_client: tuple[AsyncClient, User], db_session: AsyncSession
 ) -> None:

--- a/api/tests/test_swiss.py
+++ b/api/tests/test_swiss.py
@@ -17,14 +17,14 @@ either wrong stalls a live event silently rather than failing.
 """
 
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from app.draws import _swiss_seated_pairings
@@ -40,11 +40,16 @@ from app.models import (
     TournamentStatus,
     User,
 )
-from app.schemas.tournament import MAX_SWISS_ROUNDS, TournamentFixtureRead
+from app.results import SwissResults
+from app.schemas.tournament import (
+    MAX_SWISS_ROUNDS,
+    TournamentEntrantRead,
+    TournamentFixtureRead,
+)
 from app.tournament_draw_settings import draw_settings_of
 from app.tournament_draws import DrawCurrency, draw_currency_by_event, fixture_state
 from app.tournament_materialization import materialize_event
-from app.tournament_serialization import _seated_pairings
+from app.tournament_serialization import _field_input, _seated_pairings
 from app.tournaments import TOURNAMENT_CREATE, TOURNAMENT_VIEW
 from tests._helpers import (
     counted_statements,
@@ -884,6 +889,130 @@ async def test_a_byed_entrant_is_credited_with_a_win_worth_zero_games(
         }, "round 2 seats the byed entrant, and the bye passes to the seed without one"
 
 
+async def test_a_field_that_shrinks_mid_event_still_plays_out_and_finishes(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """**The whole of both bugs, through the real endpoints.** Four entrants, three
+    rounds — two rows a round. The cut seats round 1 (1v3, 2v4) and go-live materializes
+    it. Seed 4 then **withdraws while the event is live**, and the three survivors make
+    one pairing a round, so rounds 2 and 3 each keep a row nothing will ever seat.
+
+    Read as pending, that row made its round neither wholly unpaired nor decided: round
+    2 was paired and then round 3 never was, on that advance and every one after, with
+    no move a director could make — a played draw cannot be un-cut. And the row was
+    counted as a pairing still to come, so the event could not read ``complete`` even
+    once every match that existed had been played.
+
+    Seed 4 is in no round after the first, which is also what made them look byed. The
+    table below is where that shows: **one match, one loss**, not the two bye wins a
+    departed player was collecting.
+
+    **The withdrawal is written as the statement that causes it in production.** The
+    ordinary withdrawal endpoint is window-gated and answers 409 on a live event, so
+    nothing here could reach the pairing code through it. ``app.account_merge`` can and
+    does: when a guest who is already playing claims a verified account that is also
+    entered, the merge flips the colliding entry to ``withdrawn`` — deliberately, rather
+    than deleting it, *because* the row seats fixtures that have been played. This is
+    that ``UPDATE``. Driving ``merge_user`` itself would add a re-pointed user, a voided
+    self-play match and a re-solve without adding anything this asserts.
+    """
+    client, owner = authed_client
+    async with (
+        opponent_session(db_session, "swiss-shrink-two") as (client_2, user_2),
+        opponent_session(db_session, "swiss-shrink-three") as (client_3, user_3),
+        opponent_session(db_session, "swiss-shrink-four") as (client_4, user_4),
+    ):
+        tournament_id = await _tournament(client)
+        event_id = (await _create_event(client, tournament_id)).json()["id"]
+        entries = [
+            await _enter(db_session, event_id, user, seed=seed, minutes=seed)
+            for seed, user in enumerate((owner, user_2, user_3, user_4), start=1)
+        ]
+        assert (await _cut(client, tournament_id, event_id)).status_code == 201
+        await _set_status(db_session, tournament_id, TournamentStatus.published)
+        assert (await _go_live(client, tournament_id)).status_code == 201
+        entry_ids = [entry.id for entry in entries]
+        clients = dict(
+            zip(entry_ids, [client, client_2, client_3, client_4], strict=True)
+        )
+
+        await db_session.execute(
+            update(TournamentEntry)
+            .where(TournamentEntry.id == entry_ids[3])
+            .values(status=TournamentEntryStatus.withdrawn)
+        )
+        await db_session.commit()
+
+        async def play(round_number: int, winner_index: int) -> None:
+            """Call and win the one fixture of ``round_number`` that carries a pairing.
+
+            Round 1 has two, and both are played by the same walk — the round is only
+            decided once every pairing in it is, whoever has since left the event."""
+            db_session.expire_all()
+            rows = [
+                f
+                for f in await _fixtures(db_session, event_id)
+                if f.round == round_number and f.entry_a_id is not None
+            ]
+            await _call_fixtures(db_session, tournament_id, rows)
+            for row in rows:
+                winner = (
+                    entry_ids[winner_index]
+                    if entry_ids[winner_index] in (row.entry_a_id, row.entry_b_id)
+                    else row.entry_a_id
+                )
+                assert winner is not None
+                await _win_fixture_match(
+                    row,
+                    clients_by_entry=clients,
+                    winner_entry_id=winner,
+                    rated=False,
+                )
+
+        # Round 1 as the cut dealt it, seed 4 included: seed 1 beats 3, and 2 beats 4.
+        await play(1, winner_index=0)
+
+        db_session.expire_all()
+        round_two = [f for f in await _fixtures(db_session, event_id) if f.round == 2]
+        paired = [f for f in round_two if f.entry_a_id is not None]
+        assert len(round_two) == 2, "the cut's second row is still there"
+        assert [{f.entry_a_id, f.entry_b_id} for f in paired] == [
+            {entry_ids[0], entry_ids[1]}
+        ], "three survivors make one pairing, and seed 3 sits round 2 out"
+
+        await play(2, winner_index=0)
+
+        db_session.expire_all()
+        round_three = [f for f in await _fixtures(db_session, event_id) if f.round == 3]
+        paired = [f for f in round_three if f.entry_a_id is not None]
+        assert [{f.entry_a_id, f.entry_b_id} for f in paired] == [
+            {entry_ids[0], entry_ids[2]}
+        ], (
+            "round 3 is paired off round 2's table — the round whose unpairable row "
+            "stalled the walk for good, leaving the event unplayable from here"
+        )
+
+        await play(3, winner_index=0)
+
+        db_session.expire_all()
+        results = (await _event_read(client, tournament_id))["results"]
+
+        assert results["complete"] is True, (
+            "every fixture that could ever be paired has been played, so the event is "
+            "over — the rows the cut wrote for a field that left are not results owed"
+        )
+        assert results["champion"] == str(entry_ids[0])
+        departed = {row["entry_id"]: row for row in results["rows"]}[str(entry_ids[3])]
+        assert (departed["played"], departed["wins"], departed["losses"]) == (
+            1,
+            0,
+            1,
+        ), (
+            "the entrant who left is still listed — they played a real match — with "
+            "the record they actually have, not a bye win for every round since"
+        )
+
+
 async def test_advancing_a_swiss_event_costs_three_statements(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
@@ -1061,6 +1190,171 @@ def test_the_draw_layer_and_the_read_layer_decide_a_pairing_alike() -> None:
             f"the read layer and the draw layer must both call a {match_status} "
             f"pairing {'decided' if decided else 'undecided'}"
         )
+
+
+# ----- a field that shrinks after the cut, as the read layer sees it -----------------
+
+
+def _entry(number: int) -> uuid.UUID:
+    """The entry id of the ``number``-th seed, as a readable literal."""
+    return uuid.UUID(int=number)
+
+
+def _entrant(number: int) -> TournamentEntrantRead:
+    """One **active** entrant, in the shape ``active_entrants_by_event`` returns."""
+    return TournamentEntrantRead(
+        id=_entry(number),
+        user_id=uuid.UUID(int=100 + number),
+        username=f"seed{number}",
+        seed=number,
+        rating=None,
+    )
+
+
+def _row(
+    *,
+    round_number: int,
+    position: int,
+    pairing: tuple[int, int] | None = None,
+    winner: int | None = None,
+    voided: bool = False,
+) -> TournamentFixtureRead:
+    """One fixture row: unpaired (both sides ``None``) when ``pairing`` is omitted,
+    carrying a **completed** match when ``winner`` is given, and a **voided** one — a
+    pairing that happened and will never produce a result — when ``voided`` is set."""
+    status = MatchStatus.completed if winner is not None else None
+    if voided:
+        status = MatchStatus.voided
+    match_id = (
+        uuid.UUID(int=1000 + round_number * 10 + position)
+        if status is not None
+        else None
+    )
+    return TournamentFixtureRead(
+        id=uuid.UUID(int=2000 + round_number * 10 + position),
+        pool_id=None,
+        round=round_number,
+        position=position,
+        entry_a_id=_entry(pairing[0]) if pairing else None,
+        entry_b_id=_entry(pairing[1]) if pairing else None,
+        winner_entry_id=_entry(winner) if winner is not None else None,
+        match_id=match_id,
+        match_status=status,
+        table_id=None,
+        scheduled_start=None,
+        pinned_at=None,
+        call_notified_count=0,
+        completed_at=None,
+    )
+
+
+def _counts(
+    fixtures: Sequence[TournamentFixtureRead],
+) -> dict[uuid.UUID, tuple[int, int]]:
+    """The game counts of every **completed** match among ``fixtures``, 3–0 to
+    ``entry_a`` — keyed as ``game_counts_by_match`` keys them, which is completed
+    matches and nothing else, so a voided pairing has no entry here either."""
+    return {
+        f.match_id: (3, 0)
+        for f in fixtures
+        if f.match_id is not None and f.match_status is MatchStatus.completed
+    }
+
+
+#: A 4-entrant, 3-round swiss (two rows a round) whose field lost seed 4 **after** the
+#: cut, played out to the last round. Seed 4's round-1 match still stands — that is why
+#: the merge withdraws rather than deletes — and every round after it holds one pairing
+#: for the three survivors plus one row nothing will ever seat.
+_SHRUNK_FIXTURES = [
+    _row(round_number=1, position=1, pairing=(1, 3), winner=1),
+    _row(round_number=1, position=2, pairing=(2, 4), winner=2),
+    _row(round_number=2, position=1, pairing=(1, 2), winner=1),
+    _row(round_number=2, position=2),
+    _row(round_number=3, position=1, pairing=(1, 3), winner=1),
+    _row(round_number=3, position=2),
+]
+
+_SHRUNK_GAME_COUNTS = _counts(_SHRUNK_FIXTURES)
+
+#: The three entrants still in the event. Seed 4 is absent —
+#: ``active_entrants_by_event`` filters withdrawn entries out at the only place that
+#: reads them.
+_SURVIVORS = [_entrant(1), _entrant(2), _entrant(3)]
+
+
+def test_a_shrunk_field_can_still_finish_its_event() -> None:
+    """**The event has to be able to end.** Every round is cut with ⌊n/2⌋ rows from the
+    field at the cut, so a field that shrinks leaves rows nothing will ever seat — and
+    counting those as pairings still to come held the event one outcome short of
+    ``complete`` forever: no champion, on a table where every match had been played.
+
+    Four rows of the six here can ever carry a pairing (both of round 1's, and one each
+    of rounds 2 and 3), and all four have a result. Count the six and the event reads
+    live with two phantom matches outstanding."""
+    field = _field_input(_SURVIVORS, _SHRUNK_FIXTURES, _SHRUNK_GAME_COUNTS)
+
+    assert field.fixture_count == 4, (
+        "the two rows the cut wrote for a field that no longer exists are not "
+        "fixtures that can still yield a result"
+    )
+
+    standings = SwissResults().tabulate(field)
+
+    assert standings.complete is True
+    assert standings.champion == _entry(1)
+
+
+def test_a_void_and_a_shrink_in_one_round_both_come_off_the_count() -> None:
+    """The two ways a row stops being a result the event is waiting for, in the shape
+    that produces both at once.
+
+    An account merge that collides on a played event voids the guest-vs-survivor match
+    *and* withdraws the guest — so in a four-entrant cut the same round 1 holds a voided
+    pairing, while every round after it holds a row the shrunk field can never seat. The
+    count subtracts a voided pairing from a round that is **full** (nothing left to pair
+    there) and drops an unpairable row from rounds that are not, and the event still has
+    to be able to end."""
+    fixtures = [
+        _row(round_number=1, position=1, pairing=(1, 3), winner=1),
+        _row(round_number=1, position=2, pairing=(2, 4), voided=True),
+        _row(round_number=2, position=1, pairing=(1, 2), winner=1),
+        _row(round_number=2, position=2),
+        _row(round_number=3, position=1, pairing=(1, 3), winner=1),
+        _row(round_number=3, position=2),
+    ]
+
+    field = _field_input(_SURVIVORS, fixtures, _counts(fixtures))
+
+    assert field.fixture_count == 3, (
+        "round 1 owes one result rather than two — the voided pairing will never "
+        "produce one — and rounds 2 and 3 owe one each rather than two"
+    )
+    assert SwissResults().tabulate(field).complete is True
+
+
+def test_a_withdrawn_but_seated_entrant_is_not_given_a_bye_they_never_took() -> None:
+    """**A bye is derived from the active field, not from who the rows happen to name.**
+
+    Seed 4 left after round 1 and is in no round after it. Deriving the byes over the
+    union of the active entrants and the seated ones asked "who is missing from this
+    round?" and got seed 4 back every time — a win per remaining round, up to ``R − 1``
+    of them, credited to somebody who had gone home. Nothing about the table looked
+    wrong: the event still completed, with the wrong order in it.
+
+    Seed 4 still has a **row**, and must: they played a real match, and dropping them
+    would be a ``KeyError`` on the first outcome that names them. The row reads what
+    they actually did — one match, one loss."""
+    field = _field_input(_SURVIVORS, _SHRUNK_FIXTURES, _SHRUNK_GAME_COUNTS)
+
+    assert field.byes == (_entry(3), _entry(2)), (
+        "seed 3 sat round 2 out and seed 2 sat round 3 out — and nobody else did"
+    )
+    assert _entry(4) in field.entrants, "somebody who played is still in the table"
+
+    rows = {row.entry_id: row for row in SwissResults().tabulate(field).rows}
+
+    departed = rows[_entry(4)]
+    assert (departed.played, departed.wins, departed.losses) == (1, 0, 1)
 
 
 async def test_a_swiss_event_has_no_schedule_preview(

--- a/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
+++ b/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
@@ -46,11 +46,17 @@ position (plus a pool, when pooled), sides nullable while unknown. One table,
 Each `DrawType` is a strategy behind a `Protocol` with two pure operations:
 
 - `plan_initial(config, ordered_entrants) → [PlannedFixture]` — cuts the draw.
-- `advance(fixtures) → AdvancePlan` — reads the persisted state and returns
-  side-fills for TBD fixtures plus the fixtures now ready to materialize.
-  **Idempotent**: against an unchanged state it returns an empty plan, so it is
-  re-run after *every* result (and at go-live) rather than triggered by
-  carefully-chosen events.
+- `advance(fixtures, ordered_entrants) → AdvancePlan` — reads the persisted
+  state and returns side-fills for TBD fixtures plus the fixtures now ready to
+  materialize. **Idempotent**: against an unchanged state it returns an empty
+  plan, so it is re-run after *every* result (and at go-live) rather than
+  triggered by carefully-chosen events.
+
+  It takes the **field** as well as the fixtures because a swiss bye is the
+  absence of a fixture row, so a swiss draw cannot recover its own field from
+  the rows it wrote. The three other draw types seat every entrant somewhere and
+  never read the argument, which `app.draws.reads_entrants` says once so the
+  caller knows whether to load it at all.
 
   Idempotence forces the definition of **ready**: both sides known **and** not
   already materialized (`match_id is None`) **and** not already decided

--- a/docs/adr/20260805-swiss-pre-cuts-every-round-and-pairs-each-one-on-advance.md
+++ b/docs/adr/20260805-swiss-pre-cuts-every-round-and-pairs-each-one-on-advance.md
@@ -112,10 +112,33 @@ distinct-opponent count alone. That justification was off by one for an odd fiel
 and the rule **refused a legal draw**: a 5-entrant event could not play 5 rounds,
 which is a rematch-free swiss and the fullest one that field can play.
 
+**The bound is necessary, not sufficient.** Below it a rematch-free pairing
+exists, but the greedy walk does not always find one. Five entrants over four
+rounds repeat a pairing in round 3, while `1-4` and `5-2` was available. Finding
+the rematch-free pairing in every case is a maximum-weight matching problem, and
+this draw layer is deliberately pure and deterministic, with no solver. We accept
+the occasional avoidable rematch rather than give a pure domain a solver
+dependency, and rather than refuse to pair, which would strand a live event.
+
 ## Consequences
 
-Swiss costs no change to the strategy contract, no change to `AdvancePlan`, and no
-migration beyond the settings object it shares with every other draw type.
+Swiss costs no change to `AdvancePlan` and no migration beyond the settings object
+it shares with every other draw type.
+
+**Correction, 2026-08-05.** This section first claimed swiss cost *no change to the
+strategy contract*. That turned out to be wrong, and the reason is worth keeping.
+`advance()` now takes the ordered field as well as the fixtures.
+
+The fixtures cannot name the field. A byed entrant sits in no fixture row, by
+definition. So does a latecomer who joined a draw cut for an even field, because
+`floor(8/2)` and `floor(9/2)` are the same four fixtures. Pairing from the seated
+set therefore byes the same entrant every round and never pairs the latecomer at
+all. Only the entrants know who is playing.
+
+The claim was right about `AdvancePlan`, which is the part that mattered: swiss
+still fills existing rows and creates none, so the draw is still cut exactly once
+and ADR-0786 stands. But the contract did move, and a reader trusting the original
+sentence would have been misled.
 
 The scheduler needs no change either. It already asserts both sides are known and
 its caller already drops fixtures that do not qualify, so an unpaired later round

--- a/docs/adr/20260805-swiss-pre-cuts-every-round-and-pairs-each-one-on-advance.md
+++ b/docs/adr/20260805-swiss-pre-cuts-every-round-and-pairs-each-one-on-advance.md
@@ -120,6 +120,49 @@ this draw layer is deliberately pure and deterministic, with no solver. We accep
 the occasional avoidable rematch rather than give a pure domain a solver
 dependency, and rather than refuse to pair, which would strand a live event.
 
+### A round's capacity is `floor(active field / 2)`, and rows beyond it are unpairable
+
+Added 2026-08-06, after code review found two bugs that share this root.
+
+Pre-cutting fixes each round's row count at the cut, as `cut_size // 2`. The
+**active field can still shrink afterwards.** Cutting has no status gate, and
+`account_merge` withdraws a colliding entry on a live, played event — it withdraws
+rather than deletes precisely because the row seats played fixtures. So a guest
+playing in a live swiss draw who claims a verified account already entered in that
+event drops the field by one.
+
+When that happens the pre-written rows outnumber the pairings the field can make.
+So a round's **capacity** is `floor(len(active field) / 2)`, and a round is fully
+paired when its filled rows reach that capacity — not when every written row is
+filled. Rows beyond capacity are **permanently unpairable**, not pending.
+
+That distinction has to hold in three places or the problem only moves: the pairing
+gate, decidedness, and the completeness count. Miss the second and an unpairable
+row holds its round open forever. Miss the third and the event can never read
+complete.
+
+**The two bugs this fixes, neither of which anything pinned.** Requiring every row
+filled meant a shrunk field left rows NULL, after which the round was neither
+wholly unpaired nor decided and the draw **stopped pairing forever** — with no
+operator recourse, since a played draw cannot be un-cut. Separately, the results
+layer derived byes from the active entrants *unioned with every seated entry*, so a
+departed entrant read as byed in every later round and collected a win for each
+one.
+
+The union itself is right and stays: a player who actually played keeps a row in
+the table. Only the **bye derivation** narrows to the active field, so both layers
+pair and score from one field.
+
+The reverse case is unchanged and still correct: a field that *grew* by one has one
+more pairing than rows, and that pairing is dropped.
+
+**One claim this overturned.** `_swiss_bye`'s fallback — take the lowest-ranked
+entrant once everybody has had a bye — was documented as unreachable, on the
+grounds that a legal cut has fewer rounds than entrants. Under a shrunk field it is
+reachable: six entrants cut for five rounds, three left after round 1, and by round
+5 nobody is byeless. It is now pinned by a test driven through real cuts and
+advances rather than asserted to be impossible.
+
 ## Consequences
 
 Swiss costs no change to `AdvancePlan` and no migration beyond the settings object

--- a/docs/adr/20260805-swiss-standings-add-buchholz-and-guard-head-to-head.md
+++ b/docs/adr/20260805-swiss-standings-add-buchholz-and-guard-head-to-head.md
@@ -62,6 +62,32 @@ A bye is the absence of a fixture row, so a byed round produced no opponent and
 adds no term to the sum. This falls out of the definition rather than needing a
 special case.
 
+### But a bye win *does* count toward the Buchholz of whoever played that entrant
+
+Added 2026-08-05, after the bye's scoring landed and made the question real.
+
+A bye scores as a win. Buchholz sums an entrant's opponents' win counts. So the
+question is whether those counts are the wins the standings display, bye wins
+included, or some adjusted number that strips them out.
+
+**They are the wins the standings display.** Buchholz reads the same wins column
+a director is looking at.
+
+The case against is real: a bye win is not evidence of strength, so counting it
+slightly inflates the Buchholz of whoever happened to play the byed entrant. The
+case for wins anyway:
+
+- Stripping bye wins would mean **two definitions of "wins"** in one module — the
+  one the table shows and a private one Buchholz uses. Avoiding exactly that
+  divergence is why this chain lives in a shared module at all (ADR 20260727).
+- A director can verify Buchholz by adding up their opponents' win columns. Under
+  an adjusted number that arithmetic silently fails to reconcile, and the figure
+  reads as a bug.
+
+The inflation is bounded at one win per opponent per event, and it lands on
+whoever played the entrant the format handed a bye to, which is arbitrary rather
+than systematic.
+
 A bye still scores as a **win worth zero games** in step 1. The win is granted
 because a player must not be punished for a scheduling artifact. The games are
 zero so the bye stays neutral on steps 4 and 5, rather than awarding difference

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -331,6 +331,53 @@ export class TournamentDetailPage {
     return this.page.getByTestId(`pool-standings-${poolId}`)
   }
 
+  // ----- swiss standings (event card) ---------------------------------------
+
+  /** A **swiss** event's standings — *one* table over the whole field, because swiss has
+   * no pools (ADR "swiss pre-cuts every round and pairs each one on advance").
+   *
+   * A different section from `standingsPanel`, which groups its tables under pools: a
+   * swiss event ranks everybody against everybody, and reading the pooled one would be a
+   * spec that could not tell "the field is ranked" from "there are no pools to show". */
+  swissStandings(eventId: string): Locator {
+    return this.page.getByTestId(`swiss-standings-panel-${eventId}`)
+  }
+
+  /** **Every row of the swiss standings, in the order the page lays them out** — the
+   * finishing order a director reads, top to bottom.
+   *
+   * Addressed by the testid *pattern* so the set is "the rows", whatever entries they
+   * are; each row's own testid names the **server-minted entry id** it is for, which is
+   * what `swissStandingRow` asks for and what makes "the table is in the server's order"
+   * assertable rather than inferred from names. */
+  swissStandingsRows(eventId: string): Locator {
+    return this.swissStandings(eventId).getByTestId(/^standing-row-/)
+  }
+
+  /** One entry's row of the swiss standings, by the **entry id** the server minted. */
+  swissStandingRow(eventId: string, entryId: string): Locator {
+    return this.swissStandings(eventId).getByTestId(`standing-row-${entryId}`)
+  }
+
+  /** One entry's **wins** cell — the third column of the standings table (`#`, `Player`,
+   * `W`, `L`, `Diff`, `GW`).
+   *
+   * The columns carry no test hooks of their own, so they are addressed by index here,
+   * once, rather than in every spec that reads one. This is the cell a **bye** is visible
+   * in at all: a bye is scored as a win worth zero games (ADR "swiss standings add
+   * Buchholz"), so the byed entrant's win shows up here and nowhere else — `GW` stays 0,
+   * which is the other half of the same fact (`swissStandingGamesWon`). */
+  swissStandingWins(eventId: string, entryId: string): Locator {
+    return this.swissStandingRow(eventId, entryId).getByRole('cell').nth(2)
+  }
+
+  /** One entry's **games won** cell — the sixth column. Zero for a bye, which is what
+   * stops a scheduling artifact nobody played from lifting its holder over somebody who
+   * beat a real opponent. */
+  swissStandingGamesWon(eventId: string, entryId: string): Locator {
+    return this.swissStandingRow(eventId, entryId).getByRole('cell').nth(5)
+  }
+
   /** The **two-stage** champion callout — the one a round-robin-then-knockout event
    * crowns (ADR 20260727).
    *

--- a/e2e/support/swiss-draw.ts
+++ b/e2e/support/swiss-draw.ts
@@ -1,0 +1,218 @@
+import type { Guest } from './match-api'
+
+// Composed-stack API reader for a **swiss** event's draw and standings — the two facts a
+// swiss spec asserts that a browser cannot name on its own.
+//
+// A fixture line on screen reads "alice vs bob", which is enough to say a round is paired
+// and nothing like enough to say *who sat out*: a bye is the ABSENCE of a fixture row
+// (CONTEXT.md, "Bye"), so the byed entrant is defined by not appearing anywhere, and
+// "nobody rendered them" is exactly what a locator cannot assert about a name it does not
+// know. The same goes for the standings ORDER the next round is paired down: the rendered
+// table shows it, but a spec has to hold that order as a value before it can compare a
+// pairing against it.
+//
+// So this reads the same `GET /v1/tournaments/{id}` the page reads, joins each fixture's
+// entry refs to the usernames the spec minted, and hands back the draw round by round.
+// Read-only — nothing here writes, and every load-bearing assertion still lands on the
+// page. This is the seam that says WHICH names to look for.
+
+const API = '/api/v1'
+
+/** One fixture of a swiss round, with its sides joined to usernames.
+ *
+ * A side is `null` for a round that is cut but not yet paired — the `TBD` the draw panel
+ * renders (ADR-0786: never a bye, which has no row at all). */
+export interface SwissFixture {
+  /** The fixture's position within its round, which for swiss **is its pairing rank**
+   * (ADR "swiss pre-cuts every round and pairs each one on advance"). Fixtures come back
+   * in this order. */
+  readonly position: number
+  readonly a: string | null
+  readonly b: string | null
+}
+
+/** One round of a swiss draw as the server holds it. */
+export interface SwissRound {
+  readonly round: number
+  /** The round's fixtures in `position` — that is, pairing-rank — order. */
+  readonly fixtures: ReadonlyArray<SwissFixture>
+  /** Whether anybody at all is seated in this round. The same question the draw panel
+   * asks of the sides rather than of the round number, so a paired round 2 reads as
+   * paired here and there. */
+  readonly paired: boolean
+  /** The entrants this round seats in **no** fixture — its byes, derived exactly as the
+   * server derives them (`app.draws.swiss_byes`): by asking who is missing from a round
+   * that was paired.
+   *
+   * **Empty for an unpaired round**, which is not a round everybody was byed in but a
+   * round nobody has been paired into yet — the ordinary state of every later round of a
+   * freshly cut draw. */
+  readonly satOut: ReadonlyArray<string>
+}
+
+/** One row of a swiss event's standings, joined to the entrant's username.
+ *
+ * The **server's** row and the server's rank, not a re-derivation: this is the table the
+ * director reads and the order the next round is paired down, so a spec comparing a
+ * pairing against it has to take it from the same place both of those do. */
+export interface SwissStanding {
+  readonly entryId: string
+  readonly username: string
+  readonly rank: number
+  readonly wins: number
+  readonly losses: number
+  readonly gamesWon: number
+}
+
+/** The slice of the tournament detail this module parses: the event's field, its
+ * fixtures' rounds and sides, and its results. */
+interface SwissEventPayload {
+  readonly id: string
+  readonly entrants: ReadonlyArray<{ readonly id: string; readonly username: string }>
+  readonly fixtures: ReadonlyArray<{
+    readonly round: number
+    readonly position: number
+    readonly entry_a_id: string | null
+    readonly entry_b_id: string | null
+  }>
+  readonly results: SwissResultsPayload | null
+}
+
+/** The `swiss_standings` arm of the results union — the only arm a swiss event may read
+ * out (ADR "swiss pre-cuts every round and pairs each one on advance"). */
+interface SwissResultsPayload {
+  readonly kind: string
+  readonly rows?: ReadonlyArray<{
+    readonly entry_id: string
+    readonly rank: number
+    readonly wins: number
+    readonly losses: number
+    readonly games_won: number
+  }>
+}
+
+/** Read one event off the tournament detail, typed to the swiss slice above. */
+async function readSwissEvent(
+  viewer: Guest,
+  tournamentId: string,
+  eventId: string,
+): Promise<SwissEventPayload> {
+  const res = await viewer.ctx.get(`${API}/tournaments/${tournamentId}`)
+  if (!res.ok()) {
+    throw new Error(`load tournament failed: ${res.status()} ${await res.text()}`)
+  }
+  const detail = (await res.json()) as {
+    events: ReadonlyArray<SwissEventPayload>
+  }
+  const event = detail.events.find((candidate) => candidate.id === eventId)
+  if (!event) {
+    throw new Error(`no event ${eventId} on tournament ${tournamentId}`)
+  }
+  return event
+}
+
+/**
+ * Read a swiss event's draw **round by round**, with every side joined to a username and
+ * each round's byes derived from who it does not seat.
+ *
+ * Rounds come back in round order and their fixtures in `position` order, which for swiss
+ * is pairing-rank order — so a caller compares them against a standings order directly,
+ * without sorting anything itself.
+ */
+export async function readSwissRounds(
+  viewer: Guest,
+  tournamentId: string,
+  eventId: string,
+): Promise<SwissRound[]> {
+  const event = await readSwissEvent(viewer, tournamentId, eventId)
+  const nameOf = new Map(event.entrants.map((entrant) => [entrant.id, entrant.username]))
+  const seatOf = (entryId: string | null): string | null => {
+    if (entryId === null) return null
+    const username = nameOf.get(entryId)
+    if (username === undefined) {
+      throw new Error(
+        `event ${eventId} seats entry ${entryId}, which is on none of its ${nameOf.size} entrants`,
+      )
+    }
+    return username
+  }
+
+  const byRound = new Map<number, SwissFixture[]>()
+  for (const fixture of event.fixtures) {
+    const round = byRound.get(fixture.round) ?? []
+    round.push({
+      position: fixture.position,
+      a: seatOf(fixture.entry_a_id),
+      b: seatOf(fixture.entry_b_id),
+    })
+    byRound.set(fixture.round, round)
+  }
+
+  const field = event.entrants.map((entrant) => entrant.username)
+  return [...byRound.keys()]
+    .sort((left, right) => left - right)
+    .map((round) => {
+      const fixtures = [...byRound.get(round)!].sort(
+        (left, right) => left.position - right.position,
+      )
+      const seated = new Set(
+        fixtures
+          .flatMap((fixture) => [fixture.a, fixture.b])
+          .filter((side): side is string => side !== null),
+      )
+      return {
+        round,
+        fixtures,
+        paired: seated.size > 0,
+        // A round nobody is paired into byes nobody — the same distinction
+        // `swiss_byes` draws, and the reason it takes pairings rather than a round
+        // count. Without it every forthcoming round would read as ⌊n/2⌋ byes.
+        satOut:
+          seated.size === 0 ? [] : field.filter((username) => !seated.has(username)),
+      }
+    })
+}
+
+/**
+ * Read a swiss event's **standings** off the same payload the table on screen is rendered
+ * from, in the server's finishing order.
+ *
+ * Throws when the event reads out any other results shape, naming the one it got. That is
+ * a real failure and not defensiveness: a swiss event routed through the round-robin arm
+ * would come back with its rows grouped under pools that swiss does not have, and the
+ * caller would see an empty order rather than a wrong one.
+ */
+export async function readSwissStandings(
+  viewer: Guest,
+  tournamentId: string,
+  eventId: string,
+): Promise<SwissStanding[]> {
+  const event = await readSwissEvent(viewer, tournamentId, eventId)
+  const results = event.results
+  if (results === null) {
+    throw new Error(`event ${eventId} has no results yet — was the draw cut?`)
+  }
+  if (results.kind !== 'swiss_standings' || results.rows === undefined) {
+    throw new Error(
+      `event ${eventId} reads out "${results.kind}" results — a swiss event reads out ` +
+        'one pool-less "swiss_standings" table',
+    )
+  }
+  const nameOf = new Map(event.entrants.map((entrant) => [entrant.id, entrant.username]))
+  return results.rows.map((row) => {
+    const username = nameOf.get(row.entry_id)
+    if (username === undefined) {
+      throw new Error(
+        `standings row ${row.entry_id} names no entrant of event ${eventId}`,
+      )
+    }
+    return {
+      entryId: row.entry_id,
+      username,
+      rank: row.rank,
+      wins: row.wins,
+      losses: row.losses,
+      gamesWon: row.games_won,
+    }
+  })
+}

--- a/e2e/support/swiss-draw.ts
+++ b/e2e/support/swiss-draw.ts
@@ -60,7 +60,6 @@ export interface SwissStanding {
   readonly username: string
   readonly rank: number
   readonly wins: number
-  readonly losses: number
   readonly gamesWon: number
 }
 
@@ -86,7 +85,6 @@ interface SwissResultsPayload {
     readonly entry_id: string
     readonly rank: number
     readonly wins: number
-    readonly losses: number
     readonly games_won: number
   }>
 }
@@ -211,7 +209,6 @@ export async function readSwissStandings(
       username,
       rank: row.rank,
       wins: row.wins,
-      losses: row.losses,
       gamesWon: row.games_won,
     }
   })

--- a/e2e/support/tournament-play.ts
+++ b/e2e/support/tournament-play.ts
@@ -58,20 +58,49 @@ interface PlayableEvent {
  * nothing knocked out yet — and that moment does not exist if the helper plays on. */
 export type PlayStage = 'pools' | 'all'
 
+/** Who wins one fixture, given the two guests seated in it (side `a` first).
+ *
+ * A parameter rather than a rule, because in swiss **the winners decide the standings and
+ * the standings decide the next pairing** — so a spec proving that a round is paired from
+ * the standings has to be able to choose winners whose order is *not* the draw order. With
+ * the default rule below the two orders coincide exactly (round 1 seeds the top half
+ * against the bottom half, so the first half of the draw order wins every fixture), and a
+ * pairing that ignored the standings altogether would produce the same fixtures as one that
+ * honours them. The assertion would pass against the bug. */
+export type PickWinner = (a: Guest, b: Guest) => Guest
+
+/** **The earlier-registered entrant wins**, `entrants` being the field in registration
+ * order — `playEvent`'s default rule, and the picker `playSwissRound` is handed for a round
+ * whose outcomes are scaffolding rather than subject.
+ *
+ * Stated here and nowhere else, so the two helpers cannot drift apart on what "the boring
+ * rule" is. It is the wrong rule for a round whose outcomes ARE the subject: see
+ * `PickWinner`. */
+export function earlierRegisteredWins(entrants: ReadonlyArray<Guest>): PickWinner {
+  const rank = new Map(entrants.map((guest, index) => [guest.username, index]))
+  const rankOf = (guest: Guest): number => {
+    const index = rank.get(guest.username)
+    if (index === undefined) {
+      throw new Error(`${guest.username} is not one of the entrants this spec minted`)
+    }
+    return index
+  }
+  return (a, b) => (rankOf(a) < rankOf(b) ? a : b)
+}
+
 /**
- * Play `eventId`'s draw out over the API, **the earlier-registered entrant always
- * winning**, until no materialized fixture is left undecided. Returns how many matches
- * were decided.
+ * Play `eventId`'s draw out over the API, `pickWinner` deciding each fixture, until no
+ * materialized fixture is left undecided. Returns how many matches were decided.
  *
- * ## The winner rule is the seed's, and it is deliberately boring
+ * ## The default winner rule is the seed's, and it is deliberately boring
  *
- * `entrants` is the field **in registration order** — what `seedEntrants` returns — and
- * the entrant nearer its front wins. That makes every outcome in the tournament a
- * function of the seeded field alone: a pool's finishing order is its members' order in
- * this list, the qualifiers are the first `K` of them, and the champion is
- * `entrants[0]`. A spec can therefore write down who *should* be in the bracket before a
- * ball is hit, which is the only way an assertion about the seating can be more than "six
- * names appeared".
+ * `pickWinner` defaults to `earlierRegisteredWins(entrants)` — the rule itself is written
+ * there, and `entrants` is the field **in registration order**, what `seedEntrants`
+ * returns. What it buys a caller here: every outcome in the tournament becomes a function
+ * of the seeded field alone, so a pool's finishing order is its members' order in this
+ * list, the qualifiers are the first `K` of them, and the champion is `entrants[0]`. A spec
+ * can therefore write down who *should* be in the bracket before a ball is hit, which is
+ * the only way an assertion about the seating can be more than "six names appeared".
  *
  * It also keeps the play free of ties: in a three-player pool the rule gives 2–0, 1–1 and
  * 0–2, so the finishing order needs no tiebreak and the qualifier set is not a coin flip.
@@ -105,75 +134,27 @@ export async function playEvent(
   eventId: string,
   entrants: ReadonlyArray<Guest>,
   stage: PlayStage = 'all',
+  pickWinner: PickWinner = earlierRegisteredWins(entrants),
 ): Promise<number> {
-  const byUsername = new Map(entrants.map((guest) => [guest.username, guest]))
-  const rank = new Map(entrants.map((guest, index) => [guest.username, index]))
   let played = 0
 
   for (let pass = 0; pass < MAX_PASSES; pass += 1) {
     const event = await readPlayableEvent(director, tournamentId, eventId)
-    const seats = new Map(
-      event.entrants.map((entrant) => [entrant.id, entrant.username]),
-    )
-    const playable = event.fixtures.filter(
-      (fixture): fixture is typeof fixture & { match_id: string } =>
-        fixture.match_id !== null &&
-        fixture.match_status !== 'completed' &&
-        (stage === 'all' || fixture.pool_id !== null),
-    )
+    const playable = event.fixtures
+      .filter(isMaterialized)
+      .filter(
+        (fixture) =>
+          fixture.match_status !== 'completed' &&
+          (stage === 'all' || fixture.pool_id !== null),
+      )
     if (playable.length === 0) return played
-
-    for (const fixture of playable) {
-      const [a, b] = [fixture.entry_a_id, fixture.entry_b_id].map((entryId) =>
-        guestFor(byUsername, seats, entryId, fixture.id),
-      )
-      // Side 1 IS `entry_a` and side 2 IS `entry_b` — the fixed materialization
-      // convention (#788) — so the winner's seat decides which column of the board wins.
-      const winnerIsA = rank.get(a.username)! < rank.get(b.username)!
-      await decide(
-        winnerIsA ? a : b,
-        winnerIsA ? b : a,
-        fixture.match_id,
-        board(winnerIsA ? 1 : 2, gamesToWin(event.match_settings.length_games)),
-      )
-      played += 1
-    }
+    played += await playFixtures(event, playable, entrants, pickWinner)
   }
 
   throw new Error(
     `event ${eventId} still had playable fixtures after ${MAX_PASSES} passes ` +
       `(${played} matches decided) — is the draw advancing?`,
   )
-}
-
-/** Who wins one fixture, given the two guests seated in it (side `a` first).
- *
- * A parameter rather than a rule, because in swiss **the winners decide the standings and
- * the standings decide the next pairing** — so a spec proving that a round is paired from
- * the standings has to be able to choose winners whose order is *not* the draw order. With
- * `playEvent`'s "the earlier-registered entrant wins" the two orders coincide exactly
- * (round 1 seeds the top half against the bottom half, so the first half of the draw order
- * wins every fixture), and a pairing that ignored the standings altogether would produce
- * the same fixtures as one that honours them. The assertion would pass against the bug. */
-export type PickWinner = (a: Guest, b: Guest) => Guest
-
-/** The winner rule `playEvent` bakes in, as a picker `playSwissRound` can be handed: **the
- * earlier-registered entrant wins**, `entrants` being the field in registration order.
- *
- * Boring on purpose, and the right default for a round whose outcomes are scaffolding
- * rather than subject — every result is then a function of the seeded field alone, and no
- * pairing is left to a coin flip. It is the wrong rule for a round whose outcomes ARE the
- * subject: see `PickWinner`. */
-export function earlierRegisteredWins(entrants: ReadonlyArray<Guest>): PickWinner {
-  const rank = new Map(entrants.map((guest, index) => [guest.username, index]))
-  const rankOf = (guest: Guest): number => {
-    const index = rank.get(guest.username)
-    if (index === undefined) {
-      throw new Error(`${guest.username} is not one of the entrants this spec minted`)
-    }
-    return index
-  }
-  return (a, b) => (rankOf(a) < rankOf(b) ? a : b)
 }
 
 /**
@@ -190,7 +171,8 @@ export function earlierRegisteredWins(entrants: ReadonlyArray<Guest>): PickWinne
  * completion for every other), so they are all playable before this is called. A fixture
  * of this round that has **not** materialized is therefore a named error rather than a
  * skip — a silent one would leave the round undecided, the next round unpaired, and the
- * failure somewhere else entirely.
+ * failure somewhere else entirely. The check runs over the whole round **before** anything
+ * is decided, so a half-materialized round fails without leaving half of itself played.
  */
 export async function playSwissRound(
   director: Guest,
@@ -200,39 +182,72 @@ export async function playSwissRound(
   round: number,
   pickWinner: PickWinner,
 ): Promise<number> {
-  const byUsername = new Map(entrants.map((guest) => [guest.username, guest]))
   const event = await readPlayableEvent(director, tournamentId, eventId)
-  const seats = new Map(event.entrants.map((entrant) => [entrant.id, entrant.username]))
   const fixtures = event.fixtures.filter((fixture) => fixture.round === round)
   if (fixtures.length === 0) {
     throw new Error(`event ${eventId} has no round-${round} fixtures — was the draw cut?`)
   }
 
-  let played = 0
+  const undecided = fixtures.filter((fixture) => fixture.match_status !== 'completed')
+  const unmaterialized = undecided.find((fixture) => !isMaterialized(fixture))
+  if (unmaterialized) {
+    throw new Error(
+      `round-${round} fixture ${unmaterialized.id} has not materialized into a match — ` +
+        `is the tournament live, and is round ${round - 1} decided?`,
+    )
+  }
+  return playFixtures(event, undecided.filter(isMaterialized), entrants, pickWinner)
+}
+
+/** A fixture the draw has turned into a real match — the only kind either helper can play,
+ * and the type the two filters below narrow to. */
+type MaterializedFixture = PlayableEvent['fixtures'][number] & {
+  readonly match_id: string
+}
+
+const isMaterialized = (
+  fixture: PlayableEvent['fixtures'][number],
+): fixture is MaterializedFixture => fixture.match_id !== null
+
+/**
+ * Decide `fixtures` — every one of them, in order — and return how many matches that was.
+ *
+ * The single body both `playEvent` and `playSwissRound` play a fixture with, and it holds
+ * the two things a spec cannot see and must not have to restate: the **materialization
+ * convention** (side 1 IS `entry_a`, #788) that says which column of the board a winner
+ * takes, and the board shape the server's `validate_finalize_games` accepts. Written twice,
+ * a change to how a match is decided over the API lands in one helper and silently leaves
+ * the other playing a different game.
+ *
+ * The callers keep only what genuinely differs: which fixtures are theirs to play, and what
+ * an unplayable one means to them — `playEvent` re-reads and passes again, `playSwissRound`
+ * refuses by name.
+ */
+async function playFixtures(
+  event: PlayableEvent,
+  fixtures: ReadonlyArray<MaterializedFixture>,
+  entrants: ReadonlyArray<Guest>,
+  pickWinner: PickWinner,
+): Promise<number> {
+  const byUsername = new Map(entrants.map((guest) => [guest.username, guest]))
+  const seats = new Map(event.entrants.map((entrant) => [entrant.id, entrant.username]))
+  const wins = gamesToWin(event.match_settings.length_games)
+
   for (const fixture of fixtures) {
-    if (fixture.match_status === 'completed') continue
-    if (fixture.match_id === null) {
-      throw new Error(
-        `round-${round} fixture ${fixture.id} has not materialized into a match — is ` +
-          `the tournament live, and is round ${round - 1} decided?`,
-      )
-    }
     const [a, b] = [fixture.entry_a_id, fixture.entry_b_id].map((entryId) =>
       guestFor(byUsername, seats, entryId, fixture.id),
     )
-    const winner = pickWinner(a, b)
     // Side 1 IS `entry_a` and side 2 IS `entry_b` — the fixed materialization convention
     // (#788) — so the winner's seat decides which column of the board wins.
-    const winnerIsA = winner.username === a.username
+    const winnerIsA = pickWinner(a, b).username === a.username
     await decide(
       winnerIsA ? a : b,
       winnerIsA ? b : a,
       fixture.match_id,
-      board(winnerIsA ? 1 : 2, gamesToWin(event.match_settings.length_games)),
+      board(winnerIsA ? 1 : 2, wins),
     )
-    played += 1
   }
-  return played
+  return fixtures.length
 }
 
 /** The wins a best-of-`lengthGames` needs — the same `(n + 1) // 2` the server's

--- a/e2e/support/tournament-play.ts
+++ b/e2e/support/tournament-play.ts
@@ -40,6 +40,10 @@ interface PlayableEvent {
   readonly fixtures: ReadonlyArray<{
     readonly id: string
     readonly pool_id: string | null
+    /** Which round of the draw the fixture belongs to — what `playSwissRound` scopes
+     * itself by. A swiss draw is cut whole, so every round's rows exist from the start
+     * and "the fixtures that are playable" is never the same set as "this round's". */
+    readonly round: number
     readonly entry_a_id: string | null
     readonly entry_b_id: string | null
     readonly match_id: string | null
@@ -140,6 +144,95 @@ export async function playEvent(
     `event ${eventId} still had playable fixtures after ${MAX_PASSES} passes ` +
       `(${played} matches decided) — is the draw advancing?`,
   )
+}
+
+/** Who wins one fixture, given the two guests seated in it (side `a` first).
+ *
+ * A parameter rather than a rule, because in swiss **the winners decide the standings and
+ * the standings decide the next pairing** — so a spec proving that a round is paired from
+ * the standings has to be able to choose winners whose order is *not* the draw order. With
+ * `playEvent`'s "the earlier-registered entrant wins" the two orders coincide exactly
+ * (round 1 seeds the top half against the bottom half, so the first half of the draw order
+ * wins every fixture), and a pairing that ignored the standings altogether would produce
+ * the same fixtures as one that honours them. The assertion would pass against the bug. */
+export type PickWinner = (a: Guest, b: Guest) => Guest
+
+/** The winner rule `playEvent` bakes in, as a picker `playSwissRound` can be handed: **the
+ * earlier-registered entrant wins**, `entrants` being the field in registration order.
+ *
+ * Boring on purpose, and the right default for a round whose outcomes are scaffolding
+ * rather than subject — every result is then a function of the seeded field alone, and no
+ * pairing is left to a coin flip. It is the wrong rule for a round whose outcomes ARE the
+ * subject: see `PickWinner`. */
+export function earlierRegisteredWins(entrants: ReadonlyArray<Guest>): PickWinner {
+  const rank = new Map(entrants.map((guest, index) => [guest.username, index]))
+  const rankOf = (guest: Guest): number => {
+    const index = rank.get(guest.username)
+    if (index === undefined) {
+      throw new Error(`${guest.username} is not one of the entrants this spec minted`)
+    }
+    return index
+  }
+  return (a, b) => (rankOf(a) < rankOf(b) ? a : b)
+}
+
+/**
+ * Play **one round** of a swiss draw out over the API, `pickWinner` deciding each fixture,
+ * and return how many matches were decided.
+ *
+ * One round, not the whole draw, because a swiss round's completion is the event under
+ * test: finishing the last match of round `r` is what pairs round `r + 1` from the
+ * standings and materializes it, in the same transaction. `playEvent` would sail straight
+ * through that moment and hand back a finished tournament, with nothing left to look at.
+ *
+ * A single pass suffices and the loop `playEvent` needs is deliberately absent: a round's
+ * fixtures all materialize together (at go-live for round 1, at the previous round's last
+ * completion for every other), so they are all playable before this is called. A fixture
+ * of this round that has **not** materialized is therefore a named error rather than a
+ * skip — a silent one would leave the round undecided, the next round unpaired, and the
+ * failure somewhere else entirely.
+ */
+export async function playSwissRound(
+  director: Guest,
+  tournamentId: string,
+  eventId: string,
+  entrants: ReadonlyArray<Guest>,
+  round: number,
+  pickWinner: PickWinner,
+): Promise<number> {
+  const byUsername = new Map(entrants.map((guest) => [guest.username, guest]))
+  const event = await readPlayableEvent(director, tournamentId, eventId)
+  const seats = new Map(event.entrants.map((entrant) => [entrant.id, entrant.username]))
+  const fixtures = event.fixtures.filter((fixture) => fixture.round === round)
+  if (fixtures.length === 0) {
+    throw new Error(`event ${eventId} has no round-${round} fixtures — was the draw cut?`)
+  }
+
+  let played = 0
+  for (const fixture of fixtures) {
+    if (fixture.match_status === 'completed') continue
+    if (fixture.match_id === null) {
+      throw new Error(
+        `round-${round} fixture ${fixture.id} has not materialized into a match — is ` +
+          `the tournament live, and is round ${round - 1} decided?`,
+      )
+    }
+    const [a, b] = [fixture.entry_a_id, fixture.entry_b_id].map((entryId) =>
+      guestFor(byUsername, seats, entryId, fixture.id),
+    )
+    const winner = pickWinner(a, b)
+    // Side 1 IS `entry_a` and side 2 IS `entry_b` — the fixed materialization convention
+    // (#788) — so the winner's seat decides which column of the board wins.
+    const winnerIsA = winner.username === a.username
+    await decide(
+      winnerIsA ? a : b,
+      winnerIsA ? b : a,
+      fixture.match_id,
+      board(winnerIsA ? 1 : 2, gamesToWin(event.match_settings.length_games)),
+    )
+    played += 1
+  }
+  return played
 }
 
 /** The wins a best-of-`lengthGames` needs — the same `(n + 1) // 2` the server's

--- a/e2e/tests/tournament-swiss.spec.ts
+++ b/e2e/tests/tournament-swiss.spec.ts
@@ -841,14 +841,24 @@ test.describe('Tournament — swiss draw', () => {
         'somebody who has never sat out plays',
     ).not.toBe(byedInRoundOne)
 
-    // The same two facts on the page: round 2's lines name the entrant who sat round 1
-    // out, and do not name the one sitting round 2 out.
+    // The same facts on the page: round 2's lines name the entrant who sat round 1 out, do
+    // not name the one sitting round 2 out, and the round says who that is.
+    //
+    // The bye line is asserted on every round the bye moves to, not only on the first,
+    // because round 2 is where the derivation is doing something: round 1's bye is the
+    // entrant no fixture was ever written for, while this one has to come out of a pairing
+    // the server dealt at advance. A rotation that moved the bye and a page that kept
+    // naming round 1's would both pass on the negative alone.
     await expect(detail.swissRoundFixtures(eventId, 2)).toHaveCount(perRound)
     await expect(detail.swissRound(eventId, 2)).toContainText(byedInRoundOne)
     await expect(
       detail.swissRound(eventId, 2),
       `${byedInRoundTwo} is round 2's bye, so no round-2 fixture names them`,
     ).not.toContainText(byedInRoundTwo)
+    await expect(
+      detail.swissRoundBye(eventId, 2),
+      `${byedInRoundTwo} sits round 2 out, so the round should name them as its bye`,
+    ).toContainText(byedInRoundTwo)
 
     // ----- play round 2, and watch the SECOND bye score ---------------------
     // Read the byed entrant's tally before the round is decided, so what is asserted
@@ -904,6 +914,10 @@ test.describe('Tournament — swiss draw', () => {
       detail.swissRound(eventId, ROUNDS),
       `${byedInRoundThree} is round 3's bye, so no round-3 fixture names them`,
     ).not.toContainText(byedInRoundThree)
+    await expect(
+      detail.swissRoundBye(eventId, ROUNDS),
+      `${byedInRoundThree} sits round 3 out, so the round should name them as its bye`,
+    ).toContainText(byedInRoundThree)
 
     await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
   })

--- a/e2e/tests/tournament-swiss.spec.ts
+++ b/e2e/tests/tournament-swiss.spec.ts
@@ -5,11 +5,22 @@ import { TournamentDetailPage } from '../page-objects/tournament-detail.page'
 import { guestFromContext, type Guest } from '../support/match-api'
 import { grantBetaTester } from '../support/rbac-grant'
 import {
+  readSwissRounds,
+  readSwissStandings,
+  type SwissFixture,
+  type SwissStanding,
+} from '../support/swiss-draw'
+import {
   createTournament,
   findEventByName,
   getDrawTypeCatalogue,
   seedEntrants,
 } from '../support/tournament-api'
+import {
+  earlierRegisteredWins,
+  playSwissRound,
+  type PickWinner,
+} from '../support/tournament-play'
 
 /** The event the director authors in the browser, and the handle the spec finds it by
  * afterwards — its id is minted server-side and never crosses back through the UI. */
@@ -38,6 +49,24 @@ const ROUNDS = 3
  * used to read as a stale draw and refuse go-live. */
 const EVEN_FIELD = 8
 const ODD_FIELD = 7
+
+/**
+ * Who wins round 1 of the even field, **by registration index** — deliberately alternating
+ * across the draw order.
+ *
+ * This is the whole design of the pairing test. Round 1 seats draw-order position `i`
+ * against `i + m/2`, so "the earlier-registered entrant wins" (`earlierRegisteredWins`,
+ * what every other tournament spec plays with) makes the round-1 winners **exactly the
+ * first half of the draw order** — and then the standings order and the draw order agree,
+ * fixture for fixture. A pairing that ignored the standings entirely would deal the same
+ * round 2, and an assertion about "paired by the standings" would pass against it.
+ *
+ * So the bottom half takes fixtures 1 and 3 and the top half takes 2 and 4: the winners are
+ * registrations 4, 1, 6, 3, which interleave with the losers 0, 2, 5, 7. Now the two orders
+ * cannot be confused — pairing down the draw order puts registration 0 (a loser) against
+ * registration 1 (a winner) in the very first fixture.
+ */
+const ROUND_ONE_WINNERS = [4, 1, 6, 3]
 
 /**
  * Round one, as the ADR seeds it: **top half against bottom half in draw order**.
@@ -112,12 +141,112 @@ async function authorSwissEvent(
 }
 
 /**
+ * Cut the event's draw **from the event card**, asserting the POST's own status.
+ *
+ * The status rather than the panel appearing: a refused cut leaves the card as it was, so a
+ * spec that only waited for fixtures would fail as a timeout naming nothing. The 201's body
+ * is read into the message, so a `DegenerateDraw` refusal names its own reason here.
+ */
+async function cutTheDraw(page: Page, detail: TournamentDetailPage): Promise<void> {
+  const drawPost = page.waitForResponse(
+    (r) => r.url().endsWith('/draw') && r.request().method() === 'POST',
+  )
+  await detail.generateDrawButton(EVENT_NAME).click()
+  const response = await drawPost
+  expect(
+    response.status(),
+    `cutting the draw was refused: ${await response.text()}`,
+  ).toBe(201)
+}
+
+/**
+ * Take the tournament **live** from the header, asserting the transition's own status and
+ * then the two independent signs it landed: the header now offers the only edge a live
+ * tournament has, and the inline slot a refused transition lands in is empty.
+ *
+ * Go-live is what turns round 1's fixtures into real matches — without it there is nothing
+ * to play and therefore no round to decide.
+ */
+async function goLive(page: Page, detail: TournamentDetailPage): Promise<void> {
+  const transitionPost = page.waitForResponse(
+    (r) => r.url().endsWith('/transitions') && r.request().method() === 'POST',
+  )
+  await detail.startButton.click()
+  const response = await transitionPost
+  expect(
+    response.status(),
+    `going live was refused: ${await response.text()}`,
+  ).toBe(201)
+  await expect(detail.endButton).toBeVisible()
+  await expect(detail.lifecycleNotice).toBeHidden()
+}
+
+/** The usernames a fixture seats, refusing an unseated side by name.
+ *
+ * A `null` side is `TBD` — a round that has not been paired (ADR-0786) — so meeting one
+ * where a pairing is expected is the failure itself, not a case to skip. */
+function namesOf(fixture: SwissFixture, round: number): [string, string] {
+  const { a, b } = fixture
+  if (a === null || b === null) {
+    throw new Error(
+      `round-${round} pairing ${fixture.position} is only half seated ` +
+        `(${a ?? 'TBD'} vs ${b ?? 'TBD'}) — the round was not paired`,
+    )
+  }
+  return [a, b]
+}
+
+/** The order walked in pairs: `[o0, o1], [o2, o3], …` — what pairing a standings order
+ * produces when nobody in it has met anybody adjacent to them.
+ *
+ * That condition holds for round 2 and is not a general truth about swiss: after one round
+ * every entrant has met exactly one opponent, and wins outrank everything else in the
+ * standings, so a pair of neighbours is either two entrants with the same round-1 result
+ * (who cannot have played each other — one of them would have lost) or straddles the
+ * boundary between results, where the two are again strangers. From round 3 on the greedy
+ * walk really does have to skip somebody, and a rematch is the last resort rather than a
+ * refusal — which is why only round 2's pairings are asserted this exactly. */
+function consecutivePairs(order: ReadonlyArray<string>): Array<[string, string]> {
+  return Array.from(
+    { length: Math.floor(order.length / 2) },
+    (_, index): [string, string] => [order[index * 2], order[index * 2 + 1]],
+  )
+}
+
+/** A standings read as a lookup from username to the **server-minted entry id** its row is
+ * keyed by — the handle `TournamentDetailPage.swissStandingRow` takes.
+ *
+ * Entry ids, never names, because the row's test hook is the entry: asking for the row by
+ * id is what makes "this entrant's row" a statement about the server's entry rather than
+ * about a name that happens to be a substring of another. */
+function entryIds(standings: ReadonlyArray<SwissStanding>): Map<string, string> {
+  return new Map(standings.map((row) => [row.username, row.entryId]))
+}
+
+/** Look one entrant's standings row up, failing by name when the field does not hold them
+ * — an entrant missing from the table is a real finding, and `undefined` threaded onward
+ * would surface as an inexplicable locator timeout. */
+function standingOf(
+  standings: ReadonlyArray<SwissStanding>,
+  username: string,
+): SwissStanding {
+  const row = standings.find((candidate) => candidate.username === username)
+  if (!row) {
+    const named = standings.map((r) => r.username).join(', ') || '(none)'
+    throw new Error(`${username} has no standings row — the table holds: ${named}`)
+  }
+  return row
+}
+
+/**
  * **Swiss, through the composed stack** (#1276, ADR "swiss pre-cuts every round and pairs
  * each one on advance").
  *
  * A director creates a swiss event **in the browser**, sets its round count, publishes,
  * has a field entered, cuts the draw, and reads it: round 1 paired with real players, and
- * every later round present, cut, and announced as forthcoming.
+ * every later round present, cut, and announced as forthcoming. Then the event is played:
+ * finishing a round pairs the next one **from the standings**, and an odd field's bye moves
+ * from entrant to entrant, scoring as a win the moment its round is decided.
  *
  * ## Both parities, because they are different code
  *
@@ -135,11 +264,16 @@ async function authorSwissEvent(
  *
  * ## What this spec deliberately does NOT test
  *
- * Round 2 is never paired here, because nothing pairs it yet: `SwissStrategy.advance`
- * fills no sides — it reports round 1's readiness and nothing else. Pairing a round from
- * the standings, a bye scoring as a win, and Buchholz are later slices. A spec asserting
- * round 2 gets paired would be testing an implementation that does not exist, and would
- * either red for the wrong reason or be written weak enough to pass.
+ * **That no pairing is ever a rematch.** It is not true and it is not meant to be: the walk
+ * gives each entrant the nearest following one they have not met, and when everybody below
+ * is an old opponent it takes the nearest all the same. Refusing to pair would strand a
+ * live event with no move a director could make, which is far worse than one repeated
+ * fixture — and a greedy walk does not always find the rematch-free pairing that exists
+ * (five entrants over four rounds repeat one). So the pairing assertions below stop at
+ * round 2, the last round for which "the standings, walked in pairs" is exactly the answer.
+ *
+ * **Buchholz**, and the ordering that puts it above game difference: a later slice. The
+ * table these tests read is the shared pool finishing order.
  *
  * ## Seed vs UI split
  *
@@ -230,15 +364,7 @@ test.describe('Tournament — swiss draw', () => {
     await expect(detail.entrantsList(EVENT_NAME)).toContainText(entrants[0].username)
 
     // ----- cut the draw: all R rounds, in one stroke --------------------------
-    const drawPost = page.waitForResponse(
-      (r) => r.url().endsWith('/draw') && r.request().method() === 'POST',
-    )
-    await detail.generateDrawButton(EVENT_NAME).click()
-    const drawResponse = await drawPost
-    expect(
-      drawResponse.status(),
-      `cutting the draw was refused: ${await drawResponse.text()}`,
-    ).toBe(201)
+    await cutTheDraw(page, detail)
 
     // ----- the rounds view, NOT the bracket ----------------------------------
     // Both facts, because either alone passes against the view it is not about. Swiss and
@@ -327,15 +453,7 @@ test.describe('Tournament — swiss draw', () => {
     await detail.reload(tournamentId)
 
     // ----- cut the draw ------------------------------------------------------
-    const drawPost = page.waitForResponse(
-      (r) => r.url().endsWith('/draw') && r.request().method() === 'POST',
-    )
-    await detail.generateDrawButton(EVENT_NAME).click()
-    const drawResponse = await drawPost
-    expect(
-      drawResponse.status(),
-      `cutting the draw was refused: ${await drawResponse.text()}`,
-    ).toBe(201)
+    await cutTheDraw(page, detail)
 
     await expect(detail.swissRounds(eventId)).toBeVisible()
     await expect(detail.bracket(eventId)).toHaveCount(0)
@@ -394,20 +512,11 @@ test.describe('Tournament — swiss draw', () => {
     // used to read that shortfall as an entry that landed after the cut: the draw was
     // `stale`, and go-live answered 409 with a refusal no re-cut could clear. So the
     // transition's own status is asserted, not merely that a button changed.
-    const transitionPost = page.waitForResponse(
-      (r) => r.url().endsWith('/transitions') && r.request().method() === 'POST',
-    )
-    await detail.startButton.click()
-    const transitionResponse = await transitionPost
-    expect(
-      transitionResponse.status(),
-      `going live was refused: ${await transitionResponse.text()}`,
-    ).toBe(201)
-    // Two more independent words on the same fact: the header now offers the only edge a
-    // live tournament has, and the inline refusal a rejected transition lands on is
-    // empty. Without the second, a 409 would surface as a button that never appeared.
-    await expect(detail.endButton).toBeVisible()
-    await expect(detail.lifecycleNotice).toBeHidden()
+    //
+    // `goLive` asserts the transition's own status and the two independent words on the
+    // same fact — the live-only edge appearing, and the inline refusal slot staying empty.
+    // Without the second, a 409 would surface as a button that never appeared.
+    await goLive(page, detail)
 
     // ----- …and going live paired nothing new --------------------------------
     // Materializing the draw turns *ready* fixtures into matches; it does not seat
@@ -421,6 +530,380 @@ test.describe('Tournament — swiss draw', () => {
       await expect(detail.swissRound(eventId, round)).toHaveCount(0)
       await expect(detail.swissRoundForthcoming(eventId, round)).toBeVisible()
     }
+
+    await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
+  })
+
+  /**
+   * **A decided round pairs the next one, and pairs it from the STANDINGS.**
+   *
+   * The whole claim of `advance` (ADR "swiss pre-cuts every round and pairs each one on
+   * advance"): when every match of round `r` is decided, the field is ordered by the
+   * standings that round produced, walked, and each entrant given the nearest following one
+   * they have not met — into the rows the cut already wrote, in rank order.
+   *
+   * ## The trap this test is built around
+   *
+   * "Round 2 has real names in it" is not evidence of any of that. Round 1 seats the draw
+   * order's top half against its bottom half, so if the earlier-registered entrant wins
+   * every fixture — the rule every other tournament spec plays with — the standings after
+   * round 1 are the draw order, and **a pairing that ignored the standings entirely would
+   * deal the identical round 2**. The assertion would pass against the bug it exists to
+   * catch.
+   *
+   * So the winners alternate across the draw order (`ROUND_ONE_WINNERS`), which prises the
+   * two orders apart, and the sharp assertion is the one that follows: **no round-2 fixture
+   * puts a round-1 winner against a round-1 loser.** Pairing down the draw order pairs
+   * registration 0 with registration 1 — a loser against a winner — and reds naming both.
+   */
+  test('completing every match in round 1 pairs round 2 from the standings, not the draw order', async ({
+    page,
+    baseURL,
+  }) => {
+    // Eight minted guests, eight director-entries, a real cut, a real go-live and four
+    // matches played out over the API, on top of the ordinary page work.
+    test.setTimeout(420_000)
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    const director = await guestFromContext(page.request)
+    grantBetaTester(director.username)
+
+    const name = `Swiss pairing ${faker.string.alphanumeric(8)}`
+    const { tournamentId } = await createTournament(director, name)
+
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    const eventId = await authorSwissEvent(page, detail, director, tournamentId)
+
+    await detail.publishButton.click()
+    await expect(detail.startButton).toBeVisible()
+
+    const entrants = await seedEntrants(
+      director,
+      baseURL!,
+      tournamentId,
+      eventId,
+      EVEN_FIELD,
+    )
+    const filled = await findEventByName(director, tournamentId, EVENT_NAME)
+    expect(filled.entered).toBe(EVEN_FIELD)
+
+    await detail.reload(tournamentId)
+    await cutTheDraw(page, detail)
+
+    // ----- the state this test moves OFF -------------------------------------
+    // Round 1 seeded from the draw order, round 2 cut and announced as forthcoming. Read
+    // first, so "round 2 is paired" below is a change this test caused rather than
+    // something that was already true.
+    await expect(detail.swissRoundFixtures(eventId, 1)).toHaveText(
+      roundOneLines(entrants),
+    )
+    await expect(detail.swissRound(eventId, 2)).toHaveCount(0)
+    await expect(detail.swissRoundForthcoming(eventId, 2)).toBeVisible()
+
+    await goLive(page, detail)
+
+    // ----- play round 1, winners INTERLEAVED ---------------------------------
+    const winners = new Set(ROUND_ONE_WINNERS.map((index) => entrants[index].username))
+    // The picker refuses a fixture that names two winners or none, which is also how a
+    // round 1 seeded some other way than top-half-against-bottom-half announces itself
+    // here rather than as a baffling standings order later.
+    const pickInterleavedWinner: PickWinner = (a, b) => {
+      const aWins = winners.has(a.username)
+      if (aWins === winners.has(b.username)) {
+        throw new Error(
+          `round-1 fixture ${a.username} vs ${b.username} names ` +
+            `${aWins ? 'two' : 'no'} designated winners — was round 1 seeded top half ` +
+            'against bottom half?',
+        )
+      }
+      return aWins ? a : b
+    }
+    expect(
+      await playSwissRound(
+        director,
+        tournamentId,
+        eventId,
+        entrants,
+        1,
+        pickInterleavedWinner,
+      ),
+      'round 1 of an eight-player swiss is four matches',
+    ).toBe(EVEN_FIELD / 2)
+
+    await detail.reload(tournamentId)
+
+    // ----- round 2 is PAIRED, where it read as forthcoming -------------------
+    await expect(detail.swissRoundForthcoming(eventId, 2)).toHaveCount(0)
+    await expect(detail.swissRoundFixtures(eventId, 2)).toHaveCount(EVEN_FIELD / 2)
+    // …and ONLY round 2. One decided round pairs one round: round 3 waits for round 2,
+    // which is what stops a bug that paired everything it could from passing as this one.
+    await expect(detail.swissRound(eventId, 3)).toHaveCount(0)
+    await expect(detail.swissRoundForthcoming(eventId, 3)).toBeVisible()
+
+    // ----- the standings the pairing is judged against -----------------------
+    // Taken from the server, because that is where both the table on screen and the
+    // pairing walk take it from — a spec that re-derived its own order could only ever
+    // prove the two agreed with the spec, not with each other.
+    const standings = await readSwissStandings(director, tournamentId, eventId)
+    expect(standings.map((row) => row.rank)).toEqual(
+      Array.from({ length: EVEN_FIELD }, (_, index) => index + 1),
+    )
+    const order = standings.map((row) => row.username)
+    expect(
+      new Set(order.slice(0, EVEN_FIELD / 2)),
+      `the round-1 winners should top the table; it reads ${order.join(', ')}`,
+    ).toEqual(winners)
+    // The same order, on screen, row for row — keyed by the server-minted entry id, so
+    // this says the table a director reads IS the order paired against, not a client
+    // re-sort that happens to agree.
+    await expect(detail.swissStandingsRows(eventId)).toHaveCount(EVEN_FIELD)
+    for (const [index, row] of standings.entries()) {
+      await expect(detail.swissStandingsRows(eventId).nth(index)).toHaveAttribute(
+        'data-testid',
+        `standing-row-${row.entryId}`,
+      )
+    }
+
+    // ----- THE assertion: paired by standings, not by draw order -------------
+    const rounds = await readSwissRounds(director, tournamentId, eventId)
+    const roundTwo = rounds.find((round) => round.round === 2)
+    if (!roundTwo) throw new Error('the draw has no round 2 — was it cut for R rounds?')
+    expect(roundTwo.satOut, 'an even field byes nobody').toEqual([])
+
+    // 1 — nobody meets somebody who did not do what they did in round 1. This is the one
+    // that reds under a pairing that walks the draw order: it would seat registration 0
+    // (a loser) against registration 1 (a winner) in the very first fixture.
+    for (const fixture of roundTwo.fixtures) {
+      const [a, b] = namesOf(fixture, 2)
+      expect(
+        [a, b].filter((name) => winners.has(name)).length,
+        `round-2 pairing ${fixture.position} is ${a} vs ${b}, which puts a round-1 ` +
+          `winner against a round-1 loser — the standings read ${order.join(', ')}`,
+      ).not.toBe(1)
+    }
+
+    // 2 — and exactly the standings order, walked in pairs, in rank order. A fixture's
+    // position IS its pairing rank (ADR), so this pins the pairings AND their order in
+    // one statement: the top of the table meets the top of the table.
+    expect(roundTwo.fixtures.map((fixture) => namesOf(fixture, 2))).toEqual(
+      consecutivePairs(order),
+    )
+
+    // 3 — and the director reads those very pairings off the page. The lines carry their
+    // match link and status now that round 2 has materialized, so each is asked for the
+    // two names it seats rather than compared as whole text.
+    for (const [index, fixture] of roundTwo.fixtures.entries()) {
+      const line = detail.swissRoundFixtures(eventId, 2).nth(index)
+      for (const name of namesOf(fixture, 2)) {
+        await expect(line).toContainText(name)
+      }
+    }
+
+    await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
+  })
+
+  /**
+   * **An odd field byes exactly one entrant a round, the bye moves, and it scores as a win
+   * — but only once its round is decided** (ADR "swiss standings add Buchholz, and
+   * head-to-head is guarded on having met"; CONTEXT.md, "Bye").
+   *
+   * Seven entrants and three rounds, played out two rounds deep, so the bye is observed
+   * three times: handed out at the cut, moved at round 2, moved again at round 3.
+   *
+   * ## When the win lands is half the claim
+   *
+   * A bye is credited when its round is **decided**, not when it is paired. Crediting it at
+   * the pairing would put a win on the table for a round nobody has played — a
+   * seven-player draw would be cut and immediately show its byed entrant top of the
+   * standings, ahead of six players who have not been given the chance to hit a ball. So
+   * **both** states are asserted: nought wins on the freshly cut draw, one win once round 1
+   * is decided. Asserting only the second would pass against the version of this the ADR
+   * rejected.
+   *
+   * ## And the bye moves
+   *
+   * The next bye goes to the lowest-ranked entrant who has not had one, so nobody sits out
+   * twice while somebody else has not sat out at all. Every bye here is **derived from the
+   * fixtures** (`readSwissRounds`) rather than predicted, so the rotation is read off the
+   * draw the server dealt: a bye is the absence of a row, and who is missing is the only
+   * record of it there is.
+   */
+  test('an odd swiss field byes one entrant a round, and the bye scores as a win once its round is decided', async ({
+    page,
+    baseURL,
+  }) => {
+    // Seven minted guests, seven director-entries, a real cut, a real go-live and two
+    // rounds — six matches — played out over the API, on top of the ordinary page work.
+    test.setTimeout(420_000)
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    const director = await guestFromContext(page.request)
+    grantBetaTester(director.username)
+
+    const name = `Swiss byes ${faker.string.alphanumeric(8)}`
+    const { tournamentId } = await createTournament(director, name)
+
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    const eventId = await authorSwissEvent(page, detail, director, tournamentId)
+
+    await detail.publishButton.click()
+    await expect(detail.startButton).toBeVisible()
+
+    const entrants = await seedEntrants(
+      director,
+      baseURL!,
+      tournamentId,
+      eventId,
+      ODD_FIELD,
+    )
+    const filled = await findEventByName(director, tournamentId, EVENT_NAME)
+    expect(filled.entered).toBe(ODD_FIELD)
+
+    await detail.reload(tournamentId)
+    await cutTheDraw(page, detail)
+
+    const perRound = Math.floor(ODD_FIELD / 2)
+    await expect(detail.swissRoundFixtures(eventId, 1)).toHaveCount(perRound)
+
+    // ----- the cut credits NOBODY, not even the entrant who sits out ---------
+    // The trap, and the half of the rule that is easy to get backwards: the byed entrant
+    // is already known — they are in no fixture — and their win is still a round away.
+    const atCut = await readSwissStandings(director, tournamentId, eventId)
+    expect(atCut, 'the whole field is ranked in one pool-less table').toHaveLength(
+      ODD_FIELD,
+    )
+    const idOf = entryIds(atCut)
+    await expect(detail.swissStandingsRows(eventId)).toHaveCount(ODD_FIELD)
+    for (const row of atCut) {
+      await expect(
+        detail.swissStandingWins(eventId, row.entryId),
+        `${row.username} has a win on a draw nobody has played yet`,
+      ).toHaveText('0')
+    }
+
+    await goLive(page, detail)
+
+    // ----- round 1: who sat out, off the draw the server dealt ---------------
+    const afterCut = await readSwissRounds(director, tournamentId, eventId)
+    expect(
+      afterCut.map((round) => round.round),
+      'the cut writes all R rounds at once',
+    ).toEqual(Array.from({ length: ROUNDS }, (_, index) => index + 1))
+    const roundOne = afterCut[0]
+    expect(
+      roundOne.satOut,
+      'exactly one of an odd field sits round 1 out — a bye is the absence of a fixture',
+    ).toHaveLength(1)
+    const byedInRoundOne = roundOne.satOut[0]
+
+    expect(
+      await playSwissRound(
+        director,
+        tournamentId,
+        eventId,
+        entrants,
+        1,
+        earlierRegisteredWins(entrants),
+      ),
+      'round 1 of a seven-player swiss is three matches',
+    ).toBe(perRound)
+
+    await detail.reload(tournamentId)
+
+    // ----- NOW the bye scores: a win worth zero games ------------------------
+    const byedOneId = idOf.get(byedInRoundOne)
+    if (!byedOneId) throw new Error(`${byedInRoundOne} has no standings row`)
+    await expect(
+      detail.swissStandingWins(eventId, byedOneId),
+      `${byedInRoundOne} sat round 1 out and round 1 is decided — a bye is a win`,
+    ).toHaveText('1')
+    await expect(
+      detail.swissStandingGamesWon(eventId, byedOneId),
+      `${byedInRoundOne}'s bye is a win worth ZERO games — a nominal 3-0 would lift ` +
+        'them over somebody who beat a real opponent',
+    ).toHaveText('0')
+
+    // ----- round 2 is paired, and the bye has MOVED --------------------------
+    const afterRoundOne = await readSwissRounds(director, tournamentId, eventId)
+    const roundTwo = afterRoundOne[1]
+    expect(roundTwo.round).toBe(2)
+    expect(roundTwo.paired, 'a decided round 1 pairs round 2').toBe(true)
+    expect(roundTwo.fixtures).toHaveLength(perRound)
+    expect(roundTwo.satOut, 'exactly one entrant sits round 2 out').toHaveLength(1)
+    const byedInRoundTwo = roundTwo.satOut[0]
+    expect(
+      byedInRoundTwo,
+      `${byedInRoundOne} sat out round 1 and would sit out round 2 as well, while ` +
+        'somebody who has never sat out plays',
+    ).not.toBe(byedInRoundOne)
+
+    // The same two facts on the page: round 2's lines name the entrant who sat round 1
+    // out, and do not name the one sitting round 2 out.
+    await expect(detail.swissRoundFixtures(eventId, 2)).toHaveCount(perRound)
+    await expect(detail.swissRound(eventId, 2)).toContainText(byedInRoundOne)
+    await expect(
+      detail.swissRound(eventId, 2),
+      `${byedInRoundTwo} is round 2's bye, so no round-2 fixture names them`,
+    ).not.toContainText(byedInRoundTwo)
+
+    // ----- play round 2, and watch the SECOND bye score ---------------------
+    // Read the byed entrant's tally before the round is decided, so what is asserted
+    // afterwards is the bye's own contribution — one win, no games — rather than a number
+    // that happens to be right. The first bye's credit was an absolute (they had played
+    // nothing at all); this one is an increment on a real record.
+    const beforeRoundTwo = standingOf(
+      await readSwissStandings(director, tournamentId, eventId),
+      byedInRoundTwo,
+    )
+    expect(
+      await playSwissRound(
+        director,
+        tournamentId,
+        eventId,
+        entrants,
+        2,
+        earlierRegisteredWins(entrants),
+      ),
+      'round 2 is three matches — the byed entrant costs the round a fixture',
+    ).toBe(perRound)
+
+    await detail.reload(tournamentId)
+
+    const byedTwoId = idOf.get(byedInRoundTwo)
+    if (!byedTwoId) throw new Error(`${byedInRoundTwo} has no standings row`)
+    await expect(
+      detail.swissStandingWins(eventId, byedTwoId),
+      `${byedInRoundTwo} sat round 2 out, so round 2 being decided is worth one win`,
+    ).toHaveText(String(beforeRoundTwo.wins + 1))
+    await expect(
+      detail.swissStandingGamesWon(eventId, byedTwoId),
+      `${byedInRoundTwo}'s bye must move no game count`,
+    ).toHaveText(String(beforeRoundTwo.gamesWon))
+
+    // ----- round 3 is paired, and the bye moves a THIRD time -----------------
+    const afterRoundTwo = await readSwissRounds(director, tournamentId, eventId)
+    const roundThree = afterRoundTwo[2]
+    expect(roundThree.round).toBe(ROUNDS)
+    expect(roundThree.paired, 'a decided round 2 pairs round 3').toBe(true)
+    expect(roundThree.fixtures).toHaveLength(perRound)
+    expect(roundThree.satOut, 'exactly one entrant sits round 3 out').toHaveLength(1)
+    const byedInRoundThree = roundThree.satOut[0]
+    const byes = [byedInRoundOne, byedInRoundTwo, byedInRoundThree]
+    expect(
+      new Set(byes).size,
+      `three rounds byed ${byes.join(', ')} — somebody sat out twice while four ` +
+        'entrants have never sat out at all',
+    ).toBe(byes.length)
+
+    await expect(detail.swissRoundFixtures(eventId, ROUNDS)).toHaveCount(perRound)
+    await expect(
+      detail.swissRound(eventId, ROUNDS),
+      `${byedInRoundThree} is round 3's bye, so no round-3 fixture names them`,
+    ).not.toContainText(byedInRoundThree)
 
     await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
   })


### PR DESCRIPTION
Slice 3 of the swiss stack (#1276). **Stacked on #1281** — base is `…-s2`, so the diff here is slice 3 only.

Swiss rounds now pair themselves. Buchholz is slice 4.

## What changes

When every fixture in round `r` has a completed match, `advance()` orders the field by the standings, walks that order pairing each entrant with the nearest following one they have not met, and returns ordinary `SideFill`s against the already-written rows. A fixture's `position` is its pairing rank.

**A rematch is the last resort and never a refusal.** Refusing to pair would strand a live tournament mid-event, which is worse than a repeated fixture.

**A bye scores as a win worth zero games** — the win because nobody should be punished for a scheduling artifact, the zero games because a nominal 3-0 would hand the byed entrant game difference nobody earned and lift them above someone who beat a real opponent. It scores when its round is **decided**, not when it is paired: round 1 is paired at the cut, so crediting on pairing would show a freshly cut seven-player draw with its byed entrant top of the table before anyone had played.

## One contract change, and why it was unavoidable

`advance()` now takes the ordered field as well as the fixtures.

The fixtures cannot name the field. A byed entrant sits in no fixture row by definition, and so does a latecomer who joined a draw cut for an even field, since `floor(8/2)` and `floor(9/2)` are the same four fixtures. Pairing from the seated set byes the same entrant every round and never pairs the latecomer at all — both confirmed by falsification.

`AdvancePlan` is untouched, so swiss still fills existing rows and creates none, and ADR-0786 stands. **The ADR is amended in this PR** where it previously claimed swiss cost no contract change at all.

## An honest limit, now recorded

The ADR justified refusing `R > n-1` by saying a rematch-free swiss exists below that bound. It does — but the greedy walk does not always **find** it. Five entrants over four rounds repeat a pairing in round 3 while `1-4` / `5-2` was available. Finding it every time is maximum-weight matching, and this draw layer is deliberately pure with no solver. We take the occasional avoidable rematch over giving a pure domain a solver dependency, or over refusing to pair.

## A test that was passing for the wrong reason

The e2e chore asserted bye rotation and then flagged that its own assertion did not discriminate: at that field size a broken rule of "always bye the lowest-ranked entrant" **also** yields distinct byes, because the bye holder banks a win and floats up.

Chore `3d` pins it properly, with a field where the bye holder *sinks* instead. The measurement that matters: with the rule deliberately broken, **216 other tests stayed green** and only the new one red. Nothing else pinned this — not `3a`'s bye test, not the e2e assertion.

The e2e spec has the same hazard handled explicitly: the default "earlier-registered entrant wins" leaves the standings order identical to the draw order after round 1, so a pairing that ignored standings would deal the *same* round 2 and pass against the bug. The winners are interleaved to prise the orders apart.

## Verification

- api: `ruff`, `mypy --strict` (170 files), **2229 pytest passing** in random order
- root e2e: **exit 0, 28 passed against `--list`'s 28 collected** — the numbers agree
- No migration, no model change, and `app.openapi()` is byte-identical throughout (measured: sha256 unchanged), so no regen
- Falsified: rematch avoidance, the rematch fallback, idempotency, field-from-entrants, the entrants gate, the bye win, the bye's zero games, bye-scores-on-decided, standings-ordered pairing, and the bye rotation

**One process note for whoever repeats a falsification against the dev stack:** uvicorn's `--reload` stopped noticing edits after the first one, so a second falsification silently ran against the first one's code. Caught by counting `Started server process`. Restart the api container and grep the file inside it rather than trusting the reloader.

Chores: `3a`, `3b`, `3c`, `3d`, plus two docs commits amending the ADRs where this slice made them wrong or incomplete.

Part of #1276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
