### PR TITLE
Slice 4: swiss standings rank by who you beat, not by margin

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -438,9 +438,13 @@ _Avoid_: walkover (that is an opponent who failed to appear), forfeit, default.
 The sum of an entrant's opponents' win counts — a **swiss** tiebreak measuring
 how strong a field that entrant had to beat. It ranks above game difference,
 because who you played carries more information than your margin when the format
-deliberately pairs you against your own score. A **bye** contributes nothing,
-having produced no opponent. It moves as the event runs: an opponent winning a
-later match raises your Buchholz without you playing.
+deliberately pairs you against your own score. A **bye** cuts two ways, and the
+distinction matters: it adds nothing to the byed entrant's **own** sum, having
+produced no opponent — but the win it scores **does** count toward the Buchholz of
+whoever played that entrant, because Buchholz reads the same wins column the
+standings display. A rematch counts twice, since the sum is over games played
+rather than distinct opponents. Buchholz moves as the event runs: an opponent
+winning a later match raises yours without you playing.
 _Avoid_: strength of schedule (fine in prose, but the computed term is Buchholz),
 sonneborn-berger (a different measure we do not compute).
 

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -50,7 +50,12 @@ from datetime import datetime
 from typing import NewType, Protocol
 
 from app.models.tournament import DrawType, EventFormat
-from app.pool_finishing_order import EntryTally, MatchOutcome, finishing_order
+from app.pool_finishing_order import (
+    EntryTally,
+    MatchOutcome,
+    finishing_order,
+    swiss_finishing_order,
+)
 from app.schemas.tournament import (
     DrawSettingsWriteArm,
     RoundRobinDrawSettingsWrite,
@@ -540,9 +545,9 @@ class DrawStrategy(Protocol):
         parameters. A default here would let one implementation quietly leave the
         parameter off its signature and still satisfy the checker, and the one that did
         would be the one that needed it. The mirror case is
-        :func:`~app.pool_finishing_order.finishing_order`, a single free function whose
-        ``byes`` **is** defaulted: nothing implements it, so an omission there is a
-        caller's choice at one call site rather than a hole in a seam.
+        :func:`~app.pool_finishing_order.swiss_finishing_order`, a single free function
+        whose ``byes`` **is** defaulted: nothing implements it, so an omission there is
+        a caller's choice at one call site rather than a hole in a seam.
         """
         ...
 
@@ -1427,20 +1432,22 @@ def _swiss_standings_order(
     down.
 
     **Byes are scored here too**, as a win worth zero games, by the same
-    :func:`finishing_order` the table on screen is built by (ADR "swiss standings add
-    Buchholz"). Leaving them out would rank a byed entrant below everybody who played
-    while the director's table ranked them above — the two layers disagreeing about the
-    standings, which is precisely what one shared chain exists to prevent.
+    :func:`swiss_finishing_order` the table on screen is built by (ADR "swiss standings
+    add Buchholz"). Leaving them out would rank a byed entrant below everybody who
+    played while the director's table ranked them above — the two layers disagreeing
+    about the standings, which is precisely what one shared chain exists to prevent.
 
     ``byes`` arrives already derived (:func:`swiss_byes`, called once by
     :func:`_swiss_pairing_fills`) rather than being derived here, so that this and
     :func:`_swiss_bye` read one value instead of two derivations of it.
 
-    :func:`~app.pool_finishing_order.finishing_order` is the *shared* definition of that
-    table, the same call the standings on screen are projected through, so the order a
-    director reads and the order the pairing walks cannot disagree. (Swiss gets its own
-    chain — Buchholz above game difference — in its own slice; until then this is the
-    one that exists, and it is one call to change.)
+    :func:`~app.pool_finishing_order.swiss_finishing_order` is the *shared* definition
+    of that table — wins, guarded head-to-head, **Buchholz**, game difference, games
+    won, entry id — and the same call the standings on screen are projected through, so
+    the order a director reads and the order the pairing walks cannot disagree. It is
+    the swiss chain and not the pool one: pairing down a table ordered by margin rather
+    than by strength of schedule would seat the next round off an order nobody is
+    looking at.
 
     An outcome naming an entry that is not in the field is left out: a withdrawal
     between the cut and this advance would otherwise be a ``KeyError`` deep inside the
@@ -1470,7 +1477,10 @@ def _swiss_standings_order(
                 entry_b_games=games.entry_b_games,
             )
         )
-    return [tally.entry_id for tally in finishing_order(field, outcomes, byes)]
+    return [
+        standing.tally.entry_id
+        for standing in swiss_finishing_order(field, outcomes, byes)
+    ]
 
 
 def _swiss_bye(order: Sequence[EntryId], byes: Sequence[EntryId]) -> EntryId | None:

--- a/api/app/pool_finishing_order.py
+++ b/api/app/pool_finishing_order.py
@@ -1,5 +1,6 @@
-"""How a **pool finished** — the one definition of the tiebreak chain that orders a
-round-robin pool's entrants, shared by the draw layer and the results layer.
+"""How a **field finished** — the one definition of the tiebreak chains that order a
+round-robin pool's entrants and a swiss event's, shared by the draw layer and the
+results layer.
 
 Two layers need this answer and they must never disagree about it. ``app.results``
 reads it out as a pool's **standings** table, the thing a director is looking at on
@@ -23,38 +24,41 @@ the :class:`MatchOutcome`\\ s of its **currently-completed** matches, so nothing
 a snapshot — a corrected or voided match re-derives the order the instant it leaves
 ``completed``.
 
-The chain, in order:
+There are **two** chains, one per format, and they live side by side on purpose: they
+share every step but one, and a reader has to be able to see both at once to keep them
+in step (ADR "swiss standings add Buchholz, and head-to-head is guarded on having met").
 
-1. **wins** — most match wins first, and a **bye counts as one of them**;
-2. **head-to-head**, *only when exactly two entries are tied* on wins — the one that
-   beat the other ranks above it. A three-or-more-way tie can cycle (A beat B beat C
-   beat A), so it is **not** broken head-to-head; it falls straight through to the game
-   tiebreakers rather than a recursive mini-league;
+:func:`finishing_order` — a **round-robin pool**:
+
+1. **wins** — most match wins first;
+2. **head-to-head**, *only when exactly two entries are tied* on wins **and they have
+   actually met** — the one that beat the other ranks above it. A three-or-more-way tie
+   can cycle (A beat B beat C beat A), so it is **not** broken head-to-head; it falls
+   straight through to the game tiebreakers rather than a recursive mini-league;
 3. **game difference** — games won minus games lost;
 4. **games won**;
 5. the **entry id** — a total, deterministic fallback, so a pool in which two entries
    are genuinely level on every count still orders the same way on every read.
 
-**A bye is a win worth zero games** (ADR "swiss standings add Buchholz, and
-head-to-head is guarded on having met"). The win, because a player must not be punished
-for a scheduling artifact they did not cause. Zero games, because steps 3 and 4 are the
-ones a nominal 3-0 would corrupt: it would hand the byed entrant a game difference
-nobody earned, which can lift them above somebody who went out and beat a real
-opponent. So a bye moves step 1 and is neutral on everything below it, and it is
-slightly *under*-credited — the deliberate direction to err on a result nobody played.
+:func:`swiss_finishing_order` — a **swiss field**: the same chain with **Buchholz**
+between steps 2 and 3, and byes scored into step 1.
 
-Byes reach here as a **flat sequence of entry ids, one per bye taken**, because they are
-derived rather than stored: a bye is the absence of a fixture row (CONTEXT.md, "Bye"),
-so the byed entrant is the one with no fixture that round. :func:`app.draws.swiss_byes`
-is where that derivation lives, once, for both callers. Round-robin passes none — its
-byed entrant sits out one round of a schedule that seats them in every other, which is
-not a result and is not scored as one.
+The two share their machinery rather than agreeing by coincidence: one grouping by
+wins, one guarded head-to-head step, one tail of scalar comparators ending in the entry
+id. The swiss chain is that tail with one value in front of it.
+
+**The head-to-head step is guarded on the pair having met**, in *both* chains, and that
+is a property of the step rather than a swiss carve-out. A round-robin pool cannot reach
+the guard once it is played out — everyone meets everyone — so it costs that format
+nothing, while a swiss pair tied on wins may never have been drawn against each other
+and there is simply no result to read. (A part-played pool reaches it too, which is why
+the guard predates swiss.)
 """
 
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -121,9 +125,10 @@ class MatchOutcome:
 class EntryTally:
     """A mutable per-entry accumulator — what one entry has done in its pool so far.
 
-    Built and mutated inside :func:`finishing_order`; callers only ever see the
-    finished list. Every entrant seated in the pool gets one, including a player who
-    has not played yet (a row of zeros), so the order is a *live, partial* one.
+    Built and mutated inside :func:`_tallies`, which both orders start from; callers
+    only ever see the finished list. Every entrant seated in the field gets one,
+    including a player who has not played yet (a row of zeros), so the order is a
+    *live, partial* one.
     """
 
     entry_id: EntryId
@@ -138,10 +143,31 @@ class EntryTally:
         return self.games_won - self.games_lost
 
 
+@dataclass(frozen=True, slots=True)
+class SwissTally:
+    """One entry's swiss line: the tally every format keeps, plus the **Buchholz**
+    figure only swiss ranks on.
+
+    Composed rather than a subclass of :class:`EntryTally`, so there is exactly one
+    definition of "wins" and one of "game difference" — the divergence this module
+    exists to prevent — and so a pool's row cannot acquire a Buchholz of ``0`` that
+    really means "never computed".
+
+    ``buchholz`` rides on the row rather than staying inside the sort, because a
+    director has to be able to *see* the number that ordered the table: it is the one
+    link in the swiss chain that cannot be recomputed from the counts beside it."""
+
+    tally: EntryTally
+    buchholz: int
+
+
 # The tiebreak chain, after wins (which groups) and the two-way head-to-head (which
 # refines a pair): each entry maps to a value where HIGHER is better, tried in order.
 # A new comparator is **appended** here, not surgically inserted between the existing
 # ones — the chain is data, so extending it touches nothing already in it (ADR-0788).
+# Swiss ranks on the same two, in the same order, with Buchholz in front of them
+# (:func:`_swiss_scalar_key`) — so the two formats share this tail rather than agreeing
+# about it.
 _TIEBREAKERS: tuple[Callable[[EntryTally], int], ...] = (
     lambda tally: tally.game_difference,
     lambda tally: tally.games_won,
@@ -151,28 +177,79 @@ _TIEBREAKERS: tuple[Callable[[EntryTally], int], ...] = (
 def finishing_order(
     entrants: Iterable[EntryId],
     outcomes: Sequence[MatchOutcome],
-    byes: Iterable[EntryId] = (),
 ) -> list[EntryTally]:
-    """The pool's finishing order: its ``entrants`` tallied from ``outcomes`` and
-    ``byes``, then ordered by the chain in this module's docstring.
+    """The pool's finishing order: its ``entrants`` tallied from ``outcomes``, then
+    ordered by the round-robin chain in this module's docstring.
 
     ``entrants`` is the full seated field — not just the entries that have played — so
     the returned list always covers the whole pool. First place is index ``0``.
 
-    ``byes`` names one entry id **per bye taken**, so an entrant who has sat out twice
-    appears twice. Empty for every format but swiss, and empty for an even swiss field.
-    Both it and ``outcomes`` may only name entries that are in ``entrants``: the tallies
-    are keyed by entrant, so a stranger is a ``KeyError`` rather than a row appearing
-    from nowhere.
+    ``outcomes`` may only name entries that are in ``entrants``: the tallies are keyed
+    by entrant, so a stranger is a ``KeyError`` rather than a row appearing from
+    nowhere.
+
+    It takes **no byes**, and that is a fact about the format rather than an omission: a
+    round-robin's byed entrant sits out one round of a schedule that seats them in every
+    other, so there is no result to credit. Only swiss scores one — see
+    :func:`swiss_finishing_order`.
+    """
+    return _order(list(_tallies(entrants, outcomes).values()), outcomes, _scalar_key)
+
+
+def swiss_finishing_order(
+    entrants: Iterable[EntryId],
+    outcomes: Sequence[MatchOutcome],
+    byes: Iterable[EntryId] = (),
+) -> list[SwissTally]:
+    """A swiss field's finishing order: its ``entrants`` tallied from ``outcomes`` and
+    ``byes``, ordered by the swiss chain — wins, guarded head-to-head, **Buchholz**,
+    game difference, games won, entry id — with each row's Buchholz figure attached.
+
+    Its ``entrants`` and ``outcomes`` mean exactly what they mean in
+    :func:`finishing_order`, and first place is index ``0`` there too. The two
+    differences are the ones the format forces:
+
+    **Buchholz sits above game difference** (ADR "swiss standings add Buchholz, and
+    head-to-head is guarded on having met"). Swiss deliberately pairs you against
+    players on your own score, so two entrants level on wins may have faced completely
+    different halves of the field; game difference would rank them by margin against
+    unequal opposition. Buchholz measures who you had to beat, which in a format that
+    pairs by score is the stronger signal. A round-robin has no such thing to measure —
+    everybody plays everybody, so every entrant's opposition is identical — which is why
+    this link exists on one chain and not the other.
+
+    **Byes are scored**, as a win worth zero games. They arrive as a flat sequence of
+    entry ids, **one per bye taken**, so an entrant who has sat out twice appears twice,
+    and they may only name entries that are in ``entrants``. They are derived rather
+    than stored — a bye is the absence of a fixture row (CONTEXT.md, "Bye"), so the byed
+    entrant is the one with no fixture that round — by :func:`app.draws.swiss_byes`,
+    once, for both callers. Empty for an even field.
 
     ``byes`` **defaults to empty**, which is safe here for a reason that does not
     travel: this is one free function, so an omission is a caller declining to pass a
-    value at one call site — visible in the diff, and "no byes" is the truth for every
-    format but swiss. Contrast :meth:`app.draws.DrawStrategy.advance`, where the field
-    is a **required** parameter precisely because that is a ``Protocol`` with four
+    value at one call site — visible in the diff, and "no byes" is the truth of an even
+    field. Contrast :meth:`app.draws.DrawStrategy.advance`, where the field is a
+    **required** parameter precisely because that is a ``Protocol`` with four
     implementations: there, a default would let an implementation omit the parameter
     from its own signature and still type-check.
     """
+    tallies = _tallies(entrants, outcomes, byes)
+    buchholz = _buchholz(tallies, outcomes)
+    return [
+        SwissTally(tally=tally, buchholz=buchholz[tally.entry_id])
+        for tally in _order(
+            list(tallies.values()), outcomes, _swiss_scalar_key(buchholz)
+        )
+    ]
+
+
+def _tallies(
+    entrants: Iterable[EntryId],
+    outcomes: Sequence[MatchOutcome],
+    byes: Iterable[EntryId] = (),
+) -> dict[EntryId, EntryTally]:
+    """Every entrant's accumulator, folded from the results they have — the one place a
+    row's counts are built, so the two chains cannot disagree about what a win is."""
     tallies: dict[EntryId, EntryTally] = {
         entry_id: EntryTally(entry_id=entry_id) for entry_id in entrants
     }
@@ -182,14 +259,48 @@ def finishing_order(
         )
     for entry_id in byes:
         _record_bye(tallies[entry_id])
-    return _order(list(tallies.values()), outcomes)
+    return tallies
+
+
+def _buchholz(
+    tallies: Mapping[EntryId, EntryTally], outcomes: Sequence[MatchOutcome]
+) -> dict[EntryId, int]:
+    """Each entrant's **Buchholz**: the sum of their opponents' win counts.
+
+    The wins summed are ``tallies[...].wins`` — **the same wins column the standings
+    display, bye wins included** (ADR "swiss standings add Buchholz", amended).
+    Stripping a bye win out would put two definitions of "wins" in one module, and would
+    break the arithmetic a director does to check the figure by adding up their
+    opponents' win columns. The cost is that whoever played the byed entrant is credited
+    very slightly high, which is bounded at one win per opponent and lands arbitrarily
+    rather than systematically.
+
+    A **bye adds no term to its own holder's sum**: it produced no opponent, so there is
+    nothing to add. That falls out of summing over ``outcomes``, which a bye is not in,
+    rather than needing a case.
+
+    A **rematch counts twice** — swiss allows one as a last resort, and iterating the
+    outcomes credits that opponent's wins once per meeting. That is the standard reading
+    (Buchholz is a sum over games played, not over distinct opponents), and the ADR does
+    not settle it either way.
+
+    It is computed after the tallies are complete, never incrementally: an opponent's
+    later win changes an entrant's Buchholz without that entrant playing, which is
+    inherent to the measure.
+    """
+    totals = {entry_id: 0 for entry_id in tallies}
+    for outcome in outcomes:
+        totals[outcome.entry_a_id] += tallies[outcome.entry_b_id].wins
+        totals[outcome.entry_b_id] += tallies[outcome.entry_a_id].wins
+    return totals
 
 
 def _record_outcome(a: EntryTally, b: EntryTally, outcome: MatchOutcome) -> None:
     """Fold one decided fixture into both sides' tallies.
 
-    Private, like every other step of the order: :func:`finishing_order` is the module's
-    verb and the accumulator is its internals. Nothing outside builds a tally, so a
+    Private, like every other step of the order: :func:`finishing_order` and
+    :func:`swiss_finishing_order` are the module's verbs and the accumulator is their
+    internals. Nothing outside builds a tally, so a
     public one would advertise a protocol no caller wants — and invite a second, partial
     tallying path beside the one definition this module exists to be.
     (:func:`entry_id_order` is the exception, and is public because the *results* layer
@@ -233,33 +344,49 @@ def entry_id_order(entry_id: EntryId) -> int:
 
 
 def _order(
-    tallies: list[EntryTally], outcomes: Sequence[MatchOutcome]
+    tallies: list[EntryTally],
+    outcomes: Sequence[MatchOutcome],
+    scalar_key: Callable[[EntryTally], tuple[int, ...]],
 ) -> list[EntryTally]:
-    """Group by wins (descending), then break each tie."""
+    """Group by wins (descending), then break each tie.
+
+    ``scalar_key`` is the *only* thing that differs between the two formats' chains —
+    :func:`_scalar_key` for a pool, :func:`_swiss_scalar_key`'s closure for a swiss
+    field — so the first two links, wins and the guarded head-to-head, are shared
+    structurally rather than written twice and kept in step by hand.
+    """
     by_wins: dict[int, list[EntryTally]] = defaultdict(list)
     for tally in tallies:
         by_wins[tally.wins].append(tally)
     ordered: list[EntryTally] = []
     for wins in sorted(by_wins, reverse=True):
-        ordered.extend(_break_tie(by_wins[wins], outcomes))
+        ordered.extend(_break_tie(by_wins[wins], outcomes, scalar_key))
     return ordered
 
 
 def _break_tie(
-    group: list[EntryTally], outcomes: Sequence[MatchOutcome]
+    group: list[EntryTally],
+    outcomes: Sequence[MatchOutcome],
+    scalar_key: Callable[[EntryTally], tuple[int, ...]],
 ) -> list[EntryTally]:
     """Order a group of entries level on wins.
 
     A **two-way** tie is broken head-to-head when the pair has actually met — the
     winner of that match ranks above the loser. A larger tie (which can cycle) and a
-    two-way tie whose pair has not met yet (mid-pool) fall through to the game
-    tiebreakers.
+    two-way tie whose pair has not met fall through to ``scalar_key``.
+
+    "When the pair has actually met" is the guard, and it belongs to the step rather
+    than to either format. A part-played round-robin pool reaches it, and a swiss field
+    reaches it at the end of a completed event too: swiss pairs by score and never
+    claims to have drawn every pair together, so two entrants can finish level on wins
+    having never played each other. Without the guard the step would have to read a
+    result that does not exist.
     """
     if len(group) == 2:
         decided = _head_to_head(group[0], group[1], outcomes)
         if decided is not None:
             return decided
-    return sorted(group, key=_scalar_key)
+    return sorted(group, key=scalar_key)
 
 
 def _head_to_head(
@@ -283,3 +410,21 @@ def _scalar_key(tally: EntryTally) -> tuple[int, ...]:
         *(-tiebreaker(tally) for tiebreaker in _TIEBREAKERS),
         entry_id_order(tally.entry_id),
     )
+
+
+def _swiss_scalar_key(
+    buchholz: Mapping[EntryId, int],
+) -> Callable[[EntryTally], tuple[int, ...]]:
+    """:func:`_scalar_key` with **Buchholz in front of it** — the swiss chain's scalar
+    half, built over a field's already-computed figures.
+
+    Prepending is what puts Buchholz *above* game difference: the key is compared
+    left-to-right, so a Buchholz that separates the pair settles them before the game
+    counts are ever read. The rest of the tuple is the pool's own key, not a copy of it,
+    so the tail of the two chains is one definition.
+    """
+
+    def key(tally: EntryTally) -> tuple[int, ...]:
+        return (-buchholz[tally.entry_id], *_scalar_key(tally))
+
+    return key

--- a/api/app/pool_finishing_order.py
+++ b/api/app/pool_finishing_order.py
@@ -31,10 +31,13 @@ in step (ADR "swiss standings add Buchholz, and head-to-head is guarded on havin
 :func:`finishing_order` — a **round-robin pool**:
 
 1. **wins** — most match wins first;
-2. **head-to-head**, *only when exactly two entries are tied* on wins **and they have
-   actually met** — the one that beat the other ranks above it. A three-or-more-way tie
-   can cycle (A beat B beat C beat A), so it is **not** broken head-to-head; it falls
-   straight through to the game tiebreakers rather than a recursive mini-league;
+2. **head-to-head**, *only when exactly two entries are tied* on wins **and one of them
+   won more of their meetings than the other** — that one ranks above. It counts every
+   meeting rather than one, because swiss pairs a rematch as a last resort and a pair
+   who met twice and took one each did not beat each other: a split falls through, like
+   a pair who never met at all. A three-or-more-way tie can cycle (A beat B beat C beat
+   A), so it is **not** broken head-to-head; it falls straight through to the game
+   tiebreakers rather than a recursive mini-league;
 3. **game difference** — games won minus games lost;
 4. **games won**;
 5. the **entry id** — a total, deterministic fallback, so a pool in which two entries
@@ -47,12 +50,14 @@ The two share their machinery rather than agreeing by coincidence: one grouping 
 wins, one guarded head-to-head step, one tail of scalar comparators ending in the entry
 id. The swiss chain is that tail with one value in front of it.
 
-**The head-to-head step is guarded on the pair having met**, in *both* chains, and that
-is a property of the step rather than a swiss carve-out. A round-robin pool cannot reach
-the guard once it is played out — everyone meets everyone — so it costs that format
-nothing, while a swiss pair tied on wins may never have been drawn against each other
-and there is simply no result to read. (A part-played pool reaches it too, which is why
-the guard predates swiss.)
+**The head-to-head step is guarded on the pair having a result between them**, in *both*
+chains, and that is a property of the step rather than a swiss carve-out. A round-robin
+pool cannot reach the guard once it is played out — everyone meets everyone, once — so
+it costs that format nothing, while a swiss pair tied on wins may never have been drawn
+against each other and there is simply no result to read. (A part-played pool reaches it
+too, which is why the guard predates swiss.) Swiss adds the second way through it: a
+pair who met **twice** and took one each are level between themselves, so the step has
+no answer there either.
 """
 
 from __future__ import annotations
@@ -371,16 +376,18 @@ def _break_tie(
 ) -> list[EntryTally]:
     """Order a group of entries level on wins.
 
-    A **two-way** tie is broken head-to-head when the pair has actually met — the
-    winner of that match ranks above the loser. A larger tie (which can cycle) and a
-    two-way tie whose pair has not met fall through to ``scalar_key``.
+    A **two-way** tie is broken head-to-head when one of the pair won more of their
+    meetings than the other — that one ranks above. A larger tie (which can cycle), a
+    two-way tie whose pair has not met, and a two-way tie whose pair split their
+    meetings evenly all fall through to ``scalar_key``.
 
-    "When the pair has actually met" is the guard, and it belongs to the step rather
-    than to either format. A part-played round-robin pool reaches it, and a swiss field
-    reaches it at the end of a completed event too: swiss pairs by score and never
+    "When the pair have a result between them" is the guard, and it belongs to the step
+    rather than to either format. A part-played round-robin pool reaches it, and a swiss
+    field reaches it at the end of a completed event too: swiss pairs by score and never
     claims to have drawn every pair together, so two entrants can finish level on wins
-    having never played each other. Without the guard the step would have to read a
-    result that does not exist.
+    having never played each other — or, after a last-resort rematch, having beaten each
+    other once apiece. Without the guard the step would have to read a result that does
+    not exist, or pick one of two that disagree.
     """
     if len(group) == 2:
         decided = _head_to_head(group[0], group[1], outcomes)
@@ -392,13 +399,33 @@ def _break_tie(
 def _head_to_head(
     first: EntryTally, second: EntryTally, outcomes: Sequence[MatchOutcome]
 ) -> list[EntryTally] | None:
-    """``[winner, loser]`` if these two have met, else ``None`` (not yet played)."""
+    """``[winner, loser]`` if one of these two won **more of their meetings** than the
+    other, else ``None``.
+
+    ``None`` covers two cases and they are one answer: the pair have never met (nothing
+    to read — the guard :func:`_break_tie` describes), and the pair met an even number
+    of times and took half each. A 1-1 split is not one side beating the other, so
+    there is no head-to-head result to rank on and the chain carries on to the next
+    link, exactly as it does for a pair who never played.
+
+    **Every** meeting is counted, not the first one found, and that is what keeps the
+    step order-independent. Swiss pairs a rematch as a last resort once the walk runs
+    out of fresh opponents (CONTEXT.md, "Rematch"), so a pair genuinely can meet twice
+    — and reading only the first matching outcome made the answer depend on the order
+    the caller listed them in. The two callers do not list them alike (each loads its
+    own rows, sorted on its own key), so that was the one step in either chain that
+    could have parted them: every other link is a sum or a count, and neither cares
+    about order. This one now counts too.
+    """
     pair = {first.entry_id, second.entry_id}
+    wins = 0
     for outcome in outcomes:
         if {outcome.entry_a_id, outcome.entry_b_id} == pair:
-            if outcome.winner_entry_id == first.entry_id:
-                return [first, second]
-            return [second, first]
+            wins += 1 if outcome.winner_entry_id == first.entry_id else -1
+    if wins > 0:
+        return [first, second]
+    if wins < 0:
+        return [second, first]
     return None
 
 

--- a/api/app/results.py
+++ b/api/app/results.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import TypedDict
 
 from app.draws import EntryId, PoolId
 from app.models.tournament import DrawType
@@ -69,6 +70,7 @@ __all__ = [
     "RrThenKoResults",
     "SingleElimResults",
     "StandingRow",
+    "StandingRowColumns",
     "StandingsThenFinishes",
     "SwissResults",
     "SwissStandingRow",
@@ -264,22 +266,31 @@ class StandingsThenFinishes:
 
 
 @dataclass(frozen=True, slots=True)
-class SwissStandingRow:
+class SwissStandingRow(StandingRow):
     """One entry's line in a swiss table: the row every standings table carries, plus
     the **Buchholz** figure that ordered it.
 
-    Composed rather than a wider :class:`StandingRow`, for the reason
-    :class:`~app.pool_finishing_order.SwissTally` is: a pool has no Buchholz, so a
-    shared row would carry a ``0`` on every round-robin line that means "not applicable"
-    while reading as a real figure.
+    A **subclass**, not a wider :class:`StandingRow` and not a wrapper around one. The
+    two are different claims and only the first was ever in doubt: widening the shared
+    row would put a Buchholz of ``0`` on every round-robin line, where it would mean
+    "not applicable" while reading as a real figure. Extending it does not — a pool row
+    is a :class:`StandingRow` and is never one of these — and it says the thing that is
+    true, that a swiss line *is* a standings line with one more column. The wire models
+    (:class:`~app.schemas.tournament.SwissStandingRowRead`) and the web client's types
+    are both shaped that way, so this is also the shape the whole stack already agrees
+    on.
 
-    It is on the row because it is the one link in the swiss chain a director cannot
-    recompute from the counts beside it — the sum of *this entrant's opponents'* win
-    counts, which lives in other rows. Every other tiebreak on the table shows its own
-    working.
+    ``buchholz`` is on the row because it is the one link in the swiss chain a director
+    cannot recompute from the counts beside it — the sum of *this entrant's opponents'*
+    win counts, which lives in other rows. Every other tiebreak on the table shows its
+    own working.
+
+    (:class:`~app.pool_finishing_order.SwissTally` next door stays *composed*, and the
+    difference is real: a tally is what the chain mutates while it counts, so one shared
+    definition of "wins" there is the thing that keeps the two chains from drifting. A
+    row is the finished, frozen output.)
     """
 
-    row: StandingRow
     buchholz: int
 
 
@@ -514,7 +525,7 @@ class SwissResults:
         complete = (
             field.fixture_count > 0 and len(field.outcomes) == field.fixture_count
         )
-        champion = rows[0].row.entry_id if complete and rows else None
+        champion = rows[0].entry_id if complete and rows else None
         return SwissStandings(rows=rows, complete=complete, champion=champion)
 
 
@@ -552,13 +563,13 @@ def _swiss_standing_rows(
     **Buchholz** above game difference, and the figure itself carried out beside each
     row.
 
-    The row half is built by the same :func:`_standing_row` a pool's is, so "a standings
-    row means the same thing whichever event it is read off" stays true structurally;
-    the two tables differ in how they are *ordered* and in the one extra column, not in
-    what a row is."""
+    Its shared columns are filled from the same :func:`_standing_columns` a pool row's
+    are, so "a standings row means the same thing whichever event it is read off" stays
+    true structurally; the two tables differ in how they are *ordered* and in the one
+    extra column, not in what a row is."""
     return tuple(
         SwissStandingRow(
-            row=_standing_row(standing.tally, rank), buchholz=standing.buchholz
+            **_standing_columns(standing.tally, rank), buchholz=standing.buchholz
         )
         for rank, standing in enumerate(
             swiss_finishing_order(entrants, outcomes, byes), start=1
@@ -566,10 +577,35 @@ def _swiss_standing_rows(
     )
 
 
-def _standing_row(tally: EntryTally, rank: int) -> StandingRow:
-    """One tally as the table's row at ``rank`` — the one place a standings row is
-    built, for both shapes that carry a table."""
-    return StandingRow(
+class StandingRowColumns(TypedDict):
+    """The columns **every** standings row carries, named once.
+
+    It exists because :class:`SwissStandingRow` extends :class:`StandingRow` rather than
+    wrapping one: a frozen dataclass cannot be widened into its own subclass, so without
+    this the seven shared columns would be spelled out at two constructors that must
+    agree — the duplication the subclass was supposed to remove. Unpacked into both
+    (:func:`_standing_row`, :func:`_swiss_standing_rows`), so a column added to the row
+    is a type error at either site until it is added here too.
+
+    Public because the **wire** has the same pair of shapes and the same duplication to
+    avoid: ``app.tournament_serialization`` reads a row's columns back into it to build
+    :class:`~app.schemas.tournament.StandingRowRead` and its swiss subclass. One name
+    for the set of columns, checked statically at all four constructors.
+    """
+
+    entry_id: EntryId
+    rank: int
+    played: int
+    wins: int
+    losses: int
+    games_won: int
+    games_lost: int
+
+
+def _standing_columns(tally: EntryTally, rank: int) -> StandingRowColumns:
+    """One tally's shared columns at ``rank`` — the one place a standings row's counts
+    are read off a tally, for both shapes that carry a table."""
+    return StandingRowColumns(
         entry_id=tally.entry_id,
         rank=rank,
         played=tally.played,
@@ -578,3 +614,9 @@ def _standing_row(tally: EntryTally, rank: int) -> StandingRow:
         games_won=tally.games_won,
         games_lost=tally.games_lost,
     )
+
+
+def _standing_row(tally: EntryTally, rank: int) -> StandingRow:
+    """One tally as a **pool's** table row at ``rank``. A swiss row is built next door
+    from the same columns, with its Buchholz figure beside them."""
+    return StandingRow(**_standing_columns(tally, rank))

--- a/api/app/results.py
+++ b/api/app/results.py
@@ -21,11 +21,12 @@ snapshot, and a corrected or voided match re-derives the results the instant it 
 ``completed``, with no bookkeeping to keep in step (ADR-0788, "everything derives from
 the matches").
 
-The round-robin **tiebreak chain itself** lives in ``app.pool_finishing_order``, not
-here: the draw layer needs the same order to pick a pool's qualifiers, and this module
-already imports ``app.draws``, so a shared third module is the only place both can
-reach (ADR 20260727). ``MatchOutcome`` is re-exported from here for the callers that
-already know it by this name.
+The **tiebreak chains themselves** — the round-robin one and the swiss one — live in
+``app.pool_finishing_order``, not here: the draw layer needs the same orders to pick a
+pool's qualifiers and to pair a swiss round, and this module already imports
+``app.draws``, so a shared third module is the only place both can reach (ADR 20260727).
+``MatchOutcome`` is re-exported from here for the callers that already know it by this
+name.
 
 Four arms are implemented: :class:`RoundRobinResults`, whose shape is a **standings**
 table per pool; :class:`SingleElimResults` (ADR-0785), whose shape is the bracket's
@@ -44,7 +45,13 @@ from dataclasses import dataclass
 
 from app.draws import EntryId, PoolId
 from app.models.tournament import DrawType
-from app.pool_finishing_order import MatchOutcome, entry_id_order, finishing_order
+from app.pool_finishing_order import (
+    EntryTally,
+    MatchOutcome,
+    entry_id_order,
+    finishing_order,
+    swiss_finishing_order,
+)
 
 __all__ = [
     "BracketFinishes",
@@ -64,6 +71,7 @@ __all__ = [
     "StandingRow",
     "StandingsThenFinishes",
     "SwissResults",
+    "SwissStandingRow",
     "SwissStandings",
     "results_for",
 ]
@@ -256,6 +264,26 @@ class StandingsThenFinishes:
 
 
 @dataclass(frozen=True, slots=True)
+class SwissStandingRow:
+    """One entry's line in a swiss table: the row every standings table carries, plus
+    the **Buchholz** figure that ordered it.
+
+    Composed rather than a wider :class:`StandingRow`, for the reason
+    :class:`~app.pool_finishing_order.SwissTally` is: a pool has no Buchholz, so a
+    shared row would carry a ``0`` on every round-robin line that means "not applicable"
+    while reading as a real figure.
+
+    It is on the row because it is the one link in the swiss chain a director cannot
+    recompute from the counts beside it — the sum of *this entrant's opponents'* win
+    counts, which lives in other rows. Every other tiebreak on the table shows its own
+    working.
+    """
+
+    row: StandingRow
+    buchholz: int
+
+
+@dataclass(frozen=True, slots=True)
 class SwissStandings:
     """A swiss event's results: **one** standings table over the whole field, whether
     every round has been decided, and its champion when it has.
@@ -271,7 +299,7 @@ class SwissStandings:
     (CONTEXT.md, "Swiss"). ``None`` while any round is still to be decided.
     """
 
-    rows: tuple[StandingRow, ...]
+    rows: tuple[SwissStandingRow, ...]
     complete: bool
     champion: EntryId | None
 
@@ -447,13 +475,19 @@ class SwissResults:
     """A swiss event's results: one standings table over the whole field (ADR "swiss
     pre-cuts every round and pairs each one on advance").
 
-    Ordered by :func:`~app.pool_finishing_order.finishing_order` — the *same* chain a
-    round-robin pool is ordered by — through the same :func:`_standing_rows` a pool's
-    table is built with. That is deliberate and temporary: swiss gets its own ordering
-    function, with Buchholz above game difference and the head-to-head step guarded on
-    the pair having met, in its own slice (ADR "swiss standings add Buchholz, and
-    head-to-head is guarded on having met"). Until then this reads out the chain that
-    exists rather than a swiss-shaped approximation of the one that does not.
+    Ordered by :func:`~app.pool_finishing_order.swiss_finishing_order` — **swiss's own**
+    chain: wins, head-to-head when exactly two are tied *and they met*, then
+    **Buchholz**, then game difference, games won and the entry id (ADR "swiss standings
+    add Buchholz, and head-to-head is guarded on having met"). Buchholz sits above game
+    difference because swiss pairs by score: two entrants level on wins may have played
+    different halves of the field, so who they had to beat says more than the margin
+    they beat them by. It rides out on every row (:class:`SwissStandingRow`) because it
+    is the one tiebreak a director cannot recompute from the row it ordered.
+
+    The chain still lives in ``app.pool_finishing_order`` beside the pool one, for the
+    reason it went there in the first place (ADR 20260727): the draw layer walks this
+    same order to pair the next round, so "the standings a director reads" and "the
+    order the next round is paired down" are one definition and cannot drift.
 
     **A bye scores as a win worth zero games** (ADR "swiss standings add Buchholz, and
     head-to-head is guarded on having met"), which is the one thing this table counts
@@ -472,7 +506,7 @@ class SwissResults:
     """
 
     def tabulate(self, field: FieldInput) -> SwissStandings:
-        rows = _standing_rows(field.entrants, field.outcomes, field.byes)
+        rows = _swiss_standing_rows(field.entrants, field.outcomes, field.byes)
         # Every round decided — which, since the later rounds are cut up front with
         # their sides unknown, includes the ones nobody has been paired into yet. An
         # event with no fixtures that can still yield a result is deliberately NOT
@@ -480,7 +514,7 @@ class SwissResults:
         complete = (
             field.fixture_count > 0 and len(field.outcomes) == field.fixture_count
         )
-        champion = rows[0].entry_id if complete and rows else None
+        champion = rows[0].row.entry_id if complete and rows else None
         return SwissStandings(rows=rows, complete=complete, champion=champion)
 
 
@@ -495,28 +529,52 @@ def _pool_standings(pool: PoolInput) -> PoolStandings:
 def _standing_rows(
     entrants: Sequence[EntryId],
     outcomes: Sequence[MatchOutcome],
-    byes: Sequence[EntryId] = (),
 ) -> tuple[StandingRow, ...]:
-    """These entrants' rows, at their settled ranks — the one place a table is built,
-    for the two shapes that carry one (a pool's, and a swiss field's).
+    """A pool's rows, at their settled ranks, ordered by
+    :func:`~app.pool_finishing_order.finishing_order`.
 
-    Shared so that "a standings row means the same thing whichever event it is read
-    off" is true structurally: the ordering is
-    :func:`~app.pool_finishing_order.finishing_order` and the counts come off the
-    tallies it returns, in one function rather than two that agree today.
-
-    ``byes`` defaults to none, which is a **fact about a pool** rather than a
-    convenience: a round-robin bye is a round sat out inside a schedule that seats its
-    holder in every other one, so there is nothing to score. Only swiss passes any."""
+    It takes no byes: a round-robin bye is a round sat out inside a schedule that seats
+    its holder in every other one, so there is nothing to score. Swiss, which does score
+    one, orders through its own chain — :func:`_swiss_standing_rows`."""
     return tuple(
-        StandingRow(
-            entry_id=tally.entry_id,
-            rank=rank,
-            played=tally.played,
-            wins=tally.wins,
-            losses=tally.losses,
-            games_won=tally.games_won,
-            games_lost=tally.games_lost,
+        _standing_row(tally, rank)
+        for rank, tally in enumerate(finishing_order(entrants, outcomes), start=1)
+    )
+
+
+def _swiss_standing_rows(
+    entrants: Sequence[EntryId],
+    outcomes: Sequence[MatchOutcome],
+    byes: Sequence[EntryId],
+) -> tuple[SwissStandingRow, ...]:
+    """A swiss field's rows, at their settled ranks, ordered by
+    :func:`~app.pool_finishing_order.swiss_finishing_order` — the chain with
+    **Buchholz** above game difference, and the figure itself carried out beside each
+    row.
+
+    The row half is built by the same :func:`_standing_row` a pool's is, so "a standings
+    row means the same thing whichever event it is read off" stays true structurally;
+    the two tables differ in how they are *ordered* and in the one extra column, not in
+    what a row is."""
+    return tuple(
+        SwissStandingRow(
+            row=_standing_row(standing.tally, rank), buchholz=standing.buchholz
         )
-        for rank, tally in enumerate(finishing_order(entrants, outcomes, byes), start=1)
+        for rank, standing in enumerate(
+            swiss_finishing_order(entrants, outcomes, byes), start=1
+        )
+    )
+
+
+def _standing_row(tally: EntryTally, rank: int) -> StandingRow:
+    """One tally as the table's row at ``rank`` — the one place a standings row is
+    built, for both shapes that carry a table."""
+    return StandingRow(
+        entry_id=tally.entry_id,
+        rank=rank,
+        played=tally.played,
+        wins=tally.wins,
+        losses=tally.losses,
+        games_won=tally.games_won,
+        games_lost=tally.games_lost,
     )

--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -1653,17 +1653,44 @@ class StandingsThenFinishesResultsRead(BaseModel):
     champion: uuid.UUID | None
 
 
+class SwissStandingRowRead(StandingRowRead):
+    """One entry's line in a **swiss** table: every column a pool's row carries, plus
+    the **Buchholz** figure that ordered it.
+
+    ``buchholz`` is the sum of this entrant's opponents' win counts — the wins column
+    this same table shows, **bye wins included** (ADR "swiss standings add Buchholz, and
+    head-to-head is guarded on having met"), so a director can check the figure by
+    adding up the rows of the players this one has played. A **bye adds no term** to its
+    own holder's sum: it produced no opponent.
+
+    It is on the wire because it is the one tiebreak a client cannot derive from the row
+    it ordered: ``rank`` is settled by wins, then head-to-head, then *this*, then
+    ``game_difference`` and ``games_won``, and every other link shows its working in the
+    columns beside it. A swiss table that ranks A above B on equal wins and worse game
+    difference is unreadable without it.
+
+    It extends the round-robin row rather than replacing it, so a client renders a swiss
+    table with the component it already has and one extra column."""
+
+    buchholz: int
+
+
 class SwissStandingsResultsRead(BaseModel):
     """The **pool-less standings** shape of an event's results — the swiss arm of the
     ``results`` discriminated union, tagged ``kind: "swiss_standings"`` (ADR "swiss
     pre-cuts every round and pairs each one on advance").
 
     One table over the whole field, because swiss has no pools: everybody is ranked
-    against everybody, which is what pairing by score is for. The rows are the *same*
-    :class:`StandingRowRead` a round-robin pool carries, so a client renders this with
-    the table it already has — the difference is that they arrive as one list rather
-    than grouped under a pool, which is a fact about the format and not a second row
-    shape.
+    against everybody, which is what pairing by score is for. The rows are a
+    :class:`StandingRowRead` plus one column (:class:`SwissStandingRowRead`), and they
+    arrive as one list rather than grouped under a pool — both facts about the format
+    rather than a second row shape.
+
+    The order is swiss's own chain: wins, head-to-head when exactly two are tied **and
+    they met**, then **Buchholz**, then game difference, games won and the entry id (ADR
+    "swiss standings add Buchholz, and head-to-head is guarded on having met"). Strength
+    of schedule outranks margin here because swiss pairs by score, so two entrants level
+    on wins may have faced different halves of the field.
 
     ``complete`` is every round decided, including the later rounds that are cut up
     front with their sides still unknown. ``champion`` is the leader of a complete
@@ -1672,7 +1699,7 @@ class SwissStandingsResultsRead(BaseModel):
     completed matches like every other results shape."""
 
     kind: Literal["swiss_standings"] = "swiss_standings"
-    rows: list[StandingRowRead]
+    rows: list[SwissStandingRowRead]
     complete: bool
     champion: uuid.UUID | None
 

--- a/api/app/tournament_materialization.py
+++ b/api/app/tournament_materialization.py
@@ -264,6 +264,27 @@ async def _fixtures_with_match_statuses(
             select(TournamentFixture, Match.status)
             .outerjoin(Match, Match.id == TournamentFixture.match_id)
             .where(TournamentFixture.event_id == event_id)
+            # Ordered for **stability**, not for presentation: an unordered ``SELECT``
+            # has no guarantee even between two runs against unchanged data, and the
+            # rows go on to be projected into the outcomes a draw type ranks its field
+            # by. Nothing downstream may depend on that order — the tiebreak chain is
+            # sums and counts (``app.pool_finishing_order``), and a plan's ready list is
+            # sorted by ``app.draws.ready_fixtures`` — but "no caller depends on it" is
+            # cheaper to keep true when the order is fixed.
+            #
+            # ``(pool_id, round, position)`` is total within one event: it is the
+            # fixture's identity there, declared NULLS NOT DISTINCT so the un-pooled
+            # draws are covered too
+            # (``uq_tournament_fixtures_event_id_pool_id_round_position``). It is the
+            # read path's key (``app.tournament_queries.fixtures_by_event``) minus the
+            # pool's *position*, which that path sorts on to render the draw in the
+            # director's pool order — presentation this seam has no use for, and would
+            # pay a correlated subquery for.
+            .order_by(
+                TournamentFixture.pool_id.asc().nulls_last(),
+                TournamentFixture.round,
+                TournamentFixture.position,
+            )
         )
     ).all()
     fixtures: list[TournamentFixture] = []

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -44,6 +44,7 @@ from app.results import (
     RrThenKoResults,
     SingleElimResults,
     StandingRow,
+    StandingRowColumns,
     StandingsThenFinishes,
     SwissResults,
     SwissStandingRow,
@@ -531,18 +532,28 @@ def _pool_standings_read(pools: Sequence[PoolStandings]) -> list[PoolStandingsRe
 def _standing_rows_read(rows: Sequence[StandingRow]) -> list[StandingRowRead]:
     """A pool's standings rows, shared by the two shapes that carry one — the
     round-robin arm and the pool stage of the rr-then-ko arm."""
-    return [
-        StandingRowRead(
-            entry_id=row.entry_id,
-            rank=row.rank,
-            played=row.played,
-            wins=row.wins,
-            losses=row.losses,
-            games_won=row.games_won,
-            games_lost=row.games_lost,
-        )
-        for row in rows
-    ]
+    return [StandingRowRead(**_standing_read_columns(row)) for row in rows]
+
+
+def _standing_read_columns(row: StandingRow) -> StandingRowColumns:
+    """One domain row's columns, ready to unpack into its wire model — the one place a
+    standings row crosses onto the wire, for both tables that carry one.
+
+    The set of columns is named once, in :class:`~app.results.StandingRowColumns`, and
+    both wire models take it: :class:`StandingRowRead` alone, and
+    :class:`SwissStandingRowRead` with ``buchholz`` beside it, exactly as their domain
+    rows relate. So adding a column to a standings row is a type error at each
+    constructor until it is added here, rather than a column that quietly reaches one
+    table and not the other."""
+    return StandingRowColumns(
+        entry_id=row.entry_id,
+        rank=row.rank,
+        played=row.played,
+        wins=row.wins,
+        losses=row.losses,
+        games_won=row.games_won,
+        games_lost=row.games_lost,
+    )
 
 
 def _swiss_standing_rows_read(
@@ -552,21 +563,14 @@ def _swiss_standing_rows_read(
     the figure that ordered them (ADR "swiss standings add Buchholz, and head-to-head is
     guarded on having met").
 
-    The columns are restated rather than copied off a :class:`StandingRowRead` built
-    next door, because the read model is a *subclass* — there is no partially-built row
-    to widen, and ``model_dump`` would carry the computed ``game_difference`` back in as
-    a field it cannot be set from."""
+    The shared columns come from :func:`_standing_read_columns`, the same call a pool
+    row's do, rather than being spelled out a second time here: the shapes match on both
+    sides of the wire — :class:`SwissStandingRowRead` extends
+    :class:`~app.schemas.tournament.StandingRowRead` exactly as
+    :class:`~app.results.SwissStandingRow` extends :class:`~app.results.StandingRow` —
+    so the only thing this adds is the one column swiss has."""
     return [
-        SwissStandingRowRead(
-            entry_id=row.row.entry_id,
-            rank=row.row.rank,
-            played=row.row.played,
-            wins=row.row.wins,
-            losses=row.row.losses,
-            games_won=row.row.games_won,
-            games_lost=row.row.games_lost,
-            buchholz=row.buchholz,
-        )
+        SwissStandingRowRead(**_standing_read_columns(row), buchholz=row.buchholz)
         for row in rows
     ]
 

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -46,6 +46,7 @@ from app.results import (
     StandingRow,
     StandingsThenFinishes,
     SwissResults,
+    SwissStandingRow,
     SwissStandings,
     results_for,
 )
@@ -63,6 +64,7 @@ from app.schemas.tournament import (
     StandingRowRead,
     StandingsResultsRead,
     StandingsThenFinishesResultsRead,
+    SwissStandingRowRead,
     SwissStandingsResultsRead,
     TournamentDetailRead,
     TournamentEntrantRead,
@@ -354,10 +356,10 @@ def _field_input(
     The entries seated in fixtures are **unioned in** rather than assumed to be a
     subset, for the **rows** only. A player who withdraws after the draw is cut leaves
     the active list while their played fixtures stay, and
-    :func:`~app.pool_finishing_order.finishing_order` indexes its tallies by entrant —
-    so dropping them would be a ``KeyError`` on the first outcome that names them, on
-    the detail page of any event that had a withdrawal. Somebody who played real
-    matches belongs in the table.
+    :func:`~app.pool_finishing_order.swiss_finishing_order` indexes its tallies by
+    entrant — so dropping them would be a ``KeyError`` on the first outcome that names
+    them, on the detail page of any event that had a withdrawal. Somebody who played
+    real matches belongs in the table.
 
     The **byes** are derived here rather than stored, because there is nothing to
     store: a bye is the absence of a fixture row, so it is read off the rounds that
@@ -527,8 +529,8 @@ def _pool_standings_read(pools: Sequence[PoolStandings]) -> list[PoolStandingsRe
 
 
 def _standing_rows_read(rows: Sequence[StandingRow]) -> list[StandingRowRead]:
-    """One standings table's rows, shared by every shape that carries a table — a pool's
-    and a swiss field's — so a row means the same thing on either."""
+    """A pool's standings rows, shared by the two shapes that carry one — the
+    round-robin arm and the pool stage of the rr-then-ko arm."""
     return [
         StandingRowRead(
             entry_id=row.entry_id,
@@ -538,6 +540,32 @@ def _standing_rows_read(rows: Sequence[StandingRow]) -> list[StandingRowRead]:
             losses=row.losses,
             games_won=row.games_won,
             games_lost=row.games_lost,
+        )
+        for row in rows
+    ]
+
+
+def _swiss_standing_rows_read(
+    rows: Sequence[SwissStandingRow],
+) -> list[SwissStandingRowRead]:
+    """A swiss table's rows: the same columns a pool's row carries plus ``buchholz``,
+    the figure that ordered them (ADR "swiss standings add Buchholz, and head-to-head is
+    guarded on having met").
+
+    The columns are restated rather than copied off a :class:`StandingRowRead` built
+    next door, because the read model is a *subclass* — there is no partially-built row
+    to widen, and ``model_dump`` would carry the computed ``game_difference`` back in as
+    a field it cannot be set from."""
+    return [
+        SwissStandingRowRead(
+            entry_id=row.row.entry_id,
+            rank=row.row.rank,
+            played=row.row.played,
+            wins=row.row.wins,
+            losses=row.row.losses,
+            games_won=row.row.games_won,
+            games_lost=row.row.games_lost,
+            buchholz=row.buchholz,
         )
         for row in rows
     ]
@@ -573,11 +601,10 @@ def _serialize_finishes(results: BracketFinishes) -> FinishesResultsRead:
 
 
 def _serialize_swiss_standings(results: SwissStandings) -> SwissStandingsResultsRead:
-    """The swiss table, whose rows are serialized by the same helper a pool's are — so
-    "a swiss event's standings rows cross the wire exactly as a round-robin pool's do"
-    is true structurally rather than by two serializers agreeing."""
+    """The swiss table — a pool's columns plus the Buchholz figure each row was ordered
+    by."""
     return SwissStandingsResultsRead(
-        rows=_standing_rows_read(results.rows),
+        rows=_swiss_standing_rows_read(results.rows),
         complete=results.complete,
         champion=results.champion,
     )

--- a/api/tests/test_draws.py
+++ b/api/tests/test_draws.py
@@ -2556,7 +2556,12 @@ class TestSwissAdvance:
         """A voided match will never produce a result, so requiring one would leave the
         event one score short forever, with no move a director could make. The round
         counts as decided without it — the same exception the pool-finished test
-        makes."""
+        makes.
+
+        Seed 4 is ahead of seed 3 in the second pairing because the standings put them
+        there: 4 lost to the field's only winner (Buchholz 1) and 3's single fixture was
+        voided, so 3 has faced nobody (Buchholz 0). Both are on no wins and a game
+        difference the chain never reaches."""
         cut = self._cut(rounds=3, entrants=4)
         played = _played(cut, {frozenset({2, 4}): (2, 3, 0)})
         voided = [
@@ -2570,7 +2575,7 @@ class TestSwissAdvance:
 
         plan = self._advance(voided, _ordered(4))
 
-        assert _seed_pairs(_apply(voided, plan), 2) == [(1, 2, 1), (2, 3, 4)]
+        assert _seed_pairs(_apply(voided, plan), 2) == [(1, 2, 1), (2, 4, 3)]
 
     def test_the_field_is_the_entrants_so_round_ones_bye_is_paired_next(self) -> None:
         """**The field comes from the entrants, never from the seated set.** Seed 5 has
@@ -2629,9 +2634,14 @@ class TestSwissAdvance:
         Seven entrants, three rounds, driven through two rounds of real results. By
         round 3 the two byed entrants are seed 7 (round 1) and seed 5 (round 2), and
         their bye wins move both of them up the table: 7 into the two-win group above
-        every one-win player, and 5 above seeds 1 and 3. Score the byes as nothing and
+        every one-win player, and 5 above seed 4. Score the byes as nothing and
         the walk sees a different order and emits three different pairings —
         2v4, 7v1, 6v5 — including one the rematch rule then has to work around.
+
+        The one-win group is ordered by **Buchholz**, so it reads 1, 6, 5, 4: seed 1
+        played the eventual leader and seed 4 played the winless seed 3, which outweighs
+        seed 4's better game difference (+2 against −2). The table is therefore
+        2, 7, 1, 6, 5, 4, 3 and the walk pairs 2v7, 1v6, 5v4 with seed 3 byed.
         """
         cut = _persisted(
             SwissStrategy(rounds=3).plan_initial(DrawConfig(), _ordered(7))
@@ -2658,8 +2668,8 @@ class TestSwissAdvance:
         assert _seed_pairs(round_two, 2) == [(1, 1, 2), (2, 6, 7), (3, 3, 4)]
         assert _seed_pairs(_apply(round_two, plan), 3) == [
             (1, 2, 7),
-            (2, 4, 6),
-            (3, 5, 1),
+            (2, 1, 6),
+            (3, 5, 4),
         ]
         assert _seated(_apply(round_two, plan), 3) == {1, 2, 4, 5, 6, 7}, (
             "seed 3 takes round 3's bye, being the lowest-ranked entrant without one"
@@ -2811,16 +2821,23 @@ class TestSwissAdvance:
         a played draw cannot be un-cut — no move a director could make.
 
         The pairings are asserted exactly, in both rounds, so this cannot pass by
-        pairing *something*. Round 2's table is the seven survivors' (5, 2, 7, 4, 3, 6,
-        1 — seed 8's win over seed 4 is not theirs to count), seed 1 takes the bye, and
-        round 3 is paired off round 2's table in turn.
+        pairing *something*. Round 2's table is the seven survivors' (5, 2, 7, 3, 6, 1,
+        4), seed 4 takes the bye, and round 3 is paired off round 2's table in turn.
+
+        Seed 4 is last on it, and that is the shrink showing up in the standings rather
+        than a quirk: seed 8's departure takes seed 4's only result with it (an outcome
+        naming an entry outside the field is left out), so seed 4 has no wins and, on
+        the step above game difference, **no opposition at all** — Buchholz 0, below the
+        three entrants who lost to somebody who is still here. The one-win group is
+        ordered by game difference, the chain's next link, since all three beat a
+        winless opponent.
         """
         played = _played(self._cut(rounds=4, entrants=8), _ROUND_ONE_UPSETS)
 
         round_two = _apply(played, SwissStrategy(rounds=4).advance(played, _ordered(7)))
 
-        assert _paired_rows(round_two, 2) == [(1, 5, 2), (2, 7, 4), (3, 3, 6)]
-        assert _seated(round_two, 2) == {2, 3, 4, 5, 6, 7}, "seed 1 sits round 2 out"
+        assert _paired_rows(round_two, 2) == [(1, 5, 2), (2, 7, 6), (3, 3, 1)]
+        assert _seated(round_two, 2) == {1, 2, 3, 5, 6, 7}, "seed 4 sits round 2 out"
         assert len([f for f in round_two if f.round == 2]) == 4, (
             "the cut's fourth row is still there — it is unpairable, not deleted"
         )
@@ -2829,19 +2846,19 @@ class TestSwissAdvance:
             round_two,
             {
                 frozenset({5, 2}): (5, 3, 0),
-                frozenset({7, 4}): (7, 3, 0),
-                frozenset({3, 6}): (3, 3, 0),
+                frozenset({7, 6}): (7, 3, 0),
+                frozenset({3, 1}): (3, 3, 0),
             },
         )
         round_three = _apply(
             decided, SwissStrategy(rounds=4).advance(decided, _ordered(7))
         )
 
-        assert _paired_rows(round_three, 3) == [(1, 5, 7), (2, 3, 2), (3, 1, 4)], (
+        assert _paired_rows(round_three, 3) == [(1, 5, 7), (2, 3, 2), (3, 4, 6)], (
             "round 3 is paired off round 2's table — the round that was neither "
             "wholly unpaired nor decided, and stalled the walk forever"
         )
-        assert _seated(round_three, 3) == {1, 2, 3, 4, 5, 7}, "seed 6 sits round 3 out"
+        assert _seated(round_three, 3) == {2, 3, 4, 5, 6, 7}, "seed 1 sits round 3 out"
 
     def test_a_shrunk_round_is_not_paired_a_second_time(self) -> None:
         """The idempotence the fix must not cost. A round paired down to a shrunk field
@@ -2855,7 +2872,7 @@ class TestSwissAdvance:
         second = SwissStrategy(rounds=4).advance(applied, _ordered(7))
 
         assert second.side_fills == ()
-        assert _paired_rows(applied, 2) == [(1, 5, 2), (2, 7, 4), (3, 3, 6)]
+        assert _paired_rows(applied, 2) == [(1, 5, 2), (2, 7, 6), (3, 3, 1)]
 
     def test_a_shrunk_field_runs_out_of_byeless_entrants(self) -> None:
         """**The byeless fallback is reachable through the real cut**, and the docstring

--- a/api/tests/test_pool_finishing_order.py
+++ b/api/tests/test_pool_finishing_order.py
@@ -16,8 +16,12 @@ changes who advances.
 
 **The swiss chain's is that chain with Buchholz between head-to-head and game
 difference** (ADR "swiss standings add Buchholz, and head-to-head is guarded on having
-met"), and the head-to-head link is **guarded on the pair having met** — swiss pairs by
-score, so two entrants can finish level on wins having never played each other.
+met"), and the head-to-head link is **guarded on the pair having a result between
+them** — swiss pairs by score, so two entrants can finish level on wins having never
+played each other, and its last-resort rematch lets a pair meet twice and take one each.
+Counting **every** meeting rather than the first one found is also what keeps that link
+order-independent, and so what keeps the draw layer's answer and the results layer's the
+same one.
 
 Each test below isolates **one** link: the case is built so that link alone separates
 the pair, and so the *later* links — including the entry-id fallback — would give the
@@ -30,14 +34,22 @@ import uuid
 from pathlib import Path
 
 import app.pool_finishing_order
-from app.draws import EntryId, PoolId
+from app.draws import (
+    EntryId,
+    FixtureGames,
+    FixtureId,
+    FixtureState,
+    MatchId,
+    PoolId,
+    _swiss_standings_order,
+)
 from app.pool_finishing_order import (
     EntryTally,
     MatchOutcome,
     finishing_order,
     swiss_finishing_order,
 )
-from app.results import PoolInput, RoundRobinResults
+from app.results import FieldInput, PoolInput, RoundRobinResults, SwissResults
 
 _API_ROOT = Path(__file__).resolve().parent.parent
 
@@ -117,6 +129,57 @@ def _buchholz(
         standing.buchholz
         for standing in swiss_finishing_order(entrants, outcomes, byes)
         if standing.tally.entry_id == of
+    )
+
+
+#: The four entrants of the rematch cases below. ``_A`` carries the smallest id, so the
+#: entry-id fallback always says ``_A`` first — which is what makes an answer of ``_B``
+#: first evidence of the link under test rather than of the fallback.
+_A, _B, _C, _D = _eid(1), _eid(2), _eid(3), _eid(4)
+
+
+def _split_rematch() -> tuple[list[EntryId], list[MatchOutcome]]:
+    """A four-entrant swiss in which A and B met **twice and took one each**, with the
+    outcomes in the order the results layer reads them (round, then position).
+
+    Read the arithmetic in
+    :func:`test_a_split_rematch_leaves_the_head_to_head_undecided`, which is the test
+    the field is shaped for; the other two read the same field from the draw layer and
+    from the results layer.
+    """
+    return (
+        [_A, _B, _C, _D],
+        [
+            _outcome(_A, _B, 3, 1),
+            _outcome(_C, _D, 3, 0),
+            _outcome(_A, _D, 3, 0),
+            _outcome(_B, _C, 3, 0),
+            _outcome(_B, _A, 3, 1),
+        ],
+    )
+
+
+def _fixture(
+    round_number: int,
+    position: int,
+    first: EntryId,
+    second: EntryId,
+    first_games: int,
+    second_games: int,
+) -> FixtureState:
+    """One decided, un-pooled fixture as the **draw** layer holds it — the row shape
+    :func:`app.draws._swiss_standings_order` projects its outcomes from."""
+    slot = round_number * 16 + position
+    return FixtureState(
+        fixture_id=FixtureId(uuid.UUID(int=0xF000 + slot)),
+        pool_id=None,
+        round=round_number,
+        position=position,
+        entry_a_id=first,
+        entry_b_id=second,
+        winner_entry_id=first if first_games > second_games else second,
+        match_id=MatchId(uuid.UUID(int=0xE000 + slot)),
+        games=FixtureGames(entry_a_games=first_games, entry_b_games=second_games),
     )
 
 
@@ -394,6 +457,96 @@ def test_a_tied_pair_who_never_met_fall_through_the_head_to_head_link() -> None:
     ]
 
     assert _swiss_order(entrants, outcomes)[:3] == [s, y, x]
+
+
+def test_a_split_rematch_leaves_the_head_to_head_undecided() -> None:
+    """**A pair who met twice and took one each did not beat each other**, so the link
+    has nothing to say and the chain carries on to Buchholz.
+
+    Swiss pairs a rematch as a last resort when the walk runs out of fresh opponents,
+    so a pair *can* meet twice — and reading only one of the two meetings makes the
+    answer depend on which meeting the caller happened to list first. Here A won the
+    first meeting and B the second, and they are the only two on two wins.
+
+        A beat B 3-1, B beat A 3-1   → A: 2-1, GW 7, GL 4, GD +3
+                                       B: 2-1, GW 7, GL 4, GD +3
+        A beat D 3-0                 → Buchholz A = B(2) + B(2) + D(0) = 4
+        B beat C 3-0                 → Buchholz B = A(2) + A(2) + C(1) = 5
+        C beat D 3-0                 → C: 1-1,  D: 0-2
+
+    Buchholz says B, and it is the only link that separates them: they are level on
+    game difference (+3) and games won (7), and the entry-id fallback says A. So an
+    implementation that answered the head-to-head from *either* meeting gets a
+    different order — and one that answered it from the **first** meeting in the list
+    gets a different order depending on the order it was handed.
+    """
+    entrants, outcomes = _split_rematch()
+
+    assert _swiss_order(entrants, outcomes) == [_B, _A, _C, _D]
+    assert _swiss_order(entrants, list(reversed(outcomes))) == [_B, _A, _C, _D], (
+        "the order must not depend on which meeting the caller listed first"
+    )
+
+
+def test_a_decisive_rematch_ranks_the_side_that_won_both_above() -> None:
+    """The other half: a pair who met twice and one of them won **both** *did* beat the
+    other, so head-to-head still settles them.
+
+    A won both meetings 3-2. Every link below head-to-head says B — game difference
+    (+4 against +2), with Buchholz level at four apiece — so the pair only comes out
+    A-first because the two meetings are counted and A took both.
+
+        A beat B 3-2 twice  → A: 2-0, GW 6, GL 4, GD +2;  Buchholz B(2) + B(2) = 4
+        B beat C 3-0        → B: 2-2, GW 10, GL 6, GD +4; Buchholz A(2) + A(2)
+        B beat D 3-0                                              + C(0) + D(0) = 4
+                            → C: 0-1,  D: 0-1
+    """
+    entrants = [_A, _B, _C, _D]
+    outcomes = [
+        _outcome(_A, _B, 3, 2),
+        _outcome(_B, _C, 3, 0),
+        _outcome(_A, _B, 3, 2),
+        _outcome(_B, _D, 3, 0),
+    ]
+
+    assert _swiss_order(entrants, outcomes) == [_A, _B, _C, _D]
+    assert _swiss_order(entrants, list(reversed(outcomes))) == [_A, _B, _C, _D]
+
+
+def test_a_split_rematch_orders_the_draw_layer_and_the_results_layer_alike() -> None:
+    """**The two layers rank one table**, over the case that used to be able to part
+    them.
+
+    The results layer reads its fixtures ordered (round, then position); the draw layer
+    reads the same rows to decide which order the next round is paired down. A
+    head-to-head answered from the first meeting in the list made that a question about
+    which row came back first, so the director's table and the pairing could disagree —
+    and the draw layer's answer could differ between two advances of the same event.
+
+    Both layers are asked here, and the draw layer is asked a second time with its rows
+    **reversed** — the shape an unordered ``SELECT`` is free to hand it.
+    """
+    entrants, outcomes = _split_rematch()
+    fixtures = [
+        _fixture(1, 1, _A, _B, 3, 1),
+        _fixture(1, 2, _C, _D, 3, 0),
+        _fixture(2, 1, _A, _D, 3, 0),
+        _fixture(2, 2, _B, _C, 3, 0),
+        _fixture(3, 1, _B, _A, 3, 1),
+    ]
+
+    table = SwissResults().tabulate(
+        FieldInput(entrants=tuple(entrants), fixture_count=5, outcomes=tuple(outcomes))
+    )
+
+    assert [row.entry_id for row in table.rows] == [_B, _A, _C, _D]
+    assert _swiss_standings_order(entrants, fixtures, ()) == [_B, _A, _C, _D]
+    assert _swiss_standings_order(entrants, list(reversed(fixtures)), ()) == [
+        _B,
+        _A,
+        _C,
+        _D,
+    ], "an unordered fixture load must not move the pairing order"
 
 
 def test_buchholz_counts_an_opponents_bye_win() -> None:

--- a/api/tests/test_pool_finishing_order.py
+++ b/api/tests/test_pool_finishing_order.py
@@ -1,18 +1,27 @@
-"""Pure tests for the shared pool finishing order (ADR 20260727).
+"""Pure tests for the shared finishing orders (ADR 20260727) — the round-robin pool
+chain and the swiss one.
 
-Two properties are pinned here, because both are load-bearing for
-round-robin-then-knockout and neither is observable from ``tests/test_results.py``:
+Three properties are pinned here, because they are load-bearing for
+round-robin-then-knockout and for swiss, and none is observable from
+``tests/test_results.py``:
 
 **The module stays importable on its own** — no runtime reach into ``app.results``,
 ``app.draws``, SQLAlchemy or FastAPI. That is what lets the *draw* layer call it
 without an import cycle (``app.results`` already imports ``app.draws``).
 
-**The tiebreak chain's order is exactly wins → head-to-head → game difference →
+**The pool chain's order is exactly wins → head-to-head → game difference →
 games won → entry id.** rr-then-ko's whole correctness claim is that the qualifiers
 are the top *K* of the standings table on screen, so a silently reordered chain
-changes who advances. Each test below isolates **one** link: the case is built so
-that link alone separates the pair, and so the *later* links — including the entry-id
-fallback — would give the opposite answer if the link under test were removed.
+changes who advances.
+
+**The swiss chain's is that chain with Buchholz between head-to-head and game
+difference** (ADR "swiss standings add Buchholz, and head-to-head is guarded on having
+met"), and the head-to-head link is **guarded on the pair having met** — swiss pairs by
+score, so two entrants can finish level on wins having never played each other.
+
+Each test below isolates **one** link: the case is built so that link alone separates
+the pair, and so the *later* links — including the entry-id fallback — would give the
+opposite answer if the link under test were removed.
 """
 
 import subprocess
@@ -22,7 +31,12 @@ from pathlib import Path
 
 import app.pool_finishing_order
 from app.draws import EntryId, PoolId
-from app.pool_finishing_order import EntryTally, MatchOutcome, finishing_order
+from app.pool_finishing_order import (
+    EntryTally,
+    MatchOutcome,
+    finishing_order,
+    swiss_finishing_order,
+)
 from app.results import PoolInput, RoundRobinResults
 
 _API_ROOT = Path(__file__).resolve().parent.parent
@@ -61,12 +75,23 @@ def _outcome(
     )
 
 
-def _order(
+def _order(entrants: list[EntryId], outcomes: list[MatchOutcome]) -> list[EntryId]:
+    """The **round-robin** chain's order: wins → head-to-head → game difference →
+    games won → entry id."""
+    return [tally.entry_id for tally in finishing_order(entrants, outcomes)]
+
+
+def _swiss_order(
     entrants: list[EntryId],
     outcomes: list[MatchOutcome],
     byes: list[EntryId] | None = None,
 ) -> list[EntryId]:
-    return [tally.entry_id for tally in finishing_order(entrants, outcomes, byes or ())]
+    """The **swiss** chain's order — the one above with Buchholz between head-to-head
+    and game difference, and byes scored as wins worth zero games."""
+    return [
+        standing.tally.entry_id
+        for standing in swiss_finishing_order(entrants, outcomes, byes or ())
+    ]
 
 
 def _tally(
@@ -76,9 +101,22 @@ def _tally(
     of: EntryId,
 ) -> EntryTally:
     return next(
-        tally
-        for tally in finishing_order(entrants, outcomes, byes)
-        if tally.entry_id == of
+        standing.tally
+        for standing in swiss_finishing_order(entrants, outcomes, byes)
+        if standing.tally.entry_id == of
+    )
+
+
+def _buchholz(
+    entrants: list[EntryId],
+    outcomes: list[MatchOutcome],
+    byes: list[EntryId],
+    of: EntryId,
+) -> int:
+    return next(
+        standing.buchholz
+        for standing in swiss_finishing_order(entrants, outcomes, byes)
+        if standing.tally.entry_id == of
     )
 
 
@@ -180,28 +218,33 @@ def test_the_entry_id_is_the_final_deterministic_tiebreak() -> None:
 
 
 def test_a_bye_counts_as_a_win() -> None:
-    """A bye is a **win** in the first link of the chain (ADR "swiss standings add
+    """A bye is a **win** in the first link of the swiss chain (ADR "swiss standings add
     Buchholz"), because a player must not be punished for a scheduling artifact they
     did not cause.
 
-    Built so the win alone moves B, and moves them *past somebody*. C has a real win
-    and a game difference of −2; B has a bye and a game difference of 0. Counting the
-    bye puts B and C in the same wins group, where B's better difference ranks them
-    above. Not counting it drops B into the group below C entirely — second place to
-    third, overtaken by the player they are level with.
+    Built so the win alone moves B, and moves them *past somebody*. Counting the bye
+    puts B in C's wins group, where B ranks above; not counting it drops B into the
+    group below C entirely — second place to third, overtaken by the player they are
+    level with.
 
-        A beat C 3-0, A beat D 3-0  → A: 2-0
-        C beat D 3-2                → C: 1-1, GW 3, GL 5, GD -2
-                                      D: 0-2, GW 2, GL 6, GD -4
-        B sat out                   → B: 1-0 by bye, GW 0, GL 0, GD 0
+    **B and C have identical Buchholz (2 each)**, deliberately: the link above game
+    difference must not be the one separating them, or this would pin Buchholz rather
+    than the bye. Their entry ids disagree with the answer too (B's is the largest of
+    the four), so the deterministic fallback is not producing it either.
+
+        A beat B 3-2, A beat C 3-0  → A: 2-0
+        C beat D 3-2                → C: 1-1, GW 3, GL 5, GD -2;  Buchholz A(2)+D(0)=2
+                                      D: 0-1, GW 2, GL 3, GD -1
+        B sat out                   → B: 1-1 (the bye is the win), GW 2, GL 3, GD -1;
+                                      Buchholz A(2) = 2
     """
-    a, b, c, d = _eid(1), _eid(2), _eid(3), _eid(4)
-    outcomes = [_outcome(a, c, 3, 0), _outcome(a, d, 3, 0), _outcome(c, d, 3, 2)]
+    a, b, c, d = _eid(1), _eid(4), _eid(2), _eid(3)
+    outcomes = [_outcome(a, b, 3, 2), _outcome(a, c, 3, 0), _outcome(c, d, 3, 2)]
 
-    assert _order([a, b, c, d], outcomes, byes=[b]) == [a, b, c, d]
+    assert _swiss_order([a, b, c, d], outcomes, byes=[b]) == [a, b, c, d]
     # And the same field with the bye unscored, which is what the assertion above is
     # worth: B falls behind the entrant they outrank on every count but the win.
-    assert _order([a, b, c, d], outcomes) == [a, c, b, d]
+    assert _swiss_order([a, b, c, d], outcomes) == [a, c, b, d]
 
 
 def test_a_bye_is_worth_zero_games_not_a_nominal_win() -> None:
@@ -222,7 +265,10 @@ def test_a_bye_is_worth_zero_games_not_a_nominal_win() -> None:
     a, b, c = _eid(1), _eid(2), _eid(3)
     outcomes = [_outcome(a, c, 3, 1)]
 
-    assert _order([a, b, c], outcomes, byes=[b]) == [a, b, c]
+    # A and B are level on Buchholz too — A's only opponent (C) has no wins, and B has
+    # no opponent at all — so game difference is what separates them, which is exactly
+    # the link a phantom 3-0 would corrupt.
+    assert _swiss_order([a, b, c], outcomes, byes=[b]) == [a, b, c]
 
     tally = _tally([a, b, c], outcomes, [b], of=b)
     assert (tally.wins, tally.games_won, tally.games_lost) == (1, 0, 0)
@@ -253,13 +299,135 @@ def test_two_byes_count_twice() -> None:
 def test_a_bye_does_not_reach_the_head_to_head_link() -> None:
     """A bye has no opponent, so it cannot be read as a result *against* anybody. B
     and C are tied on wins — C's from a real match, B's from a bye — and the pair have
-    never met, so the head-to-head link falls through to the game tiebreakers, where
+    never met, so the head-to-head link falls through, past a Buchholz they are level on
+    (C's only opponent D has no wins, B has no opponent), to the game tiebreakers, where
     C's +1 outranks B's 0. A bye that leaked into head-to-head could only invent a
     result nobody played."""
     b, c, d = _eid(1), _eid(2), _eid(3)
     outcomes = [_outcome(c, d, 3, 2)]
 
-    assert _order([b, c, d], outcomes, byes=[b]) == [c, b, d]
+    assert _swiss_order([b, c, d], outcomes, byes=[b]) == [c, b, d]
+
+
+def test_buchholz_outranks_game_difference() -> None:
+    """**Buchholz is the third link of the swiss chain and game difference the fourth.**
+
+    X and Y are level on one win each and have never met. X beat the field's strongest
+    player, Y beat its weakest, so Buchholz says X (2 against 0). Every link *below* it
+    says Y: game difference (+3 against +1), and the entry id (Y's is the smaller). So
+    only the position of Buchholz in the chain can put X above Y.
+
+        S beat T 3-0, S beat W 3-0  → S: 2-1
+        X beat S 3-2                → X: 1-0, GD +1;  Buchholz S(2) = 2
+        Y beat W 3-0                → Y: 1-0, GD +3;  Buchholz W(0) = 0
+                                      W: 0-2,  T: 0-1
+
+    The same field through the **round-robin** chain, which has no Buchholz link, comes
+    out the other way — which is the whole reason swiss has a chain of its own.
+    """
+    s, x, y, t, w = _eid(5), _eid(9), _eid(1), _eid(3), _eid(2)
+    entrants = [s, x, y, t, w]
+    outcomes = [
+        _outcome(s, t, 3, 0),
+        _outcome(s, w, 3, 0),
+        _outcome(x, s, 3, 2),
+        _outcome(y, w, 3, 0),
+    ]
+
+    assert _swiss_order(entrants, outcomes) == [s, x, y, w, t]
+    # Margin, not strength of schedule: Y's +3 beats X's +1, and W (GD -6) drops below
+    # T (GD -3) for the same reason.
+    assert _order(entrants, outcomes) == [s, y, x, t, w]
+
+
+def test_head_to_head_outranks_buchholz() -> None:
+    """**Head-to-head is the second link and Buchholz the third**, so a pair who have
+    met are settled by the match rather than by the field around them.
+
+    P and Q are the only two on one win and they played each other. Q is ahead of P on
+    Buchholz (3 against 1), on game difference (+2 against +1), on games won (5 against
+    3) and on entry id — every link but one says Q. P is above Q only because P beat Q.
+
+        P beat Q 3-2                → P: 1-0, GW 3, GD +1;  Buchholz Q(1) = 1
+        Q beat S 3-0                → Q: 1-1, GW 5, GD +2;  Buchholz P(1)+S(2) = 3
+        S beat T 3-0, S beat U 3-0  → S: 2-1;  T and U: 0-1
+    """
+    s, p, q, t, u = _eid(5), _eid(9), _eid(1), _eid(6), _eid(7)
+    entrants = [s, p, q, t, u]
+    outcomes = [
+        _outcome(p, q, 3, 2),
+        _outcome(q, s, 3, 0),
+        _outcome(s, t, 3, 0),
+        _outcome(s, u, 3, 0),
+    ]
+
+    assert _swiss_order(entrants, outcomes) == [s, p, q, t, u]
+
+
+def test_a_tied_pair_who_never_met_fall_through_the_head_to_head_link() -> None:
+    """**The guard.** A swiss pair can finish level on wins having never been drawn
+    against each other — the format pairs by score and makes no claim to have played
+    every pair — so the head-to-head link has to be able to say "there is no result
+    here" and fall through.
+
+    X and Y are the only two on one win, and their opponents were different players.
+    Fed in as ``[x, y, …]``, so a head-to-head step that answered *anything* for a pair
+    that never met would leave them in that order; the chain's real answer is Y first,
+    on the Buchholz its fall-through reaches (2 against 0). Both later links — game
+    difference (+3 against +2) and the entry id (X's is smaller) — say X, so nothing
+    below Buchholz can be producing this either.
+
+        S beat T 3-0, S beat U 3-0  → S: 2-1
+        X beat W 3-0                → X: 1-0, GD +3;  Buchholz W(0) = 0
+        Y beat S 3-1                → Y: 1-0, GD +2;  Buchholz S(2) = 2
+
+    The step is shared machinery, so the pool chain is guarded by the same lines — a
+    part-played round-robin reaches it, and a finished one cannot.
+    """
+    s, x, y, t, u, w = _eid(5), _eid(1), _eid(9), _eid(6), _eid(7), _eid(8)
+    entrants = [x, y, s, t, u, w]
+    outcomes = [
+        _outcome(s, t, 3, 0),
+        _outcome(s, u, 3, 0),
+        _outcome(x, w, 3, 0),
+        _outcome(y, s, 3, 1),
+    ]
+
+    assert _swiss_order(entrants, outcomes)[:3] == [s, y, x]
+
+
+def test_buchholz_counts_an_opponents_bye_win() -> None:
+    """**The amendment.** Buchholz sums the wins the standings *display*, and a bye is
+    one of them (ADR "swiss standings add Buchholz…", amended 2026-08-05).
+
+    Y has one real win and one bye, so Y's row reads two wins. X played Y and nobody
+    else with a win, so X's Buchholz is that same two. An implementation that stripped
+    bye wins out of the sum — the alternative the ADR rejects — would answer one, and a
+    director adding up their opponents' win columns would get an answer the table
+    disagrees with.
+
+        Y beat X 3-0  → Y: 1-0 on the day
+        X beat Z 3-0  → X: 1-1
+        Y sat out     → Y: 2-0, the second win from the bye
+    """
+    x, y, z = _eid(1), _eid(2), _eid(3)
+    outcomes = [_outcome(y, x, 3, 0), _outcome(x, z, 3, 0)]
+
+    assert _buchholz([x, y, z], outcomes, [y], of=x) == 2
+
+
+def test_a_bye_adds_no_term_to_its_holders_buchholz() -> None:
+    """The other half of the rule: a bye produced **no opponent**, so it contributes
+    nothing to the byed entrant's own sum.
+
+    Y's only opponent is X, who has one win, so Y's Buchholz is exactly one — the bye
+    adds no term of its own. It is the same fixture as the test above, read from the
+    other side.
+    """
+    x, y, z = _eid(1), _eid(2), _eid(3)
+    outcomes = [_outcome(y, x, 3, 0), _outcome(x, z, 3, 0)]
+
+    assert _buchholz([x, y, z], outcomes, [y], of=y) == 1
 
 
 def test_the_standings_table_is_this_order() -> None:

--- a/api/tests/test_results.py
+++ b/api/tests/test_results.py
@@ -98,14 +98,11 @@ def test_results_for_returns_the_swiss_strategy() -> None:
     assert isinstance(results_for(DrawType.swiss), SwissResults)
 
 
-def test_a_swiss_field_stands_in_one_table_ordered_by_the_shared_chain() -> None:
+def test_a_swiss_field_stands_in_one_table_ordered_by_the_swiss_chain() -> None:
     """Four entrants over two rounds, no pools: A wins both, B wins one, C wins one, D
-    wins none. The table is one list, ordered by the same chain a pool is ordered by —
-    wins first, then (B before C) the head-to-head they played.
-
-    Buchholz is deliberately NOT part of this ordering yet (ADR "swiss standings add
-    Buchholz"): this slice reads out through the chain that exists rather than a
-    swiss-shaped approximation of the one that does not.
+    wins none. The table is one list, ordered by swiss's own chain — wins, then (B and C
+    having never met, and being level on Buchholz at two apiece) B's better game
+    difference.
     """
     field = FieldInput(
         entrants=(A, B, C, D),
@@ -120,13 +117,50 @@ def test_a_swiss_field_stands_in_one_table_ordered_by_the_shared_chain() -> None
 
     standings = SwissResults().tabulate(field)
 
-    assert [(row.entry_id, row.wins, row.losses) for row in standings.rows] == [
+    assert [
+        (row.row.entry_id, row.row.wins, row.row.losses) for row in standings.rows
+    ] == [
         (A, 2, 0),
         (B, 1, 1),
         (C, 1, 1),
         (D, 0, 2),
     ]
-    assert [row.rank for row in standings.rows] == [1, 2, 3, 4]
+    assert [row.row.rank for row in standings.rows] == [1, 2, 3, 4]
+
+
+def test_the_swiss_table_ranks_on_buchholz_and_shows_the_figure() -> None:
+    """**Strength of schedule, above margin, and visible.**
+
+    B and C are level on one win each and never met. B beat the field's strongest player
+    (A, on two wins), C beat its weakest (E, on none), so Buchholz says B — while game
+    difference (+1 against +3) and the entry id both say C. The table puts B second, and
+    carries the figure that put them there.
+
+        A beat D 3-0, A beat E 3-0  → A: 2-1
+        B beat A 3-2                → B: 1-0, GD +1;  Buchholz A(2) = 2
+        C beat E 3-0                → C: 1-0, GD +3;  Buchholz E(0) = 0
+                                      D: 0-1,  E: 0-2
+    """
+    field = FieldInput(
+        entrants=(A, B, C, D, E),
+        fixture_count=4,
+        outcomes=(
+            _outcome(A, D, 3, 0),
+            _outcome(A, E, 3, 0),
+            _outcome(B, A, 3, 2),
+            _outcome(C, E, 3, 0),
+        ),
+    )
+
+    standings = SwissResults().tabulate(field)
+
+    assert [(row.row.entry_id, row.buchholz) for row in standings.rows] == [
+        (A, 1),
+        (B, 2),
+        (C, 0),
+        (E, 3),
+        (D, 2),
+    ]
 
 
 def test_a_byed_entrant_is_credited_with_a_win_and_no_games() -> None:
@@ -146,13 +180,14 @@ def test_a_byed_entrant_is_credited_with_a_win_and_no_games() -> None:
 
     standings = SwissResults().tabulate(field)
 
-    by_entry = {row.entry_id: row for row in standings.rows}
+    by_entry = {row.row.entry_id: row.row for row in standings.rows}
     assert (by_entry[C].played, by_entry[C].wins, by_entry[C].losses) == (1, 1, 0)
     assert (by_entry[C].games_won, by_entry[C].games_lost) == (0, 0)
     assert by_entry[C].game_difference == 0
     # A won a real match 3-1, so A's +2 outranks the bye's 0 — the two are level on
-    # wins and have never met. A nominal 3-0 for the bye would put C first.
-    assert [row.entry_id for row in standings.rows] == [A, C, B]
+    # wins, on Buchholz (A's only opponent has no wins; C has no opponent) and have
+    # never met. A nominal 3-0 for the bye would put C first.
+    assert [row.row.entry_id for row in standings.rows] == [A, C, B]
 
 
 def test_a_pool_scores_no_byes() -> None:
@@ -196,7 +231,7 @@ def test_a_swiss_event_with_rounds_left_is_live_and_uncrowned() -> None:
 
     assert not standings.complete
     assert standings.champion is None
-    assert {row.entry_id for row in standings.rows} == {A, B, C, D}
+    assert {row.row.entry_id for row in standings.rows} == {A, B, C, D}
 
 
 def test_an_uncut_swiss_event_is_not_complete() -> None:

--- a/api/tests/test_results.py
+++ b/api/tests/test_results.py
@@ -117,15 +117,13 @@ def test_a_swiss_field_stands_in_one_table_ordered_by_the_swiss_chain() -> None:
 
     standings = SwissResults().tabulate(field)
 
-    assert [
-        (row.row.entry_id, row.row.wins, row.row.losses) for row in standings.rows
-    ] == [
+    assert [(row.entry_id, row.wins, row.losses) for row in standings.rows] == [
         (A, 2, 0),
         (B, 1, 1),
         (C, 1, 1),
         (D, 0, 2),
     ]
-    assert [row.row.rank for row in standings.rows] == [1, 2, 3, 4]
+    assert [row.rank for row in standings.rows] == [1, 2, 3, 4]
 
 
 def test_the_swiss_table_ranks_on_buchholz_and_shows_the_figure() -> None:
@@ -154,7 +152,7 @@ def test_the_swiss_table_ranks_on_buchholz_and_shows_the_figure() -> None:
 
     standings = SwissResults().tabulate(field)
 
-    assert [(row.row.entry_id, row.buchholz) for row in standings.rows] == [
+    assert [(row.entry_id, row.buchholz) for row in standings.rows] == [
         (A, 1),
         (B, 2),
         (C, 0),
@@ -180,14 +178,14 @@ def test_a_byed_entrant_is_credited_with_a_win_and_no_games() -> None:
 
     standings = SwissResults().tabulate(field)
 
-    by_entry = {row.row.entry_id: row.row for row in standings.rows}
+    by_entry = {row.entry_id: row for row in standings.rows}
     assert (by_entry[C].played, by_entry[C].wins, by_entry[C].losses) == (1, 1, 0)
     assert (by_entry[C].games_won, by_entry[C].games_lost) == (0, 0)
     assert by_entry[C].game_difference == 0
     # A won a real match 3-1, so A's +2 outranks the bye's 0 — the two are level on
     # wins, on Buchholz (A's only opponent has no wins; C has no opponent) and have
     # never met. A nominal 3-0 for the bye would put C first.
-    assert [row.row.entry_id for row in standings.rows] == [A, C, B]
+    assert [row.entry_id for row in standings.rows] == [A, C, B]
 
 
 def test_a_pool_scores_no_byes() -> None:
@@ -231,7 +229,7 @@ def test_a_swiss_event_with_rounds_left_is_live_and_uncrowned() -> None:
 
     assert not standings.complete
     assert standings.champion is None
-    assert {row.row.entry_id for row in standings.rows} == {A, B, C, D}
+    assert {row.entry_id for row in standings.rows} == {A, B, C, D}
 
 
 def test_an_uncut_swiss_event_is_not_complete() -> None:

--- a/api/tests/test_swiss.py
+++ b/api/tests/test_swiss.py
@@ -476,6 +476,10 @@ async def test_the_standings_carry_the_whole_field_including_the_byed_entrant(
     }
     assert [row["rank"] for row in results["rows"]] == [1, 2, 3, 4, 5, 6, 7]
     assert all(row["played"] == 0 for row in results["rows"]), "nobody has played yet"
+    assert all(row["buchholz"] == 0 for row in results["rows"]), (
+        "the column swiss adds reaches the wire — every figure is zero here because "
+        "nobody has an opponent yet; a real one is pinned in tests/test_results.py"
+    )
     assert results["complete"] is False
     assert results["champion"] is None
 
@@ -1357,7 +1361,7 @@ def test_a_withdrawn_but_seated_entrant_is_not_given_a_bye_they_never_took() -> 
     )
     assert _entry(4) in field.entrants, "somebody who played is still in the table"
 
-    rows = {row.row.entry_id: row.row for row in SwissResults().tabulate(field).rows}
+    rows = {row.entry_id: row for row in SwissResults().tabulate(field).rows}
 
     departed = rows[_entry(4)]
     assert (departed.played, departed.wins, departed.losses) == (1, 0, 1)

--- a/api/tests/test_swiss.py
+++ b/api/tests/test_swiss.py
@@ -907,6 +907,12 @@ async def test_a_field_that_shrinks_mid_event_still_plays_out_and_finishes(
     table below is where that shows: **one match, one loss**, not the two bye wins a
     departed player was collecting.
 
+    Round 2 repeats round 1's 1v3, and that is the standings speaking rather than a
+    slip. Seed 4's departure takes seed 2's only result with it, so seed 2 has no wins
+    and **no opposition** — Buchholz 0, below seed 3, who at least lost to the leader.
+    The table reads 1, 3, 2, seed 2 takes the bye, and the two left have already met:
+    the documented last resort, which pairs them again rather than stranding the round.
+
     **The withdrawal is written as the statement that causes it in production.** The
     ordinary withdrawal endpoint is window-gated and answers 409 on a live event, so
     nothing here could reach the pairing code through it. ``app.account_merge`` can and
@@ -977,8 +983,8 @@ async def test_a_field_that_shrinks_mid_event_still_plays_out_and_finishes(
         paired = [f for f in round_two if f.entry_a_id is not None]
         assert len(round_two) == 2, "the cut's second row is still there"
         assert [{f.entry_a_id, f.entry_b_id} for f in paired] == [
-            {entry_ids[0], entry_ids[1]}
-        ], "three survivors make one pairing, and seed 3 sits round 2 out"
+            {entry_ids[0], entry_ids[2]}
+        ], "three survivors make one pairing, and seed 2 sits round 2 out"
 
         await play(2, winner_index=0)
 
@@ -986,7 +992,7 @@ async def test_a_field_that_shrinks_mid_event_still_plays_out_and_finishes(
         round_three = [f for f in await _fixtures(db_session, event_id) if f.round == 3]
         paired = [f for f in round_three if f.entry_a_id is not None]
         assert [{f.entry_a_id, f.entry_b_id} for f in paired] == [
-            {entry_ids[0], entry_ids[2]}
+            {entry_ids[0], entry_ids[1]}
         ], (
             "round 3 is paired off round 2's table — the round whose unpairable row "
             "stalled the walk for good, leaving the event unplayable from here"
@@ -1351,7 +1357,7 @@ def test_a_withdrawn_but_seated_entrant_is_not_given_a_bye_they_never_took() -> 
     )
     assert _entry(4) in field.entrants, "somebody who played is still in the table"
 
-    rows = {row.entry_id: row for row in SwissResults().tabulate(field).rows}
+    rows = {row.row.entry_id: row.row for row in SwissResults().tabulate(field).rows}
 
     departed = rows[_entry(4)]
     assert (departed.played, departed.wins, departed.losses) == (1, 0, 1)

--- a/docs/adr/20260805-swiss-standings-add-buchholz-and-guard-head-to-head.md
+++ b/docs/adr/20260805-swiss-standings-add-buchholz-and-guard-head-to-head.md
@@ -18,10 +18,21 @@ difference, then games won, then the entry id.
 Swiss orders its field with the same kind of table, but two steps in that chain
 rest on a round-robin assumption that swiss breaks.
 
-**Head-to-head assumes the tied pair met.** In a round-robin everyone plays
-everyone, so a two-way tie always has a head-to-head result to read. In swiss a
-pair tied on wins may never have been paired. The existing step has no way to say
-"they did not meet", because in its own format that cannot happen.
+**Head-to-head, when the tied pair never met.** In a round-robin everyone
+eventually plays everyone, so a completed two-way tie has a head-to-head result to
+read. In swiss a pair tied on wins may never have been paired at all.
+
+**Correction, 2026-08-05.** This section originally claimed the existing step had
+no way to say "they did not meet", and that adding the guard was a correctness fix
+swiss forced. **That was wrong.** `_head_to_head` already returned `None` for a
+pair with no fixture between them, and `_break_tie` already fell through to the
+scalar chain. The guard predates swiss, because a *part-played* round-robin pool
+reaches the same state.
+
+The claim was made during design and not checked against the code. Swiss needed
+nothing here. What this ADR actually contributes on this point is a **test** for
+the guard, which nothing had — confirmed by deliberately breaking it, which reds
+both a swiss test and a pre-existing round-robin one.
 
 **Strength of schedule is invisible.** A round-robin gives every entrant the same
 opponents, so who you played carries no information and the chain rightly ignores
@@ -93,12 +104,24 @@ because a player must not be punished for a scheduling artifact. The games are
 zero so the bye stays neutral on steps 4 and 5, rather than awarding difference
 nobody earned.
 
-### The head-to-head guard is a correctness fix for both formats
+### The head-to-head guard is shared machinery, and it is now tested
 
-The guard is written into the shared understanding of the step, not bolted onto
-the swiss copy. A round-robin pool cannot reach it, because its entrants always
-met. Adding it costs a round-robin nothing and stops the swiss chain reading a
-result that does not exist.
+The guard is a property of the step, not a swiss branch. It already existed (see
+the correction above); what changes is that it is pinned. Breaking it deliberately
+reds a swiss test **and** a pre-existing round-robin one, which is the empirical
+demonstration that one piece of machinery serves both formats.
+
+### A rematch counts twice in Buchholz
+
+Buchholz iterates the outcomes, so an opponent met twice contributes their win
+count twice. This is standard Buchholz, which is a sum over games played rather
+than over distinct opponents, and it is what we take.
+
+The alternative — summing over distinct opponents — would make a player's Buchholz
+depend on how many of their games the pairing happened to repeat, which is not
+something they controlled. Since a rematch only occurs when the greedy walk could
+find no fresh opponent, double-counting keeps the measure a straight function of
+the games actually played.
 
 ## Consequences
 

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -412,25 +412,6 @@ export class TournamentDetailPage {
     return this.swissStandingCell(eventId, entryId, SWISS_STANDINGS_COLUMNS.wins)
   }
 
-  /** One entry's **Buchholz** cell — the sum of their opponents' win counts, and the
-   * tiebreak that sits *above* game difference in the swiss chain. It is on the table
-   * because it is the one link a director cannot re-derive from the columns beside it:
-   * a row ranked above another on equal wins and a worse `Diff` is unreadable without
-   * it. */
-  swissStandingBuchholz(eventId: string, entryId: string): Locator {
-    return this.swissStandingCell(eventId, entryId, SWISS_STANDINGS_COLUMNS.buchholz)
-  }
-
-  /** One entry's **game difference** cell. Rendered with an explicit sign (`+2`, `-1`),
-   * because `+2` and `-2` are different standings and a bare `2` would read as both. */
-  swissStandingGameDifference(eventId: string, entryId: string): Locator {
-    return this.swissStandingCell(
-      eventId,
-      entryId,
-      SWISS_STANDINGS_COLUMNS.gameDifference,
-    )
-  }
-
   /** One entry's **games won** cell. Zero for a bye, which is what stops a scheduling
    * artifact nobody played from lifting its holder over somebody who beat a real
    * opponent. */

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -5,6 +5,33 @@ import { ScheduleTabPage } from './tournament-detail-page/schedule-tab.page'
 import { TablesTabPage } from './tournament-detail-page/tables-tab.page'
 
 /**
+ * The **swiss** standings table's columns, by index, each with the name a screen reader
+ * hears for it — `#`, `Player`, `W`, `L`, `Buc`, `Diff`, `GW`.
+ *
+ * The cells carry no test hooks of their own, so a column can only be addressed by
+ * position, and a position is exactly the thing a *new column* silently changes. It did:
+ * `Buc` was inserted between `L` and `Diff` when swiss standings started ranking by
+ * Buchholz, which moved `GW` from index 5 to 6 — and index 5 still resolved, to game
+ * difference, so an assertion reading "games won" quietly read the wrong number.
+ *
+ * Hence one map here rather than an `nth(…)` in each accessor, and hence the **name**
+ * beside each index: a spec asserts that the header at each index is the column this map
+ * claims (`swissStandingsHeader`), which turns the next inserted column into a red naming
+ * the layout instead of a wrong number in a green run. The names are the `sr-only` words
+ * the header spans carry, since the visible glyphs (`W`, `GW`) are not the accessible
+ * name.
+ */
+export const SWISS_STANDINGS_COLUMNS = {
+  rank: { index: 0, name: 'Rank' },
+  player: { index: 1, name: 'Player' },
+  wins: { index: 2, name: 'Wins' },
+  losses: { index: 3, name: 'Losses' },
+  buchholz: { index: 4, name: 'Buchholz' },
+  gameDifference: { index: 5, name: 'Game difference' },
+  gamesWon: { index: 6, name: 'Games won' },
+} as const
+
+/**
  * The tournament detail page (`/tournaments/$tournamentId`) — scoped to the
  * lifecycle round-robin spec's load-bearing surfaces: the header's lifecycle
  * button (Publish → Start tournament → End tournament, `LifecycleActions`), an
@@ -359,23 +386,63 @@ export class TournamentDetailPage {
     return this.swissStandings(eventId).getByTestId(`standing-row-${entryId}`)
   }
 
-  /** One entry's **wins** cell — the third column of the standings table (`#`, `Player`,
-   * `W`, `L`, `Diff`, `GW`).
-   *
-   * The columns carry no test hooks of their own, so they are addressed by index here,
-   * once, rather than in every spec that reads one. This is the cell a **bye** is visible
-   * in at all: a bye is scored as a win worth zero games (ADR "swiss standings add
-   * Buchholz"), so the byed entrant's win shows up here and nowhere else — `GW` stays 0,
-   * which is the other half of the same fact (`swissStandingGamesWon`). */
-  swissStandingWins(eventId: string, entryId: string): Locator {
-    return this.swissStandingRow(eventId, entryId).getByRole('cell').nth(2)
+  /** **Every cell of one entry's row, in column order** — for an assertion that pins the
+   * whole line at once (`toHaveText([...])`), which is the only shape that can catch a
+   * column having moved as well as a number being wrong. Column order and meaning:
+   * `SWISS_STANDINGS_COLUMNS`. */
+  swissStandingCells(eventId: string, entryId: string): Locator {
+    return this.swissStandingRow(eventId, entryId).getByRole('cell')
   }
 
-  /** One entry's **games won** cell — the sixth column. Zero for a bye, which is what
-   * stops a scheduling artifact nobody played from lifting its holder over somebody who
-   * beat a real opponent. */
+  /** One entry's cell in a named column — the accessor the single-column assertions go
+   * through, so no spec writes an `nth(…)` of its own. */
+  private swissStandingCell(
+    eventId: string,
+    entryId: string,
+    column: { readonly index: number },
+  ): Locator {
+    return this.swissStandingCells(eventId, entryId).nth(column.index)
+  }
+
+  /** One entry's **wins** cell. This is the cell a **bye** is visible in at all: a bye is
+   * scored as a win worth zero games (ADR "swiss standings add Buchholz"), so the byed
+   * entrant's win shows up here and nowhere else — `GW` stays 0, which is the other half
+   * of the same fact (`swissStandingGamesWon`). */
+  swissStandingWins(eventId: string, entryId: string): Locator {
+    return this.swissStandingCell(eventId, entryId, SWISS_STANDINGS_COLUMNS.wins)
+  }
+
+  /** One entry's **Buchholz** cell — the sum of their opponents' win counts, and the
+   * tiebreak that sits *above* game difference in the swiss chain. It is on the table
+   * because it is the one link a director cannot re-derive from the columns beside it:
+   * a row ranked above another on equal wins and a worse `Diff` is unreadable without
+   * it. */
+  swissStandingBuchholz(eventId: string, entryId: string): Locator {
+    return this.swissStandingCell(eventId, entryId, SWISS_STANDINGS_COLUMNS.buchholz)
+  }
+
+  /** One entry's **game difference** cell. Rendered with an explicit sign (`+2`, `-1`),
+   * because `+2` and `-2` are different standings and a bare `2` would read as both. */
+  swissStandingGameDifference(eventId: string, entryId: string): Locator {
+    return this.swissStandingCell(
+      eventId,
+      entryId,
+      SWISS_STANDINGS_COLUMNS.gameDifference,
+    )
+  }
+
+  /** One entry's **games won** cell. Zero for a bye, which is what stops a scheduling
+   * artifact nobody played from lifting its holder over somebody who beat a real
+   * opponent. */
   swissStandingGamesWon(eventId: string, entryId: string): Locator {
-    return this.swissStandingRow(eventId, entryId).getByRole('cell').nth(5)
+    return this.swissStandingCell(eventId, entryId, SWISS_STANDINGS_COLUMNS.gamesWon)
+  }
+
+  /** The standings table's **column header** at one index — what a spec asserts the name
+   * of, to establish that the index a cell accessor reads is still the column it means.
+   * See `SWISS_STANDINGS_COLUMNS` for why that guard exists. */
+  swissStandingsHeader(eventId: string, column: { readonly index: number }): Locator {
+    return this.swissStandings(eventId).getByRole('columnheader').nth(column.index)
   }
 
   /** The **two-stage** champion callout — the one a round-robin-then-knockout event

--- a/e2e/support/swiss-draw.ts
+++ b/e2e/support/swiss-draw.ts
@@ -60,6 +60,14 @@ export interface SwissStanding {
   readonly username: string
   readonly rank: number
   readonly wins: number
+  /** **Buchholz** — the sum of this entrant's opponents' win counts, and the swiss
+   * chain's tiebreak *above* game difference. On the wire (`SwissStandingRowRead`)
+   * because it is the one link a client cannot re-derive from the row it ordered. */
+  readonly buchholz: number
+  /** `games_won - games_lost`, the server's own figure — the link Buchholz outranks. A
+   * spec that wants to prove strength of schedule beat margin has to be able to read
+   * both and show they disagree. */
+  readonly gameDifference: number
   readonly gamesWon: number
 }
 
@@ -85,6 +93,8 @@ interface SwissResultsPayload {
     readonly entry_id: string
     readonly rank: number
     readonly wins: number
+    readonly buchholz: number
+    readonly game_difference: number
     readonly games_won: number
   }>
 }
@@ -209,6 +219,8 @@ export async function readSwissStandings(
       username,
       rank: row.rank,
       wins: row.wins,
+      buchholz: row.buchholz,
+      gameDifference: row.game_difference,
       gamesWon: row.games_won,
     }
   })

--- a/e2e/support/tournament-play.ts
+++ b/e2e/support/tournament-play.ts
@@ -70,8 +70,8 @@ export type PlayStage = 'pools' | 'all'
 export type PickWinner = (a: Guest, b: Guest) => Guest
 
 /** **The earlier-registered entrant wins**, `entrants` being the field in registration
- * order — `playEvent`'s default rule, and the picker `playSwissRound` is handed for a round
- * whose outcomes are scaffolding rather than subject.
+ * order — `playEvent`'s default rule, and the picker a caller wraps in `inStraightGames` to
+ * hand `playSwissRound` a round whose outcomes are scaffolding rather than subject.
  *
  * Stated here and nowhere else, so the two helpers cannot drift apart on what "the boring
  * rule" is. It is the wrong rule for a round whose outcomes ARE the subject: see
@@ -148,7 +148,7 @@ export async function playEvent(
           (stage === 'all' || fixture.pool_id !== null),
       )
     if (playable.length === 0) return played
-    played += await playFixtures(event, playable, entrants, pickWinner)
+    played += await playFixtures(event, playable, entrants, inStraightGames(pickWinner))
   }
 
   throw new Error(
@@ -157,8 +157,32 @@ export async function playEvent(
   )
 }
 
+/** How one fixture ends: who won, and **how many games the loser took**.
+ *
+ * The margin is here because who won is not the whole of a result: game difference is a
+ * link of the standings chain, and a suite that always plays straight games can never make
+ * it disagree with anything. Proving that Buchholz outranks game difference needs two
+ * entrants level on wins whose margins and strengths of schedule point opposite ways, and
+ * the margin is half of that. */
+export interface FixtureResult {
+  readonly winner: Guest
+  readonly loserGames: number
+}
+
+/** How a fixture is decided, given the two guests seated in it (side `a` first). */
+export type PickResult = (a: Guest, b: Guest) => FixtureResult
+
+/** Play a winner rule out in **straight games** — the loser takes none.
+ *
+ * The adapter that keeps "who wins" and "by how much" separable: a round whose margins are
+ * scaffolding says so in one word at the call site, and only the round whose margins are
+ * the subject writes them down. */
+export function inStraightGames(pick: PickWinner): PickResult {
+  return (a, b) => ({ winner: pick(a, b), loserGames: 0 })
+}
+
 /**
- * Play **one round** of a swiss draw out over the API, `pickWinner` deciding each fixture,
+ * Play **one round** of a swiss draw out over the API, `decideFixture` deciding each one,
  * and return how many matches were decided.
  *
  * One round, not the whole draw, because a swiss round's completion is the event under
@@ -180,7 +204,7 @@ export async function playSwissRound(
   eventId: string,
   entrants: ReadonlyArray<Guest>,
   round: number,
-  pickWinner: PickWinner,
+  decideFixture: PickResult,
 ): Promise<number> {
   const event = await readPlayableEvent(director, tournamentId, eventId)
   const fixtures = event.fixtures.filter((fixture) => fixture.round === round)
@@ -196,7 +220,7 @@ export async function playSwissRound(
         `is the tournament live, and is round ${round - 1} decided?`,
     )
   }
-  return playFixtures(event, undecided.filter(isMaterialized), entrants, pickWinner)
+  return playFixtures(event, undecided.filter(isMaterialized), entrants, decideFixture)
 }
 
 /** A fixture the draw has turned into a real match — the only kind either helper can play,
@@ -219,6 +243,11 @@ const isMaterialized = (
  * a change to how a match is decided over the API lands in one helper and silently leaves
  * the other playing a different game.
  *
+ * It takes a `PickResult` rather than a `PickWinner` because the **margin** is part of a
+ * result: game difference is a link of the swiss standings chain, and a helper that only
+ * ever played straight games could not make it disagree with anything. A caller that does
+ * not care says so with `inStraightGames`, which is what `playEvent` hands down.
+ *
  * The callers keep only what genuinely differs: which fixtures are theirs to play, and what
  * an unplayable one means to them — `playEvent` re-reads and passes again, `playSwissRound`
  * refuses by name.
@@ -227,7 +256,7 @@ async function playFixtures(
   event: PlayableEvent,
   fixtures: ReadonlyArray<MaterializedFixture>,
   entrants: ReadonlyArray<Guest>,
-  pickWinner: PickWinner,
+  decideFixture: PickResult,
 ): Promise<number> {
   const byUsername = new Map(entrants.map((guest) => [guest.username, guest]))
   const seats = new Map(event.entrants.map((entrant) => [entrant.id, entrant.username]))
@@ -237,14 +266,15 @@ async function playFixtures(
     const [a, b] = [fixture.entry_a_id, fixture.entry_b_id].map((entryId) =>
       guestFor(byUsername, seats, entryId, fixture.id),
     )
+    const { winner, loserGames } = decideFixture(a, b)
     // Side 1 IS `entry_a` and side 2 IS `entry_b` — the fixed materialization convention
     // (#788) — so the winner's seat decides which column of the board wins.
-    const winnerIsA = pickWinner(a, b).username === a.username
+    const winnerIsA = winner.username === a.username
     await decide(
       winnerIsA ? a : b,
       winnerIsA ? b : a,
       fixture.match_id,
-      board(winnerIsA ? 1 : 2, wins),
+      board(winnerIsA ? 1 : 2, wins, loserGames),
     )
   }
   return fixtures.length
@@ -258,13 +288,32 @@ function gamesToWin(lengthGames: number): number {
   return Math.floor(lengthGames / 2) + 1
 }
 
-/** A straight-games board: `wins` games at 11–5 to `winnerSide`, numbered from 1. */
-function board(winnerSide: 1 | 2, wins: number): ResultGame[] {
-  return Array.from({ length: wins }, (_, index) => ({
+/** A board of `wins` games at 11–5 to `winnerSide`, plus `loserGames` at 11–5 the other
+ * way, numbered from 1.
+ *
+ * **The loser's games come first**, and that is the server's rule rather than a taste: a
+ * board is refused for extending "past the deciding game", so the winner's `wins`-th win
+ * has to be the last game on it. Trailing the loser's games would be a match that carried
+ * on after it was over.
+ *
+ * `loserGames` defaults to 0 — a straight-games win — so the callers that do not care
+ * about the margin say nothing about it. */
+function board(winnerSide: 1 | 2, wins: number, loserGames = 0): ResultGame[] {
+  if (loserGames >= wins) {
+    throw new Error(
+      `a best-of needing ${wins} wins cannot be lost ${wins}-${loserGames}: the loser ` +
+        'would have won it',
+    )
+  }
+  const game = (toWinner: boolean, index: number): ResultGame => ({
     game_number: index + 1,
-    side_1_points: winnerSide === 1 ? 11 : 5,
-    side_2_points: winnerSide === 2 ? 11 : 5,
-  }))
+    side_1_points: (winnerSide === 1) === toWinner ? 11 : 5,
+    side_2_points: (winnerSide === 2) === toWinner ? 11 : 5,
+  })
+  return [
+    ...Array.from({ length: loserGames }, (_, index) => game(false, index)),
+    ...Array.from({ length: wins }, (_, index) => game(true, loserGames + index)),
+  ]
 }
 
 /** Resolve a fixture's entry ref to the guest sitting in it.

--- a/e2e/tests/tournament-swiss.spec.ts
+++ b/e2e/tests/tournament-swiss.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect, type Page } from '@playwright/test'
 import { faker } from '@faker-js/faker'
 
-import { TournamentDetailPage } from '../page-objects/tournament-detail.page'
+import {
+  SWISS_STANDINGS_COLUMNS,
+  TournamentDetailPage,
+} from '../page-objects/tournament-detail.page'
 import { guestFromContext, type Guest } from '../support/match-api'
 import { grantBetaTester } from '../support/rbac-grant'
 import {
@@ -18,7 +21,9 @@ import {
 } from '../support/tournament-api'
 import {
   earlierRegisteredWins,
+  inStraightGames,
   playSwissRound,
+  type PickResult,
   type PickWinner,
 } from '../support/tournament-play'
 
@@ -68,6 +73,182 @@ const ODD_FIELD = 7
  */
 const ROUND_ONE_WINNERS = [4, 1, 6, 3]
 
+/** `n` and `R` for the **Buchholz** test: six entrants over two rounds.
+ *
+ * Six because the tied group has to face *different* opposition. A field small enough for
+ * everybody to have played everybody cannot discriminate at all: Buchholz would then be
+ * `total wins − your own wins`, identical for any two entrants level on wins, by
+ * arithmetic. Six players in two rounds leaves each of them having met a third of the
+ * field, which is what makes strength of schedule a real difference.
+ *
+ * Two rounds because the whole fixture has to be **predicted**, not observed: round 2 is
+ * paired from the round-1 standings, so the spec can only write down expected results if
+ * it knows the pairing, and round 2 is the last round for which that is derivable without
+ * re-implementing the greedy walk (see `consecutivePairs`). One round could not work — after
+ * round 1 every opponent's win count is 0 or 1 and the tied entrants' Buchholz figures are
+ * equal by symmetry.
+ */
+const BUCHHOLZ_FIELD = 6
+const BUCHHOLZ_ROUNDS = 2
+
+/** One fixture's planned outcome, by **registration index**: who wins, who loses, and how
+ * many games the loser takes. The margin is the point — see `BUCHHOLZ_ROUND_ONE`. */
+interface PlannedResult {
+  readonly winner: number
+  readonly loser: number
+  readonly loserGames: number
+}
+
+/**
+ * **Round 1 of the Buchholz fixture**, on the pairing the cut deals: draw-order position
+ * `i` against `i + 3`, so `p0-p3`, `p1-p4`, `p2-p5`.
+ *
+ * The three winners are chosen with **three different margins** on purpose. After one round
+ * every winner's Buchholz is 0 (their opponent has no wins yet) and every loser's is 1, so
+ * Buchholz separates nobody and the standings fall through to game difference — which means
+ * three distinct margins make the round-1 order, and therefore round 2's pairing, **fully
+ * determined**. Give two winners the same margin and the order between them falls to the
+ * entry-id tiebreak, the pairing becomes a coin flip, and every number below it is a
+ * guess. (The editor's default best-of-5 is what affords three margins: 3-0, 3-1, 3-2.)
+ */
+const BUCHHOLZ_ROUND_ONE: ReadonlyArray<PlannedResult> = [
+  { winner: 0, loser: 3, loserGames: 0 },
+  { winner: 1, loser: 4, loserGames: 1 },
+  { winner: 2, loser: 5, loserGames: 2 },
+]
+
+/**
+ * **Round 2**, on the pairing those results force. The standings after round 1 read
+ * `p0, p1, p2` (winners, by margin) then `p5, p4, p3` (losers, by margin), and the walk
+ * gives each entrant the nearest following one they have not met:
+ *
+ * - `p0` takes `p1` — the two at the top of the table;
+ * - `p2` skips `p5`, whom it has just beaten, and takes `p4`;
+ * - `p5` and `p3` are left, and are strangers.
+ *
+ * The results below are then chosen to make **margin and strength of schedule point
+ * opposite ways** among the four entrants who finish level on one win:
+ *
+ * | | wins | opponents | Buchholz | game difference |
+ * | --- | --- | --- | --- | --- |
+ * | `p4` | 1 | `p1` (2 wins), `p2` (1) | **3** | **-1** |
+ * | `p0` | 1 | `p3` (0), `p1` (2) | 2 | +2 |
+ * | `p2` | 1 | `p5` (1), `p4` (1) | 2 | 0 |
+ * | `p5` | 1 | `p2` (1), `p3` (0) | **1** | **+2** |
+ *
+ * `p4` has the **worst** margin of the four and the **strongest** schedule; `p5` has the
+ * joint-best margin and the weakest schedule. Buchholz above game difference ranks the
+ * four `p4, p0, p2, p5` — the order this test asserts. Demote the step below game
+ * difference and the two ends of that group swap: `p4` falls to the bottom of the field's
+ * middle and `p0` takes the top of it, which is what the falsification of this test
+ * measured.
+ */
+const BUCHHOLZ_ROUND_TWO: ReadonlyArray<PlannedResult> = [
+  { winner: 1, loser: 0, loserGames: 2 },
+  { winner: 4, loser: 2, loserGames: 2 },
+  { winner: 5, loser: 3, loserGames: 0 },
+]
+
+/** One row of the standings the fixture above produces, in **finishing order** — so the
+ * index is the rank and the whole table is one written-down expectation. Every column the
+ * table shows is here, because a wrong number in the right order is still wrong. */
+interface ExpectedStanding {
+  /** The entrant, by registration index. */
+  readonly player: number
+  readonly wins: number
+  readonly losses: number
+  readonly buchholz: number
+  readonly gameDifference: number
+  readonly gamesWon: number
+}
+
+/**
+ * **The standings the Buchholz fixture must produce**, top to bottom.
+ *
+ * `p1` leads on wins, `p3` is last on wins, and the four in between are level on one win
+ * and ordered by Buchholz — the claim this test exists to make. Read the middle four
+ * downwards: Buchholz falls 3, 2, 2, 1 while game difference goes -1, +2, 0, +2. The one
+ * column descends; the other does not. That is what "ranked by strength of schedule rather
+ * than by margin" looks like on a table.
+ */
+const BUCHHOLZ_STANDINGS: ReadonlyArray<ExpectedStanding> = [
+  { player: 1, wins: 2, losses: 0, buchholz: 2, gameDifference: 3, gamesWon: 6 },
+  { player: 4, wins: 1, losses: 1, buchholz: 3, gameDifference: -1, gamesWon: 4 },
+  { player: 0, wins: 1, losses: 1, buchholz: 2, gameDifference: 2, gamesWon: 5 },
+  { player: 2, wins: 1, losses: 1, buchholz: 2, gameDifference: 0, gamesWon: 5 },
+  { player: 5, wins: 1, losses: 1, buchholz: 1, gameDifference: 2, gamesWon: 5 },
+  { player: 3, wins: 0, losses: 2, buchholz: 2, gameDifference: -6, gamesWon: 0 },
+]
+
+/** The two entrants the claim rests on, **by registration index**: `p4` faced the stronger
+ * schedule on a worse margin, `p0` the weaker schedule on a better one. The test asserts
+ * their relationship off the *served* standings rather than off the table above, so a
+ * fixture that stopped discriminating fails instead of passing quietly. */
+const STRONGER_SCHEDULE = 4
+const BETTER_MARGIN = 0
+
+/** A game difference as the table renders it: signed when positive, because `+2` and `-2`
+ * are different standings and a bare `2` would read as both. */
+function signed(difference: number): string {
+  return difference > 0 ? `+${difference}` : String(difference)
+}
+
+/** One expected row as the seven cells the table renders, in column order
+ * (`SWISS_STANDINGS_COLUMNS`). */
+function standingRowText(
+  expected: ExpectedStanding,
+  rank: number,
+  username: string,
+): string[] {
+  return [
+    String(rank),
+    username,
+    String(expected.wins),
+    String(expected.losses),
+    String(expected.buchholz),
+    signed(expected.gameDifference),
+    String(expected.gamesWon),
+  ]
+}
+
+/**
+ * Play a round to a **written-down plan**: each fixture decided by the row naming both its
+ * entrants, at the margin that row gives.
+ *
+ * Refuses a pairing the plan does not name, and says which two it met. That refusal is
+ * load-bearing rather than defensive: the plan is written against a pairing this spec
+ * *derived* (see `BUCHHOLZ_ROUND_TWO`), so a server that paired the round differently would
+ * otherwise produce plausible results for the wrong matches, and the failure would surface
+ * as an inexplicable standings table two steps later.
+ */
+function asPlanned(
+  plan: ReadonlyArray<PlannedResult>,
+  entrants: ReadonlyArray<Guest>,
+): PickResult {
+  const indexOf = new Map(entrants.map((guest, index) => [guest.username, index]))
+  const nameOf = (index: number): string => entrants[index].username
+  return (a, b) => {
+    const pair = [indexOf.get(a.username), indexOf.get(b.username)]
+    const row = plan.find(
+      (candidate) =>
+        pair.includes(candidate.winner) && pair.includes(candidate.loser),
+    )
+    if (!row) {
+      const planned = plan
+        .map((r) => `${nameOf(r.winner)} vs ${nameOf(r.loser)}`)
+        .join('; ')
+      throw new Error(
+        `the round paired ${a.username} vs ${b.username}, which this fixture's plan ` +
+          `does not name — it expects: ${planned}`,
+      )
+    }
+    return {
+      winner: indexOf.get(a.username) === row.winner ? a : b,
+      loserGames: row.loserGames,
+    }
+  }
+}
+
 /**
  * Round one, as the ADR seeds it: **top half against bottom half in draw order**.
  *
@@ -108,6 +289,7 @@ async function authorSwissEvent(
   detail: TournamentDetailPage,
   director: Guest,
   tournamentId: string,
+  rounds: number = ROUNDS,
 ): Promise<string> {
   const editor = await detail.openNewEvent()
   await editor.nameInput.fill(EVENT_NAME)
@@ -116,7 +298,7 @@ async function authorSwissEvent(
   // a format that does not ask the question. So its appearance is the proof the picker's
   // choice reached the form, before anything is submitted.
   await expect(editor.roundsInput).toBeVisible()
-  await editor.setRounds(ROUNDS)
+  await editor.setRounds(rounds)
 
   const createPost = page.waitForResponse(
     (r) => r.url().endsWith('/events') && r.request().method() === 'POST',
@@ -136,7 +318,7 @@ async function authorSwissEvent(
   // round, or none.
   const event = await findEventByName(director, tournamentId, EVENT_NAME)
   expect(event.draw_type).toBe(DRAW_TYPE_KEY)
-  expect(event.rounds).toBe(ROUNDS)
+  expect(event.rounds).toBe(rounds)
   return event.id
 }
 
@@ -627,7 +809,9 @@ test.describe('Tournament — swiss draw', () => {
         eventId,
         entrants,
         1,
-        pickInterleavedWinner,
+        // Straight games: this test's subject is WHO won, not by how much — the margins
+        // are the Buchholz test's business.
+        inStraightGames(pickInterleavedWinner),
       ),
       'round 1 of an eight-player swiss is four matches',
     ).toBe(EVEN_FIELD / 2)
@@ -807,7 +991,7 @@ test.describe('Tournament — swiss draw', () => {
         eventId,
         entrants,
         1,
-        earlierRegisteredWins(entrants),
+        inStraightGames(earlierRegisteredWins(entrants)),
       ),
       'round 1 of a seven-player swiss is three matches',
     ).toBe(perRound)
@@ -876,7 +1060,7 @@ test.describe('Tournament — swiss draw', () => {
         eventId,
         entrants,
         2,
-        earlierRegisteredWins(entrants),
+        inStraightGames(earlierRegisteredWins(entrants)),
       ),
       'round 2 is three matches — the byed entrant costs the round a fixture',
     ).toBe(perRound)
@@ -918,6 +1102,197 @@ test.describe('Tournament — swiss draw', () => {
       detail.swissRoundBye(eventId, ROUNDS),
       `${byedInRoundThree} sits round 3 out, so the round should name them as its bye`,
     ).toContainText(byedInRoundThree)
+
+    await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
+  })
+
+  /**
+   * **Swiss standings rank by strength of schedule, not by margin** (ADR "swiss standings
+   * add Buchholz, and head-to-head is guarded on having met").
+   *
+   * Buchholz — the sum of an entrant's opponents' win counts — sits **above** game
+   * difference in the chain: wins, head-to-head when the tied pair met, Buchholz, game
+   * difference, games won, entry id. Swiss deliberately pairs you against players on your
+   * own score, so two entrants level on wins may have faced completely different halves of
+   * the field, and margin against unequal opposition says less than who you had to beat.
+   *
+   * ## The whole test is the fixture
+   *
+   * An assertion that the table comes out in *some* order proves nothing about Buchholz:
+   * for most results Buchholz and game difference agree, and then the standings are the
+   * same whether the step exists or not. So `BUCHHOLZ_ROUND_ONE` and `BUCHHOLZ_ROUND_TWO`
+   * engineer four entrants level on one win whose two columns point **opposite** ways —
+   * `p4` strongest schedule and worst margin, `p5` weakest schedule and joint-best margin —
+   * and the claim is that the table reads `p4` first and `p5` last of the four.
+   *
+   * That the fixture still discriminates is itself asserted, off the **served** standings
+   * rather than the written-down table: level on wins, higher Buchholz, *worse* game
+   * difference, ranked above. An edit that let the two columns agree again would red here
+   * instead of quietly turning this into a test of nothing.
+   *
+   * ## Six entrants, two rounds, three margins
+   *
+   * Each constant says why in its own docstring. In short: a field small enough for
+   * everybody to play everybody makes Buchholz constant across a tie by arithmetic; two
+   * rounds is as far as the pairing can be *predicted* rather than observed; and three
+   * distinct round-1 margins are what make the round-1 order — and so round 2's pairing —
+   * fall out of game difference rather than out of the entry-id tiebreak.
+   *
+   * ## And the figure itself, not merely the order
+   *
+   * A wrong number in the right order is still wrong, so every rendered cell of every row
+   * is pinned: rank, player, W, L, **Buc**, Diff, GW. The `Buc` column's *position* is
+   * pinned too (`SWISS_STANDINGS_COLUMNS`) — it was inserted between `L` and `Diff`, which
+   * moved `GW` and silently turned a "games won" assertion into a game-difference one.
+   */
+  test('swiss standings rank two entrants level on wins by Buchholz, above game difference', async ({
+    page,
+    baseURL,
+  }) => {
+    // Six minted guests, six director-entries, a real cut, a real go-live and two rounds —
+    // six matches — played out over the API, on top of the ordinary page work.
+    test.setTimeout(420_000)
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    const director = await guestFromContext(page.request)
+    grantBetaTester(director.username)
+
+    const name = `Swiss Buchholz ${faker.string.alphanumeric(8)}`
+    const { tournamentId } = await createTournament(director, name)
+
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    const eventId = await authorSwissEvent(
+      page,
+      detail,
+      director,
+      tournamentId,
+      BUCHHOLZ_ROUNDS,
+    )
+
+    await detail.publishButton.click()
+    await expect(detail.startButton).toBeVisible()
+
+    const entrants = await seedEntrants(
+      director,
+      baseURL!,
+      tournamentId,
+      eventId,
+      BUCHHOLZ_FIELD,
+    )
+    const filled = await findEventByName(director, tournamentId, EVENT_NAME)
+    expect(filled.entered).toBe(BUCHHOLZ_FIELD)
+
+    await detail.reload(tournamentId)
+    await cutTheDraw(page, detail)
+
+    // The cut deals round 1 top half against bottom half, which is the pairing
+    // `BUCHHOLZ_ROUND_ONE` is written against. Asserted before a ball is hit, so a
+    // different seeding fails here rather than as a standings table nobody can explain.
+    await expect(detail.swissRoundFixtures(eventId, 1)).toHaveText(
+      roundOneLines(entrants),
+    )
+
+    await goLive(page, detail)
+
+    // ----- two rounds, to plan -----------------------------------------------
+    const perRound = BUCHHOLZ_FIELD / 2
+    expect(
+      await playSwissRound(
+        director,
+        tournamentId,
+        eventId,
+        entrants,
+        1,
+        asPlanned(BUCHHOLZ_ROUND_ONE, entrants),
+      ),
+    ).toBe(perRound)
+
+    await detail.reload(tournamentId)
+    await expect(detail.swissRoundFixtures(eventId, 2)).toHaveCount(perRound)
+
+    expect(
+      await playSwissRound(
+        director,
+        tournamentId,
+        eventId,
+        entrants,
+        2,
+        // `asPlanned` refuses a pairing this plan does not name, so this call is also the
+        // assertion that round 2 was paired the way the fixture derived it would be.
+        asPlanned(BUCHHOLZ_ROUND_TWO, entrants),
+      ),
+    ).toBe(perRound)
+
+    await detail.reload(tournamentId)
+
+    // ----- the fixture DISCRIMINATES, off the served standings ---------------
+    // Before reading the order, establish that reading it is worth anything: the two
+    // entrants the claim rests on are level on wins and their two tiebreak columns
+    // disagree. Taken from the server, so this cannot agree with the written-down table
+    // by construction.
+    const served = await readSwissStandings(director, tournamentId, eventId)
+    const stronger = standingOf(served, entrants[STRONGER_SCHEDULE].username)
+    const weaker = standingOf(served, entrants[BETTER_MARGIN].username)
+    expect(
+      stronger.wins,
+      `${stronger.username} and ${weaker.username} must be LEVEL ON WINS for Buchholz ` +
+        'to be what separates them',
+    ).toBe(weaker.wins)
+    expect(
+      stronger.buchholz,
+      `${stronger.username} must have faced the stronger schedule`,
+    ).toBeGreaterThan(weaker.buchholz)
+    expect(
+      stronger.gameDifference,
+      `${stronger.username} must have the WORSE game difference — with the two columns ` +
+        'agreeing, this table would come out the same with no Buchholz step at all',
+    ).toBeLessThan(weaker.gameDifference)
+
+    // …and the entrant with the stronger schedule ranks above the one with the better
+    // margin. This is the sentence the chore is about.
+    expect(
+      stronger.rank,
+      `${stronger.username} (Buchholz ${stronger.buchholz}, difference ` +
+        `${stronger.gameDifference}) must rank above ${weaker.username} (Buchholz ` +
+        `${weaker.buchholz}, difference ${weaker.gameDifference})`,
+    ).toBeLessThan(weaker.rank)
+
+    // ----- the whole table, in order, off the page ---------------------------
+    // The column positions the cell accessors read, verified against the headers on
+    // screen: an inserted column would otherwise move every number one place and be read
+    // as a wrong value rather than as a wrong index.
+    for (const column of Object.values(SWISS_STANDINGS_COLUMNS)) {
+      await expect(detail.swissStandingsHeader(eventId, column)).toHaveAccessibleName(
+        column.name,
+      )
+    }
+
+    const expectedOrder = BUCHHOLZ_STANDINGS.map(
+      (row) => entrants[row.player].username,
+    )
+    expect(
+      served.map((row) => row.username),
+      'the served finishing order',
+    ).toEqual(expectedOrder)
+
+    await expect(detail.swissStandingsRows(eventId)).toHaveCount(BUCHHOLZ_FIELD)
+    for (const [index, expected] of BUCHHOLZ_STANDINGS.entries()) {
+      const username = entrants[expected.player].username
+      const entryId = standingOf(served, username).entryId
+      // The row in the position the fixture says it holds, keyed by the server-minted
+      // entry id — so this pins the order on screen, not just that the row exists.
+      await expect(detail.swissStandingsRows(eventId).nth(index)).toHaveAttribute(
+        'data-testid',
+        `standing-row-${entryId}`,
+      )
+      // …and every cell of it, Buchholz included.
+      await expect(
+        detail.swissStandingCells(eventId, entryId),
+        `${username}'s standings line`,
+      ).toHaveText(standingRowText(expected, index + 1, username))
+    }
 
     await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
   })

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -9954,16 +9954,107 @@ internal enum Components {
             case live = "live"
             case final = "final"
         }
+        /// One entry's line in a **swiss** table: every column a pool's row carries, plus
+        /// the **Buchholz** figure that ordered it.
+        ///
+        /// ``buchholz`` is the sum of this entrant's opponents' win counts — the wins column
+        /// this same table shows, **bye wins included** (ADR "swiss standings add Buchholz, and
+        /// head-to-head is guarded on having met"), so a director can check the figure by
+        /// adding up the rows of the players this one has played. A **bye adds no term** to its
+        /// own holder's sum: it produced no opponent.
+        ///
+        /// It is on the wire because it is the one tiebreak a client cannot derive from the row
+        /// it ordered: ``rank`` is settled by wins, then head-to-head, then *this*, then
+        /// ``game_difference`` and ``games_won``, and every other link shows its working in the
+        /// columns beside it. A swiss table that ranks A above B on equal wins and worse game
+        /// difference is unreadable without it.
+        ///
+        /// It extends the round-robin row rather than replacing it, so a client renders a swiss
+        /// table with the component it already has and one extra column.
+        ///
+        /// - Remark: Generated from `#/components/schemas/SwissStandingRowRead`.
+        internal struct SwissStandingRowRead: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/SwissStandingRowRead/entry_id`.
+            internal var entryId: Swift.String
+            /// - Remark: Generated from `#/components/schemas/SwissStandingRowRead/rank`.
+            internal var rank: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/SwissStandingRowRead/played`.
+            internal var played: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/SwissStandingRowRead/wins`.
+            internal var wins: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/SwissStandingRowRead/losses`.
+            internal var losses: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/SwissStandingRowRead/games_won`.
+            internal var gamesWon: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/SwissStandingRowRead/games_lost`.
+            internal var gamesLost: Swift.Int
+            /// - Remark: Generated from `#/components/schemas/SwissStandingRowRead/buchholz`.
+            internal var buchholz: Swift.Int
+            /// ``games_won - games_lost`` — the third tiebreaker, on the wire for the table
+            /// to show but derived here so it cannot disagree with the two counts beside it.
+            ///
+            /// - Remark: Generated from `#/components/schemas/SwissStandingRowRead/game_difference`.
+            internal var gameDifference: Swift.Int
+            /// Creates a new `SwissStandingRowRead`.
+            ///
+            /// - Parameters:
+            ///   - entryId:
+            ///   - rank:
+            ///   - played:
+            ///   - wins:
+            ///   - losses:
+            ///   - gamesWon:
+            ///   - gamesLost:
+            ///   - buchholz:
+            ///   - gameDifference: ``games_won - games_lost`` — the third tiebreaker, on the wire for the table
+            internal init(
+                entryId: Swift.String,
+                rank: Swift.Int,
+                played: Swift.Int,
+                wins: Swift.Int,
+                losses: Swift.Int,
+                gamesWon: Swift.Int,
+                gamesLost: Swift.Int,
+                buchholz: Swift.Int,
+                gameDifference: Swift.Int
+            ) {
+                self.entryId = entryId
+                self.rank = rank
+                self.played = played
+                self.wins = wins
+                self.losses = losses
+                self.gamesWon = gamesWon
+                self.gamesLost = gamesLost
+                self.buchholz = buchholz
+                self.gameDifference = gameDifference
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case entryId = "entry_id"
+                case rank
+                case played
+                case wins
+                case losses
+                case gamesWon = "games_won"
+                case gamesLost = "games_lost"
+                case buchholz
+                case gameDifference = "game_difference"
+            }
+        }
         /// The **pool-less standings** shape of an event's results — the swiss arm of the
         /// ``results`` discriminated union, tagged ``kind: "swiss_standings"`` (ADR "swiss
         /// pre-cuts every round and pairs each one on advance").
         ///
         /// One table over the whole field, because swiss has no pools: everybody is ranked
-        /// against everybody, which is what pairing by score is for. The rows are the *same*
-        /// :class:`StandingRowRead` a round-robin pool carries, so a client renders this with
-        /// the table it already has — the difference is that they arrive as one list rather
-        /// than grouped under a pool, which is a fact about the format and not a second row
-        /// shape.
+        /// against everybody, which is what pairing by score is for. The rows are a
+        /// :class:`StandingRowRead` plus one column (:class:`SwissStandingRowRead`), and they
+        /// arrive as one list rather than grouped under a pool — both facts about the format
+        /// rather than a second row shape.
+        ///
+        /// The order is swiss's own chain: wins, head-to-head when exactly two are tied **and
+        /// they met**, then **Buchholz**, then game difference, games won and the entry id (ADR
+        /// "swiss standings add Buchholz, and head-to-head is guarded on having met"). Strength
+        /// of schedule outranks margin here because swiss pairs by score, so two entrants level
+        /// on wins may have faced different halves of the field.
         ///
         /// ``complete`` is every round decided, including the later rounds that are cut up
         /// front with their sides still unknown. ``champion`` is the leader of a complete
@@ -9980,7 +10071,7 @@ internal enum Components {
             /// - Remark: Generated from `#/components/schemas/SwissStandingsResultsRead/kind`.
             internal var kind: Components.Schemas.SwissStandingsResultsRead.KindPayload?
             /// - Remark: Generated from `#/components/schemas/SwissStandingsResultsRead/rows`.
-            internal var rows: [Components.Schemas.StandingRowRead]
+            internal var rows: [Components.Schemas.SwissStandingRowRead]
             /// - Remark: Generated from `#/components/schemas/SwissStandingsResultsRead/complete`.
             internal var complete: Swift.Bool
             /// - Remark: Generated from `#/components/schemas/SwissStandingsResultsRead/champion`.
@@ -9994,7 +10085,7 @@ internal enum Components {
             ///   - champion:
             internal init(
                 kind: Components.Schemas.SwissStandingsResultsRead.KindPayload? = nil,
-                rows: [Components.Schemas.StandingRowRead],
+                rows: [Components.Schemas.SwissStandingRowRead],
                 complete: Swift.Bool,
                 champion: Swift.String? = nil
             ) {

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -4609,17 +4609,69 @@ export interface components {
          */
         Status: "scheduled" | "live" | "final";
         /**
+         * SwissStandingRowRead
+         * @description One entry's line in a **swiss** table: every column a pool's row carries, plus
+         *     the **Buchholz** figure that ordered it.
+         *
+         *     ``buchholz`` is the sum of this entrant's opponents' win counts — the wins column
+         *     this same table shows, **bye wins included** (ADR "swiss standings add Buchholz, and
+         *     head-to-head is guarded on having met"), so a director can check the figure by
+         *     adding up the rows of the players this one has played. A **bye adds no term** to its
+         *     own holder's sum: it produced no opponent.
+         *
+         *     It is on the wire because it is the one tiebreak a client cannot derive from the row
+         *     it ordered: ``rank`` is settled by wins, then head-to-head, then *this*, then
+         *     ``game_difference`` and ``games_won``, and every other link shows its working in the
+         *     columns beside it. A swiss table that ranks A above B on equal wins and worse game
+         *     difference is unreadable without it.
+         *
+         *     It extends the round-robin row rather than replacing it, so a client renders a swiss
+         *     table with the component it already has and one extra column.
+         */
+        SwissStandingRowRead: {
+            /**
+             * Entry Id
+             * Format: uuid
+             */
+            entry_id: string;
+            /** Rank */
+            rank: number;
+            /** Played */
+            played: number;
+            /** Wins */
+            wins: number;
+            /** Losses */
+            losses: number;
+            /** Games Won */
+            games_won: number;
+            /** Games Lost */
+            games_lost: number;
+            /** Buchholz */
+            buchholz: number;
+            /**
+             * Game Difference
+             * @description ``games_won - games_lost`` — the third tiebreaker, on the wire for the table
+             *     to show but derived here so it cannot disagree with the two counts beside it.
+             */
+            readonly game_difference: number;
+        };
+        /**
          * SwissStandingsResultsRead
          * @description The **pool-less standings** shape of an event's results — the swiss arm of the
          *     ``results`` discriminated union, tagged ``kind: "swiss_standings"`` (ADR "swiss
          *     pre-cuts every round and pairs each one on advance").
          *
          *     One table over the whole field, because swiss has no pools: everybody is ranked
-         *     against everybody, which is what pairing by score is for. The rows are the *same*
-         *     :class:`StandingRowRead` a round-robin pool carries, so a client renders this with
-         *     the table it already has — the difference is that they arrive as one list rather
-         *     than grouped under a pool, which is a fact about the format and not a second row
-         *     shape.
+         *     against everybody, which is what pairing by score is for. The rows are a
+         *     :class:`StandingRowRead` plus one column (:class:`SwissStandingRowRead`), and they
+         *     arrive as one list rather than grouped under a pool — both facts about the format
+         *     rather than a second row shape.
+         *
+         *     The order is swiss's own chain: wins, head-to-head when exactly two are tied **and
+         *     they met**, then **Buchholz**, then game difference, games won and the entry id (ADR
+         *     "swiss standings add Buchholz, and head-to-head is guarded on having met"). Strength
+         *     of schedule outranks margin here because swiss pairs by score, so two entrants level
+         *     on wins may have faced different halves of the field.
          *
          *     ``complete`` is every round decided, including the later rounds that are cut up
          *     front with their sides still unknown. ``champion`` is the leader of a complete
@@ -4634,7 +4686,7 @@ export interface components {
              */
             kind: "swiss_standings";
             /** Rows */
-            rows: components["schemas"]["StandingRowRead"][];
+            rows: components["schemas"]["SwissStandingRowRead"][];
             /** Complete */
             complete: boolean;
             /** Champion */

--- a/web-client/src/components/tournaments/data/results.test.ts
+++ b/web-client/src/components/tournaments/data/results.test.ts
@@ -7,6 +7,7 @@ type FinishesResultsRead = components['schemas']['FinishesResultsRead']
 type StandingsThenFinishesResultsRead =
   components['schemas']['StandingsThenFinishesResultsRead']
 type SwissStandingsResultsRead = components['schemas']['SwissStandingsResultsRead']
+type SwissStandingRowRead = components['schemas']['SwissStandingRowRead']
 type StandingRowRead = components['schemas']['StandingRowRead']
 type FinishRowRead = components['schemas']['FinishRowRead']
 
@@ -93,14 +94,30 @@ function wireTwoStage(
   }
 }
 
+/** A wire **swiss** row (`SwissStandingRowRead`): a pool's row plus `buchholz`. Built off
+ * `wireRow` rather than restated, exactly as the schema `.extend()`s rather than
+ * re-declaring — so the eight shared columns are written once here too.
+ *
+ * `buchholz: 5` collides with none of its neighbours (wins 2, game difference 3, games won
+ * 4), so a parser or a cell reading the wrong field cannot come out right by accident. */
+function wireSwissRow(
+  overrides: Partial<SwissStandingRowRead> = {},
+): SwissStandingRowRead {
+  return { ...wireRow(), buchholz: 5, ...overrides }
+}
+
 /** A complete `swiss_standings` results block off the wire (the swiss ADR) — **one list of
- * rows, no pools**, because swiss ranks the whole field in one table. */
+ * rows, no pools**, because swiss ranks the whole field in one table, and each row carrying
+ * the Buchholz figure that ordered it. */
 function wireSwiss(
   overrides: Partial<SwissStandingsResultsRead> = {},
 ): SwissStandingsResultsRead {
   return {
     kind: 'swiss_standings',
-    rows: [wireRow(), wireRow({ entry_id: 'entry-2', rank: 2 })],
+    rows: [
+      wireSwissRow(),
+      wireSwissRow({ entry_id: 'entry-2', rank: 2, buchholz: 4 }),
+    ],
     complete: true,
     champion: 'entry-1',
     ...overrides,
@@ -235,6 +252,10 @@ describe('parseResults', () => {
           gamesWon: 4,
           gamesLost: 1,
           gameDifference: 3,
+          // The one column a pool's row does not carry, and the reason the swiss arm has a
+          // row parser of its own. `toEqual` is exact, so a parse that dropped it — or that
+          // let a pool row through unchanged — reds here.
+          buchholz: 5,
         },
         {
           entryId: 'entry-2',
@@ -245,11 +266,44 @@ describe('parseResults', () => {
           gamesWon: 4,
           gamesLost: 1,
           gameDifference: 3,
+          // Deliberately DIFFERENT from row 1's, so a parser that read the first row's
+          // figure for every row (or a constant) cannot pass.
+          buchholz: 4,
         },
       ],
       complete: true,
       champion: 'entry-1',
     })
+  })
+
+  /** A pool's row has no `buchholz`, so a swiss payload carrying pool rows is real server
+   * drift — and it must fail at the boundary rather than reach a table with one column
+   * permanently blank. `.extend()` on a Zod object keeps the field **required**, which is
+   * what this pins; `.partial()` or an `.optional()` would quietly let it through. */
+  it('rejects a swiss row with no buchholz at the boundary', () => {
+    const { buchholz, ...withoutBuchholz } = wireSwissRow()
+    // The dropped field really was there to drop. Without this the test would still pass
+    // against a fixture that never carried a `buchholz` — asserting on the absence of
+    // something nobody removed.
+    expect(buchholz).toBe(5)
+
+    // Assembled as a plain object rather than through `wireSwiss`, because the point is a
+    // payload the generated type forbids — `parseResults` takes `unknown`, which is exactly
+    // the claim it exists to check at RUNTIME.
+    expect(() =>
+      parseResults({ ...wireSwiss(), rows: [withoutBuchholz] }),
+    ).toThrow()
+  })
+
+  /** `0` is a legitimate Buchholz — every one of this entrant's opponents has yet to win a
+   * match, which is the ordinary state of round 1 — so it must survive the parse as `0`.
+   * Anything that treated it as missing and coalesced it would be inventing a figure. */
+  it('keeps a buchholz of zero as zero', () => {
+    const parsed = parseResults(wireSwiss({ rows: [wireSwissRow({ buchholz: 0 })] }))
+
+    expect(
+      parsed?.kind === 'swiss_standings' ? parsed.rows[0].buchholz : null,
+    ).toBe(0)
   })
 
   it('keeps a LIVE swiss block incomplete, with no champion', () => {
@@ -268,8 +322,8 @@ describe('parseResults', () => {
     const parsed = parseResults(
       wireSwiss({
         rows: [
-          wireRow({ entry_id: 'entry-5', rank: 3 }),
-          wireRow({ entry_id: 'entry-1', rank: 1 }),
+          wireSwissRow({ entry_id: 'entry-5', rank: 3 }),
+          wireSwissRow({ entry_id: 'entry-1', rank: 1 }),
         ],
       }),
     )

--- a/web-client/src/components/tournaments/data/results.ts
+++ b/web-client/src/components/tournaments/data/results.ts
@@ -32,6 +32,7 @@ import type {
   FinishRow,
   PoolStandings,
   StandingRow,
+  SwissStandingRow,
 } from './types'
 
 /** The wire shape (`StandingRowRead`), snake_case, every field required — a standings row
@@ -53,18 +54,42 @@ const standingRowWireSchema = z.object({
 /** One wire row → one domain `StandingRow`. Annotated `: StandingRow` on purpose — that
  * is what keeps the domain interface in `./types` and this schema one thing: drop a field
  * from either and this line is a compile error, so the runtime parser and the type the app
- * holds cannot drift apart. */
-const standingRowSchema = standingRowWireSchema.transform(
-  (r): StandingRow => ({
-    entryId: r.entry_id,
-    rank: r.rank,
-    played: r.played,
-    wins: r.wins,
-    losses: r.losses,
-    gamesWon: r.games_won,
-    gamesLost: r.games_lost,
-    gameDifference: r.game_difference,
-  }),
+ * holds cannot drift apart.
+ *
+ * Extracted as a function rather than inlined in the transform below, because the **swiss**
+ * row is this row plus one column and reuses it: one mapping, so a column added to the
+ * shared shape reaches both tables at once and the two cannot fork. */
+const toStandingRow = (r: z.output<typeof standingRowWireSchema>): StandingRow => ({
+  entryId: r.entry_id,
+  rank: r.rank,
+  played: r.played,
+  wins: r.wins,
+  losses: r.losses,
+  gamesWon: r.games_won,
+  gamesLost: r.games_lost,
+  gameDifference: r.game_difference,
+})
+
+const standingRowSchema = standingRowWireSchema.transform(toStandingRow)
+
+/** The wire shape (`SwissStandingRowRead`): a pool's row **plus `buchholz`** — the sum of
+ * this entrant's opponents' win counts, and the tiebreak that sits above game difference in
+ * swiss (ADR "swiss standings add Buchholz, and head-to-head is guarded on having met").
+ *
+ * `.extend()`ed from the shared row rather than re-declared, so the eight columns both
+ * tables show are stated once. Required and an integer, exactly as the wire has it: a
+ * missing `buchholz` is real server drift, and it fails HERE rather than rendering as an
+ * empty cell in the one column that explains the order. `0` is a legitimate value — an
+ * entrant every one of whose opponents has yet to win — so it is not a "missing" stand-in
+ * and must never be coalesced from one. */
+const swissStandingRowWireSchema = standingRowWireSchema.extend({
+  buchholz: z.number().int(),
+})
+
+/** One wire swiss row → one domain `SwissStandingRow`. Annotated for the same reason, and
+ * built on `toStandingRow` so the shared columns are mapped by the shared mapper. */
+const swissStandingRowSchema = swissStandingRowWireSchema.transform(
+  (r): SwissStandingRow => ({ ...toStandingRow(r), buchholz: r.buchholz }),
 )
 
 /** The wire shape (`PoolStandingsRead`): a pool's rows **in the server's finishing order**
@@ -152,14 +177,15 @@ const standingsThenFinishesResultsWireSchema = z.object({
  * `kind: "swiss_standings"` — **one list of rows over the whole field**, whether every round
  * is decided, and the leader once it is.
  *
- * The rows are parsed by `standingRowSchema`, the very parser a pool's standings use, so the
- * swiss table cannot drift from the round-robin one and a malformed row fails at the same
- * boundary whichever arm carried it. The only structural difference is the absence of a pool
- * to group under — swiss ranks the whole field in one table (ADR "swiss pre-cuts every round
- * and pairs each one on advance"). */
+ * The rows are `swissStandingRowSchema` — the very parser a pool's standings use, extended
+ * by the one column swiss adds — so the two tables cannot drift on the eight they share and
+ * a malformed row fails at the same boundary whichever arm carried it. The two structural
+ * differences are both facts about the format: no pool to group under (swiss ranks the whole
+ * field in one table, ADR "swiss pre-cuts every round and pairs each one on advance") and
+ * the `buchholz` figure that ordered each row. */
 const swissStandingsResultsWireSchema = z.object({
   kind: z.literal('swiss_standings'),
-  rows: z.array(standingRowSchema),
+  rows: z.array(swissStandingRowSchema),
   complete: z.boolean(),
   champion: z.string().nullable(),
 })

--- a/web-client/src/components/tournaments/data/results.ts
+++ b/web-client/src/components/tournaments/data/results.ts
@@ -76,8 +76,10 @@ const standingRowSchema = standingRowWireSchema.transform(toStandingRow)
  * this entrant's opponents' win counts, and the tiebreak that sits above game difference in
  * swiss (ADR "swiss standings add Buchholz, and head-to-head is guarded on having met").
  *
- * `.extend()`ed from the shared row rather than re-declared, so the eight columns both
- * tables show are stated once. Required and an integer, exactly as the wire has it: a
+ * `.extend()`ed from the shared row rather than re-declared, so the eight fields both
+ * tables' rows carry are stated once. Eight is what the **wire** sends, not what either
+ * table shows: `played` and `gamesLost` are parsed and carried inward, and neither is a
+ * column. Required and an integer, exactly as the wire has it: a
  * missing `buchholz` is real server drift, and it fails HERE rather than rendering as an
  * empty cell in the one column that explains the order. `0` is a legitimate value — an
  * entrant every one of whose opponents has yet to win — so it is not a "missing" stand-in
@@ -178,7 +180,7 @@ const standingsThenFinishesResultsWireSchema = z.object({
  * is decided, and the leader once it is.
  *
  * The rows are `swissStandingRowSchema` — the very parser a pool's standings use, extended
- * by the one column swiss adds — so the two tables cannot drift on the eight they share and
+ * by the one field swiss adds — so the two tables cannot drift on the eight they share and
  * a malformed row fails at the same boundary whichever arm carried it. The two structural
  * differences are both facts about the format: no pool to group under (swiss ranks the whole
  * field in one table, ADR "swiss pre-cuts every round and pairs each one on advance") and

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -25,6 +25,7 @@ import type {
   StandingRow,
   StandingsResults,
   StandingsThenFinishesResults,
+  SwissStandingRow,
   SwissStandingsResults,
   Tournament,
   TournamentEvent,
@@ -1006,6 +1007,20 @@ export function buildStandingRow(overrides: Partial<StandingRow> = {}): Standing
   }
 }
 
+/**
+ * One line of a **swiss** table: a pool's row plus the `buchholz` figure that ordered it.
+ *
+ * `buchholz: 5` rather than a number that could be confused with one of its neighbours —
+ * not `2` (the wins), not `3` (the game difference), not `4` (the games won). A column
+ * reading the wrong field is the failure this fixture exists to catch, and a figure that
+ * collided with a sibling column would let it pass.
+ */
+export function buildSwissStandingRow(
+  overrides: Partial<SwissStandingRow> = {},
+): SwissStandingRow {
+  return { ...buildStandingRow(), buchholz: 5, ...overrides }
+}
+
 /** One pool's standings — a **complete** three-player pool in finishing order:
  * `entry-1` (2–0) over `entry-4` (1–1) over `entry-5` (0–2). In the server's order, which
  * the view renders untouched (ADR-0788 — the order *is* the result), so a factory that
@@ -1277,13 +1292,33 @@ export function swissStandingsResultsOf(
 }
 
 /**
- * A **swiss** event's results (the swiss ADR): **one complete table over the whole field**,
- * four entrants deep, with `entry-1` on top and crowned.
+ * A **swiss** event's results (the swiss ADR): **one complete table over the whole field** —
+ * five entrants over three rounds, `entry-1` on top and crowned.
  *
- * No pools, which is the whole shape: a swiss ranks everybody against everybody. The ranks
- * are distinct and the numbers descend with them, so a panel that re-sorted — or a selector
- * that lost the order — would show a visibly different table. The live state (rounds still
- * to play) is `buildSwissStandingsResults({ complete: false, champion: null })`.
+ * No pools, which is the whole shape: a swiss ranks everybody against everybody. The live
+ * state (rounds still to play) is
+ * `buildSwissStandingsResults({ complete: false, champion: null })`.
+ *
+ * ## The numbers are a real event, not decoration
+ *
+ * Five entrants is **odd on purpose**: every round byes exactly one of them, which is what
+ * makes the two Buchholz rules in the ADR ("swiss standings add Buchholz, and head-to-head
+ * is guarded on having met") visible in the figures rather than merely asserted about them.
+ * The draw behind the table:
+ *
+ *     R1  e1 v e3   e2 v e4   bye e5
+ *     R2  e1 v e2   e3 v e5   bye e4
+ *     R3  e1 v e4   e2 v e5   bye e3
+ *
+ * e1 wins everything; e2 beats e4 and e5; e3 beats e5 and takes a bye; e4 and e5 win
+ * nothing but their byes. That is 6 match wins + 3 bye wins = **9 wins**, which is what the
+ * rows total — and games won totals 24 against games lost 24, so nothing here is invented.
+ *
+ * ⚠️ **It is built to discriminate, twice over.** `e2` and `e3` are level on wins, never
+ * met, and Buchholz puts e2 first **against** game difference (0 beats +1). A table that
+ * showed the wrong number, dropped the column, or re-sorted the rows gets that pair visibly
+ * wrong; a fixture whose ranks simply descended with every column could not tell any of
+ * those apart. `e4`/`e5` repeat the shape a tier down.
  */
 export function buildSwissStandingsResults(
   overrides: Partial<SwissStandingsResults> = {},
@@ -1291,45 +1326,75 @@ export function buildSwissStandingsResults(
   return {
     kind: 'swiss_standings',
     rows: [
-      buildStandingRow({
+      // e1 won all three. Opponents 3, 2 and 4 → Buchholz 2 + 2 + 1 = 5.
+      buildSwissStandingRow({
         entryId: 'entry-1',
         rank: 1,
         played: 3,
         wins: 3,
         losses: 0,
         gamesWon: 9,
-        gamesLost: 2,
-        gameDifference: 7,
+        gamesLost: 3,
+        gameDifference: 6,
+        buchholz: 5,
       }),
-      buildStandingRow({
+      // ⚠️ **The pair the whole column is for.** e2 and e3 are level on wins and never met,
+      // so head-to-head falls through and BUCHHOLZ decides — and it puts e2 first *despite
+      // e3's better game difference* (+1 against 0). Ordered on margin alone these two are
+      // the other way round, so this is the row a table that showed the wrong number, or
+      // re-sorted, gets visibly wrong.
+      //
+      // e2's opponents are 4, 1 and 5 → 1 + 3 + 1 = 5. Two of those five points are **bye
+      // wins** (e4's and e5's only wins are byes), which is the ADR's decision made visible:
+      // Buchholz reads the same wins column this table shows.
+      buildSwissStandingRow({
         entryId: 'entry-2',
         rank: 2,
         played: 3,
         wins: 2,
         losses: 1,
-        gamesWon: 7,
-        gamesLost: 5,
-        gameDifference: 2,
+        gamesWon: 6,
+        gamesLost: 6,
+        gameDifference: 0,
+        buchholz: 5,
       }),
-      buildStandingRow({
+      // e3 played only two opponents — 1 and 5 — because its third round was a **bye**,
+      // which adds no term to its own sum: 3 + 1 = 4. Its bye is also why it has the softer
+      // schedule that puts it below e2.
+      buildSwissStandingRow({
         entryId: 'entry-3',
         rank: 3,
         played: 3,
-        wins: 1,
-        losses: 2,
-        gamesWon: 5,
-        gamesLost: 7,
-        gameDifference: -2,
+        wins: 2,
+        losses: 1,
+        gamesWon: 4,
+        gamesLost: 3,
+        gameDifference: 1,
+        buchholz: 4,
       }),
-      buildStandingRow({
+      // e4 and e5 repeat the same shape one tier down: level on a single win (each of them a
+      // bye win), never met, separated by Buchholz — 2 + 3 = 5 against 2 + 2 = 4.
+      buildSwissStandingRow({
         entryId: 'entry-4',
         rank: 4,
         played: 3,
-        wins: 0,
-        losses: 3,
+        wins: 1,
+        losses: 2,
+        gamesWon: 3,
+        gamesLost: 6,
+        gameDifference: -3,
+        buchholz: 5,
+      }),
+      buildSwissStandingRow({
+        entryId: 'entry-5',
+        rank: 5,
+        played: 3,
+        wins: 1,
+        losses: 2,
         gamesWon: 2,
-        gamesLost: 9,
-        gameDifference: -7,
+        gamesLost: 6,
+        gameDifference: -4,
+        buchholz: 4,
       }),
     ],
     complete: true,
@@ -1339,12 +1404,18 @@ export function buildSwissStandingsResults(
 }
 
 /** A **swiss** event **with results**: the pool-less swiss event `buildSwissEvent` seeds,
- * played out to a champion. Its entrants (`entry-1`…`entry-8`) include every id the table
- * names, so every row joins to a username. */
+ * played out to a champion.
+ *
+ * **Five entrants, not the eight `buildSwissEvent` defaults to**, because a swiss table
+ * ranks the *whole* field: the five rows the results carry are exactly the five entrants the
+ * event lists, so every row joins to a username and no entrant is missing from the table it
+ * is supposed to be ranked in. It is also the odd field the results' bye arithmetic
+ * describes. */
 export function buildSwissStandingsEvent(
   overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
 ): TournamentEvent {
   return buildSwissEvent({
+    entrants: buildEntrants(5),
     results: buildSwissStandingsResults(),
     ...overrides,
   })

--- a/web-client/src/components/tournaments/data/swiss-standings.test.ts
+++ b/web-client/src/components/tournaments/data/swiss-standings.test.ts
@@ -1,7 +1,7 @@
 import { WITHDRAWN_LABEL } from './draw'
 import {
   buildEntrants,
-  buildStandingRow,
+  buildSwissStandingRow,
   buildSwissStandingsEvent,
   buildSwissStandingsResults,
   swissStandingsResultsOf,
@@ -23,6 +23,7 @@ describe('eventSwissStandings', () => {
       'player.2',
       'player.3',
       'player.4',
+      'player.5',
     ])
   })
 
@@ -34,8 +35,18 @@ describe('eventSwissStandings', () => {
       buildSwissStandingsEvent({
         results: buildSwissStandingsResults({
           rows: [
-            buildStandingRow({ entryId: 'entry-3', rank: 3, gameDifference: -2 }),
-            buildStandingRow({ entryId: 'entry-1', rank: 1, gameDifference: 7 }),
+            buildSwissStandingRow({
+              entryId: 'entry-3',
+              rank: 3,
+              gameDifference: -2,
+              buchholz: 9,
+            }),
+            buildSwissStandingRow({
+              entryId: 'entry-1',
+              rank: 1,
+              gameDifference: 7,
+              buchholz: 2,
+            }),
           ],
         }),
       }),
@@ -44,6 +55,12 @@ describe('eventSwissStandings', () => {
     expect(view.rows.map((r) => r.entryId)).toEqual(['entry-3', 'entry-1'])
     expect(view.rows.map((r) => r.gameDifference)).toEqual([-2, 7])
     expect(view.rows.map((r) => r.rank)).toEqual([3, 1])
+    // **Buchholz rides through with the rest.** It is the SERVER's figure — a sum over
+    // *other* rows, which moves when an opponent wins a later match — so a selector that
+    // re-derived it from the wins column here would be a second copy that disagrees within
+    // a round. The two values are deliberately the reverse of the rank order and equal to
+    // nothing else on their rows, so a selector reading the wrong field cannot pass.
+    expect(view.rows.map((r) => r.buchholz)).toEqual([9, 2])
   })
 
   it('joins the champion to a name', () => {
@@ -73,9 +90,9 @@ describe('eventSwissStandings', () => {
     // makes, which is why this selector reuses `nameOf` rather than forking it.
     const view = viewOf(
       buildSwissStandingsEvent({
-        entrants: buildEntrants(2), // entry-3 and entry-4 are gone
+        entrants: buildEntrants(2), // entry-3, entry-4 and entry-5 are gone
         results: buildSwissStandingsResults({
-          rows: [buildStandingRow({ entryId: 'entry-4', rank: 1 })],
+          rows: [buildSwissStandingRow({ entryId: 'entry-4', rank: 1 })],
         }),
       }),
     )

--- a/web-client/src/components/tournaments/data/swiss-standings.ts
+++ b/web-client/src/components/tournaments/data/swiss-standings.ts
@@ -14,9 +14,15 @@
 // **It makes ONE join, not two.** A pool's standings also resolve a `poolId` to a pool
 // name; swiss has no pool to resolve, because it ranks the whole field in one table. That
 // absence is the only thing that distinguishes this module from `./standings` — the rows
-// themselves are the very `StandingRow`s a pool carries, joined by the very same
+// themselves are a pool's `StandingRow` plus the `buchholz` column, joined by the very same
 // `nameOf`, so the withdrawn-entrant label and every number cannot fork into a second
 // implementation.
+//
+// `buchholz` needs no work here at all, and that is the point of spreading rather than
+// re-listing the columns: it is the SERVER's figure — the sum of this entrant's opponents'
+// win counts — carried straight through to the cell, never re-derived from the wins column
+// beside it. Re-deriving it would be a second copy of a number that already moves on its
+// own (an opponent's later win raises it), and the two would disagree within a round.
 //
 // What it deliberately does **not** do is re-order or recompute anything: the server owns
 // the finishing order and every figure (ADR-0788 — "the order *is* the result"), so the
@@ -26,15 +32,30 @@
 // than asserted through a DOM.
 
 import { nameByEntryId, nameOf } from './entrant-names'
-import type { StandingLine } from './standings'
-import type { SwissStandingsResults, TournamentEvent } from './types'
+import type {
+  SwissStandingRow,
+  SwissStandingsResults,
+  TournamentEvent,
+} from './types'
+
+/** One swiss standings line, ready to render: the server's row — **`buchholz` included** —
+ * plus the entrant's name joined from the event. The `StandingLine` of `./standings` with
+ * the one extra column, and structurally assignable to it, so the shared table renders
+ * either. Every number is carried through unchanged: the client shows them, it does not
+ * compute them. */
+export interface SwissStandingLine extends SwissStandingRow {
+  /** The entrant's username (bare, no `@` — `web-client/CLAUDE.md`), or `WITHDRAWN_LABEL`
+   * when the row names an entry the event no longer lists — the same join, and the same
+   * word, a pool's table makes. */
+  name: string
+}
 
 /** A swiss event's standings, shaped for the reader: the whole field as one named table,
  * whether every round is decided, and the leader's *name* (joined) once it is. */
 export interface SwissStandingsView {
   /** Every entrant, in the server's finishing order — **one list, no pools**, rendered
    * untouched. */
-  rows: StandingLine[]
+  rows: SwissStandingLine[]
   /** True when **every round** is decided, the later ones included. */
   complete: boolean
   /** The leader's username once the event is complete, else `null` — the server's own
@@ -64,7 +85,9 @@ export function eventSwissStandings(
 
   return {
     rows: results.rows.map(
-      (row): StandingLine => ({ ...row, name: nameOf(row.entryId, names) }),
+      // Spread, so every column the server sent rides through — `buchholz` included, and
+      // whatever the shared row grows next. The join adds a name; it takes nothing away.
+      (row): SwissStandingLine => ({ ...row, name: nameOf(row.entryId, names) }),
     ),
     complete: results.complete,
     champion:

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -309,6 +309,40 @@ export interface StandingRow {
   gameDifference: number
 }
 
+/**
+ * One entry's line in a **swiss** table: every column a pool's row carries, plus the
+ * **Buchholz** figure that ordered it (ADR "swiss standings add Buchholz, and head-to-head
+ * is guarded on having met").
+ *
+ * It **extends** `StandingRow` rather than restating it, exactly as `SwissStandingRowRead`
+ * extends `StandingRowRead` on the wire: swiss's rows are a pool's rows plus one column,
+ * which is a fact about the format and not a second row shape. So one table renders both.
+ */
+export interface SwissStandingRow extends StandingRow {
+  /**
+   * The sum of this entrant's **opponents' win counts** — how strong a field they had to
+   * beat, and the tiebreak that sits **above game difference** in swiss (CONTEXT.md,
+   * "Buchholz"). Highest first.
+   *
+   * It is on the wire because it is the one link in the chain a client cannot re-derive
+   * from the row it ordered: every other step shows its working in the columns beside it,
+   * so a table that ranks A above B on equal wins and *worse* game difference is
+   * unreadable without this number.
+   *
+   * Two properties worth not breaking in the UI:
+   *
+   * - the wins it sums are the **wins this same table shows, bye wins included**, so a
+   *   director can check the figure by adding up the win columns of the players this one
+   *   has played. An adjusted number would silently fail that arithmetic and read as a bug;
+   * - a **bye adds no term** to its own holder's sum, having produced no opponent.
+   *
+   * It **moves as the event runs**: an opponent winning a later match raises it without
+   * this entrant playing. Like every other figure here it is the SERVER's, shown and never
+   * recomputed.
+   */
+  buchholz: number
+}
+
 /** One pool's standings: its rows in the server's finishing order (**never re-sorted on
  * the client**), and whether every one of the pool's fixtures is decided. `poolId` names
  * a `Pool` in this same event's `pools`, so the table titles itself from the pool the
@@ -429,11 +463,13 @@ export interface StandingsThenFinishesResults {
  * advance"): **one standings table over the whole field**, whether every round is decided,
  * and the leader once it is. The `swiss_standings` arm of the `EventResults` union.
  *
- * The rows are the very `StandingRow`s a round-robin pool carries — not a swiss-flavoured
- * near-copy — so the same table renders them and the two shapes cannot drift apart. The
- * one difference is that they arrive as **one list rather than grouped under a pool**, and
- * that is a fact about the format: swiss is pool-less, everybody is ranked against
- * everybody, which is what pairing by score is for.
+ * The rows are a round-robin pool's rows **plus one column** (`SwissStandingRow`), not a
+ * swiss-flavoured near-copy — so the same table renders them and the two shapes cannot
+ * drift apart. The two differences are both facts about the format: they arrive as **one
+ * list rather than grouped under a pool** (swiss is pool-less — everybody is ranked against
+ * everybody, which is what pairing by score is for), and each carries the **Buchholz**
+ * figure that ordered it, which a round-robin has no use for because its entrants all face
+ * the same opposition.
  *
  * Live and partial like every other results shape: the table fills in as matches land, and
  * the later rounds — cut up front with their sides still unknown — contribute nothing until
@@ -442,8 +478,10 @@ export interface StandingsThenFinishesResults {
 export interface SwissStandingsResults {
   kind: 'swiss_standings'
   /** The whole field in the server's finishing order, **never re-sorted here** (the order
-   * *is* the result — ADR-0788). One list, because there is no pool to group by. */
-  rows: StandingRow[]
+   * *is* the result — ADR-0788). One list, because there is no pool to group by; and each
+   * row carries its `buchholz`, because that is the step of the chain the other columns
+   * cannot show. */
+  rows: SwissStandingRow[]
   /** True when **every round** is decided, the later ones included. */
   complete: boolean
   /** The leader's **entry id** once the event is complete, else `null`. A swiss ranks its

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.page.tsx
@@ -3,7 +3,7 @@ import { render, screen, type Container } from '@/test/utilities'
 
 import { PoolStandingsTable, type PoolStandingsTableProps } from './pool-standings-table'
 import { buildPoolStandingsTableProps } from './pool-standings-table.factory'
-import { PLAYER_COLUMN, standingsTablePage } from './standings-table.page'
+import { standingsTablePage } from './standings-table.page'
 
 /** The accessible name a pool's table carries — the wrapper's own wiring, written once. */
 const tableName = (poolName: string) => `Standings for ${poolName}`
@@ -33,10 +33,11 @@ const scoped = (container: Container) => {
       return container.getByRole('region', { name: poolName })
     },
 
-    /** The player names, top to bottom — the shared table's Player column, read through the
-     * pool's accessible name. The ORDER is the claim: the server's, untouched (ADR-0788). */
+    /** The player names, top to bottom — the shared table's Player column, asked for by its
+     * header and read through the pool's accessible name. The ORDER is the claim: the
+     * server's, untouched (ADR-0788). */
     getRowNames(poolName: string) {
-      return table.getColumn(tableName(poolName), PLAYER_COLUMN)
+      return table.getColumnUnder(tableName(poolName), 'Player')
     },
 
     /** Everything interactive in the pool section — must be empty. Standings are a read

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/pool-standings-table.tsx
@@ -31,7 +31,11 @@ export const PoolStandingsTable = ({ pool }: PoolStandingsTableProps) => {
         {pool.name}
       </h4>
 
+      {/* `format="pool"` is the whole of what this table is not: a pool gives every
+          entrant the same opposition, so strength of schedule carries no information and
+          there is no Buchholz column to show (ADR "swiss standings add Buchholz…"). */}
       <StandingsTable
+        format="pool"
         ariaLabel={`Standings for ${pool.name}`}
         rows={pool.rows}
         className="mt-2"

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-panel.page.tsx
@@ -1,7 +1,7 @@
 import { renderedHtml } from '@/test/rendered-html'
 import { render, screen, type Container } from '@/test/utilities'
 
-import { PLAYER_COLUMN, standingsTablePage } from './standings-table.page'
+import { standingsTablePage } from './standings-table.page'
 import { StandingsPanel } from './standings-panel'
 import {
   buildStandingsPanelProps,
@@ -46,11 +46,12 @@ const scoped = (container: Container) => ({
 
   /** One pool table's player names, top to bottom (the rendered order) — for the "the
    * panel shows each pool, joined to names" assertion. Read through `standingsTablePage`,
-   * which owns the table these rows are in. */
+   * which owns the table these rows are in, and asked for by the Player header rather than
+   * by an index a new column would shift. */
   getRowNames(poolName: string) {
     return standingsTablePage
       .within(container)
-      .getColumn(`Standings for ${poolName}`, PLAYER_COLUMN)
+      .getColumnUnder(`Standings for ${poolName}`, 'Player')
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.factory.tsx
@@ -82,17 +82,30 @@ export function buildStandingLines(): StandingLine[] {
  */
 const BUCHHOLZ = [8, 6, 7]
 
-/** **Two builders, one per arm of `StandingsTableRows`** — the union cannot be built by one
- * `Partial<>`, and it should not be: which table this is decides which columns it has, so a
- * test picks the arm it means rather than half-specifying one. */
+/** **Two builders, one per arm of `StandingsTableRows`**, each with an overrides type of its
+ * own — the union cannot be built by one `Partial<>`, and it should not be: which table this
+ * is decides which columns it has, so a test picks the arm it means rather than
+ * half-specifying one. The two types are stated HERE, beside the builders that take them, so
+ * the page object's `renderPool` / `renderSwiss` import the contract rather than restate it.
+ */
+
+/** What a caller may vary on the **pool** arm — everything but the `format` tag, which IS
+ * the arm and so is chosen by picking the pool builder rather than passed. */
+export type PoolOverrides = Partial<Omit<StandingsTableProps, 'format' | 'rows'>> & {
+  rows?: StandingLine[]
+}
+
+/** The same, on the **swiss** arm — identical but for the row type, which is the one thing
+ * the tag decides. */
+export type SwissOverrides = Partial<Omit<StandingsTableProps, 'format' | 'rows'>> & {
+  rows?: SwissStandingLine[]
+}
 
 /** Props for a **pool** `StandingsTable` — the three-deep body above, named as a pool's
  * table, and no Buchholz column, because every entrant in a pool faces the same
  * opposition. */
 export function buildPoolStandingsTableProps(
-  overrides: Partial<Omit<StandingsTableProps, 'format' | 'rows'>> & {
-    rows?: StandingLine[]
-  } = {},
+  overrides: PoolOverrides = {},
 ): StandingsTableProps {
   return {
     format: 'pool',
@@ -107,9 +120,7 @@ export function buildPoolStandingsTableProps(
  * so the only difference a test can see between the two arms is the column `format` decides
  * on. */
 export function buildSwissStandingsTableProps(
-  overrides: Partial<Omit<StandingsTableProps, 'format' | 'rows'>> & {
-    rows?: SwissStandingLine[]
-  } = {},
+  overrides: SwissOverrides = {},
 ): StandingsTableProps {
   return {
     format: 'swiss',

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.factory.tsx
@@ -1,5 +1,9 @@
-import { buildStandingRow } from '../../../../data/seed.factory'
+import {
+  buildStandingRow,
+  buildSwissStandingRow,
+} from '../../../../data/seed.factory'
 import type { StandingLine } from '../../../../data/standings'
+import type { SwissStandingLine } from '../../../../data/swiss-standings'
 import type { StandingsTableProps } from './standings-table'
 
 /** One standings line, ready to render — a `StandingRow` with the username already joined
@@ -8,6 +12,13 @@ export function buildStandingLine(
   overrides: Partial<StandingLine> = {},
 ): StandingLine {
   return { ...buildStandingRow(), name: 'player.1', ...overrides }
+}
+
+/** One **swiss** standings line: the same, plus the `buchholz` figure that ordered it. */
+export function buildSwissStandingLine(
+  overrides: Partial<SwissStandingLine> = {},
+): SwissStandingLine {
+  return { ...buildSwissStandingRow(), name: 'player.1', ...overrides }
 }
 
 /**
@@ -19,9 +30,10 @@ export function buildStandingLine(
  * sign is load-bearing (`+3`, `0`, `-3`), and a body of all-positive figures could not prove
  * it is rendered.
  *
- * The one body, for the shared table and for the pool that wraps it
- * (`pool-standings-table.factory`) — two copies of these nine figures would be two fixtures
- * free to disagree about what "a pool" looks like.
+ * The one body, for the shared table (**both** arms below), and for the pool that wraps it
+ * (`pool-standings-table.factory`) — copies of these nine figures would be fixtures free to
+ * disagree about what "a pool" looks like, and a swiss table that differed from a pool one
+ * by more than its Buchholz column would stop proving the two share a component.
  */
 export function buildStandingLines(): StandingLine[] {
   return [
@@ -58,13 +70,53 @@ export function buildStandingLines(): StandingLine[] {
   ]
 }
 
-/** Props for `StandingsTable`: the three-deep body above, named as a pool's table. */
-export function buildStandingsTableProps(
-  overrides: Partial<StandingsTableProps> = {},
+/**
+ * The three rows' Buchholz figures, in the same order.
+ *
+ * ⚠️ **8, 6, 7** — deliberately NOT descending with the rank, and deliberately colliding
+ * with none of the other columns (wins 2/1/0, difference +3/0/−3, games won 4/3/1). A
+ * Buchholz column reading the wrong field, or a fixture whose figures happened to march down
+ * the table with everything else, could not be told from a correct one. Out of order is also
+ * honest: Buchholz is the step *below* wins, so within a tier it is what decides — across
+ * tiers it has no reason to be monotonic at all.
+ */
+const BUCHHOLZ = [8, 6, 7]
+
+/** **Two builders, one per arm of `StandingsTableRows`** — the union cannot be built by one
+ * `Partial<>`, and it should not be: which table this is decides which columns it has, so a
+ * test picks the arm it means rather than half-specifying one. */
+
+/** Props for a **pool** `StandingsTable` — the three-deep body above, named as a pool's
+ * table, and no Buchholz column, because every entrant in a pool faces the same
+ * opposition. */
+export function buildPoolStandingsTableProps(
+  overrides: Partial<Omit<StandingsTableProps, 'format' | 'rows'>> & {
+    rows?: StandingLine[]
+  } = {},
 ): StandingsTableProps {
   return {
+    format: 'pool',
     ariaLabel: 'Standings for Pool A',
     rows: buildStandingLines(),
+    ...overrides,
+  }
+}
+
+/** Props for a **swiss** `StandingsTable` — the very same three rows, plus the `BUCHHOLZ`
+ * figures above. The rows are the pool body with one column added and nothing else changed,
+ * so the only difference a test can see between the two arms is the column `format` decides
+ * on. */
+export function buildSwissStandingsTableProps(
+  overrides: Partial<Omit<StandingsTableProps, 'format' | 'rows'>> & {
+    rows?: SwissStandingLine[]
+  } = {},
+): StandingsTableProps {
+  return {
+    format: 'swiss',
+    ariaLabel: 'Standings for Swiss Singles',
+    rows: buildStandingLines().map((row, index) =>
+      buildSwissStandingLine({ ...row, buchholz: BUCHHOLZ[index] }),
+    ),
     ...overrides,
   }
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.page.tsx
@@ -1,7 +1,21 @@
 import { render, screen, within, type Container } from '@/test/utilities'
 
+import type { StandingLine } from '../../../../data/standings'
+import type { SwissStandingLine } from '../../../../data/swiss-standings'
 import { StandingsTable, type StandingsTableProps } from './standings-table'
-import { buildStandingsTableProps } from './standings-table.factory'
+import {
+  buildPoolStandingsTableProps,
+  buildSwissStandingsTableProps,
+} from './standings-table.factory'
+
+/** What a test may vary on either arm — everything but the `format` tag, which IS the arm
+ * and so is chosen by picking `renderPool` or `renderSwiss` rather than passed. */
+type PoolOverrides = Partial<Omit<StandingsTableProps, 'format' | 'rows'>> & {
+  rows?: StandingLine[]
+}
+type SwissOverrides = Partial<Omit<StandingsTableProps, 'format' | 'rows'>> & {
+  rows?: SwissStandingLine[]
+}
 
 /** The **Player** column's index in the header order (`#`, Player, W, L, Diff, GW) — the
  * one column every caller reads by name rather than by number, since "who is in this table,
@@ -34,13 +48,60 @@ const scoped = (container: Container) => ({
       .map((h) => (h.textContent ?? '').trim())
   },
 
-  /** One column of body cells, top to bottom, by its **index** in the header order
-   * (`#`, Player, W, L, Diff, GW). */
+  /** One column of body cells, top to bottom, by its **index** in the header order — which
+   * differs by arm: a pool table runs `#`, Player, W, L, Diff, GW, and a swiss table
+   * inserts **Buc** between L and Diff. Prefer `getColumnUnder`, which asks by header. */
   getColumn(ariaLabel: string, index: number) {
     return within(this.getTable(ariaLabel))
       .getAllByRole('row')
       .slice(1)
       .map((row) => (within(row).getAllByRole('cell')[index].textContent ?? '').trim())
+  },
+
+  /**
+   * One column of body cells, addressed by its **header's full word** ("Buchholz", "Wins")
+   * rather than by index.
+   *
+   * The index is exactly what a Buchholz column changes, so an index-addressed assertion
+   * would move under this feature and — worse — could silently start reading the neighbour
+   * it displaced. Asking by header ties the cells to the heading above them, which is also
+   * the claim a screen-reader user relies on.
+   */
+  getColumnUnder(ariaLabel: string, header: string) {
+    const table = within(this.getTable(ariaLabel))
+    const index = table
+      .getAllByRole('columnheader')
+      .findIndex((h) => (h.textContent ?? '').includes(header))
+    if (index === -1) {
+      throw new Error(
+        `No column headed "${header}" in the table "${ariaLabel}". Headers: ${table
+          .getAllByRole('columnheader')
+          .map((h) => (h.textContent ?? '').trim())
+          .join(', ')}`,
+      )
+    }
+    return table
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => (within(row).getAllByRole('cell')[index].textContent ?? '').trim())
+  },
+
+  /** Whether a column with this header exists at all — for the claim that a **pool** table
+   * has no Buchholz column, which is half of what `format` decides. */
+  hasColumn(ariaLabel: string, header: string) {
+    return within(this.getTable(ariaLabel))
+      .getAllByRole('columnheader')
+      .some((h) => (h.textContent ?? '').includes(header))
+  },
+
+  /** How many body cells a row holds — the guard that the header and the cells agree about
+   * how many columns there are. A table whose header grew a column its rows did not is not
+   * a table any assertion above would catch. */
+  getCellCounts(ariaLabel: string) {
+    return within(this.getTable(ariaLabel))
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => within(row).getAllByRole('cell').length)
   },
 
   /** One entry's row, by the entry id it is keyed on — for scoping a per-row assertion. */
@@ -52,11 +113,24 @@ const scoped = (container: Container) => ({
   },
 })
 
-/** Test page-object for `StandingsTable` — the table body shared by the pooled and the
- * pool-less standings blocks. */
+/**
+ * Test page-object for `StandingsTable` — the table shared by the pooled and the pool-less
+ * standings blocks.
+ *
+ * **Two renders, one per arm of `StandingsTableRows`**, rather than one `render` taking a
+ * `format`: the tag decides which columns exist *and* which row type is legal, so a single
+ * entry point would have to take a half-typed union and would let a test ask for a swiss
+ * table over pool rows — the exact state the component's props were shaped to forbid.
+ */
 export const standingsTablePage = {
-  render(overrides: Partial<StandingsTableProps> = {}) {
-    render(<StandingsTable {...buildStandingsTableProps(overrides)} />)
+  /** A **pool** table: no Buchholz column. */
+  renderPool(overrides: PoolOverrides = {}) {
+    render(<StandingsTable {...buildPoolStandingsTableProps(overrides)} />)
+  },
+
+  /** A **swiss** table: the same columns plus Buchholz. */
+  renderSwiss(overrides: SwissOverrides = {}) {
+    render(<StandingsTable {...buildSwissStandingsTableProps(overrides)} />)
   },
 
   within(container: Container = screen) {

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.page.tsx
@@ -1,27 +1,12 @@
 import { render, screen, within, type Container } from '@/test/utilities'
 
-import type { StandingLine } from '../../../../data/standings'
-import type { SwissStandingLine } from '../../../../data/swiss-standings'
-import { StandingsTable, type StandingsTableProps } from './standings-table'
+import { StandingsTable } from './standings-table'
 import {
   buildPoolStandingsTableProps,
   buildSwissStandingsTableProps,
+  type PoolOverrides,
+  type SwissOverrides,
 } from './standings-table.factory'
-
-/** What a test may vary on either arm — everything but the `format` tag, which IS the arm
- * and so is chosen by picking `renderPool` or `renderSwiss` rather than passed. */
-type PoolOverrides = Partial<Omit<StandingsTableProps, 'format' | 'rows'>> & {
-  rows?: StandingLine[]
-}
-type SwissOverrides = Partial<Omit<StandingsTableProps, 'format' | 'rows'>> & {
-  rows?: SwissStandingLine[]
-}
-
-/** The **Player** column's index in the header order (`#`, Player, W, L, Diff, GW) — the
- * one column every caller reads by name rather than by number, since "who is in this table,
- * in what order" is the assertion each of them makes. Stated once so a column inserted to
- * its left is one edit, not four. */
-export const PLAYER_COLUMN = 1
 
 const scoped = (container: Container) => ({
   /** The table itself, by its accessible name — the one thing the caller supplies, so a
@@ -48,24 +33,17 @@ const scoped = (container: Container) => ({
       .map((h) => (h.textContent ?? '').trim())
   },
 
-  /** One column of body cells, top to bottom, by its **index** in the header order — which
-   * differs by arm: a pool table runs `#`, Player, W, L, Diff, GW, and a swiss table
-   * inserts **Buc** between L and Diff. Prefer `getColumnUnder`, which asks by header. */
-  getColumn(ariaLabel: string, index: number) {
-    return within(this.getTable(ariaLabel))
-      .getAllByRole('row')
-      .slice(1)
-      .map((row) => (within(row).getAllByRole('cell')[index].textContent ?? '').trim())
-  },
-
   /**
-   * One column of body cells, addressed by its **header's full word** ("Buchholz", "Wins")
-   * rather than by index.
+   * One column of body cells, top to bottom, addressed by its **header's full word**
+   * ("Player", "Buchholz", "Wins") rather than by index.
    *
-   * The index is exactly what a Buchholz column changes, so an index-addressed assertion
-   * would move under this feature and — worse — could silently start reading the neighbour
-   * it displaced. Asking by header ties the cells to the heading above them, which is also
-   * the claim a screen-reader user relies on.
+   * The index is exactly what a Buchholz column changes — a pool table runs `#`, Player, W,
+   * L, Diff, GW and a swiss table inserts **Buc** between L and Diff — so an index-addressed
+   * assertion would move under this feature and, worse, could silently start reading the
+   * neighbour it displaced. Asking by header ties the cells to the heading above them, which
+   * is also the claim a screen-reader user relies on. It is the **only** column reader here
+   * for that reason: an index-taking one left beside it is an index-taking one someone
+   * reaches for.
    */
   getColumnUnder(ariaLabel: string, header: string) {
     const table = within(this.getTable(ariaLabel))

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.test.tsx
@@ -1,13 +1,19 @@
 import { screen, within } from '@/test/utilities'
 
-import { buildStandingLine } from './standings-table.factory'
+import {
+  buildStandingLine,
+  buildSwissStandingLine,
+} from './standings-table.factory'
 import { standingsTablePage } from './standings-table.page'
+
+const POOL = 'Standings for Pool A'
+const SWISS = 'Standings for Swiss Singles'
 
 describe('StandingsTable', () => {
   it('takes its accessible name from the caller', () => {
     // The one thing that varies between a pool's table and a swiss event's, so it is a prop
     // rather than something derived here — and asserted with a name neither caller uses.
-    standingsTablePage.render({ ariaLabel: 'Standings for the whole field' })
+    standingsTablePage.renderPool({ ariaLabel: 'Standings for the whole field' })
 
     expect(
       standingsTablePage.getTable('Standings for the whole field'),
@@ -15,11 +21,11 @@ describe('StandingsTable', () => {
   })
 
   it('heads the columns with rank, player and the four figures', () => {
-    standingsTablePage.render()
+    standingsTablePage.renderPool()
 
     // The glyphs a sighted reader sees. The `sr-only` full words ride in the same node, so
     // the trimmed text carries both — which is the point: neither channel is left to infer.
-    expect(standingsTablePage.getHeaderGlyphs('Standings for Pool A')).toEqual([
+    expect(standingsTablePage.getHeaderGlyphs(POOL)).toEqual([
       '#Rank',
       'Player',
       'WWins',
@@ -41,7 +47,7 @@ describe('StandingsTable', () => {
    * glyph span had lost its `aria-hidden`.
    */
   it('says each column’s FULL WORD to a screen reader, and only that word', () => {
-    standingsTablePage.render()
+    standingsTablePage.renderPool()
 
     for (const name of [
       'Rank',
@@ -58,29 +64,17 @@ describe('StandingsTable', () => {
   })
 
   it('renders the rows in the order it is handed, with the server’s figures', () => {
-    standingsTablePage.render()
+    standingsTablePage.renderPool()
 
-    expect(standingsTablePage.getColumn('Standings for Pool A', 0)).toEqual([
-      '1',
-      '2',
-      '3',
-    ])
-    expect(standingsTablePage.getColumn('Standings for Pool A', 1)).toEqual([
+    expect(standingsTablePage.getColumnUnder(POOL, 'Rank')).toEqual(['1', '2', '3'])
+    expect(standingsTablePage.getColumnUnder(POOL, 'Player')).toEqual([
       'player.1',
       'player.4',
       'player.5',
     ])
-    expect(standingsTablePage.getColumn('Standings for Pool A', 2)).toEqual([
-      '2',
-      '1',
-      '0',
-    ])
-    expect(standingsTablePage.getColumn('Standings for Pool A', 3)).toEqual([
-      '0',
-      '1',
-      '2',
-    ])
-    expect(standingsTablePage.getColumn('Standings for Pool A', 5)).toEqual([
+    expect(standingsTablePage.getColumnUnder(POOL, 'Wins')).toEqual(['2', '1', '0'])
+    expect(standingsTablePage.getColumnUnder(POOL, 'Losses')).toEqual(['0', '1', '2'])
+    expect(standingsTablePage.getColumnUnder(POOL, 'Games won')).toEqual([
       '4',
       '3',
       '1',
@@ -90,9 +84,9 @@ describe('StandingsTable', () => {
   /** The sign is load-bearing: `+2` and `-2` are different standings, and a bare `2` would
    * read as both. Zero carries no sign — a `+0` would claim a margin nobody has. */
   it('signs a positive game difference, leaves a negative one, and bares a zero', () => {
-    standingsTablePage.render()
+    standingsTablePage.renderPool()
 
-    expect(standingsTablePage.getColumn('Standings for Pool A', 4)).toEqual([
+    expect(standingsTablePage.getColumnUnder(POOL, 'Game difference')).toEqual([
       '+3',
       '0',
       '-3',
@@ -103,7 +97,7 @@ describe('StandingsTable', () => {
     // Rows out of rank order, and a game difference that does NOT equal `gamesWon -
     // gamesLost`: the server's figure is shown, never re-derived from the two counts beside
     // it (which would be a second copy that could disagree).
-    standingsTablePage.render({
+    standingsTablePage.renderPool({
       rows: [
         buildStandingLine({
           entryId: 'entry-9',
@@ -117,12 +111,15 @@ describe('StandingsTable', () => {
       ],
     })
 
-    expect(standingsTablePage.getColumn('Standings for Pool A', 0)).toEqual(['4', '1'])
-    expect(standingsTablePage.getColumn('Standings for Pool A', 4)).toEqual(['+5', '+3'])
+    expect(standingsTablePage.getColumnUnder(POOL, 'Rank')).toEqual(['4', '1'])
+    expect(standingsTablePage.getColumnUnder(POOL, 'Game difference')).toEqual([
+      '+5',
+      '+3',
+    ])
   })
 
   it('keys each row on its entry id, so a row can be addressed', () => {
-    standingsTablePage.render()
+    standingsTablePage.renderPool()
 
     expect(
       within(standingsTablePage.getRow('entry-5')).getAllByRole('cell')[1],
@@ -133,10 +130,109 @@ describe('StandingsTable', () => {
   it('renders a header and no body rows for an empty table', () => {
     // The designed state of a cut-but-unplayed event, not an error: the columns still say
     // what is coming.
-    standingsTablePage.render({ rows: [] })
+    standingsTablePage.renderPool({ rows: [] })
 
-    expect(
-      within(screen.getByRole('table')).getAllByRole('row'),
-    ).toHaveLength(1)
+    expect(within(screen.getByRole('table')).getAllByRole('row')).toHaveLength(1)
+  })
+
+  /**
+   * **The Buchholz column** (ADR "swiss standings add Buchholz, and head-to-head is guarded
+   * on having met") — the sum of an entrant's opponents' win counts, and the step of the
+   * tiebreak chain the other columns cannot show.
+   *
+   * It belongs to the `swiss` arm and to nothing else, which is why `format` is a tag on the
+   * props rather than a flag beside them: a pool gives every entrant the same opposition, so
+   * strength of schedule carries no information there.
+   */
+  describe('the Buchholz column', () => {
+    it('shows it for a swiss table, headed and spoken in full', () => {
+      standingsTablePage.renderSwiss()
+
+      expect(standingsTablePage.getHeaderGlyphs(SWISS)).toEqual([
+        '#Rank',
+        'Player',
+        'WWins',
+        'LLosses',
+        // Between losses and game difference, mirroring the chain that ordered the table:
+        // wins → head-to-head → **Buchholz** → game difference → games won.
+        'BucBuchholz',
+        'DiffGame difference',
+        'GWGames won',
+      ])
+    })
+
+    /** ⚠️ The assertion that makes this a test of the *figure* rather than of a column's
+     * existence. The three values are 8, 6, 7 — not descending with the rank, and equal to
+     * nothing in the columns beside them (wins 2/1/0, difference +3/0/−3, games won 4/3/1)
+     * — so a cell wired to the wrong field, or to a constant, cannot come out right. */
+    it('shows each row’s own Buchholz figure, not a neighbouring column’s', () => {
+      standingsTablePage.renderSwiss()
+
+      expect(standingsTablePage.getColumnUnder(SWISS, 'Buchholz')).toEqual([
+        '8',
+        '6',
+        '7',
+      ])
+    })
+
+    it('shows zero as zero — every opponent yet to win is a real standing', () => {
+      // Not blank, and not an em-dash: `0` is the ordinary state of round 1, and a cell that
+      // treated it as missing would be inventing an absence.
+      standingsTablePage.renderSwiss({
+        rows: [
+          buildSwissStandingLine({
+            entryId: 'entry-1',
+            name: 'player.1',
+            buchholz: 0,
+          }),
+        ],
+      })
+
+      expect(standingsTablePage.getColumnUnder(SWISS, 'Buchholz')).toEqual(['0'])
+    })
+
+    /** Buchholz is a sum of win counts, so it is never negative — and it is not a margin, so
+     * a `+` would suggest something it does not mean. The neighbouring game-difference cell
+     * DOES sign, in the same row, which is what makes this a real distinction rather than an
+     * untested coincidence. */
+    it('does not sign it, while the game difference beside it still does', () => {
+      standingsTablePage.renderSwiss({
+        rows: [
+          buildSwissStandingLine({
+            entryId: 'entry-1',
+            name: 'player.1',
+            buchholz: 7,
+            gameDifference: 7,
+          }),
+        ],
+      })
+
+      expect(standingsTablePage.getColumnUnder(SWISS, 'Buchholz')).toEqual(['7'])
+      expect(standingsTablePage.getColumnUnder(SWISS, 'Game difference')).toEqual([
+        '+7',
+      ])
+    })
+
+    /** The other half of what `format` decides. A pool table must not grow the column —
+     * strength of schedule is meaningless where everyone faces the same field — and this is
+     * the assertion that fails if the header were made unconditional. */
+    it('is ABSENT from a pool table', () => {
+      standingsTablePage.renderPool()
+
+      expect(standingsTablePage.hasColumn(POOL, 'Buchholz')).toBe(false)
+    })
+
+    /** Header and cells are read off the same tag, so they cannot disagree — but "cannot" is
+     * worth a measurement, because a mismatch shifts every column after it and would make a
+     * by-index assertion read the wrong neighbour rather than fail outright. */
+    it('gives every row exactly as many cells as the header has columns', () => {
+      standingsTablePage.renderSwiss()
+      expect(standingsTablePage.getCellCounts(SWISS)).toEqual([7, 7, 7])
+    })
+
+    it('gives a pool row one cell fewer', () => {
+      standingsTablePage.renderPool()
+      expect(standingsTablePage.getCellCounts(POOL)).toEqual([6, 6, 6])
+    })
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.tsx
@@ -66,60 +66,64 @@ const NumCell = ({
 )
 
 /**
- * One entrant's line: the columns **every** standings table shows, plus the Buchholz cell
- * when this table has that column.
+ * **One entrant's line, tagged the same way the table is** — `StandingsTableRows` in the
+ * singular, so the row and the columns it has are still one decision at this level.
  *
- * `buchholz` is `number | undefined` here rather than on the row, and the two arms of
- * `bodyRows` below are what supply it — so the cell exists exactly when the header does,
- * both decided by the one tag. A row type that carried an optional `buchholz` would let a
- * pool row wander in with one, or a swiss row arrive without.
+ * The alternative, a `buchholz?: number` prop beside a plain `StandingLine`, re-admits at
+ * the row exactly what the tag removed at the table: a swiss line arriving without its
+ * figure, or a pool line arriving with one, neither of which the type could refuse. Carrying
+ * the tag down means `swiss` **requires** a `SwissStandingLine` and the cell is read off the
+ * row it belongs to, one narrowing, no optional.
  */
-const StandingsLineRow = ({
-  row,
-  buchholz,
-}: {
-  row: StandingLine
-  buchholz?: number
-}) => (
-  <TableRow data-testid={`standing-row-${row.entryId}`}>
-    <NumCell className="text-[color:var(--fg-3)]">{row.rank}</NumCell>
-    <TableCell className="text-[color:var(--fg-1)]">{row.name}</TableCell>
-    <NumCell>{row.wins}</NumCell>
-    <NumCell>{row.losses}</NumCell>
-    {/* Above game difference, because that is where it sits in swiss's tiebreak chain
-        (wins → head-to-head → **Buchholz** → game difference → games won). The columns run
-        left-to-right in chain order, which is what lets a director read *why* two entrants
-        level on wins are in the order they are in. */}
-    {buchholz !== undefined && (
-      <NumCell className="text-[color:var(--fg-2)]">{buchholz}</NumCell>
-    )}
-    {/* The sign is load-bearing — `+2` and `-2` are different standings, and a bare `2`
-        would read as both. A screen reader hears "plus 2" / "minus 2" from the same glyph.
-        Buchholz above takes no sign: it is a sum of win counts, so it is never negative and
-        a `+` would suggest a margin it is not. */}
-    <NumCell className="text-[color:var(--fg-2)]">
-      {row.gameDifference > 0 ? `+${row.gameDifference}` : row.gameDifference}
-    </NumCell>
-    <NumCell>{row.gamesWon}</NumCell>
-  </TableRow>
-)
+type StandingsTableLine =
+  | { format: 'pool'; row: StandingLine }
+  | { format: 'swiss'; row: SwissStandingLine }
+
+const StandingsLineRow = (line: StandingsTableLine) => {
+  const { row } = line
+
+  return (
+    <TableRow data-testid={`standing-row-${row.entryId}`}>
+      <NumCell className="text-[color:var(--fg-3)]">{row.rank}</NumCell>
+      <TableCell className="text-[color:var(--fg-1)]">{row.name}</TableCell>
+      <NumCell>{row.wins}</NumCell>
+      <NumCell>{row.losses}</NumCell>
+      {/* Above game difference, because that is where it sits in swiss's tiebreak chain
+          (wins → head-to-head → **Buchholz** → game difference → games won). The columns run
+          left-to-right in chain order, which is what lets a director read *why* two entrants
+          level on wins are in the order they are in. */}
+      {line.format === 'swiss' && (
+        <NumCell className="text-[color:var(--fg-2)]">{line.row.buchholz}</NumCell>
+      )}
+      {/* The sign is load-bearing — `+2` and `-2` are different standings, and a bare `2`
+          would read as both. A screen reader hears "plus 2" / "minus 2" from the same glyph.
+          Buchholz above takes no sign: it is a sum of win counts, so it is never negative and
+          a `+` would suggest a margin it is not. */}
+      <NumCell className="text-[color:var(--fg-2)]">
+        {row.gameDifference > 0 ? `+${row.gameDifference}` : row.gameDifference}
+      </NumCell>
+      <NumCell>{row.gamesWon}</NumCell>
+    </TableRow>
+  )
+}
 
 /**
  * The body, one arm per table format — a `switch` with a `never` default, so a third kind
  * of standings table is a **compile error here** until it says which columns it has.
  *
  * The `map` lives *inside* the switch on purpose: that is what narrows `rows` to the arm's
- * own row type, so the swiss arm reads `row.buchholz` with no cast and the pool arm cannot.
+ * own row type, so the swiss arm hands `StandingsLineRow` a row carrying `buchholz` with no
+ * cast, and the pool arm cannot hand it one that claims to.
  */
 const bodyRows = (table: StandingsTableRows) => {
   switch (table.format) {
     case 'pool':
       return table.rows.map((row) => (
-        <StandingsLineRow key={row.entryId} row={row} />
+        <StandingsLineRow key={row.entryId} format="pool" row={row} />
       ))
     case 'swiss':
       return table.rows.map((row) => (
-        <StandingsLineRow key={row.entryId} row={row} buchholz={row.buchholz} />
+        <StandingsLineRow key={row.entryId} format="swiss" row={row} />
       ))
     default: {
       const exhaustive: never = table
@@ -134,7 +138,7 @@ const bodyRows = (table: StandingsTableRows) => {
  * **Buchholz** figure that ordered them.
  *
  * **One table for every results shape that ranks players.** A round-robin pool
- * (`PoolStandingsTable`) and a pool-less swiss event (`SwissStandingsPanel`) share eight
+ * (`PoolStandingsTable`) and a pool-less swiss event (`SwissStandingsPanel`) share six
  * columns computed the same way, so they render through this one component rather than two
  * that agree today. What differs is the *title*, the test hooks — both the caller's — and
  * the one extra column, which is `format`'s.

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/standings-table.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 import {
   Table,
   TableBody,
@@ -10,20 +12,35 @@ import {
 import { cn } from '@/lib/utils'
 
 import type { StandingLine } from '../../../../data/standings'
+import type { SwissStandingLine } from '../../../../data/swiss-standings'
 
-export interface StandingsTableProps {
+/**
+ * **Which table this is, and therefore which columns it has** — a closed sum type, not a
+ * `showBuchholz` boolean beside a loosely-typed row list.
+ *
+ * The two are one decision. A boolean could be `true` over rows that carry no `buchholz`
+ * (a header column with nothing under it) or `false` over rows that do (the one figure
+ * that explains the order, silently dropped) — and neither is a state anyone would notice
+ * in review. Tagging the table instead makes both unrepresentable: `swiss` **requires**
+ * `SwissStandingLine[]`, and the header and the cells are both read off the same tag.
+ */
+export type StandingsTableRows =
+  /** A round-robin pool's table. Every entrant in a pool faces the same opposition, so
+   * strength of schedule carries no information and there is no Buchholz column. */
+  | { format: 'pool'; rows: StandingLine[] }
+  /** A swiss event's table, which shows the **Buchholz** figure that ordered it. */
+  | { format: 'swiss'; rows: SwissStandingLine[] }
+
+export type StandingsTableProps = {
   /** The table's accessible name — what a screen reader is told this table ranks. The
    * caller owns the wording because it owns the scope: a pool names itself ("Standings for
    * Pool A"), a swiss event names the event, and neither fact is knowable here. */
   ariaLabel: string
-  /** The rows in the **server's finishing order**, already joined to usernames. Rendered in
-   * exactly that order — see below. */
-  rows: StandingLine[]
   /** Spacing from whatever sits above, which is the caller's to decide: a pool's table
    * follows an `<h4>` naming the pool and wants a gap, a swiss event's is the first thing
    * in its box and does not. The table owns no margin of its own for that reason. */
   className?: string
-}
+} & StandingsTableRows
 
 /** One numeric column's header: a terse glyph on screen (`W`, `L`) and the full word for a
  * screen reader, which cannot guess what `W` abbreviates. Both channels carry the meaning;
@@ -35,23 +52,101 @@ const NumHead = ({ short, full }: { short: string; full: string }) => (
   </TableHead>
 )
 
+/** One numeric body cell, right-aligned and tabular so the column reads as a column. */
+const NumCell = ({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}) => (
+  <TableCell className={cn('text-right font-mono tabular-nums', className)}>
+    {children}
+  </TableCell>
+)
+
+/**
+ * One entrant's line: the columns **every** standings table shows, plus the Buchholz cell
+ * when this table has that column.
+ *
+ * `buchholz` is `number | undefined` here rather than on the row, and the two arms of
+ * `bodyRows` below are what supply it — so the cell exists exactly when the header does,
+ * both decided by the one tag. A row type that carried an optional `buchholz` would let a
+ * pool row wander in with one, or a swiss row arrive without.
+ */
+const StandingsLineRow = ({
+  row,
+  buchholz,
+}: {
+  row: StandingLine
+  buchholz?: number
+}) => (
+  <TableRow data-testid={`standing-row-${row.entryId}`}>
+    <NumCell className="text-[color:var(--fg-3)]">{row.rank}</NumCell>
+    <TableCell className="text-[color:var(--fg-1)]">{row.name}</TableCell>
+    <NumCell>{row.wins}</NumCell>
+    <NumCell>{row.losses}</NumCell>
+    {/* Above game difference, because that is where it sits in swiss's tiebreak chain
+        (wins → head-to-head → **Buchholz** → game difference → games won). The columns run
+        left-to-right in chain order, which is what lets a director read *why* two entrants
+        level on wins are in the order they are in. */}
+    {buchholz !== undefined && (
+      <NumCell className="text-[color:var(--fg-2)]">{buchholz}</NumCell>
+    )}
+    {/* The sign is load-bearing — `+2` and `-2` are different standings, and a bare `2`
+        would read as both. A screen reader hears "plus 2" / "minus 2" from the same glyph.
+        Buchholz above takes no sign: it is a sum of win counts, so it is never negative and
+        a `+` would suggest a margin it is not. */}
+    <NumCell className="text-[color:var(--fg-2)]">
+      {row.gameDifference > 0 ? `+${row.gameDifference}` : row.gameDifference}
+    </NumCell>
+    <NumCell>{row.gamesWon}</NumCell>
+  </TableRow>
+)
+
+/**
+ * The body, one arm per table format — a `switch` with a `never` default, so a third kind
+ * of standings table is a **compile error here** until it says which columns it has.
+ *
+ * The `map` lives *inside* the switch on purpose: that is what narrows `rows` to the arm's
+ * own row type, so the swiss arm reads `row.buchholz` with no cast and the pool arm cannot.
+ */
+const bodyRows = (table: StandingsTableRows) => {
+  switch (table.format) {
+    case 'pool':
+      return table.rows.map((row) => (
+        <StandingsLineRow key={row.entryId} row={row} />
+      ))
+    case 'swiss':
+      return table.rows.map((row) => (
+        <StandingsLineRow key={row.entryId} row={row} buchholz={row.buchholz} />
+      ))
+    default: {
+      const exhaustive: never = table
+      return exhaustive
+    }
+  }
+}
+
 /**
  * A **standings table** (ADR-0788): entrants in the server's finishing order, one row each,
- * with wins, losses, game difference and games won.
+ * with wins, losses, game difference and games won — and, for a swiss event, the
+ * **Buchholz** figure that ordered them.
  *
  * **One table for every results shape that ranks players.** A round-robin pool
- * (`PoolStandingsTable`) and a pool-less swiss event (`SwissStandingsPanel`) show the same
+ * (`PoolStandingsTable`) and a pool-less swiss event (`SwissStandingsPanel`) share eight
  * columns computed the same way, so they render through this one component rather than two
- * that agree today. What differs between them is what *titles* the table and what scopes its
- * test hooks — both of which belong to the caller, which is why this takes only an accessible
- * name and rows.
+ * that agree today. What differs is the *title*, the test hooks — both the caller's — and
+ * the one extra column, which is `format`'s.
  *
  * **Nothing here re-sorts or recomputes.** The rows arrive in a total order decided on the
- * server (wins → head-to-head → game difference → games won) and are rendered in exactly
- * that order — the order *is* the result. `gameDifference` is the server's own figure,
- * shown, not derived from the two counts beside it (which would be a second copy that could
- * disagree). The view-model (`data/standings`, `data/swiss-standings`) has already joined
- * each row's entry id to a username; a row is never a raw uuid.
+ * server (wins → head-to-head → *Buchholz, in swiss* → game difference → games won) and are
+ * rendered in exactly that order — the order *is* the result. `gameDifference` is the
+ * server's own figure, shown, not derived from the two counts beside it; `buchholz` likewise
+ * — it is a sum over *other* rows and moves when an opponent wins a later match, so a
+ * client-side re-derivation would be a second copy that disagrees within a round. The
+ * view-model (`data/standings`, `data/swiss-standings`) has already joined each row's entry
+ * id to a username; a row is never a raw uuid.
  *
  * A real `<table>`, not a grid of divs: standings are tabular data, and a screen reader reads
  * a `<th scope>`-headed table by column ("player.1, Wins 2, Losses 0") rather than as a wall
@@ -59,8 +154,8 @@ const NumHead = ({ short, full }: { short: string; full: string }) => (
  */
 export const StandingsTable = ({
   ariaLabel,
-  rows,
   className,
+  ...table
 }: StandingsTableProps) => (
   // `className` FIRST, unusually — it is spacing from whatever sits above, and putting it
   // ahead of the table's own type scale keeps the emitted class string byte-identical to
@@ -77,34 +172,13 @@ export const StandingsTable = ({
         <TableHead>Player</TableHead>
         <NumHead short="W" full="Wins" />
         <NumHead short="L" full="Losses" />
+        {/* Read off the SAME tag the cells are (`bodyRows`), so a header column can never
+            appear without its cells or vice versa. */}
+        {table.format === 'swiss' && <NumHead short="Buc" full="Buchholz" />}
         <NumHead short="Diff" full="Game difference" />
         <NumHead short="GW" full="Games won" />
       </TableRow>
     </TableHeader>
-    <TableBody>
-      {rows.map((row) => (
-        <TableRow key={row.entryId} data-testid={`standing-row-${row.entryId}`}>
-          <TableCell className="text-right font-mono tabular-nums text-[color:var(--fg-3)]">
-            {row.rank}
-          </TableCell>
-          <TableCell className="text-[color:var(--fg-1)]">{row.name}</TableCell>
-          <TableCell className="text-right font-mono tabular-nums">
-            {row.wins}
-          </TableCell>
-          <TableCell className="text-right font-mono tabular-nums">
-            {row.losses}
-          </TableCell>
-          {/* The sign is load-bearing — `+2` and `-2` are different standings, and a bare
-              `2` would read as both. A screen reader hears "plus 2" / "minus 2" from the
-              same glyph. */}
-          <TableCell className="text-right font-mono tabular-nums text-[color:var(--fg-2)]">
-            {row.gameDifference > 0 ? `+${row.gameDifference}` : row.gameDifference}
-          </TableCell>
-          <TableCell className="text-right font-mono tabular-nums">
-            {row.gamesWon}
-          </TableCell>
-        </TableRow>
-      ))}
-    </TableBody>
+    <TableBody>{bodyRows(table)}</TableBody>
   </Table>
 )

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.factory.tsx
@@ -15,7 +15,8 @@ export type SwissStandingsPanelScenario = Partial<SwissStandingsPanelProps> & {
 
 /**
  * Props for `SwissStandingsPanel`: by default a **swiss** event with results — one complete
- * four-deep table over the whole field, and a champion (`buildSwissStandingsEvent`).
+ * five-deep table over the whole field, and a champion (`buildSwissStandingsEvent`, whose
+ * field is five entrants over three rounds).
  *
  * The panel takes a view, not an event, but a test still reasons in events — so this derives
  * the props from one **the same way `ResultsPanel` does at runtime**: `eventSwissStandings`

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.page.tsx
@@ -52,10 +52,22 @@ const scoped = (container: Container) => {
       return table.getColumn(tableName(eventName), PLAYER_COLUMN)
     },
 
-    /** One numeric column of the table, read top to bottom by its **column index** — the
-     * same order the header row declares (`#`, Player, W, L, Diff, GW). */
-    getColumn(eventName: string, index: number) {
-      return table.getColumn(tableName(eventName), index)
+    /**
+     * One column of the table, read top to bottom and addressed by its **header's full word**
+     * ("Buchholz", "Wins") rather than by index.
+     *
+     * By index would be the obvious thing and is a trap: a swiss table's Buchholz column sits
+     * between Losses and Game difference, so every index after it shifts — and an
+     * index-addressed assertion does not fail when that happens, it silently starts reading
+     * the neighbour it displaced. Asking by header also ties each cell to the heading a
+     * screen-reader user hears above it.
+     *
+     * The lookup itself is the shared table's (`standingsTablePage.getColumnUnder`), because
+     * the table is the shared table — this file only supplies the accessible name a swiss
+     * event's table carries.
+     */
+    getColumnUnder(eventName: string, header: string) {
+      return table.getColumnUnder(tableName(eventName), header)
     },
 
     /** A pool table's test hook, which must NEVER appear here: swiss has no pools, so a

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.page.tsx
@@ -1,6 +1,6 @@
 import { render, screen, type Container } from '@/test/utilities'
 
-import { PLAYER_COLUMN, standingsTablePage } from './standings-table.page'
+import { standingsTablePage } from './standings-table.page'
 import { SwissStandingsPanel } from './swiss-standings-panel'
 import {
   buildSwissStandingsPanelProps,
@@ -47,9 +47,10 @@ const scoped = (container: Container) => {
         .map((t: HTMLElement) => t.getAttribute('aria-label') ?? '')
     },
 
-    /** The table's player names, top to bottom (the rendered order). */
+    /** The table's player names, top to bottom (the rendered order) — the Player column,
+     * asked for by its header rather than by an index a new column would shift. */
     getRowNames(eventName: string) {
-      return table.getColumn(tableName(eventName), PLAYER_COLUMN)
+      return table.getColumnUnder(tableName(eventName), 'Player')
     },
 
     /**

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.test.tsx
@@ -1,5 +1,5 @@
 import {
-  buildStandingRow,
+  buildSwissStandingRow,
   buildSwissStandingsEvent,
   buildSwissStandingsResults,
 } from '../../../../data/seed.factory'
@@ -31,22 +31,26 @@ describe('SwissStandingsPanel', () => {
   it('lists every entrant in the server’s order, joined to a username', () => {
     swissStandingsPanelPage.render()
 
-    expect(
-      swissStandingsPanelPage.getRowNames('Swiss Singles'),
-    ).toEqual(['player.1', 'player.2', 'player.3', 'player.4'])
+    expect(swissStandingsPanelPage.getRowNames('Swiss Singles')).toEqual([
+      'player.1',
+      'player.2',
+      'player.3',
+      'player.4',
+      'player.5',
+    ])
   })
 
   // The order IS the result (ADR-0788), and swiss is where a client that re-sorted would go
-  // wrong most often: the format pairs by score, so level rows are ordinary and the tiebreak
-  // that separated them (head-to-head, and Buchholz once it lands) is one the client cannot
-  // see. Feed the rows out of rank order and expect them back untouched.
+  // wrong most often: the format pairs by score, so level rows are ordinary and the tiebreaks
+  // that separated them (head-to-head, and Buchholz) are ones the client must not second-
+  // guess. Feed the rows out of rank order and expect them back untouched.
   it('does not re-sort the rows it is handed', () => {
     swissStandingsPanelPage.render({
       event: buildSwissStandingsEvent({
         results: buildSwissStandingsResults({
           rows: [
-            buildStandingRow({ entryId: 'entry-3', rank: 3, wins: 1 }),
-            buildStandingRow({ entryId: 'entry-1', rank: 1, wins: 3 }),
+            buildSwissStandingRow({ entryId: 'entry-3', rank: 3, wins: 1 }),
+            buildSwissStandingRow({ entryId: 'entry-1', rank: 1, wins: 3 }),
           ],
         }),
       }),
@@ -57,33 +61,83 @@ describe('SwissStandingsPanel', () => {
       'player.1',
     ])
     // The rank column follows the rows, so a panel that sorted by rank would show 1 then 3.
-    expect(swissStandingsPanelPage.getColumn('Swiss Singles', 0)).toEqual(['3', '1'])
+    expect(swissStandingsPanelPage.getColumnUnder('Swiss Singles', 'Rank')).toEqual([
+      '3',
+      '1',
+    ])
   })
 
   // The columns are the pool table's, because they ARE the pool table's — one
-  // `StandingsTable`, not two that agree today. `+7` and `-7` are different standings, so
-  // the sign is asserted, not just the digit.
+  // `StandingsTable`, not two that agree today. `+6` and `-4` are different standings, so the
+  // sign is asserted, not just the digit.
   it('shows the server’s wins, losses, game difference and games won', () => {
     swissStandingsPanelPage.render()
 
-    expect(swissStandingsPanelPage.getColumn('Swiss Singles', 2)).toEqual([
+    expect(swissStandingsPanelPage.getColumnUnder('Swiss Singles', 'Wins')).toEqual([
       '3',
       '2',
-      '1',
-      '0',
-    ])
-    expect(swissStandingsPanelPage.getColumn('Swiss Singles', 4)).toEqual([
-      '+7',
-      '+2',
-      '-2',
-      '-7',
-    ])
-    expect(swissStandingsPanelPage.getColumn('Swiss Singles', 5)).toEqual([
-      '9',
-      '7',
-      '5',
       '2',
+      '1',
+      '1',
     ])
+    expect(
+      swissStandingsPanelPage.getColumnUnder('Swiss Singles', 'Game difference'),
+    ).toEqual(['+6', '0', '+1', '-3', '-4'])
+    expect(
+      swissStandingsPanelPage.getColumnUnder('Swiss Singles', 'Games won'),
+    ).toEqual(['9', '6', '4', '3', '2'])
+  })
+
+  /**
+   * **The Buchholz column** (ADR "swiss standings add Buchholz, and head-to-head is guarded
+   * on having met") — the number that decided the order, on the one surface where a director
+   * can see the order it decided.
+   */
+  describe('the Buchholz column', () => {
+    it('shows each entrant’s own figure', () => {
+      swissStandingsPanelPage.render()
+
+      expect(
+        swissStandingsPanelPage.getColumnUnder('Swiss Singles', 'Buchholz'),
+      ).toEqual(['5', '5', '4', '5', '4'])
+    })
+
+    /**
+     * ⚠️ **The row that makes the column worth having.** `player.2` and `player.3` are level
+     * on wins, never met, and sit in that order because of Buchholz — 5 against 4 — *against*
+     * their game difference, which is 0 and +1. Read on margin alone they are the wrong way
+     * round.
+     *
+     * So this asserts the three numbers together, in one place: without the Buchholz column
+     * the table shows a director an order it has no way of explaining, which is the whole
+     * reason the figure is on the wire (`SwissStandingRowRead`).
+     */
+    it('explains an order that game difference alone contradicts', () => {
+      swissStandingsPanelPage.render()
+
+      const names = swissStandingsPanelPage.getRowNames('Swiss Singles')
+      const wins = swissStandingsPanelPage.getColumnUnder('Swiss Singles', 'Wins')
+      const buchholz = swissStandingsPanelPage.getColumnUnder(
+        'Swiss Singles',
+        'Buchholz',
+      )
+      const diff = swissStandingsPanelPage.getColumnUnder(
+        'Swiss Singles',
+        'Game difference',
+      )
+
+      const above = names.indexOf('player.2')
+      const below = names.indexOf('player.3')
+      expect(above).toBeLessThan(below)
+      // Level on wins…
+      expect(wins[above]).toBe(wins[below])
+      // …the one above has the WORSE game difference…
+      expect(diff[above]).toBe('0')
+      expect(diff[below]).toBe('+1')
+      // …and the better Buchholz, which is what put it there.
+      expect(buchholz[above]).toBe('5')
+      expect(buchholz[below]).toBe('4')
+    })
   })
 
   it('crowns the champion once every round is decided', () => {
@@ -104,7 +158,7 @@ describe('SwissStandingsPanel', () => {
     })
 
     expect(swissStandingsPanelPage.queryChampion('ev-swiss')).toBeNull()
-    expect(swissStandingsPanelPage.getRowNames('Swiss Singles')).toHaveLength(4)
+    expect(swissStandingsPanelPage.getRowNames('Swiss Singles')).toHaveLength(5)
   })
 
   // `complete` alone is not the condition, and neither is `champion` alone. A complete

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel/standings/swiss-standings-panel.tsx
@@ -82,7 +82,11 @@ export const SwissStandingsPanel = ({
           takes no top margin here: it is the first thing in the box, not something
           following a heading. */}
       <div className="mt-2 rounded-[10px] border border-[color:var(--border-subtle)] p-3">
+        {/* `format="swiss"` is what adds the **Buchholz** column — and it is not a flag
+            beside the rows, it is the tag that *requires* rows carrying the figure, so the
+            column and its numbers arrive together or not at all (`StandingsTableRows`). */}
         <StandingsTable
+          format="swiss"
           ariaLabel={`Standings for ${eventName}`}
           rows={standings.rows}
         />


### PR DESCRIPTION
Slice 4 of the swiss stack (#1276), the last one. **Stacked on #1282** — base is `…-s3`, so the diff here is slice 4 only.

Swiss standings now rank by **who you had to beat**, not by margin.

## What changes

`swiss_finishing_order` lands beside `finishing_order` in the shared module, so the draw layer and the results layer keep reading one definition of the order. The chain is wins, head-to-head when exactly two are tied and they met, **Buchholz**, game difference, games won, entry id.

The two chains share machinery rather than agreeing by hand — one tally builder, one wins-grouping, one guarded tie-break, one scalar tail. The only difference is the sort key, where `-buchholz` is *prepended*. That is what puts the step above game difference rather than below it, and a falsification pins the position, not merely the presence.

The draw layer walks the same order, so the rank a director reads and the order the next round pairs down cannot diverge. Two pairing expectations moved as a result, both re-derived by hand rather than copied from the new output.

The table gains a `Buc` column between `L` and `Diff`, unsigned — it is a sum of win counts, never negative, and a `+` would read as a margin.

## A claim in the ADR was wrong, and is corrected here

The ADR said the head-to-head step had no way to express "these two never met", and that adding the guard was a correctness fix swiss forced.

**It already existed on `main`.** `_head_to_head` returned `None` for an unmet pair and `_break_tie` fell through — a *part-played* round-robin pool reaches the same state, so the guard predates swiss entirely. The claim was made during design and never checked against the code.

What this slice actually contributes there is a **test**, which nothing had. Breaking the guard deliberately reds a swiss test *and* a pre-existing round-robin one, which is the empirical demonstration that it is shared machinery.

## Two fixtures that could not have failed

Both found and fixed here, and both are the same failure mode: a test that passes whether or not the feature works.

**The web standings fixture** had every column descending with rank, so nothing about ordering could be discriminated. It is now a real five-entrant, three-round event where two entrants level on wins, who never met, are ordered by Buchholz **against** their game difference. Two of the winner's Buchholz points come from bye wins, so the fixture embodies the "a bye win counts for your opponent, a bye adds nothing to your own" rule rather than asserting it separately.

**The e2e fixture** needed engineering to discriminate at all: in a field small enough for everybody to play everybody, Buchholz reduces to "total wins minus your own" and is identical for any two level on wins, *by arithmetic*. Six entrants over two rounds with three distinct round-1 margins is the smallest case where margin and strength of schedule can point opposite ways.

## A regression this slice introduced and this slice caught

Inserting the `Buc` column moved `GW` from cell index 5 to 6, so slice 3's e2e page object started reading **game difference** as "games won". It stayed green only by coincidence — the first bye assertion compares against `0`, and a bye's game difference is also `0`.

Demonstrated before fixing (the bye test reds with `Received "-3"` for a games count), then fixed at the root: cell accessors go through one column map carrying each column's index *and* its accessible header name, with a guard asserting the header at each index. The next inserted column reds naming the layout instead of silently returning the neighbouring number.

**Worth doing separately:** `data-testid` on the standings cells would end this class outright. Index-addressing is the only option a spec has today.

## Verification

- api: `ruff`, `mypy --strict` (170 files), **2235 pytest passing**
- web: `tsc -b` at zero, **3520 vitest passing**, `eslint` clean, 321 Playwright
- root e2e: **exit 0, 29 passed against `--list`'s 29 collected**
- Falsified: bye wins stripped from Buchholz (reds exactly one test, so that test is the sole pin on the decision), the Buchholz comparator removed, Buchholz demoted below game difference, the head-to-head guard removed, the rendered column showing a neighbouring field, and the column showing a hardcoded value

**One coupling worth knowing:** the e2e fixture is deterministic because the editor's default best-of is 5, which affords three distinct margins. If that default drops to 3, only two margins exist, round-1 order falls to the entry-id fallback, and this test starts flaking in a way that looks exactly like a Buchholz bug.

Chores: `4ab`, `4c`, `4d`, `4e`, plus a docs commit correcting the ADR.

Part of #1276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
