### PR TITLE
Slice 3: a director whose draw is under way sees why they can no longer re-cut or delete it

### DIFF
--- a/web-client/src/components/tournaments/data/draw.test.ts
+++ b/web-client/src/components/tournaments/data/draw.test.ts
@@ -19,6 +19,7 @@ import {
   buildEntrants,
   buildEvent,
   buildFixture,
+  buildMaterializedDrawnEvent,
   buildPlayedDrawnEvent,
   buildPool,
   buildSwissDrawnEvent,
@@ -26,6 +27,7 @@ import {
   buildSwissOddMidEvent,
   buildTwoStageDrawnEvent,
 } from './seed.factory'
+import type { TournamentEvent } from './types'
 
 /** The drawn arm, or a failed assertion — so the tests below can read `.pools`
  * without a cast, and an accidental `undrawn` fails loudly instead of quietly
@@ -609,6 +611,14 @@ describe('drawTypeFreeze', () => {
  * halves, apart, plus the negative.
  */
 describe('drawVerbFreeze', () => {
+  /** The frozen reason, or a failed assertion — so a test that is about the *words* reads
+   * them without a narrowing dance, and an accidentally open freeze fails loudly. */
+  const frozenReason = (event: TournamentEvent) => {
+    const freeze = drawVerbFreeze(event)
+    if (freeze.kind !== 'frozen') throw new Error('expected a frozen draw verb')
+    return freeze.reason
+  }
+
   it('is open on a draw that has been cut but not played', () => {
     // The day-of re-cut ADR-0786 preserves: a full draw, no result and no match, and both
     // verbs live. Freezing on the *draw* rather than on the *evidence* would break this.
@@ -668,17 +678,43 @@ describe('drawVerbFreeze', () => {
   })
 
   it('says both verbs are gone, and why — and names no way out, because there is none', () => {
-    const freeze = drawVerbFreeze(buildPlayedDrawnEvent())
-    if (freeze.kind !== 'frozen') throw new Error('expected a frozen draw verb')
+    const reason = frozenReason(buildPlayedDrawnEvent())
 
     // What is true, in the director's terms…
-    expect(freeze.reason).toContain('already under way')
-    expect(freeze.reason).toContain('re-cut or removed')
-    // …and why it costs something to ignore.
-    expect(freeze.reason).toMatch(/throw away a result/i)
+    expect(reason).toContain('under way')
+    // …and what it would cost to ignore: the two verbs, named as the acts they are.
+    expect(reason).toMatch(/re-cutting or removing the draw/i)
     // The half the sibling freezes' copy register would drag in and that would be a LIE
     // here: deleting the draw is the act being refused, so there is no exit to offer.
-    expect(freeze.reason).not.toContain('Delete the draw')
-    expect(freeze.reason).not.toContain('cut it again')
+    expect(reason).not.toContain('Delete the draw')
+    expect(reason).not.toContain('cut it again')
+  })
+
+  /**
+   * ⚠️ **The reason must be true of a draw nobody has played** — the commonest frozen draw
+   * there is, and the one the copy used to contradict.
+   *
+   * `materialize_live_draw` stamps a `match_id` on every ready fixture inside the go-live
+   * transaction, so the ordinary way a draw freezes is: the tournament goes live, every
+   * fixture becomes a real match, **zero results**. The sentence said a re-deal "would
+   * throw away a result somebody has already played for" — false here, and flatly against
+   * its own first clause, which offered the match as an *alternative* to a winner.
+   *
+   * The assertion is therefore on the **hedge**, not on a replacement fragment: a result
+   * may be named only as one of two alternatives, the way the server's own guard hedges it
+   * ("a linked match, which **may** already carry games"). Pinning another literal string
+   * is what let the false claim through the first time.
+   */
+  it('claims no result on a draw that has merely materialized', () => {
+    const reason = frozenReason(buildMaterializedDrawnEvent())
+
+    // Nothing has been played on this event, so nothing can be thrown away.
+    expect(reason).not.toMatch(/throw away/i)
+    expect(reason).not.toMatch(/has already been played/i)
+    // The match is the fact; the result is the alternative ("… or …").
+    expect(reason).toMatch(/real match now, or/i)
+    // One sentence covers both halves of the guard — a director cannot be shown a reason
+    // that names the half their own draw does not have.
+    expect(reason).toBe(frozenReason(buildPlayedDrawnEvent()))
   })
 })

--- a/web-client/src/components/tournaments/data/draw.test.ts
+++ b/web-client/src/components/tournaments/data/draw.test.ts
@@ -4,6 +4,7 @@ import {
   drawRefusalNotice,
   drawState,
   drawTypeFreeze,
+  drawVerbFreeze,
   poolSetFreeze,
   unpooledShape,
   type DrawState,
@@ -18,6 +19,7 @@ import {
   buildEntrants,
   buildEvent,
   buildFixture,
+  buildPlayedDrawnEvent,
   buildPool,
   buildSwissDrawnEvent,
   buildSwissOddDrawnEvent,
@@ -598,5 +600,85 @@ describe('drawTypeFreeze', () => {
     expect(freeze.reason).not.toContain('dealt as')
     expect(freeze.reason).toContain('its draw type is frozen')
     expect(freeze.reason).toContain('Delete the draw to change the type')
+  })
+})
+
+/**
+ * The third freeze — the one on the draw **verbs** themselves (#1060). It restates the
+ * server's `draw_has_play` and nothing else, so the cases below are that guard's own two
+ * halves, apart, plus the negative.
+ */
+describe('drawVerbFreeze', () => {
+  it('is open on a draw that has been cut but not played', () => {
+    // The day-of re-cut ADR-0786 preserves: a full draw, no result and no match, and both
+    // verbs live. Freezing on the *draw* rather than on the *evidence* would break this.
+    expect(drawVerbFreeze(buildDrawnEvent()).kind).toBe('open')
+  })
+
+  it('is open on an event with no draw at all', () => {
+    // Not a special case in the predicate — no fixtures, nothing to find evidence on —
+    // and stated anyway, because it is what keeps Generate (the undrawn verb) unfrozen.
+    expect(drawVerbFreeze(buildEvent()).kind).toBe('open')
+  })
+
+  // Half one, alone: a decided fixture. A result exists, and a re-cut would discard it.
+  it('freezes on a fixture with a recorded WINNER, match or no match', () => {
+    const freeze = drawVerbFreeze(
+      buildDrawnEvent({
+        fixtures: [
+          buildFixture({ id: 'fx-a-1', winnerEntryId: 'entry-1', matchId: null }),
+          buildFixture({ id: 'fx-a-2', round: 2 }),
+        ],
+      }),
+    )
+
+    expect(freeze.kind).toBe('frozen')
+  })
+
+  /**
+   * Half two, alone, and the half a laxer client would get wrong: a fixture that has
+   * become a real match with **no winner and no status**.
+   *
+   * The `matchStatus: null` is the load-bearing part. `matchOf` (the renderer's helper in
+   * the same module) requires an id *and* a status before it will call a fixture
+   * materialized, so a freeze derived from `FixtureLine.match` — or from `drawState` —
+   * would read this fixture as un-played and offer a verb the server answers 409 to. The
+   * guard is `match_id IS NOT NULL`, and so is this.
+   */
+  it('freezes on a merely LINKED match, even with no winner and no status', () => {
+    const freeze = drawVerbFreeze(
+      buildDrawnEvent({
+        fixtures: [
+          buildFixture({
+            id: 'fx-a-1',
+            winnerEntryId: null,
+            matchId: 'm-1',
+            matchStatus: null,
+          }),
+        ],
+      }),
+    )
+
+    expect(freeze.kind).toBe('frozen')
+  })
+
+  // ANY fixture, not every one: the seeded event materializes one of its four.
+  it('freezes on one played fixture among four unplayed ones', () => {
+    expect(drawVerbFreeze(buildPlayedDrawnEvent()).kind).toBe('frozen')
+  })
+
+  it('says both verbs are gone, and why — and names no way out, because there is none', () => {
+    const freeze = drawVerbFreeze(buildPlayedDrawnEvent())
+    if (freeze.kind !== 'frozen') throw new Error('expected a frozen draw verb')
+
+    // What is true, in the director's terms…
+    expect(freeze.reason).toContain('already under way')
+    expect(freeze.reason).toContain('re-cut or removed')
+    // …and why it costs something to ignore.
+    expect(freeze.reason).toMatch(/throw away a result/i)
+    // The half the sibling freezes' copy register would drag in and that would be a LIE
+    // here: deleting the draw is the act being refused, so there is no exit to offer.
+    expect(freeze.reason).not.toContain('Delete the draw')
+    expect(freeze.reason).not.toContain('cut it again')
   })
 })

--- a/web-client/src/components/tournaments/data/draw.ts
+++ b/web-client/src/components/tournaments/data/draw.ts
@@ -567,6 +567,14 @@ export function drawTypeFreeze(
  * gives every ready fixture a `match_id` — but it is the `match_id` that seals the draw,
  * not the status.)
  *
+ * **The reason must be true of a match nobody has played**, and that is the whole reason
+ * it is worded the way it is. Go-live stamps a `match_id` on *every* ready fixture in one
+ * transaction, so the ordinary frozen draw has real matches and **zero results** — a
+ * sentence claiming a re-cut would discard a result somebody played for would be false in
+ * the commonest case this freeze meets. The server's own guard is careful about exactly
+ * this: a linked match "**may** already carry games" (`_enforce_unplayed`). So the result
+ * is named as one of two alternatives, never as a fact.
+ *
  * The server remains the enforcement: `_enforce_unplayed` answers **409**, and
  * `drawRefusalNotice`'s 409 arm is still there for the director who loses the race
  * between a page load and the first score. What this buys is a better refusal — a verb
@@ -577,9 +585,9 @@ export function drawVerbFreeze(event: TournamentEvent): EditFreeze {
   return {
     kind: 'frozen',
     reason:
-      'This event’s draw is already under way — at least one fixture has a recorded ' +
-      'winner, or has become a real match — so it can no longer be re-cut or removed. ' +
-      'Re-dealing it now would throw away a result somebody has already played for.',
+      'This event’s draw is under way: one of its fixtures is a real match now, or ' +
+      'carries a result somebody played for. Re-cutting or removing the draw would ' +
+      'take that back from the players.',
   }
 }
 

--- a/web-client/src/components/tournaments/data/draw.ts
+++ b/web-client/src/components/tournaments/data/draw.ts
@@ -360,6 +360,33 @@ function swissByesOf(event: TournamentEvent, unpooled: Fixture[]): SwissByes {
 const hasDraw = (event: TournamentEvent): boolean => event.fixtures.length > 0
 
 /**
+ * Whether this event's draw shows **evidence of play** — the client's mirror of the
+ * server's `draw_has_play` (`api/app/tournament_draws.py`), which is the one thing a
+ * cut, a re-cut and an un-cut are refused for (ADR-0786).
+ *
+ * The two halves are deliberately **not one condition**, because they are two different
+ * facts:
+ *
+ * - a **winner** — the fixture is decided, and a result exists to be thrown away;
+ * - a **linked match** — the fixture has materialized into a real match (#788), which may
+ *   already carry games on its scratchpad or a proposed result. A merely-linked match is
+ *   enough on its own: replacing the draw wholesale would orphan that match along with
+ *   whatever has been entered on it, and a draw must never silently eat a score.
+ *
+ * ⚠️ Read straight off the **parsed fixture**, never through `matchOf` / `FixtureLine`.
+ * That helper wants an id *and* a status before it will render a link, and being stricter
+ * about what is renderable is right for a renderer — but the server refuses on the id
+ * alone. Routing this question through it would make the client **laxer** than the guard
+ * it is restating, and a fixture with an id and no status would show a live verb that can
+ * only 409.
+ *
+ * Not gated on `hasDraw`: an undrawn event has no fixtures, so this is already false, and
+ * a gate would say the condition is *drawn-ness* when it is *evidence*.
+ */
+const drawIsUnderWay = (event: TournamentEvent): boolean =>
+  event.fixtures.some((f) => f.winnerEntryId !== null || f.matchId !== null)
+
+/**
  * An event's draw, shaped for the reader: pools with their members and rounds, or the
  * designed `undrawn` state.
  *
@@ -446,9 +473,14 @@ export type EditFreeze =
   | { kind: 'open' }
   | {
       kind: 'frozen'
-      /** Why this control is unavailable, and — the load-bearing half — the way out of
-       * it: delete the draw, edit, cut it again. Reads standalone in whichever surface
-       * shows it (a `Field` hint, an `Alert` beneath the section header). */
+      /** Why this control is unavailable — and, **when there is one**, the way out of it:
+       * delete the draw, edit, cut it again. Reads standalone in whichever surface shows
+       * it (a `Field` hint, an `Alert` beneath the section header).
+       *
+       * The way out is the load-bearing half of the two config freezes, and it is the
+       * thing `drawVerbFreeze` must NOT invent: a draw that is under way stays that way,
+       * so a sentence ending "delete the draw, then cut it again" would name an escape
+       * that is itself refused. A refusal with no exit says so, plainly, and stops. */
       reason: string
     }
 
@@ -515,6 +547,39 @@ export function drawTypeFreeze(
     reason:
       `This event’s draw is cut, so its draw type is frozen${dealtAs}. ` +
       `Delete the draw to change the type, then cut it again.`,
+  }
+}
+
+/**
+ * May the director **re-cut or remove** this event's draw?
+ *
+ * The third freeze, and the one whose refusal has **no way out**. Its two siblings are
+ * about an event's *configuration* — change the draw type, change the pool set — and both
+ * end by telling the director how to get unstuck, because deleting the draw really does
+ * unstick them. This one is about the draw *itself*, and once it shows evidence of play
+ * (`drawIsUnderWay`) neither verb is available again: deleting the draw is the very act
+ * being refused, so there is no exit to name and this reason does not invent one.
+ *
+ * Frozen on the **evidence**, never on the tournament's status. That is ADR-0786's choice
+ * and the panel must not tighten it: a director may cut and re-cut right up to the moment
+ * the first fixture becomes real, which is the day-of re-cut the ADR deliberately
+ * preserves. (Going live is what usually produces the evidence — `materialize_live_draw`
+ * gives every ready fixture a `match_id` — but it is the `match_id` that seals the draw,
+ * not the status.)
+ *
+ * The server remains the enforcement: `_enforce_unplayed` answers **409**, and
+ * `drawRefusalNotice`'s 409 arm is still there for the director who loses the race
+ * between a page load and the first score. What this buys is a better refusal — a verb
+ * that says why it cannot be used, instead of a click that can only fail (#1060).
+ */
+export function drawVerbFreeze(event: TournamentEvent): EditFreeze {
+  if (!drawIsUnderWay(event)) return { kind: 'open' }
+  return {
+    kind: 'frozen',
+    reason:
+      'This event’s draw is already under way — at least one fixture has a recorded ' +
+      'winner, or has become a real match — so it can no longer be re-cut or removed. ' +
+      'Re-dealing it now would throw away a result somebody has already played for.',
   }
 }
 

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -542,30 +542,59 @@ export function buildPlayerConflict(
  * `buildDrawnEvent`, with its draw **under way** — the state `drawVerbFreeze` (`./draw`)
  * refuses a re-cut and a delete on (#1060), and the state the server answers 409 from.
  *
- * Only ONE of its four fixtures carries the evidence, on purpose: the guard is "**any**
+ * Only ONE of its fixtures carries the evidence, on purpose: the guard is "**any**
  * fixture", and one-of-four is what tells a predicate asking `some` from one asking
  * `every`.
+ *
+ * The evidence is stamped on **whatever fixtures the overrides produced**, not on the
+ * default four, so a caller passing `fixtures` gets those fixtures *with* the evidence.
+ * Spreading `overrides` over a pre-stamped `fixtures` key instead would hand back an event
+ * with no evidence at all — an unplayed draw, from a factory whose name promises the
+ * opposite, and a silent green for every test built on it.
  *
  * The evidence is a **recorded winner**, and that choice is load-bearing for the DOM
  * surfaces that use this. A winner is not rendered anywhere on a fixture line, so the draw
  * this builds paints **identically** to `buildDrawnEvent`'s — which leaves the freeze as
  * the only difference between a frozen panel and an open one. The other half of the guard
- * (a linked `matchId`) would also render a `<Link>` to the match, which costs two things:
- * a `RouterProvider` in every test of a panel that is not about routing, **and** an
- * `a[href]` — which `INTERACTIVE_SELECTOR` matches, so the ADR-0015 "a non-owner sees zero
- * controls" sweep would red as well. Neither red would be about the freeze. Both halves of
- * the guard are pinned apart, on the predicate itself, in `draw.test.ts`.
+ * is `buildMaterializedDrawnEvent` below. Both halves are also pinned apart, on the
+ * predicate itself, in `draw.test.ts`.
  */
 export function buildPlayedDrawnEvent(
   overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
 ): TournamentEvent {
-  const drawn = buildDrawnEvent()
-  return buildDrawnEvent({
+  const drawn = buildDrawnEvent(overrides)
+  return {
+    ...drawn,
     fixtures: drawn.fixtures.map((fixture, i) =>
       i === 0 ? { ...fixture, winnerEntryId: fixture.entryAId } : fixture,
     ),
-    ...overrides,
-  })
+  }
+}
+
+/**
+ * The **other** half of the play guard: a draw whose first fixture has *materialized* —
+ * a linked `matchId`, no winner, nothing played. This is the state go-live actually
+ * produces (`materialize_live_draw` stamps a `match_id` on every ready fixture in one
+ * transaction), so it is the commonest frozen draw a director meets.
+ *
+ * `matchStatus` stays `null`, and that is what makes this usable in a DOM test. `matchOf`
+ * (`./draw`) calls a fixture materialized only when it has an id **and** a status, so this
+ * fixture renders no `<Link>`: no `RouterProvider` is needed in a panel test that is not
+ * about routing, and no `a[href]` lands in the ADR-0015 "a non-owner sees zero controls"
+ * sweep (`INTERACTIVE_SELECTOR` matches one). `drawVerbFreeze` reads the parsed fixture
+ * rather than `matchOf`, which is exactly why it still freezes here — the server refuses
+ * on `match_id` alone.
+ */
+export function buildMaterializedDrawnEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  const drawn = buildDrawnEvent(overrides)
+  return {
+    ...drawn,
+    fixtures: drawn.fixtures.map((fixture, i) =>
+      i === 0 ? { ...fixture, matchId: 'm-1', matchStatus: null } : fixture,
+    ),
+  }
 }
 
 /**

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -539,6 +539,36 @@ export function buildPlayerConflict(
 }
 
 /**
+ * `buildDrawnEvent`, with its draw **under way** — the state `drawVerbFreeze` (`./draw`)
+ * refuses a re-cut and a delete on (#1060), and the state the server answers 409 from.
+ *
+ * Only ONE of its four fixtures carries the evidence, on purpose: the guard is "**any**
+ * fixture", and one-of-four is what tells a predicate asking `some` from one asking
+ * `every`.
+ *
+ * The evidence is a **recorded winner**, and that choice is load-bearing for the DOM
+ * surfaces that use this. A winner is not rendered anywhere on a fixture line, so the draw
+ * this builds paints **identically** to `buildDrawnEvent`'s — which leaves the freeze as
+ * the only difference between a frozen panel and an open one. The other half of the guard
+ * (a linked `matchId`) would also render a `<Link>` to the match, which costs two things:
+ * a `RouterProvider` in every test of a panel that is not about routing, **and** an
+ * `a[href]` — which `INTERACTIVE_SELECTOR` matches, so the ADR-0015 "a non-owner sees zero
+ * controls" sweep would red as well. Neither red would be about the freeze. Both halves of
+ * the guard are pinned apart, on the predicate itself, in `draw.test.ts`.
+ */
+export function buildPlayedDrawnEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  const drawn = buildDrawnEvent()
+  return buildDrawnEvent({
+    fixtures: drawn.fixtures.map((fixture, i) =>
+      i === 0 ? { ...fixture, winnerEntryId: fixture.entryAId } : fixture,
+    ),
+    ...overrides,
+  })
+}
+
+/**
  * An event whose draw **is cut**: a round-robin U1200 Singles, five entrants
  * (`player.1`…`player.5`) dealt across two pools by the snake the API uses, and the
  * fixtures that field really produces.

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.page.tsx
@@ -60,19 +60,35 @@ const scoped = (container: Container) => ({
   },
 
   /** The inline **refusal** — the 409, the 422 and every other failure, in the place the
-   * click happened. Found by role (`alert`), which is the contract: it is the app talking
-   * back, and a screen reader must hear it without hunting for it. */
+   * click happened.
+   *
+   * Addressed by its own testid, not by `role="alert"`. The freeze notice below is an
+   * `Alert` too, and the two genuinely co-occur: a director who clicks Re-cut a moment
+   * before the first score lands meets the 409 *and* then refetches into the evidence that
+   * freezes the verbs. "The alert" would throw on exactly that overlap — the same lesson
+   * `pools-section` wrote down one surface over. */
   queryNotice() {
-    return container.queryByRole('alert')
+    return container.queryByTestId(/^draw-notice-/)
   },
   findNotice() {
-    return container.findByRole('alert')
+    return container.findByTestId(/^draw-notice-/)
   },
   /** The notice as one normalised string — title *and* the sentence beneath it, since
    * the whole point of the 409/422 copy is that both halves are there. */
   async findNoticeText() {
-    const notice = await container.findByRole('alert')
+    const notice = await container.findByTestId(/^draw-notice-/)
     return (notice.textContent ?? '').replace(/\s+/g, ' ').trim()
+  },
+
+  /** The **freeze** notice — why Re-cut and Delete are dead on a draw that is under way
+   * (`drawVerbFreeze`). Shown to the director alone: a reader has no verbs to explain.
+   * `query…` because "a non-owner is told nothing about a freeze that is not theirs" is
+   * half the claim. */
+  queryFrozenNotice(eventId: string) {
+    return container.queryByTestId(`draw-frozen-notice-${eventId}`)
+  },
+  getFrozenNotice(eventId: string) {
+    return container.getByTestId(`draw-frozen-notice-${eventId}`)
   },
 
   /** EVERY control in the panel. The sweep a "a non-owner is offered nothing" claim

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.page.tsx
@@ -63,10 +63,11 @@ const scoped = (container: Container) => ({
    * click happened.
    *
    * Addressed by its own testid, not by `role="alert"`. The freeze notice below is an
-   * `Alert` too, and the two genuinely co-occur: a director who clicks Re-cut a moment
-   * before the first score lands meets the 409 *and* then refetches into the evidence that
-   * freezes the verbs. "The alert" would throw on exactly that overlap — the same lesson
-   * `pools-section` wrote down one surface over. */
+   * `Alert` too, so "the alert" never named one of them — the same lesson `pools-section`
+   * wrote down one surface over. (The freeze is a `status` now and this one is still an
+   * `alert`, and the panel shows only one of them at a time: the freeze supersedes a
+   * standing refusal. A testid still says *which* notice a test means, which is what an
+   * accessor owes its reader.) */
   queryNotice() {
     return container.queryByTestId(/^draw-notice-/)
   },
@@ -146,8 +147,23 @@ const scoped = (container: Container) => ({
  * is the exception: the first cut fires on its single click.
  */
 export const drawPanelPage = {
+  /** Mount the panel. Returns the render result, plus `rerenderWith` — the only honest way
+   * to say "the event changed **underneath** this panel", which is what the refetch after a
+   * settled draw verb does. A draw that freezes while a refusal is on screen is exactly
+   * that shape.
+   *
+   * ⚠️ `rerenderWith` rebuilds the props from the factory, so anything a test does not
+   * repeat reverts to the default — pass the whole set both times. And calling `render` a
+   * second time does NOT replace the first tree: Testing Library appends a second one and
+   * `screen` spans the body, so the queries would find two panels. */
   render(overrides: Partial<DrawPanelProps> = {}) {
-    render(<DrawPanel {...buildDrawPanelProps(overrides)} />)
+    const utils = render(<DrawPanel {...buildDrawPanelProps(overrides)} />)
+    return {
+      ...utils,
+      rerenderWith(next: Partial<DrawPanelProps> = {}) {
+        utils.rerender(<DrawPanel {...buildDrawPanelProps(next)} />)
+      },
+    }
   },
 
   within(container: Container = screen) {

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
@@ -15,6 +15,7 @@ import {
   buildEntrants,
   buildEvent,
   buildFixture,
+  buildPlayedDrawnEvent,
   buildPool,
   buildSwissDrawnEvent,
   buildTenPoolDrawnEvent,
@@ -27,6 +28,11 @@ import { drawPanelPage as page } from './draw-panel.page'
 /** The seeded drawn event: round-robin, `player.1`…`player.5`, Pool A (1/4/5 — odd) and
  * Pool B (2/3). */
 const DRAWN = buildDrawnEvent()
+
+/** The same draw, **under way**: one of its four fixtures has a recorded winner. Nothing
+ * else differs — a winner is not drawn on a fixture line — so the freeze is the only thing
+ * that can make a test here read differently from the same test against `DRAWN`. */
+const PLAYED = buildPlayedDrawnEvent()
 
 /** The panel's own verbs that are still live — swept by DOM rather than by role, because
  * an open dialog puts `aria-hidden` over everything behind it and a role query then finds
@@ -547,6 +553,162 @@ describe('DrawPanel', () => {
     })
   })
 
+  /**
+   * **A draw that is under way freezes both verbs** (#1060, ADR "a confirm prices an
+   * irreversible act, a freeze explains an illegal one"). The server refuses a re-cut and
+   * a delete with a 409 once any fixture has a winner or a match, and the client had gone
+   * on offering both — a live button for an act that can only fail.
+   *
+   * Frozen means **present, dead and explained**, not hidden: hiding is ADR-0015's answer
+   * to a *permission* boundary, and this director is entitled to the act and could have
+   * performed it a minute ago.
+   */
+  describe('a draw that is already under way', () => {
+    it('renders both verbs dead — and reachable, with the reason attached', () => {
+      page.render({ event: PLAYED })
+
+      const recut = page.queryRecutButton('U1200 Singles')
+      const del = page.queryDeleteButton('U1200 Singles')
+
+      // Present. A verb that vanished from under a director who could use it a minute ago
+      // asks a loud question and answers none of it.
+      expect(recut).toBeInTheDocument()
+      expect(del).toBeInTheDocument()
+      // Dead — and dead the way that keeps them **focusable**. `aria-disabled`, not the
+      // `disabled` attribute: a disabled button leaves the tab order and most screen
+      // readers skip it, so its description is a sentence nobody ever hears.
+      expect(recut).toHaveAttribute('aria-disabled', 'true')
+      expect(del).toHaveAttribute('aria-disabled', 'true')
+      expect(recut).toBeEnabled()
+      expect(del).toBeEnabled()
+      // ⚠️ THE assertion of this slice, and the one #1223 is open against on the frozen
+      // draw-type control: the reason reaches a screen reader THROUGH the control.
+      // `toHaveAccessibleDescription` resolves the `aria-describedby` reference — an
+      // assertion that merely compared ids would pass against a control pointing at
+      // nothing, which is precisely the defect.
+      expect(recut).toHaveAccessibleDescription(/already under way/i)
+      expect(recut).toHaveAccessibleDescription(/throw away a result/i)
+      expect(del).toHaveAccessibleDescription(/already under way/i)
+      expect(del).toHaveAccessibleDescription(/throw away a result/i)
+      // …and it is on screen for a sighted director too.
+      expect(page.getFrozenNotice('ev-u1200')).toHaveTextContent(
+        'Re-cut and Delete are unavailable',
+      )
+    })
+
+    /**
+     * The behaviour half, and a **second, independent witness** to the state assertions
+     * above: a frozen verb opens no confirm and sends nothing.
+     *
+     * Two things make this evidence rather than a vacuous pass:
+     *
+     * - The identical click on an *unfrozen* event **does** open the dialog (the two
+     *   "sends NOTHING on a bare click" tests above). So "no dialog" discriminates the
+     *   freeze from the panel's ordinary behaviour, rather than describing a page where
+     *   clicking does nothing anywhere.
+     * - The click really **landed**. The frozen verb is styled dead but keeps its pointer
+     *   events on purpose, so `userEvent.click` delivers it (it throws outright on a
+     *   `pointer-events: none` target) and the button takes focus. Without that probe,
+     *   "no dialog appeared" could not tell a working guard from a click swallowed by CSS.
+     */
+    it('opens no confirm and sends nothing when the frozen Re-cut is clicked', async () => {
+      let calls = 0
+      mockEventCutDrawEndpoint(server, async () => {
+        calls += 1
+        await delay('infinite')
+        return HttpResponse.json(cutResponse(), { status: 201 })
+      })
+      page.render({ tournamentId: 't-1', event: PLAYED })
+
+      const recut = await page.findRecutButton('U1200 Singles')
+      await userEvent.click(recut)
+
+      // The claim first, so a freeze that stopped working reds *as* "the confirm opened".
+      expect(page.confirm.queryDialog()).toBeNull()
+      // Then the probe that says the click was really delivered — read second so its
+      // message only ever means what it says.
+      expect(recut).toHaveFocus()
+      expect(calls).toBe(0)
+      // A refused click is not a failure to report: the notice slot stays empty and the
+      // standing freeze notice is what does the talking.
+      expect(page.queryNotice()).toBeNull()
+    })
+
+    it('opens no confirm and sends nothing when the frozen Delete is clicked', async () => {
+      let calls = 0
+      mockEventUncutDrawEndpoint(server, async () => {
+        calls += 1
+        await delay('infinite')
+        return new HttpResponse(null, { status: 204 })
+      })
+      page.render({ tournamentId: 't-1', event: PLAYED })
+
+      const del = await page.findDeleteButton('U1200 Singles')
+      await userEvent.click(del)
+
+      expect(page.confirm.queryDialog()).toBeNull()
+      expect(del).toHaveFocus()
+      expect(calls).toBe(0)
+      expect(page.queryNotice()).toBeNull()
+    })
+
+    // The day-of re-cut ADR-0786 deliberately preserves. The freeze is on the EVIDENCE,
+    // never on the draw existing — an over-eager predicate would take this away, and no
+    // amount of correct freezing copy would make that right.
+    it('leaves both verbs live on a cut draw nobody has played yet', () => {
+      page.render({ event: DRAWN })
+
+      expect(page.queryRecutButton('U1200 Singles')).not.toHaveAttribute(
+        'aria-disabled',
+      )
+      expect(page.queryDeleteButton('U1200 Singles')).not.toHaveAttribute(
+        'aria-disabled',
+      )
+      expect(page.queryFrozenNotice('ev-u1200')).toBeNull()
+    })
+
+    // Generate is untouched, and structurally so: an undrawn event has no fixtures, so it
+    // has no evidence to find. Stated anyway, because "the freeze leaked onto the first
+    // cut" is the one way this slice could break the exemption slice 1 exists to protect.
+    it('does not freeze Generate on an undrawn event', async () => {
+      let calls = 0
+      mockEventCutDrawEndpoint(server, () => {
+        calls += 1
+        return HttpResponse.json(cutResponse(), { status: 201 })
+      })
+      page.render({
+        tournamentId: 't-1',
+        event: buildEvent({ id: 'ev-1', name: 'Open Singles' }),
+      })
+
+      const generate = await page.findGenerateButton('Open Singles')
+      expect(generate).not.toHaveAttribute('aria-disabled')
+      expect(page.queryFrozenNotice('ev-1')).toBeNull()
+
+      await userEvent.click(generate)
+
+      await waitFor(() => expect(calls).toBe(1))
+    })
+
+    /**
+     * The non-owner branch is **unchanged by the freeze**: absent, not frozen.
+     *
+     * Two claims, and they are different. A reader gets no verbs at all — the ADR-0015
+     * guard sweep still finds zero controls, which it would not if a frozen verb had been
+     * rendered to them (`INTERACTIVE_SELECTOR` matches a `button` whatever its
+     * `aria-disabled` says). And they get no freeze notice either: it explains two
+     * controls they do not have, in the organizer's voice.
+     */
+    it('shows a NON-owner no verbs and no freeze — absent, not frozen', () => {
+      page.render({ event: PLAYED, canEdit: false })
+
+      expect(page.getPanelControls('ev-u1200')).toHaveLength(0)
+      expect(page.queryFrozenNotice('ev-u1200')).toBeNull()
+      // The draw itself is still theirs to read.
+      expect(page.getPoolLines('p-a')).toHaveLength(3)
+    })
+  })
+
   // The refusals. Each is rendered INLINE, where the click happened — the draw verbs
   // carry no toast (`web-client/CLAUDE.md`, ## Forms) — and for the 409 and the 422 the
   // sentence beneath the title is the SERVER'S: it is written for the director and names
@@ -568,6 +730,11 @@ describe('DrawPanel', () => {
       const notice = await page.findNoticeText()
       expect(notice).toContain('This draw is already under way')
       expect(notice).toContain(PLAY_GUARD)
+      // …and a screen reader hears it without hunting for it. Asserted here because the
+      // page object no longer *finds* the notice by role: the freeze notice is an `Alert`
+      // too and the two co-occur, so the accessor moved to a testid. The role is still
+      // the contract — this is where it is now pinned.
+      expect(await page.findNotice()).toHaveAttribute('role', 'alert')
       // The standing draw is untouched — a refused cut destroys nothing.
       expect(page.getPoolLines('p-a')).toHaveLength(3)
     })

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.test.tsx
@@ -15,6 +15,7 @@ import {
   buildEntrants,
   buildEvent,
   buildFixture,
+  buildMaterializedDrawnEvent,
   buildPlayedDrawnEvent,
   buildPool,
   buildSwissDrawnEvent,
@@ -585,15 +586,46 @@ describe('DrawPanel', () => {
       // draw-type control: the reason reaches a screen reader THROUGH the control.
       // `toHaveAccessibleDescription` resolves the `aria-describedby` reference — an
       // assertion that merely compared ids would pass against a control pointing at
-      // nothing, which is precisely the defect.
-      expect(recut).toHaveAccessibleDescription(/already under way/i)
-      expect(recut).toHaveAccessibleDescription(/throw away a result/i)
-      expect(del).toHaveAccessibleDescription(/already under way/i)
-      expect(del).toHaveAccessibleDescription(/throw away a result/i)
-      // …and it is on screen for a sighted director too.
-      expect(page.getFrozenNotice('ev-u1200')).toHaveTextContent(
-        'Re-cut and Delete are unavailable',
+      // nothing, which is precisely the defect. ONE short token each: the sentence itself
+      // belongs to `drawVerbFreeze`'s own test, and pinning it in two files is the shape
+      // that greens one of them on a copy edit and leaves the other stale.
+      expect(recut).toHaveAccessibleDescription(/under way/i)
+      expect(del).toHaveAccessibleDescription(/under way/i)
+      // …and it is on screen for a sighted director too — as a **status**, not an alert.
+      // The `Alert` hardcodes `role="alert"` (assertive), which interrupts a screen reader
+      // to announce a condition that was simply true when the page loaded. The refusal
+      // below keeps `alert`; that one answers a click.
+      const frozenNotice = page.getFrozenNotice('ev-u1200')
+      expect(frozenNotice).toHaveTextContent('Re-cut and Delete are unavailable')
+      expect(frozenNotice).toHaveAttribute('role', 'status')
+    })
+
+    /**
+     * The **other half of the guard**, through the panel: a fixture that has merely
+     * materialized — a linked `matchId`, no winner, nothing played. This is what go-live
+     * produces on every ready fixture, so it is the commonest frozen draw there is, and
+     * until now only the data module covered it.
+     *
+     * The control count is the load-bearing second assertion. This fixture's `matchStatus`
+     * is `null`, so `matchOf` renders no "View match" `<Link>` — which is what keeps this
+     * event usable in a panel test with no router, and what keeps the ADR-0015 sweep
+     * (`INTERACTIVE_SELECTOR` matches an `a[href]`) counting verbs and nothing else.
+     */
+    it('freezes on a fixture that is a match but has no result yet', () => {
+      page.render({ event: buildMaterializedDrawnEvent() })
+
+      expect(page.queryRecutButton('U1200 Singles')).toHaveAttribute(
+        'aria-disabled',
+        'true',
       )
+      expect(page.queryDeleteButton('U1200 Singles')).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      )
+      expect(page.getFrozenNotice('ev-u1200')).toBeInTheDocument()
+      // The two verbs, and no link: a materialized fixture with no status paints exactly
+      // as an un-materialized one does.
+      expect(page.getPanelControls('ev-u1200')).toHaveLength(2)
     })
 
     /**
@@ -649,6 +681,46 @@ describe('DrawPanel', () => {
       expect(page.confirm.queryDialog()).toBeNull()
       expect(del).toHaveFocus()
       expect(calls).toBe(0)
+      expect(page.queryNotice()).toBeNull()
+    })
+
+    /**
+     * ⚠️ **The freeze supersedes a standing refusal.** The race it settles is real and it
+     * has one exit: the director clicks Re-cut on a draw nobody had played, the first score
+     * lands first, the server answers 409, and the refetch the mutation settles into brings
+     * back the evidence that freezes the verbs.
+     *
+     * Left alone, the two notices sit on the card **permanently**, saying nearly the same
+     * thing in different words. `setNotice(null)` runs in exactly one place — the top of
+     * `attempt` — and once frozen, `attempt` is unreachable: both destructive verbs
+     * short-circuit before it, and Generate is not rendered on a drawn event. So the red
+     * one has no way to clear, ever.
+     *
+     * A `rerenderWith` rather than a second `render`, because the claim is that the event
+     * changed **underneath** a panel that is holding a refusal in its state — a fresh mount
+     * would have no refusal to supersede and the test would pass against no fix at all.
+     */
+    it('drops a standing refusal once the freeze engages — one notice, not two', async () => {
+      const playGuard =
+        "This event's draw is already under way — at least one fixture has a match " +
+        'or a recorded winner — so it can no longer be cut or removed.'
+      mockEventCutDrawEndpoint(server, () =>
+        HttpResponse.json({ detail: playGuard }, { status: 409 }),
+      )
+      const { rerenderWith } = page.render({ tournamentId: 't-1', event: DRAWN })
+
+      await userEvent.click(await page.findRecutButton('U1200 Singles'))
+      await userEvent.click(page.confirm.getConfirmButton())
+      // The refusal is up, on a draw that is still open — the two-notice state, mid-race.
+      expect(await page.findNoticeText()).toContain(playGuard)
+      expect(page.queryFrozenNotice('ev-u1200')).toBeNull()
+
+      // …and now the refetch lands, carrying the score that beat the click.
+      rerenderWith({ tournamentId: 't-1', event: PLAYED })
+
+      expect(page.getFrozenNotice('ev-u1200')).toBeInTheDocument()
+      // The whole assertion: the red one is gone, because no further request is possible
+      // and a refusal nobody can retire is worse than none.
       expect(page.queryNotice()).toBeNull()
     })
 
@@ -730,10 +802,12 @@ describe('DrawPanel', () => {
       const notice = await page.findNoticeText()
       expect(notice).toContain('This draw is already under way')
       expect(notice).toContain(PLAY_GUARD)
-      // …and a screen reader hears it without hunting for it. Asserted here because the
-      // page object no longer *finds* the notice by role: the freeze notice is an `Alert`
-      // too and the two co-occur, so the accessor moved to a testid. The role is still
-      // the contract — this is where it is now pinned.
+      // …and a screen reader is interrupted to hear it, because a refusal is an EVENT: it
+      // lands in answer to this click. That is the half the freeze notice does not share —
+      // it is a standing condition and carries `role="status"`. Asserted here because the
+      // page object finds the notice by testid rather than by role (the freeze notice is
+      // an `Alert` too, so "the alert" named neither of them). The role is still the
+      // contract — this is where it is pinned.
       expect(await page.findNotice()).toHaveAttribute('role', 'alert')
       // The standing draw is untouched — a refused cut destroys nothing.
       expect(page.getPoolLines('p-a')).toHaveLength(3)

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
@@ -1,4 +1,4 @@
-import { Shuffle, Trash2 } from 'lucide-react'
+import { Lock, Shuffle, Trash2 } from 'lucide-react'
 import { useId, useState } from 'react'
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -8,6 +8,7 @@ import { useCutDraw, useUncutDraw } from '../../data/api'
 import {
   drawRefusalNotice,
   drawState,
+  drawVerbFreeze,
   type DrawNotice,
   type DrawRound,
   type SwissByes,
@@ -31,6 +32,34 @@ import { SwissRounds } from './draw-panel/swiss-rounds'
 // lifecycle edges live in the header (`../lifecycle-actions`) and there is no draw verb
 // that could fire one. Widening it would turn the `never` default into a dead arm that
 // has to invent an answer for an act the panel cannot perform.
+
+/**
+ * How a **frozen** draw verb is dressed: unavailable, focusable, and pointing at the
+ * sentence that says why.
+ *
+ * `aria-disabled` rather than the `disabled` attribute, deliberately — see the component
+ * doc. The three parts are one decision and travel together, which is why they are a
+ * function and not three props repeated on two buttons:
+ *
+ * - **`aria-disabled`** announces the state without removing the verb from the tab order.
+ * - **`aria-describedby`** is the only channel the reason has. It is what makes this a
+ *   frozen control rather than #1223's grey box with a sentence painted beside it.
+ * - **the classes** are what `disabled:` would have given for free. `pointer-events-none`
+ *   is pointedly NOT among them: the click must still land and be refused *by the
+ *   handler*, or "a frozen verb opens no confirm" becomes untestable — a dialog that never
+ *   appeared cannot tell a working guard from a click that was swallowed by CSS.
+ *
+ * Open, it contributes nothing at all — not `aria-disabled="false"`, which is a claim of
+ * its own that a screen reader will read out.
+ */
+const frozenVerb = (frozen: boolean, reasonId: string) =>
+  frozen
+    ? {
+        'aria-disabled': true,
+        'aria-describedby': reasonId,
+        className: 'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+      }
+    : {}
 
 export interface DrawPanelProps {
   tournamentId: string
@@ -78,6 +107,29 @@ export interface DrawPanelProps {
  * confirm is not a debounce: it asks a question once, while the lock is what keeps two
  * whole-draw replacements from racing.
  *
+ * ## Once the draw is under way, both verbs freeze — disabled with the reason, not hidden
+ *
+ * `drawVerbFreeze` (`../../data/draw`) restates the server's play guard, so a draw with a
+ * recorded winner or a linked match renders Re-cut and Delete **dead, present, and
+ * explained** — instead of offering a click that can only 409 (#1060). A frozen verb opens
+ * no confirm: a dialog pricing an act that cannot happen is pure ceremony.
+ *
+ * **Hiding them would be the wrong rule.** ADR-0015's "hide, never disable" answers a
+ * *permission* boundary — a person who can never do this, for whom the button's absence
+ * asks no question. This is a *state* boundary, and the director in front of it could
+ * re-cut a minute ago. A button that vanishes from under someone entitled to it asks a
+ * very loud question and answers none of it; the fix for an unexplained dead end is the
+ * explanation, not a deeper silence.
+ *
+ * **`aria-disabled`, not `disabled`** — and that is not a detail. A `disabled` button is
+ * out of the tab order, so a director driving this page by keyboard never reaches it and
+ * many screen readers skip it entirely: its `aria-describedby` reason is a sentence
+ * nobody will ever hear. That is exactly the omission #1223 is open against on the frozen
+ * draw-type control, and copying the pattern would copy the defect. `aria-disabled` keeps
+ * the verb focusable and announced *as* unavailable, with the reason attached, and the
+ * click it still receives is refused in the handler. `disabled` is kept for `isPending`,
+ * which is a momentary lock nobody needs read to them.
+ *
  * ## Refusals are inline, and the server's sentence is the copy
  *
  * The panel surfaces its own failures — `useCutDraw` / `useUncutDraw` carry **no global
@@ -103,6 +155,9 @@ export interface DrawPanelProps {
  */
 export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
   const headingId = useId()
+  // The one place the freeze's reason is written, and the one thing both frozen verbs
+  // point at with `aria-describedby`: one explanation, said once.
+  const freezeNoticeId = useId()
   const cut = useCutDraw(tournamentId)
   const uncut = useUncutDraw(tournamentId)
   // The last refusal, in words. Cleared when a new attempt starts — a notice about the
@@ -118,6 +173,11 @@ export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
   // One in-flight draw verb at a time. A second click on Re-cut while the first is still
   // flying would race two whole-draw replacements against each other.
   const isPending = cut.isPending || uncut.isPending
+  // Evidence of play seals the draw (ADR-0786). Asked of the EVENT, not of `state`: the
+  // renderer's `FixtureLine` drops a match that arrived without a status, and a freeze
+  // read off it would be laxer than the guard it restates (`drawVerbFreeze`).
+  const freeze = drawVerbFreeze(event)
+  const frozen = freeze.kind === 'frozen'
 
   const attempt = async (verb: string, fire: () => Promise<unknown>) => {
     setNotice(null)
@@ -184,15 +244,19 @@ export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
               <>
                 {/* The two destructive verbs. Neither one mutates on this click: it
                     opens the confirm, and the act is what the confirm's own button
-                    fires. */}
+                    fires — unless the draw is under way, in which case neither the
+                    confirm nor the request happens at all and the notice below says
+                    why (`frozenVerb`). */}
                 <Button
                   size="sm"
                   variant="outline"
                   aria-label={`Re-cut draw for ${event.name}`}
                   disabled={isPending}
-                  onClick={() =>
+                  {...frozenVerb(frozen, freezeNoticeId)}
+                  onClick={() => {
+                    if (frozen) return
                     setPending({ variant: 'recut-draw', eventName: event.name })
-                  }
+                  }}
                 >
                   <Shuffle size={14} />
                   Re-cut draw
@@ -202,9 +266,11 @@ export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
                   variant="ghost"
                   aria-label={`Delete draw for ${event.name}`}
                   disabled={isPending}
-                  onClick={() =>
+                  {...frozenVerb(frozen, freezeNoticeId)}
+                  onClick={() => {
+                    if (frozen) return
                     setPending({ variant: 'delete-draw', eventName: event.name })
-                  }
+                  }}
                 >
                   <Trash2 size={14} />
                   Delete draw
@@ -214,6 +280,34 @@ export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
           </div>
         )}
       </div>
+
+      {/* Why the two verbs above are dead — the whole content of the freeze, in one place,
+          and the sentence both of them `aria-describedby`. Not `destructive`: nothing has
+          gone wrong, a draw under way is the *correct* state of an event being played.
+
+          The director's alone. A reader has no verbs to explain and no draw to delete, so
+          this is organizer-voiced copy they could do nothing with (ADR-0015, rule 5) — and
+          gating it with the buttons keeps the description from ever pointing at an element
+          that is not on the page.
+
+          Addressed by testid rather than by `role="alert"`, exactly as the pools section
+          learned to be: this and the refusal below are both `Alert`s, and they genuinely
+          co-occur — a director who clicks Re-cut just before the first score lands gets the
+          409 *and* then refetches into evidence. A page object asking for "the alert" would
+          throw on that overlap. */}
+      {canEdit && freeze.kind === 'frozen' && (
+        <Alert data-testid={`draw-frozen-notice-${event.id}`} className="mt-2.5">
+          <Lock size={16} />
+          {/* The title names what it means for the two controls; the description names the
+              cause. Between them they say it once each — the title is not a shorter copy
+              of the sentence beneath it. */}
+          <AlertTitle>Re-cut and Delete are unavailable</AlertTitle>
+          {/* The id sits on the DESCRIPTION, not on the `Alert`, so a verb's accessible
+              description is the reason and only the reason — not the reason with the title
+              read out in front of it. */}
+          <AlertDescription id={freezeNoticeId}>{freeze.reason}</AlertDescription>
+        </Alert>
+      )}
 
       {/* The refusal, where the click was — an `Alert` (the app talking back), not a
           toast that leaves after four seconds carrying the one sentence that says what

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
@@ -11,6 +11,7 @@ import {
   drawVerbFreeze,
   type DrawNotice,
   type DrawRound,
+  type EditFreeze,
   type SwissByes,
   type UnpooledShape,
 } from '../../data/draw'
@@ -34,6 +35,35 @@ import { SwissRounds } from './draw-panel/swiss-rounds'
 // has to invent an answer for an act the panel cannot perform.
 
 /**
+ * The classes a frozen verb wears — what `disabled:` would have given for free, re-hung on
+ * `aria-disabled`. `cursor-not-allowed` and `opacity-50` are that pair; the four after
+ * them are what make a dead verb *look* dead:
+ *
+ * - **`text-…`** mutes the label at rest. `outline`'s Re-cut is `text-foreground` and
+ *   `ghost`'s Delete is already `--fg-2`, so without it the two frozen verbs would sit
+ *   side by side in different weights of dead.
+ * - **`hover:bg-transparent`** and **`hover:text-…`** take back the variant's hover tint
+ *   (`outline` lifts its background, `ghost` lifts its background *and* its text). Both
+ *   land on the resting colour above, so the verb does not change at all under the cursor:
+ *   a control that lights up while the cursor beside it reads `not-allowed` is telling the
+ *   director two different things.
+ * - **`active:…translate-y-0`** takes back the depress. A button that sinks under the
+ *   click is saying the click was taken. The `not-aria-[haspopup]` qualifier is carried
+ *   over from the base rule this overrides, so that this one is strictly *more* specific —
+ *   the two would otherwise tie at three selectors and be settled by stylesheet order.
+ *
+ * `pointer-events-none` is pointedly NOT among them: the click must still land and be
+ * refused *by the handler*, or "a frozen verb opens no confirm" becomes untestable — a
+ * dialog that never appeared cannot tell a working guard from a click that was swallowed
+ * by CSS.
+ */
+const FROZEN_VERB_CLASSES =
+  'aria-disabled:cursor-not-allowed aria-disabled:opacity-50 ' +
+  'aria-disabled:text-[color:var(--fg-2)] aria-disabled:hover:bg-transparent ' +
+  'aria-disabled:hover:text-[color:var(--fg-2)] ' +
+  'aria-disabled:active:not-aria-[haspopup]:translate-y-0'
+
+/**
  * How a **frozen** draw verb is dressed: unavailable, focusable, and pointing at the
  * sentence that says why.
  *
@@ -44,20 +74,22 @@ import { SwissRounds } from './draw-panel/swiss-rounds'
  * - **`aria-disabled`** announces the state without removing the verb from the tab order.
  * - **`aria-describedby`** is the only channel the reason has. It is what makes this a
  *   frozen control rather than #1223's grey box with a sentence painted beside it.
- * - **the classes** are what `disabled:` would have given for free. `pointer-events-none`
- *   is pointedly NOT among them: the click must still land and be refused *by the
- *   handler*, or "a frozen verb opens no confirm" becomes untestable — a dialog that never
- *   appeared cannot tell a working guard from a click that was swallowed by CSS.
+ * - **the classes** (`FROZEN_VERB_CLASSES`) make the dead state look dead.
+ *
+ * It takes the **`EditFreeze` itself**, never a boolean and an id. The boolean and the
+ * reason are one decision, and the sum type exists precisely so the pair cannot be
+ * reconstructed by hand: `frozenVerb(true, someUnrelatedId)` type-checked, and dressing a
+ * verb as frozen while the freeze was open was a two-argument slip away.
  *
  * Open, it contributes nothing at all — not `aria-disabled="false"`, which is a claim of
  * its own that a screen reader will read out.
  */
-const frozenVerb = (frozen: boolean, reasonId: string) =>
-  frozen
+const frozenVerb = (freeze: EditFreeze, reasonId: string) =>
+  freeze.kind === 'frozen'
     ? {
         'aria-disabled': true,
         'aria-describedby': reasonId,
-        className: 'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+        className: FROZEN_VERB_CLASSES,
       }
     : {}
 
@@ -179,6 +211,23 @@ export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
   const freeze = drawVerbFreeze(event)
   const frozen = freeze.kind === 'frozen'
 
+  /** Everything the two destructive verbs share: the in-flight lock, the frozen dress, and
+   * the click that names an act **without performing it** — the confirm's button is what
+   * fires it. One helper rather than two copies, because the guard and the dress are the
+   * same decision on both buttons and a verb that kept one without the other would be
+   * either a dead-looking button that still fires or a live-looking one that cannot. All
+   * that differs between them is the act. */
+  const destructiveVerb = (variant: DrawActConsequence['variant']) => ({
+    disabled: isPending,
+    ...frozenVerb(freeze, freezeNoticeId),
+    onClick: () => {
+      // The refusal is HERE, not in CSS: the click lands on a frozen verb (see
+      // `FROZEN_VERB_CLASSES`) and is turned away, so no confirm opens and nothing is sent.
+      if (frozen) return
+      setPending({ variant, eventName: event.name })
+    },
+  })
+
   const attempt = async (verb: string, fire: () => Promise<unknown>) => {
     setNotice(null)
     try {
@@ -251,12 +300,7 @@ export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
                   size="sm"
                   variant="outline"
                   aria-label={`Re-cut draw for ${event.name}`}
-                  disabled={isPending}
-                  {...frozenVerb(frozen, freezeNoticeId)}
-                  onClick={() => {
-                    if (frozen) return
-                    setPending({ variant: 'recut-draw', eventName: event.name })
-                  }}
+                  {...destructiveVerb('recut-draw')}
                 >
                   <Shuffle size={14} />
                   Re-cut draw
@@ -265,12 +309,7 @@ export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
                   size="sm"
                   variant="ghost"
                   aria-label={`Delete draw for ${event.name}`}
-                  disabled={isPending}
-                  {...frozenVerb(frozen, freezeNoticeId)}
-                  onClick={() => {
-                    if (frozen) return
-                    setPending({ variant: 'delete-draw', eventName: event.name })
-                  }}
+                  {...destructiveVerb('delete-draw')}
                 >
                   <Trash2 size={14} />
                   Delete draw
@@ -290,13 +329,23 @@ export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
           gating it with the buttons keeps the description from ever pointing at an element
           that is not on the page.
 
-          Addressed by testid rather than by `role="alert"`, exactly as the pools section
-          learned to be: this and the refusal below are both `Alert`s, and they genuinely
-          co-occur — a director who clicks Re-cut just before the first score lands gets the
-          409 *and* then refetches into evidence. A page object asking for "the alert" would
-          throw on that overlap. */}
+          Addressed by testid rather than by role, exactly as the pools section learned to
+          be: this and the refusal below are both `Alert`s, so "the alert" was never a name
+          for one of them. It is not one now either — this notice is a `status` and that one
+          is an `alert` — but a testid says which notice a test means, where a role only
+          says which kind of announcement it is. */}
       {canEdit && freeze.kind === 'frozen' && (
-        <Alert data-testid={`draw-frozen-notice-${event.id}`} className="mt-2.5">
+        <Alert
+          // `role="status"` — polite — over the `Alert`'s own hardcoded `role="alert"`,
+          // which is assertive and interrupts whatever a screen reader is saying. This is
+          // a **standing condition**, true on load and true for as long as the page is
+          // open: nothing just happened. (The `Alert` spreads `{...props}` after its own
+          // role, so this wins.) The refusal below keeps `alert` — that one *is* an event,
+          // and it lands in answer to a click.
+          role="status"
+          data-testid={`draw-frozen-notice-${event.id}`}
+          className="mt-2.5"
+        >
           <Lock size={16} />
           {/* The title names what it means for the two controls; the description names the
               cause. Between them they say it once each — the title is not a shorter copy
@@ -311,8 +360,18 @@ export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
 
       {/* The refusal, where the click was — an `Alert` (the app talking back), not a
           toast that leaves after four seconds carrying the one sentence that says what
-          to change. */}
-      {notice && (
+          to change.
+
+          **The freeze supersedes it.** A refusal is a standing notice about the last
+          *attempt*, and it is cleared when the next one starts (`attempt`) — but once the
+          verbs are frozen there is no next attempt: both short-circuit before `attempt`
+          runs, and Generate is not rendered on a drawn event. So a refusal caught on the
+          way into the freeze — the director clicks Re-cut on an unplayed draw, a score
+          lands first, the 409 comes back, the refetch brings the evidence — would sit
+          there for good, a red alert saying almost what the freeze above it says, with
+          nothing in the panel able to clear it. The freeze is the same fact, current and
+          complete, so it does the talking alone. */}
+      {!frozen && notice && (
         <Alert
           variant="destructive"
           data-testid={`draw-notice-${event.id}`}


### PR DESCRIPTION
Third and last of the stacked slices closing cluster A. **Stacked on #1286** (itself on #1285) — review those first; this PR's diff is slice 3 alone.

## What this slice does

Once an event's draw shows evidence of play, **Re-cut draw** and **Delete draw** render present, dead and explained, instead of offering an action the server can only refuse with a 409.

Closes #1060.

## Present and disabled, not hidden

ADR-0015 says "hide, never disable" — and that rule is about a **permission** boundary, someone who can *never* do this. A director whose draw went live is entitled to the action and could have taken it a minute ago. A button that silently vanishes from under them asks a loud question and answers none of it. The new ADR records the split: who is asking → hidden; what state the resource is in → disabled with the reason.

The non-owner branch is untouched. They still see no draw verbs at all — absent, not frozen.

## `aria-disabled`, not `disabled`

A `disabled` button leaves the tab order and most screen readers skip it, so a reason attached to it is a sentence nobody hears. That is precisely **#1223**, still open against the frozen draw-type control — this slice pointedly does not copy that pattern. `aria-disabled` keeps the verb focusable and announced as unavailable with the reason attached; the click it still receives is refused in the handler.

`pointer-events-none` is deliberately absent: the click must land and be refused by the guard, or "a frozen verb opens no confirm" cannot distinguish a working guard from a click swallowed by CSS.

## The predicate mirrors the server, and is not routed through `matchOf`

A draw is under way when any fixture has a recorded winner **or** a linked match — read straight off the parsed fixture. `matchOf` wants an id *and* a status before it calls a fixture materialized, but the server refuses on `match_id` alone, so routing the freeze through it would make the client **laxer** than the guard it restates. Both halves are pinned apart, including a `matchId` with a null `matchStatus`.

Both fields were already on the parsed fixture, so there is no API change and nothing extra is fetched.

## Verification

`vitest run` 3566 passed · `tsc -b` clean · `eslint .` clean · `playwright test` 322 collected / 322 passed.

Falsified: forcing the freeze open reds 7 tests, each for its stated reason. The two behaviour tests carry a second, independent witness — focus landing on the clicked verb — which proves the click was really delivered rather than swallowed.

## Known gap

**No e2e spec exercises the frozen state in a browser.** The 322 green prove no regression (the lifecycle spec re-cuts *before* go-live, so it never meets the freeze), but nothing positive about the freeze end-to-end. The e2e store already carries `drawHasPlay`, `DRAW_UNDER_WAY_DETAIL` and `materializeFixtures`, so a live-seeded spec would be short. Flagged rather than silently skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)