### PR TITLE
qa-review: stop slash-command injection from collapsing the two QA browsers into one

### DIFF
--- a/.claude/commands/qa-review.md
+++ b/.claude/commands/qa-review.md
@@ -95,30 +95,43 @@ CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 QA_SLUG="${QA_PROJECT:-fortymm-qa-$(git rev-parse --abbrev-ref HEAD)}"
 RUN_DIR=".qa-review/$QA_SLUG"; mkdir -p "$RUN_DIR"
 
-launch_cdp() {  # $1=label
-  local dir="/tmp/qa-chrome-$QA_SLUG-$1" port
+# NEVER use shell positional parameters — a dollar sign followed by a digit — or
+# a shell function that takes them, anywhere in this file. Slash-command
+# injection replaces positionals with the words YOU typed after /qa-review,
+# before this text ever reaches the model, so such a parameter silently becomes
+# a word from the user's prompt. That is not theoretical: it turned this very
+# loop into one that launched a single browser under two labels, giving a
+# "two-user" pass in which both identities were the same person. Loop variables
+# like $label are untouched by the substitution — use those.
+for label in poster opponent; do
+  dir="/tmp/qa-chrome-$QA_SLUG-$label"
   # Reuse this run's own browser if it's still alive (a resumed session), but
   # never adopt a stranger's: the port came from OUR profile dir.
   if [ -s "$dir/DevToolsActivePort" ]; then
     port="$(head -1 "$dir/DevToolsActivePort")"
     if curl -sf -o /dev/null "http://localhost:$port/json/version"; then
-      echo "$1: reusing CDP on $port"; echo "$port" > "$RUN_DIR/$1.port"; return
+      echo "$label: reusing CDP on $port"; echo "$port" > "$RUN_DIR/$label.port"; continue
     fi
   fi
   rm -f "$dir/DevToolsActivePort"
   nohup "$CHROME" --remote-debugging-port=0 --user-data-dir="$dir" \
     --no-first-run --no-default-browser-check about:blank >/dev/null 2>&1 &
-  echo $! > "$RUN_DIR/$1.pid"
+  echo $! > "$RUN_DIR/$label.pid"
   disown
   for _ in $(seq 1 60); do [ -s "$dir/DevToolsActivePort" ] && break; sleep 1; done
   port="$(head -1 "$dir/DevToolsActivePort")"
-  echo "$port" > "$RUN_DIR/$1.port"
-  echo "$1: CDP up on $port (pid $(cat "$RUN_DIR/$1.pid"))"
-}
+  echo "$port" > "$RUN_DIR/$label.port"
+  echo "$label: CDP up on $port (pid $(cat "$RUN_DIR/$label.pid"))"
+done
 
-launch_cdp poster
-launch_cdp opponent
 echo "poster=$(cat "$RUN_DIR/poster.port")  opponent=$(cat "$RUN_DIR/opponent.port")"
+
+# Prove you got TWO browsers, not one reused under two labels. Different ports
+# AND different debugger UUIDs, or you do not have two identities.
+for label in poster opponent; do
+  p="$(cat "$RUN_DIR/$label.port")"
+  echo "$label port=$p $(curl -s "localhost:$p/json/version" | tr ',' '\n' | grep webSocketDebuggerUrl)"
+done
 ```
 
 Steps 3 and 4 read `.qa-review/$QA_SLUG/{poster,opponent}.port` and `.pid` — read


### PR DESCRIPTION
Found while running `/qa-review` for the weekly QA sweep. Targets `quinn_update`, because it builds on that branch's rewrite of this file.

## The bug

Step 2's browser launcher was a shell function that took a positional parameter:

```bash
launch_cdp() {  # <positional>=label
  local dir="/tmp/qa-chrome-$QA_SLUG-<positional>" port
  ...
}
launch_cdp poster
launch_cdp opponent
```

Slash-command injection replaces positional parameters with the words the user typed after `/qa-review`, before the text reaches the model. This session was invoked as `/qa-review on just everything, ...`, and the parameter resolved to the literal word `just`.

Both calls therefore pointed at the same profile directory. The second call found the first browser's live `DevToolsActivePort`, printed "reusing", and returned.

**One browser, one cookie jar, two labels.** The two-browser setup exists precisely so the poster and opponent are different identities. Without it, every multi-user and concurrency finding in a pass is one identity acting on itself, and the state-integrity category the skill weights highest becomes untestable while still appearing to run.

Note the file on disk was always correct. The corruption happened at injection time, which is why it survived review.

## The fix

Rewrite the launcher as a loop. Loop variables are untouched by the substitution, and Step 4 of the same document already uses that shape and arrives intact, so it is a control that proves the approach.

Two details worth review:

- The early exit becomes `continue`, not `return`. Inlined into a loop, `return` would exit the whole loop and skip the opponent browser whenever the poster browser was reused — the same one-identity failure by another route.
- The new comment avoids writing a dollar-digit sequence, or the warning would be substituted itself.

Also adds a verification loop that prints both ports and both debugger UUIDs, so a run proves it has two browsers rather than assuming it.

## Verification

Extracted the block and ran it twice:

- **Fresh pass** — two browsers on distinct ports, distinct debugger UUIDs.
- **Second pass** — both reused. Under the old `return`, the opponent would have been skipped. This is the falsification for the `continue` change.

`grep` for any dollar-digit sequence in the file returns nothing, and `bash -n` parses the block cleanly. Test browsers and profile dirs were cleaned up.

## Scope note, not fixed here

Step 2's prose says the launched Chrome is headless. The command has no `--headless` flag, and the browsers this session launched were real windows. Left alone as out of scope, but it should probably be reconciled one way or the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
