### PR TITLE
Slice 2: a director who publishes, starts or ends a tournament is asked first, and told what that costs

### DIFF
--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -34,7 +34,8 @@ export const SWISS_STANDINGS_COLUMNS = {
 /**
  * The tournament detail page (`/tournaments/$tournamentId`) — scoped to the
  * lifecycle round-robin spec's load-bearing surfaces: the header's lifecycle
- * button (Publish → Start tournament → End tournament, `LifecycleActions`), an
+ * button (Publish → Start tournament → End tournament, `LifecycleActions`) and the
+ * confirm each of those edges now opens before it fires (`publishTournament`), an
  * event card's Enter control and draw panel (both on the default **Events** tab),
  * the fixture's link into its materialized match, and the standings the completed
  * event derives.
@@ -117,9 +118,21 @@ export class TournamentDetailPage {
 
   // ----- lifecycle (header) -------------------------------------------------
 
-  /** `draft → published`. Present only for the owner, only while `draft`. */
+  /** `draft → published`. Present only for the owner, only while `draft`.
+   *
+   * **`exact` is load-bearing here and only here.** `getByRole`'s name option is a
+   * *substring* match by default, and the confirm this button opens carries the act's own
+   * verb — `Publish the tournament` — which contains `Publish`. Measured against both
+   * buttons on one page: the loose locator resolves **2**, the exact one **1**. So while
+   * the dialog is open the loose locator is a strict-mode violation at best, and at worst
+   * an assertion that means the header and silently checks the dialog.
+   *
+   * The other two edges do **not** need it and do not have it: `Start the tournament`
+   * does not contain `Start tournament`, nor `End the tournament` contain `End
+   * tournament` (the definite article breaks the substring). Don't "tidy" all three into
+   * agreement — the asymmetry is the fact, not an oversight. */
   get publishButton(): Locator {
-    return this.page.getByRole('button', { name: 'Publish' })
+    return this.page.getByRole('button', { name: 'Publish', exact: true })
   }
 
   /** `published → live` — the edge that materializes the draw into real matches. */
@@ -136,6 +149,57 @@ export class TournamentDetailPage {
   /** The inline `Alert` a refused transition raises (e.g. Start on a stale draw). */
   get lifecycleNotice(): Locator {
     return this.page.getByTestId('lifecycle-notice')
+  }
+
+  /** The **confirm** button of `ConfirmIrreversibleActDialog` — the dialog every
+   * one-way act opens before it is performed (ADR "a confirm prices an irreversible
+   * act, a freeze explains an illegal one").
+   *
+   * Not scoped to anything: Radix portals an `AlertDialog` to the body, so a
+   * header-scoped query finds nothing whether it opened or not. Addressed by testid
+   * rather than by name because the name is the act's own verb and differs per edge
+   * (`Publish the tournament`, `Start the tournament`, `End the tournament`) — one stable
+   * hook, three sentences. */
+  get confirmActButton(): Locator {
+    return this.page.getByTestId('confirm-irreversible-act-confirm')
+  }
+
+  /** Publish the tournament: click the header's edge, then answer the confirm it opens.
+   *
+   * A method rather than two lines at each call site, for the same reason `openSchedule`
+   * is one: the click and the confirm are **one act** a director performs, and the button
+   * alone now moves nothing. A spec that clicked the edge and stopped would leave the
+   * tournament in `draft` behind an unanswered dialog — which is exactly how this suite
+   * went red when the confirms landed. */
+  async publishTournament(): Promise<void> {
+    await this.publishButton.click()
+    await this.answerConfirm()
+  }
+
+  /** Go live: click **Start tournament**, then answer its confirm. The transition
+   * (`POST …/transitions`) is fired by the confirm, so a spec awaiting that response
+   * must arm its `waitForResponse` before calling this. */
+  async startTournament(): Promise<void> {
+    await this.startButton.click()
+    await this.answerConfirm()
+  }
+
+  /** Archive: click **End tournament**, then answer its confirm. */
+  async endTournament(): Promise<void> {
+    await this.endButton.click()
+    await this.answerConfirm()
+  }
+
+  /** Click the standing confirm and wait for the dialog to actually leave.
+   *
+   * The `detached` wait is the method's postcondition — "the act was answered *and* the
+   * dialog is gone" — and it is not decoration: Radix animates the overlay out, and the
+   * next thing a spec does after publishing is click a button on the page underneath it.
+   * A `waitFor`, not an `expect`, so page objects stay assertion-free like the rest of
+   * this suite. */
+  private async answerConfirm(): Promise<void> {
+    await this.confirmActButton.click()
+    await this.confirmActButton.waitFor({ state: 'detached' })
   }
 
   // ----- events (Events tab) ------------------------------------------------

--- a/e2e/tests/tournament-lifecycle.spec.ts
+++ b/e2e/tests/tournament-lifecycle.spec.ts
@@ -94,7 +94,9 @@ test.describe('Tournament — round-robin lifecycle', () => {
     const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
 
     // ----- publish: draft → published (opens registration) ------------------
-    await detail.publishButton.click()
+    // Click plus confirm: the header's edge only asks the question, and the transition
+    // is what the dialog's own button fires.
+    await detail.publishTournament()
     await expect(detail.startButton).toBeVisible()
 
     // ----- enter the director themselves, through the UI --------------------
@@ -117,7 +119,7 @@ test.describe('Tournament — round-robin lifecycle', () => {
     await expect(detail.viewMatchLink(eventId)).toBeHidden()
 
     // ----- go live: published → live (materializes the fixture) -------------
-    await detail.startButton.click()
+    await detail.startTournament()
     // Now live: the only edge left is End. But the fixture is materialized as a
     // *scheduled* match, not a live one (#1073): it is born `pending`, so it reads
     // "Not started" and is NOT yet scorable. The materialized fixture already

--- a/e2e/tests/tournament-rr-then-ko.spec.ts
+++ b/e2e/tests/tournament-rr-then-ko.spec.ts
@@ -261,7 +261,7 @@ test.describe('Tournament — rr-then-ko draw', () => {
     for (const pool of pools) expect(pool.id).toMatch(UUID)
 
     // ----- publish, then fill the field --------------------------------------
-    await detail.publishButton.click()
+    await detail.publishTournament()
     await expect(detail.startButton).toBeVisible()
 
     const entrants = await seedEntrants(
@@ -349,7 +349,7 @@ test.describe('Tournament — rr-then-ko draw', () => {
     }
 
     // ----- go live: the pool fixtures become real matches --------------------
-    await detail.startButton.click()
+    await detail.startTournament()
     await expect(detail.endButton).toBeVisible()
 
     // ----- play the POOL STAGE, and only it, over the API --------------------

--- a/e2e/tests/tournament-swiss.spec.ts
+++ b/e2e/tests/tournament-swiss.spec.ts
@@ -353,7 +353,10 @@ async function goLive(page: Page, detail: TournamentDetailPage): Promise<void> {
   const transitionPost = page.waitForResponse(
     (r) => r.url().endsWith('/transitions') && r.request().method() === 'POST',
   )
-  await detail.startButton.click()
+  // `startTournament`, not `startButton.click()`: the header's button only opens the
+  // confirm now, and the transition is fired by the dialog's. Armed before the act so the
+  // response lands inside the wait either way.
+  await detail.startTournament()
   const response = await transitionPost
   expect(
     response.status(),
@@ -526,7 +529,7 @@ test.describe('Tournament — swiss draw', () => {
     const eventId = await authorSwissEvent(page, detail, director, tournamentId)
 
     // ----- publish, then fill the field --------------------------------------
-    await detail.publishButton.click()
+    await detail.publishTournament()
     await expect(detail.startButton).toBeVisible()
 
     const entrants = await seedEntrants(
@@ -616,7 +619,7 @@ test.describe('Tournament — swiss draw', () => {
 
     const eventId = await authorSwissEvent(page, detail, director, tournamentId)
 
-    await detail.publishButton.click()
+    await detail.publishTournament()
     await expect(detail.startButton).toBeVisible()
 
     const entrants = await seedEntrants(
@@ -758,7 +761,7 @@ test.describe('Tournament — swiss draw', () => {
 
     const eventId = await authorSwissEvent(page, detail, director, tournamentId)
 
-    await detail.publishButton.click()
+    await detail.publishTournament()
     await expect(detail.startButton).toBeVisible()
 
     const entrants = await seedEntrants(
@@ -934,7 +937,7 @@ test.describe('Tournament — swiss draw', () => {
 
     const eventId = await authorSwissEvent(page, detail, director, tournamentId)
 
-    await detail.publishButton.click()
+    await detail.publishTournament()
     await expect(detail.startButton).toBeVisible()
 
     const entrants = await seedEntrants(
@@ -1171,7 +1174,7 @@ test.describe('Tournament — swiss draw', () => {
       BUCHHOLZ_ROUNDS,
     )
 
-    await detail.publishButton.click()
+    await detail.publishTournament()
     await expect(detail.startButton).toBeVisible()
 
     const entrants = await seedEntrants(

--- a/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
+++ b/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
@@ -118,7 +118,14 @@ export class TournamentDetailPage {
   /** ANY lifecycle button — the locator for the two states in which the header
    * must offer *none*: an archived tournament (no edge out of it), and a viewer
    * (every transition is owner-only). `toHaveCount(0)` against a per-edge locator
-   * would only prove the absence of the one edge it named. */
+   * would only prove the absence of the one edge it named.
+   *
+   * The regex is **anchored**, and that is load-bearing: the confirm dialog's own buttons
+   * are verb-plus-object (`Publish the tournament`, `Start the tournament`), so anchoring
+   * keeps this counting the HEADER's buttons alone. It stopped being a live hazard when
+   * the publish confirm was renamed off the bare `Publish` this pattern also matches —
+   * until then, a count taken with that dialog open could resolve to the dialog's button
+   * and pass while measuring the wrong control. */
   get anyLifecycleButton(): Locator {
     return this.page.getByRole('button', {
       name: /^(Publish|Start tournament|End tournament)$/,

--- a/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
+++ b/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
@@ -189,11 +189,15 @@ export class TournamentDetailPage {
     return this.page.getByRole('button', { name: `Delete draw for ${eventName}` })
   }
 
-  /** The consequence-stating confirm that Re-cut and Delete open, and the button that
-   * actually fires the act (ADR "a confirm prices an irreversible act, a freeze explains
-   * an illegal one"). Addressed by testid, because the label is the act's own verb —
-   * `Re-cut the draw` / `Delete the draw` — not a fixed string. **Generate opens no
-   * dialog**: the first cut is one click, by design. */
+  /** The consequence-stating confirm that every irreversible act opens, and the button
+   * that actually fires it (ADR "a confirm prices an irreversible act, a freeze explains
+   * an illegal one"). Five acts share it: the two draw verbs (Re-cut, Delete) and the
+   * three lifecycle edges (Publish, Start tournament, End tournament) — the lifecycle is
+   * forward-only, so none of its edges can be walked back either.
+   *
+   * Addressed by testid, because the label is the act's own verb — `Re-cut the draw`,
+   * `Start the tournament` — not a fixed string. **Generate draw opens no dialog**: the
+   * first cut is one click, by design. */
   get irreversibleActConfirmButton(): Locator {
     return this.page.getByTestId('confirm-irreversible-act-confirm')
   }

--- a/web-client/e2e/tournaments/tournament-draw.spec.ts
+++ b/web-client/e2e/tournaments/tournament-draw.spec.ts
@@ -391,7 +391,12 @@ test.describe('Tournaments · going live needs a current draw', () => {
     await pom.enterButton(EVENT.JOURNEY).click()
     await expect(pom.withdrawButton(EVENT.JOURNEY)).toBeVisible()
 
+    // Starting is priced too — registration shuts and every ready fixture becomes a real
+    // match — so the refusal below is answered to the confirm's own button, not to the
+    // header's. What the director reads afterwards is unchanged: the server's sentence,
+    // inline, where the click was.
     await pom.lifecycleButton('Start tournament').click()
+    await pom.irreversibleActConfirmButton.click()
 
     // THE assertion, half one: the refusal is inline, beside the button that was clicked,
     // and it is a WORK LIST — it names the event whose draw went stale. A director with
@@ -423,6 +428,7 @@ test.describe('Tournaments · going live needs a current draw', () => {
     await expect(pom.drawPanel(EVENT.JOURNEY)).toContainText(ME.username)
 
     await pom.lifecycleButton('Start tournament').click()
+    await pom.irreversibleActConfirmButton.click()
 
     await pom.expectLifecycle('Live', 'End tournament')
     expect(store.status).toBe('live')
@@ -443,6 +449,7 @@ test.describe('Tournaments · going live needs a current draw', () => {
     })
 
     await pom.lifecycleButton('Start tournament').click()
+    await pom.irreversibleActConfirmButton.click()
 
     await expect(pom.lifecycleNotice).toBeVisible()
     await expect(pom.lifecycleNotice).toContainText(SAY.cannotStart)
@@ -688,6 +695,7 @@ test.describe('Tournaments · the draw · accessibility', () => {
     await expect(pom.withdrawButton(EVENT.JOURNEY)).toBeVisible()
 
     await pom.lifecycleButton('Start tournament').click()
+    await pom.irreversibleActConfirmButton.click()
     await expect(pom.lifecycleNotice).toContainText(SAY.staleDraw)
 
     await expectAxeClean(page, 'tournament detail — the refused go-live notice')

--- a/web-client/e2e/tournaments/tournament-lifecycle.spec.ts
+++ b/web-client/e2e/tournaments/tournament-lifecycle.spec.ts
@@ -76,13 +76,19 @@ test.describe('Tournaments · the lifecycle', () => {
     // went would fail here rather than pass on "the one I asked for is present".
     await pom.expectLifecycle('Draft', 'Publish')
 
+    // Every edge is priced before it is posted: the header's button opens the confirm and
+    // the confirm's own button is what moves the tournament. The lifecycle is
+    // forward-only, so all three get one.
     await pom.lifecycleButton('Publish').click()
+    await pom.irreversibleActConfirmButton.click()
     await pom.expectLifecycle('Published', 'Start tournament')
 
     await pom.lifecycleButton('Start tournament').click()
+    await pom.irreversibleActConfirmButton.click()
     await pom.expectLifecycle('Live', 'End tournament')
 
     await pom.lifecycleButton('End tournament').click()
+    await pom.irreversibleActConfirmButton.click()
     // `archived` is terminal: no edge out of it, so no button — not a disabled
     // one. This is the assertion that would fail if the header ever went back to
     // offering all three.
@@ -120,7 +126,11 @@ test.describe('Tournaments · the lifecycle', () => {
     await expect(pom.enterButton(EVENT.JOURNEY)).toHaveCount(0)
 
     // --- publish: the door opens ---------------------------------------------
+    // Priced first — the confirm's button is what publishes. The dialog is dismissed by
+    // that click, which matters here: the modal overlay would otherwise swallow the Enter
+    // click below.
     await pom.lifecycleButton('Publish').click()
+    await pom.irreversibleActConfirmButton.click()
 
     await expect(pom.enterButton(EVENT.JOURNEY)).toBeVisible()
     await expect(pom.registrationNotice(EVENT.JOURNEY)).toHaveCount(0)
@@ -146,6 +156,7 @@ test.describe('Tournaments · the lifecycle', () => {
     await expect(pom.drawPanel(EVENT.JOURNEY)).toContainText(ME.username)
 
     await pom.lifecycleButton('Start tournament').click()
+    await pom.irreversibleActConfirmButton.click()
 
     // THE assertion of this slice's subtlest case. I am still an entrant — the
     // field is fixed, which is what going live MEANS — so my chip stays on the
@@ -168,6 +179,7 @@ test.describe('Tournaments · the lifecycle', () => {
     // "under way" and "has ended" are two states, not one "closed": a player who
     // arrives late is owed the difference.
     await pom.lifecycleButton('End tournament').click()
+    await pom.irreversibleActConfirmButton.click()
 
     await expect(pom.registrationNotice(EVENT.JOURNEY)).toContainText(
       NOTICE.archived.reason,
@@ -201,7 +213,10 @@ test.describe('Tournaments · the lifecycle', () => {
     await pom.expectLifecycle('Draft', 'Publish')
 
     // --- click the button that names an edge which no longer exists -----------
+    // Through the confirm, because that is the only way anything is sent. A confirm
+    // prices an act; it cannot tell that this one is already spent.
     await pom.lifecycleButton('Publish').click()
+    await pom.irreversibleActConfirmButton.click()
 
     // The server refuses it: `published → published` is not an edge, it is a
     // conflict (ADR-0017 — "the only caller that sends it is a stale one").
@@ -244,6 +259,7 @@ test.describe('Tournaments · the lifecycle', () => {
     // …and the corrected view is a WORKING one, not a picture: the edge it now
     // offers is one the server accepts.
     await pom.lifecycleButton('Start tournament').click()
+    await pom.irreversibleActConfirmButton.click()
     await pom.expectLifecycle('Live', 'End tournament')
     expect(store.status).toBe('live')
 
@@ -477,6 +493,7 @@ test.describe('Tournaments · the lifecycle · accessibility', () => {
     })
     store.transitionElsewhere('published')
     await pom.lifecycleButton('Publish').click()
+    await pom.irreversibleActConfirmButton.click()
 
     // Prove the state is really rendered before scanning it: an axe pass over a page
     // that has not reached the state is a green that means nothing. (And unlike the
@@ -485,6 +502,30 @@ test.describe('Tournaments · the lifecycle · accessibility', () => {
 
     await expectAxeClean(page, 'tournament detail — refused transition notice')
     await expect(pom.lifecycleNotice).toBeVisible()
+  })
+
+  /**
+   * The **confirm** is a state too, and it is the one where the choice of button
+   * treatment is cashed out. No `exclude` is passed, deliberately: the three lifecycle
+   * edges wear the default confirm rather than `variant="destructive"`, which fails AA
+   * colour contrast (#1039, open) and forces a `KNOWN_DESTRUCTIVE_BUTTON_CONTRAST`
+   * exclusion everywhere it appears in this suite. If somebody paints these red, this
+   * scan goes red with them.
+   */
+  test('is axe-clean with the Start confirm on screen, and needs no contrast exclusion', async ({
+    page,
+  }) => {
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      ...READY_TO_START,
+      status: 'published',
+    })
+
+    await pom.lifecycleButton('Start tournament').click()
+    // Prove the dialog is really up before scanning it — an axe pass over a page that
+    // has not reached the state is a green that means nothing.
+    await expect(pom.irreversibleActConfirmButton).toBeVisible()
+
+    await expectAxeClean(page, 'tournament detail — the Start tournament confirm')
   })
 
   test('is axe-clean for a viewer, who is offered no lifecycle button at all', async ({

--- a/web-client/src/components/tournaments/data/lifecycle.ts
+++ b/web-client/src/components/tournaments/data/lifecycle.ts
@@ -44,6 +44,20 @@ export interface LifecycleEdge {
   verb: string
   icon: LucideIcon
   tone: LifecycleTone
+  /** Which consequence the confirm prices before this edge is posted — every edge has
+   * one, because the lifecycle is forward-only and none of the three can be walked back
+   * (ADR "a confirm prices an irreversible act, a freeze explains an illegal one").
+   *
+   * It sits on the edge for the same reason `verb` does: everything the UI knows about an
+   * edge is on the edge, so a new one cannot acquire a button without also acquiring the
+   * question asked before it. A separate table keyed on the target status would need an
+   * unreachable `draft` row to stay total, and could disagree with this one.
+   *
+   * Spelled as bare literals rather than imported from
+   * `IrreversibleActConsequence['variant']`: this is the data layer, and it must not
+   * depend on the component that renders it. `LifecycleActions` makes the join, and the
+   * compiler checks it there. */
+  confirm: 'publish-tournament' | 'start-tournament' | 'end-tournament'
 }
 
 /**
@@ -70,6 +84,7 @@ export const LIFECYCLE_EDGE: Record<TournamentStatus, LifecycleEdge | null> = {
     verb: 'publish the tournament',
     icon: Rocket,
     tone: 'default',
+    confirm: 'publish-tournament',
   },
   published: {
     to: 'live',
@@ -77,6 +92,7 @@ export const LIFECYCLE_EDGE: Record<TournamentStatus, LifecycleEdge | null> = {
     verb: 'start the tournament',
     icon: Radio,
     tone: 'go-live',
+    confirm: 'start-tournament',
   },
   live: {
     to: 'archived',
@@ -84,6 +100,7 @@ export const LIFECYCLE_EDGE: Record<TournamentStatus, LifecycleEdge | null> = {
     verb: 'end the tournament',
     icon: Square,
     tone: 'ghost',
+    confirm: 'end-tournament',
   },
   archived: null,
 }

--- a/web-client/src/components/tournaments/tournament-detail-page.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.page.tsx
@@ -7,6 +7,7 @@ import {
   type TournamentDetailPageProps,
 } from './tournament-detail-page'
 import { buildTournamentDetailPageProps } from './tournament-detail-page.factory'
+import { confirmIrreversibleActDialogPage } from './tournament-detail-page/confirm-irreversible-act-dialog.page'
 import { eventsTabPage } from './tournament-detail-page/events-tab.page'
 
 const scoped = (container: Container) => ({
@@ -38,6 +39,17 @@ const scoped = (container: Container) => ({
   getLifecycleButton(name: RegExp) {
     return container.getByRole('button', { name })
   },
+  /** The **confirm** every lifecycle edge is gated by (ADR "a confirm prices an
+   * irreversible act…"): the header's button opens it and posts nothing, and the
+   * transition is fired by the dialog's own button. Addressed at `screen` whatever the
+   * scope, because the dialog portals to the document body.
+   *
+   * Named `lifecycleConfirm`, not `confirm`: the Events tab spreads a `confirm` of its
+   * own for the two draw acts, and one name for both would be the last spread silently
+   * winning. The rename buys a readable call site, **not** isolation — there is one
+   * dialog component behind one testid, so both accessors resolve to whichever act is
+   * open. Nothing here opens two at once, and nothing should. */
+  lifecycleConfirm: confirmIrreversibleActDialogPage.within(screen),
   /** The hero's status pill (`StatusBadge`) — the page's one claim about where the
    * tournament stands. Read it after a refused transition: nothing here is optimistic,
    * so a refused **Start tournament** must leave it saying **Published**. */

--- a/web-client/src/components/tournaments/tournament-detail-page.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page.test.tsx
@@ -266,6 +266,9 @@ describe('TournamentDetailPage', () => {
     })
 
     await userEvent.click(tournamentDetailPagePage.getLifecycleButton(/Publish/))
+    // Publishing is one-way, so it is priced first: the header's click opens the confirm
+    // and the confirm's own button is what posts.
+    await userEvent.click(tournamentDetailPagePage.lifecycleConfirm.getConfirmButton())
 
     await waitFor(() => expect(seen).toHaveLength(1))
     expect(seen[0].url).toContain('/v1/tournaments/t-1/transitions')
@@ -302,6 +305,7 @@ describe('TournamentDetailPage', () => {
     await userEvent.click(
       tournamentDetailPagePage.getLifecycleButton(/Start tournament/),
     )
+    await userEvent.click(tournamentDetailPagePage.lifecycleConfirm.getConfirmButton())
 
     const notice = await tournamentDetailPagePage.findLifecycleNoticeText()
     expect(notice).toContain("Couldn't start the tournament")

--- a/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.factory.tsx
@@ -19,6 +19,47 @@ export function buildDeleteDrawConsequence(
   return { variant: 'delete-draw', eventName: "Men's Singles", ...overrides }
 }
 
+/** The **publish** consequence — a draft tournament opening to the public. Named after a
+ * *tournament*, not an event: a lifecycle act moves the whole thing. */
+export function buildPublishTournamentConsequence(
+  overrides: Partial<
+    Extract<IrreversibleActConsequence, { variant: 'publish-tournament' }>
+  > = {},
+): IrreversibleActConsequence {
+  return {
+    variant: 'publish-tournament',
+    tournamentName: 'Bay Area Open 2026',
+    ...overrides,
+  }
+}
+
+/** The **start** consequence — registration closing and every ready fixture becoming a
+ * real match (#788). */
+export function buildStartTournamentConsequence(
+  overrides: Partial<
+    Extract<IrreversibleActConsequence, { variant: 'start-tournament' }>
+  > = {},
+): IrreversibleActConsequence {
+  return {
+    variant: 'start-tournament',
+    tournamentName: 'Bay Area Open 2026',
+    ...overrides,
+  }
+}
+
+/** The **end** consequence — the move into `archived`, which has no edge out of it. */
+export function buildEndTournamentConsequence(
+  overrides: Partial<
+    Extract<IrreversibleActConsequence, { variant: 'end-tournament' }>
+  > = {},
+): IrreversibleActConsequence {
+  return {
+    variant: 'end-tournament',
+    tournamentName: 'Bay Area Open 2026',
+    ...overrides,
+  }
+}
+
 /** Props for `ConfirmIrreversibleActDialog` — an open **re-cut** confirm on
  * `Men's Singles`. A test that wants the delete act passes a `consequence` of its own. */
 export function buildConfirmIrreversibleActDialogProps(

--- a/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.test.tsx
@@ -74,7 +74,11 @@ describe('ConfirmIrreversibleActDialog', () => {
     expect(dialog).toHaveTextContent('puts it in front of everybody')
     expect(dialog).toHaveTextContent('players can find it and enter it')
     expect(dialog).toHaveTextContent('There is no un-publishing it.')
-    expect(page.getConfirmButton()).toHaveTextContent('Publish')
+    // Verb plus object, like every other act's button — and asserted as an EXACT name,
+    // because a bare `Publish` is what the header's own button says: two controls sharing
+    // one accessible name put them in the same role query, where an assertion meant for
+    // one can resolve to the other and pass while checking nothing.
+    expect(page.getConfirmButton()).toHaveAccessibleName('Publish the tournament')
   })
 
   it('prices a START: registration shuts and every ready fixture becomes a real match', () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.test.tsx
@@ -1,6 +1,9 @@
 import {
   buildDeleteDrawConsequence,
+  buildEndTournamentConsequence,
+  buildPublishTournamentConsequence,
   buildRecutDrawConsequence,
+  buildStartTournamentConsequence,
 } from './confirm-irreversible-act-dialog.factory'
 import { confirmIrreversibleActDialogPage as page } from './confirm-irreversible-act-dialog.page'
 
@@ -41,10 +44,139 @@ describe('ConfirmIrreversibleActDialog', () => {
     expect(page.getConfirmButton()).toHaveTextContent('Delete the draw')
   })
 
-  it('neither variant borrows the other act’s sentence', () => {
+  it('neither draw variant borrows the other act’s sentence', () => {
     page.render({ consequence: buildRecutDrawConsequence() })
     expect(page.getDialog()).not.toHaveTextContent('Nothing is kept.')
     expect(page.getConfirmButton()).not.toHaveTextContent('Delete the draw')
+  })
+
+  /**
+   * The three **lifecycle** edges (ADR-0017): `draft → published → live → archived`, with
+   * no edge back and `archived` terminal. They are one-way exactly as the draw acts are,
+   * and each is priced in its own terms — what it opens, what it mints, where it ends.
+   *
+   * The copy is asserted phrase by phrase rather than by "some dialog appeared", because
+   * the ADR's whole demand is that a variant cannot borrow another act's sentence: a
+   * generic "This cannot be undone. Continue?" would satisfy every looser assertion.
+   */
+  it('prices a PUBLISH: the tournament leaves the drafts and becomes enterable by anyone', () => {
+    page.render({
+      consequence: buildPublishTournamentConsequence({
+        tournamentName: 'Spring Open',
+      }),
+    })
+
+    const dialog = page.getDialog()
+    expect(dialog).toHaveTextContent('Publish this tournament?')
+    // The TOURNAMENT is named — not an event. A lifecycle act moves the whole thing.
+    expect(dialog).toHaveTextContent('Publishing Spring Open')
+    // The visibility boundary, which is what this edge and only this edge crosses.
+    expect(dialog).toHaveTextContent('puts it in front of everybody')
+    expect(dialog).toHaveTextContent('players can find it and enter it')
+    expect(dialog).toHaveTextContent('There is no un-publishing it.')
+    expect(page.getConfirmButton()).toHaveTextContent('Publish')
+  })
+
+  it('prices a START: registration shuts and every ready fixture becomes a real match', () => {
+    page.render({
+      consequence: buildStartTournamentConsequence({
+        tournamentName: 'Spring Open',
+      }),
+    })
+
+    const dialog = page.getDialog()
+    expect(dialog).toHaveTextContent('Start this tournament?')
+    expect(dialog).toHaveTextContent('Starting Spring Open')
+    // BOTH halves. Since #788 this edge spends the players' attention, not merely the
+    // tournament's visibility, and copy that named only the closing window would be
+    // pricing the smaller half of what the click buys.
+    expect(dialog).toHaveTextContent('closes registration for good')
+    expect(dialog).toHaveTextContent(
+      'turns every ready fixture into a match its players can go and play',
+    )
+    expect(dialog).toHaveTextContent('It cannot be un-started.')
+    expect(page.getConfirmButton()).toHaveTextContent('Start the tournament')
+  })
+
+  it('prices an END: archived is terminal, with no edge out of it', () => {
+    page.render({
+      consequence: buildEndTournamentConsequence({ tournamentName: 'Spring Open' }),
+    })
+
+    const dialog = page.getDialog()
+    expect(dialog).toHaveTextContent('End this tournament?')
+    expect(dialog).toHaveTextContent('Ending Spring Open')
+    expect(dialog).toHaveTextContent('archived is the last thing a tournament is')
+    expect(dialog).toHaveTextContent('no way back to live and no way to re-open it')
+    expect(page.getConfirmButton()).toHaveTextContent('End the tournament')
+  })
+
+  // Said the other way round, across all five: the sum type exists so that a variant
+  // cannot render another act's sentence, and "X is present" alone would never catch a
+  // dialog that also said everything else — or a generic "This cannot be undone" that
+  // said nothing in particular.
+  const SAID = {
+    'recut-draw': 'deals a completely new set of pairings',
+    'delete-draw': 'Nothing is kept.',
+    'publish-tournament': 'puts it in front of everybody',
+    'start-tournament': 'closes registration for good',
+    'end-tournament': 'archived is the last thing a tournament is',
+  } as const
+
+  it.each([
+    { variant: 'recut-draw', consequence: buildRecutDrawConsequence() },
+    { variant: 'delete-draw', consequence: buildDeleteDrawConsequence() },
+    {
+      variant: 'publish-tournament',
+      consequence: buildPublishTournamentConsequence(),
+    },
+    { variant: 'start-tournament', consequence: buildStartTournamentConsequence() },
+    { variant: 'end-tournament', consequence: buildEndTournamentConsequence() },
+  ] as const)(
+    'gives $variant a sentence no other act says',
+    ({ variant, consequence }) => {
+      page.render({ consequence })
+
+      for (const [other, sentence] of Object.entries(SAID)) {
+        if (other === variant) expect(page.getDialog()).toHaveTextContent(sentence)
+        else expect(page.getDialog()).not.toHaveTextContent(sentence)
+      }
+    },
+  )
+
+  /**
+   * The button treatment, per act — decided in the same switch that writes the copy.
+   *
+   * `destructive` is for the two verbs that throw work away (pairings, and the schedule
+   * solved on them). The three lifecycle edges destroy nothing: publishing opens a door,
+   * starting mints matches, ending archives. They are one-way, which is what earns them
+   * the dialog — not destructive, which is what would earn them the red. It also keeps
+   * them off `variant="destructive"`, which fails AA colour contrast (#1039, open) and
+   * carries an axe exclusion wherever it is on screen in `e2e/tournaments/`.
+   */
+  it.each([
+    { name: 'a re-cut', consequence: buildRecutDrawConsequence(), destructive: true },
+    { name: 'a delete', consequence: buildDeleteDrawConsequence(), destructive: true },
+    {
+      name: 'a publish',
+      consequence: buildPublishTournamentConsequence(),
+      destructive: false,
+    },
+    {
+      name: 'a start',
+      consequence: buildStartTournamentConsequence(),
+      destructive: false,
+    },
+    { name: 'an end', consequence: buildEndTournamentConsequence(), destructive: false },
+  ])('paints the confirm for $name', ({ consequence, destructive }) => {
+    page.render({ consequence })
+
+    // `bg-destructive` is the class the axe exclusion is keyed on
+    // (`KNOWN_DESTRUCTIVE_BUTTON_CONTRAST`), so it is the thing worth pinning rather
+    // than a prop name that never reaches the DOM.
+    expect(page.getConfirmButton().className.includes('bg-destructive')).toBe(
+      destructive,
+    )
   })
 
   it('reports the confirm ONCE and as no kind of cancel — Radix closes on the action click through the same channel Escape uses', () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.tsx
@@ -40,11 +40,20 @@ import {
 export type DrawActConsequence =
   | { variant: 'recut-draw'; eventName: string }
   | { variant: 'delete-draw'; eventName: string }
+
+/** The acts that belong to a **tournament's lifecycle** — the mirror of
+ * `DrawActConsequence`, and narrow for the same reason: `LifecycleActions` owns exactly
+ * these three, so its state must be unable to hold a draw act it has no way to perform.
+ * The two aliases are what keep the wide union out of both components; nothing but the
+ * dialog itself is typed on `IrreversibleActConsequence`. */
+export type LifecycleActConsequence =
   | { variant: 'publish-tournament'; tournamentName: string }
   | { variant: 'start-tournament'; tournamentName: string }
   | { variant: 'end-tournament'; tournamentName: string }
 
-export type IrreversibleActConsequence = DrawActConsequence
+export type IrreversibleActConsequence =
+  | DrawActConsequence
+  | LifecycleActConsequence
 
 export interface ConfirmIrreversibleActDialogProps {
   open: boolean
@@ -150,7 +159,11 @@ export const ConfirmIrreversibleActDialog = ({
               enter it from this moment on. There is no un-publishing it.
             </>
           ),
-          confirmLabel: 'Publish',
+          // Verb plus object, like every other act's button — and never the bare
+          // `Publish` the HEADER button says. Two controls with one accessible name put
+          // the dialog's button and the header's in the same role query, so an assertion
+          // that meant one could resolve to the other and pass while checking nothing.
+          confirmLabel: 'Publish the tournament',
           confirmVariant: 'default' as const,
         }
       // The costliest of the three, and the reason none of them is exempt: since #788

--- a/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.tsx
@@ -14,17 +14,22 @@ import {
 /**
  * What confirming would SPEND — the dialog's whole content, as a sum type (no bag of
  * optional props): each variant carries exactly the context its copy names, so a draw
- * act cannot be rendered without the event whose pairings it discards (ADR
- * "a confirm prices an irreversible act, a freeze explains an illegal one").
+ * act cannot be rendered without the event whose pairings it discards, nor a lifecycle
+ * act without the tournament it moves (ADR "a confirm prices an irreversible act, a
+ * freeze explains an illegal one").
  *
- * The union is deliberately open: the three lifecycle edges (publish / start / end) are
- * the same kind of one-way act and join it later. The `never` default in the body switch
- * is what keeps that honest — a variant added here is a **type error** until it has copy
- * of its own, rather than a dialog that silently renders another act's sentence.
+ * Five acts, of two kinds. The two **draw** acts discard a standing draw and the schedule
+ * solved on it. The three **lifecycle** edges are the forward-only path a tournament walks
+ * — `draft → published → live → archived` — with no edge back and `archived` terminal, so
+ * every one of them is one-way too.
+ *
+ * The `never` default in the body switch is what keeps the union honest: a variant added
+ * here is a **type error** until it has copy of its own, rather than a dialog that
+ * silently renders another act's sentence.
  *
  * Note what is NOT shared across the variants: there is no top-level `eventName` prop.
- * A lifecycle act is about a *tournament*, not an event, so hoisting the name would
- * oblige every future variant to supply a field its copy never says.
+ * A lifecycle act is about a *tournament*, not an event, so hoisting either name would
+ * oblige the other kind of variant to supply a field its copy never says.
  */
 /** The acts that belong to an event's **draw**. Named apart from the whole union
  * because the draw panel owns exactly these and must be able to say so: a component
@@ -35,6 +40,9 @@ import {
 export type DrawActConsequence =
   | { variant: 'recut-draw'; eventName: string }
   | { variant: 'delete-draw'; eventName: string }
+  | { variant: 'publish-tournament'; tournamentName: string }
+  | { variant: 'start-tournament'; tournamentName: string }
+  | { variant: 'end-tournament'; tournamentName: string }
 
 export type IrreversibleActConsequence = DrawActConsequence
 
@@ -50,27 +58,46 @@ const Strong = ({ children }: { children: React.ReactNode }) => (
 )
 
 /**
- * The consequence-stating confirm on an act a director **cannot undo**. Today the two
- * draw acts: re-cutting a standing draw, and deleting one. The first cut is exempt by
- * design — it is constructive and re-cuttable, and a confirm there would only train the
- * director to click through the ones that matter.
+ * The consequence-stating confirm on an act a director **cannot undo**: the two draw acts
+ * (re-cutting a standing draw, deleting one) and the three lifecycle edges (publish,
+ * start, end). The first cut of a draw is exempt by design — it is constructive and
+ * re-cuttable, and a confirm there would only train the director to click through the
+ * ones that matter.
  *
- * The body names what the click *discards*, in the director's own terms, and names the
- * **event** with it: the Events tab renders one card per event, so "the draw" alone is
- * ambiguous the moment a tournament has more than one.
+ * The body names what the click *spends*, in the director's own terms, and names the
+ * thing it spends it on: the **event** for a draw act (the Events tab renders one card
+ * per event, so "the draw" alone is ambiguous the moment a tournament has more than one),
+ * the **tournament** for a lifecycle one.
  *
- * The confirm button carries the act's own verb — `Re-cut the draw` / `Delete the draw` —
- * never a bare "OK" or "Confirm". Cancel is a no-op, and so is Escape — nothing fires.
+ * The confirm button carries the act's own verb — `Re-cut the draw`, `Start the
+ * tournament` — never a bare "OK" or "Confirm". Cancel is a no-op, and so is Escape —
+ * nothing fires.
  *
  * A click on the **overlay does nothing at all**: Radix's `AlertDialogContent`
  * `preventDefault`s both `onPointerDownOutside` and `onInteractOutside`, so the dialog
- * neither closes nor reports a cancel. That is the behaviour a destructive confirm wants —
- * a mis-click beside "Delete this draw?" must not dismiss it — so do not "restore" an
- * outside-click dismissal here. It is a property of `AlertDialog`, and it is the reason to
- * use `AlertDialog` rather than `Dialog` for a decision.
+ * neither closes nor reports a cancel. That is the behaviour a consequential confirm
+ * wants — a mis-click beside "Delete this draw?" must not dismiss it — so do not
+ * "restore" an outside-click dismissal here. It is a property of `AlertDialog`, and it is
+ * the reason to use `AlertDialog` rather than `Dialog` for a decision.
  *
  * Focus is trapped, and Radix's own `onOpenAutoFocus` lands it on **Go back** — the safe
- * default when the other button destroys something.
+ * default when the other button spends something that does not come back.
+ *
+ * ## Why only two of the five wear the destructive treatment
+ *
+ * The confirm's `variant` is decided by the same `switch` that writes the copy, so a new
+ * variant cannot acquire a sentence without also answering for how its button looks.
+ * `destructive` is reserved for the acts that **throw work away** — the two draw verbs
+ * discard pairings and the schedule solved on them. The three lifecycle edges destroy
+ * nothing: publishing opens a door, starting mints matches, ending archives. They are
+ * consequential and one-way, which is what earns them a dialog — not destructive, which
+ * is what would earn them the red.
+ *
+ * There is a second reason not to spend the red here. `variant="destructive"` fails AA
+ * colour contrast (#1039, open), which is why `e2e/tournaments/` carries a
+ * `KNOWN_DESTRUCTIVE_BUTTON_CONTRAST` axe exclusion wherever one is on screen. Painting
+ * three more surfaces with it would widen a known defect to the lifecycle flows for
+ * nothing the copy does not already say.
  */
 export const ConfirmIrreversibleActDialog = ({
   open,
@@ -96,6 +123,7 @@ export const ConfirmIrreversibleActDialog = ({
             </>
           ),
           confirmLabel: 'Re-cut the draw',
+          confirmVariant: 'destructive' as const,
         }
       case 'delete-draw':
         return {
@@ -108,6 +136,53 @@ export const ConfirmIrreversibleActDialog = ({
             </>
           ),
           confirmLabel: 'Delete the draw',
+          confirmVariant: 'destructive' as const,
+        }
+      // The visibility boundary. A draft is the director's alone — a stranger's GET of
+      // one is a 404 (#967) — and publishing is what puts it in front of everybody else.
+      case 'publish-tournament':
+        return {
+          title: 'Publish this tournament?',
+          description: (
+            <>
+              Publishing <Strong>{consequence.tournamentName}</Strong> takes it out of
+              your drafts and puts it in front of everybody: players can find it and
+              enter it from this moment on. There is no un-publishing it.
+            </>
+          ),
+          confirmLabel: 'Publish',
+          confirmVariant: 'default' as const,
+        }
+      // The costliest of the three, and the reason none of them is exempt: since #788
+      // going live does not merely change a label, it MINTS the matches. The copy says
+      // both halves, because both are spent on the players and neither comes back.
+      case 'start-tournament':
+        return {
+          title: 'Start this tournament?',
+          description: (
+            <>
+              Starting <Strong>{consequence.tournamentName}</Strong> closes
+              registration for good — nobody can enter or withdraw afterwards — and
+              turns every ready fixture into a match its players can go and play. It
+              cannot be un-started.
+            </>
+          ),
+          confirmLabel: 'Start the tournament',
+          confirmVariant: 'default' as const,
+        }
+      // The one edge with nowhere to go afterwards.
+      case 'end-tournament':
+        return {
+          title: 'End this tournament?',
+          description: (
+            <>
+              Ending <Strong>{consequence.tournamentName}</Strong> archives it, and
+              archived is the last thing a tournament is. There is no way back to live
+              and no way to re-open it.
+            </>
+          ),
+          confirmLabel: 'End the tournament',
+          confirmVariant: 'default' as const,
         }
       default: {
         // A variant without copy of its own is a TYPE error here, not a dialog that
@@ -145,7 +220,9 @@ export const ConfirmIrreversibleActDialog = ({
           </AlertDialogCancel>
           <AlertDialogAction
             data-testid="confirm-irreversible-act-confirm"
-            variant="destructive"
+            // Decided by the act, in the same switch that wrote its sentence — see the
+            // component doc: the red is for the two verbs that throw work away.
+            variant={body.confirmVariant}
             onClick={() => {
               confirmed.current = true
               onConfirm()

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
@@ -25,19 +25,12 @@ import { ResultsPanel } from './draw-panel/results-panel'
 import { RoundList } from './draw-panel/round-list'
 import { SwissRounds } from './draw-panel/swiss-rounds'
 
-/**
- * The two acts THIS panel can price — the draw half of `IrreversibleActConsequence`.
- *
- * Narrowed rather than carrying the whole union, because the panel's `switch` below has
- * to be exhaustive over exactly what it can hold: the three lifecycle edges live in the
- * header (`../lifecycle-actions`) and there is no draw verb that could fire one. Widening
- * this would turn the `never` default into a dead arm that has to invent an answer for an
- * act the panel cannot perform.
- */
-type DrawActConsequence = Extract<
-  IrreversibleActConsequence,
-  { variant: 'recut-draw' | 'delete-draw' }
->
+// `DrawActConsequence` — the two acts THIS panel can price — is imported above rather
+// than re-derived here. It is narrower than `IrreversibleActConsequence` because the
+// panel's `switch` below has to be exhaustive over exactly what it can hold: the three
+// lifecycle edges live in the header (`../lifecycle-actions`) and there is no draw verb
+// that could fire one. Widening it would turn the `never` default into a dead arm that
+// has to invent an answer for an act the panel cannot perform.
 
 export interface DrawPanelProps {
   tournamentId: string

--- a/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/events-tab/draw-panel.tsx
@@ -25,6 +25,20 @@ import { ResultsPanel } from './draw-panel/results-panel'
 import { RoundList } from './draw-panel/round-list'
 import { SwissRounds } from './draw-panel/swiss-rounds'
 
+/**
+ * The two acts THIS panel can price — the draw half of `IrreversibleActConsequence`.
+ *
+ * Narrowed rather than carrying the whole union, because the panel's `switch` below has
+ * to be exhaustive over exactly what it can hold: the three lifecycle edges live in the
+ * header (`../lifecycle-actions`) and there is no draw verb that could fire one. Widening
+ * this would turn the `never` default into a dead arm that has to invent an answer for an
+ * act the panel cannot perform.
+ */
+type DrawActConsequence = Extract<
+  IrreversibleActConsequence,
+  { variant: 'recut-draw' | 'delete-draw' }
+>
+
 export interface DrawPanelProps {
   tournamentId: string
   event: TournamentEvent
@@ -125,8 +139,8 @@ export const DrawPanel = ({ tournamentId, event, canEdit }: DrawPanelProps) => {
   /** The confirmed act, fired. The switch is exhaustive on `DrawActConsequence` — the
    * acts this panel OWNS — so a third destructive draw verb is a TYPE error here rather
    * than a dialog that prices one act and performs another. Deliberately not the whole
-   * `IrreversibleActConsequence`: the lifecycle edges join that union later, and a panel
-   * checked against them would red in a slice it has no part in. */
+   * `IrreversibleActConsequence`: the lifecycle edges are in that union too, and a panel
+   * checked against them would red for acts it has no part in. */
   const runConfirmed = (consequence: DrawActConsequence) => {
     setPending(null)
     switch (consequence.variant) {

--- a/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.page.tsx
@@ -1,5 +1,7 @@
+import { interactiveElementsIn } from '@/test/read-only'
 import { render, screen, type Container } from '@/test/utilities'
 
+import { confirmIrreversibleActDialogPage } from './confirm-irreversible-act-dialog.page'
 import { LifecycleActions, type LifecycleActionsProps } from './lifecycle-actions'
 import { buildLifecycleActionsProps } from './lifecycle-actions.factory'
 
@@ -18,6 +20,25 @@ const scoped = (container: Container) => ({
     return container.queryAllByRole('button')
   },
 
+  /** Every control in the component's own root, swept by **DOM** rather than by role.
+   * The sweep an "is the button still live?" claim needs while the confirm is open:
+   * Radix marks everything behind a modal `aria-hidden`, so `queryAllByRole('button')`
+   * finds none of them and would pass vacuously. The dialog portals to the body, i.e.
+   * outside this root, so it never joins the count.
+   *
+   * ⚠️ Requires the component to have rendered something. It **throws** for a non-owner
+   * and for the terminal `archived`, where `LifecycleActions` returns `null` and there is
+   * no root to sweep. Those two cases want `queryAllButtons()`, whose `[]` is the
+   * assertion. */
+  getActionControls() {
+    return interactiveElementsIn(container.getByTestId('lifecycle-actions'))
+  },
+
+  /** The **confirm** every lifecycle edge is gated by — the button opens it and sends
+   * nothing; the transition is fired by the dialog's own button. Always addressed at
+   * `screen`, whatever the scope: the dialog portals to the document body. */
+  confirm: confirmIrreversibleActDialogPage.within(screen),
+
   /** The inline **refusal** — the 409 (a stale view, or go-live's precondition), and
    * every other failure, in the place the click happened. Found by role (`alert`),
    * which is the contract: it is the app talking back, and a screen reader must hear it
@@ -27,6 +48,13 @@ const scoped = (container: Container) => ({
   },
   findNotice() {
     return container.findByRole('alert')
+  },
+  /** The same notice, found by **testid** rather than by role — the accessor a test needs
+   * while the confirm is open. Radix marks everything behind a modal `aria-hidden`, so
+   * `queryByRole('alert')` finds nothing there and would report a standing refusal as
+   * gone. This one reads the DOM, where it actually still is. */
+  queryNoticeElement() {
+    return container.queryByTestId('lifecycle-notice')
   },
   /** The notice as one normalised string — title *and* the sentence beneath it, since
    * the whole point of the 409 copy is that the second half **names the events** the
@@ -50,6 +78,9 @@ const scoped = (container: Container) => ({
  * the transitions endpoint itself — `mockTournamentTransitionEndpoint`
  * (`@/mocks/endpoints/tournaments/tournaments.endpoint`). Rendering alone fetches
  * nothing.
+ *
+ * A test driving any of the three edges must go through `confirm`: clicking the lifecycle
+ * button alone opens the dialog and sends nothing, which is the whole point of it.
  */
 export const lifecycleActionsPage = {
   render(overrides: Partial<LifecycleActionsProps> = {}) {

--- a/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.page.tsx
@@ -83,8 +83,26 @@ const scoped = (container: Container) => ({
  * button alone opens the dialog and sends nothing, which is the whole point of it.
  */
 export const lifecycleActionsPage = {
+  /** Mount the header action. Returns the render result, plus `rerenderWith` — the only
+   * honest way to say "the tournament changed **underneath** this component", which is
+   * what a refetch landing under an open confirm does.
+   *
+   * ⚠️ Calling `render` a second time does NOT replace the first tree: Testing Library
+   * appends a second one and `screen` spans the whole body, so the queries would find two
+   * `lifecycle-actions` roots and the assertion would be about the wrong one (or throw on
+   * the ambiguity). Prop-change claims use this. */
   render(overrides: Partial<LifecycleActionsProps> = {}) {
-    render(<LifecycleActions {...buildLifecycleActionsProps(overrides)} />)
+    const utils = render(
+      <LifecycleActions {...buildLifecycleActionsProps(overrides)} />,
+    )
+    return {
+      ...utils,
+      rerenderWith(next: Partial<LifecycleActionsProps> = {}) {
+        utils.rerender(
+          <LifecycleActions {...buildLifecycleActionsProps(next)} />,
+        )
+      },
+    }
   },
 
   within(container: Container = screen) {

--- a/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.test.tsx
@@ -46,6 +46,12 @@ function refuseTransition(status: number, detail: string) {
   )
 }
 
+/** One shape of the go-live 409, short enough to read in an assertion: the server naming
+ * the event whose draw is missing. Hard-coded, not read from the mock store — a test that
+ * took the copy from the code it is testing would pass whatever the copy became. */
+const NO_DRAW_FOR_OPEN_SINGLES =
+  'This tournament cannot start yet: “Open Singles” has no draw yet.'
+
 /** Click **Start tournament** on a published tournament the viewer owns, and pay for it —
  * the one edge that carries a precondition (ADR-0786). Two clicks, because the button
  * opens the confirm and the confirm's own button is what posts. */
@@ -492,5 +498,154 @@ describe('LifecycleActions · the confirm on every edge', () => {
 
     expect(lifecycleActionsPage.queryAllButtons()).toHaveLength(0)
     expect(lifecycleActionsPage.confirm.queryDialog()).toBeNull()
+  })
+
+  // The dialog names the TOURNAMENT — by its name, which is the only handle a director
+  // has on it. Pinned because a component that passed `tournament.id` instead renders a
+  // sentence that is still grammatical, still one line, and still passed every other test
+  // in this file: "Starting bay-area-open-2026 closes registration for good".
+  it('names the tournament the director is about to move — its name, not its id', async () => {
+    lifecycleActionsPage.render({
+      tournament: buildTournament({
+        id: 't-1',
+        name: 'Bay Area Open 2026',
+        status: 'published',
+      }),
+    })
+
+    await userEvent.click(
+      lifecycleActionsPage.getLifecycleButton(/Start tournament/),
+    )
+
+    const dialog = lifecycleActionsPage.confirm.getDialog()
+    expect(dialog).toHaveTextContent('Bay Area Open 2026')
+    // The discriminating half: the id must not be what reached the copy.
+    expect(dialog).not.toHaveTextContent('t-1')
+  })
+})
+
+/**
+ * **The confirm posts the edge it PRICED** — the regression this file exists to hold shut.
+ *
+ * `edge` is recomputed from the `tournament` prop on every render, and this page polls
+ * (`useSchedulePolling`, ~3s on the Schedule tab). So the tournament can move underneath an
+ * open dialog: a co-director starts it from their phone while this director is reading
+ * "Start this tournament?", the refetch lands, and `edge` becomes `live → archived`.
+ *
+ * With the edge read live at confirm time, clicking **Start the tournament** posted
+ * `{ to: 'archived' }` — the app ENDING a tournament under a dialog that had just described
+ * starting it. Capturing the edge at the click is the fix, and a stale capture is the
+ * designed outcome: `(current, to)` is the server's judgement (ADR-0017), so it answers 409
+ * and this component renders that sentence inline. Being told beats silently performing an
+ * act nobody chose.
+ */
+describe('LifecycleActions · a refetch under the open confirm', () => {
+  it('posts the edge the dialog PRICED, not the one the refetch moved on to', async () => {
+    const seen = captureTransition()
+    const { rerenderWith } = lifecycleActionsPage.render({
+      tournament: buildTournament({ id: 't-1', status: 'published' }),
+    })
+
+    // The director opens the confirm on `published → live`.
+    await userEvent.click(
+      lifecycleActionsPage.getLifecycleButton(/Start tournament/),
+    )
+    expect(lifecycleActionsPage.confirm.getDialog()).toHaveTextContent(
+      'Start this tournament?',
+    )
+
+    // …and the tournament moves underneath them: somebody else started it, the poll
+    // landed, and the edge this component would compute is now `live → archived`.
+    rerenderWith({ tournament: buildTournament({ id: 't-1', status: 'live' }) })
+
+    // The refetch LANDED — the positive witness, and the half this test cannot do
+    // without: the dialog's own copy comes from the captured edge, so it reads "Start
+    // this tournament?" whether the new prop applied or not, and a `rerenderWith` that
+    // silently did nothing would leave every other assertion here green. The HEADER's
+    // button is the thing that moves, and it has moved on to `live → archived`.
+    //
+    // Read by DOM sweep, not by role: Radix marks everything behind the open modal
+    // `aria-hidden`, so `getByRole('button')` finds none of these and would report the
+    // header as empty either way.
+    expect(
+      lifecycleActionsPage.getActionControls().map((el) => el.textContent),
+    ).toEqual(['End tournament'])
+
+    // And the question they are answering is still the question they were asked.
+    expect(lifecycleActionsPage.confirm.getDialog()).toHaveTextContent(
+      'Start this tournament?',
+    )
+
+    await userEvent.click(lifecycleActionsPage.confirm.getConfirmButton())
+
+    await waitFor(() => expect(seen).toHaveLength(1))
+    // The whole regression, in one line: `{ to: 'live' }` is the act that was priced.
+    // `{ to: 'archived' }` is the act the live `edge` would have performed — ending the
+    // tournament — and it is a request too, so "something was sent" would pass either way.
+    expect(seen[0].body).toEqual({ to: 'live' })
+  })
+
+  /** The same capture, seen from the other end: a captured edge the server has since
+   * refused is a **409**, and the notice frames it with the edge the director actually
+   * clicked. A refusal titled after the edge now on offer would tell them the wrong move
+   * failed. */
+  it('reports a refused stale edge as the move the director made', async () => {
+    refuseTransition(409, 'This tournament is already live.')
+    const { rerenderWith } = lifecycleActionsPage.render({
+      tournament: buildTournament({ id: 't-1', status: 'published' }),
+    })
+
+    await userEvent.click(
+      lifecycleActionsPage.getLifecycleButton(/Start tournament/),
+    )
+    // No landing witness of its own: the test above pins that this same `rerenderWith`
+    // reaches the component, so a helper that stopped working reds there first.
+    rerenderWith({ tournament: buildTournament({ id: 't-1', status: 'live' }) })
+    await userEvent.click(lifecycleActionsPage.confirm.getConfirmButton())
+
+    const text = await lifecycleActionsPage.findNoticeText()
+    expect(text).toContain("Couldn't start the tournament")
+    expect(text).toContain('This tournament is already live.')
+    // Not the edge the refetch moved on to.
+    expect(text).not.toContain("Couldn't end the tournament")
+    expectNoToast()
+  })
+})
+
+/**
+ * The standing refusal is about the last **attempt**, and opening or cancelling a dialog is
+ * not one. A 409 on Start names the events whose draws are missing or stale — a work list
+ * the director reads *while* going to fix it — so a second look at the confirm, thought
+ * better of, must not take it away.
+ */
+describe('LifecycleActions · the refusal notice and the dialog', () => {
+  it('keeps a standing refusal when the director opens the confirm and goes back', async () => {
+    refuseTransition(409, NO_DRAW_FOR_OPEN_SINGLES)
+    lifecycleActionsPage.render({
+      tournament: buildTournament({ id: 't-1', status: 'published' }),
+    })
+
+    await userEvent.click(
+      lifecycleActionsPage.getLifecycleButton(/Start tournament/),
+    )
+    await userEvent.click(lifecycleActionsPage.confirm.getConfirmButton())
+    await lifecycleActionsPage.findNotice()
+
+    // Second thoughts: open the question again, then go back.
+    await userEvent.click(
+      lifecycleActionsPage.getLifecycleButton(/Start tournament/),
+    )
+    await userEvent.click(lifecycleActionsPage.confirm.getCancelButton())
+    await waitFor(() =>
+      expect(lifecycleActionsPage.confirm.queryDialog()).toBeNull(),
+    )
+
+    // Still there — a cancel sent nothing, so it changed nothing, so it explains nothing
+    // away. (Read by testid: while the dialog was up, Radix had this `aria-hidden`, and a
+    // role query would have reported a standing notice as gone.)
+    expect(lifecycleActionsPage.queryNoticeElement()).not.toBeNull()
+    expect(await lifecycleActionsPage.findNoticeText()).toContain(
+      '“Open Singles” has no draw yet',
+    )
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event'
-import { HttpResponse } from 'msw'
+import { delay, HttpResponse } from 'msw'
 import { toast } from 'sonner'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -46,13 +46,15 @@ function refuseTransition(status: number, detail: string) {
   )
 }
 
-/** Click **Start tournament** on a published tournament the viewer owns — the one edge
- * that carries a precondition (ADR-0786). */
+/** Click **Start tournament** on a published tournament the viewer owns, and pay for it —
+ * the one edge that carries a precondition (ADR-0786). Two clicks, because the button
+ * opens the confirm and the confirm's own button is what posts. */
 async function clickStart() {
   lifecycleActionsPage.render({
     tournament: buildTournament({ id: 't-1', status: 'published' }),
   })
   await userEvent.click(lifecycleActionsPage.getLifecycleButton(/Start tournament/))
+  await userEvent.click(lifecycleActionsPage.confirm.getConfirmButton())
 }
 
 /** No toast, ever, for a refusal this component reports inline (`web-client/CLAUDE.md`,
@@ -82,6 +84,9 @@ describe('LifecycleActions', () => {
       })
 
       await userEvent.click(lifecycleActionsPage.getLifecycleButton(label))
+      // The act is the CONFIRM's button, never the header's (see the confirm suite
+      // below). The header's click only asks the question.
+      await userEvent.click(lifecycleActionsPage.confirm.getConfirmButton())
 
       // The transitions RESOURCE, not a status-carrying PATCH: `TournamentUpdate`
       // has no `status` field, so a PATCH here would be a no-op that looked fine.
@@ -307,9 +312,185 @@ describe('LifecycleActions · the other outcomes', () => {
     await userEvent.click(
       lifecycleActionsPage.getLifecycleButton(/Start tournament/),
     )
+    // The standing refusal is STILL there at this point — opening the confirm is not an
+    // attempt, and the 409's work list is what the director is reading while they decide.
+    // It is cleared by the next attempt, not by the next question. Read by testid, not by
+    // role: the open dialog aria-hides everything behind it.
+    expect(lifecycleActionsPage.queryNoticeElement()).not.toBeNull()
+
+    await userEvent.click(lifecycleActionsPage.confirm.getConfirmButton())
 
     await waitFor(() =>
       expect(lifecycleActionsPage.queryNotice()).toBeNull(),
     )
+  })
+})
+
+/**
+ * **The confirm is what moves the tournament** (ADR "a confirm prices an irreversible act,
+ * a freeze explains an illegal one"). The lifecycle is forward-only — `draft → published
+ * → live → archived`, no edge back, `archived` terminal — so all three edges are one-way
+ * and all three are priced. None is exempt, and **Start** least of all: since #788 it does
+ * not merely relabel the tournament, it closes registration and mints a match for every
+ * ready fixture.
+ */
+describe('LifecycleActions · the confirm on every edge', () => {
+  /** What a successful transition answers with — a bare `TournamentRead`, as the API
+   * sends it. The stubs below are never *meant* to answer, but the body must still be one
+   * the parser accepts: a mutant that leaked a request past the confirm would otherwise
+   * reject on the payload rather than on the thing under test. */
+  const transitionRead = () => {
+    const { events, ...read } = buildTournamentDetailRead()
+    void events
+    return read
+  }
+
+  /** The panel's own controls that are still LIVE — swept by DOM rather than by role,
+   * because an open dialog puts `aria-hidden` over everything behind it and a role query
+   * then finds none of them. A header offers exactly one lifecycle button, and it goes
+   * dead while a transition is in flight, so the count is a synchronous read of "nothing
+   * was sent". */
+  const liveControls = () =>
+    lifecycleActionsPage
+      .getActionControls()
+      .filter((el) => !el.hasAttribute('disabled'))
+
+  /**
+   * The endpoint **hangs** (`delay('infinite')`) in these three, and that is what makes
+   * them evidence rather than a race. An edge wired to the dialog *and* the mutation would
+   * send a request that completes in milliseconds, and by the time an assertion ran
+   * `isPending` would be back to false and the header would look untouched. A request that
+   * never answers cannot settle away: it holds the button disabled for as long as the test
+   * cares to look, so "the button is still live" is a second witness to "nothing was sent"
+   * that does not depend on when MSW got there.
+   */
+  it.each([
+    { status: 'draft', label: /Publish/, title: 'Publish this tournament?' },
+    {
+      status: 'published',
+      label: /Start tournament/,
+      title: 'Start this tournament?',
+    },
+    { status: 'live', label: /End tournament/, title: 'End this tournament?' },
+  ] as const)(
+    'sends NOTHING on a bare click from $status — the dialog is what gates it',
+    async ({ status, label, title }) => {
+      let calls = 0
+      mockTournamentTransitionEndpoint(server, async () => {
+        calls += 1
+        await delay('infinite')
+        const { events, ...read } = buildTournamentDetailRead()
+        void events
+        return HttpResponse.json(read, { status: 201 })
+      })
+      lifecycleActionsPage.render({
+        tournament: buildTournament({ id: 't-1', status }),
+      })
+
+      await userEvent.click(lifecycleActionsPage.getLifecycleButton(label))
+
+      // Settle on the dialog first — the count is only evidence once the click has been
+      // given somewhere to have gone. Bounded under `testTimeout`, so a failure reads
+      // "unable to find role=alertdialog" rather than an undiscriminated 5s timeout
+      // (`web-client/CLAUDE.md`).
+      await waitFor(
+        () => expect(lifecycleActionsPage.confirm.getDialog()).toBeInTheDocument(),
+        { timeout: 2000 },
+      )
+      // …and it priced THIS edge, not another one.
+      expect(lifecycleActionsPage.confirm.getDialog()).toHaveTextContent(title)
+      expect(calls).toBe(0)
+      expect(liveControls()).toHaveLength(1)
+      expectNoToast()
+    },
+  )
+
+  // Go back is a no-op: the tournament stands exactly where it was, and the button that
+  // named the edge is still on offer — the director changed their mind, they did not
+  // spend anything.
+  it('sends nothing when the director goes back', async () => {
+    let calls = 0
+    mockTournamentTransitionEndpoint(server, () => {
+      calls += 1
+      return HttpResponse.json(transitionRead(), { status: 201 })
+    })
+    lifecycleActionsPage.render({
+      tournament: buildTournament({ id: 't-1', status: 'draft' }),
+    })
+
+    await userEvent.click(lifecycleActionsPage.getLifecycleButton(/Publish/))
+    await userEvent.click(lifecycleActionsPage.confirm.getCancelButton())
+
+    await waitFor(() =>
+      expect(lifecycleActionsPage.confirm.queryDialog()).toBeNull(),
+    )
+    expect(calls).toBe(0)
+    expect(
+      lifecycleActionsPage.getLifecycleButton(/Publish/),
+    ).toBeInTheDocument()
+    // A cancel is not a failure: there is nothing to explain, so there is no notice.
+    expect(lifecycleActionsPage.queryNotice()).toBeNull()
+    expectNoToast()
+  })
+
+  it('sends nothing when the dialog is dismissed with Escape', async () => {
+    let calls = 0
+    mockTournamentTransitionEndpoint(server, () => {
+      calls += 1
+      return HttpResponse.json(transitionRead(), { status: 201 })
+    })
+    lifecycleActionsPage.render({
+      tournament: buildTournament({ id: 't-1', status: 'live' }),
+    })
+
+    await userEvent.click(lifecycleActionsPage.getLifecycleButton(/End tournament/))
+    await userEvent.keyboard('{Escape}')
+
+    await waitFor(() =>
+      expect(lifecycleActionsPage.confirm.queryDialog()).toBeNull(),
+    )
+    expect(calls).toBe(0)
+    expect(
+      lifecycleActionsPage.getLifecycleButton(/End tournament/),
+    ).toBeInTheDocument()
+  })
+
+  // One in-flight move at a time. The confirm does NOT make this redundant — it asks a
+  // question once, per click, and two clicks would ask it twice. The lock is what stops
+  // the second one being asked at all.
+  it('locks the button while a move is in flight, so the question cannot be asked twice', async () => {
+    let calls = 0
+    mockTournamentTransitionEndpoint(server, async () => {
+      calls += 1
+      await delay('infinite')
+      return HttpResponse.json(transitionRead(), { status: 201 })
+    })
+    lifecycleActionsPage.render({
+      tournament: buildTournament({ id: 't-1', status: 'draft' }),
+    })
+
+    const publish = lifecycleActionsPage.getLifecycleButton(/Publish/)
+    await userEvent.click(publish)
+    await userEvent.click(lifecycleActionsPage.confirm.getConfirmButton())
+
+    await waitFor(() => expect(publish).toBeDisabled())
+    await userEvent.click(publish)
+    expect(calls).toBe(1)
+    // …and the second click did not even get as far as the question: a locked edge opens
+    // no dialog. Without this the assertion above would only be saying that a disabled
+    // button is disabled, since the move now needs a confirm it never got.
+    expect(lifecycleActionsPage.confirm.queryDialog()).toBeNull()
+  })
+
+  // The confirm is the only new gate: a non-owner still gets no button to open it with,
+  // and the terminal `archived` still offers none — hidden, never disabled (ADR-0015).
+  it.each([
+    { name: 'a non-owner', tournament: { status: 'published', canEdit: false } },
+    { name: 'an archived tournament', tournament: { status: 'archived' } },
+  ] as const)('gives $name no button, and therefore no dialog', ({ tournament }) => {
+    lifecycleActionsPage.render({ tournament: buildTournament(tournament) })
+
+    expect(lifecycleActionsPage.queryAllButtons()).toHaveLength(0)
+    expect(lifecycleActionsPage.confirm.queryDialog()).toBeNull()
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.tsx
@@ -7,10 +7,15 @@ import { useTransitionTournament } from '../data/api'
 import {
   lifecycleEdgeFor,
   lifecycleRefusalNotice,
+  type LifecycleEdge,
   type LifecycleRefusal,
   type LifecycleTone,
 } from '../data/lifecycle'
 import type { Tournament } from '../data/types'
+import {
+  ConfirmIrreversibleActDialog,
+  type IrreversibleActConsequence,
+} from './confirm-irreversible-act-dialog'
 
 export interface LifecycleActionsProps {
   tournament: Tournament
@@ -38,6 +43,35 @@ const TONE: Record<
 }
 
 /**
+ * The edge, as the consequence its confirm will price — the one join between the
+ * lifecycle table (`../data/lifecycle`, which knows nothing about this dialog) and the
+ * dialog's sum type.
+ *
+ * A `switch` over `edge.confirm` rather than a spread of `{ variant: edge.confirm, … }`:
+ * the spread only typechecks while all three variants carry an identical payload, and
+ * would break confusingly the day one of them names something the others do not. This
+ * stays total with no unreachable arm, because `confirm` has exactly these three values.
+ */
+const consequenceFor = (
+  edge: LifecycleEdge,
+  tournamentName: string,
+): IrreversibleActConsequence => {
+  switch (edge.confirm) {
+    case 'publish-tournament':
+      return { variant: 'publish-tournament', tournamentName }
+    case 'start-tournament':
+      return { variant: 'start-tournament', tournamentName }
+    case 'end-tournament':
+      return { variant: 'end-tournament', tournamentName }
+    default: {
+      // A fourth edge without a priced consequence is a TYPE error here.
+      const exhaustive: never = edge.confirm
+      return exhaustive
+    }
+  }
+}
+
+/**
  * The detail header's lifecycle affordance — and the **only** way a tournament's
  * status changes in this UI (ADR-0017). It posts the edge the tournament's status
  * offers to `POST /v1/tournaments/{id}/transitions`:
@@ -53,6 +87,25 @@ const TONE: Record<
  * It renders **nothing** — not a disabled button — for a non-owner (`canEdit`),
  * because every transition is owner-only server-side (403); and at most ONE
  * button, the one legal from the status the tournament is actually in.
+ *
+ * ## Every edge is priced before it is posted
+ *
+ * The button does not move the tournament. It opens `ConfirmIrreversibleActDialog` on the
+ * consequence *this* edge spends, and the transition is what the confirm's own button
+ * fires. Go back, Escape and the overlay all send nothing and leave the tournament exactly
+ * where it stands. That is the whole lifecycle, not a subset of it: the path is
+ * forward-only, so there is no un-publish, no un-start and no un-end (ADR "a confirm
+ * prices an irreversible act, a freeze explains an illegal one").
+ *
+ * **Start tournament** is the one that would most tempt an exemption and least deserves
+ * it. Since #788 it does not merely relabel the tournament — it closes registration and
+ * mints a match for every ready fixture, which spends the *players'* attention rather than
+ * the tournament's visibility.
+ *
+ * The `isPending` lock stays alongside the confirm rather than being replaced by it. A
+ * confirm is not a debounce: it asks a question once, per click, while the lock is what
+ * keeps a double-click from sending a second transition whose only possible answer is a
+ * 409 shown to somebody who did nothing wrong.
  *
  * ## A refused move is reported HERE, in the server's own words
  *
@@ -87,8 +140,14 @@ const TONE: Record<
 export const LifecycleActions = ({ tournament }: LifecycleActionsProps) => {
   const transition = useTransitionTournament(tournament.id)
   // The last refusal, in words. Cleared when a new attempt starts — a notice about the
-  // click before last is worse than none.
+  // click before last is worse than none. An opened (or cancelled) dialog is NOT an
+  // attempt, so it leaves the standing 409 work list alone: the director reads it *while*
+  // going to fix it.
   const [refusal, setRefusal] = useState<LifecycleRefusal | null>(null)
+  // The edge awaiting its confirm, held as the CONSEQUENCE the dialog will price rather
+  // than as a queued closure: the dialog needs it anyway, and a stored callback would
+  // capture whatever `tournament` was when the button was clicked.
+  const [pending, setPending] = useState<IrreversibleActConsequence | null>(null)
 
   const edge = lifecycleEdgeFor(tournament)
   if (!edge) return null
@@ -96,6 +155,7 @@ export const LifecycleActions = ({ tournament }: LifecycleActionsProps) => {
   const tone = TONE[edge.tone]
 
   const move = async () => {
+    setPending(null)
     setRefusal(null)
     try {
       await transition.mutateAsync(edge)
@@ -106,7 +166,10 @@ export const LifecycleActions = ({ tournament }: LifecycleActionsProps) => {
   }
 
   return (
-    <div className="flex w-[380px] max-w-full flex-col items-end gap-2.5">
+    <div
+      data-testid="lifecycle-actions"
+      className="flex w-[380px] max-w-full flex-col items-end gap-2.5"
+    >
       <Button
         variant={tone.variant}
         className={tone.className}
@@ -114,7 +177,9 @@ export const LifecycleActions = ({ tournament }: LifecycleActionsProps) => {
         // second transition, whose only possible answer is the 409 "already
         // published" — an error shown to a user who did nothing wrong.
         disabled={transition.isPending}
-        onClick={move}
+        // This click moves nothing. It opens the confirm on the consequence this edge
+        // spends; the transition is fired by the confirm's own button.
+        onClick={() => setPending(consequenceFor(edge, tournament.name))}
       >
         <Icon size={16} />
         {edge.label}
@@ -131,6 +196,19 @@ export const LifecycleActions = ({ tournament }: LifecycleActionsProps) => {
           <AlertTitle>{refusal.title}</AlertTitle>
           <AlertDescription>{refusal.description}</AlertDescription>
         </Alert>
+      )}
+
+      {/* The price of a one-way edge, asked before it is paid. Mounted only while an edge
+          is awaiting its answer, so the dialog cannot be on screen with nothing behind it.
+          Confirm posts the transition it named; cancel — and Escape, and the overlay —
+          drops it, and the tournament is untouched because nothing was ever sent. */}
+      {pending && (
+        <ConfirmIrreversibleActDialog
+          open
+          consequence={pending}
+          onConfirm={() => void move()}
+          onCancel={() => setPending(null)}
+        />
       )}
     </div>
   )

--- a/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/lifecycle-actions.tsx
@@ -14,7 +14,7 @@ import {
 import type { Tournament } from '../data/types'
 import {
   ConfirmIrreversibleActDialog,
-  type IrreversibleActConsequence,
+  type LifecycleActConsequence,
 } from './confirm-irreversible-act-dialog'
 
 export interface LifecycleActionsProps {
@@ -55,7 +55,7 @@ const TONE: Record<
 const consequenceFor = (
   edge: LifecycleEdge,
   tournamentName: string,
-): IrreversibleActConsequence => {
+): LifecycleActConsequence => {
   switch (edge.confirm) {
     case 'publish-tournament':
       return { variant: 'publish-tournament', tournamentName }
@@ -102,6 +102,11 @@ const consequenceFor = (
  * mints a match for every ready fixture, which spends the *players'* attention rather than
  * the tournament's visibility.
  *
+ * The edge is **captured at the click** and it is the captured one the confirm posts —
+ * never the one recomputed from a `tournament` prop that may have been refetched out from
+ * under the open dialog. See the `pending` state below: that is what stops the dialog
+ * pricing one act and performing another.
+ *
  * The `isPending` lock stays alongside the confirm rather than being replaced by it. A
  * confirm is not a debounce: it asks a question once, per click, while the lock is what
  * keeps a double-click from sending a second transition whose only possible answer is a
@@ -144,24 +149,53 @@ export const LifecycleActions = ({ tournament }: LifecycleActionsProps) => {
   // attempt, so it leaves the standing 409 work list alone: the director reads it *while*
   // going to fix it.
   const [refusal, setRefusal] = useState<LifecycleRefusal | null>(null)
-  // The edge awaiting its confirm, held as the CONSEQUENCE the dialog will price rather
-  // than as a queued closure: the dialog needs it anyway, and a stored callback would
-  // capture whatever `tournament` was when the button was clicked.
-  const [pending, setPending] = useState<IrreversibleActConsequence | null>(null)
+  /**
+   * The **edge** awaiting its confirm — captured at the click, and the thing the confirm
+   * posts. Typed as the edge rather than as the consequence, and narrowed to
+   * `LifecycleEdge` rather than the whole five-variant act union, for two reasons:
+   *
+   * 1. **The dialog must price the act it performs.** `edge` below is recomputed from the
+   *    `tournament` prop on *every* render, and this page polls (`useSchedulePolling`, ~3s
+   *    on the Schedule tab). A co-director starting the tournament from their phone while
+   *    this director reads "Start this tournament?" would move `edge` on to `live →
+   *    archived` underneath them — and a confirm that posted the live `edge` would END the
+   *    tournament under a dialog that had just described starting it. The captured edge is
+   *    both what the dialog prices (via `consequenceFor`) and what `move` posts, so the two
+   *    cannot disagree. It is the hazard `useUpdateTableCatalogue` names next door (`../data/api`):
+   *    a refetch under an open dialog swapping the thing the pending act was computed from.
+   *
+   *    A *stale* captured edge is safe, and designed for: `(current, to)` is the server's
+   *    judgement (ADR-0017), so re-asserting an edge that no longer exists is a 409 — which
+   *    this component already renders inline, in the server's own words ("This tournament is
+   *    already live."). Being told is the correct outcome. Silently performing an act nobody
+   *    chose is not. The alternative — keep a boolean and re-derive the consequence from the
+   *    live `edge` — stays self-consistent by rewriting the dialog's copy under the
+   *    director's eyes mid-decision, which is the same theft with better manners.
+   *
+   * 2. **This component can only hold acts it can perform.** A state typed on the whole
+   *    `IrreversibleActConsequence` could hold `recut-draw` / `delete-draw`, which no
+   *    lifecycle button can fire — the mirror of the narrowing the draw panel already has
+   *    (`DrawActConsequence`).
+   */
+  const [pending, setPending] = useState<LifecycleEdge | null>(null)
 
   const edge = lifecycleEdgeFor(tournament)
   if (!edge) return null
   const Icon = edge.icon
   const tone = TONE[edge.tone]
 
-  const move = async () => {
+  /** Post the edge the director was ASKED about — the captured one, passed in — never the
+   * one `lifecycleEdgeFor` happens to offer by the time they answer. The refusal is framed
+   * with that same edge, so a 409 on a stale one reads as the move they actually made
+   * ("Couldn't start the tournament"), not as the move now on offer. */
+  const move = async (confirmed: LifecycleEdge) => {
     setPending(null)
     setRefusal(null)
     try {
-      await transition.mutateAsync(edge)
+      await transition.mutateAsync(confirmed)
     } catch (error) {
       // `mutateAsync` rejects; this notice IS the error surface (there is no toast).
-      setRefusal(lifecycleRefusalNotice(error, edge))
+      setRefusal(lifecycleRefusalNotice(error, confirmed))
     }
   }
 
@@ -177,9 +211,9 @@ export const LifecycleActions = ({ tournament }: LifecycleActionsProps) => {
         // second transition, whose only possible answer is the 409 "already
         // published" — an error shown to a user who did nothing wrong.
         disabled={transition.isPending}
-        // This click moves nothing. It opens the confirm on the consequence this edge
-        // spends; the transition is fired by the confirm's own button.
-        onClick={() => setPending(consequenceFor(edge, tournament.name))}
+        // This click moves nothing. It captures the edge and opens the confirm on it; the
+        // transition is fired by the confirm's own button, on that same captured edge.
+        onClick={() => setPending(edge)}
       >
         <Icon size={16} />
         {edge.label}
@@ -200,13 +234,15 @@ export const LifecycleActions = ({ tournament }: LifecycleActionsProps) => {
 
       {/* The price of a one-way edge, asked before it is paid. Mounted only while an edge
           is awaiting its answer, so the dialog cannot be on screen with nothing behind it.
-          Confirm posts the transition it named; cancel — and Escape, and the overlay —
-          drops it, and the tournament is untouched because nothing was ever sent. */}
+          Confirm posts the transition it named — the CAPTURED edge, both here and in
+          `move`, so the sentence read and the request sent are the same act. Cancel — and
+          Escape, and the overlay — drops it, and the tournament is untouched because
+          nothing was ever sent. */}
       {pending && (
         <ConfirmIrreversibleActDialog
           open
-          consequence={pending}
-          onConfirm={() => void move()}
+          consequence={consequenceFor(pending, tournament.name)}
+          onConfirm={() => void move(pending)}
           onCancel={() => setPending(null)}
         />
       )}


### PR DESCRIPTION
Second of three slices closing cluster A. Slice 1 merged as #1285. (This replaces PR #1286, which GitHub auto-**closed** rather than retargeted when its base branch was deleted on merge — a closed PR cannot have its base changed or be reopened.)

## What this slice does

All three lifecycle edges now open a confirm naming **its own** consequence:

- **Publish** — the tournament becomes publicly enterable.
- **Start tournament** — registration closes and every ready fixture becomes a real in-progress match. Since #788 this is the one that spends the *players'* attention.
- **End tournament** — `archived` is terminal.

The lifecycle is forward-only, so all three are one-way and none is exempt. #1089 left Start and End open on the assumption Publish was the consequential one; that predates #788.

Closes #1089 and the lifecycle half of #1094.

## A real bug the review caught

`pending` froze the dialog's copy at click time while `move()` posted whatever `edge` the latest render held. A refetch under an open dialog therefore made the confirm perform a **different act** from the one it described: open "Start this tournament?", a co-director starts it from their phone, the Schedule tab's ~3s poll lands, and clicking **Start the tournament** posts `{to:'archived'}` and **ends** it.

`pending` now holds the `LifecycleEdge` captured at the click. A stale capture is a designed case — ADR-0017 makes `(current, to)` the server's judgement and the 409 already renders inline, so the director is told rather than silently performing an act nobody chose.

Falsified: restoring `mutateAsync(edge)` reds with `{to:'archived'}` where `{to:'live'}` was priced.

## Button treatment

Draw verbs stay `destructive`; the three lifecycle edges are `default` — red should mean work is thrown away, and none of these destroys anything. Adds **no** new AA-contrast exclusion: the new axe scan runs with the Start confirm open and passes no `exclude` at all (#1039 stays open, unwidened).

## The composed-stack suite

`compose-e2e` went red here and caught a miss of mine: I swept the root `e2e/` suite for button *labels*, but it drives the lifecycle through page objects. The page object gained a confirm accessor plus `publishTournament()`/`startTournament()`/`endTournament()`; five publish sites and the swiss `goLive` helper now answer the confirm. 26 collected, 26 passed.

## Verification

`vitest` 3558 · `tsc -p tsconfig.app.json --noEmit` clean · `eslint .` clean · `playwright` 322/322 · `compose-e2e` green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)