### PR TITLE
Drop the decorative table glyph from the empty recent-matches card

### DIFF
--- a/web-client/src/components/dashboard/first-match/no-matches-card.tsx
+++ b/web-client/src/components/dashboard/first-match/no-matches-card.tsx
@@ -2,52 +2,21 @@ import { Card } from '@/components/dashboard/your-game-row/card'
 import { C, UI } from '@/components/dashboard/dashboard-tokens'
 import { Overline } from '@/components/overline'
 
-/** Decorative table-tennis table glyph for the empty recent-matches card.
- * `aria-hidden` since the adjacent text already carries the meaning. */
-function TableGlyph() {
-  return (
-    <svg
-      width="56"
-      height="40"
-      viewBox="0 0 56 40"
-      fill="none"
-      aria-hidden
-      style={{ color: C.ink500 }}
-    >
-      <rect x="2" y="6" width="22" height="16" rx="2" stroke="currentColor" strokeWidth="2" />
-      <rect x="32" y="6" width="22" height="16" rx="2" stroke="currentColor" strokeWidth="2" />
-      <line x1="27" y1="6" x2="27" y2="22" stroke="currentColor" strokeWidth="2" />
-      <line x1="4" y1="28" x2="10" y2="36" stroke="currentColor" strokeWidth="2" />
-      <line x1="52" y1="28" x2="46" y2="36" stroke="currentColor" strokeWidth="2" />
-    </svg>
-  )
-}
-
 /** The zero-match dashboard's replacement for the recent-matches card — a
  * friendlier empty state than the terse placeholder shown once a rated
- * league exists but nothing's been played there yet. */
+ * league exists but nothing's been played there yet.
+ *
+ * The words carry the state on their own, so the card holds no illustration:
+ * a decorative table glyph sat here and read as clutter rather than meaning. */
 export const NoMatchesCard = () => {
   return (
     <Card style={{ minWidth: 0 }}>
       <Overline>Recent matches</Overline>
-      <div
-        style={{
-          marginTop: 16,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          textAlign: 'center',
-          gap: 10,
-          padding: '18px 8px 6px',
-        }}
-      >
-        <TableGlyph />
-        <div style={{ font: `600 14px ${UI}`, color: C.chalk100 }}>
-          No matches yet. Go play.
-        </div>
-        <div style={{ font: `400 13px ${UI}`, color: C.chalk300 }}>
-          Your completed matches will show up here.
-        </div>
+      <div style={{ marginTop: 10, font: `600 14px ${UI}`, color: C.chalk100 }}>
+        No matches yet. Go play.
+      </div>
+      <div style={{ marginTop: 6, font: `400 13px ${UI}`, color: C.chalk300 }}>
+        Your completed matches will show up here.
       </div>
     </Card>
   )


### PR DESCRIPTION
## What

The zero-match dashboard's "Recent matches" card drew a small table-tennis table in SVG above its copy. Remove it.

The glyph was `aria-hidden` and carried no meaning the text did not already carry. It read as clutter. The words are enough.

Without the glyph the centered, padded block has nothing to frame, so the card now uses the same left-aligned rhythm as its sibling `UnratedCard` (`marginTop: 10` headline, `marginTop: 6` body).

Copy is unchanged.

## Verification

- `vitest run src/components/dashboard` — 31 files, 234 tests pass. Collected count (`vitest list --filesOnly`) is also 31, so nothing was silently skipped.
- `tsc -b` clean, `eslint .` clean.
- No screenshot baseline covers this card. The only spec calling `toHaveScreenshot` is `web-client/e2e/design-system.spec.ts`, and every committed PNG is a design-system control.
- The two tests that pin `'No matches yet. Go play.'` (`first-match-dashboard.test.tsx`, `dashboard-page.test.tsx`) still pass, because the copy did not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)