### PR TITLE
Link the landing page at the iOS beta it already ships

### DIFF
--- a/web-client/src/App.page.tsx
+++ b/web-client/src/App.page.tsx
@@ -1,0 +1,54 @@
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+} from '@tanstack/react-router'
+
+import { render, screen, type Container } from '@/test/utilities'
+
+import App from './App'
+
+const scoped = (container: Container) => ({
+  /**
+   * The landing page's iOS call to action, in the CTA band above the footer.
+   * A `link` role, deliberately: it points at the public TestFlight beta, so
+   * an `aria-disabled` span here would be a failure, not a match.
+   */
+  getIosAppLink() {
+    return container.getByRole('link', { name: 'Get the iOS app' })
+  },
+  /**
+   * The Android call to action beside it. Android does not exist yet, so this
+   * is inert text with `aria-disabled` — there is no link to find, which is
+   * why the accessor reads the element rather than a role.
+   */
+  getAndroidAppCta() {
+    return container.getByText('Get the Android app')
+  },
+})
+
+/**
+ * Test page-object for the logged-out landing page (`App`, the `/` route).
+ *
+ * `App` renders TanStack `<Link>`s, so `render()` mounts it under a memory
+ * router seeded at `/` — the same context it has in production. The router
+ * resolves on a tick, so tests start with an `await` (a `find*` query, or the
+ * `findByRole` the hero test uses) before reading anything synchronously.
+ */
+export const appPage = {
+  render() {
+    const router = createRouter({
+      routeTree: createRootRoute({ component: App }),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+    render(<RouterProvider router={router} />)
+  },
+
+  /** Scope the accessors to a container — the whole `screen` by default. */
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/App.test.tsx
+++ b/web-client/src/App.test.tsx
@@ -1,27 +1,11 @@
-import { render, screen, within } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {
-  RouterProvider,
-  createMemoryHistory,
-  createRootRoute,
-  createRouter,
-} from '@tanstack/react-router'
 import { describe, expect, it } from 'vitest'
-import App from './App'
-
-// App renders <Link>s, so it must be mounted inside a router context — the
-// same way it runs in production as the `/` route.
-function renderApp() {
-  const router = createRouter({
-    routeTree: createRootRoute({ component: App }),
-    history: createMemoryHistory({ initialEntries: ['/'] }),
-  })
-  return render(<RouterProvider router={router} />)
-}
+import { appPage } from './App.page'
 
 describe('App', () => {
   it('renders the FortyMM hero', async () => {
-    renderApp()
+    appPage.render()
     expect(
       await screen.findByRole('heading', {
         level: 1,
@@ -36,7 +20,7 @@ describe('App', () => {
     // through a hamburger toggle + collapsible menu. Before the fix neither
     // existed, leaving the nav unreachable on mobile.
     const user = userEvent.setup()
-    renderApp()
+    appPage.render()
 
     // The toggle is `display:none` on desktop (jsdom applies the stylesheet),
     // so it's hidden from the a11y tree until the mobile breakpoint — query it
@@ -82,7 +66,7 @@ describe('App', () => {
 
   it('switches the active product feature when a tab is clicked', async () => {
     const user = userEvent.setup()
-    renderApp()
+    appPage.render()
 
     expect(
       await screen.findByRole('heading', { name: /scores in, history out\./i }),
@@ -93,5 +77,47 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', { name: /the schedule, solved\./i }),
     ).toBeInTheDocument()
+  })
+})
+
+/**
+ * The CTA band's store buttons. The iOS one mirrors the sidebar's TestFlight
+ * link (`app-shell.test.tsx`): the beta is public, so a logged-out visitor gets
+ * the same working link a signed-in user does. Android has no build at all, so
+ * it stays inert.
+ */
+describe('App CTA band', () => {
+  it('links to the public TestFlight beta, opening in a new tab', async () => {
+    appPage.render()
+    await screen.findByRole('heading', {
+      level: 1,
+      name: /play more\.\s*pay never\./i,
+    })
+
+    // A `link` role at all is half the assertion: this was an
+    // `aria-disabled` <span> titled "Coming soon", which no role query finds.
+    const link = appPage.getIosAppLink()
+    expect(link).toHaveAttribute(
+      'href',
+      'https://testflight.apple.com/join/5pGVbku3',
+    )
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(link).not.toHaveAttribute('aria-disabled')
+    // `.btn-disabled` is `pointer-events: none` (landing.css), so the class
+    // alone would leave the link unclickable however good its href is.
+    expect(link).not.toHaveClass('btn-disabled')
+  })
+
+  it('leaves the Android button inert — there is no Android build', async () => {
+    appPage.render()
+    await screen.findByRole('heading', {
+      level: 1,
+      name: /play more\.\s*pay never\./i,
+    })
+
+    const android = appPage.getAndroidAppCta()
+    expect(android).toHaveAttribute('aria-disabled', 'true')
+    expect(android).toHaveClass('btn-disabled')
   })
 })

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -146,7 +146,7 @@ function Hero() {
                   <path d="M2 7h12" />
                 </svg>
               </span>
-              Web. iOS &amp; Android soon.
+              Web. iOS in beta. Android soon.
             </span>
             <span className="meta-divider" />
             <span className="meta-item">
@@ -981,7 +981,7 @@ function FAQ() {
     },
     {
       q: "What's on the web vs. in the apps?",
-      a: 'Right now: the web is the whole product. Match tracking, ratings, club feeds, the full tournament admin, the spectator view — it all works in your browser on any phone or laptop. Native iOS and Android apps are next; they\'ll be the same product with nicer score entry and push notifications.',
+      a: "Right now: the web is the whole product. Match tracking, ratings, club feeds, the full tournament admin, the spectator view — it all works in your browser on any phone or laptop. The iOS app is in open beta on TestFlight — anyone with the link can join, no invite needed — and it's the same product with nicer score entry and push notifications. Android is next.",
     },
     {
       q: 'How does the rating work?',
@@ -1093,7 +1093,7 @@ function CtaBand() {
           </span>
         </div>
         <div className="cta-foot mono">
-          ● Web is live · iOS in beta · Android in beta
+          ● Web is live · iOS in beta · Android soon
         </div>
       </div>
     </section>
@@ -1118,8 +1118,8 @@ function Footer() {
           h="Product"
           items={[
             { label: 'Web app', to: '/matches/new' },
-            { label: 'iOS (beta)', disabled: true },
-            { label: 'Android (beta)', disabled: true },
+            { label: 'iOS (beta)', href: TESTFLIGHT_URL, external: true },
+            { label: 'Android', disabled: true },
             { label: 'Spectator view', disabled: true },
             { label: 'Changelog', disabled: true },
           ]}

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { Wordmark } from '@/components/wordmark'
+import { TESTFLIGHT_URL } from '@/lib/external-links'
 import './landing.css'
 
 /** Public source repository — FortyMM is GPLv3 and open to contributors. */
@@ -1068,13 +1069,21 @@ function CtaBand() {
             <span className="btn-dot" />
             Start playing now
           </Link>
-          <span
-            className="btn btn-secondary btn-xl btn-disabled"
-            aria-disabled="true"
-            title="Coming soon — iOS is in beta"
+          {/*
+            The TestFlight beta is public — anyone with the link can join — so
+            a logged-out visitor gets the same working link the signed-in
+            sidebar shows (`app-shell.tsx`). Android has no build at all, which
+            is why the button beside this one stays inert.
+          */}
+          <a
+            className="btn btn-secondary btn-xl"
+            href={TESTFLIGHT_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Join the public TestFlight beta"
           >
             Get the iOS app
-          </span>
+          </a>
           <span
             className="btn btn-secondary btn-xl btn-disabled"
             aria-disabled="true"

--- a/web-client/src/components/app-shell.tsx
+++ b/web-client/src/components/app-shell.tsx
@@ -19,6 +19,7 @@ import {
 import { useSession } from '@/api/session'
 import { Wordmark } from '@/components/wordmark'
 import { cn } from '@/lib/utils'
+import { TESTFLIGHT_URL } from '@/lib/external-links'
 import { PERM } from '@/lib/permissions'
 import { NotificationBell } from './notifications/notification-bell'
 import { UserMenu } from './user-menu'
@@ -48,9 +49,6 @@ type NavSection = {
   label?: string
   items: NavItem[]
 }
-
-/** The app's public TestFlight beta — anyone with the link can join, no invite needed. */
-const TESTFLIGHT_URL = 'https://testflight.apple.com/join/5pGVbku3'
 
 const NAV_SECTIONS: NavSection[] = [
   {

--- a/web-client/src/lib/external-links.ts
+++ b/web-client/src/lib/external-links.ts
@@ -1,0 +1,12 @@
+/**
+ * Off-site URLs the app links to from more than one surface. One name, one
+ * place — a URL written twice drifts, and half the app then points at a dead
+ * beta.
+ */
+
+/**
+ * The app's public TestFlight beta — anyone with the link can join, no invite
+ * needed. Linked from the signed-in sidebar footer (`app-shell.tsx`) and the
+ * landing page's CTA band (`App.tsx`), which must agree.
+ */
+export const TESTFLIGHT_URL = 'https://testflight.apple.com/join/5pGVbku3'

--- a/web-client/src/routes/index.test.tsx
+++ b/web-client/src/routes/index.test.tsx
@@ -107,9 +107,11 @@ describe('/ route', () => {
     renderAt('/')
     await expectLandingVisible()
 
-    // "Get the iOS app" has no destination yet — it must not be a clickable link.
+    // "Get the Android app" has no destination yet — there is no Android build
+    // at all — so it must not be a clickable link. (Its iOS neighbour *is* a
+    // link now: the TestFlight beta is public. See `App.test.tsx`.)
     expect(
-      screen.queryByRole('link', { name: /get the ios app/i }),
+      screen.queryByRole('link', { name: /get the android app/i }),
     ).not.toBeInTheDocument()
     // Footer "Discord" has no invite URL yet — also not a link.
     expect(


### PR DESCRIPTION
The TestFlight beta is public — anyone with the link can join, no invite needed — and the signed-in sidebar has linked to it for a while. The landing page still rendered a **disabled span**:

```
title="Coming soon — iOS is in beta"
aria-disabled="true"
```

So a logged-out visitor was told the app wasn't available yet, while a signed-in user could install it from the same page's shell. `btn-disabled` is `pointer-events: none` in `landing.css`, so it wasn't just dimmed — it was genuinely unclickable.

## What changed

- The landing page's iOS button is now a real `<a>` to the TestFlight URL, opening in a new tab with `rel="noopener noreferrer"`, matching the sidebar link.
- The URL moves to `web-client/src/lib/external-links.ts`, imported by both surfaces. It was a module-level const in `app-shell.tsx`; the landing page would otherwise have written it a second time, and a URL written twice drifts.
- **Android is untouched.** There is no `android/` directory in this repo, so its disabled button is still accurate.

## On the one existing test that changed

`routes/index.test.tsx` had an assertion that "Get the iOS app" is *not* a link, under a test named "renders affordances that do not exist yet as inert, non-link text". That premise is now false for iOS, so the assertion moved its subject to Android — which genuinely has no build. The test's stated behaviour still holds and still guards something real, and iOS is now covered positively in `App.test.tsx`.

Flagging it explicitly because repointing an existing assertion is how coverage quietly weakens, and it deserves a reviewer's eye rather than being buried in the diff.

## Verification

The new test was run against the **unmodified** page first and failed for the stated reason — `Unable to find an accessible element with the role "link"`, since the old `<span>` satisfies no role query. Then made to pass.

Full suite: `Test Files 325 passed`, `Tests 3586 passed`, checked against `vitest list --filesOnly` (325 collected) so a stale `node_modules/.vite` cache couldn't silently skip the new file. `tsc -b` clean, `vite build` clean, eslint clean apart from a pre-existing warning in an unchanged file.

## Not addressed, same understatement

`App.tsx:148` ("Web. iOS & Android soon.") and the FAQ at `App.tsx:983` ("Native iOS and Android apps are next") describe iOS the same outdated way. Left alone — it's copy, not wiring, and worth deciding deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Second commit — the rest of the platform copy.**

Chasing the same defect found four more places, in **both** directions.

Understating iOS, like the button:
- hero meta line: "Web. iOS & Android soon."
- FAQ: "Native iOS and Android apps are next"
- footer: "iOS (beta)" as inert text with no destination

**Overstating Android**, which is the one worth catching: the status line under the CTA read "Android in beta", and the footer called it "Android (beta)". There is no `android/` directory in this repo — Android is not in beta, it does not exist. That line promised a build nobody can install.

The footer's iOS entry now links to the same TestFlight URL, using the `href` + `external` fields `FooterItem` already supported. Android keeps its inert entry, minus the beta claim.

No test pinned any of this copy. Full suite green at 325 files / 3586 tests, `tsc -b` clean.

One observation worth recording: two consecutive full runs of the unchanged tree reported 3584 and then 3586 tests. Both had 325/325 files passing and matched `vitest list --filesOnly`, so nothing was silently skipped — a couple of tests appear to be registered dynamically. Not a failure, but noting it since this repo treats count mismatches as a signal.
