### PR TITLE
Match the slide-in nav backdrop to the modal overlay

### DIFF
--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1017,8 +1017,11 @@ body.dark.fortymm-theme {
 .app-shell__backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(2px);
+  /* Match the Dialog/Sheet overlays, which use `bg-black/10 backdrop-blur-xs`.
+     Tailwind compiles those to oklab(0 0 0 / 0.1) and blur(4px); over the
+     --ink-950 canvas both scrims composite to the same rgb(9, 11, 16). */
+  background: rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(4px);
   z-index: 35;
   opacity: 0;
   pointer-events: none;


### PR DESCRIPTION
The app-shell slide-in nav dimmed the page with `rgba(0, 0, 0, 0.6)` and `blur(2px)`. Every Radix overlay in the app — Dialog, AlertDialog, Sheet, Drawer — uses `bg-black/10 backdrop-blur-xs`. Two scrims at different strengths read as two different colors.

Tailwind v4 compiles `bg-black/10` to `oklab(0 0 0 / 0.1)`, not to an `rgba()` literal, so the computed-style strings differ even when the rendered color does not. Composited over the `--ink-950` (`#0b0d12`) canvas in headless chromium and sampled the pixel:

| scrim | composited pixel |
| --- | --- |
| `bg-black/10` (the modals) | `rgb(9, 11, 16)` |
| `rgba(0, 0, 0, 0.1)` (this change) | `rgb(9, 11, 16)` |
| `rgba(0, 0, 0, 0.6)` (before) | `rgb(4, 5, 7)` |

The blur moves 2px → 4px, because `backdrop-blur-xs` resolves to `--blur-xs: 4px` in `tailwindcss/theme.css`.

The dimmed page reads blue-tinted at this strength. That is correct, and it is how the modals have always looked: the scrim is neutral black, but `--ink-950` is a blue-tinted charcoal, and a 10% scrim lets the page's own tint through.

## Scope note

The event-editor side panel is a `Sheet`, and its overlay already used `bg-black/10`. This is the only overlay in the codebase whose color differed from the modals'.
