### PR TITLE
Slice 1: a director who cuts a single-elimination draw sees the bracket on tables, at call times (#1228)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -472,11 +472,13 @@ longer be added, removed, or re-identified, because every **fixture** names the
 pool it belongs to — but a pool's venue attributes (its tables, its time window)
 and its display name stay editable mid-event, because the venue changes under a
 running tournament (a table breaks, a table frees up).
-A pool **restricts** scheduling rather than enabling it (ADR 20260807): its
-**fixtures** are placed on its tables inside its window, while an event with no
-pools is scheduled across the whole venue over its own window. Every draw type
-may have pools, including the un-pooled ones — a **bracket** has no pool of its
-own, but its event may still reserve one to confine where and when it is played.
+A pool **restricts** scheduling rather than enabling it, and it restricts per
+**fixture** (ADR 20260807): a fixture that names a pool is placed on that pool's
+tables inside its window, while a fixture that names none is placed across the
+whole venue over its **event**'s window. A pool never confines a fixture that
+does not name it — a **knockout stage**'s fixtures take the event-wide
+reservation even though their event has pools, because those pools describe the
+**pool stage**.
 _Avoid_: group (a pool is not a grouping abstraction separate from the venue
 slice), division.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -472,6 +472,11 @@ longer be added, removed, or re-identified, because every **fixture** names the
 pool it belongs to — but a pool's venue attributes (its tables, its time window)
 and its display name stay editable mid-event, because the venue changes under a
 running tournament (a table breaks, a table frees up).
+A pool **restricts** scheduling rather than enabling it (ADR 20260807): its
+**fixtures** are placed on its tables inside its window, while an event with no
+pools is scheduled across the whole venue over its own window. Every draw type
+may have pools, including the un-pooled ones — a **bracket** has no pool of its
+own, but its event may still reserve one to confine where and when it is played.
 _Avoid_: group (a pool is not a grouping abstraction separate from the venue
 slice), division.
 
@@ -588,7 +593,8 @@ event's), first place.
 **Schedule**:
 Where and when a tournament's **matches** are played: the assignment of each
 **match** to a **table** and a **wall-clock time**, within the reserved window of its
-**pool** (or, for an un-pooled draw, its event). It is **tournament-scoped, not
+**pool** — or, for a fixture with no pool, within its **event**'s own window and on
+any table in the tournament (ADR 20260807). It is **tournament-scoped, not
 per-event** — the venue's tables are shared across events, so "two matches on one
 table at once" is a cross-event fact — which is why it is its own surface rather than
 a panel inside a single event's draw. A **placement** is written two ways that touch

--- a/api/app/schedule_preview_solve.py
+++ b/api/app/schedule_preview_solve.py
@@ -580,14 +580,24 @@ def _resolve_reason(
     of ``app.schedule_solves._resolve_reason`` (same union, same arms) taking the
     resolution maps directly rather than a ``SolveInputs``. Exhaustive with an
     ``assert_never`` floor: adding an :data:`~app.scheduling.InfeasibilityReason`
-    arm is a type error here until handled."""
+    arm is a type error here until handled.
+
+    Every reservation a preview can blame is a real **pool**: the builder draws
+    over the event's pools and drops an rr-then-ko draw's un-pooled knockout
+    (ADR 20260727, and the honest note that says so), so no event-wide
+    reservation is ever in a preview snapshot. Hence the literal ``"pool"`` — the
+    preview's resolutions carry no reservation kind to read, because there is
+    only one for them to carry."""
     match reason:
         case PoolHasNoTables():
-            return PoolHasNoTablesRead(pool_name=pool_resolutions[reason.pool_id].name)
+            return PoolHasNoTablesRead(
+                pool_name=pool_resolutions[reason.pool_id].name, reservation="pool"
+            )
         case WindowTooShortForMatch():
             pool = pool_resolutions[reason.pool_id]
             return WindowTooShortForMatchRead(
                 pool_name=pool.name,
+                reservation="pool",
                 window_start=pool.window_start,
                 window_end=pool.window_end,
                 best_of=best_of[reason.fixture_id],
@@ -598,6 +608,7 @@ def _resolve_reason(
             pool = pool_resolutions[reason.pool_id]
             return PoolOverCapacityRead(
                 pool_name=pool.name,
+                reservation="pool",
                 window_start=pool.window_start,
                 window_end=pool.window_end,
                 required_min=reason.required_min,
@@ -614,6 +625,7 @@ def _resolve_reason(
             return PlayerOverSubscribedRead(
                 player_name=placeholder_label(reason.player_id),
                 pool_name=pool.name,
+                reservation="pool",
                 window_start=pool.window_start,
                 window_end=pool.window_end,
                 match_count=reason.match_count,

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -228,6 +228,7 @@ from app.schemas.schedule_solve import (
     PlayerOverSubscribedRead,
     PoolHasNoTablesRead,
     PoolOverCapacityRead,
+    ReservationKind,
     ResolvedConflict,
     ResolvedReason,
     TableConflictRead,
@@ -564,13 +565,22 @@ def event_wide_pool_name(event_name: str) -> str:
 
 @dataclass(frozen=True, slots=True)
 class _PoolResolution:
-    """The DB-side facts an infeasibility reason needs to name a pool a human
-    can act on: its display ``name`` and the ``HH:MM`` clock bounds of its
-    window (already strings on the pool's ``Slot`` — no minute→clock math)."""
+    """The DB-side facts an infeasibility reason needs to name a reservation a
+    human can act on: its display ``name``, the ``HH:MM`` clock bounds of its
+    window (already strings on the pool's ``Slot`` — no minute→clock math), and
+    which kind of ``reservation`` it is.
+
+    ``reservation`` is what stops a remedy naming a control that does not exist
+    (:data:`~app.schemas.schedule_solve.ReservationKind`): "add a table to" and
+    "a smaller pool" are pool verbs, and an event-wide reservation already holds
+    every table the tournament has. It is carried beside the name rather than
+    inferred from it — a display name is copy, and bending copy to carry a fact
+    is how the wrong remedy got rendered in the first place."""
 
     name: str
     window_start: str
     window_end: str
+    reservation: ReservationKind = "pool"
 
 
 @dataclass(frozen=True, slots=True)
@@ -915,6 +925,11 @@ async def _load_solver_inputs(
                 name=event_wide_pool_name(event.name),
                 window_start=event_slot.start,
                 window_end=event_slot.end,
+                # Not a pool: a reason blaming this one must not be answered with
+                # a pool remedy (add a table to it, make it smaller, widen its
+                # window). Its controls are the event's window and the
+                # tournament's table catalogue.
+                reservation="event",
             )
 
     # The minute frame's origin: the earliest reservation window start — a
@@ -1205,13 +1220,16 @@ def _resolve_reason(reason: InfeasibilityReason, inputs: SolveInputs) -> Resolve
     until it is handled."""
     match reason:
         case PoolHasNoTables():
+            no_tables_pool = inputs.pool_resolutions[reason.pool_id]
             return PoolHasNoTablesRead(
-                pool_name=inputs.pool_resolutions[reason.pool_id].name
+                pool_name=no_tables_pool.name,
+                reservation=no_tables_pool.reservation,
             )
         case WindowTooShortForMatch():
             pool = inputs.pool_resolutions[reason.pool_id]
             return WindowTooShortForMatchRead(
                 pool_name=pool.name,
+                reservation=pool.reservation,
                 window_start=pool.window_start,
                 window_end=pool.window_end,
                 best_of=inputs.fixture_best_of[reason.fixture_id],
@@ -1222,6 +1240,7 @@ def _resolve_reason(reason: InfeasibilityReason, inputs: SolveInputs) -> Resolve
             pool = inputs.pool_resolutions[reason.pool_id]
             return PoolOverCapacityRead(
                 pool_name=pool.name,
+                reservation=pool.reservation,
                 window_start=pool.window_start,
                 window_end=pool.window_end,
                 required_min=reason.required_min,
@@ -1237,6 +1256,7 @@ def _resolve_reason(reason: InfeasibilityReason, inputs: SolveInputs) -> Resolve
             return PlayerOverSubscribedRead(
                 player_name=inputs.player_names[reason.player_id],
                 pool_name=pool.name,
+                reservation=pool.reservation,
                 window_start=pool.window_start,
                 window_end=pool.window_end,
                 match_count=reason.match_count,

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -527,6 +527,41 @@ async def latest_solve(
     return locked
 
 
+#: The suffix that spells an event's **event-wide reservation** in the solver's
+#: namespaced ``{event}:{pool}`` id space (ADR "a pool restricts scheduling, it
+#: does not enable it"): the synthetic ``SchedulePool`` an un-pooled fixture is
+#: placed in — the event's own ``slot`` for a window, the whole tournament
+#: catalogue for tables.
+#:
+#: It cannot collide with a real pool's key. A real key's suffix is
+#: ``str(pool.id)`` and ``Pool.id`` is typed ``uuid.UUID`` (server-minted since
+#: ADR 20260801), so every one of them is a UUID's canonical text — 32 hex
+#: digits and four hyphens, and nothing else. ``event-wide`` holds letters that
+#: are not hex digits, so no UUID can ever spell it.
+EVENT_WIDE_POOL_SUFFIX = "event-wide"
+
+
+def event_wide_pool_key(event_id: uuid.UUID) -> PoolId:
+    """The solver ``PoolId`` of ``event_id``'s event-wide reservation — the one
+    spelling of it, so the snapshot's ``SchedulePool``, the fixtures that name
+    it and the resolution maps keyed by it cannot drift apart."""
+    return PoolId(f"{event_id}:{EVENT_WIDE_POOL_SUFFIX}")
+
+
+def event_wide_pool_name(event_name: str) -> str:
+    """What a director reads when an infeasibility reason blames an event-wide
+    reservation (ADR: "the event-wide reservation needs a name a director can
+    read").
+
+    The event's own name plus the ADR's own phrase for what it reserves. Not the
+    bare event name: the no-tables copy reads "<name> has no tables assigned —
+    assign at least one table to <name>", and there is no surface that assigns a
+    table to an *event*, so a bare event name would send the director looking for
+    a control that does not exist. Naming the venue points them at the
+    tournament's table catalogue, which is the thing to fix."""
+    return f"{event_name} (whole venue)"
+
+
 @dataclass(frozen=True, slots=True)
 class _PoolResolution:
     """The DB-side facts an infeasibility reason needs to name a pool a human
@@ -796,6 +831,13 @@ async def _load_solver_inputs(
         )
         for event in drawn_events
     ]
+    # The event's own ``slot``, parsed once at this boundary with the model the
+    # write boundary validated it with (parse, don't validate). It is the window
+    # an event-wide reservation runs in, and — being a real solver input now —
+    # part of the fingerprint below.
+    event_slots: dict[uuid.UUID, Slot] = {
+        event.id: Slot.model_validate(event.slot) for event, _s, _p in parsed_events
+    }
 
     # Pool ids are per-event value-objects — two events may both hold a
     # "pool-a" — so the solver's PoolId is namespaced by the event id.
@@ -847,10 +889,38 @@ async def _load_solver_inputs(
                 window_start=pool.slot.start,
                 window_end=pool.slot.end,
             )
+        if any(fixture.pool_id is None for fixture in fixtures_by_event[event.id]):
+            # The event-wide reservation (ADR "a pool restricts scheduling, it
+            # does not enable it"): one synthetic pool for the event's un-pooled
+            # fixtures — a single-elim or swiss draw's whole field, an
+            # rr-then-ko draw's knockout stage. Its window is the event's own
+            # ``slot`` read in the event's zone; its tables are the whole
+            # tournament catalogue. No pool row exists or is minted — it lives
+            # only in this snapshot.
+            #
+            # Keyed on "the event HAS an un-pooled fixture", not on "an
+            # un-pooled fixture reached the snapshot": a knockout's fixtures
+            # arrive with their sides still TBD and gain them round by round, so
+            # the placeable-only rule would make the reservation (and with it
+            # ``base``, the minute frame's origin) appear and disappear under a
+            # running tournament. An event-wide reservation carrying no
+            # placeable fixture constrains nothing and can prove no cause — the
+            # pure module's per-pool arms all require unpinned demand.
+            event_wide_key = event_wide_pool_key(event.id)
+            event_slot = event_slots[event.id]
+            start, end = _slot_bounds(event_slot, event_tz)
+            pool_specs.append((event_wide_key, catalogue, start, end))
+            pool_dates[event_wide_key] = date.fromisoformat(event_slot.date)
+            pool_resolutions[event_wide_key] = _PoolResolution(
+                name=event_wide_pool_name(event.name),
+                window_start=event_slot.start,
+                window_end=event_slot.end,
+            )
 
-    # The minute frame's origin: the earliest pool window start. Everything —
-    # windows, pins, previous placements, ``now`` itself — is offset from it,
-    # and the apply converts back with the same base.
+    # The minute frame's origin: the earliest reservation window start — a
+    # pool's, or an event-wide one's. Everything — windows, pins, previous
+    # placements, ``now`` itself — is offset from it, and the apply converts
+    # back with the same base.
     base = min((start for _, _, start, _ in pool_specs), default=now)
 
     def to_min(moment: datetime) -> int:
@@ -878,17 +948,18 @@ async def _load_solver_inputs(
     broken_pin_voids: set[uuid.UUID] = set()
     for event, settings, _pools in parsed_events:
         for fixture in fixtures_by_event[event.id]:
-            if fixture.pool_id is None:
-                # Un-pooled (single-elim / swiss / a KO stage): no pool, no
-                # window — KO scheduling is a later layer (module docstring).
-                #
-                # For swiss this `continue` skips the ENTIRE event rather than a
-                # stage of it: a swiss draw is un-pooled end to end, so no
-                # fixture of one is ever given a SOLVED table or start and
-                # nothing in one is ever placed automatically. The only table
-                # and time a swiss fixture gets is one a director typed in
-                # (module docstring).
-                continue
+            # Which reservation restricts this fixture (ADR "a pool restricts
+            # scheduling, it does not enable it"). A pooled fixture takes its
+            # own pool's tables and window, exactly as it always has. An
+            # un-pooled one — a single-elim or swiss fixture, or an rr-then-ko
+            # draw's knockout stage — takes its event's event-wide reservation,
+            # built above; the branch is present for the event precisely because
+            # this fixture is, so the lookup is total.
+            pool_key = (
+                event_wide_pool_key(event.id)
+                if fixture.pool_id is None
+                else PoolId(f"{event.id}:{fixture.pool_id}")
+            )
             if fixture.entry_a_id is None or fixture.entry_b_id is None:
                 # TBD side: cannot be placed; the snapshot builder leaves it
                 # out (app.scheduling's contract).
@@ -934,7 +1005,7 @@ async def _load_solver_inputs(
                     start_min=to_min(fixture.scheduled_start),
                 )
             fixture_id = FixtureId(str(fixture.id))
-            # Only placeable (pooled, both-sides-known) fixtures reach here, and
+            # Only placeable (both-sides-known) fixtures reach here, and
             # only such a fixture can surface in a WindowTooShortForMatch reason
             # or a placement conflict — so this is exactly the set the apply
             # resolves best_of and matchup names for. Both entries are non-None
@@ -948,7 +1019,7 @@ async def _load_solver_inputs(
                 ScheduleFixture(
                     id=fixture_id,
                     event_id=EventId(str(event.id)),
-                    pool_id=PoolId(f"{event.id}:{fixture.pool_id}"),
+                    pool_id=pool_key,
                     # User-level ids, not entry ids: the no-double-booking and
                     # rest constraints hold across events, on humans.
                     player_a_id=PlayerId(str(entry_user[fixture.entry_a_id])),
@@ -1033,6 +1104,19 @@ async def _load_solver_inputs(
             {
                 "id": str(event.id),
                 "length_games": settings.length_games,
+                # The event's own window and zone: what an event-wide
+                # reservation is built from (ADR "a pool restricts scheduling,
+                # it does not enable it"), so an edit to either is input drift
+                # the apply must discard as stale. Written for EVERY event, not
+                # only the ones that have un-pooled fixtures: a payload whose
+                # *shape* varied with a fact would make that fact unhashed,
+                # which is the very drift this guard exists to catch.
+                "timezone": event.timezone,
+                "slot": {
+                    "date": event_slots[event.id].date,
+                    "start": event_slots[event.id].start,
+                    "end": event_slots[event.id].end,
+                },
                 "pools": [
                     {
                         # ``str``, because the fingerprint is canonical JSON and a

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -490,8 +490,10 @@ class NoSingleCause:
     structural cause (arms above) explains it — the infeasibility lives in the
     combinatorial interaction of windows, rest, and no-double-booking that only
     search sees. Carries the whole-day aggregate for context: ``required_min``
-    (Σ every active fixture's duration) against ``available_min`` (Σ over pools
-    of ``window_span × table_count``). Typically ``required_min ≤ available_min``
+    (Σ every active fixture's duration) against ``available_min``, the venue's
+    own table-minutes — the *union* of what the reservations cover, per table, so
+    two reservations over one table at one hour offer that hour once
+    (:func:`_aggregate_capacity`). Typically ``required_min ≤ available_min``
     here — aggregate room exists, but it cannot be packed."""
 
     required_min: int
@@ -646,19 +648,41 @@ def _no_plan(
 
 def _aggregate_capacity(snapshot: ScheduleSnapshot) -> tuple[int, int]:
     """``(required_min, available_min)`` for the whole day: Σ every active
-    fixture's duration against Σ over pools of ``window_span × table_count``.
+    fixture's duration against the table-minutes the **venue** actually offers.
     The rough aggregate behind :class:`NoSingleCause`. Reads the event map
     directly — a solve only reaches this on a *built* model, so the snapshot's
-    cross-references have already passed :func:`_validated`."""
+    cross-references have already passed :func:`_validated`.
+
+    ``available_min`` is the union of the reservations' coverage, per table, not
+    their sum. **Reservations overlap**: pools may share a table (per-table
+    no-overlap is global, see :class:`SchedulePool`), and a snapshot builder may
+    lay a whole-venue reservation over an event's own pools — which is exactly
+    what an rr-then-ko event carries, a pool for its group stage and an
+    event-wide reservation for its bracket, on the same tables at the same hours.
+    Summing them would count one table's hour once per reservation that reserves
+    it, and this number is *director-facing*: it renders as "there's enough total
+    table-time (about Nh available)". A physical table gives an hour once, so it
+    is counted once, however many reservations claim it."""
     events = {e.id: e for e in snapshot.events}
     required = sum(
         match_minutes(events[f.event_id].length_games)
         for f in snapshot.fixtures
         if not f.completed
     )
+    spans_by_table: dict[TableId, list[tuple[int, int]]] = defaultdict(list)
+    for pool in snapshot.pools:
+        # A degenerate (empty or inverted) window offers nothing — and must not
+        # subtract from what the other reservations offer.
+        if pool.window.end_min <= pool.window.start_min:
+            continue
+        for table_id in pool.table_ids:
+            spans_by_table[table_id].append(
+                (pool.window.start_min, pool.window.end_min)
+            )
     available = sum(
-        (p.window.end_min - p.window.start_min) * len(p.table_ids)
-        for p in snapshot.pools
+        end - start
+        for spans in spans_by_table.values()
+        for start, end in _merge_spans(spans)
     )
     return required, available
 

--- a/api/app/schemas/schedule_solve.py
+++ b/api/app/schemas/schedule_solve.py
@@ -4,9 +4,10 @@
 only reasons (:data:`app.scheduling.InfeasibilityReason`) — pure and DB-blind on
 purpose. This module is the DB-aware humanizer: it carries the *resolved* form a
 client can render without any further lookup — the pool's display **name**, the
-window's ``HH:MM`` clock bounds, the event's ``best_of`` — while leaving the raw
-integer minutes (needed / span / required / capacity / available) untouched so
-the client formats hours itself.
+kind of **reservation** that name belongs to (:data:`ReservationKind`, so a
+remedy can name a control the director has), the window's ``HH:MM`` clock bounds,
+the event's ``best_of`` — while leaving the raw integer minutes (needed / span /
+required / capacity / available) untouched so the client formats hours itself.
 
 Structured, not prose (ADR "an infeasible solve explains itself with a resolved
 reason"): a discriminated union over ``kind`` — the *same* discriminator strings
@@ -23,23 +24,44 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, TypeAdapter
 
+#: Which **kind of reservation** a reason blames (ADR 20260807 "a pool restricts
+#: scheduling, it does not enable it"). ``"pool"`` is a pool the director created
+#: and can edit — tables, window and all. ``"event"`` is the **event-wide
+#: reservation**: the synthetic one an un-pooled fixture (a single-elim or swiss
+#: field, an rr-then-ko draw's knockout stage) is placed in, which carries the
+#: event's own window and the whole tournament's tables and exists only inside a
+#: solve. The distinction is not cosmetic: a remedy must name a control that
+#: exists, and there is no "add a table to" or "shrink" verb for an event-wide
+#: reservation — its controls are the event's window and the tournament's table
+#: catalogue. The same two words the web view model uses for the same fact.
+#:
+#: Every reason that names a reservation carries this. It defaults to ``"pool"``
+#: because that is the true value for every reason recorded before the event-wide
+#: reservation existed: until then a reason could only blame a pool row, so a
+#: ledger row read back from JSONB without the field *did* blame a pool.
+ReservationKind = Literal["pool", "event"]
+
 
 class PoolHasNoTablesRead(BaseModel):
     """A pool with active fixtures but no tables at all — nowhere to place them.
-    Resolved: the pool's display ``name`` (never the namespaced solver id)."""
+    Resolved: the pool's display ``name`` (never the namespaced solver id) and
+    which kind of ``reservation`` that name belongs to."""
 
     kind: Literal["pool_has_no_tables"] = "pool_has_no_tables"
     pool_name: str
+    reservation: ReservationKind = "pool"
 
 
 class WindowTooShortForMatchRead(BaseModel):
     """A single fixture whose pool window cannot hold even one match: its
     ``best_of`` match needs ``needed_min`` minutes but the window spans only
-    ``window_span_min``. Resolved: the pool ``name`` and its ``HH:MM`` window
-    bounds; the minutes pass through as integers for the client to format."""
+    ``window_span_min``. Resolved: the pool ``name``, which kind of
+    ``reservation`` it is, and its ``HH:MM`` window bounds; the minutes pass
+    through as integers for the client to format."""
 
     kind: Literal["window_too_short_for_match"] = "window_too_short_for_match"
     pool_name: str
+    reservation: ReservationKind = "pool"
     window_start: str
     window_end: str
     best_of: Literal[1, 3, 5, 7]
@@ -50,11 +72,12 @@ class WindowTooShortForMatchRead(BaseModel):
 class PoolOverCapacityRead(BaseModel):
     """A pool whose aggregate match-time (``required_min``) exceeds the
     table-minutes its window offers (``capacity_min`` = window span ×
-    ``table_count``). Resolved: the pool ``name`` and its ``HH:MM`` bounds; the
-    minutes stay integers."""
+    ``table_count``). Resolved: the pool ``name``, which kind of ``reservation``
+    it is, and its ``HH:MM`` bounds; the minutes stay integers."""
 
     kind: Literal["pool_over_capacity"] = "pool_over_capacity"
     pool_name: str
+    reservation: ReservationKind = "pool"
     window_start: str
     window_end: str
     required_min: int
@@ -68,12 +91,15 @@ class PlayerOverSubscribedRead(BaseModel):
     minutes of *their* time, against a window spanning only ``window_span_min``.
     A pigeonhole over one person, so adding tables cannot fix it — the remedy is
     fewer matches for them in this pool, or a longer window. Resolved: the
-    human's display ``player_name`` and the pool's ``name`` + ``HH:MM`` bounds;
-    the minutes stay integers for the client to format."""
+    human's display ``player_name``, the pool's ``name`` + ``HH:MM`` bounds, and
+    which kind of ``reservation`` that name is — "a smaller pool" is not a remedy
+    an event-wide reservation has; the minutes stay integers for the client to
+    format."""
 
     kind: Literal["player_over_subscribed"] = "player_over_subscribed"
     player_name: str
     pool_name: str
+    reservation: ReservationKind = "pool"
     window_start: str
     window_end: str
     match_count: int

--- a/api/tests/test_schedule_preview_solve.py
+++ b/api/tests/test_schedule_preview_solve.py
@@ -570,6 +570,10 @@ async def test_preview_solve_infeasible_resolves_its_reasons(
     assert reason.pool_name == "Pool A"
     assert reason.window_start == "09:00"
     assert reason.best_of == 5
+    # A preview schedules pooled fixtures only — it drops an rr-then-ko draw's
+    # un-pooled knockout — so the reservation it blames is always a real pool,
+    # and the remedy the client offers may name a pool control.
+    assert reason.reservation == "pool"
 
 
 async def test_preview_over_subscribed_placeholder_resolves_to_its_label(
@@ -619,6 +623,7 @@ async def test_preview_over_subscribed_placeholder_resolves_to_its_label(
     assert first.match_count == 3
     assert first.required_min == 125  # 3 * 35 + 2 * REST_MIN
     assert first.window_span_min == 120
+    assert first.reservation == "pool"
 
 
 async def test_preview_solve_past_dated_window_resolves_past_window(

--- a/api/tests/test_schedule_solve_models.py
+++ b/api/tests/test_schedule_solve_models.py
@@ -40,6 +40,10 @@ from app.models import (
     TournamentStatus,
     VenueTable,
 )
+from app.schemas.schedule_solve import (
+    PoolHasNoTablesRead,
+    parse_infeasibility_reasons,
+)
 from app.schemas.tournament import ScheduleSolveRead
 from tests._helpers import event_pools, make_user, venue_tables
 
@@ -316,3 +320,17 @@ async def test_a_pinned_fixture_round_trips_its_pin_facts(
     assert fresh.pinned_at == called_at
     assert fresh.pinned_at is not None and fresh.pinned_at.tzinfo is not None
     assert fresh.call_notified_count == 2
+
+
+def test_a_reason_stored_before_the_discriminator_reads_as_a_pool() -> None:
+    """The ledger's ``infeasibility_reasons`` is JSONB written at apply, so rows
+    recorded before a reason carried ``reservation`` are still on disk and are
+    read back by this same parser. ``"pool"`` is the true value for every one of
+    them: until the event-wide reservation existed the only thing a reason could
+    blame was a pool row (ADR 20260807)."""
+    (reason,) = parse_infeasibility_reasons(
+        [{"kind": "pool_has_no_tables", "pool_name": "Pool A"}]
+    )
+    assert isinstance(reason, PoolHasNoTablesRead)
+    assert reason.pool_name == "Pool A"
+    assert reason.reservation == "pool"

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -26,9 +26,11 @@ load-bearing and the green above isn't scheduler luck.
 import asyncio
 import threading
 import uuid
+from collections import defaultdict
 from collections.abc import Callable
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
+from itertools import combinations
 from zoneinfo import ZoneInfo
 
 import fakeredis
@@ -65,6 +67,7 @@ from app.models import (
     TournamentEvent,
     TournamentEventDrawSettings,
     TournamentEventPool,
+    TournamentEventPoolTable,
     TournamentFixture,
     TournamentStatus,
     User,
@@ -79,6 +82,7 @@ from app.schedule_solves import (
 )
 from app.scheduling import (
     REST_MIN,
+    PastWindow,
     PlacedFixture,
     PlayerId,
     PlayerOverSubscribed,
@@ -1863,3 +1867,334 @@ class TestCalledMatchSlides:
         assert ledger.status is ScheduleSolveStatus.succeeded
         assert ledger.fixtures_placed == 0  # nothing moved
         assert ledger.fixtures_pinned == 1  # the verbatim echo
+
+
+async def _make_bracket_tournament(
+    db: AsyncSession,
+    *,
+    status: TournamentStatus = TournamentStatus.published,
+    entrants: int = 4,
+    tables: tuple[str, ...] = ("t1", "t2"),
+    window: tuple[str, str] = ("09:00", "17:00"),
+    slot_date: str = DATE,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    """A tournament whose one event is a **single-elimination** event with **no
+    pools** — the un-pooled shape the event-wide reservation exists for (ADR "a
+    pool restricts scheduling, it does not enable it").
+
+    Deliberately not a variant of ``_make_tournament``: the point of this seed is
+    everything it does *not* have (no pool row, so every fixture's ``pool_id`` is
+    NULL), and a flag on that helper would hide exactly that. Returns
+    ``(tournament_id, event_id)`` as plain ids, for the reason it does.
+    """
+    owner = await make_user(db, f"director-{uuid.uuid4().hex[:8]}")
+    league = await get_default_league(db)
+    assert league is not None, "the autouse default_league fixture seeds this"
+
+    tournament = Tournament(
+        name="Bracket Open",
+        status=status,
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "1 Shattuck Ave",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94704",
+            "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
+        },
+        tables=venue_tables(*((table.upper(), "Main") for table in tables)),
+        league_id=league.id,
+        created_by_user_id=owner.id,
+    )
+    db.add(tournament)
+    await db.flush()
+
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Open Bracket",
+        format=EventFormat.singles,
+        draw_settings=TournamentEventDrawSettings.for_draw_type(DrawType.single_elim),
+        max_players=None,
+        entry_fee=Decimal("0.00"),
+        timezone="America/Chicago",
+        slot={"date": slot_date, "start": window[0], "end": window[1]},
+        match_settings={"rated": False, "length_games": 3},
+        pools=[],
+    )
+    db.add(event)
+    await db.flush()
+
+    for _ in range(entrants):
+        player = await make_user(db, f"player-{uuid.uuid4().hex[:8]}")
+        db.add(TournamentEntry(event_id=event.id, user_id=player.id))
+    await db.flush()
+
+    await cut_draw(db, event)
+    await db.commit()
+    return tournament.id, event.id
+
+
+async def _make_two_pool_tournament(
+    db: AsyncSession,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    """A round-robin event with **two pools that genuinely restrict**: Pool A on
+    table 1 in the morning, Pool B on table 2 in the afternoon, inside an event
+    window that spans both. The regression bed for "a pool still confines its
+    fixtures" — an event whose single pool spans every table and the whole day
+    (``_make_tournament``) could not tell a confined solve from an unconfined
+    one."""
+    owner = await make_user(db, f"director-{uuid.uuid4().hex[:8]}")
+    league = await get_default_league(db)
+    assert league is not None, "the autouse default_league fixture seeds this"
+
+    catalogue = venue_tables(("T1", "Main"), ("T2", "Main"))
+    tournament = Tournament(
+        name="Pooled Open",
+        status=TournamentStatus.published,
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "1 Shattuck Ave",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94704",
+            "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
+        },
+        tables=catalogue,
+        league_id=league.id,
+        created_by_user_id=owner.id,
+    )
+    db.add(tournament)
+    await db.flush()
+
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Pooled Singles",
+        format=EventFormat.singles,
+        draw_settings=TournamentEventDrawSettings.for_draw_type(DrawType.round_robin),
+        max_players=None,
+        entry_fee=Decimal("0.00"),
+        timezone="America/Chicago",
+        # The event window spans the whole day, so an event-wide reservation —
+        # if one wrongly claimed these fixtures — would look feasible on any
+        # table at any hour. That is what makes the pool assertions below able
+        # to fail.
+        slot={"date": DATE, "start": "09:00", "end": "17:00"},
+        match_settings={"rated": False, "length_games": 3},
+        pools=event_pools(
+            [
+                {
+                    "name": "Pool A",
+                    "slot": {"date": DATE, "start": "09:00", "end": "12:00"},
+                    "table_ids": ["t1"],
+                },
+                {
+                    "name": "Pool B",
+                    "slot": {"date": DATE, "start": "13:00", "end": "17:00"},
+                    "table_ids": ["t2"],
+                },
+            ],
+            tournament=tournament,
+        ),
+    )
+    db.add(event)
+    await db.flush()
+
+    for _ in range(6):
+        player = await make_user(db, f"player-{uuid.uuid4().hex[:8]}")
+        db.add(TournamentEntry(event_id=event.id, user_id=player.id))
+    await db.flush()
+
+    await cut_draw(db, event)
+    await db.commit()
+    return tournament.id, event.id
+
+
+class TestEventWideReservation:
+    """A fixture with no pool is placed over its event's whole timeline (ADR "a
+    pool restricts scheduling, it does not enable it"): the event's own ``slot``
+    for a window, every table in the tournament for tables. The snapshot builder
+    synthesizes one such reservation per event that has un-pooled fixtures —
+    nothing is written, no pool row exists, and ``app.scheduling`` is untouched.
+
+    These probe ``_load_solver_inputs`` and run the real solver over what it
+    built, because the claim is about the snapshot the pure module receives."""
+
+    async def test_a_bracket_is_placed_on_the_tournaments_tables_in_its_window(
+        self, db_session: AsyncSession
+    ) -> None:
+        """The headline: a single-elim event's first round gets a table and a
+        time, where before this it got nothing at all. Every placement lands on
+        a table of the tournament's own catalogue, inside the event's window,
+        and two matches never share a table at the same moment."""
+        tournament_id, event_id = await _make_bracket_tournament(db_session)
+        catalogue = await table_ids_of(db_session, tournament_id)
+
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=BASE, lock=False
+        )
+        assert inputs is not None
+        result = scheduling.solve(inputs.snapshot)
+
+        assert result.verdict in (Verdict.optimal, Verdict.feasible)
+        # Both round-1 fixtures of a 4-entrant bracket, placed.
+        fixtures = await _fixtures_of(db_session, event_id)
+        round_one = {str(f.id) for f in fixtures if f.round == 1}
+        assert len(round_one) == 2
+        assert {p.fixture_id for p in result.placements} == round_one
+
+        window_start = datetime(2030, 1, 1, 9, 0, tzinfo=VENUE_TZ)
+        window_end = datetime(2030, 1, 1, 17, 0, tzinfo=VENUE_TZ)
+        for placement in result.placements:
+            assert placement.table_id in catalogue
+            start = inputs.base + timedelta(minutes=placement.start_min)
+            end = inputs.base + timedelta(minutes=placement.end_min)
+            assert window_start <= start
+            assert end <= window_end
+        # "A table at a time": two matches on one table never overlap.
+        for first, second in combinations(result.placements, 2):
+            if first.table_id != second.table_id:
+                continue
+            assert (
+                first.end_min <= second.start_min or second.end_min <= first.start_min
+            )
+
+    async def test_a_pool_still_confines_its_fixtures_to_its_tables_and_window(
+        self, db_session: AsyncSession
+    ) -> None:
+        """THE regression the design rests on: a pooled fixture is placed on its
+        **own pool's** tables inside its **own pool's** window — never on the
+        event-wide reservation's, which here spans both tables and the whole day.
+
+        The expectations come from the pool ROWS, not from the snapshot's own
+        fixture→pool link: a builder that handed these fixtures the event-wide
+        reservation would still satisfy "placed inside the pool it was given",
+        so that assertion would pass while the confinement was gone."""
+        tournament_id, event_id = await _make_two_pool_tournament(db_session)
+
+        pool_rows = (
+            await db_session.execute(
+                select(
+                    TournamentEventPool.id,
+                    TournamentEventPool.slot_start,
+                    TournamentEventPool.slot_end,
+                ).where(TournamentEventPool.event_id == event_id)
+            )
+        ).all()
+        assert len(pool_rows) == 2
+        pool_windows = {
+            pool_id: (
+                datetime.combine(date.fromisoformat(DATE), start, tzinfo=VENUE_TZ),
+                datetime.combine(date.fromisoformat(DATE), end, tzinfo=VENUE_TZ),
+            )
+            for pool_id, start, end in pool_rows
+        }
+        pool_tables: defaultdict[uuid.UUID, set[str]] = defaultdict(set)
+        for pool_id, table_id in (
+            await db_session.execute(
+                select(
+                    TournamentEventPoolTable.pool_id, TournamentEventPoolTable.table_id
+                ).where(TournamentEventPoolTable.event_id == event_id)
+            )
+        ).all():
+            pool_tables[pool_id].add(str(table_id))
+        assert [len(tables) for tables in pool_tables.values()] == [1, 1]
+
+        fixture_pool = {
+            str(fixture.id): fixture.pool_id
+            for fixture in await _fixtures_of(db_session, event_id)
+        }
+        assert all(pool_id is not None for pool_id in fixture_pool.values())
+
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=BASE, lock=False
+        )
+        assert inputs is not None
+        result = scheduling.solve(inputs.snapshot)
+
+        assert result.verdict in (Verdict.optimal, Verdict.feasible)
+        assert len(result.placements) == len(fixture_pool)
+        for placement in result.placements:
+            pool_id = fixture_pool[placement.fixture_id]
+            assert pool_id is not None
+            assert placement.table_id in pool_tables[pool_id]
+            window_start, window_end = pool_windows[pool_id]
+            assert window_start <= inputs.base + timedelta(minutes=placement.start_min)
+            assert inputs.base + timedelta(minutes=placement.end_min) <= window_end
+
+    async def test_a_tournament_with_no_tables_blames_the_reservation_by_name(
+        self, db_session: AsyncSession
+    ) -> None:
+        """A bracket at a venue with no tables is infeasible for the reason it
+        always was — ``PoolHasNoTables`` — now fired against the event-wide
+        reservation, and resolved to something a director can read rather than
+        to the namespaced solver id."""
+        tournament_id, _event_id = await _make_bracket_tournament(db_session, tables=())
+
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=BASE, lock=False
+        )
+        assert inputs is not None
+        result = scheduling.solve(inputs.snapshot)
+
+        assert result.verdict is Verdict.infeasible
+        (reason,) = [r for r in result.reasons if isinstance(r, PoolHasNoTables)]
+        resolved = schedule_solves._resolve_reason(reason, inputs)
+        assert isinstance(resolved, PoolHasNoTablesRead)
+        # The event a director knows, plus what is actually reserved. Not the
+        # namespaced id, and not the bare event name (which would send them
+        # looking for a table control an event does not have).
+        assert resolved.pool_name == "Open Bracket (whole venue)"
+        assert str(reason.pool_id) not in resolved.pool_name
+
+    async def test_a_past_event_window_resolves_to_its_venue_local_date(
+        self, db_session: AsyncSession
+    ) -> None:
+        """``pool_dates`` carries the event-wide reservation too: a pre-live
+        bracket dated in the past is named by the DAY to move (ADR "a past day is
+        named"), which is a ``KeyError`` at exactly the wrong moment if the
+        synthesized reservation is missing from that map."""
+        tournament_id, _event_id = await _make_bracket_tournament(
+            db_session, slot_date="2020-01-01"
+        )
+
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session,
+            tournament_id,
+            now=datetime(2020, 1, 2, 9, 0, tzinfo=VENUE_TZ),
+            lock=False,
+        )
+        assert inputs is not None
+        result = scheduling.solve(inputs.snapshot)
+
+        assert result.verdict is Verdict.infeasible
+        (reason,) = [r for r in result.reasons if isinstance(r, PastWindow)]
+        resolved = schedule_solves._resolve_reason(reason, inputs)
+        assert isinstance(resolved, PastWindowReasonRead)
+        assert resolved.date == date(2020, 1, 1)
+
+    async def test_a_fixture_with_a_side_still_unknown_stays_unplaced(
+        self, db_session: AsyncSession
+    ) -> None:
+        """The TBD guard is what lets a knockout fill in round by round: a
+        4-entrant bracket's final has no sides yet, so it is left out of the
+        snapshot — while its two feeders, which do have sides, are in it. (A
+        test that only asserted the final's absence would pass against a build
+        that skipped the whole event, which is the state before this slice.)"""
+        tournament_id, event_id = await _make_bracket_tournament(db_session)
+        fixtures = await _fixtures_of(db_session, event_id)
+        final = next(f for f in fixtures if f.round == 2)
+        assert final.entry_a_id is None and final.entry_b_id is None
+        round_one = {str(f.id) for f in fixtures if f.round == 1}
+
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=BASE, lock=False
+        )
+
+        assert inputs is not None
+        snapshot_ids = {fixture.id for fixture in inputs.snapshot.fixtures}
+        assert str(final.id) not in snapshot_ids
+        assert round_one <= snapshot_ids

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -27,10 +27,11 @@ import asyncio
 import threading
 import uuid
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from itertools import combinations
+from typing import Any
 from zoneinfo import ZoneInfo
 
 import fakeredis
@@ -151,13 +152,29 @@ async def _make_tournament(
     window: tuple[str, str] = ("09:00", "17:00"),
     length_games: int = 3,
     slot_date: str = DATE,
+    draw_type: DrawType = DrawType.round_robin,
+    pools: Sequence[Mapping[str, Any]] | None = None,
 ) -> tuple[uuid.UUID, uuid.UUID]:
-    """A published tournament with a table catalogue, one pooled round-robin
-    event whose single pool spans every table, ``entrants`` entered players,
-    and a cut draw. Written straight to the database — nothing here is about
-    the create routes. Returns ``(tournament_id, event_id)`` as plain ids: the
-    tests expire the session after the job runs, and an expired ORM instance's
-    attribute access would try a sync lazy-load (``MissingGreenlet``)."""
+    """A published tournament with a table catalogue, one event of ``draw_type``,
+    ``entrants`` entered players, and a cut draw. Written straight to the
+    database — nothing here is about the create routes. Returns
+    ``(tournament_id, event_id)`` as plain ids: the tests expire the session
+    after the job runs, and an expired ORM instance's attribute access would try
+    a sync lazy-load (``MissingGreenlet``).
+
+    ``pools`` is the event's pools in the ``{name, slot, table_ids}`` dict shape
+    ``tests._helpers.event_pools`` speaks, naming tables by the positional
+    aliases (``"t1"``, ``"t2"``, …) of this tournament's own catalogue. Left out,
+    the event gets one pool spanning every table for the whole event window,
+    which is what most of this module's tests want.
+
+    Passing ``pools=[]`` is the un-pooled event the event-wide reservation exists
+    for (ADR "a pool restricts scheduling, it does not enable it"): no pool row,
+    so every fixture's ``pool_id`` is NULL. It is spelled that way at the call
+    site, rather than hidden behind a named variant helper, because in those
+    tests the absent pool is the whole subject — an explicit empty list says so
+    louder than a helper name does.
+    """
     owner = await make_user(db, f"director-{uuid.uuid4().hex[:8]}")
     league = await get_default_league(db)
     assert league is not None, "the autouse default_league fixture seeds this"
@@ -183,26 +200,28 @@ async def _make_tournament(
     db.add(tournament)
     await db.flush()
 
+    pool_specs: Sequence[Mapping[str, Any]] = (
+        [
+            {
+                "name": "Pool A",
+                "slot": {"date": slot_date, "start": window[0], "end": window[1]},
+                "table_ids": [str(row.id) for row in catalogue],
+            }
+        ]
+        if pools is None
+        else pools
+    )
     event = TournamentEvent(
         tournament_id=tournament.id,
         name="Open Singles",
         format=EventFormat.singles,
-        draw_settings=TournamentEventDrawSettings.for_draw_type(DrawType.round_robin),
+        draw_settings=TournamentEventDrawSettings.for_draw_type(draw_type),
         max_players=None,
         entry_fee=Decimal("0.00"),
         timezone="America/Chicago",
         slot={"date": slot_date, "start": window[0], "end": window[1]},
         match_settings={"rated": False, "length_games": length_games},
-        pools=event_pools(
-            [
-                {
-                    "name": "Pool A",
-                    "slot": {"date": slot_date, "start": window[0], "end": window[1]},
-                    "table_ids": [str(row.id) for row in catalogue],
-                }
-            ],
-            tournament=tournament,
-        ),
+        pools=event_pools(pool_specs, tournament=tournament),
     )
     db.add(event)
     await db.flush()
@@ -1869,73 +1888,6 @@ class TestCalledMatchSlides:
         assert ledger.fixtures_pinned == 1  # the verbatim echo
 
 
-async def _make_bracket_tournament(
-    db: AsyncSession,
-    *,
-    status: TournamentStatus = TournamentStatus.published,
-    entrants: int = 4,
-    tables: tuple[str, ...] = ("t1", "t2"),
-    window: tuple[str, str] = ("09:00", "17:00"),
-    slot_date: str = DATE,
-) -> tuple[uuid.UUID, uuid.UUID]:
-    """A tournament whose one event is a **single-elimination** event with **no
-    pools** — the un-pooled shape the event-wide reservation exists for (ADR "a
-    pool restricts scheduling, it does not enable it").
-
-    Deliberately not a variant of ``_make_tournament``: the point of this seed is
-    everything it does *not* have (no pool row, so every fixture's ``pool_id`` is
-    NULL), and a flag on that helper would hide exactly that. Returns
-    ``(tournament_id, event_id)`` as plain ids, for the reason it does.
-    """
-    owner = await make_user(db, f"director-{uuid.uuid4().hex[:8]}")
-    league = await get_default_league(db)
-    assert league is not None, "the autouse default_league fixture seeds this"
-
-    tournament = Tournament(
-        name="Bracket Open",
-        status=status,
-        address={
-            "venue": "Berkeley TT Club",
-            "street": "1 Shattuck Ave",
-            "city": "Berkeley",
-            "region": "CA",
-            "postal": "94704",
-            "country": "USA",
-            "latitude": 37.8703,
-            "longitude": -122.2731,
-        },
-        tables=venue_tables(*((table.upper(), "Main") for table in tables)),
-        league_id=league.id,
-        created_by_user_id=owner.id,
-    )
-    db.add(tournament)
-    await db.flush()
-
-    event = TournamentEvent(
-        tournament_id=tournament.id,
-        name="Open Bracket",
-        format=EventFormat.singles,
-        draw_settings=TournamentEventDrawSettings.for_draw_type(DrawType.single_elim),
-        max_players=None,
-        entry_fee=Decimal("0.00"),
-        timezone="America/Chicago",
-        slot={"date": slot_date, "start": window[0], "end": window[1]},
-        match_settings={"rated": False, "length_games": 3},
-        pools=[],
-    )
-    db.add(event)
-    await db.flush()
-
-    for _ in range(entrants):
-        player = await make_user(db, f"player-{uuid.uuid4().hex[:8]}")
-        db.add(TournamentEntry(event_id=event.id, user_id=player.id))
-    await db.flush()
-
-    await cut_draw(db, event)
-    await db.commit()
-    return tournament.id, event.id
-
-
 async def _make_two_pool_tournament(
     db: AsyncSession,
 ) -> tuple[uuid.UUID, uuid.UUID]:
@@ -1943,74 +1895,32 @@ async def _make_two_pool_tournament(
     table 1 in the morning, Pool B on table 2 in the afternoon, inside an event
     window that spans both. The regression bed for "a pool still confines its
     fixtures" — an event whose single pool spans every table and the whole day
-    (``_make_tournament``) could not tell a confined solve from an unconfined
-    one."""
-    owner = await make_user(db, f"director-{uuid.uuid4().hex[:8]}")
-    league = await get_default_league(db)
-    assert league is not None, "the autouse default_league fixture seeds this"
+    (``_make_tournament``'s default pool) could not tell a confined solve from an
+    unconfined one.
 
-    catalogue = venue_tables(("T1", "Main"), ("T2", "Main"))
-    tournament = Tournament(
-        name="Pooled Open",
-        status=TournamentStatus.published,
-        address={
-            "venue": "Berkeley TT Club",
-            "street": "1 Shattuck Ave",
-            "city": "Berkeley",
-            "region": "CA",
-            "postal": "94704",
-            "country": "USA",
-            "latitude": 37.8703,
-            "longitude": -122.2731,
-        },
-        tables=catalogue,
-        league_id=league.id,
-        created_by_user_id=owner.id,
+    The event window is left at the default whole day deliberately: an event-wide
+    reservation — if one wrongly claimed these fixtures — would look feasible on
+    any table at any hour. That is what makes the pool assertions able to fail.
+
+    Kept as its own name rather than inlined into the one test that seeds it: the
+    test reads its expectations back out of the pool ROWS, so a pool literal
+    sitting beside those reads would look like a round-trip worth deleting."""
+    return await _make_tournament(
+        db,
+        entrants=6,
+        pools=[
+            {
+                "name": "Pool A",
+                "slot": {"date": DATE, "start": "09:00", "end": "12:00"},
+                "table_ids": ["t1"],
+            },
+            {
+                "name": "Pool B",
+                "slot": {"date": DATE, "start": "13:00", "end": "17:00"},
+                "table_ids": ["t2"],
+            },
+        ],
     )
-    db.add(tournament)
-    await db.flush()
-
-    event = TournamentEvent(
-        tournament_id=tournament.id,
-        name="Pooled Singles",
-        format=EventFormat.singles,
-        draw_settings=TournamentEventDrawSettings.for_draw_type(DrawType.round_robin),
-        max_players=None,
-        entry_fee=Decimal("0.00"),
-        timezone="America/Chicago",
-        # The event window spans the whole day, so an event-wide reservation —
-        # if one wrongly claimed these fixtures — would look feasible on any
-        # table at any hour. That is what makes the pool assertions below able
-        # to fail.
-        slot={"date": DATE, "start": "09:00", "end": "17:00"},
-        match_settings={"rated": False, "length_games": 3},
-        pools=event_pools(
-            [
-                {
-                    "name": "Pool A",
-                    "slot": {"date": DATE, "start": "09:00", "end": "12:00"},
-                    "table_ids": ["t1"],
-                },
-                {
-                    "name": "Pool B",
-                    "slot": {"date": DATE, "start": "13:00", "end": "17:00"},
-                    "table_ids": ["t2"],
-                },
-            ],
-            tournament=tournament,
-        ),
-    )
-    db.add(event)
-    await db.flush()
-
-    for _ in range(6):
-        player = await make_user(db, f"player-{uuid.uuid4().hex[:8]}")
-        db.add(TournamentEntry(event_id=event.id, user_id=player.id))
-    await db.flush()
-
-    await cut_draw(db, event)
-    await db.commit()
-    return tournament.id, event.id
 
 
 class TestEventWideReservation:
@@ -2030,7 +1940,9 @@ class TestEventWideReservation:
         time, where before this it got nothing at all. Every placement lands on
         a table of the tournament's own catalogue, inside the event's window,
         and two matches never share a table at the same moment."""
-        tournament_id, event_id = await _make_bracket_tournament(db_session)
+        tournament_id, event_id = await _make_tournament(
+            db_session, draw_type=DrawType.single_elim, pools=[]
+        )
         catalogue = await table_ids_of(db_session, tournament_id)
 
         inputs = await schedule_solves._load_solver_inputs(
@@ -2132,7 +2044,9 @@ class TestEventWideReservation:
         always was — ``PoolHasNoTables`` — now fired against the event-wide
         reservation, and resolved to something a director can read rather than
         to the namespaced solver id."""
-        tournament_id, _event_id = await _make_bracket_tournament(db_session, tables=())
+        tournament_id, _event_id = await _make_tournament(
+            db_session, draw_type=DrawType.single_elim, pools=[], tables=()
+        )
 
         inputs = await schedule_solves._load_solver_inputs(
             db_session, tournament_id, now=BASE, lock=False
@@ -2147,7 +2061,7 @@ class TestEventWideReservation:
         # The event a director knows, plus what is actually reserved. Not the
         # namespaced id, and not the bare event name (which would send them
         # looking for a table control an event does not have).
-        assert resolved.pool_name == "Open Bracket (whole venue)"
+        assert resolved.pool_name == "Open Singles (whole venue)"
         assert str(reason.pool_id) not in resolved.pool_name
 
     async def test_a_past_event_window_resolves_to_its_venue_local_date(
@@ -2157,8 +2071,11 @@ class TestEventWideReservation:
         bracket dated in the past is named by the DAY to move (ADR "a past day is
         named"), which is a ``KeyError`` at exactly the wrong moment if the
         synthesized reservation is missing from that map."""
-        tournament_id, _event_id = await _make_bracket_tournament(
-            db_session, slot_date="2020-01-01"
+        tournament_id, _event_id = await _make_tournament(
+            db_session,
+            draw_type=DrawType.single_elim,
+            pools=[],
+            slot_date="2020-01-01",
         )
 
         inputs = await schedule_solves._load_solver_inputs(
@@ -2184,7 +2101,9 @@ class TestEventWideReservation:
         snapshot — while its two feeders, which do have sides, are in it. (A
         test that only asserted the final's absence would pass against a build
         that skipped the whole event, which is the state before this slice.)"""
-        tournament_id, event_id = await _make_bracket_tournament(db_session)
+        tournament_id, event_id = await _make_tournament(
+            db_session, draw_type=DrawType.single_elim, pools=[]
+        )
         fixtures = await _fixtures_of(db_session, event_id)
         final = next(f for f in fixtures if f.round == 2)
         assert final.entry_a_id is None and final.entry_b_id is None

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -66,7 +66,6 @@ from app.models import (
     TournamentEntry,
     TournamentEntryStatus,
     TournamentEvent,
-    TournamentEventDrawSettings,
     TournamentEventPool,
     TournamentEventPoolTable,
     TournamentFixture,
@@ -83,6 +82,7 @@ from app.schedule_solves import (
 )
 from app.scheduling import (
     REST_MIN,
+    InfeasibilityReason,
     PastWindow,
     PlacedFixture,
     PlayerId,
@@ -94,9 +94,11 @@ from app.scheduling import (
     SolveResult,
     SolveStats,
     Verdict,
+    WindowTooShortForMatch,
 )
 from app.schemas.notification import NotificationJob
 from app.schemas.schedule_solve import (
+    NoSingleCauseRead,
     PastWindowReasonRead,
     PlayerConflictRead,
     PlayerOverSubscribedRead,
@@ -109,6 +111,7 @@ from app.schemas.schedule_solve import (
 from app.schemas.tournament import ScheduleSolveRead
 from app.tournament_draws import cut_draw
 from tests._helpers import (
+    event_draw_settings,
     event_pools,
     hijack_solve,
     make_user,
@@ -153,6 +156,7 @@ async def _make_tournament(
     length_games: int = 3,
     slot_date: str = DATE,
     draw_type: DrawType = DrawType.round_robin,
+    qualifiers_per_pool: int | None = None,
     pools: Sequence[Mapping[str, Any]] | None = None,
 ) -> tuple[uuid.UUID, uuid.UUID]:
     """A published tournament with a table catalogue, one event of ``draw_type``,
@@ -167,6 +171,12 @@ async def _make_tournament(
     aliases (``"t1"``, ``"t2"``, …) of this tournament's own catalogue. Left out,
     the event gets one pool spanning every table for the whole event window,
     which is what most of this module's tests want.
+
+    ``qualifiers_per_pool`` is the one setting ``rr-then-ko`` carries — how many
+    of each pool's finishers reach the bracket. It goes through the same parse
+    the request boundary uses (``tests._helpers.event_draw_settings``), so a
+    count named for a draw type that has none reds here instead of writing a row
+    the app could not have made.
 
     Passing ``pools=[]`` is the un-pooled event the event-wide reservation exists
     for (ADR "a pool restricts scheduling, it does not enable it"): no pool row,
@@ -215,7 +225,9 @@ async def _make_tournament(
         tournament_id=tournament.id,
         name="Open Singles",
         format=EventFormat.singles,
-        draw_settings=TournamentEventDrawSettings.for_draw_type(draw_type),
+        draw_settings=event_draw_settings(
+            draw_type, qualifiers_per_pool=qualifiers_per_pool
+        ),
         max_players=None,
         entry_fee=Decimal("0.00"),
         timezone="America/Chicago",
@@ -1393,9 +1405,13 @@ class TestSolveJob:
         assert isinstance(no_tables, PoolHasNoTablesRead)
         # The DISPLAY name, never the namespaced ``{event_id}:pool-a`` id.
         assert no_tables.pool_name == "Pool A"
+        # Blamed reservation: a real pool, so a remedy may name a pool control
+        # ("add a table to Pool A"). It survives the JSONB round-trip.
+        assert no_tables.reservation == "pool"
 
         assert isinstance(over_capacity, PoolOverCapacityRead)
         assert over_capacity.pool_name == "Pool A"
+        assert over_capacity.reservation == "pool"
         assert over_capacity.window_start == "09:00"
         assert over_capacity.window_end == "17:00"
         assert over_capacity.required_min == 600
@@ -1470,6 +1486,7 @@ class TestSolveJob:
         assert reason.match_count == 3
         assert reason.required_min == 95
         assert reason.window_span_min == 60
+        assert reason.reservation == "pool"
 
     async def test_succeeded_apply_leaves_infeasibility_reasons_null(
         self, db_session: AsyncSession, solver_queue: Queue
@@ -2092,6 +2109,105 @@ class TestEventWideReservation:
         resolved = schedule_solves._resolve_reason(reason, inputs)
         assert isinstance(resolved, PastWindowReasonRead)
         assert resolved.date == date(2020, 1, 1)
+
+    async def test_a_reason_says_which_kind_of_reservation_it_blames(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Every reason that names a reservation says whether that reservation is
+        a **pool** or the **event-wide** one, so a client can offer a remedy that
+        names a control the director actually has.
+
+        Without it the pool-shaped copy is offered against a reservation that is
+        not a pool: "add a table to Open Singles (whole venue)", which already
+        holds every table there is, or "give P fewer matches in Open Singles
+        (whole venue) — a smaller pool", which names a pool the event does not
+        have. The name alone cannot carry that distinction, and bending the name
+        to fit the sentence is what produced the problem.
+
+        All four named arms are checked against the event-wide reservation
+        (:class:`~app.scheduling.NoSingleCause` names none, and
+        :class:`~app.scheduling.PastWindow` names only a date). The reasons are
+        built by hand: their *resolution* is what is under test, and a real solve
+        can only be made to prove one arm at a time."""
+        tournament_id, event_id = await _make_tournament(
+            db_session, draw_type=DrawType.single_elim, pools=[]
+        )
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=BASE, lock=False
+        )
+        assert inputs is not None
+        key = schedule_solves.event_wide_pool_key(event_id)
+        fixture = inputs.snapshot.fixtures[0]
+        reasons: tuple[InfeasibilityReason, ...] = (
+            PoolHasNoTables(pool_id=key),
+            WindowTooShortForMatch(
+                pool_id=key,
+                fixture_id=fixture.id,
+                needed_min=25,
+                window_span_min=10,
+            ),
+            PoolOverCapacity(
+                pool_id=key, required_min=600, capacity_min=480, table_count=2
+            ),
+            PlayerOverSubscribed(
+                pool_id=key,
+                player_id=fixture.player_a_id,
+                match_count=3,
+                required_min=95,
+                window_span_min=60,
+            ),
+        )
+
+        for reason in reasons:
+            resolved = schedule_solves._resolve_reason(reason, inputs)
+            # The two arms that name no reservation are not in this tuple.
+            assert not isinstance(
+                resolved, (NoSingleCauseRead, PastWindowReasonRead)
+            ), resolved
+            assert resolved.reservation == "event"
+            assert resolved.pool_name == "Open Singles (whole venue)"
+
+    async def test_an_rr_then_ko_event_counts_its_venue_once(
+        self, db_session: AsyncSession
+    ) -> None:
+        """An rr-then-ko event carries BOTH reservations at once — a real pool
+        for its group stage, the event-wide one for its bracket — and they cover
+        the same two tables over the same eight hours.
+
+        The day aggregate behind ``no_single_cause`` is director-facing: it
+        renders as "there's enough total table-time (about Nh available)", beside
+        copy that already asserts the room exists. Summing the reservations would
+        report 32 table-hours at a venue that has 16, making a confident claim
+        more wrong. Two tables, 09:00 to 17:00: 960 table-minutes."""
+        tournament_id, event_id = await _make_tournament(
+            db_session,
+            entrants=6,
+            draw_type=DrawType.rr_then_ko,
+            qualifiers_per_pool=2,
+        )
+
+        fixtures = await _fixtures_of(db_session, event_id)
+        # The shape the double-count needs: a pooled group stage and an un-pooled
+        # bracket in one event. Asserted from the fixture rows, so this reds if a
+        # later change stops the draw leaving its knockout un-pooled.
+        assert any(fixture.pool_id is not None for fixture in fixtures)
+        assert any(fixture.pool_id is None for fixture in fixtures)
+
+        inputs = await schedule_solves._load_solver_inputs(
+            db_session, tournament_id, now=BASE, lock=False
+        )
+        assert inputs is not None
+        pool_key = await _solver_pool_id(db_session, event_id)
+        event_wide_key = schedule_solves.event_wide_pool_key(event_id)
+        by_id = {pool.id: pool for pool in inputs.snapshot.pools}
+        assert set(by_id) == {pool_key, event_wide_key}
+        # They overlap wholesale — same tables, same window — which is why one
+        # venue must not be counted twice.
+        assert set(by_id[pool_key].table_ids) == set(by_id[event_wide_key].table_ids)
+        assert by_id[pool_key].window == by_id[event_wide_key].window
+
+        _required_min, available_min = scheduling._aggregate_capacity(inputs.snapshot)
+        assert available_min == 2 * 8 * 60
 
     async def test_a_fixture_with_a_side_still_unknown_stays_unplaced(
         self, db_session: AsyncSession

--- a/api/tests/test_scheduling_solver.py
+++ b/api/tests/test_scheduling_solver.py
@@ -679,6 +679,45 @@ class TestInfeasibility:
         assert isinstance(only, NoSingleCause)
         assert only.required_min <= only.available_min
 
+    def test_overlapping_reservations_do_not_double_count_the_venue(self) -> None:
+        """An rr-then-ko event's shape: its group stage sits in a pool, and its
+        knockout stage — which belongs to no pool — sits in the event-wide
+        reservation, which covers the SAME tables over the SAME window (ADR
+        20260807 "a pool restricts scheduling, it does not enable it"). Both
+        reservations describe one venue, so the day aggregate must describe that
+        venue once.
+
+        ``available_min`` is director-facing — it renders as "there's enough
+        total table-time (about Nh available)" — so summing the two reservations
+        would claim 4 table-hours on a venue that has 2, and would say it beside
+        copy that already asserts the room exists.
+
+        Two tables from 0 to 50, reserved twice over: 100 table-minutes, not 200.
+        Infeasible for a cause no arm proves — P1's two matches plus the rest
+        floor need 60 minutes of P1's own time, and the windows end at 50, yet
+        each match fits its own reservation and no single reservation
+        over-subscribes anyone (one match each)."""
+        p1, p2, p3 = _players(3)
+        table_ids = _tables(2)
+        pool_key = PoolId("E1:A")
+        event_wide_key = PoolId("E1:event-wide")
+        snapshot = ScheduleSnapshot(
+            table_ids=table_ids,
+            pools=(
+                SchedulePool(pool_key, table_ids, Window(0, 50)),
+                SchedulePool(event_wide_key, table_ids, Window(0, 50)),
+            ),
+            events=(EventSettings(EventId("E1"), 3),),
+            fixtures=(
+                _fixture(1, p1, p2, pool=pool_key),  # the group stage
+                _fixture(2, p1, p3, pool=event_wide_key),  # the knockout
+            ),
+            now_min=0,
+        )
+        result = solve(snapshot, time_cap_s=CAP)
+        assert result.verdict is Verdict.infeasible
+        assert result.reasons == (NoSingleCause(required_min=50, available_min=100),)
+
     def test_pool_with_no_tables_is_infeasible(self) -> None:
         p1, p2 = _players(2)
         snapshot = ScheduleSnapshot(

--- a/docs/adr/20260807-a-pool-restricts-scheduling-it-does-not-enable-it.md
+++ b/docs/adr/20260807-a-pool-restricts-scheduling-it-does-not-enable-it.md
@@ -1,0 +1,132 @@
+# A pool restricts scheduling, it does not enable it
+
+Date: 2026-08-07 (date-numbered — sequential numbers collide across concurrent
+worktrees; see `scripts/check-adr-numbering.sh`)
+
+## Status
+
+Accepted. Decided during the grill for #1228, which schedules the knockout stage.
+It replaces the design recorded in #1228's comment thread on 2026-08-01, which
+minted a pool row for the bracket. ADR-0790 stands unchanged.
+
+## Context
+
+The solver reads its windows and its tables from pools. A pool carries a `Slot`
+and a set of reserved tables. `schedule_solves.py` builds one `SchedulePool` per
+pool, then places fixtures inside it.
+
+A fixture with no pool has nowhere to go, so the solver skips it:
+
+```python
+if fixture.pool_id is None:
+    continue
+```
+
+Three draw shapes are un-pooled. A single-elim event is un-pooled end to end. A
+swiss event is un-pooled end to end. A round-robin-then-knockout event is pooled
+in its first stage and un-pooled in its second. So the solver places no
+single-elim match, no swiss match, and no knockout match at all.
+
+A pool is already available to every draw type. The event editor's "Table pools"
+tab is not gated: `SECTIONS` lists it as a static entry, and the editor maps over
+that list whatever the draw type. The API agrees. `draw_config` passes every
+configured pool "whatever the draw type", and an un-pooled strategy ignores them
+for grouping — `SingleElimStrategy.plan_initial` never reads `config.pool_ids`.
+
+So a director can already reserve tables and a window for a single-elim or swiss
+event. Nothing consumes that reservation. The gap is not that these events lack
+a way to reserve the venue. The gap is that a fixture's `pool_id` is written only
+by the draw, so an un-pooled draw leaves it `NULL`, and the solver reads that
+`NULL` as "cannot be placed" when it means "not tied to one particular
+reservation".
+
+## Decision
+
+**A pool restricts where and when an event's fixtures may be placed. It is not a
+precondition for placing them.**
+
+1. **A fixture with no pool is placed over its event's whole timeline.** The
+   window is `TournamentEvent.slot`, read in the event's own `timezone`. The
+   tables are every table in the tournament.
+
+2. **A fixture with a pool is placed exactly as it is today** — inside that
+   pool's window, on that pool's tables. Nothing about pooled scheduling
+   changes.
+
+3. **No pool row is minted, and no schema changes.** The event-wide reservation
+   exists only inside the solver's snapshot.
+
+The mechanism is already in place. The solver's `PoolId` is not a database key.
+It is a namespaced string the snapshot builds, `f"{event.id}:{pool.id}"`, which
+the apply resolves back to a name and clock through `_PoolResolution`. An
+event-wide reservation is one more value in that scheme: one synthetic
+`SchedulePool` per event that has un-pooled fixtures, carrying the event's window
+and the tournament's tables.
+
+`scheduling.py`, the pure solver, is therefore untouched. Every pool-keyed
+infeasibility reason — `PoolHasNoTables`, `PoolOverCapacity`,
+`WindowTooShortForMatch`, the per-pool-per-player pigeonhole — keeps working, and
+reports against the event-wide reservation by name.
+
+## Consequences
+
+**Single-elim becomes schedulable**, which is what #1228 asked for. A
+round-robin-then-knockout event's knockout stage becomes schedulable by the same
+rule, and the solver still knows nothing about stages.
+
+**Swiss becomes schedulable.** A swiss draw is un-pooled end to end, so it takes
+the event-wide reservation and its matches are placed. Before this decision a
+swiss match only ever got the table and time a director typed in. This is
+intended, not a side effect.
+
+**The `pool_id is None` skip cannot simply be deleted.** It becomes a branch: a
+pooled fixture resolves its reservation from its pool, an un-pooled one from its
+event. Deleting the guard outright would feed the solver fixtures with no window
+at all.
+
+**A director gains control by adding pools, not by losing them.** An event with
+no pools uses the whole venue across its own window. A director who wants the
+knockout on Sunday, or confined to tables 1 to 4, creates a pool that says so.
+This is why an event's single-day window is not a limitation in practice: pools
+carry their own dates, so multi-day play is expressed the way it already is.
+
+**The event-wide reservation needs a name a director can read.** Infeasibility
+copy names the reservation it blames. A synthetic reservation must resolve to
+something meaningful in that copy rather than to a raw id.
+
+**An event with no tables in its tournament still cannot be scheduled.** That is
+`PoolHasNoTables` doing its job, and it now fires against the event-wide
+reservation with the same message.
+
+**Preview is unchanged.** At preview time no match has been played, so every
+knockout fixture past the first round has unknown sides. That is true in
+principle, not merely in this implementation. #1228 keeps the "not previewed"
+note for knockout rounds. It only stops a single-elim event from aborting its
+whole tournament's preview.
+
+## Alternatives considered
+
+**Mint a pool row for the bracket** — the 2026-08-01 design. Rejected. Since
+#1226 a pool is a row the director creates, names, and orders, and the event
+editor renders every pool as a card. A minted pool would appear as a pool the
+director never asked for, and they could rename or delete it. It also
+contradicts `CONTEXT.md`'s **Pool** entry, which defines a pool's second face as
+"the group of entrants who play all-play-all on that slice". A bracket's
+entrants do not.
+
+**Assign bracket fixtures to a pool the director already made.** Rejected as a
+scheduling decision taken too early. It also needs a rule for which pool when an
+event has several, and that rule is a new director-facing concept.
+
+**Let the solver choose among an event's pools per fixture.** Rejected as
+expensive for no gain here. Every infeasibility reason is keyed by one pool, so
+"which pool was over capacity" would stop having a single answer, and the
+director-facing copy would have to change with it.
+
+**Give the event its own table-assignment surface.** Rejected as unnecessary. It
+needs a new join table and a new event-editor section. Pools already are that
+surface.
+
+**Add a stage column, a stages table, or a `draw_type_key` on the fixture.**
+Rejected in the 2026-08-01 design pass, and still rejected. Nothing here needs to
+know about stages.

--- a/docs/adr/20260807-a-pool-restricts-scheduling-it-does-not-enable-it.md
+++ b/docs/adr/20260807-a-pool-restricts-scheduling-it-does-not-enable-it.md
@@ -84,15 +84,40 @@ pooled fixture resolves its reservation from its pool, an un-pooled one from its
 event. Deleting the guard outright would feed the solver fixtures with no window
 at all.
 
-**A director gains control by adding pools, not by losing them.** An event with
-no pools uses the whole venue across its own window. A director who wants the
-knockout on Sunday, or confined to tables 1 to 4, creates a pool that says so.
-This is why an event's single-day window is not a limitation in practice: pools
-carry their own dates, so multi-day play is expressed the way it already is.
+**A pool cannot confine an un-pooled fixture, and a director has no other way to
+confine one.** The rule is per **fixture**, not per event. A fixture that names a
+pool is held to that pool's tables and window. A fixture that names none takes
+the whole venue over its event's window, and the event's own pools are not
+consulted — an rr-then-ko event has pools, and its knockout fixtures still take
+the event-wide reservation, which is exactly right, because those pools describe
+the **group** stage and the knockout must not inherit their windows.
 
-**The event-wide reservation needs a name a director can read.** Infeasibility
-copy names the reservation it blames. A synthetic reservation must resolve to
-something meaningful in that copy rather than to a raw id.
+So a director who adds a pool to a single-elim event changes nothing about where
+that bracket is played. The only controls over an un-pooled fixture are the
+event's own window and the tournament's table list.
+
+Whether a director should be able to say "the knockout runs Sunday, on tables 1
+to 4" is a real question this ADR does not answer. It needs a control that is not
+a pool, because a pool already means something else. Left open deliberately
+rather than half-answered.
+
+**The event-wide reservation needs a name a director can read, and a kind.** An
+infeasibility reason names the reservation it blames, so a synthetic one must
+resolve to something meaningful rather than to a raw id. A name alone is not
+enough: the remedies are pool-shaped, and "add a table to it" or "a smaller
+pool" are not things a director can do to an event-wide reservation. Each reason
+therefore carries **which kind** of reservation it blames, so the remedy can name
+a control that exists — the tournament's table list and the event's window,
+rather than a pool's.
+
+**The venue's capacity is counted once per table-hour, however many reservations
+claim it.** The day aggregate summed span times table count over every
+reservation. An event-wide reservation overlaps its event's real pools by
+construction, so a round-robin-then-knockout event double-counted the same tables
+for the same hours and reported roughly twice the table-time a venue has, under
+copy that already asserts "there's enough". It is now the union of coverage per
+table. This also fixes overlapping *pools*, which had the same defect before this
+ADR.
 
 **An event with no tables in its tournament still cannot be scheduled.** That is
 `PoolHasNoTables` doing its job, and it now fires against the event-wide

--- a/e2e/page-objects/tournament-detail-page/schedule-tab.page.ts
+++ b/e2e/page-objects/tournament-detail-page/schedule-tab.page.ts
@@ -40,6 +40,20 @@ export class ScheduleTabPage {
 
   // ----- the solve strip ------------------------------------------------------
 
+  /** The owner's **Run scheduler** button — the director's own way to ask for a solve,
+   * allowed in any tournament status from the moment an event has a cut draw. Hidden for
+   * a non-owner (ADR-0015), and disabled only while a run is already in flight. */
+  get runScheduler(): Locator {
+    return this.page.getByTestId('run-scheduler')
+  }
+
+  /** The refusal a rejected run raises inline — e.g. the designed `no_drawn_events` 422
+   * for running the scheduler before any draw is cut. Asserted *absent* by a spec whose
+   * run must have been accepted. */
+  get runSchedulerNotice(): Locator {
+    return this.page.getByTestId('run-scheduler-notice')
+  }
+
   /** The strip's `succeeded` state — the solver ran and its plan was applied.
    * Its text carries the verdict vocabulary (`VERDICT_LABEL`): "Best possible
    * plan" (OPTIMAL) or "Good plan, found under the time cap" (FEASIBLE). */

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -191,18 +191,42 @@ export interface StoredAddress extends Coords {
   readonly venue: string
 }
 
+/** The draw types this seed can author. Two, because these are the two shapes the seed
+ * itself can express: `round-robin`, whose draw settings are the empty object, and
+ * `single-elim`, whose settings are empty too (`SingleElimDrawSettingsWrite` — a bracket
+ * has no pools to qualify out of and its depth is derived from the field).
+ *
+ * The two formats that DO carry a setting are deliberately absent. `rr-then-ko` needs
+ * `qualifiers_per_pool` and `swiss` needs `rounds`, both **required with no default** on
+ * their arm of the server's draw-settings union — and both are authored through the event
+ * editor **in the browser** by the specs that use them, because the payload that editor
+ * builds is the seam their 422 lived in. Adding them here would give those specs a way to
+ * skip the surface they exist to test. */
+export type SeededDrawType = 'round-robin' | 'single-elim'
+
 /** Optional knobs on `seedTournament`. Defaults reproduce the original minimal
- * shape (one table, one pool, a far-future window), so existing specs are
- * untouched; the solver-schedule spec overrides both — its pool window must
+ * shape (one round-robin, one table, one pool, a far-future window), so existing specs
+ * are untouched; the solver-schedule spec overrides two of them — its pool window must
  * bracket the stack's real NOW for the call-ahead pinning to fire naturally,
  * and a 4-entrant round-robin wants two tables to run its rounds in parallel. */
 export interface SeedTournamentOptions {
+  /** The event's draw type. Omitted = `round-robin`, the original minimal shape.
+   *
+   * `single-elim` is what `tournament-single-elim-schedule.spec.ts` seeds, and it is
+   * seeded **with `pools: []`**: a bracket is un-pooled end to end (ADR-0786), so a pool
+   * on such an event would reserve a slice of the venue no fixture is ever drawn into —
+   * and the spec's whole subject is what the scheduler does with a fixture that names no
+   * pool (ADR 20260807, "a pool restricts scheduling, it does not enable it"). */
+  readonly drawType?: SeededDrawType
   /** The window both the event and its single pool carry. */
   readonly slot?: SlotSpec
   /** The table catalogue; the pool references every listed table. */
   readonly tables?: ReadonlyArray<TableSpec>
   /** The event's pools, **in the director's order** — omitted = the original single
-   * `Pool A` over the whole catalogue, so existing specs are untouched.
+   * `Pool A` over the whole catalogue, so existing specs are untouched. **`[]` seeds an
+   * event with NO pools**, which is what an un-pooled draw type wants: the create verb
+   * takes any number of pools, zero included, and `??` leaves an explicit empty list
+   * alone (only an *omitted* option falls back to the default).
    *
    * The list's order is the whole point of the option: it is what the server turns into
    * the stored `position`s, and therefore what the draw, the deal and the rendered pool
@@ -247,8 +271,13 @@ export interface SeededTournament extends CreatedTournament {
    * The only handle a spec has on a pool id, and the order the draw must read in. */
   readonly pools: ReadonlyArray<StoredPool>
   /** The event's **first** pool id — its only one under the default seed — so a spec
-   * can scope its standings assertions without indexing `pools` itself. */
-  readonly poolId: string
+   * can scope its standings assertions without indexing `pools` itself.
+   *
+   * **`null` for a seed with no pools** (`pools: []`, an un-pooled draw type). Nullable
+   * rather than "the first element of a possibly-empty list", which reads as a `string`
+   * and is `undefined`: a pool-less event has no first pool, and saying so here is what
+   * stops that `undefined` travelling into a locator and resolving nothing. */
+  readonly poolId: string | null
 }
 
 /**
@@ -370,7 +399,11 @@ export async function seedTournament(
         // timezone-aware instants"), so the window still brackets NOW.
         timezone: 'UTC',
         format: 'singles',
-        draw_type: 'round-robin',
+        // The caller's draw type, defaulting to the original round-robin. Both types
+        // this seed can author take **no** further draw settings, so there is nothing
+        // to send beside it (see `SeededDrawType` for the two that do, and why they
+        // are authored in the browser instead).
+        draw_type: options.drawType ?? 'round-robin',
         entry_fee: 0,
         // Only sent when the caller caps the field; omitting the key leaves the
         // event uncapped (the API treats a missing `max_players` as no cap).
@@ -422,7 +455,7 @@ export async function seedTournament(
     tables: storedTables,
     eventId: created.id,
     pools: created.pools,
-    poolId: created.pools[0].id,
+    poolId: created.pools[0]?.id ?? null,
   }
 }
 
@@ -709,6 +742,10 @@ export interface FixtureDetail {
    * position** (ADR 20260801) — so the order these ids first appear in *is* the
    * server's statement of the event's pool order, before any client touches it. */
   readonly pool_id: string | null
+  /** Which round of its draw the fixture belongs to, 1-based. The handle on a bracket's
+   * **first round** — the only round of a freshly cut single-elim draw whose fixtures
+   * have both sides, and therefore the only one the solver can place at all. */
+  readonly round: number
   readonly entry_a_id: string | null
   readonly entry_b_id: string | null
   readonly match_id: string | null

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -45,7 +45,9 @@ export interface SlotSpec {
   readonly end: string
 }
 
-/** Tomorrow, `YYYY-MM-DD`, UTC — the date the default pool window sits on.
+/** Tomorrow, `YYYY-MM-DD`, UTC — the date a seeded window sits on. The default pool
+ * window uses it, and so does any spec that builds its own `SlotSpec`, so the rule lives
+ * here once.
  *
  * **Computed, never a literal.** This used to be the string `'2026-08-01'`, which
  * was comfortably far-future when it was written and then arrived: from 17:00 UTC
@@ -63,7 +65,7 @@ export interface SlotSpec {
  * UTC because the compose stack's clock is UTC and `seedTournament` anchors its
  * events to `timezone: 'UTC'` — the date and the frame have to agree, or the
  * window drifts by a day either side of midnight. */
-function tomorrowUtc(): string {
+export function tomorrowUtc(): string {
   const DAY_MS = 24 * 60 * 60 * 1000
   return new Date(Date.now() + DAY_MS).toISOString().slice(0, 10)
 }

--- a/e2e/tests/tournament-lifecycle.spec.ts
+++ b/e2e/tests/tournament-lifecycle.spec.ts
@@ -173,7 +173,10 @@ test.describe('Tournament — round-robin lifecycle', () => {
     await expect(played.standingsChampion(eventId)).toBeVisible()
     await expect(played.standingsChampion(eventId)).toContainText(director.username)
     // And the pool table shows both entrants, with the director in the top row.
-    const standings = played.poolStandings(poolId)
+    // `poolId` is nullable on the seed — a pool-less seed (`pools: []`) has no first
+    // pool — but this seed took the default single pool, so it is a string here.
+    expect(poolId, 'the default seed reserves one pool').not.toBeNull()
+    const standings = played.poolStandings(poolId!)
     await expect(standings).toContainText(director.username)
     await expect(standings).toContainText(opponent.username)
     // Row 0 is the header; row 1 is rank 1 — the director, the champion.

--- a/e2e/tests/tournament-single-elim-schedule.spec.ts
+++ b/e2e/tests/tournament-single-elim-schedule.spec.ts
@@ -1,0 +1,366 @@
+import { test, expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+
+import { TournamentDetailPage } from '../page-objects/tournament-detail.page'
+import { guestFromContext } from '../support/match-api'
+import { grantBetaTester } from '../support/rbac-grant'
+import {
+  getScheduleDetail,
+  seedEntrants,
+  seedTournament,
+  transitionTournament,
+  type FixtureDetail,
+  type TableSpec,
+} from '../support/tournament-api'
+
+/** The event this spec seeds and cuts — a single-elimination draw, which is un-pooled
+ * end to end (ADR-0786: every one of its fixtures carries `pool_id IS NULL`). */
+const EVENT_NAME = 'Open Singles'
+
+/** The venue: two tables, so the two first-round matches can run at once. Neither is
+ * reserved by any pool, because the event has no pools — they are reachable only as
+ * "every table in the tournament", which is exactly what an event-wide reservation is
+ * made of (ADR 20260807). Their ids are minted by the server and read back off the seed. */
+const TABLES: ReadonlyArray<TableSpec> = [
+  { label: 'Table 1', court: 'A' },
+  { label: 'Table 2', court: 'A' },
+]
+
+/** `N` — four entrants, which is a full bracket of four: two first-round fixtures, no
+ * byes, and one final. The smallest field that gives the solver more than one thing to
+ * place while leaving a genuinely un-placeable fixture behind (the final's sides are TBD
+ * until somebody wins), so the spec can say what happens to each. */
+const FIELD = 4
+/** Round one of a four-slot bracket: two fixtures, both with real entrants on both
+ * sides — the only fixtures a freshly cut bracket can be placed at all. */
+const ROUND_ONE_FIXTURES = 2
+/** Two first-round fixtures plus the final. */
+const BRACKET_FIXTURES = 3
+
+/** The event's own window, `HH:MM` in its own timezone — which the seed anchors to `UTC`,
+ * the compose stack's clock, so venue-local and UTC are the same wall clock here.
+ *
+ * This is the window the ADR says an un-pooled fixture is placed over, so the spec
+ * asserts each placement lands inside it. Eight hours is far more than three best-of-1
+ * matches need, so a day that does not fit would be a real infeasibility and not a
+ * squeeze this spec engineered. */
+const WINDOW_START = '09:00'
+const WINDOW_END = '17:00'
+
+/** Tomorrow, `YYYY-MM-DD`, UTC — the date the event's window sits on.
+ *
+ * Computed, never a literal, for the reason `support/tournament-api.ts` computes its own
+ * default: the solver never places a fixture in the past, so a window behind `now` is
+ * honestly infeasible and would red this spec for a reason that has nothing to do with
+ * pools. Tomorrow is ahead of any run, at any hour. */
+function tomorrowUtc(): string {
+  return new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+}
+
+/** `HH:MM` as minutes since midnight — the form the two window bounds and a placement's
+ * own clock time can be compared in. */
+function minutesOfClock(clock: string): number {
+  const [hours, minutes] = clock.split(':').map(Number)
+  return hours * 60 + minutes
+}
+
+/** A placement instant's UTC date (`YYYY-MM-DD`) and its minutes since midnight.
+ *
+ * Read off the UTC getters rather than by slicing the string: `instant` is an
+ * offset-bearing ISO-8601 timestamp normalized to `+00:00` (`FixtureTimeRead`), and the
+ * event's timezone is `UTC`, so its UTC clock **is** the venue wall clock the window is
+ * written in. */
+function placedAt(instant: string): { date: string; minutes: number } {
+  const moment = new Date(instant)
+  return {
+    date: moment.toISOString().slice(0, 10),
+    minutes: moment.getUTCHours() * 60 + moment.getUTCMinutes(),
+  }
+}
+
+/**
+ * **A single-elimination bracket reaches the schedule with a real table and a real time**
+ * (#1228, ADR 20260807 "a pool restricts scheduling, it does not enable it").
+ *
+ * Before that ADR the solver placed a fixture only if it belonged to a pool —
+ * `if fixture.pool_id is None: continue` — and a bracket has no pool, so no bracket match
+ * was ever given a table or a call time. A director could reserve tables and a window for
+ * a single-elim event and nothing consumed the reservation. The ADR replaced the skip
+ * with a branch: an un-pooled fixture is placed over its **event's own window**, on
+ * **every table in the tournament**.
+ *
+ * ## Why this proof has to be the composed one
+ *
+ * The two commits before this one prove the rule at the unit level — the api's snapshot
+ * builder mints the event-wide reservation, and the schedule tab's view model carries it
+ * — and neither can say the two halves meet. The reservation is built inside the
+ * **worker's** solve, not the api process: the browser's Run-scheduler click enqueues, an
+ * RQ worker runs real CP-SAT, and the guarded apply writes the placement columns the
+ * detail BFF then serves. Nothing that stubs the network sees that round trip, so only a
+ * spec against the real stack can say a bracket match ends up on a real table at a real
+ * time.
+ *
+ * ## What is asserted, and why each half is load-bearing
+ *
+ * * **The premise.** The event is seeded with `pools: []` and every fixture reads back
+ *   `pool_id: null`. Without this a green run could not rule out that some pool did the
+ *   work — which is the one thing that was never in doubt.
+ * * **The placement, on the wire.** Each first-round fixture carries a `table_id` **of
+ *   this tournament's catalogue** and a `scheduled_start` **inside the event's own
+ *   window**. "Has a non-null time" would also pass an implementation that placed the
+ *   bracket at some arbitrary default; the window is the ADR's actual claim.
+ * * **The placement, on the page.** Each first-round match's row is rendered *inside* its
+ *   table's column with the server's own rendered time (`local_label` + `tz_abbrev`) —
+ *   what a director can see. Under the old behaviour those rows sit in "Awaiting
+ *   placement" with an em dash where the time goes, so a row-count assertion would go
+ *   green against it and prove nothing.
+ * * **The final stays awaiting**, because its sides are TBD and a fixture with an unknown
+ *   side cannot be placed by anyone. That is the un-pooled rule doing its job rather than
+ *   placing everything indiscriminately.
+ *
+ * ## Seed vs UI split
+ *
+ * Inert scaffolding over the API (`support/tournament-api.ts`): the tournament, its two
+ * tables, the pool-less single-elim event and its four entrants — director-entry has no
+ * web UI, and four browser sign-ins to test the *scheduler* would be four chances to fail
+ * for an unrelated reason. The load-bearing steps are the director's, in the browser:
+ * cutting the draw, running the scheduler, and reading the board.
+ *
+ * ## RBAC
+ *
+ * As in `tournament-lifecycle.spec.ts`: a minted user holds only the permissionless
+ * default role, so `grantBetaTester` hands the director the tournament bundle over the
+ * stack's own `postgres` container before any tournament write. Skipped against an
+ * external `E2E_BASE_URL` stack, where the caller owns provisioning.
+ */
+test.describe('Tournament — single-elim schedule', () => {
+  test('a director schedules a pool-less bracket onto real tables at real times', async ({
+    page,
+    baseURL,
+  }) => {
+    // Four minted guests and four director-entries, a real draw cut, and a real CP-SAT
+    // solve that rides an RQ round trip before its placements reach the page.
+    test.setTimeout(300_000)
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    // The director IS the browser's own session (`page.request` shares its cookie jar),
+    // so page navigations run as them and the owner-only controls are on screen.
+    const director = await guestFromContext(page.request)
+    grantBetaTester(director.username)
+
+    // ----- the venue and the event, over the API ------------------------------
+    const slot = { date: tomorrowUtc(), start: WINDOW_START, end: WINDOW_END }
+    const name = `KO ${faker.string.alphanumeric(8)}`
+    const { tournamentId, eventId, tables, pools } = await seedTournament(
+      director,
+      name,
+      { slot, tables: TABLES, pools: [], drawType: 'single-elim' },
+    )
+
+    // THE PREMISE. The event reserves nothing: no pool, so no pool window and no pool
+    // tables. Everything below is therefore a statement about a fixture that names no
+    // reservation of its own — which is the whole subject.
+    expect(pools, 'the seeded event must hold no pools at all').toEqual([])
+    expect(tables).toHaveLength(TABLES.length)
+    const tableIds = tables.map((table) => table.id)
+
+    // ----- publish, then fill the field ---------------------------------------
+    await transitionTournament(director, tournamentId, 'published')
+    const entrants = await seedEntrants(
+      director,
+      baseURL!,
+      tournamentId,
+      eventId,
+      FIELD,
+    )
+
+    // ----- the browser: the director cuts the draw ----------------------------
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    // The long timeout is for the FIRST navigation only, and it is about the stack rather
+    // than the app: the composed web-client is a Vite **dev** server, so the very first
+    // request for a route pays for transforming it on demand.
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    const drawPost = page.waitForResponse(
+      (r) => r.url().endsWith('/draw') && r.request().method() === 'POST',
+    )
+    await detail.generateDrawButton(EVENT_NAME).click()
+    const drawResponse = await drawPost
+    // The status, not merely "a panel appeared": a refused cut leaves the card as it was,
+    // and a spec that waited for fixtures would fail as a timeout naming nothing.
+    expect(
+      drawResponse.status(),
+      `cutting the draw was refused: ${await drawResponse.text()}`,
+    ).toBe(201)
+    // The bracket is the un-pooled block — a draw with no pool sections at all.
+    await expect(detail.bracket(eventId)).toBeVisible()
+
+    // ----- the fixtures belong to no pool -------------------------------------
+    const fixturesOf = async (): Promise<ReadonlyArray<FixtureDetail>> => {
+      const schedule = await getScheduleDetail(director, tournamentId)
+      const event = schedule.events.find((e) => e.id === eventId)
+      expect(event, 'the seeded event must be on the detail payload').toBeTruthy()
+      return event!.fixtures
+    }
+
+    const cut = await fixturesOf()
+    expect(cut, 'a four-slot bracket is two first-round fixtures and a final').toHaveLength(
+      BRACKET_FIXTURES,
+    )
+    for (const fixture of cut) {
+      expect(
+        fixture.pool_id,
+        `fixture ${fixture.id} belongs to a pool — the premise of this spec is that none do`,
+      ).toBeNull()
+    }
+    const roundOneIds = cut
+      .filter((fixture) => fixture.round === 1)
+      .map((fixture) => fixture.id)
+    expect(roundOneIds).toHaveLength(ROUND_ONE_FIXTURES)
+    for (const fixture of cut.filter((f) => f.round === 1)) {
+      // Both sides known is what makes a fixture placeable at all, so this establishes
+      // that a failure below is about the pool rule and not about a TBD side.
+      expect(fixture.entry_a_id, `round-1 fixture ${fixture.id} has an A side`).not.toBeNull()
+      expect(fixture.entry_b_id, `round-1 fixture ${fixture.id} has a B side`).not.toBeNull()
+    }
+    const finalId = cut.find((fixture) => !roundOneIds.includes(fixture.id))!.id
+
+    // ----- the browser: the director runs the scheduler ------------------------
+    const schedule = await detail.openSchedule()
+    await expect(schedule.runScheduler).toBeVisible()
+    const solvePost = page.waitForResponse(
+      (r) =>
+        r.url().endsWith('/schedule/solves') && r.request().method() === 'POST',
+    )
+    await schedule.runScheduler.click()
+    const solveResponse = await solvePost
+    // The run was ACCEPTED. A tournament with nothing cut is refused `no_drawn_events`
+    // (422), and asserting the status here makes that refusal name itself rather than
+    // surfacing later as "no placements".
+    expect(
+      solveResponse.status(),
+      `the scheduler run was refused: ${await solveResponse.text()}`,
+    ).toBe(202)
+    await expect(schedule.runSchedulerNotice).toBeHidden()
+
+    // ----- the solve terminates ------------------------------------------------
+    // Terminal, not `succeeded`: this gate exists to separate "the worker never ran" from
+    // "the worker ran and placed nothing", so it must pass in BOTH states. The
+    // discriminating assertion is the next one.
+    await expect
+      .poll(
+        async () => {
+          const solve = (await getScheduleDetail(director, tournamentId))
+            .latest_schedule_solve
+          return solve === null ? null : solve.status
+        },
+        {
+          message: 'the queued solve must reach a terminal status on the real worker',
+          timeout: 180_000,
+          intervals: [2_000],
+        },
+      )
+      .toMatch(/^(succeeded|infeasible|failed)$/)
+
+    // ----- THE CLAIM: the bracket was placed -----------------------------------
+    // The fixtures belong to no pool, so every table and every minute below came from the
+    // event's own window over the tournament's whole catalogue — the event-wide
+    // reservation. Under the pre-ADR behaviour the solver skipped these fixtures and this
+    // count stays 0.
+    await expect
+      .poll(
+        async () => {
+          const placed = (await fixturesOf()).filter(
+            (fixture) =>
+              roundOneIds.includes(fixture.id) &&
+              fixture.table_id !== null &&
+              fixture.scheduled_start !== null,
+          )
+          return placed.length
+        },
+        {
+          message:
+            "the bracket's first round must be given a table and a time — a fixture with " +
+            'no pool is scheduled against its event window, on any table in the tournament',
+          timeout: 180_000,
+          intervals: [2_000],
+        },
+      )
+      .toBe(ROUND_ONE_FIXTURES)
+
+    // The plan the director was shown is a real one, not a shrug: the strip reports the
+    // solver's verdict in its own vocabulary, and the designed "the day doesn't fit"
+    // state is absent — three best-of-1 matches over eight hours on two tables fit.
+    await expect(schedule.solveSucceeded).toBeVisible({ timeout: 60_000 })
+    await expect(schedule.solveSucceeded).toContainText(
+      /Best possible plan|Good plan, found under the time cap/,
+    )
+    await expect(schedule.solveInfeasible).toBeHidden()
+
+    // ----- each placement names a real table, inside the EVENT's window ---------
+    const solved = await fixturesOf()
+    const roundOne = solved.filter((fixture) => roundOneIds.includes(fixture.id))
+    for (const fixture of roundOne) {
+      expect(
+        tableIds,
+        `fixture ${fixture.id} is on a table this tournament does not have`,
+      ).toContain(fixture.table_id)
+      const at = placedAt(fixture.scheduled_start!.instant)
+      // The event's own Slot is the window, so both the DATE and the clock time are the
+      // event's. A placement on another day would mean the reservation came from
+      // somewhere else entirely.
+      expect(at.date, `fixture ${fixture.id} was placed off the event's date`).toBe(
+        slot.date,
+      )
+      expect(
+        at.minutes,
+        `fixture ${fixture.id} starts before the event's window opens`,
+      ).toBeGreaterThanOrEqual(minutesOfClock(WINDOW_START))
+      expect(
+        at.minutes,
+        `fixture ${fixture.id} starts after the event's window closes`,
+      ).toBeLessThan(minutesOfClock(WINDOW_END))
+      expect(fixture.scheduled_start!.local_label).not.toBe('')
+    }
+
+    // The final could not be placed by anybody: both its sides are TBD until a
+    // first-round match is won, so the un-pooled rule places what it can and leaves the
+    // rest — it does not hand out tables indiscriminately.
+    const bracketFinal = solved.find((fixture) => fixture.id === finalId)!
+    expect(bracketFinal.entry_a_id).toBeNull()
+    expect(bracketFinal.table_id, 'a TBD-sided fixture cannot be placed').toBeNull()
+
+    // ----- what the DIRECTOR sees ----------------------------------------------
+    // A fresh load rather than the tab's polling: the tab polls while a solve is in
+    // flight and stops once it is terminal, so a reload removes any dependence on which
+    // poll happened to carry the placements.
+    await detail.reload(tournamentId)
+    await expect(detail.title).toContainText(name)
+    const board = await detail.openSchedule()
+    for (const fixture of roundOne) {
+      // Inside the table's own column — that IS the fact "this match is on that table",
+      // as a director reads it.
+      await expect(
+        board.placedRow(fixture.table_id!, fixture.id),
+        `the board does not show fixture ${fixture.id} on its table`,
+      ).toBeVisible({ timeout: 30_000 })
+      // …carrying the time the server rendered, timezone and all — the client displays
+      // `local_label` + `tz_abbrev` verbatim.
+      await expect(board.matchRow(fixture.id)).toContainText(
+        `${fixture.scheduled_start!.local_label} ${fixture.scheduled_start!.tz_abbrev}`,
+      )
+      // …and not in the awaiting group, which is where an unplaced match lives and where
+      // every one of these sat before a bracket could be scheduled.
+      await expect(
+        board.awaitingSection.getByTestId(`schedule-match-${fixture.id}`),
+      ).toHaveCount(0)
+    }
+    // The final is the one match still awaiting a placement, named.
+    await expect(board.awaitingSection).toBeVisible()
+    await expect(
+      board.awaitingSection.getByTestId(`schedule-match-${finalId}`),
+    ).toBeVisible()
+
+    await Promise.all(entrants.map((entrant) => entrant.ctx.dispose()))
+  })
+})

--- a/e2e/tests/tournament-single-elim-schedule.spec.ts
+++ b/e2e/tests/tournament-single-elim-schedule.spec.ts
@@ -8,6 +8,7 @@ import {
   getScheduleDetail,
   seedEntrants,
   seedTournament,
+  tomorrowUtc,
   transitionTournament,
   type FixtureDetail,
   type TableSpec,
@@ -46,16 +47,6 @@ const BRACKET_FIXTURES = 3
  * squeeze this spec engineered. */
 const WINDOW_START = '09:00'
 const WINDOW_END = '17:00'
-
-/** Tomorrow, `YYYY-MM-DD`, UTC — the date the event's window sits on.
- *
- * Computed, never a literal, for the reason `support/tournament-api.ts` computes its own
- * default: the solver never places a fixture in the past, so a window behind `now` is
- * honestly infeasible and would red this spec for a reason that has nothing to do with
- * pools. Tomorrow is ahead of any run, at any hour. */
-function tomorrowUtc(): string {
-  return new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
-}
 
 /** `HH:MM` as minutes since midnight — the form the two window bounds and a placement's
  * own clock time can be compared in. */
@@ -213,17 +204,25 @@ test.describe('Tournament — single-elim schedule', () => {
         `fixture ${fixture.id} belongs to a pool — the premise of this spec is that none do`,
       ).toBeNull()
     }
-    const roundOneIds = cut
-      .filter((fixture) => fixture.round === 1)
-      .map((fixture) => fixture.id)
-    expect(roundOneIds).toHaveLength(ROUND_ONE_FIXTURES)
-    for (const fixture of cut.filter((f) => f.round === 1)) {
+    const cutRoundOne = cut.filter((fixture) => fixture.round === 1)
+    expect(cutRoundOne).toHaveLength(ROUND_ONE_FIXTURES)
+    const roundOneIds = cutRoundOne.map((fixture) => fixture.id)
+    for (const fixture of cutRoundOne) {
       // Both sides known is what makes a fixture placeable at all, so this establishes
       // that a failure below is about the pool rule and not about a TBD side.
       expect(fixture.entry_a_id, `round-1 fixture ${fixture.id} has an A side`).not.toBeNull()
       expect(fixture.entry_b_id, `round-1 fixture ${fixture.id} has a B side`).not.toBeNull()
     }
-    const finalId = cut.find((fixture) => !roundOneIds.includes(fixture.id))!.id
+    // The final is round 2 of a four-slot bracket, named by its round rather than as
+    // "the fixture that is not in round one": an id derived by exclusion still resolves to
+    // something the day the bracket grows a round, and would quietly assert about the
+    // wrong match. An explicit round check fails loudly instead.
+    const finals = cut.filter((fixture) => fixture.round === 2)
+    expect(
+      finals,
+      'a four-slot bracket holds exactly one round-2 fixture: the final',
+    ).toHaveLength(1)
+    const finalId = finals[0].id
 
     // ----- the browser: the director runs the scheduler ------------------------
     const schedule = await detail.openSchedule()

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -7479,8 +7479,10 @@ internal enum Components {
         /// minutes of *their* time, against a window spanning only ``window_span_min``.
         /// A pigeonhole over one person, so adding tables cannot fix it — the remedy is
         /// fewer matches for them in this pool, or a longer window. Resolved: the
-        /// human's display ``player_name`` and the pool's ``name`` + ``HH:MM`` bounds;
-        /// the minutes stay integers for the client to format.
+        /// human's display ``player_name``, the pool's ``name`` + ``HH:MM`` bounds, and
+        /// which kind of ``reservation`` that name is — "a smaller pool" is not a remedy
+        /// an event-wide reservation has; the minutes stay integers for the client to
+        /// format.
         ///
         /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead`.
         internal struct PlayerOverSubscribedRead: Codable, Hashable, Sendable {
@@ -7494,6 +7496,13 @@ internal enum Components {
             internal var playerName: Swift.String
             /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/pool_name`.
             internal var poolName: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/reservation`.
+            internal enum ReservationPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case pool = "pool"
+                case event = "event"
+            }
+            /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/reservation`.
+            internal var reservation: Components.Schemas.PlayerOverSubscribedRead.ReservationPayload?
             /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/window_start`.
             internal var windowStart: Swift.String
             /// - Remark: Generated from `#/components/schemas/PlayerOverSubscribedRead/window_end`.
@@ -7510,6 +7519,7 @@ internal enum Components {
             ///   - kind:
             ///   - playerName:
             ///   - poolName:
+            ///   - reservation:
             ///   - windowStart:
             ///   - windowEnd:
             ///   - matchCount:
@@ -7519,6 +7529,7 @@ internal enum Components {
                 kind: Components.Schemas.PlayerOverSubscribedRead.KindPayload? = nil,
                 playerName: Swift.String,
                 poolName: Swift.String,
+                reservation: Components.Schemas.PlayerOverSubscribedRead.ReservationPayload? = nil,
                 windowStart: Swift.String,
                 windowEnd: Swift.String,
                 matchCount: Swift.Int,
@@ -7528,6 +7539,7 @@ internal enum Components {
                 self.kind = kind
                 self.playerName = playerName
                 self.poolName = poolName
+                self.reservation = reservation
                 self.windowStart = windowStart
                 self.windowEnd = windowEnd
                 self.matchCount = matchCount
@@ -7538,6 +7550,7 @@ internal enum Components {
                 case kind
                 case playerName = "player_name"
                 case poolName = "pool_name"
+                case reservation
                 case windowStart = "window_start"
                 case windowEnd = "window_end"
                 case matchCount = "match_count"
@@ -7770,7 +7783,8 @@ internal enum Components {
             }
         }
         /// A pool with active fixtures but no tables at all — nowhere to place them.
-        /// Resolved: the pool's display ``name`` (never the namespaced solver id).
+        /// Resolved: the pool's display ``name`` (never the namespaced solver id) and
+        /// which kind of ``reservation`` that name belongs to.
         ///
         /// - Remark: Generated from `#/components/schemas/PoolHasNoTablesRead`.
         internal struct PoolHasNoTablesRead: Codable, Hashable, Sendable {
@@ -7782,27 +7796,38 @@ internal enum Components {
             internal var kind: Components.Schemas.PoolHasNoTablesRead.KindPayload?
             /// - Remark: Generated from `#/components/schemas/PoolHasNoTablesRead/pool_name`.
             internal var poolName: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PoolHasNoTablesRead/reservation`.
+            internal enum ReservationPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case pool = "pool"
+                case event = "event"
+            }
+            /// - Remark: Generated from `#/components/schemas/PoolHasNoTablesRead/reservation`.
+            internal var reservation: Components.Schemas.PoolHasNoTablesRead.ReservationPayload?
             /// Creates a new `PoolHasNoTablesRead`.
             ///
             /// - Parameters:
             ///   - kind:
             ///   - poolName:
+            ///   - reservation:
             internal init(
                 kind: Components.Schemas.PoolHasNoTablesRead.KindPayload? = nil,
-                poolName: Swift.String
+                poolName: Swift.String,
+                reservation: Components.Schemas.PoolHasNoTablesRead.ReservationPayload? = nil
             ) {
                 self.kind = kind
                 self.poolName = poolName
+                self.reservation = reservation
             }
             internal enum CodingKeys: String, CodingKey {
                 case kind
                 case poolName = "pool_name"
+                case reservation
             }
         }
         /// A pool whose aggregate match-time (``required_min``) exceeds the
         /// table-minutes its window offers (``capacity_min`` = window span ×
-        /// ``table_count``). Resolved: the pool ``name`` and its ``HH:MM`` bounds; the
-        /// minutes stay integers.
+        /// ``table_count``). Resolved: the pool ``name``, which kind of ``reservation``
+        /// it is, and its ``HH:MM`` bounds; the minutes stay integers.
         ///
         /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead`.
         internal struct PoolOverCapacityRead: Codable, Hashable, Sendable {
@@ -7814,6 +7839,13 @@ internal enum Components {
             internal var kind: Components.Schemas.PoolOverCapacityRead.KindPayload?
             /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/pool_name`.
             internal var poolName: Swift.String
+            /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/reservation`.
+            internal enum ReservationPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case pool = "pool"
+                case event = "event"
+            }
+            /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/reservation`.
+            internal var reservation: Components.Schemas.PoolOverCapacityRead.ReservationPayload?
             /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/window_start`.
             internal var windowStart: Swift.String
             /// - Remark: Generated from `#/components/schemas/PoolOverCapacityRead/window_end`.
@@ -7829,6 +7861,7 @@ internal enum Components {
             /// - Parameters:
             ///   - kind:
             ///   - poolName:
+            ///   - reservation:
             ///   - windowStart:
             ///   - windowEnd:
             ///   - requiredMin:
@@ -7837,6 +7870,7 @@ internal enum Components {
             internal init(
                 kind: Components.Schemas.PoolOverCapacityRead.KindPayload? = nil,
                 poolName: Swift.String,
+                reservation: Components.Schemas.PoolOverCapacityRead.ReservationPayload? = nil,
                 windowStart: Swift.String,
                 windowEnd: Swift.String,
                 requiredMin: Swift.Int,
@@ -7845,6 +7879,7 @@ internal enum Components {
             ) {
                 self.kind = kind
                 self.poolName = poolName
+                self.reservation = reservation
                 self.windowStart = windowStart
                 self.windowEnd = windowEnd
                 self.requiredMin = requiredMin
@@ -7854,6 +7889,7 @@ internal enum Components {
             internal enum CodingKeys: String, CodingKey {
                 case kind
                 case poolName = "pool_name"
+                case reservation
                 case windowStart = "window_start"
                 case windowEnd = "window_end"
                 case requiredMin = "required_min"
@@ -12193,8 +12229,9 @@ internal enum Components {
         }
         /// A single fixture whose pool window cannot hold even one match: its
         /// ``best_of`` match needs ``needed_min`` minutes but the window spans only
-        /// ``window_span_min``. Resolved: the pool ``name`` and its ``HH:MM`` window
-        /// bounds; the minutes pass through as integers for the client to format.
+        /// ``window_span_min``. Resolved: the pool ``name``, which kind of
+        /// ``reservation`` it is, and its ``HH:MM`` window bounds; the minutes pass
+        /// through as integers for the client to format.
         ///
         /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead`.
         internal struct WindowTooShortForMatchRead: Codable, Hashable, Sendable {
@@ -12206,6 +12243,13 @@ internal enum Components {
             internal var kind: Components.Schemas.WindowTooShortForMatchRead.KindPayload?
             /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/pool_name`.
             internal var poolName: Swift.String
+            /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/reservation`.
+            internal enum ReservationPayload: String, Codable, Hashable, Sendable, CaseIterable {
+                case pool = "pool"
+                case event = "event"
+            }
+            /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/reservation`.
+            internal var reservation: Components.Schemas.WindowTooShortForMatchRead.ReservationPayload?
             /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/window_start`.
             internal var windowStart: Swift.String
             /// - Remark: Generated from `#/components/schemas/WindowTooShortForMatchRead/window_end`.
@@ -12228,6 +12272,7 @@ internal enum Components {
             /// - Parameters:
             ///   - kind:
             ///   - poolName:
+            ///   - reservation:
             ///   - windowStart:
             ///   - windowEnd:
             ///   - bestOf:
@@ -12236,6 +12281,7 @@ internal enum Components {
             internal init(
                 kind: Components.Schemas.WindowTooShortForMatchRead.KindPayload? = nil,
                 poolName: Swift.String,
+                reservation: Components.Schemas.WindowTooShortForMatchRead.ReservationPayload? = nil,
                 windowStart: Swift.String,
                 windowEnd: Swift.String,
                 bestOf: Components.Schemas.WindowTooShortForMatchRead.BestOfPayload,
@@ -12244,6 +12290,7 @@ internal enum Components {
             ) {
                 self.kind = kind
                 self.poolName = poolName
+                self.reservation = reservation
                 self.windowStart = windowStart
                 self.windowEnd = windowEnd
                 self.bestOf = bestOf
@@ -12253,6 +12300,7 @@ internal enum Components {
             internal enum CodingKeys: String, CodingKey {
                 case kind
                 case poolName = "pool_name"
+                case reservation
                 case windowStart = "window_start"
                 case windowEnd = "window_end"
                 case bestOf = "best_of"

--- a/web-client/e2e/tournaments/tournament-schedule-solve.spec.ts
+++ b/web-client/e2e/tournaments/tournament-schedule-solve.spec.ts
@@ -247,7 +247,7 @@ test.describe('Tournaments · schedule solve strip', () => {
     page,
   }) => {
     // A `player_over_subscribed` arm of `infeasibility_reasons` crosses the real
-    // wire (MSW off, this stub IS the API) with all seven of its fields; the
+    // wire (MSW off, this stub IS the API) with all eight of its fields; the
     // client Zod-parses it in the queryFn and the strip renders the human-named
     // sentence (ADR "the conflict core is a second, max-placed solve", decision 1).
     const { pom } = await TournamentDetailPage.navigateTo(page, {
@@ -263,6 +263,8 @@ test.describe('Tournaments · schedule solve strip', () => {
             kind: 'player_over_subscribed',
             player_name: 'spiked-frigatebird',
             pool_name: 'Pool A',
+            // A real pool, so the remedy may offer the pool verbs.
+            reservation: 'pool',
             window_start: '09:00',
             window_end: '10:30',
             match_count: 4,
@@ -296,6 +298,58 @@ test.describe('Tournaments · schedule solve strip', () => {
       page,
       'schedule tab — over-subscribed-player infeasible solve on the strip',
     )
+  })
+
+  test('blames the EVENT-WIDE reservation with remedies a director can actually carry out — never a pool control the event does not have', async ({
+    page,
+  }) => {
+    // The same arm, `reservation: 'event'` — an un-pooled fixture (a bracket, a
+    // swiss round, a knockout stage) is placed against the event's own window over
+    // every table in the tournament (ADR 20260807). There is no pool row behind
+    // that reservation, so the remedy must name the event and its field, not a pool
+    // to shrink or a pool window to widen. MSW is off: this stub IS the API, so the
+    // discriminator crosses the real wire and the real Zod parse.
+    const { pom } = await TournamentDetailPage.navigateTo(page, {
+      ...DRAWN_SEED,
+      latestSolve: buildScheduleSolveRead({
+        status: 'infeasible',
+        verdict: 'infeasible',
+        trigger: 'manual',
+        fixtures_placed: null,
+        fixtures_pinned: null,
+        infeasibility_reasons: [
+          {
+            kind: 'player_over_subscribed',
+            player_name: 'spiked-frigatebird',
+            pool_name: 'Open Singles (whole venue)',
+            reservation: 'event',
+            window_start: '09:00',
+            window_end: '10:30',
+            match_count: 4,
+            required_min: 150,
+            window_span_min: 90,
+          },
+        ],
+      }),
+    })
+    await pom.openScheduleTab()
+
+    const state = pom.solveStripState('infeasible')
+    await expect(state).toBeVisible()
+    // The same honest figures…
+    await expect(state).toContainText('spiked-frigatebird is in 4 matches')
+    await expect(state).toContainText('they need about 2.5h')
+    // …and a remedy whose every control exists for an un-pooled fixture.
+    await expect(state).toContainText('fewer matches in this event')
+    await expect(state).toContainText('a smaller field')
+    await expect(state).toContainText("widen the event's window")
+    // NOT the pool controls: the event has no pool to shrink, and no pool window.
+    await expect(state).not.toContainText('a smaller pool')
+    await expect(state).not.toContainText('widen its window')
+    // Still a designed state, and the raw wire words stay off screen.
+    await expect(pom.runSchedulerNotice).not.toBeVisible()
+    await expect(state).not.toContainText('player_over_subscribed')
+    await expect(state).not.toContainText('reservation')
   })
 
   test('answers the coded 422 with the designed "cut a draw first" message, inline on the strip', async ({

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -3568,8 +3568,10 @@ export interface components {
          *     minutes of *their* time, against a window spanning only ``window_span_min``.
          *     A pigeonhole over one person, so adding tables cannot fix it — the remedy is
          *     fewer matches for them in this pool, or a longer window. Resolved: the
-         *     human's display ``player_name`` and the pool's ``name`` + ``HH:MM`` bounds;
-         *     the minutes stay integers for the client to format.
+         *     human's display ``player_name``, the pool's ``name`` + ``HH:MM`` bounds, and
+         *     which kind of ``reservation`` that name is — "a smaller pool" is not a remedy
+         *     an event-wide reservation has; the minutes stay integers for the client to
+         *     format.
          */
         PlayerOverSubscribedRead: {
             /**
@@ -3581,6 +3583,12 @@ export interface components {
             player_name: string;
             /** Pool Name */
             pool_name: string;
+            /**
+             * Reservation
+             * @default pool
+             * @enum {string}
+             */
+            reservation: "pool" | "event";
             /** Window Start */
             window_start: string;
             /** Window End */
@@ -3710,7 +3718,8 @@ export interface components {
         /**
          * PoolHasNoTablesRead
          * @description A pool with active fixtures but no tables at all — nowhere to place them.
-         *     Resolved: the pool's display ``name`` (never the namespaced solver id).
+         *     Resolved: the pool's display ``name`` (never the namespaced solver id) and
+         *     which kind of ``reservation`` that name belongs to.
          */
         PoolHasNoTablesRead: {
             /**
@@ -3720,13 +3729,19 @@ export interface components {
             kind: "pool_has_no_tables";
             /** Pool Name */
             pool_name: string;
+            /**
+             * Reservation
+             * @default pool
+             * @enum {string}
+             */
+            reservation: "pool" | "event";
         };
         /**
          * PoolOverCapacityRead
          * @description A pool whose aggregate match-time (``required_min``) exceeds the
          *     table-minutes its window offers (``capacity_min`` = window span ×
-         *     ``table_count``). Resolved: the pool ``name`` and its ``HH:MM`` bounds; the
-         *     minutes stay integers.
+         *     ``table_count``). Resolved: the pool ``name``, which kind of ``reservation``
+         *     it is, and its ``HH:MM`` bounds; the minutes stay integers.
          */
         PoolOverCapacityRead: {
             /**
@@ -3736,6 +3751,12 @@ export interface components {
             kind: "pool_over_capacity";
             /** Pool Name */
             pool_name: string;
+            /**
+             * Reservation
+             * @default pool
+             * @enum {string}
+             */
+            reservation: "pool" | "event";
             /** Window Start */
             window_start: string;
             /** Window End */
@@ -5439,8 +5460,9 @@ export interface components {
          * WindowTooShortForMatchRead
          * @description A single fixture whose pool window cannot hold even one match: its
          *     ``best_of`` match needs ``needed_min`` minutes but the window spans only
-         *     ``window_span_min``. Resolved: the pool ``name`` and its ``HH:MM`` window
-         *     bounds; the minutes pass through as integers for the client to format.
+         *     ``window_span_min``. Resolved: the pool ``name``, which kind of
+         *     ``reservation`` it is, and its ``HH:MM`` window bounds; the minutes pass
+         *     through as integers for the client to format.
          */
         WindowTooShortForMatchRead: {
             /**
@@ -5450,6 +5472,12 @@ export interface components {
             kind: "window_too_short_for_match";
             /** Pool Name */
             pool_name: string;
+            /**
+             * Reservation
+             * @default pool
+             * @enum {string}
+             */
+            reservation: "pool" | "event";
             /** Window Start */
             window_start: string;
             /** Window End */

--- a/web-client/src/components/scheduling/solve-ledger-page.factory.ts
+++ b/web-client/src/components/scheduling/solve-ledger-page.factory.ts
@@ -72,6 +72,7 @@ export function buildLedgerVariety(): AdminScheduleSolveRead[] {
         {
           kind: 'window_too_short_for_match',
           pool_name: 'Pool A',
+          reservation: 'pool',
           window_start: '09:00',
           window_end: '10:00',
           best_of: 5,
@@ -82,6 +83,7 @@ export function buildLedgerVariety(): AdminScheduleSolveRead[] {
           kind: 'player_over_subscribed',
           player_name: 'spiked-frigatebird',
           pool_name: 'Pool A',
+          reservation: 'pool',
           window_start: '09:00',
           window_end: '10:30',
           match_count: 4,

--- a/web-client/src/components/scheduling/solve-ledger-page.test.tsx
+++ b/web-client/src/components/scheduling/solve-ledger-page.test.tsx
@@ -18,6 +18,7 @@ import { solveLedgerPage } from './solve-ledger-page.page'
 const windowReasonCopy = infeasibilityReasonCopy({
   kind: 'window_too_short_for_match',
   poolName: 'Pool A',
+  reservation: 'pool',
   windowStart: '09:00',
   windowEnd: '10:00',
   bestOf: 5,
@@ -28,6 +29,7 @@ const overSubscribedCopy = infeasibilityReasonCopy({
   kind: 'player_over_subscribed',
   playerName: 'spiked-frigatebird',
   poolName: 'Pool A',
+  reservation: 'pool',
   windowStart: '09:00',
   windowEnd: '10:30',
   matchCount: 4,

--- a/web-client/src/components/tournaments/data/preview.test.tsx
+++ b/web-client/src/components/tournaments/data/preview.test.tsx
@@ -188,7 +188,7 @@ describe('schedulePreviewQueryOptions', () => {
     // The reason is mapped snake→camel through `./solve`'s discriminated union —
     // `pool_name` → `poolName`, the `kind` discriminant preserved.
     expect(preview.infeasibilityReasons).toEqual([
-      { kind: 'pool_has_no_tables', poolName: 'Pool A' },
+      { kind: 'pool_has_no_tables', poolName: 'Pool A', reservation: 'pool' },
     ])
   })
 

--- a/web-client/src/components/tournaments/data/schedule.test.ts
+++ b/web-client/src/components/tournaments/data/schedule.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildBracketDrawnEvent,
   buildDrawnEvent,
   buildEntrants,
   buildEvent,
@@ -183,6 +184,59 @@ describe('buildSchedule', () => {
     })
     const [match] = buildSchedule(tournament, buildTables()).awaiting
     expect(match.window).toEqual({ date: '2026-07-01', start: '13:00', end: '17:00' })
+  })
+
+  // ----- an UN-POOLED fixture (ADR 20260807, "a pool restricts scheduling, it does
+  // not enable it"): a bracket, a swiss round and a knockout stage carry no pool, so
+  // their reservation is the EVENT's own window over the WHOLE tournament's tables.
+  // A pool must keep restricting — the two claims are pinned as a pair. -----------
+
+  it('inherits an un-pooled fixture’s placement window from its EVENT slot', () => {
+    const tournament = buildTournament({
+      events: [
+        // A single-elim bracket: `pools: []`, every fixture `poolId: null`. Its event
+        // window is the SECOND day of the tournament, deliberately — `buildPool` and
+        // `buildEvent` both default to 2026-06-13, so a fixture left on the default
+        // date could not tell "read the event slot" from "read a pool slot".
+        buildBracketDrawnEvent({
+          slot: { date: '2026-06-14', start: '10:00', end: '16:00' },
+        }),
+      ],
+    })
+    const [match] = buildSchedule(tournament, buildTables()).awaiting
+    expect(match.window).toEqual({ date: '2026-06-14', start: '10:00', end: '16:00' })
+    expect(match.reservation).toBe('event')
+  })
+
+  it('suggests the WHOLE tournament’s tables for an un-pooled fixture', () => {
+    const tournament = buildTournament({ events: [buildBracketDrawnEvent()] })
+    // `buildTournament` reserves t1…t8 while the catalogue runs to t12: the
+    // suggestion is the TOURNAMENT's reservation, not every table that exists.
+    const [match] = buildSchedule(tournament, buildTables()).awaiting
+    expect(match.suggestedTableIds).toEqual([
+      't1',
+      't2',
+      't3',
+      't4',
+      't5',
+      't6',
+      't7',
+      't8',
+    ])
+  })
+
+  it('keeps a POOLED fixture on its own pool’s tables — a pool still restricts', () => {
+    const tournament = buildTournament({
+      events: [
+        buildDrawnEvent({
+          pools: [buildPool({ id: 'p-a', tableIds: ['t2', 't3'] })],
+          fixtures: [buildFixture({ id: 'x', poolId: 'p-a' })],
+        }),
+      ],
+    })
+    const [match] = buildSchedule(tournament, buildTables()).awaiting
+    expect(match.suggestedTableIds).toEqual(['t2', 't3'])
+    expect(match.reservation).toBe('pool')
   })
 })
 

--- a/web-client/src/components/tournaments/data/schedule.ts
+++ b/web-client/src/components/tournaments/data/schedule.ts
@@ -66,8 +66,24 @@ export interface ScheduleMatch {
   /** The window whose **date** the placement is fixed to: the fixture's pool Slot, or the
    * event Slot when the fixture is un-pooled (ADR-0790). The time picker chooses within it. */
   window: Slot
-  /** The tables the fixture's pool reserves — the natural suggestion for a placement
-   * (empty for an un-pooled fixture, whose whole venue is fair game). */
+  /** **Which reservation** the two fields above came from (ADR 20260807, "a pool restricts
+   * scheduling, it does not enable it"):
+   *
+   * - `pool` — the fixture names a pool, so its window and its tables are that pool's. A
+   *   pool RESTRICTS: it is a strict slice of the venue, and naming it is information.
+   * - `event` — the fixture names no pool (a bracket, a swiss round, a knockout stage), so
+   *   it is scheduled against the **event's own window** over **every table in the
+   *   tournament**. That is not "no reservation": it is the event-wide one.
+   *
+   * Carried rather than re-derived from `poolId` downstream so a reader states the source
+   * once, in the words the ADR uses. */
+  reservation: 'pool' | 'event'
+  /** The tables the fixture's reservation covers — the natural suggestion for a placement:
+   * a pooled fixture's pool tables, and an un-pooled fixture's whole tournament (ADR
+   * 20260807). An un-pooled fixture is therefore offered a suggestion whenever the
+   * tournament has any table at all. A **pooled** one can still be empty, because a pool
+   * that reserves no tables is a real (and infeasible) state — the server's own
+   * `PoolHasNoTables`. */
   suggestedTableIds: string[]
   /** Whether the placement can still be changed. `false` once the match is
    * `completed`/`voided` — its placement is frozen server-side, so the control is hidden
@@ -138,6 +154,11 @@ function toScheduleMatch(
   event: TournamentEvent,
   byId: Map<string, Entrant>,
   poolById: Map<string, TournamentEvent['pools'][number]>,
+  /** Every table the TOURNAMENT reserves — the event-wide reservation an un-pooled
+   * fixture is scheduled against (ADR 20260807). The tournament's own `tableIds`, not
+   * the catalogue passed to `buildSchedule`: the catalogue is what a placement is
+   * *resolved* through, the tournament's ids are what it may be placed *on*. */
+  tournamentTableIds: string[],
 ): ScheduleMatch {
   const pool = fixture.poolId !== null ? (poolById.get(fixture.poolId) ?? null) : null
   return {
@@ -152,7 +173,13 @@ function toScheduleMatch(
     // The pool fixes the date the placement falls on; an un-pooled fixture inherits the
     // event's own Slot (ADR-0790).
     window: pool?.slot ?? event.slot,
-    suggestedTableIds: pool?.tableIds ?? [],
+    reservation: pool ? 'pool' : 'event',
+    // A pool RESTRICTS scheduling, it does not enable it (ADR 20260807): a pooled
+    // fixture is suggested its pool's slice of the venue, and an un-pooled one the
+    // whole tournament — the reservation it is actually scheduled against. An empty
+    // list here would offer a bracket, a swiss round and a knockout stage no
+    // suggestion at all, which is what it used to do.
+    suggestedTableIds: pool?.tableIds ?? tournamentTableIds,
     placeable:
       fixture.matchStatus === null || !FROZEN_STATUSES.has(fixture.matchStatus),
     tier: fixtureTier(fixture),
@@ -198,7 +225,9 @@ export function buildSchedule(
     const byId = new Map(event.entrants.map((e) => [e.id, e]))
     const poolById = new Map(event.pools.map((p) => [p.id, p]))
     for (const fixture of event.fixtures) {
-      matches.push(toScheduleMatch(fixture, event, byId, poolById))
+      matches.push(
+        toScheduleMatch(fixture, event, byId, poolById, tournament.tableIds),
+      )
     }
   }
 

--- a/web-client/src/components/tournaments/data/solve.test.ts
+++ b/web-client/src/components/tournaments/data/solve.test.ts
@@ -85,8 +85,9 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
       infeasibilityReasonSchema.parse({
         kind: 'pool_has_no_tables',
         pool_name: 'Pool B',
+        reservation: 'pool',
       }),
-    ).toEqual({ kind: 'pool_has_no_tables', poolName: 'Pool B' })
+    ).toEqual({ kind: 'pool_has_no_tables', poolName: 'Pool B', reservation: 'pool' })
   })
 
   it('parses window_too_short_for_match, mapping snake→camel and keeping best_of narrow', () => {
@@ -94,6 +95,7 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
       infeasibilityReasonSchema.parse({
         kind: 'window_too_short_for_match',
         pool_name: 'Pool A',
+        reservation: 'pool',
         window_start: '09:00',
         window_end: '09:20',
         best_of: 5,
@@ -103,6 +105,7 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
     ).toEqual({
       kind: 'window_too_short_for_match',
       poolName: 'Pool A',
+      reservation: 'pool',
       windowStart: '09:00',
       windowEnd: '09:20',
       bestOf: 5,
@@ -116,6 +119,7 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
       infeasibilityReasonSchema.parse({
         kind: 'pool_over_capacity',
         pool_name: 'Pool C',
+        reservation: 'pool',
         window_start: '09:00',
         window_end: '13:00',
         required_min: 480,
@@ -125,6 +129,7 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
     ).toEqual({
       kind: 'pool_over_capacity',
       poolName: 'Pool C',
+      reservation: 'pool',
       windowStart: '09:00',
       windowEnd: '13:00',
       requiredMin: 480,
@@ -139,6 +144,7 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
         kind: 'player_over_subscribed',
         player_name: 'spiked-frigatebird',
         pool_name: 'Pool A',
+        reservation: 'pool',
         window_start: '09:00',
         window_end: '10:30',
         match_count: 4,
@@ -149,12 +155,52 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
       kind: 'player_over_subscribed',
       playerName: 'spiked-frigatebird',
       poolName: 'Pool A',
+      reservation: 'pool',
       windowStart: '09:00',
       windowEnd: '10:30',
       matchCount: 4,
       requiredMin: 150,
       windowSpanMin: 90,
     })
+  })
+
+  it('carries an event-wide reservation through as `event` — the name is not the fact', () => {
+    // The synthetic reservation an un-pooled fixture is placed in (ADR 20260807).
+    // Its `pool_name` is decorated copy ("… (whole venue)"); the *fact* rides in
+    // `reservation`, so the copy below never has to read a name to know what it
+    // may offer as a remedy.
+    expect(
+      infeasibilityReasonSchema.parse({
+        kind: 'pool_has_no_tables',
+        pool_name: 'Open Singles (whole venue)',
+        reservation: 'event',
+      }),
+    ).toEqual({
+      kind: 'pool_has_no_tables',
+      poolName: 'Open Singles (whole venue)',
+      reservation: 'event',
+    })
+  })
+
+  it('refuses a reason that names no reservation kind — the remedy would have to guess', () => {
+    // Not defaulted to `pool`: guessing here is how a director gets told to add a
+    // table to a reservation that already holds every table there is.
+    expect(() =>
+      infeasibilityReasonSchema.parse({
+        kind: 'pool_has_no_tables',
+        pool_name: 'Pool B',
+      }),
+    ).toThrow()
+  })
+
+  it('refuses a reservation kind this client has no words for', () => {
+    expect(() =>
+      infeasibilityReasonSchema.parse({
+        kind: 'pool_has_no_tables',
+        pool_name: 'Pool B',
+        reservation: 'venue',
+      }),
+    ).toThrow()
   })
 
   it('parses no_single_cause (the residual, no pool)', () => {
@@ -186,7 +232,7 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
           status: 'infeasible',
           verdict: 'infeasible',
           infeasibility_reasons: [
-            { kind: 'pool_has_no_tables', pool_name: 'Pool B' },
+            { kind: 'pool_has_no_tables', pool_name: 'Pool B', reservation: 'pool' },
             { kind: 'gremlins' },
           ] as never,
         }),
@@ -199,11 +245,13 @@ describe('infeasibilityReasonSchema (the parse boundary)', () => {
       buildScheduleSolveRead({
         status: 'infeasible',
         verdict: 'infeasible',
-        infeasibility_reasons: [{ kind: 'pool_has_no_tables', pool_name: 'Pool B' }],
+        infeasibility_reasons: [
+          { kind: 'pool_has_no_tables', pool_name: 'Pool B', reservation: 'pool' },
+        ],
       }),
     )
     expect(parsed?.infeasibilityReasons).toEqual([
-      { kind: 'pool_has_no_tables', poolName: 'Pool B' },
+      { kind: 'pool_has_no_tables', poolName: 'Pool B', reservation: 'pool' },
     ])
   })
 
@@ -336,7 +384,11 @@ describe('placementConflictSentence', () => {
 describe('infeasibilityReasonCopy', () => {
   it('words pool_has_no_tables with the pool name interpolated into both lines', () => {
     expect(
-      infeasibilityReasonCopy({ kind: 'pool_has_no_tables', poolName: 'Pool B' }),
+      infeasibilityReasonCopy({
+        kind: 'pool_has_no_tables',
+        poolName: 'Pool B',
+        reservation: 'pool',
+      }),
     ).toEqual({
       sentence: 'Pool B has no tables assigned.',
       remedy: 'Assign at least one table to Pool B, then run the scheduler again.',
@@ -348,6 +400,7 @@ describe('infeasibilityReasonCopy', () => {
       infeasibilityReasonCopy({
         kind: 'window_too_short_for_match',
         poolName: 'Pool A',
+        reservation: 'pool',
         windowStart: '09:00',
         windowEnd: '09:20',
         bestOf: 5,
@@ -366,6 +419,7 @@ describe('infeasibilityReasonCopy', () => {
       infeasibilityReasonCopy({
         kind: 'pool_over_capacity',
         poolName: 'Pool C',
+        reservation: 'pool',
         windowStart: '09:00',
         windowEnd: '13:00',
         requiredMin: 480,
@@ -384,6 +438,7 @@ describe('infeasibilityReasonCopy', () => {
       infeasibilityReasonCopy({
         kind: 'pool_over_capacity',
         poolName: 'Pool D',
+        reservation: 'pool',
         windowStart: '09:00',
         windowEnd: '10:15',
         requiredMin: 90,
@@ -399,6 +454,7 @@ describe('infeasibilityReasonCopy', () => {
         kind: 'player_over_subscribed',
         playerName: 'spiked-frigatebird',
         poolName: 'Pool A',
+        reservation: 'pool',
         windowStart: '09:00',
         windowEnd: '10:30',
         matchCount: 4,
@@ -421,6 +477,7 @@ describe('infeasibilityReasonCopy', () => {
       kind: 'player_over_subscribed',
       playerName: 'spiked-frigatebird',
       poolName: 'Pool A',
+      reservation: 'pool',
       windowStart: '09:00',
       windowEnd: '10:30',
       matchCount: 4,
@@ -467,10 +524,11 @@ describe('infeasibilityReasonCopy', () => {
 
   it('gives each arm a distinct sentence and remedy', () => {
     const arms: InfeasibilityReason[] = [
-      { kind: 'pool_has_no_tables', poolName: 'Pool B' },
+      { kind: 'pool_has_no_tables', poolName: 'Pool B', reservation: 'pool' },
       {
         kind: 'window_too_short_for_match',
         poolName: 'Pool A',
+        reservation: 'pool',
         windowStart: '09:00',
         windowEnd: '09:20',
         bestOf: 3,
@@ -480,6 +538,7 @@ describe('infeasibilityReasonCopy', () => {
       {
         kind: 'pool_over_capacity',
         poolName: 'Pool C',
+        reservation: 'pool',
         windowStart: '09:00',
         windowEnd: '13:00',
         requiredMin: 480,
@@ -490,6 +549,7 @@ describe('infeasibilityReasonCopy', () => {
         kind: 'player_over_subscribed',
         playerName: 'spiked-frigatebird',
         poolName: 'Pool A',
+        reservation: 'pool',
         windowStart: '09:00',
         windowEnd: '10:30',
         matchCount: 4,
@@ -501,6 +561,190 @@ describe('infeasibilityReasonCopy', () => {
     ]
     const sentences = arms.map((a) => infeasibilityReasonCopy(a).sentence)
     expect(new Set(sentences).size).toBe(arms.length)
+  })
+})
+
+// ----- the infeasibility reasons: the POOL copy, pinned ----------------------
+//
+// A director reads these four today, and they are asserted in the API's own
+// tests too. The event-wide reservation (below) must not have moved a byte of
+// them: this block is the regression guard, exact-equality, in one place.
+
+describe('infeasibilityReasonCopy — the pool copy is unchanged', () => {
+  it('pins all four pool-naming arms, byte for byte', () => {
+    expect(
+      infeasibilityReasonCopy({
+        kind: 'pool_has_no_tables',
+        poolName: 'Pool B',
+        reservation: 'pool',
+      }),
+    ).toEqual({
+      sentence: 'Pool B has no tables assigned.',
+      remedy: 'Assign at least one table to Pool B, then run the scheduler again.',
+    })
+
+    expect(
+      infeasibilityReasonCopy({
+        kind: 'window_too_short_for_match',
+        poolName: 'Pool A',
+        reservation: 'pool',
+        windowStart: '09:00',
+        windowEnd: '09:20',
+        bestOf: 5,
+        neededMin: 35,
+        windowSpanMin: 20,
+      }),
+    ).toEqual({
+      sentence:
+        "Pool A's 09:00–09:20 window is too short for a best-of-5 match — it needs 35 min but the window is only 20.",
+      remedy: "Widen Pool A's window, or use a shorter match format.",
+    })
+
+    expect(
+      infeasibilityReasonCopy({
+        kind: 'pool_over_capacity',
+        poolName: 'Pool C',
+        reservation: 'pool',
+        windowStart: '09:00',
+        windowEnd: '13:00',
+        requiredMin: 480,
+        capacityMin: 450,
+        tableCount: 5,
+      }),
+    ).toEqual({
+      sentence:
+        "Pool C can't fit all its matches: they need about 8h of table-time, but its 09:00–13:00 window on 5 tables only holds about 7.5h.",
+      remedy: 'Add a table to Pool C, widen its window, or trim the field.',
+    })
+
+    expect(
+      infeasibilityReasonCopy({
+        kind: 'player_over_subscribed',
+        playerName: 'spiked-frigatebird',
+        poolName: 'Pool A',
+        reservation: 'pool',
+        windowStart: '09:00',
+        windowEnd: '10:30',
+        matchCount: 4,
+        requiredMin: 150,
+        windowSpanMin: 90,
+      }),
+    ).toEqual({
+      sentence:
+        "spiked-frigatebird is in 4 matches inside Pool A's 09:00–10:30 window — playing one at a time, with a rest between, they need about 2.5h, but the window is only 1.5h long.",
+      remedy:
+        "Give spiked-frigatebird fewer matches in Pool A — a smaller pool, or a shorter match format — or widen its window; adding tables won't help one player.",
+    })
+  })
+})
+
+// ----- the infeasibility reasons: the EVENT-WIDE reservation ------------------
+//
+// An un-pooled fixture — a bracket, a swiss round, a knockout stage — is placed
+// against the event-wide reservation: the event's own window over every table in
+// the tournament (ADR 20260807). There is no pool row behind it, so a remedy must
+// name a control the director actually has — the tournament's table list, the
+// event's window, the match format, the field size — and must NOT offer a pool
+// verb ("add a table to it", "make it a smaller pool", "assign a table to it").
+// The name it carries is decorated copy, "Open Singles (whole venue)"; the fact
+// is `reservation: 'event'`.
+
+const EVENT_RESERVATION_NAME = 'Open Singles (whole venue)'
+
+describe('infeasibilityReasonCopy — the event-wide reservation', () => {
+  it('sends pool_has_no_tables to the TOURNAMENT\'s table list, not to an assignment that does not exist', () => {
+    const copy = infeasibilityReasonCopy({
+      kind: 'pool_has_no_tables',
+      poolName: EVENT_RESERVATION_NAME,
+      reservation: 'event',
+    })
+    expect(copy.remedy).toBe(
+      'Add at least one table to this tournament, then run the scheduler again.',
+    )
+    // The pool verb: there is nothing to assign a table TO.
+    expect(copy.remedy).not.toContain('Assign at least one table to')
+    expect(copy.remedy).not.toContain(EVENT_RESERVATION_NAME)
+  })
+
+  it("sends window_too_short_for_match to the EVENT's own window, not to a pool's", () => {
+    const copy = infeasibilityReasonCopy({
+      kind: 'window_too_short_for_match',
+      poolName: EVENT_RESERVATION_NAME,
+      reservation: 'event',
+      windowStart: '09:00',
+      windowEnd: '09:20',
+      bestOf: 5,
+      neededMin: 35,
+      windowSpanMin: 20,
+    })
+    expect(copy.remedy).toBe(
+      "Widen the event's window, or use a shorter match format.",
+    )
+    // Not "Widen Open Singles (whole venue)'s window" — that control is a pool's.
+    expect(copy.remedy).not.toContain(EVENT_RESERVATION_NAME)
+    // The figures are the same honest ones the pool form reports.
+    expect(copy.sentence).toContain('it needs 35 min but the window is only 20')
+  })
+
+  it('sends pool_over_capacity to the tournament, the event window and the field — never "add a table to" the reservation', () => {
+    const copy = infeasibilityReasonCopy({
+      kind: 'pool_over_capacity',
+      poolName: EVENT_RESERVATION_NAME,
+      reservation: 'event',
+      windowStart: '09:00',
+      windowEnd: '17:00',
+      requiredMin: 600,
+      capacityMin: 480,
+      tableCount: 4,
+    })
+    expect(copy).toEqual({
+      sentence:
+        "Open Singles (whole venue) can't fit all its matches: they need about 10h of table-time, but the event's 09:00–17:00 window on the tournament's 4 tables only holds about 8h.",
+      remedy:
+        "Add a table to this tournament, widen the event's window, or trim the field.",
+    })
+    // The reservation already holds every table there is: adding one TO IT is
+    // impossible, and the sentence must not claim the window/tables are its own.
+    expect(copy.remedy).not.toContain(`Add a table to ${EVENT_RESERVATION_NAME}`)
+    expect(copy.sentence).not.toContain('but its 09:00–17:00 window')
+  })
+
+  it('offers player_over_subscribed a smaller FIELD and the event\'s window — a "smaller pool" is not a control here', () => {
+    const copy = infeasibilityReasonCopy({
+      kind: 'player_over_subscribed',
+      playerName: 'spiked-frigatebird',
+      poolName: EVENT_RESERVATION_NAME,
+      reservation: 'event',
+      windowStart: '09:00',
+      windowEnd: '10:30',
+      matchCount: 4,
+      requiredMin: 150,
+      windowSpanMin: 90,
+    })
+    expect(copy.remedy).toBe(
+      "Give spiked-frigatebird fewer matches in this event — a smaller field, or a shorter match format — or widen the event's window; adding tables won't help one player.",
+    )
+    // The event has no pool to shrink, and no pool window to widen.
+    expect(copy.remedy).not.toContain('a smaller pool')
+    expect(copy.remedy).not.toContain(EVENT_RESERVATION_NAME)
+    // The arm's own rule still holds: a table is parallelism, one human is not.
+    expect(copy.remedy).not.toMatch(/add (a |another |more )?tables?/i)
+    expect(copy.remedy).toContain("adding tables won't help one player")
+  })
+
+  it('leaves the reservation-blind arms alone — they name no reservation to get wrong', () => {
+    expect(
+      infeasibilityReasonCopy({
+        kind: 'no_single_cause',
+        requiredMin: 360,
+        availableMin: 480,
+      }).remedy,
+    ).toBe(
+      'Trim a field, widen a window, or split the event across days — adding tables won\'t help here.',
+    )
+    expect(
+      infeasibilityReasonCopy({ kind: 'past_window', date: '2026-07-18' }).remedy,
+    ).toBe('Move the event to a future date, then run the scheduler again.')
   })
 })
 

--- a/web-client/src/components/tournaments/data/solve.test.ts
+++ b/web-client/src/components/tournaments/data/solve.test.ts
@@ -505,6 +505,23 @@ describe('infeasibilityReasonCopy', () => {
     expect(copy.remedy).toContain("adding tables won't help here")
   })
 
+  it('stops claiming there is enough table-time when the day needs more than the venue has', () => {
+    // Reachable whenever two reservations share tables in overlapping windows —
+    // routinely, for a round-robin-then-knockout event, whose knockout is placed
+    // over the same tables as its own pools. Neither is over capacity alone.
+    const copy = infeasibilityReasonCopy({
+      kind: 'no_single_cause',
+      requiredMin: 2220,
+      availableMin: 1920,
+    })
+    expect(copy.sentence).toContain('need about 37h of table-time')
+    expect(copy.sentence).toContain('only offers about 32h')
+    expect(copy.sentence).not.toContain("There's enough")
+    // The opposite of the truth in this state: the venue is short of tables.
+    expect(copy.remedy).not.toContain("adding tables won't help")
+    expect(copy.remedy).toContain('Add a table')
+  })
+
   it('words past_window as a dated "in the past" sentence, remedy "move the date"', () => {
     expect(
       infeasibilityReasonCopy({ kind: 'past_window', date: '2026-07-18' }),

--- a/web-client/src/components/tournaments/data/solve.ts
+++ b/web-client/src/components/tournaments/data/solve.ts
@@ -83,6 +83,31 @@ export type SolverVerdict = z.infer<typeof solverVerdictSchema>
 // like a username); the *sentence* is still the client's, minted in
 // `infeasibilityReasonCopy` below, so "raw API strings never reach the UI" holds.
 
+/**
+ * **Which kind of reservation** a reason blames (ADR 20260807, "a pool restricts
+ * scheduling, it does not enable it") — the same two words `ScheduleMatch.reservation`
+ * uses for the same fact, deliberately:
+ *
+ * - `pool` — a pool the director created, and can rename, re-table, re-window or
+ *   delete. Every pool verb is available to a remedy.
+ * - `event` — the **event-wide reservation**: the synthetic one an un-pooled fixture
+ *   (a bracket, a swiss round, a knockout stage) is placed against, carrying the
+ *   **event's own window** over **every table in the tournament**. There is no row
+ *   behind it, so a director cannot add a table to it, shrink it, or widen *its*
+ *   window — the controls they really have are the tournament's table list, the
+ *   event's window, the match format and the field size.
+ *
+ * Carried as data rather than sniffed out of the reservation's display name: the
+ * name is copy (`Open Singles (whole venue)`), and reading copy to decide what a
+ * remedy may offer is exactly how a director gets told to do the impossible.
+ */
+export type ReservationKind = 'pool' | 'event'
+
+/** The wire's `reservation` discriminator. Required, never defaulted: guessing
+ * `pool` for a payload that did not say so is how the wrong remedy gets printed,
+ * so an absent or unknown value must fail the parse here. */
+export const reservationKindSchema = z.enum(['pool', 'event'])
+
 type PoolHasNoTablesWire =
   components['schemas']['PoolHasNoTablesRead']
 type WindowTooShortForMatchWire =
@@ -104,6 +129,10 @@ type PastWindowReasonWire =
  * module + admin ledger switch on it); every other field is mapped snake→camel
  * like the rest of this module.
  *
+ * The four arms that name a reservation also carry **which kind** it is
+ * (`ReservationKind`), because a pool and the event-wide reservation offer a
+ * director different controls — see `infeasibilityReasonCopy`.
+ *
  * - **`pool_has_no_tables`** — a pool with fixtures but nowhere to place them.
  * - **`window_too_short_for_match`** — a single match cannot fit its pool window
  *   contiguously, whatever the table count.
@@ -124,10 +153,11 @@ type PastWindowReasonWire =
  *   tz math of its own).
  */
 export type InfeasibilityReason =
-  | { kind: 'pool_has_no_tables'; poolName: string }
+  | { kind: 'pool_has_no_tables'; poolName: string; reservation: ReservationKind }
   | {
       kind: 'window_too_short_for_match'
       poolName: string
+      reservation: ReservationKind
       windowStart: string
       windowEnd: string
       bestOf: 1 | 3 | 5 | 7
@@ -137,6 +167,7 @@ export type InfeasibilityReason =
   | {
       kind: 'pool_over_capacity'
       poolName: string
+      reservation: ReservationKind
       windowStart: string
       windowEnd: string
       requiredMin: number
@@ -147,6 +178,7 @@ export type InfeasibilityReason =
       kind: 'player_over_subscribed'
       playerName: string
       poolName: string
+      reservation: ReservationKind
       windowStart: string
       windowEnd: string
       matchCount: number
@@ -163,11 +195,13 @@ export type InfeasibilityReason =
 const poolHasNoTablesWireSchema = z.object({
   kind: z.literal('pool_has_no_tables'),
   pool_name: z.string(),
+  reservation: reservationKindSchema,
 }) satisfies z.ZodType<PoolHasNoTablesWire>
 
 const windowTooShortForMatchWireSchema = z.object({
   kind: z.literal('window_too_short_for_match'),
   pool_name: z.string(),
+  reservation: reservationKindSchema,
   window_start: z.string(),
   window_end: z.string(),
   best_of: z.union([z.literal(1), z.literal(3), z.literal(5), z.literal(7)]),
@@ -178,6 +212,7 @@ const windowTooShortForMatchWireSchema = z.object({
 const poolOverCapacityWireSchema = z.object({
   kind: z.literal('pool_over_capacity'),
   pool_name: z.string(),
+  reservation: reservationKindSchema,
   window_start: z.string(),
   window_end: z.string(),
   required_min: z.number().int(),
@@ -189,6 +224,7 @@ const playerOverSubscribedWireSchema = z.object({
   kind: z.literal('player_over_subscribed'),
   player_name: z.string(),
   pool_name: z.string(),
+  reservation: reservationKindSchema,
   window_start: z.string(),
   window_end: z.string(),
   match_count: z.number().int(),
@@ -228,11 +264,12 @@ export function infeasibilityReasonFromWire(
 ): InfeasibilityReason {
   switch (r.kind) {
     case 'pool_has_no_tables':
-      return { kind: r.kind, poolName: r.pool_name }
+      return { kind: r.kind, poolName: r.pool_name, reservation: r.reservation }
     case 'window_too_short_for_match':
       return {
         kind: r.kind,
         poolName: r.pool_name,
+        reservation: r.reservation,
         windowStart: r.window_start,
         windowEnd: r.window_end,
         bestOf: r.best_of,
@@ -243,6 +280,7 @@ export function infeasibilityReasonFromWire(
       return {
         kind: r.kind,
         poolName: r.pool_name,
+        reservation: r.reservation,
         windowStart: r.window_start,
         windowEnd: r.window_end,
         requiredMin: r.required_min,
@@ -254,6 +292,7 @@ export function infeasibilityReasonFromWire(
         kind: r.kind,
         playerName: r.player_name,
         poolName: r.pool_name,
+        reservation: r.reservation,
         windowStart: r.window_start,
         windowEnd: r.window_end,
         matchCount: r.match_count,
@@ -673,6 +712,23 @@ export interface InfeasibilityReasonCopy {
  * default makes a further arm added to the API a compile error here until it is
  * given words, so a reason can never reach the UI as a blank line.
  *
+ * **A remedy must name a control the director actually has**, so the four
+ * reservation-naming arms branch on `reservation` (ADR 20260807):
+ *
+ * - a **pool** is a row the director made, so every pool verb is fair game — add a
+ *   table to it, widen its window, make it a smaller pool. This copy is unchanged,
+ *   byte for byte, and pinned by a test.
+ * - the **event-wide reservation** is not a pool. It already holds every table in
+ *   the tournament, so there is no table to add *to it*; it has no row to rename or
+ *   shrink; and its window is the **event's** own. Its remedies therefore point at
+ *   the tournament's table list, the event's window, the match format and the field
+ *   — and never at the reservation itself, whose name (`… (whole venue)`) is copy
+ *   rather than a control.
+ *
+ * `pool_over_capacity`'s *sentence* branches too: its figures are honest either way,
+ * but "its window on N tables" claims an ownership an event-wide reservation does
+ * not have.
+ *
  * Two arms are deliberately worded to steer the director *away* from adding
  * tables, for two different reasons:
  *
@@ -691,17 +747,37 @@ export function infeasibilityReasonCopy(
     case 'pool_has_no_tables':
       return {
         sentence: `${reason.poolName} has no tables assigned.`,
-        remedy: `Assign at least one table to ${reason.poolName}, then run the scheduler again.`,
+        // The event-wide reservation covers every table the tournament has, so
+        // "no tables" means the tournament itself has none — and the table list
+        // is where the director fixes it, not an assignment they cannot make.
+        remedy:
+          reason.reservation === 'pool'
+            ? `Assign at least one table to ${reason.poolName}, then run the scheduler again.`
+            : `Add at least one table to this tournament, then run the scheduler again.`,
       }
     case 'window_too_short_for_match':
       return {
         sentence: `${reason.poolName}'s ${reason.windowStart}–${reason.windowEnd} window is too short for a best-of-${reason.bestOf} match — it needs ${reason.neededMin} min but the window is only ${reason.windowSpanMin}.`,
-        remedy: `Widen ${reason.poolName}'s window, or use a shorter match format.`,
+        // The window under an un-pooled fixture is the EVENT's own, edited on the
+        // event rather than on a pool that does not exist.
+        remedy:
+          reason.reservation === 'pool'
+            ? `Widen ${reason.poolName}'s window, or use a shorter match format.`
+            : `Widen the event's window, or use a shorter match format.`,
       }
     case 'pool_over_capacity':
       return {
-        sentence: `${reason.poolName} can't fit all its matches: they need about ${fmtTableTime(reason.requiredMin)} of table-time, but its ${reason.windowStart}–${reason.windowEnd} window on ${fmtTables(reason.tableCount)} only holds about ${fmtTableTime(reason.capacityMin)}.`,
-        remedy: `Add a table to ${reason.poolName}, widen its window, or trim the field.`,
+        sentence:
+          reason.reservation === 'pool'
+            ? `${reason.poolName} can't fit all its matches: they need about ${fmtTableTime(reason.requiredMin)} of table-time, but its ${reason.windowStart}–${reason.windowEnd} window on ${fmtTables(reason.tableCount)} only holds about ${fmtTableTime(reason.capacityMin)}.`
+            : // Same figures, honestly attributed: the window is the event's and
+              // the tables are the tournament's — neither belongs to the
+              // reservation the way a pool's do.
+              `${reason.poolName} can't fit all its matches: they need about ${fmtTableTime(reason.requiredMin)} of table-time, but the event's ${reason.windowStart}–${reason.windowEnd} window on the tournament's ${fmtTables(reason.tableCount)} only holds about ${fmtTableTime(reason.capacityMin)}.`,
+        remedy:
+          reason.reservation === 'pool'
+            ? `Add a table to ${reason.poolName}, widen its window, or trim the field.`
+            : `Add a table to this tournament, widen the event's window, or trim the field.`,
       }
     case 'player_over_subscribed':
       // The ticket's headline example, in the director's words: "player X is in 4
@@ -715,7 +791,14 @@ export function infeasibilityReasonCopy(
         // NOT "add tables": a table is parallelism, and one human cannot play two
         // matches at once, so a second table would relieve nothing here (the same
         // trap `no_single_cause`'s remedy avoids, for a different reason).
-        remedy: `Give ${reason.playerName} fewer matches in ${reason.poolName} — a smaller pool, or a shorter match format — or widen its window; adding tables won't help one player.`,
+        //
+        // "A smaller pool" is a control only a pool has. For an un-pooled fixture
+        // the field is the event's, and the window is the event's — and the
+        // reservation's name is not something the director can type into.
+        remedy:
+          reason.reservation === 'pool'
+            ? `Give ${reason.playerName} fewer matches in ${reason.poolName} — a smaller pool, or a shorter match format — or widen its window; adding tables won't help one player.`
+            : `Give ${reason.playerName} fewer matches in this event — a smaller field, or a shorter match format — or widen the event's window; adding tables won't help one player.`,
       }
     case 'no_single_cause':
       return {

--- a/web-client/src/components/tournaments/data/solve.ts
+++ b/web-client/src/components/tournaments/data/solve.ts
@@ -801,10 +801,21 @@ export function infeasibilityReasonCopy(
             : `Give ${reason.playerName} fewer matches in this event — a smaller field, or a shorter match format — or widen the event's window; adding tables won't help one player.`,
       }
     case 'no_single_cause':
-      return {
-        sentence: `There's enough total table-time (about ${fmtTableTime(reason.availableMin)} available for about ${fmtTableTime(reason.requiredMin)} of matches), so this is a timing conflict — a player is in too many matches too close together, or tables are shared across overlapping windows.`,
-        remedy: `Trim a field, widen a window, or split the event across days — adding tables won't help here.`,
-      }
+      // The "there's enough, so it's a timing conflict" reading only holds when
+      // the day's demand actually fits the venue. It need not: no single
+      // reservation is over capacity on its own, yet two that share tables in
+      // overlapping windows can outgrow the venue between them. Printing "there's
+      // enough" above "37h of matches, 32h available" contradicts its own figures,
+      // and "adding tables won't help" is then the opposite of the truth.
+      return reason.requiredMin > reason.availableMin
+        ? {
+            sentence: `This tournament's matches need about ${fmtTableTime(reason.requiredMin)} of table-time, but the venue only offers about ${fmtTableTime(reason.availableMin)} across every reserved window — and no single pool or event is over its own capacity, so nothing here is wrong on its own.`,
+            remedy: `Add a table, widen a window, trim a field, or split the event across days.`,
+          }
+        : {
+            sentence: `There's enough total table-time (about ${fmtTableTime(reason.availableMin)} available for about ${fmtTableTime(reason.requiredMin)} of matches), so this is a timing conflict — a player is in too many matches too close together, or tables are shared across overlapping windows.`,
+            remedy: `Trim a field, widen a window, or split the event across days — adding tables won't help here.`,
+          }
     case 'past_window':
       // The venue-local `date` is formatted through the tournament's own date
       // formatter (`fmtDate`, tz-safe local-midnight — no hand-slicing, no drift),

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.page.tsx
@@ -98,6 +98,15 @@ const scoped = (container: Container) => ({
   queryPlaceEditor(fixtureId: string) {
     return container.queryByTestId(`place-editor-${fixtureId}`)
   },
+  /** The table picker in an open editor. It is a radix `Select`, whose listbox only
+   * exists once opened — but its TRIGGER already renders the chosen option's label,
+   * which is where the `· pool table` mark shows up. So this reads what the director
+   * actually sees on the closed control, with no portal to open. */
+  getPlaceTable(fixtureId: string) {
+    return within(container.getByTestId(`place-editor-${fixtureId}`)).getByRole(
+      'combobox',
+    )
+  },
   /** The predicted-start time input in an open editor. */
   getPlaceTime(fixtureId: string) {
     return container.getByTestId(`place-time-${fixtureId}`) as HTMLInputElement

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.test.tsx
@@ -22,6 +22,7 @@ import { server } from '@/mocks/server'
 import { schedulePreviewModalPage } from './schedule-preview-modal.page'
 
 import {
+  buildBracketDrawnEvent,
   buildDrawnEvent,
   buildFixture,
   buildScheduleSolve,
@@ -156,6 +157,108 @@ describe('ScheduleTab', () => {
     // (its pool's first suggested table, `t1`) with no prediction, never a composed
     // `YYYY-MM-DDT:00`.
     expect(sent).toMatchObject({ table_id: 't1', scheduled_start: null })
+  })
+
+  // ----- an UN-POOLED match on the schedule tab (ADR 20260807, "a pool restricts
+  // scheduling, it does not enable it"). A bracket, a swiss round and a knockout
+  // stage carry no pool, so they are placed against their EVENT's own window over
+  // the WHOLE tournament's tables. The pooled behaviour underneath must not move:
+  // a pool must still restrict. -----------------------------------------------
+
+  /** A single-elim bracket (`pools: []`, every fixture `poolId: null`) whose event
+   * window is the tournament's SECOND day. The date is deliberately not the pool
+   * default (`2026-06-13`, which `buildPool` and `buildEvent` share): a bracket left
+   * on it could not tell "composed from the event window" from "composed from some
+   * pool's window". */
+  const buildUnpooledEvent = () =>
+    buildBracketDrawnEvent({
+      slot: { date: '2026-06-14', start: '10:00', end: '16:00' },
+    })
+
+  it('places an UN-POOLED match against its EVENT window’s date, on a tournament table', async () => {
+    let sent: unknown = null
+    mockFixturePlacementEndpoint(server, async ({ request }) => {
+      sent = await request.json()
+      return HttpResponse.json(
+        buildTournamentFixtureRead({
+          id: 'fx-se-r1-p1',
+          table_id: 't3',
+          scheduled_start: '2026-06-14T14:00:00',
+        }),
+      )
+    })
+
+    page.render({
+      // The tournament reserves t3…t5 out of a t1…t12 catalogue, on purpose. With the
+      // default t1-first reservation the suggestion and the catalogue's first table are
+      // the same `t1`, so the pre-selected table could not tell "offered the
+      // tournament's own tables" from "fell back to the first table that exists".
+      tournament: buildTournament({
+        tableIds: ['t3', 't4', 't5'],
+        events: [buildUnpooledEvent()],
+      }),
+      tables: buildTables(),
+    })
+
+    page.openPlacement('fx-se-r1-p1')
+    page.setPlaceTime('fx-se-r1-p1', '14:00')
+    page.savePlacement('fx-se-r1-p1')
+
+    await waitFor(() =>
+      expect(page.queryPlaceEditor('fx-se-r1-p1')).not.toBeInTheDocument(),
+    )
+    // The DATE is the event window's, and the TABLE is the tournament's first reserved
+    // one — an un-pooled match is offered the event-wide reservation, not nothing.
+    expect(sent).toMatchObject({
+      table_id: 't3',
+      scheduled_start: '2026-06-14T14:00:00',
+    })
+  })
+
+  it('marks a POOLED match’s own pool tables, and marks nothing on an un-pooled one', () => {
+    // Both kinds in ONE tournament, so the mark is proven to discriminate rather
+    // than to be on or off everywhere.
+    page.render({
+      tournament: buildTournament({
+        events: [buildScheduledEvent(), buildUnpooledEvent()],
+      }),
+      tables: buildTables(),
+    })
+
+    // Pool A reserves t1…t4, so the chosen table wears the mark — unchanged.
+    page.openPlacement('fx-a-2')
+    expect(page.getPlaceTable('fx-a-2')).toHaveTextContent('T1 · pool table')
+
+    // The bracket match names no pool. Every table in the tournament is fair game,
+    // so a mark on all of them would say nothing — and would claim a pool that does
+    // not exist.
+    page.openPlacement('fx-se-r1-p1')
+    expect(page.getPlaceTable('fx-se-r1-p1')).toHaveTextContent('T1')
+    expect(page.getPlaceTable('fx-se-r1-p1')).not.toHaveTextContent('pool table')
+  })
+
+  it('tells the director where a placement’s date comes from — for a pooled match AND an un-pooled one', () => {
+    page.render({
+      tournament: buildTournament({ events: [buildScheduledEvent()] }),
+      tables: buildTables(),
+    })
+    expect(page.getTab()).toHaveTextContent(
+      'the date comes from its pool window, or from its event window when it has no pool',
+    )
+  })
+
+  it('leaves the non-owner’s subtitle alone — it never claimed a pool', () => {
+    page.render({
+      tournament: buildTournament({
+        canEdit: false,
+        events: [buildScheduledEvent()],
+      }),
+      tables: buildTables(),
+    })
+    expect(page.getTab()).toHaveTextContent(
+      'Every match, by table, with its predicted start time.',
+    )
+    expect(page.getTab()).not.toHaveTextContent('pool window')
   })
 
   // ----- the consequence gate on the placement submit path (ADR "the schedule

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-tab.tsx
@@ -111,15 +111,15 @@ const Side = ({ side }: { side: FixtureSide }) => {
   }
 }
 
-/** The director's placement editor for one match (owner only): pick a **table** (the
- * pool's own tables are marked as the natural suggestion) and a **time** within the
+/** The director's placement editor for one match (owner only): pick a **table** (a pooled
+ * match's own pool tables are marked as the natural suggestion) and a **time** within the
  * fixture's window, then Save — or Clear an existing placement.
  *
- * Only the **time** is asked: the placement's date is fixed by the pool/event Slot
- * (ADR-0790), so the naive timestamp is composed from that date + this time
- * (`composeScheduledStart`) — no `Date`, no timezone. The control is a plain
- * reveal-on-click panel, not a portal'd popover, so what a director (and a test) sees is
- * the DOM, in place. */
+ * Only the **time** is asked: the placement's date is fixed by the match's reservation —
+ * its pool's Slot, or its event's own Slot when it has no pool (ADR-0790, ADR 20260807) —
+ * so the naive timestamp is composed from that date + this time (`composeScheduledStart`)
+ * — no `Date`, no timezone. The control is a plain reveal-on-click panel, not a portal'd
+ * popover, so what a director (and a test) sees is the DOM, in place. */
 const PlacementControl = ({
   match,
   tables,
@@ -151,9 +151,16 @@ const PlacementControl = ({
     consequence: CallConsequence
   } | null>(null)
 
+  // The `pool table` mark is carried only by a POOLED match (ADR 20260807). A mark is
+  // information only when it discriminates: an un-pooled match is suggested every table
+  // in the tournament, so marking all of them would say nothing — and would name a pool
+  // the match does not have.
   const options = tables.map((t) => ({
     value: t.id,
-    label: match.suggestedTableIds.includes(t.id) ? `${t.label} · pool table` : t.label,
+    label:
+      match.reservation === 'pool' && match.suggestedTableIds.includes(t.id)
+        ? `${t.label} · pool table`
+        : t.label,
   }))
   // A placement can name a table the catalogue no longer lists (a dangling ref, ADR-0790):
   // keep it selectable so the editor can *see* what it is on before moving off it, rather
@@ -579,7 +586,10 @@ export const ScheduleTab = ({ tournament, tables }: ScheduleTabProps) => {
         title="Schedule"
         subtitle={
           canEdit
-            ? 'Every match, by table. Place a match on a table and a predicted time — the date comes from its pool window.'
+            ? // The date's source is named for BOTH kinds of match (ADR 20260807): a
+              // pooled match takes its pool's window, and an un-pooled one — a bracket,
+              // a swiss round, a knockout stage — takes its event's own.
+              'Every match, by table. Place a match on a table and a predicted time — the date comes from its pool window, or from its event window when it has no pool.'
             : 'Every match, by table, with its predicted start time.'
         }
         action={

--- a/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/solve-strip.test.tsx
@@ -128,10 +128,11 @@ describe('SolveStrip', () => {
         fixturesPlaced: null,
         fixturesPinned: null,
         infeasibilityReasons: [
-          { kind: 'pool_has_no_tables', poolName: 'Pool B' },
+          { kind: 'pool_has_no_tables', poolName: 'Pool B', reservation: 'pool' },
           {
             kind: 'pool_over_capacity',
             poolName: 'Pool A',
+            reservation: 'pool',
             windowStart: '09:00',
             windowEnd: '12:30',
             requiredMin: 480,
@@ -201,6 +202,7 @@ describe('SolveStrip', () => {
             kind: 'player_over_subscribed',
             playerName: 'spiked-frigatebird',
             poolName: 'Pool A',
+            reservation: 'pool',
             windowStart: '09:00',
             windowEnd: '10:30',
             matchCount: 4,

--- a/web-client/src/mocks/factories/tournaments/preview.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/preview.factory.ts
@@ -107,7 +107,14 @@ export function buildPreviewEventBreakdown(
 export function buildPoolHasNoTablesRead(
   overrides: Partial<PoolHasNoTablesRead> = {},
 ): PoolHasNoTablesRead {
-  return { kind: 'pool_has_no_tables', pool_name: 'Pool A', ...overrides }
+  // A real pool by default (`reservation: 'pool'`) — the un-pooled case is the
+  // event-wide reservation, which a caller opts into with `reservation: 'event'`.
+  return {
+    kind: 'pool_has_no_tables',
+    pool_name: 'Pool A',
+    reservation: 'pool',
+    ...overrides,
+  }
 }
 
 /** A schedule preview's whole answer on the wire — by default a *fitting* day: an


### PR DESCRIPTION
Part of #1228. First of three stacked slices.

## Why

The solver skipped every fixture whose `pool_id` was `NULL`, because its windows and tables came from pools. That is why no single-elimination match, no swiss match and no knockout match was ever placed.

The 2026-08-01 design pass in #1228 proposed minting a pool row for the bracket. Two facts moved under that plan and this branch takes a different route:

- **#1226 landed.** A pool is now a row the director creates, names and orders, and the event editor renders every one as a card. A minted pool would show up as a pool nobody asked for.
- **The "Table pools" tab was never gated by draw type.** A single-elimination or swiss event can already reserve tables and a window. Nothing consumed the reservation.

So a pool is a **restriction**, not a precondition. ADR `docs/adr/20260807-a-pool-restricts-scheduling-it-does-not-enable-it.md` carries the decision and the rejected alternatives.

## What

- A fixture **with no pool** is placed over its event's own window, on any table in the tournament.
- A fixture **with a pool** is placed exactly as before. Pools still restrict — that is the regression this slice guards hardest.
- The pure solver (`app/scheduling.py`) is untouched: a fixture still binds to exactly one reservation. The event-wide reservation is synthesised in the snapshot, in the `PoolId` namespace that already exists.

No schema change, no migration, no pool row, no draw-strategy change. `openapi.json` does not move, so `schema.d.ts` and `Types.swift` are unchanged.

## Chores

- `1a [api]` — give a fixture with no pool an event-wide reservation
- `1b [main]` — OpenAPI regen and drift check (no diff; verified three ways)
- `1c [web-client]` — let the schedule tab place a match that belongs to no pool
- `1d [e2e]` — prove a single-elimination bracket reaches the schedule with a table and a time

## Verification

- `pytest` 2257 passed. The new reservation tests were re-run independently against this worktree's module, with provenance checked.
- vitest 325 files / 3591 tests passed, collected-vs-ran checked against `vitest list --filesOnly`; `tsc -b`, `vite build` and `eslint` clean.
- Root `e2e` 29 passed, 1 skipped, 30 collected. The new spec was **seen red**: restoring the old un-pooled skip and rebuilding the stack with `down -v` fails it for the stated reason (no table or time on the bracket's matches), not on a bare timeout. Provenance confirmed by grepping the running container.

## Known follow-ups, deliberately not in this slice

- The MSW mock solver still skips un-pooled fixtures, so `npm run dev` places nothing for a bracket. Does not affect the QA stack, which runs the real API.
- The infeasibility remedy copy still says "widen a pool window", which is not the remedy for an un-pooled event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)