### PR TITLE
Slice 2: swiss rounds and a knockout stage are placed as their sides become known (#1228)

### DIFF
--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -95,9 +95,13 @@ class UnsupportedDrawType(DrawError):
     strategy by construction, because the enum holds only what runs (ADR "a draw type
     is a seeded row, and the enum holds only what runs"), and :func:`strategy_for` is
     total. What survives is the *caller-specific* refusal —
-    :mod:`app.schedule_preview` raises this for ``single_elim``, a fully supported draw
-    type, because the CP-SAT table scheduler is pool-based and a pool-less bracket has
-    no windows to solve over.
+    :mod:`app.schedule_preview` raises this for ``single_elim`` and ``swiss``, both
+    fully supported draw types, because the **preview** does not cover them.
+
+    It is no longer the scheduler that cannot place them: a live solve places a fixture
+    belonging to no pool over its event's own window, on the tournament's tables (ADR
+    "a pool restricts scheduling, it does not enable it"). The reason the preview
+    refuses is the preview's own, and :mod:`app.schedule_preview` states it in full.
 
     Carries the offending :class:`DrawType` **structurally**, so the HTTP/MCP layers
     compose their own sentence from the fact rather than parsing a message.
@@ -1043,7 +1047,10 @@ class SwissStrategy:
     rank.
 
     Fixtures are **un-pooled** (``pool_id=None``): swiss ranks the whole field in one
-    table, which is why the schedule preview refuses it exactly as it refuses a bracket.
+    table. That no longer keeps them off the schedule — a live solve places an un-pooled
+    fixture over its event's own window (ADR "a pool restricts scheduling, it does not
+    enable it") — but the schedule **preview** still refuses a swiss event exactly as it
+    refuses a bracket, for the reason :mod:`app.schedule_preview` states in full.
     """
 
     #: How many rounds the event plays. ``R >= 1`` is static — a Pydantic constraint at

--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -2058,7 +2058,7 @@ def _map_preview_draw_error(error: DrawError) -> ToolError:
     refusing to produce fixtures for one of the tournament's events — to an
     actionable ``ToolError``.
 
-    A preview must never invent a schedule for a format production cannot run (the
+    A preview must never invent a schedule for a format it does not cover (the
     false-confidence failure the real-engine decision exists to prevent, ADR "draw
     coverage is round-robin only; every other type is refused loud"), so an
     un-drawable event refuses the *whole* preview, never a partial grid. A ``match``
@@ -2066,9 +2066,12 @@ def _map_preview_draw_error(error: DrawError) -> ToolError:
     and why, mirroring ``_map_draw_refusal_tool_error`` but in the preview's voice:
 
     * ``UnsupportedDrawType`` carries its ``draw_type`` structurally — the event's
-      draw type has no schedule generator yet (only round-robin does today; single-elim
-      can be *cut* but not yet *placed*), a fact to change on the event, not a
-      transient one to retry. **This arm is the reason the mirror is not exact:**
+      draw type is not one this PREVIEW covers (it previews an event's pool stage, and
+      single-elim and swiss have none), a fact to change on the event, not a
+      transient one to retry. A *live* solve does place those events, over the event's
+      own window (ADR "a pool restricts scheduling, it does not enable it"), so what
+      the caller is told here is that the draw type cannot be **previewed**.
+      **This arm is the reason the mirror is not exact:**
       ``_map_draw_refusal_tool_error`` has no ``UnsupportedDrawType`` arm, because on
       the CUT path the error is unreachable (``strategy_for`` is total). On the PREVIEW
       path it is genuinely raised — ``schedule_preview`` raises it for single-elim — so
@@ -2140,9 +2143,10 @@ async def preview_schedule(
     look at, or it is over).
 
     Draw coverage is ROUND-ROBIN ONLY: an event with any other draw type (today that
-    means single-elim) refuses the WHOLE preview with an actionable ``ToolError`` —
-    never a partial grid — because a preview must not invent a schedule for a format
-    production cannot run.
+    means single-elim or swiss) refuses the WHOLE preview with an actionable
+    ``ToolError`` — never a partial grid — because a preview must not invent a
+    schedule for a format it does not cover. The refusal is the preview's own: a real
+    solve does place a single-elim or swiss event, over the event's own window.
 
     Raises a ``ToolError`` when no tournament with that id exists, when you are not
     the tournament's owner (only the creator may preview), when the tournament is no

--- a/api/app/schedule_preview.py
+++ b/api/app/schedule_preview.py
@@ -28,31 +28,39 @@ cross-event contention a multi-event human would cause — a deliberate,
 honestly-noted simplification, ADR).
 
 **Draw coverage is the POOL stage; a pool-less stage is skipped, and a pool-less
-draw type is refused loud (ADR).** Every event's draw is planned by
+draw type is refused loud (ADR).** That is this **preview's** coverage, not the
+scheduler's reach: since ADR "a pool restricts scheduling, it does not enable it"
+(20260807) a *live* solve places an un-pooled fixture over its event's own window
+on the tournament's tables, so preview and live solve now deliberately differ
+here. A later slice of #1228 revisits *how* this module refuses; *that* it
+refuses is unchanged.
+Every event's draw is planned by
 :func:`app.tournament_draws.strategy_for_event` — the single source of truth
 production's own ``cut_draw`` uses:
 
 * **round-robin** — the whole draw is planned;
 * **rr-then-ko** — the whole draw is planned, and only its **pool stage** is
   previewed: the knockout fixtures (``pool_id IS NULL``) are dropped in the
-  conversion pass below. Scheduling a bracket is #1228 and deliberately out of
-  scope — a freshly cut one is entirely TBD-sided, so it is placeable only
-  incrementally, as pools resolve. The *live* solver already behaves this way for
-  free (``schedule_solves.py`` skips un-pooled and TBD-sided fixtures
-  independently), so this is the preview catching up with it rather than a new
-  rule;
+  conversion pass below. What still *justifies* that drop
+  is the **TBD-side** rule rather than anything about pools: a preview runs before
+  anyone has registered, so no pool has been played, so both sides of every
+  knockout fixture are unknown — and no engine, live or preview, places a fixture
+  with a TBD side. A live solve does schedule that bracket, incrementally, as the
+  pools feeding it resolve; a preview has nothing to resolve it from;
 * **single-elim** — refused loud with :class:`~app.draws.UnsupportedDrawType`. It
-  *has* a draw strategy (#785) — its bracket can be cut — but the table scheduler is
-  pool-based and a pool-less bracket has no windows to solve over, and unlike
-  rr-then-ko there is no other stage left to preview: the refusal is about the whole
-  event, so a partial snapshot would be a fiction rather than a subset. This is the
-  only surviving raiser of ``UnsupportedDrawType``:
+  *has* a draw strategy (#785) — its bracket can be cut, and a live solve places
+  it — but this module previews the **pool stage**, and a bracket has none: unlike
+  rr-then-ko there is no other stage left to preview, so a snapshot of it would be
+  an empty day rather than a subset of a real one, and the refusal is about the
+  whole event. This is the only surviving raiser of ``UnsupportedDrawType``:
   :func:`app.draws.strategy_for` is total, because the enum holds only draw types
   that run (ADR);
 * **swiss** — refused loud too, and it shares single-elim's ``case`` arm because it
   is refused for single-elim's reason: its draw is pool-less **end to end** (ADR
   "swiss pre-cuts every round and pairs each one on advance"), so there is no pool
-  stage for the pool-based scheduler to solve over and no partial preview to give.
+  stage for this builder to preview and no partial preview to give. A live solve
+  does place a swiss event, round by round as each round is paired; this builder
+  shows none of it.
 
 The refusal is per **event** but aborts the whole **tournament**'s preview — this
 builder sits inside a per-event loop of a whole-tournament build. That is why
@@ -265,13 +273,15 @@ def build_preview_snapshot(
 
     Persists nothing: no ``TournamentEntry`` / ``TournamentFixture`` row is
     created. Raises :class:`~app.draws.UnsupportedDrawType` — itself, not from
-    :func:`app.draws.strategy_for`, which is total — for any event this SCHEDULER
-    cannot place *at all*, today meaning single-elim: a bracket has no pools, and pools
-    are where the solver's windows come from. An **rr-then-ko** event is not such an
-    event: its pool stage places exactly as a round-robin's does and is previewed, and
-    only its knockout fixtures are dropped (ADR 20260727) — which matters because this
-    builder is per-tournament, so refusing one event takes every event beside it with
-    it. Also raises
+    :func:`app.draws.strategy_for`, which is total — for any event this PREVIEW does
+    not cover *at all*, today meaning single-elim and swiss: this builder previews an
+    event's pool stage, and neither draw has one. Not a limit of the solver any more —
+    a live solve places an un-pooled fixture over its event's own window (ADR "a pool
+    restricts scheduling, it does not enable it"). An **rr-then-ko** event is not
+    such an event: its pool stage places exactly as a round-robin's does and is
+    previewed, and only its knockout fixtures are dropped (ADR 20260727) — which
+    matters because this builder is per-tournament, so refusing one event takes every
+    event beside it with it. Also raises
     :class:`~app.draws.DegenerateDraw` if a synthesized field is too small for
     the event's pools — a clear domain error either way, never a partial
     snapshot. An event with no pools configured is one such case: the
@@ -307,14 +317,16 @@ def build_preview_snapshot(
             for offset in range(field_size)
         ]
         next_entrant += field_size
-        # The real draw, dispatched exactly as production's ``cut_draw`` does. The table
-        # scheduler is POOL-based (ADR): single-elim *has* a draw strategy (#785) — its
-        # bracket can be cut — but a pool-less bracket has no windows to solve over yet,
-        # so the preview refuses it loud with ``UnsupportedDrawType`` rather than invent
-        # a grid the solver cannot place. This is now the only place that exception is
-        # raised: ``strategy_for`` is total (ADR "the enum holds only what runs"), so
-        # the refusal is this builder's, about scheduling, not the domain's about
-        # planning.
+        # The real draw, dispatched exactly as production's ``cut_draw`` does. This
+        # PREVIEW covers the pool stage (module docstring): single-elim *has* a draw
+        # strategy (#785) — its bracket can be cut, and a live solve now places it over
+        # the event's own window (ADR "a pool restricts scheduling, it does not enable
+        # it") — but there is no pool stage here to preview, so the preview refuses it
+        # loud with ``UnsupportedDrawType`` rather than hand back an empty day dressed
+        # as a schedule. This is now the only place that exception is raised:
+        # ``strategy_for`` is total (ADR "the enum holds only what runs"), so the
+        # refusal is this builder's, about what a preview covers, not the domain's
+        # about planning.
         #
         # ``rr-then-ko`` is planned in FULL and previewed in part: its pools schedule
         # exactly as a round-robin's do, and its knockout fixtures are dropped in the
@@ -416,11 +428,14 @@ def build_preview_snapshot(
         for fixture in plan.fixtures:
             if fixture.pool_id is None:
                 # The knockout stage of an rr-then-ko draw (``pool_id IS NULL`` *is* the
-                # stage, ADR-0786). It is skipped rather than refused: the solver places
-                # fixtures into their pool's window on their pool's tables, and a
-                # bracket has neither — so there is nothing to place it against, and
-                # inventing one would preview a schedule production will never run.
-                # #1228 schedules it, incrementally, as the pools that feed it resolve.
+                # stage, ADR-0786). Dropped here rather than refused, and the drop is
+                # still right for a reason that is no longer about pools: a preview runs
+                # before anyone has registered, so no pool has been played, so both
+                # sides of every one of these fixtures are unknown — and a TBD-sided
+                # fixture is unplaceable in this engine and in the live one alike. A
+                # live solve does schedule the bracket (ADR "a pool restricts
+                # scheduling, it does not enable it"), incrementally, as the pools
+                # feeding it resolve; a preview has nothing to resolve it from.
                 knockout_fixtures += 1
                 continue
             schedule_fixtures.append(

--- a/api/app/schedule_preview_solve.py
+++ b/api/app/schedule_preview_solve.py
@@ -661,8 +661,11 @@ def _honest_notes(inputs: PreviewJobInputs) -> list[str]:
     The knockout line is what stops the strip lying by omission about an
     **rr-then-ko** event: the preview plans that event's whole draw but schedules only
     its pool stage (ADR 20260727 — a bracket is placeable only incrementally, as the
-    pools that feed it resolve, which is #1228), so without a note the director reads a
-    schedule that silently covers part of their event. It is emitted off the count of
+    pools that feed it resolve), so without a note the director reads a
+    schedule that silently covers part of their event. The *live* solve does place
+    that bracket, incrementally (ADR "a pool restricts scheduling, it does not enable
+    it"); a preview run before anyone has registered has nothing to resolve it from,
+    which is why the note stays. It is emitted off the count of
     fixtures actually dropped, so a tournament of plain round-robins — which drops none
     — gets the strip it always had, unchanged."""
     notes = [

--- a/api/app/schedule_solves.py
+++ b/api/app/schedule_solves.py
@@ -131,26 +131,44 @@ start; the pure module holds its table to ``max(estimated end, now + bucket)``
 so an overrun keeps blocking. A real "match started" fact is a later drop-in
 that replaces one condition here.
 
-Un-pooled fixtures (``pool_id IS NULL`` — single-elim, swiss, and an rr-then-ko
-draw type's KO stage) are not scheduled: the solver's windows come
-from pools (KO-stage
-scheduling is a designed later layer, per the ADR). Fixtures with a TBD side
-cannot be placed and are left out of the snapshot; both still count toward the
-fingerprint, so their arrival or resolution is drift like any other.
+**Un-pooled fixtures (``pool_id IS NULL``) ARE scheduled, over their event's own
+reservation** (ADR "a pool restricts scheduling, it does not enable it",
+20260807). Until that ADR they were skipped outright — the solver's windows and
+tables came from pools, so a fixture naming none had nowhere to go — which is
+why no single-elim match, no swiss match and no rr-then-ko knockout match was
+ever placed. The skip is now a **branch**: a pooled fixture resolves its window
+and its tables from its own pool exactly as it always has, and an un-pooled one
+resolves them from a synthetic **event-wide reservation**
+(:func:`event_wide_pool_key`) carrying the event's own ``slot``, read in the
+event's zone, over the whole tournament catalogue. No pool row is minted, and
+:mod:`app.scheduling` is untouched: a fixture still binds to exactly one
+reservation, and every pool-keyed infeasibility reason reports against whichever
+one it named.
 
-**For swiss that rule costs the WHOLE event, and nothing else states it.**
-Single-elim and rr-then-ko each lose a *stage* to it, but a swiss draw is
-un-pooled end to end (ADR "swiss pre-cuts every round and pairs each one on
-advance"), so **every** fixture of one is skipped here. No swiss fixture is ever
-given a *solved* table or a *solved* start: a swiss event is absent from every
-schedule this module produces, and nothing in one is ever placed automatically.
+**A TBD side is a separate rule, and it did not change.** A fixture missing
+either entrant cannot be placed and is left out of the snapshot, pooled or not.
+Un-pooled and TBD-sided fixtures alike still count toward the fingerprint, so
+their arrival or resolution is drift like any other. That surviving rule is what
+leaves a bracket placed only in part at first. A single-elim first round is
+seeded, so its two sides are known and it is placed straight away; every round
+above it, and every round of an rr-then-ko knockout stage — which waits on the
+pools feeding it — becomes placeable only as its sides resolve, at the very
+re-solve a completed match already triggers.
 
-The only table and time a swiss fixture ever gets is one a director typed in.
-A manual placement (:func:`app.tournaments.place_fixture`) pins whatever it is
-given and never asks the fixture for a pool, and from there the fixture flows
-through the ordinary pin/call machinery like any other hand placement — so a
-hand-placed swiss fixture *is* called, this module simply never plans one.
-Solving swiss for real is unbuilt, not designed away.
+**Swiss rides the same reservation, and for swiss that is the WHOLE event.**
+An rr-then-ko draw carries *one* un-pooled stage, its knockout, while a
+single-elim draw and a swiss draw are un-pooled end to end — so for those two
+the event-wide reservation covers the whole event. Swiss is the case nothing
+else in this module states (ADR "swiss pre-cuts every round and pairs each one
+on advance"): **every** fixture of one takes its event's event-wide
+reservation. Before the 20260807 ADR the only table and time a swiss fixture
+ever got was one a director typed in; this module now plans one like any other,
+round by round as each round is paired and its sides stop being TBD.
+A manual placement (:func:`app.tournaments.place_fixture`) still pins whatever
+it is given and never asks the fixture for a pool, so a hand-placed swiss
+fixture is pinned and called exactly as before — the difference is that the
+solver now packs the free remainder around it rather than leaving it the only
+placement the event will ever have.
 """
 
 import hashlib

--- a/api/app/scheduling.py
+++ b/api/app/scheduling.py
@@ -214,7 +214,15 @@ class SchedulePool:
     """A pool as the solver needs to see it: which tables it may use and when.
 
     ``table_ids`` is the slice of the venue catalogue this pool draws on;
-    tables may be shared between pools (per-table no-overlap is global)."""
+    tables may be shared between pools (per-table no-overlap is global).
+
+    A ``SchedulePool`` is a **reservation**, and not always a director's pool.
+    The snapshot builder names one per pool, plus one **event-wide** reservation
+    for an event that has fixtures belonging to no pool — that event's own
+    window over the whole catalogue (ADR "a pool restricts scheduling, it does
+    not enable it"). This module cannot tell the two apart and does not need to:
+    either way a fixture binds to exactly one of them, and every pool-keyed
+    infeasibility reason is reported against whichever one it named."""
 
     id: PoolId
     table_ids: tuple[TableId, ...]

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -1134,10 +1134,9 @@ def _draw_refusal(error: DrawError) -> HTTPException:
       "a pool restricts scheduling, it does not enable it"). A director previewing a
       bracket's schedule must be told it is the *draw type* that cannot be previewed,
       not left with the generic sentence, which says the event's own state is at fault
-      and would
-      send them hunting through pools and entrants that are perfectly fine. (The
-      sentence composed below still names the pre-ADR reason: a later slice of #1228
-      revisits how the preview refuses, and rewrites that copy with it.)
+      and would send them hunting through pools and entrants that are perfectly fine.
+      (The sentence composed below still names the pre-ADR reason: a later slice of
+      #1228 revisits how the preview refuses, and rewrites that copy with it.)
     * The fallback arm is a **generic** sentence, never the exception's own. A
       ``DrawError`` subclass added tomorrow gets a vague refusal rather than leaking a
       message nobody wrote for a human — refusing vaguely is a bug report; leaking

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -1128,11 +1128,16 @@ def _draw_refusal(error: DrawError) -> HTTPException:
       reason. It can no longer arrive from the **cut** route — ``strategy_for`` is total
       now that the enum holds only what runs (ADR 20260726) — but this mapper is shared
       with the **schedule-preview** route below, and ``app.schedule_preview`` still
-      raises it for ``single_elim``: the CP-SAT scheduler is round-robin-only, so a
-      pool-less bracket has no windows to solve over. A director previewing a bracket's
-      schedule must be told it is the *draw type* that cannot be previewed, not left
-      with the generic sentence, which says the event's own state is at fault and would
-      send them hunting through pools and entrants that are perfectly fine.
+      raises it for ``single_elim`` and ``swiss``: the *preview* covers an event's pool
+      stage, and neither draw has one. The scheduler itself is no longer the limit — a
+      live solve places a fixture belonging to no pool over its event's own window (ADR
+      "a pool restricts scheduling, it does not enable it"). A director previewing a
+      bracket's schedule must be told it is the *draw type* that cannot be previewed,
+      not left with the generic sentence, which says the event's own state is at fault
+      and would
+      send them hunting through pools and entrants that are perfectly fine. (The
+      sentence composed below still names the pre-ADR reason: a later slice of #1228
+      revisits how the preview refuses, and rewrites that copy with it.)
     * The fallback arm is a **generic** sentence, never the exception's own. A
       ``DrawError`` subclass added tomorrow gets a vague refusal rather than leaking a
       message nobody wrote for a human — refusing vaguely is a bug report; leaking

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -2790,9 +2790,11 @@ async def test_preview_mcp_unsupported_draw_type_raises_tool_error(
 ) -> None:
     """An event whose draw type is not round-robin (here single-elim) refuses the
     WHOLE preview with an actionable ``ToolError`` naming round-robin — never a
-    partial result — because a preview must not invent a schedule for a format
-    production cannot run. The refusal happens at snapshot build, before anything is
-    queued."""
+    partial result — because a preview covers an event's pool stage and a bracket has
+    none. Production runs the format perfectly well: a live solve places a fixture
+    belonging to no pool over its event's own window (ADR "a pool restricts
+    scheduling, it does not enable it"). The refusal happens at snapshot build, before
+    anything is queued."""
     owner = await make_user(db_session, "preview-mcp-ko-owner")
     raw = await _mint(db_session, owner)
     tournament, _ = await _seed_previewable_tournament(

--- a/api/tests/test_schedule_preview_snapshot.py
+++ b/api/tests/test_schedule_preview_snapshot.py
@@ -410,8 +410,10 @@ async def test_preview_snapshot_count_override_resizes_field(
 @pytest.mark.parametrize(
     "draw_type",
     # The two POOL-LESS draw types, which is the whole criterion: both *can* be cut,
-    # but the CP-SAT table scheduler is pool-based and a draw with no pools has no
-    # windows to solve over, so the preview refuses them rather than invent a grid.
+    # but a preview covers an event's POOL stage, and neither draw has one — so the
+    # preview refuses them rather than invent a grid. Not because the scheduler cannot
+    # place them: a live solve places a fixture belonging to no pool over its event's
+    # own window (ADR "a pool restricts scheduling, it does not enable it").
     # Single-elim is the bracket (#785); swiss ranks one field in one table (ADR "swiss
     # pre-cuts every round and pairs each one on advance"). ``rr-then-ko`` is
     # deliberately NOT here: it has a pool stage that schedules perfectly well, so it
@@ -445,9 +447,10 @@ async def test_preview_snapshot_previews_an_rr_then_ko_events_pool_stage_only(
     """An ``rr-then-ko`` event is previewed, and what is previewed is its **pools**.
 
     The knockout fixtures the cut emits alongside them (``pool_id IS NULL``) are
-    dropped: the solver places a fixture into its pool's window on its pool's tables,
-    and a bracket has neither. Scheduling it is #1228 — a freshly cut bracket is
-    entirely TBD-sided, so it is placeable only incrementally, as the pools resolve.
+    dropped: at preview time a freshly cut bracket is entirely TBD-sided, so there is
+    no field to lay out. A live solve *does* place them — over the event's own window
+    on the tournament's tables, once their pools decide who is in them (ADR "a pool
+    restricts scheduling, it does not enable it") — which is #1228.
 
     Six synthetic entrants in one pool, so the pool stage is C(6, 2) = 15 pairings and
     the bracket for the top 2 would add 1 more fixture on top. The count is what

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -162,7 +162,9 @@ async def _make_tournament(
     slot_date: str = DATE,
     draw_type: DrawType = DrawType.round_robin,
     qualifiers_per_pool: int | None = None,
+    rounds: int | None = None,
     pools: Sequence[Mapping[str, Any]] | None = None,
+    materialize: bool = False,
 ) -> tuple[uuid.UUID, uuid.UUID]:
     """A published tournament with a table catalogue, one event of ``draw_type``,
     ``entrants`` entered players, and a cut draw. Written straight to the
@@ -178,10 +180,15 @@ async def _make_tournament(
     which is what most of this module's tests want.
 
     ``qualifiers_per_pool`` is the one setting ``rr-then-ko`` carries — how many
-    of each pool's finishers reach the bracket. It goes through the same parse
-    the request boundary uses (``tests._helpers.event_draw_settings``), so a
-    count named for a draw type that has none reds here instead of writing a row
-    the app could not have made.
+    of each pool's finishers reach the bracket — and ``rounds`` is the one
+    ``swiss`` carries. Both go through the same parse the request boundary uses
+    (``tests._helpers.event_draw_settings``), so a setting named for a draw type
+    that has none reds here instead of writing a row the app could not have made.
+
+    ``materialize`` runs the cut draw's ready fixtures into matches, as go-live
+    does. A test wants it when what it is about happens *after* a result: a
+    fixture with no match can never complete, and a draw seeded from results
+    (``rr-then-ko``) can never advance past its first stage without one.
 
     Passing ``pools=[]`` is the un-pooled event the event-wide reservation exists
     for (ADR "a pool restricts scheduling, it does not enable it"): no pool row,
@@ -231,7 +238,7 @@ async def _make_tournament(
         name="Open Singles",
         format=EventFormat.singles,
         draw_settings=event_draw_settings(
-            draw_type, qualifiers_per_pool=qualifiers_per_pool
+            draw_type, qualifiers_per_pool=qualifiers_per_pool, rounds=rounds
         ),
         max_players=None,
         entry_fee=Decimal("0.00"),
@@ -249,6 +256,8 @@ async def _make_tournament(
     await db.flush()
 
     await cut_draw(db, event)
+    if materialize:
+        await materialize_event(db, tournament, event)
     await db.commit()
     return tournament.id, event.id
 
@@ -2259,53 +2268,7 @@ async def _make_swiss_tournament(db: AsyncSession) -> tuple[uuid.UUID, uuid.UUID
     Returns ``(tournament_id, event_id)`` as plain ids, for the reason
     ``_make_tournament`` does.
     """
-    owner = await make_user(db, f"director-{uuid.uuid4().hex[:8]}")
-    league = await get_default_league(db)
-    assert league is not None, "the autouse default_league fixture seeds this"
-
-    tournament = Tournament(
-        name="Swiss Open",
-        status=TournamentStatus.published,
-        address={
-            "venue": "Berkeley TT Club",
-            "street": "1 Shattuck Ave",
-            "city": "Berkeley",
-            "region": "CA",
-            "postal": "94704",
-            "country": "USA",
-            "latitude": 37.8703,
-            "longitude": -122.2731,
-        },
-        tables=venue_tables(("T1", "Main"), ("T2", "Main")),
-        league_id=league.id,
-        created_by_user_id=owner.id,
-    )
-    db.add(tournament)
-    await db.flush()
-
-    event = TournamentEvent(
-        tournament_id=tournament.id,
-        name="Open Swiss",
-        format=EventFormat.singles,
-        draw_settings=event_draw_settings(DrawType.swiss, rounds=2),
-        max_players=None,
-        entry_fee=Decimal("0.00"),
-        timezone="America/Chicago",
-        slot={"date": DATE, "start": "09:00", "end": "17:00"},
-        match_settings={"rated": False, "length_games": 3},
-        pools=[],
-    )
-    db.add(event)
-    await db.flush()
-
-    for _ in range(4):
-        player = await make_user(db, f"player-{uuid.uuid4().hex[:8]}")
-        db.add(TournamentEntry(event_id=event.id, user_id=player.id))
-    await db.flush()
-
-    await cut_draw(db, event)
-    await db.commit()
-    return tournament.id, event.id
+    return await _make_tournament(db, draw_type=DrawType.swiss, pools=[], rounds=2)
 
 
 async def _make_pools_then_knockout_tournament(
@@ -2313,14 +2276,27 @@ async def _make_pools_then_knockout_tournament(
 ) -> tuple[uuid.UUID, uuid.UUID]:
     """A tournament whose one event is **round-robin-then-knockout**: two pools of
     three that genuinely restrict — Pool A on table 1 in the morning, Pool B on
-    table 2 in the afternoon — and a knockout stage of four qualifiers (two semis
+    table 1 in the afternoon — and a knockout stage of four qualifiers (two semis
     and a final) that belongs to no pool at all.
 
-    The event window spans both pool windows and then some (``09:00``-``19:00``),
-    so a knockout fixture placed over the event-wide reservation has somewhere to
-    go that neither pool would allow, and a pool fixture wrongly given that
-    reservation would still look feasible — which is what makes both halves of
-    the confinement claim falsifiable.
+    The geometry is contrived, deliberately, so that a knockout **wrongly confined
+    to a pool** is distinguishable from one placed over the event-wide
+    reservation. Both halves of that confinement are ruled out by a fact the
+    solver is forced to produce, because the objective's top tier is makespan:
+
+    * **The event opens at 08:00, an hour before the first pool does.** Once the
+      pools are decided they leave the model, so the two semis are the whole of
+      it, and the earliest finish puts them in that opening hour — a time **no
+      pool's window covers**.
+    * **Table 2 is reserved by no pool**, since both pools share table 1. The two
+      semis have four distinct players, so the earliest finish plays them in
+      parallel, one table each — which puts one of them on a table **no pool
+      holds**.
+
+    Both facts also arm the other half of the claim, the one about *pooled*
+    fixtures: a pool fixture handed the event-wide reservation would be free to
+    take the idle second table, or the hour before its pool opens, and
+    :func:`_assert_confined_to_its_pool` reads exactly that.
 
     Its pool fixtures are **materialized into matches** before the return, as
     go-live does, because the knockout is seeded from *results*: a pool's
@@ -2328,68 +2304,30 @@ async def _make_pools_then_knockout_tournament(
     with no match can never complete. Nothing is played here — that is the test's
     own second act.
     """
-    owner = await make_user(db, f"director-{uuid.uuid4().hex[:8]}")
-    league = await get_default_league(db)
-    assert league is not None, "the autouse default_league fixture seeds this"
-
-    tournament = Tournament(
-        name="Pools Then Bracket Open",
-        status=TournamentStatus.published,
-        address={
-            "venue": "Berkeley TT Club",
-            "street": "1 Shattuck Ave",
-            "city": "Berkeley",
-            "region": "CA",
-            "postal": "94704",
-            "country": "USA",
-            "latitude": 37.8703,
-            "longitude": -122.2731,
-        },
-        tables=venue_tables(("T1", "Main"), ("T2", "Main")),
-        league_id=league.id,
-        created_by_user_id=owner.id,
+    return await _make_tournament(
+        db,
+        entrants=6,
+        # Spelled out rather than left to the default, because the docstring's
+        # geometry is about *this* catalogue: "table 2 is reserved by no pool"
+        # stops being a local fact if the default ever grows a third table.
+        tables=("t1", "t2"),
+        window=("08:00", "19:00"),
+        draw_type=DrawType.rr_then_ko,
+        qualifiers_per_pool=2,
+        pools=[
+            {
+                "name": "Pool A",
+                "slot": {"date": DATE, "start": "09:00", "end": "13:00"},
+                "table_ids": ["t1"],
+            },
+            {
+                "name": "Pool B",
+                "slot": {"date": DATE, "start": "14:00", "end": "18:00"},
+                "table_ids": ["t1"],
+            },
+        ],
+        materialize=True,
     )
-    db.add(tournament)
-    await db.flush()
-
-    event = TournamentEvent(
-        tournament_id=tournament.id,
-        name="Open Pools Then Bracket",
-        format=EventFormat.singles,
-        draw_settings=event_draw_settings(DrawType.rr_then_ko, qualifiers_per_pool=2),
-        max_players=None,
-        entry_fee=Decimal("0.00"),
-        timezone="America/Chicago",
-        slot={"date": DATE, "start": "09:00", "end": "19:00"},
-        match_settings={"rated": False, "length_games": 3},
-        pools=event_pools(
-            [
-                {
-                    "name": "Pool A",
-                    "slot": {"date": DATE, "start": "09:00", "end": "13:00"},
-                    "table_ids": ["t1"],
-                },
-                {
-                    "name": "Pool B",
-                    "slot": {"date": DATE, "start": "14:00", "end": "18:00"},
-                    "table_ids": ["t2"],
-                },
-            ],
-            tournament=tournament,
-        ),
-    )
-    db.add(event)
-    await db.flush()
-
-    for _ in range(6):
-        player = await make_user(db, f"player-{uuid.uuid4().hex[:8]}")
-        db.add(TournamentEntry(event_id=event.id, user_id=player.id))
-    await db.flush()
-
-    await cut_draw(db, event)
-    await materialize_event(db, tournament, event)
-    await db.commit()
-    return tournament.id, event.id
 
 
 async def _pool_reservations(
@@ -2447,6 +2385,37 @@ def _assert_confined_to_its_pool(
         fixture.scheduled_start + timedelta(minutes=scheduling.match_minutes(3))
         <= window_end
     )
+
+
+def _assert_no_pool_would_have_allowed_it(
+    fixture: TournamentFixture,
+    reservations: dict[uuid.UUID, tuple[datetime, datetime, set[str]]],
+) -> None:
+    """An un-pooled fixture is placed where **no pool of its event would have
+    allowed it** — the discriminating half of "a knockout does not inherit its
+    event's pool windows" (ADR "a pool restricts scheduling, it does not enable
+    it").
+
+    "Inside the event window, on a catalogue table" cannot say this on its own:
+    the event window contains every pool window and the catalogue contains every
+    pool's tables, so a fixture wrongly confined to a pool satisfies both. This
+    asks the opposite question of each pool in turn — could this placement have
+    come out of *your* reservation? — and every answer must be no.
+    ``_make_pools_then_knockout_tournament``'s geometry is what makes that
+    answerable: see its docstring."""
+    assert fixture.table_id is not None
+    assert fixture.scheduled_start is not None
+    end = fixture.scheduled_start + timedelta(minutes=scheduling.match_minutes(3))
+    for pool_id, (window_start, window_end, tables) in reservations.items():
+        assert not (
+            fixture.table_id in tables
+            and window_start <= fixture.scheduled_start
+            and end <= window_end
+        ), (
+            f"placed on {fixture.table_id} at {fixture.scheduled_start}, which pool "
+            f"{pool_id} would have allowed — the event-wide reservation is not "
+            "distinguishable from that pool's here"
+        )
 
 
 async def _score_and_complete(
@@ -2604,9 +2573,13 @@ class TestUnPooledDrawShapes:
         so both states are asserted, on the persisted rows, either side of the
         completions.
 
-        The pools stay confined to their own tables and windows throughout — the
-        event-wide reservation spans both tables and a longer day, so a builder
-        that handed the pooled fixtures that reservation would show up here.
+        Where the semis land is the other claim: on a table and at an hour **no
+        pool of this event reserves**, which is the knockout not inheriting its
+        event's pool windows. The pools stay confined to their own table and
+        their own half of the day throughout, so a builder that handed the pooled
+        fixtures the event-wide reservation would show up here too. The seed's
+        geometry is what makes both readable — see
+        ``_make_pools_then_knockout_tournament``.
         """
         tournament_id, event_id = await _make_pools_then_knockout_tournament(db_session)
         reservations = await _pool_reservations(db_session, event_id)
@@ -2618,6 +2591,15 @@ class TestUnPooledDrawShapes:
         (final,) = [fixture.id for fixture in knockout if fixture.round == 2]
         assert len(pooled) == 6  # two pools of three, three pairings each
         assert len(semis) == 2  # four qualifiers: two semi-finals and a final
+        pooled_tables = {
+            table_id
+            for _start, _end, tables in reservations.values()
+            for table_id in tables
+        }
+        assert pooled_tables < catalogue, (
+            "the seed must leave a table no pool reserves, or 'the semis took a "
+            "table no pool holds' is not a claim this test can make"
+        )
         assert all(
             fixture.entry_a_id is None and fixture.entry_b_id is None
             for fixture in knockout
@@ -2673,7 +2655,7 @@ class TestUnPooledDrawShapes:
         after = {
             fixture.id: fixture for fixture in await _fixtures_of(db_session, event_id)
         }
-        event_start = datetime(2030, 1, 1, 9, 0, tzinfo=VENUE_TZ)
+        event_start = datetime(2030, 1, 1, 8, 0, tzinfo=VENUE_TZ)
         event_end = datetime(2030, 1, 1, 19, 0, tzinfo=VENUE_TZ)
         for fixture_id in semis:
             semi = after[fixture_id]
@@ -2684,6 +2666,13 @@ class TestUnPooledDrawShapes:
                 semi.scheduled_start + timedelta(minutes=scheduling.match_minutes(3))
                 <= event_end
             )
+            # The whole of the confinement claim: inside the event's own
+            # reservation, and inside none of its pools'.
+            _assert_no_pool_would_have_allowed_it(semi, reservations)
+        # The pair together takes a table no pool reserves — the seed's idle
+        # second one. A knockout confined to a pool has one table between the two
+        # semis, so it could only ever have played them one after the other.
+        assert {after[fixture_id].table_id for fixture_id in semis} == catalogue
         # The final's feeders are the semis, which nobody has played: still TBD,
         # so still unplaced — in the very same solve that placed the semis.
         assert after[final].entry_a_id is None and after[final].entry_b_id is None

--- a/api/tests/test_schedule_solve_service.py
+++ b/api/tests/test_schedule_solve_service.py
@@ -45,6 +45,7 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
+from sqlalchemy.orm import selectinload
 from sqlalchemy.pool import NullPool
 from sqlalchemy.sql import Executable
 
@@ -55,6 +56,8 @@ from app.models import (
     DrawType,
     EventFormat,
     Match,
+    MatchGame,
+    MatchGameScore,
     MatchSettings,
     MatchStatus,
     Notification,
@@ -109,7 +112,9 @@ from app.schemas.schedule_solve import (
     parse_placement_conflicts,
 )
 from app.schemas.tournament import ScheduleSolveRead
+from app.tournament_advancement import on_match_completed
 from app.tournament_draws import cut_draw
+from app.tournament_materialization import materialize_event
 from tests._helpers import (
     event_draw_settings,
     event_pools,
@@ -296,10 +301,16 @@ async def _solve_rows(
     )
 
 
-def _run_recorded_job(queue: Queue, expected_solve_id: uuid.UUID) -> None:
-    """Run the oldest recorded job the way a worker would: resolve the dotted
-    path (``job.func`` imports it) and call it with the enqueued args."""
-    job = queue.jobs[0]
+def _run_recorded_job(
+    queue: Queue, expected_solve_id: uuid.UUID, *, index: int = 0
+) -> None:
+    """Run a recorded job the way a worker would: resolve the dotted path
+    (``job.func`` imports it) and call it with the enqueued args.
+
+    ``index`` is which recorded job to run, oldest first — ``0`` (the default)
+    for the single-solve tests, and later indices for a test that solves, moves
+    the tournament on, and solves again."""
+    job = queue.jobs[index]
     assert job.func_name == RUN_SCHEDULE_SOLVE_JOB
     assert job.args == (str(expected_solve_id),)
     job.func(*job.args)
@@ -2233,3 +2244,460 @@ class TestEventWideReservation:
         snapshot_ids = {fixture.id for fixture in inputs.snapshot.fixtures}
         assert str(final.id) not in snapshot_ids
         assert round_one <= snapshot_ids
+
+
+async def _make_swiss_tournament(db: AsyncSession) -> tuple[uuid.UUID, uuid.UUID]:
+    """A tournament whose one event is a **swiss** event with **no pools** — the
+    other un-pooled shape (ADR "a pool restricts scheduling, it does not enable
+    it"), and the only one that is un-pooled in every round it will ever play.
+    Four entrants over two tables, in the ``09:00``-``17:00`` window ``BASE``
+    anchors.
+
+    **Two rounds**, deliberately: swiss cuts every round up front, so a second
+    round exists from the cut with both sides ``None``, which is what makes
+    "exactly round one is placed" a statement the seed can actually falsify.
+    Returns ``(tournament_id, event_id)`` as plain ids, for the reason
+    ``_make_tournament`` does.
+    """
+    owner = await make_user(db, f"director-{uuid.uuid4().hex[:8]}")
+    league = await get_default_league(db)
+    assert league is not None, "the autouse default_league fixture seeds this"
+
+    tournament = Tournament(
+        name="Swiss Open",
+        status=TournamentStatus.published,
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "1 Shattuck Ave",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94704",
+            "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
+        },
+        tables=venue_tables(("T1", "Main"), ("T2", "Main")),
+        league_id=league.id,
+        created_by_user_id=owner.id,
+    )
+    db.add(tournament)
+    await db.flush()
+
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Open Swiss",
+        format=EventFormat.singles,
+        draw_settings=event_draw_settings(DrawType.swiss, rounds=2),
+        max_players=None,
+        entry_fee=Decimal("0.00"),
+        timezone="America/Chicago",
+        slot={"date": DATE, "start": "09:00", "end": "17:00"},
+        match_settings={"rated": False, "length_games": 3},
+        pools=[],
+    )
+    db.add(event)
+    await db.flush()
+
+    for _ in range(4):
+        player = await make_user(db, f"player-{uuid.uuid4().hex[:8]}")
+        db.add(TournamentEntry(event_id=event.id, user_id=player.id))
+    await db.flush()
+
+    await cut_draw(db, event)
+    await db.commit()
+    return tournament.id, event.id
+
+
+async def _make_pools_then_knockout_tournament(
+    db: AsyncSession,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    """A tournament whose one event is **round-robin-then-knockout**: two pools of
+    three that genuinely restrict — Pool A on table 1 in the morning, Pool B on
+    table 2 in the afternoon — and a knockout stage of four qualifiers (two semis
+    and a final) that belongs to no pool at all.
+
+    The event window spans both pool windows and then some (``09:00``-``19:00``),
+    so a knockout fixture placed over the event-wide reservation has somewhere to
+    go that neither pool would allow, and a pool fixture wrongly given that
+    reservation would still look feasible — which is what makes both halves of
+    the confinement claim falsifiable.
+
+    Its pool fixtures are **materialized into matches** before the return, as
+    go-live does, because the knockout is seeded from *results*: a pool's
+    qualifiers are seated when its matches complete with scores, and a fixture
+    with no match can never complete. Nothing is played here — that is the test's
+    own second act.
+    """
+    owner = await make_user(db, f"director-{uuid.uuid4().hex[:8]}")
+    league = await get_default_league(db)
+    assert league is not None, "the autouse default_league fixture seeds this"
+
+    tournament = Tournament(
+        name="Pools Then Bracket Open",
+        status=TournamentStatus.published,
+        address={
+            "venue": "Berkeley TT Club",
+            "street": "1 Shattuck Ave",
+            "city": "Berkeley",
+            "region": "CA",
+            "postal": "94704",
+            "country": "USA",
+            "latitude": 37.8703,
+            "longitude": -122.2731,
+        },
+        tables=venue_tables(("T1", "Main"), ("T2", "Main")),
+        league_id=league.id,
+        created_by_user_id=owner.id,
+    )
+    db.add(tournament)
+    await db.flush()
+
+    event = TournamentEvent(
+        tournament_id=tournament.id,
+        name="Open Pools Then Bracket",
+        format=EventFormat.singles,
+        draw_settings=event_draw_settings(DrawType.rr_then_ko, qualifiers_per_pool=2),
+        max_players=None,
+        entry_fee=Decimal("0.00"),
+        timezone="America/Chicago",
+        slot={"date": DATE, "start": "09:00", "end": "19:00"},
+        match_settings={"rated": False, "length_games": 3},
+        pools=event_pools(
+            [
+                {
+                    "name": "Pool A",
+                    "slot": {"date": DATE, "start": "09:00", "end": "13:00"},
+                    "table_ids": ["t1"],
+                },
+                {
+                    "name": "Pool B",
+                    "slot": {"date": DATE, "start": "14:00", "end": "18:00"},
+                    "table_ids": ["t2"],
+                },
+            ],
+            tournament=tournament,
+        ),
+    )
+    db.add(event)
+    await db.flush()
+
+    for _ in range(6):
+        player = await make_user(db, f"player-{uuid.uuid4().hex[:8]}")
+        db.add(TournamentEntry(event_id=event.id, user_id=player.id))
+    await db.flush()
+
+    await cut_draw(db, event)
+    await materialize_event(db, tournament, event)
+    await db.commit()
+    return tournament.id, event.id
+
+
+async def _pool_reservations(
+    db: AsyncSession, event_id: uuid.UUID
+) -> dict[uuid.UUID, tuple[datetime, datetime, set[str]]]:
+    """What each of the event's pools reserves — ``(window start, window end,
+    table ids)`` per pool id, windows as instants in the venue frame.
+
+    Read from the pool ROWS, never from the snapshot's own fixture→reservation
+    link: a builder that handed a pooled fixture the event-wide reservation would
+    still satisfy "placed inside the reservation it was given"."""
+    windows = {
+        pool_id: (
+            datetime.combine(date.fromisoformat(DATE), start, tzinfo=VENUE_TZ),
+            datetime.combine(date.fromisoformat(DATE), end, tzinfo=VENUE_TZ),
+        )
+        for pool_id, start, end in (
+            await db.execute(
+                select(
+                    TournamentEventPool.id,
+                    TournamentEventPool.slot_start,
+                    TournamentEventPool.slot_end,
+                ).where(TournamentEventPool.event_id == event_id)
+            )
+        ).all()
+    }
+    tables: defaultdict[uuid.UUID, set[str]] = defaultdict(set)
+    for pool_id, table_id in (
+        await db.execute(
+            select(
+                TournamentEventPoolTable.pool_id, TournamentEventPoolTable.table_id
+            ).where(TournamentEventPoolTable.event_id == event_id)
+        )
+    ).all():
+        tables[pool_id].add(str(table_id))
+    return {
+        pool_id: (start, end, tables[pool_id])
+        for pool_id, (start, end) in windows.items()
+    }
+
+
+def _assert_confined_to_its_pool(
+    fixture: TournamentFixture,
+    reservations: dict[uuid.UUID, tuple[datetime, datetime, set[str]]],
+) -> None:
+    """A pooled fixture is placed on its **own pool's** tables inside its **own
+    pool's** window — not on the event-wide reservation's, which spans every table
+    and a longer day."""
+    assert fixture.pool_id is not None
+    window_start, window_end, tables = reservations[fixture.pool_id]
+    assert fixture.table_id in tables
+    assert fixture.scheduled_start is not None
+    assert window_start <= fixture.scheduled_start
+    assert (
+        fixture.scheduled_start + timedelta(minutes=scheduling.match_minutes(3))
+        <= window_end
+    )
+
+
+async def _score_and_complete(
+    db: AsyncSession, fixture: TournamentFixture, *, winner_entry_id: uuid.UUID
+) -> None:
+    """Play ``fixture``'s match out 2-0 for ``winner_entry_id`` and run it through
+    the completion seam a real result acceptance runs
+    (:func:`app.tournament_advancement.on_match_completed`) — which writes the
+    winner back, advances the draw, materializes whatever the result made ready,
+    and requests the re-solve this test is about.
+
+    The board is real games with real scores, not a bare ``winner_entry_id``: a
+    pools-then-knockout draw seats its qualifiers from the **games** each side won
+    (ADR 20260727's tiebreak chain), so a scoreless completion would leave the
+    pool unfinished — or refused outright.
+
+    ``completed_at`` stays ``None`` on purpose. A stamped completion casts a
+    ``REST_MIN`` shadow on both players, and these seeds are dated 2030 while the
+    suite runs today, so every shadow would still be open and would push the
+    knockout around for reasons that have nothing to do with the reservation
+    under test.
+    """
+    assert fixture.match_id is not None
+    match = (
+        await db.execute(
+            select(Match)
+            .options(selectinload(Match.sides))
+            .where(Match.id == fixture.match_id)
+        )
+    ).scalar_one()
+    side_1_wins = winner_entry_id == fixture.entry_a_id
+    for number in (1, 2):
+        game = MatchGame(match_id=match.id, game_number=number)
+        db.add(game)
+        await db.flush()
+        db.add(
+            MatchGameScore(
+                match_game_id=game.id,
+                side_1_points=11 if side_1_wins else 5,
+                side_2_points=5 if side_1_wins else 11,
+            )
+        )
+    for side in match.sides:
+        side.won = (side.side_number == 1) == side_1_wins
+    match.status = MatchStatus.completed
+    await db.flush()
+    await on_match_completed(db, match)
+
+
+async def _play_out_the_pools(db: AsyncSession, event_id: uuid.UUID) -> None:
+    """Decide every **pool** fixture of a pools-then-knockout event, leaving the
+    knockout untouched.
+
+    Each pool gets a strict finishing order rather than a three-way tie: the first
+    fixture's ``entry_a`` wins both of the matches it plays, and the pool's
+    remaining pairing goes to its own ``entry_a``. So the pool comes out 2-0, 1-1,
+    0-2 and its top two are named by the wins alone — this test is about
+    scheduling, and a tiebreak deciding who qualifies would make it about
+    something else.
+    """
+    by_pool: defaultdict[uuid.UUID, list[TournamentFixture]] = defaultdict(list)
+    for fixture in await _fixtures_of(db, event_id):
+        if fixture.pool_id is not None:
+            by_pool[fixture.pool_id].append(fixture)
+    for pool_fixtures in by_pool.values():
+        top = pool_fixtures[0].entry_a_id
+        for fixture in pool_fixtures:
+            entry_a_id, entry_b_id = fixture.entry_a_id, fixture.entry_b_id
+            assert entry_a_id is not None and entry_b_id is not None
+            winner = top if top in (entry_a_id, entry_b_id) else entry_a_id
+            assert winner is not None
+            await _score_and_complete(db, fixture, winner_entry_id=winner)
+    await db.commit()
+
+
+class TestUnPooledDrawShapes:
+    """The two un-pooled shapes that are **not** single-elim ride the same
+    event-wide reservation, with no further production change (ADR "a pool
+    restricts scheduling, it does not enable it"): a swiss draw, which is
+    un-pooled end to end, and a round-robin-then-knockout draw, whose second
+    stage is.
+
+    These run the whole job through the queue and read the fixture ROWS back,
+    rather than reading a snapshot: the claim is that these events' matches now
+    get a table and a time at all, which before this was only ever one a director
+    typed in by hand."""
+
+    async def test_a_swiss_round_is_placed_on_the_tournaments_tables(
+        self, db_session: AsyncSession, solver_queue: Queue
+    ) -> None:
+        """A swiss event's first round is placed over the event's own window on
+        the tournament's own tables. Its second round, cut at the same stroke with
+        both sides still unknown, is left alone — so this cannot pass by placing
+        everything the event holds."""
+        tournament_id, event_id = await _make_swiss_tournament(db_session)
+        fixtures = await _fixtures_of(db_session, event_id)
+        assert all(fixture.pool_id is None for fixture in fixtures)
+        round_one = [fixture.id for fixture in fixtures if fixture.round == 1]
+        round_two = [fixture for fixture in fixtures if fixture.round == 2]
+        assert len(round_one) == 2  # four entrants, two pairings
+        assert len(round_two) == 2
+        assert all(
+            fixture.entry_a_id is None and fixture.entry_b_id is None
+            for fixture in round_two
+        ), "a later swiss round is paired on advance, not at the cut"
+
+        row = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.manual
+        )
+        assert row is not None
+        row_id = row.id
+        await db_session.commit()
+
+        _run_recorded_job(solver_queue, row_id)
+
+        db_session.expire_all()
+        catalogue = set(await table_ids_of(db_session, tournament_id))
+        placed = {
+            fixture.id: fixture for fixture in await _fixtures_of(db_session, event_id)
+        }
+        window_end = BASE + timedelta(hours=8)
+        for fixture_id in round_one:
+            fixture = placed[fixture_id]
+            assert fixture.table_id in catalogue
+            assert fixture.scheduled_start is not None
+            assert BASE <= fixture.scheduled_start
+            assert (
+                fixture.scheduled_start + timedelta(minutes=scheduling.match_minutes(3))
+                <= window_end
+            )
+        for fixture in round_two:
+            assert placed[fixture.id].table_id is None
+            assert placed[fixture.id].scheduled_start is None
+        # Two matches, two tables or two times — never one table at one moment.
+        starts = {
+            (placed[fixture_id].table_id, placed[fixture_id].scheduled_start)
+            for fixture_id in round_one
+        }
+        assert len(starts) == 2
+
+        (ledger,) = await _solve_rows(db_session, tournament_id)
+        assert ledger.status is ScheduleSolveStatus.succeeded
+        assert ledger.fixtures_placed == 2
+
+    async def test_a_knockout_stage_is_placed_once_its_pools_have_decided(
+        self, db_session: AsyncSession, solver_queue: Queue
+    ) -> None:
+        """The sequence, which is the whole point: a knockout fixture whose sides
+        are unknown is left **unplaced** — never invented a table or a time — and
+        becomes placed by the re-solve a completed match already triggers, once
+        the pool fixtures that feed it are decided.
+
+        A test that only looked at the end state could not tell "the knockout was
+        placed once its feeders landed" from "the knockout was placed all along",
+        so both states are asserted, on the persisted rows, either side of the
+        completions.
+
+        The pools stay confined to their own tables and windows throughout — the
+        event-wide reservation spans both tables and a longer day, so a builder
+        that handed the pooled fixtures that reservation would show up here.
+        """
+        tournament_id, event_id = await _make_pools_then_knockout_tournament(db_session)
+        reservations = await _pool_reservations(db_session, event_id)
+        catalogue = set(await table_ids_of(db_session, tournament_id))
+        fixtures = await _fixtures_of(db_session, event_id)
+        pooled = [fixture.id for fixture in fixtures if fixture.pool_id is not None]
+        knockout = [fixture for fixture in fixtures if fixture.pool_id is None]
+        semis = [fixture.id for fixture in knockout if fixture.round == 1]
+        (final,) = [fixture.id for fixture in knockout if fixture.round == 2]
+        assert len(pooled) == 6  # two pools of three, three pairings each
+        assert len(semis) == 2  # four qualifiers: two semi-finals and a final
+        assert all(
+            fixture.entry_a_id is None and fixture.entry_b_id is None
+            for fixture in knockout
+        ), "nobody has qualified yet"
+
+        first = await request_solve(
+            db_session, tournament_id, ScheduleSolveTrigger.go_live
+        )
+        assert first is not None
+        first_id = first.id
+        await db_session.commit()
+
+        _run_recorded_job(solver_queue, first_id)
+
+        db_session.expire_all()
+        before = {
+            fixture.id: fixture for fixture in await _fixtures_of(db_session, event_id)
+        }
+        for fixture_id in pooled:
+            _assert_confined_to_its_pool(before[fixture_id], reservations)
+        for fixture_id in (*semis, final):
+            assert before[fixture_id].table_id is None
+            assert before[fixture_id].scheduled_start is None
+        (ledger,) = await _solve_rows(db_session, tournament_id)
+        assert ledger.status is ScheduleSolveStatus.succeeded
+        assert ledger.fixtures_placed == 6, "the pools, and nothing else"
+        pool_placements = {
+            fixture_id: (
+                before[fixture_id].table_id,
+                before[fixture_id].scheduled_start,
+            )
+            for fixture_id in pooled
+        }
+
+        await _play_out_the_pools(db_session, event_id)
+
+        db_session.expire_all()
+        seeded = {
+            fixture.id: fixture for fixture in await _fixtures_of(db_session, event_id)
+        }
+        assert all(
+            seeded[fixture_id].entry_a_id is not None
+            and seeded[fixture_id].entry_b_id is not None
+            for fixture_id in semis
+        ), "both pools finished, so all four qualifiers are seated"
+        rows = await _solve_rows(db_session, tournament_id)
+        assert len(rows) == 2, "six completions coalesce onto one queued re-solve"
+        second_id = rows[1].id
+
+        _run_recorded_job(solver_queue, second_id, index=1)
+
+        db_session.expire_all()
+        after = {
+            fixture.id: fixture for fixture in await _fixtures_of(db_session, event_id)
+        }
+        event_start = datetime(2030, 1, 1, 9, 0, tzinfo=VENUE_TZ)
+        event_end = datetime(2030, 1, 1, 19, 0, tzinfo=VENUE_TZ)
+        for fixture_id in semis:
+            semi = after[fixture_id]
+            assert semi.table_id in catalogue
+            assert semi.scheduled_start is not None
+            assert event_start <= semi.scheduled_start
+            assert (
+                semi.scheduled_start + timedelta(minutes=scheduling.match_minutes(3))
+                <= event_end
+            )
+        # The final's feeders are the semis, which nobody has played: still TBD,
+        # so still unplaced — in the very same solve that placed the semis.
+        assert after[final].entry_a_id is None and after[final].entry_b_id is None
+        assert after[final].table_id is None
+        assert after[final].scheduled_start is None
+        # The pools were decided, so they are out of the model — their placements
+        # stand exactly as the first solve left them, inside their own pools.
+        for fixture_id in pooled:
+            _assert_confined_to_its_pool(after[fixture_id], reservations)
+            assert (
+                after[fixture_id].table_id,
+                after[fixture_id].scheduled_start,
+            ) == pool_placements[fixture_id]
+        _first, second = await _solve_rows(db_session, tournament_id)
+        assert second.id == second_id
+        assert second.status is ScheduleSolveStatus.succeeded
+        assert second.fixtures_placed == 2, "the two semi-finals, and nothing else"


### PR DESCRIPTION
Part of #1228. Stacked on #1306 — review that first.

## Why

Slice 1 made the solver place a fixture that belongs to no pool, and proved it on a single-elimination bracket. Two other draw shapes are un-pooled and should ride the same path with no further production code:

- **swiss** — un-pooled end to end, every fixture, every round.
- **round-robin-then-knockout** — pooled in its first stage, un-pooled in its knockout.

This slice proves that, and stops the codebase documenting a rule it no longer follows.

## What

**`2a` is tests only, deliberately.** The chore was fenced: if a production change had been needed, that was a finding about slice 1's design and I wanted to hear it rather than have it absorbed. None was needed.

The knockout test asserts a **sequence**, not an end state:

1. Both semis and the final are unplaced while their sides are unknown.
2. Every pool match is scored and completed through the same seam a real result acceptance uses.
3. On the re-solve that triggers, both semis are placed, the final is still TBD and still unplaced, and the pool fixtures keep byte-identical placements, still confined to their own pools.

A test that only checked the end state could not tell "placed once its feeders landed" from "placed all along" — which is the bug it exists to catch.

**`2b` corrects seven modules** that still stated, as a standing decision, that the table scheduler is pool-based and a swiss match only ever gets a table a director typed in. Every stale sentence welded two rules together: "un-pooled, so unschedulable" (dead) and "sides unknown, so unplaceable" (alive, and what makes a knockout fill in round by round). They are now stated separately.

The preview's refusal is corrected in its *reason* only, not its effect — it still does not preview a bracket, because at preview time nothing has been played.

## Verification

- `pytest` 2259 passed, `mypy` clean on 170 files, `ruff` clean.
- Every new test **seen red**, including the two failure modes that matter: seating the semis at the cut reds the "still unplaced" assertion, and replacing the played-out pools with a bare re-solve reds the "now placed" one.
- `2b` proven prose-only mechanically — docstring-stripped ASTs compared before and after, identical for all seven files. No executable line moved.
- No OpenAPI change; nothing touched is a route or a Pydantic schema.

## Known follow-up, deliberately left for slice 3

Two director-facing strings still name the pre-ADR reason — the draw-refusal copy in the tournaments router and the equivalent MCP `ToolError`. They belong with slice 3's preview-gate change, which is what makes them reachable or not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)