### PR TITLE
Slice 3: one unpreviewable event no longer costs its tournament every other preview (#1228)

### DIFF
--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -2059,23 +2059,23 @@ def _map_preview_draw_error(error: DrawError) -> ToolError:
     actionable ``ToolError``.
 
     A preview must never invent a schedule for a format it does not cover (the
-    false-confidence failure the real-engine decision exists to prevent, ADR "draw
-    coverage is round-robin only; every other type is refused loud"), so an
-    un-drawable event refuses the *whole* preview, never a partial grid. A ``match``
-    over the error names which of the caller's events is not schedulable to preview
-    and why, mirroring ``_map_draw_refusal_tool_error`` but in the preview's voice:
+    false-confidence failure the real-engine decision exists to prevent), so a
+    tournament it can lay out **nothing** of is refused rather than answered with an
+    empty grid. A ``match`` over the error names what the caller has to change and
+    why, mirroring ``_map_draw_refusal_tool_error`` but in the preview's voice:
 
-    * ``UnsupportedDrawType`` carries its ``draw_type`` structurally — the event's
-      draw type is not one this PREVIEW covers (it previews an event's pool stage, and
-      single-elim and swiss have none), a fact to change on the event, not a
-      transient one to retry. A *live* solve does place those events, over the event's
-      own window (ADR "a pool restricts scheduling, it does not enable it"), so what
-      the caller is told here is that the draw type cannot be **previewed**.
-      **This arm is the reason the mirror is not exact:**
+    * ``UnsupportedDrawType`` carries its ``draw_type`` structurally — every event of
+      the tournament is a draw type this PREVIEW cannot lay out (single-elim, swiss),
+      a fact to change on an event, not a transient one to retry. One such event
+      *beside* a previewable one refuses nothing now: the builder skips it, previews
+      the rest, and the honest-notes strip names it. A *live* solve does place those
+      events, over the event's own window (ADR "a pool restricts scheduling, it does
+      not enable it"), so what the caller is told here is that the draw type cannot be
+      **previewed**. **This arm is the reason the mirror is not exact:**
       ``_map_draw_refusal_tool_error`` has no ``UnsupportedDrawType`` arm, because on
       the CUT path the error is unreachable (``strategy_for`` is total). On the PREVIEW
-      path it is genuinely raised — ``schedule_preview`` raises it for single-elim — so
-      the arm here is live code with its own coverage in
+      path it is genuinely raised — ``schedule_preview`` raises it for a tournament of
+      nothing but brackets — so the arm here is live code with its own coverage in
       ``test_schedule_preview_snapshot``.
     * ``NonSinglesDraw`` carries its ``event_format`` structurally — a doubles/teams
       event can never be given a draw (ADR-0788), so it can never be previewed.
@@ -2086,10 +2086,11 @@ def _map_preview_draw_error(error: DrawError) -> ToolError:
     match error:
         case UnsupportedDrawType():
             return ToolError(
-                f"This tournament isn't schedulable to preview yet: an event's "
-                f"{error.draw_type.value} draw has no schedule generator — only "
-                "round-robin draws can be previewed. Change the event's draw type "
-                "to round-robin, or wait for support."
+                f"No event of this tournament can be previewed: a "
+                f"{error.draw_type.value} draw is decided round by round as it is "
+                "played, so before anyone has entered there is nothing to lay out. "
+                "A round-robin event beside it would still be previewed, and the "
+                "scheduler does place this one once the tournament is live."
             )
         case NonSinglesDraw():
             return ToolError(
@@ -2142,18 +2143,21 @@ async def preview_schedule(
     ``archived`` tournament is refused (there is a real field and a real solve to
     look at, or it is over).
 
-    Draw coverage is ROUND-ROBIN ONLY: an event with any other draw type (today that
-    means single-elim or swiss) refuses the WHOLE preview with an actionable
-    ``ToolError`` — never a partial grid — because a preview must not invent a
-    schedule for a format it does not cover. The refusal is the preview's own: a real
-    solve does place a single-elim or swiss event, over the event's own window.
+    Draw coverage is the POOL STAGE: an event whose draw is decided as it is played
+    (today single-elim or swiss) is SKIPPED, and the ``notes`` strip says which event
+    was left out and why. Every other event of the tournament is previewed as usual,
+    so one bracket no longer costs the day its whole preview. Skipping is the preview's
+    own limit, not the scheduler's: a real solve does place a single-elim or swiss
+    event, over the event's own window. Only a tournament with NO previewable event at
+    all refuses, with an actionable ``ToolError`` — there is nothing to hand back, and
+    an empty grid would read as "it fits".
 
     Raises a ``ToolError`` when no tournament with that id exists, when you are not
     the tournament's owner (only the creator may preview), when the tournament is no
-    longer pre-live (``live`` / ``archived``), when an event's draw type is not
-    round-robin (not schedulable to preview yet — change it or wait for support),
-    when the preview queue is unreachable (nothing was queued; safe to retry), or
-    when the solve is still running past the internal wait (still solving — retry).
+    longer pre-live (``live`` / ``archived``), when no event of the tournament can be
+    previewed (every one of them is a bracket or a swiss draw), when the preview queue
+    is unreachable (nothing was queued; safe to retry), or when the solve is still
+    running past the internal wait (still solving — retry).
     """
     user_id = _authenticated_user_id()
     async with mcp_session() as db:
@@ -2182,8 +2186,8 @@ async def preview_schedule(
                 "Try again in a moment."
             ) from exc
         except DrawError as error:
-            # A non-round-robin (or otherwise un-drawable) event refuses the whole
-            # preview loud — never a partial grid. The enqueue already rolled back
+            # An un-drawable event, or a tournament with nothing previewable in it at
+            # all, refuses loud — never a partial grid. The enqueue already rolled back
             # (nothing was written or queued).
             raise _map_preview_draw_error(error) from error
 

--- a/api/app/schedule_preview.py
+++ b/api/app/schedule_preview.py
@@ -27,52 +27,59 @@ events, which is what makes the preview *optimistic on duration* (it ignores the
 cross-event contention a multi-event human would cause — a deliberate,
 honestly-noted simplification, ADR).
 
-**Draw coverage is the POOL stage; a pool-less stage is skipped, and a pool-less
-draw type is refused loud (ADR).** That is this **preview's** coverage, not the
-scheduler's reach: since ADR "a pool restricts scheduling, it does not enable it"
-(20260807) a *live* solve places an un-pooled fixture over its event's own window
-on the tournament's tables, so preview and live solve now deliberately differ
-here. A later slice of #1228 revisits *how* this module refuses; *that* it
-refuses is unchanged.
+**Draw coverage is the POOL stage; everything else is skipped and said so.** That
+is this **preview's** coverage, not the scheduler's reach: since ADR "a pool
+restricts scheduling, it does not enable it" (20260807) a *live* solve places an
+un-pooled fixture over its event's own window on the tournament's tables, so
+preview and live solve deliberately differ here. What a preview cannot do is
+older than pools and unchanged by that ADR: it runs **before anyone has
+registered**, so no match has been played, so every fixture past a pool stage has
+unknown sides — and no engine, live or preview, places a TBD-sided fixture.
 Every event's draw is planned by
 :func:`app.tournament_draws.strategy_for_event` — the single source of truth
 production's own ``cut_draw`` uses:
 
-* **round-robin** — the whole draw is planned;
+* **round-robin** — the whole draw is planned and previewed;
 * **rr-then-ko** — the whole draw is planned, and only its **pool stage** is
   previewed: the knockout fixtures (``pool_id IS NULL``) are dropped in the
-  conversion pass below. What still *justifies* that drop
-  is the **TBD-side** rule rather than anything about pools: a preview runs before
-  anyone has registered, so no pool has been played, so both sides of every
-  knockout fixture are unknown — and no engine, live or preview, places a fixture
-  with a TBD side. A live solve does schedule that bracket, incrementally, as the
-  pools feeding it resolve; a preview has nothing to resolve it from;
-* **single-elim** — refused loud with :class:`~app.draws.UnsupportedDrawType`. It
-  *has* a draw strategy (#785) — its bracket can be cut, and a live solve places
-  it — but this module previews the **pool stage**, and a bracket has none: unlike
-  rr-then-ko there is no other stage left to preview, so a snapshot of it would be
-  an empty day rather than a subset of a real one, and the refusal is about the
-  whole event. This is the only surviving raiser of ``UnsupportedDrawType``:
-  :func:`app.draws.strategy_for` is total, because the enum holds only draw types
-  that run (ADR);
-* **swiss** — refused loud too, and it shares single-elim's ``case`` arm because it
-  is refused for single-elim's reason: its draw is pool-less **end to end** (ADR
-  "swiss pre-cuts every round and pairs each one on advance"), so there is no pool
-  stage for this builder to preview and no partial preview to give. A live solve
-  does place a swiss event, round by round as each round is paired; this builder
-  shows none of it.
+  conversion pass below, because they are TBD-sided until the pools that feed them
+  are played. A live solve does schedule that bracket, incrementally, as those
+  pools resolve; a preview has nothing to resolve it from;
+* **single-elim** — the **event** is skipped, and the skip is reported. Its
+  bracket *has* a draw strategy (#785) and a live solve places it, but a preview
+  would be laying out a round or two and guessing at the rest, so this builder
+  previews none of it. The event still reaches the caller as an
+  :class:`EventFieldSummary` carrying ``unpreviewable_draw_type``, which is what
+  turns it into an honest note instead of an event that silently vanished;
+* **swiss** — skipped the same way, sharing single-elim's ``case`` arm for
+  single-elim's reason: a swiss draw pre-cuts a round and pairs each one only on
+  advance (ADR "swiss pre-cuts every round and pairs each one on advance"), so
+  before a ball is hit there is nothing to lay out. A live solve does place a
+  swiss event, round by round as each round is paired.
 
-The refusal is per **event** but aborts the whole **tournament**'s preview — this
-builder sits inside a per-event loop of a whole-tournament build. That is why
-rr-then-ko is skipped rather than refused: refusing it would take every unrelated
-round-robin event beside it down too (ADR 20260727).
+**A skipped event costs its tournament nothing else.** This builder sits inside a
+per-event loop of a whole-tournament build, so a refusal raised for one event
+takes the preview of every unrelated event beside it (ADR 20260727 made that the
+reason rr-then-ko's knockout stage is dropped rather than refused). A skipped
+event contributes no fixtures, no pool windows and no event settings to the
+snapshot — its pools are left out of the minute frame too, so a window it happens
+to reserve can never make the rest of the day report a false ``infeasible``.
 
-The per-event :class:`EventFieldSummary` (the count used, and how many knockout
-fixtures were left out) is returned alongside the snapshot so
-:mod:`app.schedule_preview_solve` composes the preview's honest-notes strip and
-per-event breakdown from it without re-deriving it — including the note that tells
-a director an rr-then-ko event's knockout stage is not in the schedule they are
-looking at.
+**One refusal survives, and it is about the whole tournament.** When *no* event is
+previewable, :func:`build_preview_snapshot` raises
+:class:`~app.draws.UnsupportedDrawType` naming the first skipped draw type. A
+snapshot of nothing at all would solve to "it fits" over zero matches, which is
+the false confidence a preview exists to avoid. This is the only surviving raiser
+of that exception: :func:`app.draws.strategy_for` is total, because the enum holds
+only draw types that run (ADR).
+
+The per-event :class:`EventFieldSummary` (the count used, how many knockout
+fixtures were left out, and the draw type that made the event unpreviewable) is
+returned alongside the snapshot so :mod:`app.schedule_preview_solve` composes the
+preview's honest-notes strip and per-event breakdown from it without re-deriving
+it — including the notes that tell a director an rr-then-ko event's knockout stage
+is not in the schedule they are looking at, and that a bracket or swiss event is
+not in it at all.
 """
 
 from __future__ import annotations
@@ -167,11 +174,21 @@ class EventFieldSummary:
     re-derived from the draw type downstream, so the honest note the caller writes
     from it says something is missing exactly when something is (api/CLAUDE.md —
     don't carry a field and its own derivation).
+
+    ``unpreviewable_draw_type`` is the draw type that made this builder skip the
+    **whole** event (single-elim or swiss), and ``None`` for an event that was
+    previewed. A skipped event still gets a summary — that is the channel the
+    caller's honest note is written from, and the reason the director is told the
+    event was left out instead of wondering where it went. Nothing was synthesized
+    for it, so its ``field_size`` and ``knockout_fixtures`` are ``0``: no field was
+    minted, no draw was planned, and the caller reports the skip rather than an
+    assumed count.
     """
 
     event_id: EventId
     field_size: int
     knockout_fixtures: int
+    unpreviewable_draw_type: DrawType | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -231,15 +248,30 @@ def _slot_bounds(
 @dataclass(frozen=True, slots=True)
 class _EventPlan:
     """One event's synthesized field and draw, held between the two passes: the
-    first pass plans every event (and finds the earliest window that anchors the
-    minute frame); the second converts to the pure snapshot once ``base`` is
-    known."""
+    first pass plans every previewable event (and finds the earliest window that
+    anchors the minute frame); the second converts to the pure snapshot once
+    ``base`` is known."""
 
     event: TournamentEvent
     pools: list[Pool]
     settings: MatchSettings
     fixtures: list[PlannedFixture]
     field_size: int
+
+
+@dataclass(frozen=True, slots=True)
+class _SkippedEvent:
+    """One event this preview covers **nothing** of, and the ``draw_type`` that is
+    why (single-elim or swiss).
+
+    A sibling of :class:`_EventPlan` rather than a flag on it, so a skipped event
+    cannot carry a field size, a pool window or a fixture it never had: it keeps its
+    place in the tournament's event order (the second pass walks both kinds in one
+    list) and contributes only its summary, which the caller turns into the honest
+    note naming it."""
+
+    event: TournamentEvent
+    draw_type: DrawType
 
 
 def build_preview_snapshot(
@@ -272,19 +304,26 @@ def build_preview_snapshot(
     old hardcoded ``now_min = 0`` that could never trip the past-window guard.
 
     Persists nothing: no ``TournamentEntry`` / ``TournamentFixture`` row is
-    created. Raises :class:`~app.draws.UnsupportedDrawType` — itself, not from
-    :func:`app.draws.strategy_for`, which is total — for any event this PREVIEW does
-    not cover *at all*, today meaning single-elim and swiss: this builder previews an
-    event's pool stage, and neither draw has one. Not a limit of the solver any more —
-    a live solve places an un-pooled fixture over its event's own window (ADR "a pool
-    restricts scheduling, it does not enable it"). An **rr-then-ko** event is not
-    such an event: its pool stage places exactly as a round-robin's does and is
-    previewed, and only its knockout fixtures are dropped (ADR 20260727) — which
-    matters because this builder is per-tournament, so refusing one event takes every
-    event beside it with it. Also raises
-    :class:`~app.draws.DegenerateDraw` if a synthesized field is too small for
-    the event's pools — a clear domain error either way, never a partial
-    snapshot. An event with no pools configured is one such case: the
+    created.
+
+    An event this PREVIEW covers nothing of — today single-elim and swiss, whose
+    every fixture is TBD-sided before a ball is hit — is **skipped**, not refused:
+    it contributes no fixtures, no pool windows and no event settings, and comes
+    back as an :class:`EventFieldSummary` carrying ``unpreviewable_draw_type`` for
+    the caller to write an honest note from. Every other event of the tournament is
+    previewed as usual, which is the point: this builder is per-tournament, so a
+    refusal raised for one event takes every event beside it with it. An
+    **rr-then-ko** event is not skipped at all — its pool stage places exactly as a
+    round-robin's does and is previewed, and only its knockout fixtures are dropped
+    (ADR 20260727).
+
+    Raises :class:`~app.draws.UnsupportedDrawType` — itself, not from
+    :func:`app.draws.strategy_for`, which is total — only when **no** event of the
+    tournament is previewable, naming the first skipped draw type: there is nothing
+    left to hand back, and an empty snapshot would solve to "it fits" over zero
+    matches. Also raises :class:`~app.draws.DegenerateDraw` if a synthesized field
+    is too small for the event's pools — a clear domain error either way, never a
+    partial snapshot. An event with no pools configured is one such case: the
     round-robin strategy refuses an empty pool set with
     :class:`~app.draws.DegenerateDraw`, which propagates.
     """
@@ -300,41 +339,13 @@ def build_preview_snapshot(
     catalogue = tuple(TableId(str(table.id)) for table in catalogue_tables)
     catalogue_ids = set(catalogue)
 
-    # First pass: plan every event's synthetic draw. A global counter mints the
-    # entrant ids so they are disjoint across events (event A: 1..N, event B:
-    # N+1.., ...) — no synthetic player is ever seated in two events.
+    # First pass: plan every previewable event's synthetic draw. A global counter
+    # mints the entrant ids so they are disjoint across events (event A: 1..N, event
+    # B: N+1.., ...) — no synthetic player is ever seated in two events. A skipped
+    # event mints none: no field is synthesized for an event nothing is previewed of.
     next_entrant = 1
-    plans: list[_EventPlan] = []
+    plans: list[_EventPlan | _SkippedEvent] = []
     for event in tournament.events:
-        pools = event_pools(event)
-        settings = MatchSettings.model_validate(event.match_settings)
-        field_size = _field_size(event, overrides.get(event.id))
-        ordered_entrants = [
-            OrderedEntrant(
-                entry_id=EntryId(uuid.UUID(int=next_entrant + offset)),
-                position=offset + 1,
-            )
-            for offset in range(field_size)
-        ]
-        next_entrant += field_size
-        # The real draw, dispatched exactly as production's ``cut_draw`` does. This
-        # PREVIEW covers the pool stage (module docstring): single-elim *has* a draw
-        # strategy (#785) — its bracket can be cut, and a live solve now places it over
-        # the event's own window (ADR "a pool restricts scheduling, it does not enable
-        # it") — but there is no pool stage here to preview, so the preview refuses it
-        # loud with ``UnsupportedDrawType`` rather than hand back an empty day dressed
-        # as a schedule. This is now the only place that exception is raised:
-        # ``strategy_for`` is total (ADR "the enum holds only what runs"), so the
-        # refusal is this builder's, about what a preview covers, not the domain's
-        # about planning.
-        #
-        # ``rr-then-ko`` is planned in FULL and previewed in part: its pools schedule
-        # exactly as a round-robin's do, and its knockout fixtures are dropped in the
-        # conversion pass below (ADR 20260727). Planning the whole draw rather than
-        # cutting a round-robin in its place is what keeps the previewed pools the ones
-        # production would deal — the same snake, and the same cut-time refusals
-        # (``DegenerateDraw`` when K exceeds the smallest pool) a director would meet
-        # for real.
         # Off the event's ``draw_settings`` row — the one home of the draw type
         # (ADR "an event's draw configuration is a row, not a column") — bound once
         # so the exhaustive ``match`` below narrows a name rather than re-deriving it
@@ -342,33 +353,71 @@ def build_preview_snapshot(
         draw_type = event.draw_settings.draw_type
         match draw_type:
             case DrawType.round_robin | DrawType.rr_then_ko:
-                fixtures = strategy_for_event(event).plan_initial(
-                    draw_config(event), ordered_entrants
+                # The real draw, dispatched exactly as production's ``cut_draw`` does.
+                #
+                # ``rr-then-ko`` is planned in FULL and previewed in part: its pools
+                # schedule exactly as a round-robin's do, and its knockout fixtures are
+                # dropped in the conversion pass below (ADR 20260727). Planning the
+                # whole draw rather than cutting a round-robin in its place is what
+                # keeps the previewed pools the ones production would deal — the same
+                # snake, and the same cut-time refusals (``DegenerateDraw`` when K
+                # exceeds the smallest pool) a director would meet for real.
+                field_size = _field_size(event, overrides.get(event.id))
+                ordered_entrants = [
+                    OrderedEntrant(
+                        entry_id=EntryId(uuid.UUID(int=next_entrant + offset)),
+                        position=offset + 1,
+                    )
+                    for offset in range(field_size)
+                ]
+                next_entrant += field_size
+                plans.append(
+                    _EventPlan(
+                        event=event,
+                        pools=event_pools(event),
+                        settings=MatchSettings.model_validate(event.match_settings),
+                        fixtures=strategy_for_event(event).plan_initial(
+                            draw_config(event), ordered_entrants
+                        ),
+                        field_size=field_size,
+                    )
                 )
             case DrawType.single_elim | DrawType.swiss:
-                # Swiss takes single-elim's path for single-elim's reason: it is
-                # POOL-LESS (ADR "swiss pre-cuts every round and pairs each one on
-                # advance"), and the preview covers the pool stage. A director asking
-                # for one is told the format has no preview, rather than shown an empty
-                # day that silently covers nothing.
-                raise UnsupportedDrawType(draw_type)
+                # Skipped, not refused — and skipped for a reason that is no longer
+                # about pools. A live solve does place both of these, over the event's
+                # own window (ADR "a pool restricts scheduling, it does not enable
+                # it"); what a PREVIEW cannot do is lay out a draw that is decided as
+                # it is played, since it runs before anyone has registered. Refusing
+                # here would be per-event in name only: this loop builds one
+                # tournament, so it would take the preview of every round-robin event
+                # beside it (the same reasoning ADR 20260727 applied to rr-then-ko's
+                # knockout stage). Swiss shares the arm for single-elim's reason (ADR
+                # "swiss pre-cuts every round and pairs each one on advance").
+                plans.append(_SkippedEvent(event=event, draw_type=draw_type))
             case _:
                 assert_never(draw_type)
-        plans.append(
-            _EventPlan(
-                event=event,
-                pools=pools,
-                settings=settings,
-                fixtures=fixtures,
-                field_size=field_size,
-            )
-        )
+
+    # The one refusal left, and it is about the whole tournament rather than an
+    # event: nothing at all is previewable here, so there is no partial preview to
+    # give and an empty snapshot would solve to "it fits" over zero matches — the
+    # false confidence a preview exists to avoid. Named after the first skipped draw
+    # type, so the director-facing sentence says which format it is. A tournament with
+    # no events at all is *not* this case: it has nothing to preview and nothing to
+    # blame, and keeps answering with an empty snapshot.
+    skipped = [plan for plan in plans if isinstance(plan, _SkippedEvent)]
+    if skipped and len(skipped) == len(plans):
+        raise UnsupportedDrawType(skipped[0].draw_type)
 
     # The minute frame's origin: the earliest pool window start across every
-    # event — the same anchor ``_load_solver_inputs`` uses, so ``now_min`` and
-    # the windows share one frame.
+    # previewable event — the same anchor ``_load_solver_inputs`` uses, so ``now_min``
+    # and the windows share one frame. A skipped event's pools are deliberately absent:
+    # nothing of that event is placed, so a window it reserves must neither move the
+    # frame nor reach the solver, where an empty or past-dated one would report an
+    # infeasibility against an event that was never drawn.
     windows: dict[str, tuple[datetime, datetime]] = {}
     for plan in plans:
+        if isinstance(plan, _SkippedEvent):
+            continue
         for pool in plan.pools:
             key = preview_pool_key(plan.event.id, pool.id)
             # The event's own venue ``timezone`` anchors its pools' wall-clock
@@ -404,6 +453,22 @@ def build_preview_snapshot(
     summaries: list[EventFieldSummary] = []
     for plan in plans:
         event_id = EventId(str(plan.event.id))
+        if isinstance(plan, _SkippedEvent):
+            # The whole contribution of a skipped event: a summary naming the draw
+            # type that made it unpreviewable. No fixtures, no pools, no
+            # ``EventSettings`` — the snapshot must not carry an event the solver
+            # would then have nothing to place — but it keeps its seat in the
+            # tournament's event order so the caller's note, and the per-event
+            # breakdown built beside it, still name the event the director is missing.
+            summaries.append(
+                EventFieldSummary(
+                    event_id=event_id,
+                    field_size=0,
+                    knockout_fixtures=0,
+                    unpreviewable_draw_type=plan.draw_type,
+                )
+            )
+            continue
         event_settings.append(
             EventSettings(id=event_id, length_games=plan.settings.length_games)
         )

--- a/api/app/schedule_preview_solve.py
+++ b/api/app/schedule_preview_solve.py
@@ -59,7 +59,7 @@ from app import queue as queue_module
 from app import scheduling
 from app.config import get_settings
 from app.match_calls import _wall_now
-from app.models import Tournament, TournamentStatus, User
+from app.models import DrawType, Tournament, TournamentStatus, User
 from app.schedule_preview import (
     build_preview_snapshot,
     placeholder_label,
@@ -158,12 +158,19 @@ class _PreviewEventMeta:
     drawn fixtures the preview **left out** — ``knockout_fixtures``, the un-pooled
     knockout stage of an rr-then-ko draw, ``0`` for a plain round-robin. Carried from
     the enqueue verb (which has the loaded events) to the job (which has only the pure
-    snapshot, from which "a bracket was dropped" is no longer visible)."""
+    snapshot, from which "a bracket was dropped" is no longer visible).
+
+    ``unpreviewable_draw_type`` is the draw type that made the builder skip the whole
+    event (single-elim or swiss), ``None`` for an event that was previewed. Such an
+    event is in this tuple precisely *because* nothing of it is in the snapshot: it is
+    the only place the job can learn the event exists, and the note it writes from it
+    is what tells the director the event was left out rather than lost."""
 
     event_id: str
     name: str
     field_size: int
     knockout_fixtures: int
+    unpreviewable_draw_type: DrawType | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -299,8 +306,11 @@ async def request_schedule_preview(
     ``count_overrides`` (event id → synthetic field size) lets a caller explore
     "what if 24 show up"; omitted, each event fills to its cap (or the uncapped
     default). Propagates :class:`~app.draws.UnsupportedDrawType` /
-    :class:`~app.draws.DegenerateDraw` from the builder untouched — a preview is
-    refused loud for any non-round-robin draw, never a partial grid. Raises
+    :class:`~app.draws.DegenerateDraw` from the builder untouched. An event the
+    preview covers nothing of (single-elim, swiss) no longer refuses anything: the
+    builder skips it, every other event is previewed, and the honest-notes strip
+    names it. ``UnsupportedDrawType`` now arrives only when *no* event of the
+    tournament is previewable, so there is no partial grid to hand back. Raises
     :class:`ScheduleQueueUnavailableError` if the enqueue cannot be placed (Redis
     down), mirroring the real solve verb, so the return type stays non-optional.
 
@@ -335,6 +345,7 @@ async def request_schedule_preview(
                 name=event_names.get(summary.event_id, summary.event_id),
                 field_size=summary.field_size,
                 knockout_fixtures=summary.knockout_fixtures,
+                unpreviewable_draw_type=summary.unpreviewable_draw_type,
             )
             for summary in preview.field_summaries
         ),
@@ -354,10 +365,15 @@ async def request_schedule_preview(
     return PreviewEnqueued(
         token=job.id,
         field_summaries=[
+            # Only the events a field was actually synthesized for. A skipped event
+            # (single-elim, swiss) has none, and this skeleton payload carries no
+            # notes channel to explain a zero — so it is left out here and named in
+            # the honest-notes strip the finished result carries instead.
             PreviewFieldSummary(
                 event_id=summary.event_id, field_size=summary.field_size
             )
             for summary in preview.field_summaries
+            if summary.unpreviewable_draw_type is None
         ],
         fixtures=[
             PreviewFixture(
@@ -654,9 +670,18 @@ def _honest_notes(inputs: PreviewJobInputs) -> list[str]:
     """The always-present honest-notes strip (ADR): first the disjoint-field
     caveat that makes a preview *optimistic* (its synthetic fields are disjoint
     across events, so it ignores multi-event contention), then a line for each event
-    whose knockout stage this preview left out, then one line per event naming the
-    synthetic count it assumed — so the estimate reads as the floor it is, never a
-    hidden simplification.
+    this preview left out **whole**, then a line for each event whose knockout stage
+    it left out, then one line per previewed event naming the synthetic count it
+    assumed — so the estimate reads as the floor it is, never a hidden
+    simplification.
+
+    The skipped-event line is what makes skipping an unpreviewable event honest
+    rather than silent. The builder no longer refuses a whole tournament because one
+    of its events is a bracket or a swiss draw (that refusal took every unrelated
+    event's preview with it); it previews everything else and reports the event it
+    could not lay out. Without the line, the director would read a schedule that is
+    quietly missing an event and have nothing to tell them why — so the note names the
+    event, names the draw type, and says the live scheduler does place it.
 
     The knockout line is what stops the strip lying by omission about an
     **rr-then-ko** event: the preview plans that event's whole draw but schedules only
@@ -667,11 +692,26 @@ def _honest_notes(inputs: PreviewJobInputs) -> list[str]:
     it"); a preview run before anyone has registered has nothing to resolve it from,
     which is why the note stays. It is emitted off the count of
     fixtures actually dropped, so a tournament of plain round-robins — which drops none
-    — gets the strip it always had, unchanged."""
+    — gets the strip it always had, unchanged.
+
+    A skipped event earns **no** "Assumed N entrants" line: no field was synthesized
+    for it, so claiming one would contradict the line above it."""
     notes = [
         "This estimate assumes no player is entered in more than one event; a "
         "real multi-event field would take longer."
     ]
+    for meta in inputs.events:
+        # Bound before the guard rather than read through it: the draw type is what
+        # the sentence names, and narrowing it here keeps the note total.
+        draw_type = meta.unpreviewable_draw_type
+        if draw_type is None:
+            continue
+        notes.append(
+            f"{meta.name} is not in this preview: a {draw_type.value} draw is "
+            "decided round by round as it is played, so before anyone has entered "
+            "there is nothing to lay out. The scheduler does place it once the "
+            "tournament is live."
+        )
     notes.extend(
         f"Only the pool stage of {meta.name} is scheduled here: its knockout "
         f"bracket ({meta.knockout_fixtures} further "
@@ -681,7 +721,9 @@ def _honest_notes(inputs: PreviewJobInputs) -> list[str]:
         if meta.knockout_fixtures > 0
     )
     notes.extend(
-        f"Assumed {meta.field_size} entrants for {meta.name}." for meta in inputs.events
+        f"Assumed {meta.field_size} entrants for {meta.name}."
+        for meta in inputs.events
+        if meta.unpreviewable_draw_type is None
     )
     return notes
 

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -1127,16 +1127,17 @@ def _draw_refusal(error: DrawError) -> HTTPException:
     * ``UnsupportedDrawType`` carries its ``draw_type`` **structurally**, for the same
       reason. It can no longer arrive from the **cut** route — ``strategy_for`` is total
       now that the enum holds only what runs (ADR 20260726) — but this mapper is shared
-      with the **schedule-preview** route below, and ``app.schedule_preview`` still
-      raises it for ``single_elim`` and ``swiss``: the *preview* covers an event's pool
-      stage, and neither draw has one. The scheduler itself is no longer the limit — a
-      live solve places a fixture belonging to no pool over its event's own window (ADR
-      "a pool restricts scheduling, it does not enable it"). A director previewing a
-      bracket's schedule must be told it is the *draw type* that cannot be previewed,
-      not left with the generic sentence, which says the event's own state is at fault
-      and would send them hunting through pools and entrants that are perfectly fine.
-      (The sentence composed below still names the pre-ADR reason: a later slice of
-      #1228 revisits how the preview refuses, and rewrites that copy with it.)
+      with the **schedule-preview** route below, and ``app.schedule_preview`` raises it
+      when *no* event of a tournament can be previewed (every event is a single-elim or
+      a swiss draw). One such event beside a round-robin no longer refuses anything:
+      the builder skips it, previews the rest, and the honest-notes strip names it. A
+      director previewing a bracket-only tournament must be told it is the *draw type*
+      that cannot be previewed, not left with the generic sentence, which says the
+      event's own state is at fault and would send them hunting through pools and
+      entrants that are perfectly fine. The sentence blames the right thing now: not
+      the scheduler, which does place a bracket over its event's own window (ADR "a
+      pool restricts scheduling, it does not enable it"), but the preview, which runs
+      before anyone has entered and so has no field to lay a played-out draw over.
     * The fallback arm is a **generic** sentence, never the exception's own. A
       ``DrawError`` subclass added tomorrow gets a vague refusal rather than leaking a
       message nobody wrote for a human — refusing vaguely is a bug report; leaking
@@ -1159,12 +1160,15 @@ def _draw_refusal(error: DrawError) -> HTTPException:
             detail = str(error)
         case UnsupportedDrawType():
             # Reachable from the SCHEDULE-PREVIEW route only (the cut route's
-            # ``strategy_for`` is total). Named from the structural ``draw_type`` so the
+            # ``strategy_for`` is total), and only when the tournament has no
+            # previewable event at all. Named from the structural ``draw_type`` so the
             # sentence says which format cannot be previewed.
             detail = (
-                f"A {error.draw_type.value} draw cannot be scheduled yet. The "
-                "scheduler places pooled draws over their pools' time windows, and a "
-                "bracket has none to place. Preview a round-robin event instead."
+                f"A {error.draw_type.value} draw cannot be previewed, and this "
+                "tournament has no other event to preview. A draw of that kind is "
+                "decided round by round as it is played, so before anyone has "
+                "entered there is nothing to lay out. The scheduler does place it "
+                "once the tournament is live."
             )
         case _:
             detail = "This event's draw cannot be cut as the event stands."
@@ -1688,9 +1692,11 @@ async def request_schedule_preview(
         # question, refused with the status-carrying sentence the domain authored.
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except DrawError as error:
-        # A non-round-robin (or otherwise degenerate) draw the synthetic field
-        # cannot be planned — the same 422 the cut route produces, in words a
-        # director can read.
+        # A draw the synthetic field cannot be planned (a degenerate one), or a
+        # tournament whose every event is a draw type the preview cannot lay out —
+        # the same 422 the cut route produces, in words a director can read. A single
+        # unpreviewable event beside a previewable one is not this: it is skipped, and
+        # the honest-notes strip on the finished preview names it.
         raise _draw_refusal(error) from error
     except ScheduleQueueUnavailableError as exc:
         raise HTTPException(

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -2815,6 +2815,14 @@ async def test_preview_mcp_unsupported_draw_type_raises_tool_error(
     # lands on the preview rather than on a scheduler that would now place it.
     assert DrawType.single_elim.value in message, message
     assert "can be previewed" in message, message
+    # Pin a phrase only the CURRENT copy carries. The three assertions above are all
+    # satisfied by the sentence this arc deleted ("…has no schedule generator — only
+    # round-robin draws can be previewed…"), which carried "round-robin",
+    # "single-elim" and "can be previewed" too — so on their own they would stay green
+    # through a revert to copy that blames a scheduler now placing brackets. The HTTP
+    # twin discriminates on "cannot be previewed"; this is the MCP arm's equivalent.
+    assert "No event of this tournament" in message, message
+    assert "no schedule generator" not in message, message
 
     # Nothing was queued — the refusal is raised before the enqueue.
     assert sync_preview_queue.jobs == []

--- a/api/tests/test_mcp_server.py
+++ b/api/tests/test_mcp_server.py
@@ -2382,8 +2382,9 @@ async def test_build_cut_non_singles_event_raises_readable_tool_error(
 # ``test_draws`` (``strategy_for`` is total). The ``UnsupportedDrawType`` arm of
 # ``_map_draw_refusal_tool_error`` has since been deleted as dead code — the test below
 # is what covers the generic fallback a future raiser would now reach instead. The
-# preview's own ``UnsupportedDrawType`` path (single-elim) is genuinely reachable and
-# keeps both its arm (``_map_preview_draw_error``) and its coverage in
+# preview's own ``UnsupportedDrawType`` path is genuinely reachable — a tournament
+# whose every event is a bracket or a swiss draw has nothing to preview — and keeps
+# both its arm (``_map_preview_draw_error``) and its coverage in
 # ``test_schedule_preview_snapshot``.
 
 
@@ -2788,13 +2789,15 @@ async def test_preview_mcp_unsupported_draw_type_raises_tool_error(
     default_league: League,
     sync_preview_queue: Queue,
 ) -> None:
-    """An event whose draw type is not round-robin (here single-elim) refuses the
-    WHOLE preview with an actionable ``ToolError`` naming round-robin — never a
-    partial result — because a preview covers an event's pool stage and a bracket has
-    none. Production runs the format perfectly well: a live solve places a fixture
-    belonging to no pool over its event's own window (ADR "a pool restricts
-    scheduling, it does not enable it"). The refusal happens at snapshot build, before
-    anything is queued."""
+    """A tournament whose only event is one the preview lays out nothing of (here
+    single-elim) is refused with an actionable ``ToolError`` — never an empty result
+    an agent would read as "it fits".
+
+    The sentence still names round-robin, because that is the actionable half: such an
+    event beside a round-robin one is skipped now, not refused, and the preview covers
+    the rest of the day. What it must NOT say any more is that the scheduler cannot
+    place a bracket — a live solve does (ADR "a pool restricts scheduling, it does not
+    enable it"). The refusal happens at snapshot build, before anything is queued."""
     owner = await make_user(db_session, "preview-mcp-ko-owner")
     raw = await _mint(db_session, owner)
     tournament, _ = await _seed_previewable_tournament(
@@ -2802,10 +2805,16 @@ async def test_preview_mcp_unsupported_draw_type_raises_tool_error(
     )
 
     async with _mcp_client(raw) as client, client:
-        with pytest.raises(ToolError, match="round-robin"):
+        with pytest.raises(ToolError, match="round-robin") as caught:
             await client.call_tool(
                 "preview_schedule", {"tournament_id": str(tournament.id)}
             )
+
+    message = str(caught.value)
+    # The draw type is named off the error's structural ``draw_type``, and the blame
+    # lands on the preview rather than on a scheduler that would now place it.
+    assert DrawType.single_elim.value in message, message
+    assert "can be previewed" in message, message
 
     # Nothing was queued — the refusal is raised before the enqueue.
     assert sync_preview_queue.jobs == []

--- a/api/tests/test_schedule_preview_route.py
+++ b/api/tests/test_schedule_preview_route.py
@@ -15,10 +15,11 @@ status codes:
 * ``DELETE …/schedule/preview/{token}`` best-effort cancels — ``204`` for a real
   token (dropping the job so it can no longer be polled) and ``204`` for a token
   Redis never knew (a no-op success, never a ``500``);
-* a non-owner is ``403``, a ``live``/``archived`` tournament ``409``, an event
-  whose draw type the scheduler cannot place (single-elim) ``422`` — in a
-  sentence that names the draw type — and exceeding the per-session rate limit
-  ``429``.
+* a non-owner is ``403``, a ``live``/``archived`` tournament ``409``, a tournament
+  with no previewable event at all (only a single-elim one) ``422`` — in a sentence
+  that names the draw type — and exceeding the per-session rate limit ``429``. One
+  such event *beside* a round-robin is skipped, not refused: the preview is still
+  enqueued and still covers the round-robin.
 
 Under the async (record-only) ``preview_queue`` fixture the enqueued job is
 inspected and then run through a real in-process worker (the DB-blind preview job
@@ -101,12 +102,15 @@ async def _make_tournament(
     status: TournamentStatus = TournamentStatus.draft,
     with_event: bool = True,
     draw_type: DrawType = DrawType.round_robin,
+    with_single_elim_event: bool = False,
 ) -> uuid.UUID:
     """A tournament owned by ``owner`` (a two-table catalogue and, unless
     ``with_event=False``, one pooled event of ``draw_type`` capped at four players
-    over both tables). Written straight to the database — creation routes are not
-    under test here. No ``TournamentEntry`` rows: a preview draws a synthetic
-    field."""
+    over both tables). ``with_single_elim_event`` adds a second event the preview
+    lays out nothing of, to prove it costs the first event nothing; it needs no pools,
+    since a skipped event's pools are never read. Written straight to the database —
+    creation routes are not under test here. No ``TournamentEntry`` rows: a preview
+    draws a synthetic field."""
     league = await get_default_league(db)
     assert league is not None, "the autouse default_league fixture seeds this"
 
@@ -157,6 +161,25 @@ async def _make_tournament(
             ),
         )
         db.add(event)
+        await db.flush()
+
+    if with_single_elim_event:
+        db.add(
+            TournamentEvent(
+                tournament_id=tournament.id,
+                name="Championship",
+                format=EventFormat.singles,
+                draw_settings=TournamentEventDrawSettings.for_draw_type(
+                    DrawType.single_elim
+                ),
+                max_players=8,
+                entry_fee=Decimal("0.00"),
+                slot={"date": "2030-01-01", "start": "09:00", "end": "17:00"},
+                match_settings={"rated": False, "length_games": 3},
+                timezone="America/Los_Angeles",
+                pools=[],
+            )
+        )
         await db.flush()
 
     await db.commit()
@@ -451,23 +474,24 @@ async def test_preview_on_a_post_live_tournament_is_409(
     assert preview_queue.jobs == []
 
 
-async def test_preview_of_a_single_elim_event_is_a_422_that_names_the_draw_type(
+async def test_preview_of_a_bracket_only_tournament_is_a_422_that_names_the_draw_type(
     authed_client: tuple[AsyncClient, User],
     db_session: AsyncSession,
     preview_queue: Queue,
 ) -> None:
-    """A single-elim event is a 422 whose sentence names the **draw type** — the one
-    thing the director has to change — not the generic "as the event stands".
+    """A tournament whose only event is a single-elim one is a 422 whose sentence
+    names the **draw type** — the one thing the director has to change — not the
+    generic "as the event stands".
 
-    ``app.schedule_preview`` is the last live raiser of ``UnsupportedDrawType``: the
-    CP-SAT scheduler places pooled draws over their pools' windows and a bracket has
-    none, so the preview refuses rather than invent a grid. That refusal reaches this
-    route through ``_draw_refusal`` — the mapper the **cut** route shares, where the
-    error is now unreachable because ``strategy_for`` is total. That asymmetry is
-    exactly the trap: the arm looks dead from the cut route's side, and deleting it
-    still leaves this route answering 422 — just with the generic fallback, which
-    blames the event's own pools and field and sends the director hunting through two
-    things that are perfectly fine.
+    ``app.schedule_preview`` is the last live raiser of ``UnsupportedDrawType``, and
+    it raises it only when nothing at all can be previewed: a preview runs before
+    anyone has registered, so a draw decided as it is played has nothing to lay out.
+    That refusal reaches this route through ``_draw_refusal`` — the mapper the **cut**
+    route shares, where the error is now unreachable because ``strategy_for`` is
+    total. That asymmetry is exactly the trap: the arm looks dead from the cut route's
+    side, and deleting it still leaves this route answering 422 — just with the
+    generic fallback, which blames the event's own pools and field and sends the
+    director hunting through two things that are perfectly fine.
 
     So the assertion is on the **sentence**, not the status. ``status_code == 422``
     passes with the arm deleted; naming ``single-elim`` does not.
@@ -488,9 +512,41 @@ async def test_preview_of_a_single_elim_event_is_a_422_that_names_the_draw_type(
     # the cut route's voice, about cutting — a verb this route never performs).
     assert detail != "This event's draw cannot be cut as the event stands."
     assert "cannot be cut" not in detail
-    # Nothing is queued: an un-schedulable event refuses the whole preview up front,
-    # never a partial solve over the events that would have worked.
+    # The sentence blames the PREVIEW, not the scheduler: a live solve does place a
+    # bracket now (ADR "a pool restricts scheduling, it does not enable it"), so copy
+    # saying the scheduler cannot would send the director to fix a thing that works.
+    assert "cannot be previewed" in detail, detail
+    # Nothing is queued: with nothing previewable there is no partial solve to run.
     assert preview_queue.jobs == []
+
+
+async def test_a_bracket_event_beside_a_round_robin_still_enqueues_a_preview(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+    preview_queue: Queue,
+) -> None:
+    """The other side of the 422 above, at the route: a single-elim event sitting
+    beside a round-robin one is **skipped**, and the round-robin is previewed.
+
+    The route is where this used to hurt. One bracket in a director's day turned the
+    whole preview into a 422, so they saw no schedule for events that were perfectly
+    schedulable. The round-robin's own six fixtures are asserted in the 202 body,
+    which is the claim "not a 422" alone would not make.
+    """
+    client, owner = authed_client
+    tournament_id = await _make_tournament(
+        db_session, owner, with_single_elim_event=True
+    )
+
+    response = await client.post(_preview_url(tournament_id))
+
+    assert response.status_code == 202, response.text
+    body = response.json()
+    # The round-robin event is previewed in full — C(4, 2) = 6 — and it is the only
+    # event a synthetic field was made for.
+    assert len(body["fixtures"]) == 6
+    assert [s["field_size"] for s in body["field_summaries"]] == [4]
+    assert len(preview_queue.jobs) == 1
 
 
 async def test_exceeding_the_rate_limit_is_429(

--- a/api/tests/test_schedule_preview_snapshot.py
+++ b/api/tests/test_schedule_preview_snapshot.py
@@ -9,8 +9,10 @@ non-persistent solve over a synthetic field"). These tests prove:
   entrants and exactly the round-robin fixture set (``C(N, 2)`` in one pool);
 * the field is disjoint across events (no synthetic player is in two events);
 * a per-event count override changes the field size and the fixture count;
-* every non-round-robin draw type (today: single-elim) is refused loud with
-  the unsupported-draw domain error and produces no partial snapshot;
+* an event the preview lays out nothing of (today: single-elim, swiss) is skipped
+  and reported, leaving every event beside it previewed;
+* a tournament with no previewable event at all is refused loud with the
+  unsupported-draw domain error, rather than answered with an empty snapshot;
 * no ``TournamentEntry`` / ``TournamentFixture`` row is ever created;
 * the snapshot is coherent enough for the real solver to place.
 """
@@ -409,20 +411,26 @@ async def test_preview_snapshot_count_override_resizes_field(
 
 @pytest.mark.parametrize(
     "draw_type",
-    # The two POOL-LESS draw types, which is the whole criterion: both *can* be cut,
-    # but a preview covers an event's POOL stage, and neither draw has one — so the
-    # preview refuses them rather than invent a grid. Not because the scheduler cannot
-    # place them: a live solve places a fixture belonging to no pool over its event's
-    # own window (ADR "a pool restricts scheduling, it does not enable it").
-    # Single-elim is the bracket (#785); swiss ranks one field in one table (ADR "swiss
-    # pre-cuts every round and pairs each one on advance"). ``rr-then-ko`` is
-    # deliberately NOT here: it has a pool stage that schedules perfectly well, so it
-    # is previewed in part rather than refused (see the two tests below).
+    # The two draw types a preview lays out NOTHING of: both *can* be cut and a live
+    # solve now places both (ADR "a pool restricts scheduling, it does not enable
+    # it"), but a preview runs before anyone has registered, so a draw decided as it
+    # is played has nothing to lay out. Single-elim is the bracket (#785); swiss
+    # pre-cuts a round and pairs it only on advance. ``rr-then-ko`` is deliberately
+    # NOT here: it has a pool stage that schedules perfectly well, so it is previewed
+    # in part (see the tests below).
     [DrawType.single_elim, DrawType.swiss],
 )
-async def test_preview_snapshot_unsupported_draw_raises(
+async def test_a_tournament_with_no_previewable_event_at_all_is_refused(
     db_session: AsyncSession, default_league: League, draw_type: DrawType
 ) -> None:
+    """The one refusal that survives: nothing here can be previewed, so there is no
+    partial preview to hand back.
+
+    Skipping the event instead would answer with an empty snapshot, which the solver
+    calls ``optimal`` over zero matches — a director reading "it fits" about a day
+    that was never evaluated. That false confidence is the whole reason a preview
+    refuses anything, so an all-unpreviewable tournament stays loud.
+    """
     owner = await make_user(db_session, f"prev-unsup-{draw_type.value}")
     tournament = await _make_tournament(db_session, owner=owner, league=default_league)
     await _add_event(
@@ -430,15 +438,83 @@ async def test_preview_snapshot_unsupported_draw_raises(
         tournament,
         draw_type=draw_type,
         # Swiss requires a round count on its settings arm; single-elim carries no
-        # setting at all. The refusal is about neither — it is about the pools these
-        # draw types do not have.
+        # setting at all. The refusal is about neither — it is about a draw that is
+        # decided as it is played.
         rounds=3 if draw_type is DrawType.swiss else None,
         max_players=8,
     )
     loaded = await _load(db_session, tournament.id)
 
-    with pytest.raises(UnsupportedDrawType):
+    with pytest.raises(UnsupportedDrawType) as caught:
         build_preview_snapshot(loaded)
+
+    # Structural, so the director-facing sentence composed from it names the format.
+    assert caught.value.draw_type is draw_type
+
+
+@pytest.mark.parametrize("draw_type", [DrawType.single_elim, DrawType.swiss])
+async def test_an_unpreviewable_event_does_not_abort_the_tournaments_whole_preview(
+    db_session: AsyncSession, default_league: League, draw_type: DrawType
+) -> None:
+    """The behaviour this slice buys: an event the preview cannot lay out is SKIPPED,
+    and every event beside it is previewed as it always was.
+
+    This builder runs a per-event loop inside a whole-tournament build, so raising for
+    one event was never scoped to that event — it took the preview of every unrelated
+    round-robin beside it, and the director saw no schedule at all. The round-robin
+    event's own 15 fixtures are asserted present, which is the claim a bare "it did
+    not raise" would miss.
+
+    The skipped event's **pool** is asserted absent too, and that is the part a
+    fixture-count test would wave through: a pool of a skipped event reaching the
+    snapshot would be solved over, so an empty or past-dated window on an event that
+    was never drawn could report the whole day infeasible.
+    """
+    owner = await make_user(db_session, f"prev-beside-{draw_type.value}")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    round_robin = await _add_event(
+        db_session, tournament, name="Open Singles", max_players=6
+    )
+    unpreviewable = await _add_event(
+        db_session,
+        tournament,
+        name="Championship",
+        draw_type=draw_type,
+        rounds=3 if draw_type is DrawType.swiss else None,
+        max_players=8,
+        pools=[_one_pool(["t2"])],
+    )
+    loaded = await _load(db_session, tournament.id)
+
+    preview = build_preview_snapshot(loaded)
+
+    # The round-robin event is previewed in full — C(6, 2) = 15 — and it is the only
+    # event with fixtures.
+    by_event: dict[str, int] = {}
+    for fixture in preview.snapshot.fixtures:
+        by_event[fixture.event_id] = by_event.get(fixture.event_id, 0) + 1
+    assert by_event == {scheduling.EventId(str(round_robin.id)): 15}
+
+    # Nothing of the skipped event reaches the solver: no pool window (which would
+    # move the frame origin and be solved over), and no event settings.
+    assert all(
+        not pool.id.startswith(f"{unpreviewable.id}:")
+        for pool in preview.snapshot.pools
+    )
+    assert [e.id for e in preview.snapshot.events] == [
+        scheduling.EventId(str(round_robin.id))
+    ]
+
+    # It is *reported*, not silently dropped: the summary keeps the event's seat in
+    # the tournament's order and names the draw type that made it unpreviewable —
+    # the fact the honest-notes strip turns into a line the director reads.
+    previewed, skipped = preview.field_summaries
+    assert previewed.event_id == scheduling.EventId(str(round_robin.id))
+    assert previewed.unpreviewable_draw_type is None
+    assert skipped.event_id == scheduling.EventId(str(unpreviewable.id))
+    assert skipped.unpreviewable_draw_type is draw_type
+    # No field was synthesized for it, so it claims no entrants and drops no bracket.
+    assert (skipped.field_size, skipped.knockout_fixtures) == (0, 0)
 
 
 async def test_preview_snapshot_previews_an_rr_then_ko_events_pool_stage_only(

--- a/api/tests/test_schedule_preview_solve.py
+++ b/api/tests/test_schedule_preview_solve.py
@@ -430,6 +430,81 @@ async def test_preview_notes_say_an_rr_then_ko_events_knockout_stage_is_not_sche
     assert "Assumed 6 entrants for Championship." in result.notes
 
 
+#: The exact honest note an event the preview lays out NOTHING of earns, pinned so
+#: the wording a director reads cannot drift silently.
+_SKIPPED_EVENT_NOTE = (
+    "Championship is not in this preview: a single-elim draw is decided round by "
+    "round as it is played, so before anyone has entered there is nothing to lay "
+    "out. The scheduler does place it once the tournament is live."
+)
+
+
+async def test_preview_notes_say_a_bracket_event_is_not_previewed_at_all(
+    db_session: AsyncSession, default_league: League, preview_queue: Queue
+) -> None:
+    """A single-elim event no longer refuses its tournament's preview: it is skipped,
+    the round-robin beside it is previewed as usual, and the strip says which event
+    was left out and why.
+
+    The note is the whole point of skipping rather than refusing. Silently omitting an
+    event would leave the director reading a schedule that is missing a day's worth of
+    play with nothing to explain it — a quieter version of the failure the loud
+    refusal existed to prevent.
+
+    The round-robin's own six matches are asserted present, which is the claim the
+    note alone would not make: this is a per-event loop over a whole tournament, so
+    the old refusal took the round-robin's preview down with the bracket's.
+    """
+    owner = await make_user(db_session, "prev-skip-note")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    await _add_event(
+        db_session,
+        tournament,
+        name="Open Singles",
+        max_players=4,
+        pools=[_pool(["t1"])],
+    )
+    await _add_event(
+        db_session,
+        tournament,
+        name="Championship",
+        max_players=8,
+        pools=[_pool(["t2"])],
+        draw_type=DrawType.single_elim,
+    )
+
+    enqueued = await request_schedule_preview(
+        db_session, tournament_id=tournament.id, actor=owner
+    )
+    # The skeleton payload carries no notes channel to explain a zero, so it names
+    # only the event a field was actually synthesized for.
+    assert [s.field_size for s in enqueued.field_summaries] == [4]
+
+    (job,) = preview_queue.jobs
+    (inputs,) = job.args
+    assert isinstance(inputs, PreviewJobInputs)
+
+    result = PreviewResult.model_validate(run_schedule_preview(inputs))
+
+    # The round-robin is previewed in full — C(4, 2) = 6 — and the skipped event keeps
+    # its seat in the breakdown at zero, so it is visibly left out rather than absent.
+    assert {e.name: e.matches for e in result.events} == {
+        "Open Singles": 6,
+        "Championship": 0,
+    }
+    assert result.total_matches == 6
+
+    # The strip, pinned whole: the always-on caveat, the skipped event's line, and an
+    # assumed-entrants line for the previewed event ONLY. A count claimed for an event
+    # no field was synthesized for would contradict the line above it.
+    assert result.notes == [
+        "This estimate assumes no player is entered in more than one event; a "
+        "real multi-event field would take longer.",
+        _SKIPPED_EVENT_NOTE,
+        "Assumed 4 entrants for Open Singles.",
+    ]
+
+
 async def test_a_round_robin_only_previews_notes_carry_no_knockout_caveat(
     db_session: AsyncSession, default_league: League, preview_queue: Queue
 ) -> None:

--- a/e2e/page-objects/tournament-detail-page/schedule-preview.page.ts
+++ b/e2e/page-objects/tournament-detail-page/schedule-preview.page.ts
@@ -64,6 +64,57 @@ export class SchedulePreviewPage {
     return this.page.getByTestId('preview-failed')
   }
 
+  /** The **refused enqueue** alert — what the modal shows *instead of* any structure
+   * when the POST is rejected (422 nothing previewable, 409 not pre-live, 429, 403).
+   *
+   * Asserted absent by a spec whose preview must have been accepted. It is the state
+   * a director used to be left in whenever one event of the tournament was a bracket
+   * (#1228): the whole preview refused, no grid, no verdict, nothing about the
+   * round-robin standing beside it. */
+  get enqueueError(): Locator {
+    return this.page.getByTestId('preview-enqueue-error')
+  }
+
+  /** The always-present **honest-notes** strip — the ADR's "say what this estimate
+   * assumes" footer: the disjoint-field caveat, then a line for each event the preview
+   * left out (whole, or its knockout stage), then the synthetic count assumed per
+   * previewed event.
+   *
+   * This is where a director *reads* that an event is missing on purpose, so a spec
+   * about a skipped event asserts on this text rather than on its own absence
+   * elsewhere. The lines past the first arrive with the solve result, so wait for the
+   * `verdict` before reading it. */
+  get notes(): Locator {
+    return this.page.getByTestId('preview-notes')
+  }
+
+  /** The per-event **override** row — one field-size box per event a synthetic field
+   * was minted for, plus Re-run. An event the preview covers nothing of has no box
+   * here, because the server sends no field summary for it. */
+  get overrides(): Locator {
+    return this.page.getByTestId('preview-overrides')
+  }
+
+  /** One event's field-size box, by the event's **name** — the handle a director has
+   * on it (`aria-label="Field size for <event>"`). */
+  overrideFor(eventName: string): Locator {
+    return this.overrides.getByLabel(`Field size for ${eventName}`)
+  }
+
+  /** One event's section of the synthetic grid, by event id. Its presence is "this
+   * event was previewed"; a `toHaveCount(0)` on it is "this event contributed nothing
+   * to the plan on screen". */
+  eventSection(eventId: string): Locator {
+    return this.page.getByTestId(`preview-event-${eventId}`)
+  }
+
+  /** The synthetic fixture cards of ONE event's section — the count that says how much
+   * of *that* event was laid out, as opposed to `placeholderMatches`, which counts the
+   * whole tournament's grid and so cannot tell one event's matches from another's. */
+  placeholderMatchesFor(eventId: string): Locator {
+    return this.eventSection(eventId).locator('[data-testid^="unscheduled-"]')
+  }
+
   /** The synthetic grid — reuses the real schedule grid components, so preview
    * and reality render identically. */
   get grid(): Locator {

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -206,6 +206,44 @@ export interface StoredAddress extends Coords {
  * skip the surface they exist to test. */
 export type SeededDrawType = 'round-robin' | 'single-elim'
 
+/** Optional knobs on `addEvent` — one event of an existing tournament.
+ *
+ * Every knob is also a `seedTournament` knob, because `seedTournament` is
+ * "`createTournament` + one `addEvent`". The one field only this interface carries is
+ * `name`: a tournament's name is `seedTournament`'s own positional argument, and its
+ * one event has always been called `Open Singles`. A caller adding a **second** event
+ * has to be able to tell the two apart — the preview's honest notes, its synthetic-field
+ * line and its per-event override boxes all name an event by name, so a spec that reads
+ * them needs two names it chose itself. */
+export interface SeedEventOptions {
+  /** The event's name. Omitted = `Open Singles`, the name every existing spec's single
+   * event carries and asserts on. */
+  readonly name?: string
+  /** The event's draw type. Omitted = `round-robin`, the original minimal shape.
+   *
+   * `single-elim` is what `tournament-single-elim-schedule.spec.ts` seeds, and it is
+   * seeded **with `pools: []`**: a bracket is un-pooled end to end (ADR-0786), so a pool
+   * on such an event would reserve a slice of the venue no fixture is ever drawn into —
+   * and the spec's whole subject is what the scheduler does with a fixture that names no
+   * pool (ADR 20260807, "a pool restricts scheduling, it does not enable it"). */
+  readonly drawType?: SeededDrawType
+  /** The window both the event and its pools carry. Omitted = tomorrow, 09:00–17:00. */
+  readonly slot?: SlotSpec
+  /** The event's pools, **in the director's order** — see
+   * `SeedTournamentOptions.pools`, which is this same option. */
+  readonly pools?: ReadonlyArray<PoolSpec>
+  /** The event's `max_players` cap. Omitted = uncapped — see
+   * `SeedTournamentOptions.maxPlayers`. */
+  readonly maxPlayers?: number
+}
+
+/** One event as `addEvent` reads it back: the uuid the server minted for it, and its
+ * pools **as stored** (empty for an event seeded with `pools: []`). */
+export interface SeededEvent {
+  readonly eventId: string
+  readonly pools: ReadonlyArray<StoredPool>
+}
+
 /** Optional knobs on `seedTournament`. Defaults reproduce the original minimal
  * shape (one round-robin, one table, one pool, a far-future window), so existing specs
  * are untouched; the solver-schedule spec overrides two of them — its pool window must
@@ -361,24 +399,19 @@ export async function createTournament(
  * can drive the whole thing. `max_players` is left uncapped (omitted): the spec
  * enters exactly two, and a cap only adds a way to fail.
  *
- * Two API calls, both as the director: `POST /tournaments` then
- * `POST /tournaments/{id}/events`. The lifecycle (publish → cut → go live) and
- * the entries are the browser's job.
+ * Two API calls, both as the director: `createTournament` then one `addEvent`. A
+ * tournament that needs a **second** event calls `addEvent` again itself, with the
+ * catalogue this returned. The lifecycle (publish → cut → go live) and the entries are
+ * the browser's job.
  */
 export async function seedTournament(
   director: Guest,
   name: string,
   options: SeedTournamentOptions = {},
 ): Promise<SeededTournament> {
-  const slot = options.slot ?? {
-    date: tomorrowUtc(),
-    start: '09:00',
-    end: '17:00',
-  }
   const tables = options.tables ?? [{ label: TABLE_LABEL, court: 'A' }]
-  const pools = options.pools ?? [{ name: POOL_NAME }]
   // Resolve the catalogue HERE and pass it down, rather than letting
-  // `createTournament` default it again: the pools below reserve tables out of the
+  // `createTournament` default it again: the event's pools reserve tables out of the
   // catalogue it creates, so the two must be the same list by construction. What comes
   // back (`storedTables`) is that same list carrying the ids the server minted — the
   // only form in which a pool can name a table on the wire.
@@ -388,12 +421,64 @@ export async function seedTournament(
     { ...options, tables },
   )
 
+  // The options are forwarded ONE BY ONE rather than spread. `SeedTournamentOptions`
+  // also carries `tables` and `address`, which are the *tournament's*, and a spread
+  // would hand them to an event that has no such fields. `pools` in particular must
+  // travel as-is: an explicit `[]` is "this event has NO pools", and only an *omitted*
+  // option may fall back to the single `Pool A`.
+  const { eventId, pools } = await addEvent(director, tournamentId, storedTables, {
+    drawType: options.drawType,
+    slot: options.slot,
+    pools: options.pools,
+    maxPlayers: options.maxPlayers,
+  })
+
+  return {
+    tournamentId,
+    tables: storedTables,
+    eventId,
+    pools,
+    poolId: pools[0]?.id ?? null,
+  }
+}
+
+/**
+ * Add **one event** to an existing tournament (`POST …/events`), against a catalogue
+ * that already exists — the seam `seedTournament` is built out of, exported so a spec
+ * can seed a tournament holding **more than one** event.
+ *
+ * The multi-event seed is not a convenience: some behaviour only exists between events.
+ * `schedule-preview-mixed-draw.spec.ts` needs a round-robin event standing beside a
+ * single-elimination one, because the fact under test is that the unpreviewable event is
+ * skipped **and the other one is still previewed** — which a one-event tournament cannot
+ * express either way.
+ *
+ * `catalogue` is the tournament's stored tables (from `createTournament` or
+ * `seedTournament`), because a pool names the tables it reserves by catalogue **id** and
+ * a caller only holds labels — see `PoolSpec`.
+ */
+export async function addEvent(
+  director: Guest,
+  tournamentId: string,
+  catalogue: ReadonlyArray<StoredTable>,
+  options: SeedEventOptions = {},
+): Promise<SeededEvent> {
+  const slot = options.slot ?? {
+    date: tomorrowUtc(),
+    start: '09:00',
+    end: '17:00',
+  }
+  // `??`, never `||` or a truthiness test: `[]` is a MEANINGFUL value here ("this event
+  // has no pools", which is what an un-pooled draw type wants), and a truthy check would
+  // quietly give it `Pool A` back and destroy the premise of any spec that asked for one.
+  const pools = options.pools ?? [{ name: POOL_NAME }]
+
   const eventRes = await director.ctx.post(
     `${API}/tournaments/${tournamentId}/events`,
     {
       headers: { [CSRF_HEADER]: director.csrf },
       data: {
-        name: 'Open Singles',
+        name: options.name ?? 'Open Singles',
         // The compose stack's clock is UTC, and the solver-schedule spec builds
         // its pool window around the stack's real NOW; anchoring the event to
         // UTC keeps a naive wall-clock window resolving to the same instant it
@@ -428,7 +513,7 @@ export async function seedTournament(
           // are catalogue ids on the wire, and a stale one is silently intersected
           // away by the solver ("a stale ref is a table the pool cannot use"), so a
           // typo would surface as an inexplicably infeasible day rather than an error.
-          table_ids: tableIdsFor(storedTables, pool.tableLabels),
+          table_ids: tableIdsFor(catalogue, pool.tableLabels),
         })),
       },
     },
@@ -452,13 +537,7 @@ export async function seedTournament(
     )
   }
 
-  return {
-    tournamentId,
-    tables: storedTables,
-    eventId: created.id,
-    pools: created.pools,
-    poolId: created.pools[0]?.id ?? null,
-  }
+  return { eventId: created.id, pools: created.pools }
 }
 
 /** Resolve a pool's reserved-table **labels** to the catalogue ids the wire wants;

--- a/e2e/tests/schedule-preview-mixed-draw.spec.ts
+++ b/e2e/tests/schedule-preview-mixed-draw.spec.ts
@@ -1,0 +1,249 @@
+import { test, expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+
+import { TournamentDetailPage } from '../page-objects/tournament-detail.page'
+import { guestFromContext } from '../support/match-api'
+import { grantBetaTester } from '../support/rbac-grant'
+import { addEvent, seedTournament } from '../support/tournament-api'
+
+/** The **round-robin** event — the one this preview must still lay out. `Open Singles`
+ * is `seedTournament`'s default event name, so it is not typed anywhere but here. */
+const RR_EVENT_NAME = 'Open Singles'
+/** The **single-elimination** event standing beside it — the one the preview covers
+ * nothing of. Named distinctly from the round-robin because the assertions below turn on
+ * which of the two names a director-facing line carries. */
+const KO_EVENT_NAME = 'Championship Bracket'
+
+/** The synthetic field the preview auto-fills the round-robin to — its `max_players`
+ * cap. Small on purpose, for `schedule-preview.spec.ts`'s reason: a 4-player round-robin
+ * is 6 matches over a whole day, which the real 5s-capped solver settles fast and
+ * cleanly, where an uncapped 16-player field is 120 matches and comes back `unknown`. */
+const FIELD_SIZE = 4
+/** C(4,2) = 6 pairings, and an even field byes nobody. **All six belong to the
+ * round-robin**: the bracket contributes none, which is the whole subject. */
+const RR_MATCHES = 6
+
+/** A two-table venue, so the round-robin's rounds run in parallel and its day fits. */
+const TABLES = [
+  { label: 'Table 1', court: 'A' },
+  { label: 'Table 2', court: 'A' },
+]
+
+/** The **exact** honest note a skipped event earns, composed the way
+ * `app.schedule_preview_solve._honest_notes` composes it: the event's own name, the draw
+ * type by its wire value, the reason, and what the live scheduler does instead.
+ *
+ * Pinned verbatim rather than matched by keyword because the sentence *is* the
+ * deliverable. "Reported as not previewed" is not a state of the DOM a director reads —
+ * it is these words. A looser match (`/not in this preview/`) would go green against copy
+ * that had lost the event's name, the format, or the promise that the scheduler places it
+ * once the tournament is live, which are the three things that stop the note being a
+ * shrug. The api pins the same string in `test_schedule_preview_solve.py`; this end asserts
+ * it survives the queue, the poll and the render. */
+const SKIPPED_EVENT_NOTE =
+  `${KO_EVENT_NAME} is not in this preview: a single-elim draw is decided round ` +
+  'by round as it is played, so before anyone has entered there is nothing to lay ' +
+  'out. The scheduler does place it once the tournament is live.'
+
+/**
+ * **One unpreviewable event no longer costs the whole tournament its preview**
+ * (#1228; ADR 20260807 "a pool restricts scheduling, it does not enable it",
+ * *Consequences* → "Preview is unchanged").
+ *
+ * A director whose tournament holds a round-robin **and** a single-elimination event
+ * asks for a schedule preview. Before this arc they got nothing at all: the preview
+ * builder sits inside a per-event loop, so the `UnsupportedDrawType` it raised for the
+ * bracket aborted the build of the whole tournament, and the modal rendered its refusal
+ * alert where the plan should have been. The round-robin beside it — perfectly
+ * previewable, pooled, and the reason they opened the modal — went down with it.
+ *
+ * Now the bracket is **skipped and named**, and everything else is previewed as usual.
+ *
+ * ## What a preview still cannot do, and why that is not what changed
+ *
+ * A preview runs *before anyone has registered*. No match has been played, so every
+ * fixture of a draw that is decided as it is played has unknown sides, and no engine
+ * places a TBD-sided fixture. That limit is real and untouched here. What changed is its
+ * blast radius: it now costs the offending event, not the tournament.
+ *
+ * ## Why this proof has to be the composed one
+ *
+ * The refusal and the skip live in two different processes. `build_preview_snapshot`
+ * runs in the **api** at enqueue time — it is what decides between a 422 and a 202
+ * carrying the instant structure — while the honest note the director reads is composed
+ * in the **worker's** job and arrives later, over the poll. Nothing that stubs the
+ * network sees that round trip, so only a spec against the real stack can say that a
+ * director asking for a mixed tournament's preview gets a plan *and* is told what is
+ * missing from it.
+ *
+ * ## What is asserted, and why each part is load-bearing
+ *
+ * * **The enqueue was accepted, by status.** The old behaviour's 422 arrives instantly,
+ *   so a spec that only waited for a verdict would red as a bare 120s timeout — which
+ *   cannot tell "the preview was refused" from "the worker never ran"
+ *   (`.claude/rules/verify-the-artifact-under-test.md`). Asserting `202` makes the red
+ *   quote the refusal sentence itself.
+ * * **The round-robin's OWN matches are on screen.** Six cards inside
+ *   `preview-event-<the round-robin's id>`, not six cards somewhere in the grid: the
+ *   grid is grouped by event, and a count taken across the whole modal would pass just
+ *   as happily if those cards belonged to the bracket.
+ * * **The bracket contributed nothing to the plan.** No section of its own, no
+ *   synthetic-field entry, no field-size box — the three places a previewed event
+ *   appears.
+ * * **The director is told why, in the words they read.** The honest-notes strip carries
+ *   the skipped-event sentence verbatim, and carries **no** "Assumed N entrants" line for
+ *   the bracket: no field was synthesized for it, so claiming one would contradict the
+ *   sentence above it.
+ *
+ * ## Seed vs UI split
+ *
+ * Both events are inert scaffolding over the API (`support/tournament-api.ts`) — an
+ * event editor drives the same `POST …/events` this does, and authoring two of them in
+ * the browser would be two chances to fail for a reason that has nothing to do with the
+ * preview. The load-bearing steps are the director's, in the browser: opening the
+ * Schedule tab and reading the preview.
+ *
+ * The tournament is left **draft** and never drawn: a preview is a pre-registration
+ * question, allowed only while the tournament is pre-live.
+ *
+ * ## RBAC
+ *
+ * As in `schedule-preview.spec.ts`: a minted guest holds only the permissionless default
+ * role, so `grantBetaTester` hands the director the tournament bundle over the stack's
+ * own `postgres` container before any tournament write. Skipped against an external
+ * `E2E_BASE_URL` stack, where the caller owns provisioning.
+ */
+test.describe('Tournament — schedule preview with a mixed draw', () => {
+  test('a director gets the round-robin preview back, and is told the bracket was left out', async ({
+    page,
+    baseURL,
+  }) => {
+    // The enqueue is instant; the verdict rides the preview queue + real CP-SAT +
+    // ~700ms polling — generous, bounded waits throughout.
+    test.setTimeout(240_000)
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    // The director IS the browser's own session (`page.request` shares its cookie jar),
+    // so page navigations run as the owner and the owner-only Preview trigger is offered.
+    const director = await guestFromContext(page.request)
+    grantBetaTester(director.username)
+
+    // ----- a DRAFT tournament holding TWO events, over the API -----------------
+    // First the round-robin, pooled and capped — the event that must survive.
+    const name = `Mixed ${faker.string.alphanumeric(8)}`
+    const {
+      tournamentId,
+      eventId: roundRobinEventId,
+      tables,
+      pools,
+    } = await seedTournament(director, name, {
+      tables: TABLES,
+      maxPlayers: FIELD_SIZE,
+    })
+    expect(pools, 'the round-robin needs a pool to be drawn into').toHaveLength(1)
+
+    // Then the bracket, beside it — un-pooled end to end (ADR-0786), which is how a
+    // director really configures one. Same catalogue, so the two events share a venue.
+    const { eventId: bracketEventId, pools: bracketPools } = await addEvent(
+      director,
+      tournamentId,
+      tables,
+      { name: KO_EVENT_NAME, drawType: 'single-elim', pools: [] },
+    )
+    // THE PREMISE, both halves. Two distinct events on one tournament, and the second
+    // is the un-pooled draw type the preview covers nothing of. Without this a green
+    // run could not rule out that the seed had quietly made one event, or two
+    // round-robins.
+    expect(bracketPools, 'a bracket is un-pooled end to end').toEqual([])
+    expect(bracketEventId).not.toBe(roundRobinEventId)
+
+    // ----- the browser: the director opens the preview -------------------------
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    // The long timeout is for the FIRST navigation only, and it is about the stack
+    // rather than the app: the composed web-client is a Vite **dev** server, so the very
+    // first request for a route pays for transforming it on demand.
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    const schedule = await detail.openSchedule()
+    // Pre-live + owner ⇒ the trigger is offered, and the board is still empty.
+    await expect(schedule.previewTrigger).toBeVisible()
+    await expect(schedule.emptyState).toBeVisible()
+
+    // The enqueue POST, watched from before the click. Matching on the method as well
+    // as the path keeps the poll (`GET …/preview/{token}`) and the close-time cancel
+    // (`DELETE …/preview/{token}`) out of it.
+    const enqueuePost = page.waitForResponse(
+      (r) =>
+        r.request().method() === 'POST' &&
+        r.url().endsWith('/schedule/preview'),
+    )
+    const preview = await schedule.openPreview()
+    await expect(preview.dialog).toBeVisible()
+
+    // ----- THE CLAIM, at its narrowest: the preview was ACCEPTED ---------------
+    // Under the old behaviour this is the 422 the bracket raised for the whole
+    // tournament, and the message quotes the refusal the director used to be given.
+    const enqueued = await enqueuePost
+    expect(
+      enqueued.status(),
+      `the preview was refused: ${await enqueued.text()}`,
+    ).toBe(202)
+    await expect(preview.enqueueError).toBeHidden()
+
+    // ----- the instant structure — the round-robin, and only it ----------------
+    // The synthetic-field line names every event a field was minted for. The bracket is
+    // absent from it because no field was minted for an event nothing is previewed of —
+    // this is the difference between "skipped" and "previewed as empty".
+    await expect(preview.fieldSummary).toContainText(
+      `${RR_EVENT_NAME} ${FIELD_SIZE}`,
+    )
+    await expect(preview.fieldSummary).not.toContainText(KO_EVENT_NAME)
+    // Six matches, no byes — the round-robin's whole draw and nothing else. A bracket
+    // that had leaked into the snapshot would push this number up.
+    await expect(preview.counts).toHaveText(`${RR_MATCHES} matches · 0 byes`)
+
+    // The grid is grouped by event, so this counts the ROUND-ROBIN's own cards. The
+    // bracket has no section at all.
+    await expect(preview.eventSection(roundRobinEventId)).toBeVisible()
+    await expect(preview.placeholderMatchesFor(roundRobinEventId)).toHaveCount(
+      RR_MATCHES,
+    )
+    await expect(preview.eventSection(bracketEventId)).toHaveCount(0)
+    // …and those cards are the fake field, not real entrants (nobody has registered).
+    await expect(preview.placeholderPairing.first()).toBeVisible()
+
+    // The re-run control offers a field size for the previewed event only: there is
+    // nothing to re-run a bracket's preview with.
+    await expect(preview.overrideFor(RR_EVENT_NAME)).toBeVisible()
+    await expect(preview.overrideFor(KO_EVENT_NAME)).toHaveCount(0)
+
+    // ----- the streamed verdict — a real plan, not a shrug ---------------------
+    // The verdict lands only when the stack's own `preview`-queue worker returns from
+    // real CP-SAT. A fitting day reads OPTIMAL/FEASIBLE; the designed "doesn't fit" and
+    // "didn't finish" states are absent — six best-of-1 matches over eight hours on two
+    // tables fit, and the bracket's absence must not have made the day infeasible.
+    await expect(preview.verdict).toBeVisible({ timeout: 120_000 })
+    await expect(preview.verdict).toContainText(
+      /Best possible plan|Good plan, found under the time cap/,
+    )
+    await expect(preview.infeasible).toBeHidden()
+    await expect(preview.failed).toBeHidden()
+    // The grid is still the round-robin's whole draw after the solve.
+    await expect(preview.placeholderMatchesFor(roundRobinEventId)).toHaveCount(
+      RR_MATCHES,
+    )
+
+    // ----- what the DIRECTOR is told about the missing event -------------------
+    // The honest-notes strip, whose lines past the first arrive with the result. This is
+    // the sentence that turns a skipped event into a reported one — without it the
+    // director reads a schedule quietly missing an event and has nothing to tell them
+    // why.
+    await expect(preview.notes).toContainText(SKIPPED_EVENT_NOTE)
+    // The previewed event still declares the count it assumed…
+    await expect(preview.notes).toContainText(
+      `Assumed ${FIELD_SIZE} entrants for ${RR_EVENT_NAME}.`,
+    )
+    // …and the skipped one claims no field, which would contradict the line above it.
+    await expect(preview.notes).not.toContainText(`entrants for ${KO_EVENT_NAME}`)
+  })
+})


### PR DESCRIPTION
Closes #1228. Top of a three-PR stack — review #1306 and #1307 first.

## Why

The schedule preview refused `single_elim` and `swiss` loud. The refusal was raised **per event** but killed the **whole tournament's** preview, because the builder sits inside a per-event loop. So one single-elimination event meant the director saw no preview at all, including for unrelated round-robin events beside it. Round-robin-then-knockout was already handled properly — its knockout stage is skipped and the rest is still previewed.

## What

The unsupported-draw-type case now **skips the offending event** and says so in the honest notes.

A skipped event contributes nothing to the snapshot — no fixtures, no event settings, and crucially **no pool windows**. A window it reserves can therefore neither move the minute frame's origin nor be solved over, which would have reported a false `infeasible`.

**One refusal survives**: if *every* event is unpreviewable there is nothing to lay out, and an empty snapshot would solve to "optimal" over zero matches. That false confidence is what the refusal exists to prevent.

### The limitation is unchanged

A bracket still is not previewed. At preview time nobody has played, so rounds past the first have unknown sides *in principle*, not merely in this implementation. This slice changes only how the refusal behaves.

What did change is the **reason** the director is given. The old copy said a bracket cannot be scheduled because the scheduler places pooled draws over their pools' windows "and a bracket has none to place". This arc made that untrue — the scheduler does place a bracket now. The copy says so.

## Verification

- `pytest` 2263 collected, 2263 passed; `mypy` clean on 170 files; `ruff` clean. Run in full, not scoped — refusal copy in this repo has been pinned in two test files at once before.
- Root `e2e` 31 passed against 31 collected. The new spec was **seen red**: restoring the old abort and cycling the stack with `down -v` fails it at the enqueue with `Expected: 202  Received: 422`, quoting the old refusal verbatim — a discriminating red, not a timeout. Provenance confirmed by grepping inside both the api and worker containers in each state.
- **No OpenAPI change.** `EventFieldSummary` gained a field but is internal, not the exposed Pydantic model — verified by regenerating the spec and byte-comparing it against the slice-1 baseline.

## One cross-layer note for review

`PreviewEnqueued.field_summaries` can now be *shorter* than `PreviewResult.events`: a skipped event appears in the breakdown with 0 matches but has no field summary. Any client pairing those two lists **by index** needs checking. Left unfixed here deliberately — the fix touches schema docstrings, which would drift `openapi.json` and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)