### PR TITLE
Show a director why a preview was refused, and stop one bad event blanking it

### DIFF
--- a/api/app/mcp_server.py
+++ b/api/app/mcp_server.py
@@ -2064,9 +2064,10 @@ def _map_preview_draw_error(error: DrawError) -> ToolError:
     empty grid. A ``match`` over the error names what the caller has to change and
     why, mirroring ``_map_draw_refusal_tool_error`` but in the preview's voice:
 
-    * ``UnsupportedDrawType`` carries its ``draw_type`` structurally — every event of
-      the tournament is a draw type this PREVIEW cannot lay out (single-elim, swiss),
-      a fact to change on an event, not a transient one to retry. One such event
+    * ``UnsupportedDrawType`` carries its ``draw_type`` structurally — no event of the
+      tournament can be previewed, and the first that cannot is a draw type this
+      PREVIEW does not lay out (single-elim, swiss): a fact to change on an event, not
+      a transient one to retry. One such event
       *beside* a previewable one refuses nothing now: the builder skips it, previews
       the rest, and the honest-notes strip names it. A *live* solve does place those
       events, over the event's own window (ADR "a pool restricts scheduling, it does
@@ -2081,6 +2082,9 @@ def _map_preview_draw_error(error: DrawError) -> ToolError:
       event can never be given a draw (ADR-0788), so it can never be previewed.
     * ``DegenerateDraw``'s message is domain-authored copy (the numbers the director
       must change), passed through so the agent reads exactly what a director would.
+      It arrives only when the tournament has no other event to preview: an event the
+      draw refuses beside a healthy one is skipped, and the honest-notes strip on the
+      finished preview carries this same sentence.
     * The fallback arm is a generic sentence, never a future subclass's own message.
     """
     match error:

--- a/api/app/schedule_preview.py
+++ b/api/app/schedule_preview.py
@@ -49,13 +49,25 @@ production's own ``cut_draw`` uses:
   bracket *has* a draw strategy (#785) and a live solve places it, but a preview
   would be laying out a round or two and guessing at the rest, so this builder
   previews none of it. The event still reaches the caller as an
-  :class:`EventFieldSummary` carrying ``unpreviewable_draw_type``, which is what
-  turns it into an honest note instead of an event that silently vanished;
+  :class:`EventFieldSummary` carrying an :class:`UnpreviewableDrawType` reason,
+  which is what turns it into an honest note instead of an event that silently
+  vanished;
 * **swiss** — skipped the same way, sharing single-elim's ``case`` arm for
   single-elim's reason: a swiss draw pre-cuts a round and pairs each one only on
   advance (ADR "swiss pre-cuts every round and pairs each one on advance"), so
   before a ball is hit there is nothing to lay out. A live solve does place a
   swiss event, round by round as each round is paired.
+
+**A configuration that cannot be cut skips its event too, and says the strategy's
+own sentence.** A draw strategy refuses a config that would not be a competition
+— a pool of one, a knockout stage with a single qualifier in it — with
+:class:`~app.draws.DegenerateDraw`. That refusal is correct and is not weakened
+here: what is wrong is its *blast radius*, because it was raised per event and
+propagated out of a per-tournament loop, so one misconfigured event blanked the
+preview of every healthy event beside it. The event is skipped instead, carrying
+the strategy's **verbatim** message (a :class:`DegenerateConfiguration`), because
+that sentence names the numbers the director has to change and no other layer
+knows them.
 
 **A skipped event costs its tournament nothing else.** This builder sits inside a
 per-event loop of a whole-tournament build, so a refusal raised for one event
@@ -63,22 +75,26 @@ takes the preview of every unrelated event beside it (ADR 20260727 made that the
 reason rr-then-ko's knockout stage is dropped rather than refused). A skipped
 event contributes no fixtures, no pool windows and no event settings to the
 snapshot — its pools are left out of the minute frame too, so a window it happens
-to reserve can never make the rest of the day report a false ``infeasible``.
+to reserve can never make the rest of the day report a false ``infeasible`` — and
+it mints no synthetic entrant.
 
 **One refusal survives, and it is about the whole tournament.** When *no* event is
-previewable, :func:`build_preview_snapshot` raises
-:class:`~app.draws.UnsupportedDrawType` naming the first skipped draw type. A
-snapshot of nothing at all would solve to "it fits" over zero matches, which is
-the false confidence a preview exists to avoid. This is the only surviving raiser
-of that exception: :func:`app.draws.strategy_for` is total, because the enum holds
-only draw types that run (ADR).
+previewable, :func:`build_preview_snapshot` re-raises the **first** skipped
+event's own reason, in the tournament's own event order:
+:class:`~app.draws.UnsupportedDrawType` naming that draw type, or
+:class:`~app.draws.DegenerateDraw` carrying that message. A snapshot of nothing at
+all would solve to "it fits" over zero matches, which is the false confidence a
+preview exists to avoid. This module is the only surviving raiser of
+``UnsupportedDrawType``: :func:`app.draws.strategy_for` is total, because the enum
+holds only draw types that run (ADR).
 
 The per-event :class:`EventFieldSummary` (the count used, how many knockout
-fixtures were left out, and the draw type that made the event unpreviewable) is
-returned alongside the snapshot so :mod:`app.schedule_preview_solve` composes the
-preview's honest-notes strip and per-event breakdown from it without re-deriving
-it — including the notes that tell a director an rr-then-ko event's knockout stage
-is not in the schedule they are looking at, and that a bracket or swiss event is
+fixtures were left out, and the :data:`SkipReason` that left the event out of the
+preview whole) is returned alongside the snapshot so
+:mod:`app.schedule_preview_solve` composes the preview's honest-notes strip and
+per-event breakdown from it without re-deriving it — including the notes that tell
+a director an rr-then-ko event's knockout stage is not in the schedule they are
+looking at, and that a bracket, a swiss event or an event that cannot be cut is
 not in it at all.
 """
 
@@ -91,6 +107,8 @@ from datetime import UTC, datetime
 from typing import assert_never
 
 from app.draws import (
+    DegenerateDraw,
+    DrawError,
     EntryId,
     OrderedEntrant,
     PlannedFixture,
@@ -160,6 +178,63 @@ def preview_pool_key(event_id: uuid.UUID, pool_id: uuid.UUID) -> str:
 
 
 @dataclass(frozen=True, slots=True)
+class UnpreviewableDrawType:
+    """This event is out of the preview because of its **draw type** — single-elim or
+    swiss, both fully supported and both placed by a live solve, but decided round by
+    round as they are played, so before anyone has entered there is nothing to lay out.
+
+    Carries the :class:`DrawType` **structurally**, so the layer that writes the
+    director-facing sentence composes it from the fact rather than parsing a message,
+    and so an all-unpreviewable tournament can be refused with an
+    :class:`~app.draws.UnsupportedDrawType` that names the format."""
+
+    draw_type: DrawType
+
+
+@dataclass(frozen=True, slots=True)
+class DegenerateConfiguration:
+    """This event is out of the preview because its **configuration cannot be cut** —
+    the draw strategy refused it with :class:`~app.draws.DegenerateDraw` (a pool that
+    would hold one entrant, a knockout stage that would hold one qualifier, an event
+    with no pools at all).
+
+    Carries the strategy's message **verbatim**, and that is the whole point: a
+    ``DegenerateDraw``'s message is domain-authored copy naming the numbers the
+    director has to change, and only the strategy knows which degeneracy it hit
+    (``app.tournaments._draw_refusal`` passes it through unaltered for the same
+    reason). A generic "could not be previewed" here would leave the director with
+    nothing to act on."""
+
+    message: str
+
+
+#: Why this preview covers **nothing** of an event — a closed set, so the note the
+#: director reads is written by an exhaustive ``match`` and a third reason is a type
+#: error until it is handled. Two cases with genuinely different content: a draw type
+#: (structural, no message to carry) and a refused configuration (a message and
+#: nothing else), which is why this is a union rather than one class with two
+#: optional fields that could contradict each other.
+SkipReason = UnpreviewableDrawType | DegenerateConfiguration
+
+
+def skip_refusal(reason: SkipReason) -> DrawError:
+    """The whole-tournament refusal that a :data:`SkipReason` becomes when it is the
+    **only** thing a tournament had to say — see :func:`build_preview_snapshot`.
+
+    One place, so the mapping from "why this event was left out" to "why this
+    tournament cannot be previewed at all" cannot drift between them, and each error
+    keeps the payload its own transport arm reads: ``UnsupportedDrawType`` its
+    structural ``draw_type``, ``DegenerateDraw`` the strategy's verbatim message."""
+    match reason:
+        case UnpreviewableDrawType():
+            return UnsupportedDrawType(reason.draw_type)
+        case DegenerateConfiguration():
+            return DegenerateDraw(reason.message)
+        case _:
+            assert_never(reason)
+
+
+@dataclass(frozen=True, slots=True)
 class EventFieldSummary:
     """What one event contributed to the synthetic field — the honest-notes
     ingredients (ADR "always an honest-notes strip"), per event.
@@ -175,20 +250,20 @@ class EventFieldSummary:
     from it says something is missing exactly when something is (api/CLAUDE.md —
     don't carry a field and its own derivation).
 
-    ``unpreviewable_draw_type`` is the draw type that made this builder skip the
-    **whole** event (single-elim or swiss), and ``None`` for an event that was
-    previewed. A skipped event still gets a summary — that is the channel the
-    caller's honest note is written from, and the reason the director is told the
-    event was left out instead of wondering where it went. Nothing was synthesized
-    for it, so its ``field_size`` and ``knockout_fixtures`` are ``0``: no field was
-    minted, no draw was planned, and the caller reports the skip rather than an
-    assumed count.
+    ``skip_reason`` is why this builder skipped the **whole** event — its draw type
+    (single-elim or swiss) or a configuration the draw refused — and ``None`` for an
+    event that was previewed. A skipped event still gets a summary: that is the
+    channel the caller's honest note is written from, and the reason the director is
+    told the event was left out instead of wondering where it went. Nothing was
+    synthesized for it, so its ``field_size`` and ``knockout_fixtures`` are ``0``: no
+    field was minted, no draw was planned, and the caller reports the skip rather than
+    an assumed count.
     """
 
     event_id: EventId
     field_size: int
     knockout_fixtures: int
-    unpreviewable_draw_type: DrawType | None = None
+    skip_reason: SkipReason | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -261,17 +336,19 @@ class _EventPlan:
 
 @dataclass(frozen=True, slots=True)
 class _SkippedEvent:
-    """One event this preview covers **nothing** of, and the ``draw_type`` that is
-    why (single-elim or swiss).
+    """One event this preview covers **nothing** of, and the :data:`SkipReason` that
+    is why — its draw type, or a configuration the draw refused.
 
     A sibling of :class:`_EventPlan` rather than a flag on it, so a skipped event
     cannot carry a field size, a pool window or a fixture it never had: it keeps its
     place in the tournament's event order (the second pass walks both kinds in one
     list) and contributes only its summary, which the caller turns into the honest
-    note naming it."""
+    note naming it. One kind of skipped event, whatever the reason, so a degenerate
+    configuration inherits every one of those guarantees rather than getting a second,
+    weaker path to the same place."""
 
     event: TournamentEvent
-    draw_type: DrawType
+    reason: SkipReason
 
 
 def build_preview_snapshot(
@@ -306,26 +383,33 @@ def build_preview_snapshot(
     Persists nothing: no ``TournamentEntry`` / ``TournamentFixture`` row is
     created.
 
-    An event this PREVIEW covers nothing of — today single-elim and swiss, whose
-    every fixture is TBD-sided before a ball is hit — is **skipped**, not refused:
-    it contributes no fixtures, no pool windows and no event settings, and comes
-    back as an :class:`EventFieldSummary` carrying ``unpreviewable_draw_type`` for
-    the caller to write an honest note from. Every other event of the tournament is
-    previewed as usual, which is the point: this builder is per-tournament, so a
-    refusal raised for one event takes every event beside it with it. An
-    **rr-then-ko** event is not skipped at all — its pool stage places exactly as a
-    round-robin's does and is previewed, and only its knockout fixtures are dropped
-    (ADR 20260727).
+    An event this PREVIEW covers nothing of is **skipped**, not refused: it
+    contributes no fixtures, no pool windows, no event settings and no synthetic
+    entrants, and comes back as an :class:`EventFieldSummary` carrying its
+    :data:`SkipReason` for the caller to write an honest note from. Two things put an
+    event there:
 
-    Raises :class:`~app.draws.UnsupportedDrawType` — itself, not from
-    :func:`app.draws.strategy_for`, which is total — only when **no** event of the
-    tournament is previewable, naming the first skipped draw type: there is nothing
-    left to hand back, and an empty snapshot would solve to "it fits" over zero
-    matches. Also raises :class:`~app.draws.DegenerateDraw` if a synthesized field
-    is too small for the event's pools — a clear domain error either way, never a
-    partial snapshot. An event with no pools configured is one such case: the
-    round-robin strategy refuses an empty pool set with
-    :class:`~app.draws.DegenerateDraw`, which propagates.
+    * its **draw type** — today single-elim and swiss, whose every fixture is
+      TBD-sided before a ball is hit (:class:`UnpreviewableDrawType`);
+    * its **configuration** — the draw strategy refusing a cut that would not be a
+      competition, with :class:`~app.draws.DegenerateDraw`
+      (:class:`DegenerateConfiguration`, carrying that refusal's message verbatim).
+      An event with no pools configured is one such case.
+
+    Every other event of the tournament is previewed as usual, which is the point:
+    this builder is per-tournament, so a refusal raised for one event takes every
+    event beside it with it. An **rr-then-ko** event is not skipped for its draw type
+    at all — its pool stage places exactly as a round-robin's does and is previewed,
+    and only its knockout fixtures are dropped (ADR 20260727).
+
+    Raises only when **no** event of the tournament is previewable, and raises the
+    **first** skipped event's own reason (:func:`skip_refusal`): there is nothing left
+    to hand back, and an empty snapshot would solve to "it fits" over zero matches. So
+    a bracket-only tournament is an :class:`~app.draws.UnsupportedDrawType` naming
+    that draw type — this module raises it itself; :func:`app.draws.strategy_for` is
+    total — and a tournament whose one event cannot be cut is the strategy's own
+    :class:`~app.draws.DegenerateDraw`, message intact, which is what puts the numbers
+    the director must change in the 422 they read.
     """
     overrides = count_overrides or {}
     now = now if now is not None else datetime.now(UTC)
@@ -370,9 +454,8 @@ def build_preview_snapshot(
                     )
                     for offset in range(field_size)
                 ]
-                next_entrant += field_size
-                plans.append(
-                    _EventPlan(
+                try:
+                    planned = _EventPlan(
                         event=event,
                         pools=event_pools(event),
                         settings=MatchSettings.model_validate(event.match_settings),
@@ -381,7 +464,29 @@ def build_preview_snapshot(
                         ),
                         field_size=field_size,
                     )
-                )
+                except DegenerateDraw as refusal:
+                    # The draw refusing a configuration that would not be a
+                    # competition — a pool of one, a knockout stage of one qualifier,
+                    # no pools at all. The refusal is right and is left alone; only its
+                    # reach is fixed. It is raised per event, but this loop builds one
+                    # TOURNAMENT, so letting it propagate blanked the preview of every
+                    # healthy event beside it (exactly the defect a skipped draw type
+                    # was already fixed for). The strategy's message rides along
+                    # verbatim: it names the numbers the director has to change, and
+                    # recomposing it here would be a second copy of a rule this module
+                    # does not own.
+                    plans.append(
+                        _SkippedEvent(
+                            event=event,
+                            reason=DegenerateConfiguration(str(refusal)),
+                        )
+                    )
+                    continue
+                # Only a planned event consumes its slice of the id space — a skipped
+                # one mints no entrant, so the counter advances past the fields that
+                # actually exist.
+                next_entrant += field_size
+                plans.append(planned)
             case DrawType.single_elim | DrawType.swiss:
                 # Skipped, not refused — and skipped for a reason that is no longer
                 # about pools. A live solve does place both of these, over the event's
@@ -393,20 +498,25 @@ def build_preview_snapshot(
                 # beside it (the same reasoning ADR 20260727 applied to rr-then-ko's
                 # knockout stage). Swiss shares the arm for single-elim's reason (ADR
                 # "swiss pre-cuts every round and pairs each one on advance").
-                plans.append(_SkippedEvent(event=event, draw_type=draw_type))
+                plans.append(
+                    _SkippedEvent(event=event, reason=UnpreviewableDrawType(draw_type))
+                )
             case _:
                 assert_never(draw_type)
 
     # The one refusal left, and it is about the whole tournament rather than an
     # event: nothing at all is previewable here, so there is no partial preview to
     # give and an empty snapshot would solve to "it fits" over zero matches — the
-    # false confidence a preview exists to avoid. Named after the first skipped draw
-    # type, so the director-facing sentence says which format it is. A tournament with
-    # no events at all is *not* this case: it has nothing to preview and nothing to
-    # blame, and keeps answering with an empty snapshot.
+    # false confidence a preview exists to avoid. It speaks the FIRST skipped event's
+    # own reason, in the tournament's own event order — the same positional rule as
+    # before, generalized from "the first skipped draw type" to "the first event that
+    # could not be previewed, and why" — so a mixed tournament needs no priority
+    # ranking between two refusals that reach the director through the one 422 mapper.
+    # A tournament with no events at all is *not* this case: it has nothing to preview
+    # and nothing to blame, and keeps answering with an empty snapshot.
     skipped = [plan for plan in plans if isinstance(plan, _SkippedEvent)]
     if skipped and len(skipped) == len(plans):
-        raise UnsupportedDrawType(skipped[0].draw_type)
+        raise skip_refusal(skipped[0].reason)
 
     # The minute frame's origin: the earliest pool window start across every
     # previewable event — the same anchor ``_load_solver_inputs`` uses, so ``now_min``
@@ -454,18 +564,18 @@ def build_preview_snapshot(
     for plan in plans:
         event_id = EventId(str(plan.event.id))
         if isinstance(plan, _SkippedEvent):
-            # The whole contribution of a skipped event: a summary naming the draw
-            # type that made it unpreviewable. No fixtures, no pools, no
-            # ``EventSettings`` — the snapshot must not carry an event the solver
-            # would then have nothing to place — but it keeps its seat in the
-            # tournament's event order so the caller's note, and the per-event
-            # breakdown built beside it, still name the event the director is missing.
+            # The whole contribution of a skipped event: a summary carrying the reason
+            # it was left out. No fixtures, no pools, no ``EventSettings`` — the
+            # snapshot must not carry an event the solver would then have nothing to
+            # place — but it keeps its seat in the tournament's event order so the
+            # caller's note, and the per-event breakdown built beside it, still name
+            # the event the director is missing.
             summaries.append(
                 EventFieldSummary(
                     event_id=event_id,
                     field_size=0,
                     knockout_fixtures=0,
-                    unpreviewable_draw_type=plan.draw_type,
+                    skip_reason=plan.reason,
                 )
             )
             continue

--- a/api/app/schedule_preview_solve.py
+++ b/api/app/schedule_preview_solve.py
@@ -59,8 +59,11 @@ from app import queue as queue_module
 from app import scheduling
 from app.config import get_settings
 from app.match_calls import _wall_now
-from app.models import DrawType, Tournament, TournamentStatus, User
+from app.models import Tournament, TournamentStatus, User
 from app.schedule_preview import (
+    DegenerateConfiguration,
+    SkipReason,
+    UnpreviewableDrawType,
     build_preview_snapshot,
     placeholder_label,
     preview_pool_key,
@@ -160,8 +163,9 @@ class _PreviewEventMeta:
     the enqueue verb (which has the loaded events) to the job (which has only the pure
     snapshot, from which "a bracket was dropped" is no longer visible).
 
-    ``unpreviewable_draw_type`` is the draw type that made the builder skip the whole
-    event (single-elim or swiss), ``None`` for an event that was previewed. Such an
+    ``skip_reason`` is why the builder skipped the whole event — its draw type
+    (single-elim or swiss) or a configuration the draw refused, carrying that
+    refusal's own sentence — and ``None`` for an event that was previewed. Such an
     event is in this tuple precisely *because* nothing of it is in the snapshot: it is
     the only place the job can learn the event exists, and the note it writes from it
     is what tells the director the event was left out rather than lost."""
@@ -170,7 +174,7 @@ class _PreviewEventMeta:
     name: str
     field_size: int
     knockout_fixtures: int
-    unpreviewable_draw_type: DrawType | None = None
+    skip_reason: SkipReason | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -306,13 +310,15 @@ async def request_schedule_preview(
     ``count_overrides`` (event id → synthetic field size) lets a caller explore
     "what if 24 show up"; omitted, each event fills to its cap (or the uncapped
     default). Propagates :class:`~app.draws.UnsupportedDrawType` /
-    :class:`~app.draws.DegenerateDraw` from the builder untouched. An event the
-    preview covers nothing of (single-elim, swiss) no longer refuses anything: the
-    builder skips it, every other event is previewed, and the honest-notes strip
-    names it. ``UnsupportedDrawType`` now arrives only when *no* event of the
-    tournament is previewable, so there is no partial grid to hand back. Raises
-    :class:`ScheduleQueueUnavailableError` if the enqueue cannot be placed (Redis
-    down), mirroring the real solve verb, so the return type stays non-optional.
+    :class:`~app.draws.DegenerateDraw` from the builder untouched — but neither is a
+    per-event refusal any more. An event the preview covers nothing of, whether for
+    its draw type (single-elim, swiss) or because the draw refuses its configuration,
+    is skipped: every other event is previewed and the honest-notes strip names it,
+    with the strategy's own sentence when there is one. Either error now arrives only
+    when *no* event of the tournament is previewable, so there is no partial grid to
+    hand back. Raises :class:`ScheduleQueueUnavailableError` if the enqueue cannot be
+    placed (Redis down), mirroring the real solve verb, so the return type stays
+    non-optional.
 
     Returns a :class:`PreviewEnqueued`: the ``token`` (the RQ job id) to poll/wait
     on, plus the field sizes and the drawn fixtures a caller renders a skeleton
@@ -345,7 +351,7 @@ async def request_schedule_preview(
                 name=event_names.get(summary.event_id, summary.event_id),
                 field_size=summary.field_size,
                 knockout_fixtures=summary.knockout_fixtures,
-                unpreviewable_draw_type=summary.unpreviewable_draw_type,
+                skip_reason=summary.skip_reason,
             )
             for summary in preview.field_summaries
         ),
@@ -366,14 +372,15 @@ async def request_schedule_preview(
         token=job.id,
         field_summaries=[
             # Only the events a field was actually synthesized for. A skipped event
-            # (single-elim, swiss) has none, and this skeleton payload carries no
-            # notes channel to explain a zero — so it is left out here and named in
-            # the honest-notes strip the finished result carries instead.
+            # (an unpreviewable draw type, or a configuration the draw refused) has
+            # none, and this skeleton payload carries no notes channel to explain a
+            # zero — so it is left out here and named in the honest-notes strip the
+            # finished result carries instead.
             PreviewFieldSummary(
                 event_id=summary.event_id, field_size=summary.field_size
             )
             for summary in preview.field_summaries
-            if summary.unpreviewable_draw_type is None
+            if summary.skip_reason is None
         ],
         fixtures=[
             PreviewFixture(
@@ -677,11 +684,25 @@ def _honest_notes(inputs: PreviewJobInputs) -> list[str]:
 
     The skipped-event line is what makes skipping an unpreviewable event honest
     rather than silent. The builder no longer refuses a whole tournament because one
-    of its events is a bracket or a swiss draw (that refusal took every unrelated
+    of its events is a bracket or a swiss draw, or because one of its events is
+    configured in a way the draw will not cut (either refusal took every unrelated
     event's preview with it); it previews everything else and reports the event it
     could not lay out. Without the line, the director would read a schedule that is
-    quietly missing an event and have nothing to tell them why — so the note names the
-    event, names the draw type, and says the live scheduler does place it.
+    quietly missing an event and have nothing to tell them why.
+
+    **What the line says depends on why, and both are written from one loop** — an
+    exhaustive ``match`` over the event's :data:`~app.schedule_preview.SkipReason`, in
+    the tournament's own event order, so a third reason is a type error until it is
+    handled and no reason is grouped ahead of another in the strip:
+
+    * an unpreviewable **draw type** names the format and says the live scheduler does
+      place it — the event is fine, the preview simply runs before there is a played
+      draw to lay out;
+    * a **degenerate configuration** carries the draw strategy's own sentence
+      verbatim, because that sentence names the numbers the director has to change and
+      only the strategy knows them. Paraphrasing it into "could not be previewed"
+      would leave them with nothing to act on, which is the whole reason this case
+      earns its own arm.
 
     The knockout line is what stops the strip lying by omission about an
     **rr-then-ko** event: the preview plans that event's whole draw but schedules only
@@ -701,17 +722,29 @@ def _honest_notes(inputs: PreviewJobInputs) -> list[str]:
         "real multi-event field would take longer."
     ]
     for meta in inputs.events:
-        # Bound before the guard rather than read through it: the draw type is what
-        # the sentence names, and narrowing it here keeps the note total.
-        draw_type = meta.unpreviewable_draw_type
-        if draw_type is None:
+        # Bound before the guard rather than read through it: the reason is what the
+        # sentence is composed from, and narrowing it here keeps the note total.
+        reason = meta.skip_reason
+        if reason is None:
             continue
-        notes.append(
-            f"{meta.name} is not in this preview: a {draw_type.value} draw is "
-            "decided round by round as it is played, so before anyone has entered "
-            "there is nothing to lay out. The scheduler does place it once the "
-            "tournament is live."
-        )
+        match reason:
+            case UnpreviewableDrawType():
+                notes.append(
+                    f"{meta.name} is not in this preview: a "
+                    f"{reason.draw_type.value} draw is decided round by round as it "
+                    "is played, so before anyone has entered there is nothing to lay "
+                    "out. The scheduler does place it once the tournament is live."
+                )
+            case DegenerateConfiguration():
+                # The strategy's message, unaltered — domain-authored copy naming the
+                # fix, the same sentence the 422 carries when this is the tournament's
+                # only event.
+                notes.append(
+                    f"{meta.name} is not in this preview: its draw cannot be cut as "
+                    f"the event stands. {reason.message}"
+                )
+            case _:
+                assert_never(reason)
     notes.extend(
         f"Only the pool stage of {meta.name} is scheduled here: its knockout "
         f"bracket ({meta.knockout_fixtures} further "
@@ -723,7 +756,7 @@ def _honest_notes(inputs: PreviewJobInputs) -> list[str]:
     notes.extend(
         f"Assumed {meta.field_size} entrants for {meta.name}."
         for meta in inputs.events
-        if meta.unpreviewable_draw_type is None
+        if meta.skip_reason is None
     )
     return notes
 

--- a/api/app/tournaments.py
+++ b/api/app/tournaments.py
@@ -1123,14 +1123,17 @@ def _draw_refusal(error: DrawError) -> HTTPException:
       nobody to play — and the numbers in that sentence ("5 entrants across 3 pool(s)")
       are the numbers the director has to change. Recomposing it here would be a second
       copy of a rule this route does not own, and the copy that drifts is the one a
-      director reads.
+      director reads. From the **schedule-preview** route it arrives only when the
+      tournament has no other event to preview: one event the draw refuses beside a
+      healthy one is skipped, and the honest-notes strip carries this same sentence.
     * ``UnsupportedDrawType`` carries its ``draw_type`` **structurally**, for the same
       reason. It can no longer arrive from the **cut** route — ``strategy_for`` is total
       now that the enum holds only what runs (ADR 20260726) — but this mapper is shared
       with the **schedule-preview** route below, and ``app.schedule_preview`` raises it
-      when *no* event of a tournament can be previewed (every event is a single-elim or
-      a swiss draw). One such event beside a round-robin no longer refuses anything:
-      the builder skips it, previews the rest, and the honest-notes strip names it. A
+      when *no* event of a tournament can be previewed and the first such event is a
+      single-elim or a swiss draw. One such event beside a round-robin no longer
+      refuses anything: the builder skips it, previews the rest, and the honest-notes
+      strip names it. A
       director previewing a bracket-only tournament must be told it is the *draw type*
       that cannot be previewed, not left with the generic sentence, which says the
       event's own state is at fault and would send them hunting through pools and

--- a/api/tests/test_schedule_preview_snapshot.py
+++ b/api/tests/test_schedule_preview_snapshot.py
@@ -9,10 +9,11 @@ non-persistent solve over a synthetic field"). These tests prove:
   entrants and exactly the round-robin fixture set (``C(N, 2)`` in one pool);
 * the field is disjoint across events (no synthetic player is in two events);
 * a per-event count override changes the field size and the fixture count;
-* an event the preview lays out nothing of (today: single-elim, swiss) is skipped
-  and reported, leaving every event beside it previewed;
-* a tournament with no previewable event at all is refused loud with the
-  unsupported-draw domain error, rather than answered with an empty snapshot;
+* an event the preview lays out nothing of — for its draw type (today: single-elim,
+  swiss) or because the draw refuses its configuration — is skipped and reported,
+  leaving every event beside it previewed;
+* a tournament with no previewable event at all is refused loud with the first
+  skipped event's own domain error, rather than answered with an empty snapshot;
 * no ``TournamentEntry`` / ``TournamentFixture`` row is ever created;
 * the snapshot is coherent enough for the real solver to place.
 """
@@ -41,7 +42,12 @@ from app.models import (
     User,
 )
 from app.models.tournament import DrawType, EventFormat
-from app.schedule_preview import DEFAULT_UNCAPPED_FIELD, build_preview_snapshot
+from app.schedule_preview import (
+    DEFAULT_UNCAPPED_FIELD,
+    DegenerateConfiguration,
+    UnpreviewableDrawType,
+    build_preview_snapshot,
+)
 from tests._helpers import (
     event_draw_settings,
     make_user,
@@ -510,9 +516,9 @@ async def test_an_unpreviewable_event_does_not_abort_the_tournaments_whole_previ
     # the fact the honest-notes strip turns into a line the director reads.
     previewed, skipped = preview.field_summaries
     assert previewed.event_id == scheduling.EventId(str(round_robin.id))
-    assert previewed.unpreviewable_draw_type is None
+    assert previewed.skip_reason is None
     assert skipped.event_id == scheduling.EventId(str(unpreviewable.id))
-    assert skipped.unpreviewable_draw_type is draw_type
+    assert skipped.skip_reason == UnpreviewableDrawType(draw_type)
     # No field was synthesized for it, so it claims no entrants and drops no bracket.
     assert (skipped.field_size, skipped.knockout_fixtures) == (0, 0)
 
@@ -599,6 +605,90 @@ async def test_an_rr_then_ko_event_does_not_abort_the_tournaments_whole_preview(
     }
 
 
+#: The domain's own refusal for the degeneracy a real director hit: an rr-then-ko
+#: event whose single pool takes one qualifier. Pinned whole because it is the
+#: *point* of skipping such an event rather than refusing the tournament — this
+#: sentence names the two numbers the director has to change, and a generic "could
+#: not be previewed" would name nothing.
+_ONE_QUALIFIER_REFUSAL = (
+    "Taking 1 qualifier from a single pool leaves one player in the knockout "
+    "stage, who would have nobody to play — take more qualifiers from each pool, "
+    "or configure more pools."
+)
+
+
+async def test_a_degenerate_event_does_not_abort_the_tournaments_whole_preview(
+    db_session: AsyncSession, default_league: League
+) -> None:
+    """An event whose configuration cannot be cut is SKIPPED, exactly as an
+    unpreviewable draw type is, and every event beside it is previewed.
+
+    ``DegenerateDraw`` is raised per event but this builder is per **tournament**, so
+    letting it propagate took the preview of every healthy event beside it — one
+    misconfigured event and the director saw no schedule at all. The round-robin's own
+    15 fixtures are asserted present, which is the claim a bare "it did not raise"
+    would miss, and the skipped event's pool is asserted absent because a window of an
+    event that was never drawn would otherwise be solved over.
+
+    The skipped event carries the strategy's own sentence, not a generic one: the
+    reason is the actionable part, and only the strategy knows which degeneracy it hit.
+
+    The refused event is created **first** on purpose. It mints no synthetic entrant,
+    so the round-robin behind it still gets the ordinals ``1..6``; an accounting that
+    charged the skipped event its field would push them to ``7..12``, which the
+    ``placeholder-N`` assertion below is what catches.
+    """
+    owner = await make_user(db_session, "prev-degenerate-beside")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    degenerate = await _add_event(
+        db_session,
+        tournament,
+        name="Championship",
+        draw_type=DrawType.rr_then_ko,
+        # One pool taking one qualifier: the knockout stage would hold a single
+        # player with nobody to play, so ``RrThenKoStrategy.plan_initial`` refuses.
+        qualifiers_per_pool=1,
+        max_players=6,
+        pools=[_one_pool(["t2"])],
+    )
+    round_robin = await _add_event(
+        db_session, tournament, name="Open Singles", max_players=6
+    )
+    loaded = await _load(db_session, tournament.id)
+
+    preview = build_preview_snapshot(loaded)
+
+    # The round-robin event is previewed in full — C(6, 2) = 15 — and it is the only
+    # event with fixtures.
+    by_event: dict[str, int] = {}
+    for fixture in preview.snapshot.fixtures:
+        by_event[fixture.event_id] = by_event.get(fixture.event_id, 0) + 1
+    assert by_event == {scheduling.EventId(str(round_robin.id)): 15}
+    # And it minted the first six ordinals: the refused event ahead of it synthesized
+    # no field, so it consumed none of the id space either.
+    assert _players(preview.snapshot) == {f"placeholder-{n}" for n in range(1, 7)}
+
+    # Nothing of the skipped event reaches the solver: no pool window (which would
+    # move the frame origin and be solved over), and no event settings.
+    assert all(
+        not pool.id.startswith(f"{degenerate.id}:") for pool in preview.snapshot.pools
+    )
+    assert [e.id for e in preview.snapshot.events] == [
+        scheduling.EventId(str(round_robin.id))
+    ]
+
+    skipped, previewed = preview.field_summaries
+    assert previewed.event_id == scheduling.EventId(str(round_robin.id))
+    assert previewed.skip_reason is None
+    assert skipped.event_id == scheduling.EventId(str(degenerate.id))
+    # The domain's own copy, verbatim — the whole reason this is a skip and not a
+    # silent omission. A summary carrying only "unpreviewable" would pass a test that
+    # merely asserted the event was left out.
+    assert skipped.skip_reason == DegenerateConfiguration(_ONE_QUALIFIER_REFUSAL)
+    # No field was synthesized for it, so it claims no entrants and drops no bracket.
+    assert (skipped.field_size, skipped.knockout_fixtures) == (0, 0)
+
+
 async def test_preview_snapshot_event_without_pools_refuses(
     db_session: AsyncSession, default_league: League
 ) -> None:
@@ -611,6 +701,89 @@ async def test_preview_snapshot_event_without_pools_refuses(
     # pool set — a clear domain error, never a partial snapshot.
     with pytest.raises(DegenerateDraw):
         build_preview_snapshot(loaded)
+
+
+async def test_a_tournament_whose_only_event_is_degenerate_is_still_refused(
+    db_session: AsyncSession, default_league: League
+) -> None:
+    """The all-unpreviewable refusal, extended to a degenerate configuration: with
+    nothing left to preview, an empty snapshot would solve to "it fits" over zero
+    matches — the false confidence a preview exists to avoid.
+
+    It is refused with the **strategy's own** ``DegenerateDraw``, message intact, so
+    the 422 a director reads names the numbers they have to change (the route passes a
+    ``DegenerateDraw``'s message through verbatim for exactly that reason).
+    """
+    owner = await make_user(db_session, "prev-degenerate-only")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    await _add_event(
+        db_session,
+        tournament,
+        name="Championship",
+        draw_type=DrawType.rr_then_ko,
+        qualifiers_per_pool=1,
+        max_players=6,
+    )
+    loaded = await _load(db_session, tournament.id)
+
+    with pytest.raises(DegenerateDraw) as caught:
+        build_preview_snapshot(loaded)
+
+    assert str(caught.value) == _ONE_QUALIFIER_REFUSAL
+
+
+@pytest.mark.parametrize("degenerate_first", [True, False])
+async def test_a_wholly_unpreviewable_tournament_speaks_its_first_events_reason(
+    db_session: AsyncSession, default_league: League, degenerate_first: bool
+) -> None:
+    """Mixed reasons, one rule: with nothing previewable, the refusal is the **first**
+    unpreviewable event's own, in the tournament's own event order.
+
+    Positional, not ranked. Both refusals reach the director as the same 422 through
+    the same mapper, so inventing a priority between them would be a second rule for a
+    reader to learn on top of the one this builder already stated ("the first skipped
+    draw type"). Parametrized both ways because a rule that only holds in one ordering
+    is a coincidence, and the two events are created in the order under test.
+    """
+    owner = await make_user(db_session, f"prev-mixed-{degenerate_first}")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+
+    async def add_degenerate() -> None:
+        await _add_event(
+            db_session,
+            tournament,
+            name="Championship",
+            draw_type=DrawType.rr_then_ko,
+            qualifiers_per_pool=1,
+            max_players=6,
+            pools=[_one_pool(["t2"])],
+        )
+
+    async def add_bracket() -> None:
+        await _add_event(
+            db_session,
+            tournament,
+            name="Cup",
+            draw_type=DrawType.single_elim,
+            max_players=8,
+        )
+
+    if degenerate_first:
+        await add_degenerate()
+        await add_bracket()
+    else:
+        await add_bracket()
+        await add_degenerate()
+    loaded = await _load(db_session, tournament.id)
+
+    if degenerate_first:
+        with pytest.raises(DegenerateDraw) as degenerate:
+            build_preview_snapshot(loaded)
+        assert str(degenerate.value) == _ONE_QUALIFIER_REFUSAL
+    else:
+        with pytest.raises(UnsupportedDrawType) as unsupported:
+            build_preview_snapshot(loaded)
+        assert unsupported.value.draw_type is DrawType.single_elim
 
 
 async def test_preview_snapshot_creates_no_entry_or_fixture_rows(

--- a/api/tests/test_schedule_preview_solve.py
+++ b/api/tests/test_schedule_preview_solve.py
@@ -505,6 +505,96 @@ async def test_preview_notes_say_a_bracket_event_is_not_previewed_at_all(
     ]
 
 
+#: The draw strategy's own refusal for the configuration a real director hit — one
+#: pool taking one qualifier — and the note the preview wraps it in. Pinned whole
+#: because the domain's sentence reaching the director IS the fix: it names the two
+#: things they can change, and a generic "could not be previewed" names neither.
+_ONE_QUALIFIER_REFUSAL = (
+    "Taking 1 qualifier from a single pool leaves one player in the knockout "
+    "stage, who would have nobody to play — take more qualifiers from each pool, "
+    "or configure more pools."
+)
+_DEGENERATE_EVENT_NOTE = (
+    "Championship is not in this preview: its draw cannot be cut as the event "
+    f"stands. {_ONE_QUALIFIER_REFUSAL}"
+)
+
+
+async def test_preview_notes_carry_a_degenerate_events_own_refusal(
+    db_session: AsyncSession, default_league: League, preview_queue: Queue
+) -> None:
+    """An event the draw refuses to cut no longer takes its tournament's preview with
+    it, and the strip says — in the domain's own words — why it is missing.
+
+    ``DegenerateDraw`` is raised per event, but the builder runs a per-event loop over
+    a whole tournament, so it blanked the preview of every healthy event beside it.
+    The round-robin's own six matches are asserted present, which the note alone would
+    not claim.
+
+    The note's discriminating part is the strategy's **verbatim** sentence. A skip
+    that reported only "Championship is not in this preview" would pass a test that
+    checked the event was left out, and would leave the director with a schedule
+    missing an event and nothing to change to get it back.
+
+    Run through a **real worker**, not by calling the job body on the in-memory
+    inputs: a skip reason is an RQ job argument, so it reaches the code that writes
+    the note as a pickle. A reason that did not survive that trip would take the
+    director's sentence with it, and an in-process call would never notice.
+    """
+    owner = await make_user(db_session, "prev-degenerate-note")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    await _add_event(
+        db_session,
+        tournament,
+        name="Open Singles",
+        max_players=4,
+        pools=[_pool(["t1"])],
+    )
+    await _add_event(
+        db_session,
+        tournament,
+        name="Championship",
+        max_players=6,
+        pools=[_pool(["t2"])],
+        draw_type=DrawType.rr_then_ko,
+        # One pool taking one qualifier: the knockout stage would hold a single
+        # player with nobody to play, so the strategy refuses the cut.
+        qualifiers_per_pool=1,
+    )
+
+    enqueued = await request_schedule_preview(
+        db_session, tournament_id=tournament.id, actor=owner
+    )
+    # The skeleton payload carries no notes channel to explain a zero, so it names
+    # only the event a field was actually synthesized for.
+    assert [s.field_size for s in enqueued.field_summaries] == [4]
+
+    _run_recorded_preview_job(preview_queue)
+    state = preview_job_state(enqueued.token, tournament.id)
+    assert state.status is PreviewJobStatus.done
+    result = state.result
+    assert result is not None
+
+    # The round-robin is previewed in full — C(4, 2) = 6 — and the refused event keeps
+    # its seat in the breakdown at zero, so it is visibly left out rather than absent.
+    assert {e.name: e.matches for e in result.events} == {
+        "Open Singles": 6,
+        "Championship": 0,
+    }
+    assert result.total_matches == 6
+
+    # The strip, pinned whole: the always-on caveat, the refused event's line carrying
+    # the strategy's sentence, and an assumed-entrants line for the previewed event
+    # ONLY — a count claimed for an event no field was synthesized for would
+    # contradict the line above it.
+    assert result.notes == [
+        "This estimate assumes no player is entered in more than one event; a "
+        "real multi-event field would take longer.",
+        _DEGENERATE_EVENT_NOTE,
+        "Assumed 4 entrants for Open Singles.",
+    ]
+
+
 async def test_a_round_robin_only_previews_notes_carry_no_knockout_caveat(
     db_session: AsyncSession, default_league: League, preview_queue: Queue
 ) -> None:

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-preview-modal.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-preview-modal.test.tsx
@@ -144,14 +144,161 @@ describe('SchedulePreviewModal', () => {
 
     schedulePreviewModalPage.render()
 
-    // The inline error, with the client's own copy — never the raw server sentence.
+    // The inline error: the client's cause-neutral title over the server's own
+    // director-facing sentence (the 422 detail is domain-authored copy).
     const error = await screen.findByTestId('preview-enqueue-error')
     expect(error).toHaveTextContent("This schedule can't be previewed yet")
+    expect(error).toHaveTextContent('Only round-robin draws can be previewed.')
     // NOT a permanent spinner.
     expect(screen.queryByTestId('preview-preparing')).toBeNull()
     // Actionable: a retry and a close.
     expect(screen.getByTestId('preview-enqueue-retry')).toBeInTheDocument()
     expect(screen.getByTestId('preview-enqueue-close')).toBeInTheDocument()
+  })
+
+  // The bug behind this block: EVERY 422 was mapped to one hardcoded "this
+  // tournament uses a draw type the preview does not support yet" notice, and the
+  // server's `detail` was discarded. A director whose round-robin-then-knockout
+  // event took one qualifier per pool was told the draw type was unsupported — false
+  // twice over (rr-then-ko IS previewed, in part) — instead of being told the one
+  // thing they could act on. The API passes the domain's own sentence through on
+  // purpose (`_draw_refusal`, `case DegenerateDraw(): detail = str(error)`), so the
+  // modal must show it (`web-client/CLAUDE.md`: "surface server 4xx inline, don't
+  // swallow it").
+  describe('the enqueue-refusal notice', () => {
+    /** Drive one enqueue refusal and return the rendered inline notice. */
+    const refuseWith = async (status: number, body: unknown) => {
+      mockSchedulePreviewEnqueueEndpoint(server, () =>
+        HttpResponse.json(body as never, { status }),
+      )
+      schedulePreviewModalPage.render()
+      return await screen.findByTestId('preview-enqueue-error')
+    }
+
+    // The real report, verbatim from the server. This is the assertion that reds
+    // against the pre-fix code — as a text-content diff on an alert that IS on
+    // screen, not a timeout, so the red says "wrong copy" and nothing else.
+    it('shows the degenerate-draw sentence the server sent, not the draw-type guess', async () => {
+      const detail =
+        'Taking 1 qualifier from a single pool leaves one player in the knockout ' +
+        'stage, who would have nobody to play — take more qualifiers from each ' +
+        'pool, or configure more pools.'
+
+      const error = await refuseWith(422, { detail })
+
+      expect(error).toHaveTextContent(detail)
+      // Replaced, not appended: the false draw-type sentence must be gone.
+      expect(error).not.toHaveTextContent(
+        'This tournament uses a draw type the preview does not support yet',
+      )
+      // The title stays cause-neutral, so it cannot contradict the detail.
+      expect(error).toHaveTextContent("This schedule can't be previewed yet")
+    })
+
+    // The route's other 422 — no event of the tournament is previewable. Same path,
+    // and the title has to read honestly over this sentence too.
+    it('shows the no-previewable-event sentence the server sent', async () => {
+      const detail =
+        'A single_elimination draw cannot be previewed, and this tournament has ' +
+        'no other event to preview. A draw of that kind is decided round by round ' +
+        'as it is played, so before anyone has entered there is nothing to lay out.'
+
+      const error = await refuseWith(422, { detail })
+
+      expect(error).toHaveTextContent(detail)
+      expect(error).toHaveTextContent("This schedule can't be previewed yet")
+    })
+
+    // No detail: the generic wording, never a blank description or "undefined".
+    it('falls back to the generic description when the 422 carries no detail', async () => {
+      const error = await refuseWith(422, {})
+
+      expect(error).toHaveTextContent("This schedule can't be previewed yet")
+      expect(error).toHaveTextContent(
+        'A preview runs over a round-robin draw. This tournament uses a draw type the preview does not support yet.',
+      )
+      expect(error).not.toHaveTextContent('undefined')
+    })
+
+    // A whitespace-only detail is "no detail" — an empty description would leave the
+    // notice with a title and nothing to act on.
+    it('falls back to the generic description when the 422 detail is blank', async () => {
+      const error = await refuseWith(422, { detail: '   ' })
+
+      expect(error).toHaveTextContent(
+        'A preview runs over a round-robin draw. This tournament uses a draw type the preview does not support yet.',
+      )
+    })
+
+    // FastAPI's per-field 422 array is the ONE 422 body whose message is machine
+    // prose ("Input should be a valid integer"), not a sentence anybody wrote for a
+    // director — `extractDetail` still yields a string from it, so the shape decides
+    // (`data/save-failure.ts`: `validationFields` is non-null only for that array).
+    it('does not show Pydantic machine prose from a request-validation 422', async () => {
+      const error = await refuseWith(422, {
+        detail: [
+          {
+            loc: ['body', 'overrides', 'ev-1'],
+            msg: 'Input should be a valid integer',
+          },
+        ],
+      })
+
+      expect(error).not.toHaveTextContent('Input should be a valid integer')
+      expect(error).toHaveTextContent(
+        'A preview runs over a round-robin draw. This tournament uses a draw type the preview does not support yet.',
+      )
+    })
+
+    // The detail is TEXT. A server sentence carrying angle brackets is rendered
+    // literally, and injects no element.
+    it('renders the 422 detail as text, not markup', async () => {
+      const error = await refuseWith(422, {
+        detail: 'Take more qualifiers <b>from each pool</b>.',
+      })
+
+      expect(error).toHaveTextContent('Take more qualifiers <b>from each pool</b>.')
+      expect(error.querySelector('b')).toBeNull()
+    })
+
+    // The transport/lifecycle branches are about the request, not the domain, so
+    // their hardcoded copy is right and stays put. Pinned so the 422 change cannot
+    // bleed into them.
+    it('keeps the hardcoded 409 notice, ignoring any server detail', async () => {
+      const error = await refuseWith(409, {
+        detail: 'Tournament is not pre-live.',
+      })
+
+      expect(error).toHaveTextContent('The preview is only for a pre-live schedule')
+      expect(error).toHaveTextContent(
+        'This tournament is already live, so there is nothing to preview — the real schedule is on the board.',
+      )
+      expect(error).not.toHaveTextContent('Tournament is not pre-live.')
+    })
+
+    it('keeps the hardcoded 429 notice, ignoring any server detail', async () => {
+      const error = await refuseWith(429, {
+        detail: 'Rate limited: one preview at a time.',
+      })
+
+      expect(error).toHaveTextContent('A preview is already running')
+      expect(error).toHaveTextContent(
+        'Only one preview runs at a time. Wait a moment for the current one to finish, then try again.',
+      )
+      expect(error).not.toHaveTextContent('Rate limited')
+    })
+
+    it('keeps the hardcoded 403 notice, ignoring any server detail', async () => {
+      const error = await refuseWith(403, {
+        detail: 'You can only preview tournaments you created.',
+      })
+
+      expect(error).toHaveTextContent('The preview wasn’t run')
+      expect(error).toHaveTextContent(
+        'Only the tournament owner can preview the schedule.',
+      )
+      expect(error).not.toHaveTextContent('You can only preview tournaments you created.')
+    })
   })
 
   it('heads a synthetic grid card with the human pool name, not the composite id', async () => {

--- a/web-client/src/components/tournaments/tournament-detail-page/schedule-preview-modal.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/schedule-preview-modal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Loader2, RotateCw, TriangleAlert } from 'lucide-react'
 import { type UseQueryResult, useQuery } from '@tanstack/react-query'
 
-import { ApiError } from '@/api/client'
+import { ApiError, validationFields } from '@/api/client'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -88,27 +88,66 @@ function fmtPreviewFinish(iso: string): string | null {
   return fmt12(Number(m[1]) * 60 + Number(m[2]))
 }
 
-/** The four refusals the enqueue POST can answer with, each a designed notice in
- * the director's words — never the server's prose (`DEFINITION_OF_COMPLETE.md`).
- * The trigger button is NOT gated on draw type, so a `422` (only round-robin is
- * previewable today) is a real, reachable refusal, not a bug. */
+/** The refusals the enqueue POST can answer with, each a designed inline notice.
+ * The trigger button is NOT gated on draw type, so a `422` is a real, reachable
+ * refusal, not a bug. */
 interface PreviewEnqueueNotice {
   title: string
   description: string
 }
 
-/** Map an enqueue refusal to its inline notice. `422` — the draw type can't be
- * previewed yet (only round-robin is); `409` — the tournament is no longer pre-live;
- * `429` — the single preview slot is busy (retry in a moment); `403` — not the
- * owner; status `0` — the server was never reached; anything else — the honest
- * generic. */
+/** The 422 description when the server sent no sentence of its own — kept verbatim
+ * from the pre-fix code. Note it does name a cause (the draw type), which is only
+ * safe here because we have nothing else to say: it is exactly the guess that was
+ * wrong when it was shown over EVERY 422. A cause-neutral sentence would be a better
+ * fallback; changing it is a follow-up, not part of this fix. */
+const PREVIEW_422_FALLBACK =
+  'A preview runs over a round-robin draw. This tournament uses a draw type the preview does not support yet.'
+
+/**
+ * The server's own sentence for a refusal, when that sentence was written for a
+ * director — otherwise `null`.
+ *
+ * The shape decides, not the status. FastAPI's per-field validation array is the one
+ * 422 body whose `msg` is machine prose ("Input should be a valid integer"), and
+ * `extractDetail` happily returns a string from it, so a status-only check would put
+ * Pydantic's words on screen. `validationFields` returns non-`null` **only** for that
+ * array, which is exactly the "are the server's words safe to show" test
+ * (`data/save-failure.ts`, whose `invalid` arm exists because that prose reached a
+ * screen once).
+ */
+function serverSentence(error: ApiError): string | null {
+  if (validationFields(error) !== null) return null
+  const detail = error.detail?.trim()
+  return detail ? detail : null
+}
+
+/**
+ * Map an enqueue refusal to its inline notice.
+ *
+ * `422` is the **domain** speaking, so it speaks: the route composes that detail for
+ * a director and passes the domain's own copy straight through
+ * (`api/app/tournaments.py`, `_draw_refusal` — "the one error whose message is
+ * domain-authored copy"). Only the strategy knows *which* refusal fired and which
+ * numbers the director has to change, so a hardcoded sentence here can only be a
+ * guess, and it was a wrong one: a round-robin-then-knockout event taking one
+ * qualifier per pool was told its draw type is unsupported, hiding a two-click fix
+ * (`web-client/CLAUDE.md`: "surface server 4xx inline, don't swallow it"). The title
+ * stays **cause-neutral** for the same reason — it must not contradict a detail it
+ * has not read.
+ *
+ * The rest are about the transport and the lifecycle, not the domain, so their copy
+ * is ours and the server's words add nothing: `409` — the tournament is no longer
+ * pre-live; `429` — the single preview slot is busy (retry in a moment); `403` — not
+ * the owner; status `0` — the server was never reached; anything else — the honest
+ * generic.
+ */
 function previewEnqueueNotice(error: unknown): PreviewEnqueueNotice {
   if (error instanceof ApiError) {
     if (error.status === 422) {
       return {
         title: "This schedule can't be previewed yet",
-        description:
-          'A preview runs over a round-robin draw. This tournament uses a draw type the preview does not support yet.',
+        description: serverSentence(error) ?? PREVIEW_422_FALLBACK,
       }
     }
     if (error.status === 409) {
@@ -281,9 +320,9 @@ const PreviewBody = ({
 
   const eventName = (id: string) => events.find((e) => e.id === id)?.name ?? id
 
-  // Refused loud (ADR): the enqueue POST was rejected (422 unpreviewable draw type,
-  // 409 not pre-live, 429 rate-limited, 403, network), so there is no structure to
-  // render — show the actionable notice with a Close/Retry, never a permanent
+  // Refused loud (ADR): the enqueue POST was rejected (422 the domain will not draw
+  // this, 409 not pre-live, 429 rate-limited, 403, network), so there is no structure
+  // to render — show the actionable notice with a Close/Retry, never a permanent
   // spinner.
   if (!enqueued && enqueue.isError) {
     const notice = previewEnqueueNotice(enqueue.error)

--- a/web-client/src/mocks/endpoints/tournaments/preview.endpoint.ts
+++ b/web-client/src/mocks/endpoints/tournaments/preview.endpoint.ts
@@ -10,8 +10,9 @@ type Backend = typeof server | typeof worker
 /** Resolver for the **schedule-preview enqueue** endpoint (ADR "a schedule
  * preview is a non-persistent solve over a synthetic field") — the `202`
  * `PreviewEnqueued` (token + the instant structure), or an error envelope: 403
- * (not the owner), 409/422 (not pre-live, or an unpreviewable draw type), 429
- * (rate-limited), 404. The body is the optional per-event field-size overrides. */
+ * (not the owner), 409 (not pre-live), 422 (the domain will not draw this — its
+ * `detail` is the director-facing sentence the modal shows), 429 (rate-limited),
+ * 404. The body is the optional per-event field-size overrides. */
 export type SchedulePreviewEnqueueResolver = HttpResponseResolver<
   { tournamentId: string },
   components['schemas']['PreviewRequest'] | null,


### PR DESCRIPTION
Two defects found by a director who could not preview a round-robin-then-knockout event, and lost real time to it.

## 1. The modal threw away the server's explanation

The preview modal mapped **every** 422 to one hardcoded notice:

> "A preview runs over a round-robin draw. This tournament uses a draw type the preview does not support yet."

The server had sent the actual reason — one pool taking one qualifier sends a single player to the bracket, who would have nobody to play, so the draw cannot be cut. That sentence is passed through deliberately: the router documents `DegenerateDraw` as *"the one error whose message is domain-authored copy"*.

The director was told, instead, that their draw type was unsupported. It is supported, and rr-then-ko is previewed in part. The real problem was a two-click config fix the app knew about and would not say.

The 422 branch now renders the server's `detail`. FastAPI's per-field validation 422 is still excluded — its `msg` is machine prose ("Input should be a valid integer") and belongs nowhere near a director. The 409, 429, 403 and transport branches keep their existing wording, which is correct for them.

This also restores the unit's own documented rule: *"Surface server 4xx inline, don't swallow it."*

## 2. One degenerate event still blanked the whole tournament's preview

#1308 fixed exactly this for `UnsupportedDrawType` — a per-event refusal that aborted the whole tournament, because the builder sits inside a per-event loop. `DegenerateDraw` propagated out of that same loop untouched.

So a single misconfigured event took the preview of every healthy event beside it. It now skips the event and carries **the strategy's own sentence** into the honest notes, so the director learns what to change. A tournament with no previewable event at all still refuses, rather than returning a confidently empty plan.

## Verification

- Both **seen red first**. The modal test failed showing the draw-type sentence where the degenerate-draw sentence belonged; the api test errored with `DegenerateDraw` escaping the loop and taking a round-robin's 15 fixtures with it.
- `pytest` **2272 passed**, `mypy` clean on 170 files, `ruff` clean.
- vitest **325 files / 3612 tests passed** (collected == ran, after clearing the vite cache), `tsc -b` / `eslint` / `vite build` all exit 0.
- Two guards that passed pre-fix were falsified separately, since a test never seen red is not evidence.
- No OpenAPI change: no route, schema or route docstring touched.

Related: #1318 (the "Try again" button on a refusal that can never succeed) is untouched here. #1320 covers the underlying UX — that a director can only set draw structure indirectly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)