### PR TITLE
Slice 2: a director reads the draw their pool rows already imply (#1320)

### DIFF
--- a/docs/designs/rr-then-ko-draw-structure/README.md
+++ b/docs/designs/rr-then-ko-draw-structure/README.md
@@ -9,6 +9,11 @@ The copy and the math below come from the reference's own bundle
 (`/assets/page-CZ2t-Xlt.js`), not from reading the rendered page. Treat the strings as
 exact.
 
+**The apostrophes are exact too.** Every one in the reference's copy is a right single
+quote, `U+2019`, with one exception: `today's behaviour` uses a straight `U+0027`. Do
+not normalise either way. A test that pins this copy fails on the wrong glyph, which is
+the point.
+
 Read `../rr-then-ko-current-state/README.md` first. It records the editor this work
 replaces.
 
@@ -42,7 +47,7 @@ The left column carries a heading block and then four setting rows. The rows sha
 list and use dividers, not cards.
 
 - Overline: `Draw structure`
-- Heading: `Set what matters. We'll work out the rest.`
+- Heading: `Set what matters. We’ll work out the rest.`
 - Body: `Pools play all-play-all. The top finishers move into a knockout bracket.`
 - Preview basis block: label `Preview field`, the field size, and a link
   `Change in Basics`
@@ -96,7 +101,7 @@ This row has no numeric input. It shows one of two values.
 
 - Hint: `Who lands in each pool. Entrants do not exist until you cut the draw.`
 - Automatic value: `Snake automatically`, source `Seeds spread 1, 2, 3, 3, 2, 1.`
-- Manual value: `Assign at cut time`, source `You'll place entrants once registration closes.`
+- Manual value: `Assign at cut time`, source `You’ll place entrants once registration closes.`
 - Action: `Assign myself` or `Use snake`
 - When manual, the row also shows: `Repeat protection turns off when you assign pools by hand.`
 
@@ -198,13 +203,13 @@ Only one panel shows at a time. The order above decides which.
 
 ### Impossible
 
-Role `alert`. Topline `Can't save` with a red dot.
+Role `alert`. Topline `Can’t save` with a red dot.
 
 | Case | Title | Body |
 | --- | --- | --- |
 | Pool | `Pool {letter} would have one player` (or `no players`) | `They would have nobody to play. Use fewer pools or raise the player limit.` |
 | Bracket | `The knockout would have one player` | `One player has nobody to play. Take more qualifiers or run more pools.` |
-| Qualifier | `You can't take {q} qualifiers from a pool of {min}` | `Take {min} or fewer, or make the smallest pool bigger.` |
+| Qualifier | `You can’t take {q} qualifiers from a pool of {min}` | `Take {min} or fewer, or make the smallest pool bigger.` |
 
 Fixes offered:
 
@@ -220,8 +225,8 @@ Each fix is a row with a label, a detail line and an `Apply` button.
 Role `status`. Topline `Needs your call` with a yellow dot.
 
 - Title: `{count} pools of {size} seat {seats}. Your field is {field}.`
-- Body when the field is bigger: `{n} entrants have nowhere to go. We won't change your numbers behind your back.`
-- Body when the field is smaller: `{n} seats would be empty. We won't change your numbers behind your back.`
+- Body when the field is bigger: `{n} entrants have nowhere to go. We won’t change your numbers behind your back.`
+- Body when the field is smaller: `{n} seats would be empty. We won’t change your numbers behind your back.`
 
 Three fixes:
 
@@ -245,7 +250,7 @@ Overline `The draw as it stands`. The heading and the badge follow the state:
 
 | State | Heading | Badge |
 | --- | --- | --- |
-| Impossible | `This draw can't work yet` | `Impossible` |
+| Impossible | `This draw can’t work yet` | `Impossible` |
 | Disagreement | `Your numbers disagree` | `Your call` |
 | Otherwise | `Ready to save` | `Sound` |
 
@@ -304,7 +309,7 @@ Choosing by hand shows a warning that stays on screen:
 
 ```
 Repeat protection turns off.
-A first-round knockout match may repeat a pool match. We'll flag it, not block it.
+A first-round knockout match may repeat a pool match. We’ll flag it, not block it.
 ```
 
 The assignment area holds two panes.

--- a/e2e/page-objects/tournament-detail-page/event-editor.page.ts
+++ b/e2e/page-objects/tournament-detail-page/event-editor.page.ts
@@ -1,5 +1,7 @@
 import { expect, Locator, Page } from '@playwright/test'
 
+import { DrawStructureTabPage } from './event-editor/draw-structure-tab.page'
+
 /**
  * The **event editor** — the slide-in sheet the Events tab opens for "New event" and
  * for any event card. Scoped to what the rr-then-ko spec authors through it: the name,
@@ -88,11 +90,48 @@ export class EventEditorPage {
     await expect(this.roundsInput).toHaveValue(String(rounds))
   }
 
+  // ----- the sheet's tabs ---------------------------------------------------
+
+  /** One of the sheet's section tabs, by the word on it.
+   *
+   * The union is the tab list itself, and `Draw structure` is the **conditional** member
+   * (ADR 20260808): it exists only while the draft's draw type is `rr-then-ko`, so a spec
+   * reaching for it on any other format is asking for a tab that is deliberately not
+   * there. Typed rather than left as a bare `string` so that "assert this tab is absent"
+   * cannot quietly become "assert a tab I misspelled is absent", which passes for free. */
+  tab(
+    name:
+      | 'Basics'
+      | 'Eligibility'
+      | 'Match settings'
+      | 'Table pools'
+      | 'Draw structure',
+  ): Locator {
+    return this.page.getByRole('tab', { name, exact: true })
+  }
+
+  // ----- Draw structure (rr-then-ko only) -----------------------------------
+
+  /** The **Draw structure** tab's surfaces, composed as a child page object. A getter
+   * rather than a field, so it cannot depend on whether a field initializer runs before
+   * or after the constructor's parameter property — and a page object holds no state, so
+   * handing back a fresh one costs nothing. */
+  get drawStructure(): DrawStructureTabPage {
+    return new DrawStructureTabPage(this.page)
+  }
+
+  /** Switch to the Draw structure tab and return its page object — plain component
+   * state, no navigation, the same shape `TournamentDetailPage.openSchedule` takes. */
+  async openDrawStructure(): Promise<DrawStructureTabPage> {
+    await this.tab('Draw structure').click()
+    return this.drawStructure
+  }
+
   // ----- Table pools --------------------------------------------------------
 
   /** The "Table pools" tab of the sheet — plain component state, no navigation. */
   get poolsTab(): Locator {
-    return this.page.getByRole('tab', { name: 'Table pools' })
+    return this.tab('Table pools')
   }
 
   /** Every pool card currently in the draft, so a spec can count them. */

--- a/e2e/page-objects/tournament-detail-page/event-editor/draw-structure-tab.page.ts
+++ b/e2e/page-objects/tournament-detail-page/event-editor/draw-structure-tab.page.ts
@@ -1,0 +1,132 @@
+import { Locator, Page } from '@playwright/test'
+
+/**
+ * The event editor's **Draw structure** tab (#1320) — the four structural settings of a
+ * round-robin-then-knockout draw, and the live preview of the draw they add up to.
+ *
+ * A child page object of `EventEditorPage`, composed the way `DashboardPage.userMenu` is:
+ * the tab is a surface of its own with a dozen readings on it, and folding those into the
+ * editor class would grow one flat object past the point a spec can read it.
+ *
+ * ## Two vocabularies, deliberately
+ *
+ * The **settings** are addressed by the words a director reads. Each row renders a named
+ * `region` (`<section aria-labelledby>` over the setting's name), so `settingValue('Pool
+ * count')` asks for the row by the thing it sets rather than by its position in a list of
+ * four identically-shaped rows. The **preview** is addressed by testid, because its parts
+ * are one card each with no accessible name of their own.
+ *
+ * ## Why nothing here is a `toHaveText` of a whole card
+ *
+ * `textContent` inserts no whitespace between block elements, so a pool card reads
+ * `Pool A8playerstop 2 advance` and the knockout card reads
+ * `Knockout8-player bracketNo first-round byes112 pool matches`. A spec therefore states
+ * one fact per assertion, each against a string that lives inside a single element. The
+ * equation is the exception and is safe whole: its literals carry their own spaces.
+ */
+export class DrawStructureTabPage {
+  constructor(private readonly page: Page) {}
+
+  /** The tab's panel. Present only for an `rr-then-ko` event (ADR 20260808), so a spec
+   * that asserts on this has already asserted the tab itself exists. */
+  get section(): Locator {
+    return this.page.getByTestId('draw-structure-section')
+  }
+
+  /** The tab's heading — `Set what matters. We’ll work out the rest.` (a right single
+   * quote, `U+2019`, as the reference has it). */
+  get heading(): Locator {
+    return this.page.getByTestId('draw-structure-heading')
+  }
+
+  /** The field every number on the tab is derived from: the event's cap, or the
+   * synthetic 16 an uncapped event is previewed against. */
+  get fieldSize(): Locator {
+    return this.page.getByTestId('draw-structure-field-size')
+  }
+
+  /** Where that field came from, in words — `32-player cap`, or the honest sentence for
+   * an event with no cap (which is where this implementation departs from the reference
+   * on purpose). */
+  get previewBasis(): Locator {
+    return this.page.getByTestId('draw-structure-preview-basis')
+  }
+
+  // ----- the four setting rows ----------------------------------------------
+
+  /** One setting row, **by the setting's name** — `Pool count`, `Pool size`,
+   * `Membership`, `Qualifiers per pool`. The row is a named `region`, which is the whole
+   * reason a spec never needs an `nth(…)` here. */
+  settingRow(name: string): Locator {
+    return this.page.getByRole('region', { name, exact: true })
+  }
+
+  /** The number (or phrase) the row currently reads. */
+  settingValue(name: string): Locator {
+    return this.settingRow(name).getByTestId('draw-setting-value')
+  }
+
+  /** The plain words after the value — `pools`, `players per pool`. A `Membership` row
+   * has none: its value is already a sentence. */
+  settingUnit(name: string): Locator {
+    return this.settingRow(name).getByTestId('draw-setting-unit')
+  }
+
+  /** The ownership badge — `Automatic` or `Yours`, and nothing else (ADR 20260808: the
+   * owner is stated in words, never only in colour). Uppercased by CSS only, so the text
+   * an assertion reads is still the capitalised word. */
+  settingOwnership(name: string): Locator {
+    return this.settingRow(name).getByTestId('draw-setting-ownership')
+  }
+
+  /** The one line under the badge saying where the value came from. Derived alongside
+   * the number it describes, so this string and the value above it cannot fork. */
+  settingSource(name: string): Locator {
+    return this.settingRow(name).getByTestId('draw-setting-source')
+  }
+
+  // ----- the live preview ----------------------------------------------------
+
+  /** The sticky preview panel — `The draw as it stands`. */
+  get preview(): Locator {
+    return this.page.getByTestId('draw-preview')
+  }
+
+  /** The preview's verdict heading: `Ready to save`, `Your numbers disagree`, or
+   * `This draw can’t work yet`. */
+  get previewVerdict(): Locator {
+    return this.page.getByTestId('draw-preview-verdict')
+  }
+
+  /** The badge beside it — `Sound`, `Your call`, `Impossible`. One decision with the
+   * heading, so a spec reads both. */
+  get previewBadge(): Locator {
+    return this.page.getByTestId('draw-preview-badge')
+  }
+
+  /** The whole draw in one line: `{field} players ÷ {count} pools = {size} per pool`.
+   * Safe to assert whole — every literal in it carries its own spaces. */
+  get previewEquation(): Locator {
+    return this.page.getByTestId('draw-preview-equation')
+  }
+
+  /** Every projected pool card, in pool order, so a spec can count them. */
+  get previewPoolCards(): Locator {
+    return this.page.getByTestId('draw-preview-pool-card')
+  }
+
+  /** One projected pool card, **by its letter** — `A`, `B`, … Filtered on the card's own
+   * `Pool {letter}` line with `exact`, because `Pool A` is a substring of `Pool AA` and
+   * the letters run past `Z` on a large field. */
+  previewPoolCard(letter: string): Locator {
+    return this.previewPoolCards.filter({
+      has: this.page.getByText(`Pool ${letter}`, { exact: true }),
+    })
+  }
+
+  /** The knockout card: the bracket size, the first-round byes, and how many matches the
+   * pool stage plays to fill it. */
+  get previewKnockout(): Locator {
+    return this.page.getByTestId('draw-preview-knockout')
+  }
+}

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -221,6 +221,37 @@ export class TournamentDetailPage {
     return new EventEditorPage(this.page)
   }
 
+  /** The **full-card open target** for one event — a stretched `<button>` sibling of the
+   * card, named `Edit {event}` for the director and `View {event}` for everyone else.
+   *
+   * `exact`, for the reason `publishButton` and `poolDrawNamed` are: `getByRole`'s name
+   * option is a *substring* match, so `Edit Open` would also resolve `Edit Open Singles`
+   * — and a spec that seeds two events on one tournament (the only way to state "this
+   * format has the tab and that one does not") is exactly where two events' names overlap. */
+  openEventButton(eventName: string): Locator {
+    return this.page.getByRole('button', {
+      name: `Edit ${eventName}`,
+      exact: true,
+    })
+  }
+
+  /**
+   * Open an **existing** event's editor by clicking its card, and return the editor's
+   * page object — the read-back counterpart of `openNewEvent`.
+   *
+   * ⚠️ **Clicked near its top-left corner, not at its centre.** The open target is a
+   * `z-0` button stretched under the card, and the card raises its own *controls* above it
+   * (`relative z-10`) — the Enter control and the whole draw panel, whose Generate /
+   * Re-cut / Delete would otherwise never receive a click. On a tall card the overlay's
+   * geometric centre (where a bare `.click()` lands) is inside the draw panel, so the
+   * click hits the panel and the editor never opens. The same positioned click is what
+   * `web-client/e2e`'s own detail page object does, for the same reason.
+   */
+  async openEvent(eventName: string): Promise<EventEditorPage> {
+    await this.openEventButton(eventName).click({ position: { x: 30, y: 20 } })
+    return new EventEditorPage(this.page)
+  }
+
   // ----- entry (event card) -------------------------------------------------
 
   /** The self-registration **Enter** button on an event's card, by event name. */

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -193,18 +193,26 @@ export interface StoredAddress extends Coords {
   readonly venue: string
 }
 
-/** The draw types this seed can author. Two, because these are the two shapes the seed
- * itself can express: `round-robin`, whose draw settings are the empty object, and
- * `single-elim`, whose settings are empty too (`SingleElimDrawSettingsWrite` — a bracket
- * has no pools to qualify out of and its depth is derived from the field).
+/** The draw types this seed can author.
  *
- * The two formats that DO carry a setting are deliberately absent. `rr-then-ko` needs
- * `qualifiers_per_pool` and `swiss` needs `rounds`, both **required with no default** on
- * their arm of the server's draw-settings union — and both are authored through the event
- * editor **in the browser** by the specs that use them, because the payload that editor
- * builds is the seam their 422 lived in. Adding them here would give those specs a way to
- * skip the surface they exist to test. */
-export type SeededDrawType = 'round-robin' | 'single-elim'
+ * `round-robin` and `single-elim` carry no draw settings at all (their arms of the
+ * server's union are the empty object — a bracket has no pools to qualify out of and its
+ * depth is derived from the field), so seeding them is one key on the wire.
+ *
+ * `rr-then-ko` carries **K** (`qualifiers_per_pool`), required with no default on its arm,
+ * so seeding it means sending `SeedEventOptions.qualifiersPerPool` too — the option says
+ * what happens when you don't.
+ *
+ * ⚠️ **`swiss` is still deliberately absent, and `rr-then-ko`'s CREATE PAYLOAD is still
+ * the browser's job.** The payload the event editor builds (`drawSettingsToApi`) is the
+ * seam the arc's 422 lived in — the client named `rr-then-ko` and sent no K — and no
+ * mocked suite can see it. `tournament-rr-then-ko.spec.ts` and `tournament-swiss.spec.ts`
+ * therefore author their event **through the sheet**, and must go on doing so: this
+ * option exists for the specs whose subject is the **read** path (what the server sends
+ * back and the client renders from it), not the write one. Seeding an rr-then-ko event
+ * here to test the create would prove only that the server accepts a body the test itself
+ * composed. */
+export type SeededDrawType = 'round-robin' | 'single-elim' | 'rr-then-ko'
 
 /** Optional knobs on `addEvent` — one event of an existing tournament.
  *
@@ -227,6 +235,14 @@ export interface SeedEventOptions {
    * and the spec's whole subject is what the scheduler does with a fixture that names no
    * pool (ADR 20260807, "a pool restricts scheduling, it does not enable it"). */
   readonly drawType?: SeededDrawType
+  /** **K** — how many finishers of each pool reach the knockout. Sent only when given,
+   * because the key is a **422 naming itself** on every arm but `rr-then-ko`: the union's
+   * arms are `extra="forbid"`, and a qualifier count on a format with no knockout stage is
+   * refused at the request boundary rather than dropped.
+   *
+   * Required *with* `drawType: 'rr-then-ko'`, and required in the other direction too —
+   * that arm has no default. Omitting it there is the same 422, naming the field. */
+  readonly qualifiersPerPool?: number
   /** The window both the event and its pools carry. Omitted = tomorrow, 09:00–17:00. */
   readonly slot?: SlotSpec
   /** The event's pools, **in the director's order** — see
@@ -258,6 +274,9 @@ export interface SeedTournamentOptions {
    * and the spec's whole subject is what the scheduler does with a fixture that names no
    * pool (ADR 20260807, "a pool restricts scheduling, it does not enable it"). */
   readonly drawType?: SeededDrawType
+  /** **K** — see `SeedEventOptions.qualifiersPerPool`, which is this same option on the
+   * one event `seedTournament` adds. */
+  readonly qualifiersPerPool?: number
   /** The window both the event and its single pool carry. */
   readonly slot?: SlotSpec
   /** The table catalogue; the pool references every listed table. */
@@ -428,6 +447,7 @@ export async function seedTournament(
   // option may fall back to the single `Pool A`.
   const { eventId, pools } = await addEvent(director, tournamentId, storedTables, {
     drawType: options.drawType,
+    qualifiersPerPool: options.qualifiersPerPool,
     slot: options.slot,
     pools: options.pools,
     maxPlayers: options.maxPlayers,
@@ -486,11 +506,16 @@ export async function addEvent(
         // timezone-aware instants"), so the window still brackets NOW.
         timezone: 'UTC',
         format: 'singles',
-        // The caller's draw type, defaulting to the original round-robin. Both types
-        // this seed can author take **no** further draw settings, so there is nothing
-        // to send beside it (see `SeededDrawType` for the two that do, and why they
-        // are authored in the browser instead).
+        // The caller's draw type, defaulting to the original round-robin.
         draw_type: options.drawType ?? 'round-robin',
+        // **K**, beside the draw type it belongs to — the server parses the two as one
+        // pair (ADR 20260727). Sent only when the caller gives it: the key is refused on
+        // every other arm of the union (`extra="forbid"`), so an unconditional
+        // `qualifiers_per_pool: null` would 422 every round-robin this helper has ever
+        // seeded.
+        ...(options.qualifiersPerPool !== undefined
+          ? { qualifiers_per_pool: options.qualifiersPerPool }
+          : {}),
         entry_fee: 0,
         // Only sent when the caller caps the field; omitting the key leaves the
         // event uncapped (the API treats a missing `max_players` as no cap).

--- a/e2e/tests/tournament-draw-structure.spec.ts
+++ b/e2e/tests/tournament-draw-structure.spec.ts
@@ -1,0 +1,242 @@
+import { test, expect } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+
+import { TournamentDetailPage } from '../page-objects/tournament-detail.page'
+import { guestFromContext } from '../support/match-api'
+import { grantBetaTester } from '../support/rbac-grant'
+import {
+  addEvent,
+  createTournament,
+  findEventByName,
+  type PoolSpec,
+} from '../support/tournament-api'
+
+/** The two-stage event, and the handle every reading below finds it by. */
+const RR_KO_EVENT = 'Two-stage Open'
+/** The plain round-robin standing beside it — the control. Named so that neither event's
+ * name is a substring of the other's, since both are addressed by name on one page. */
+const ROUND_ROBIN_EVENT = 'One-stage Open'
+
+/** The event's **cap**, which is the field the tab derives against (a capped event
+ * previews against its cap; an uncapped one against a synthetic 16). Thirty-two because
+ * it is the reference's own "nothing set" state, and because it divides by four exactly —
+ * so the uneven notice is absent and any `6–8` on screen is a real failure. */
+const FIELD_CAP = 32
+/** How many **pool rows** the event carries. Today's behaviour, and the automatic source
+ * of the pool count: one reservation is one pool (ADR 20260808). */
+const POOL_COUNT = 4
+/** The four pool rows, reserving **no** tables — a draw is cut without regard to tables,
+ * and an empty `table_ids` is what the editor's own pool section sends. Four tables
+ * shared four ways would be scenery this spec never looks at. */
+const POOLS: ReadonlyArray<PoolSpec> = ['A', 'B', 'C', 'D'].map((letter) => ({
+  name: `Pool ${letter}`,
+  tableLabels: [],
+}))
+
+/** **K as the event STORES it** — required with no default on the server's `rr-then-ko`
+ * arm, so the seed must send it or the create is a 422 naming the field.
+ *
+ * ⚠️ It is **not** what the tab reads. Nothing on the Draw structure tab looks at the
+ * stored column this slice: every number there comes from the derivation, which aims at
+ * an eight-player knockout and lands on `ceil(8 / 4)` = 2 for this event. The two agree
+ * here, which is why the row is not asserted as proof of anything about storage. Chore 3e
+ * moves the setting onto this tab for good and makes them one number. */
+const STORED_QUALIFIERS_PER_POOL = 2
+
+/** What the derivation makes of `32` across `4`, and the only numbers this spec asserts.
+ * Worked from the reference's own arithmetic (`docs/designs/rr-then-ko-draw-structure`):
+ * a balanced split of 32 into 4 is `8, 8, 8, 8`; the automatic qualifier count is
+ * `ceil(8 / 4)` = 2; the bracket is `4 × 2` = 8, which is already a power of two and so
+ * takes no byes; and the pool stage plays `4 × C(8,2)` = 112 matches. */
+const POOL_SIZE = 8
+const QUALIFIERS_ADVANCING = 2
+const BRACKET_SIZE = 8
+const POOL_MATCHES = 112
+
+/** The equation, whole. Safe to assert as one string — unlike the cards below it, every
+ * literal in that line carries its own spaces (`textContent` inserts none of its own, so
+ * a pool card reads `Pool A8playerstop 2 advance` and is stated one fact at a time). */
+const EQUATION = `${FIELD_CAP} players ÷ ${POOL_COUNT} pools = ${POOL_SIZE} per pool`
+
+/** The source line under the Pool count row, **verbatim**.
+ *
+ * The glyphs are the reference's and are load-bearing: a middle dot (`·`, U+00B7), and a
+ * **straight** apostrophe (U+0027) in `today's` — the one exception to the reference's
+ * right-single-quote rule, which the design README states at the top and this string
+ * exists to pin. A test that normalises either way is a test that stops noticing. */
+const POOL_COUNT_SOURCE = `${POOL_COUNT} pool reservations · today's behaviour`
+
+/** Where the preview field came from. `{n}-player cap` for a capped event — the honest
+ * label an uncapped one gets instead is `preview-field.ts`'s deviation from the reference
+ * and belongs to a different event than this one. */
+const PREVIEW_BASIS = `${FIELD_CAP}-player cap`
+
+/**
+ * **The Draw structure tab, through the whole composed stack** (#1320).
+ *
+ * A director opens a round-robin-then-knockout event they have already saved, and reads
+ * the draw their four pool rows and their 32-player cap already imply: four pools of
+ * eight, two out of each, an eight-player bracket with no byes, and 112 pool matches to
+ * decide it.
+ *
+ * ## What only this suite can say
+ *
+ * The arithmetic is already proved. `data/draw-structure.test.ts` runs the derivation's
+ * whole vector table against a Python twin, and the component tests render each part of
+ * the tab from a fixture. Both stop at the same edge: they hand the derivation numbers
+ * that a *test* chose.
+ *
+ * This spec hands it numbers the **server** chose. The cap is a `max_players` column, the
+ * pool count is four rows in `tournament_event_pools`, and both reach the tab only by
+ * being serialized onto `GET /v1/tournaments/{id}`, parsed at the client's fetch
+ * boundary, and mapped into the editor's draft. Every step of that is real here and
+ * mocked everywhere else — so `112 pool matches` on this screen is the statement that the
+ * real payload, decoded through the real fetch stack, produces the reference's number.
+ *
+ * ## …and the tab is CONDITIONAL, which is the regression worth a control
+ *
+ * The tab exists only while the draw type is `rr-then-ko` (ADR 20260808). A round-robin
+ * has no bracket to aim at, so a Draw structure tab on one would invite a director to
+ * configure a draw their event will never cut. The happy path alone cannot see that
+ * going wrong, so the tournament carries a **second, plain round-robin event** and the
+ * spec asserts the tab is absent from its editor — after asserting that editor opened at
+ * all, since a sheet that never opened offers no tabs of any kind.
+ *
+ * ## Seed vs UI split
+ *
+ * Both events are seeded over the real API (`support/tournament-api.ts`): they are the
+ * scaffolding, and what is under test is what the editor *renders* from them. The create
+ * payload is deliberately somebody else's subject — `tournament-rr-then-ko.spec.ts`
+ * authors its event through the sheet, because the body that editor builds is the seam
+ * that arc's 422 lived in. Every reading below is the browser's.
+ */
+test.describe('Tournament — the rr-then-ko draw structure', () => {
+  test('a director reads the draw their pool rows already imply, and only this format offers it', async ({
+    page,
+    baseURL,
+  }) => {
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    // The director IS the browser's own session, so page navigations run as them and the
+    // event cards carry the owner's `Edit …` open target rather than a viewer's `View …`.
+    const director = await guestFromContext(page.request)
+    grantBetaTester(director.username)
+
+    // ----- the shell, over the API: two events, one tournament ---------------
+    const name = `Draw structure ${faker.string.alphanumeric(8)}`
+    const { tournamentId, tables } = await createTournament(director, name)
+
+    await addEvent(director, tournamentId, tables, {
+      name: RR_KO_EVENT,
+      drawType: 'rr-then-ko',
+      qualifiersPerPool: STORED_QUALIFIERS_PER_POOL,
+      maxPlayers: FIELD_CAP,
+      pools: POOLS,
+    })
+    // The control, and the reason it is on the SAME tournament: two events one click
+    // apart is the sharpest form of "this format has the tab and that one does not".
+    await addEvent(director, tournamentId, tables, {
+      name: ROUND_ROBIN_EVENT,
+      pools: [{ name: 'Pool A', tableLabels: [] }],
+    })
+
+    // ----- the SERVER holds what the tab is about to be derived from ---------
+    // Read back before a browser is involved, so a wrong number on screen below can only
+    // be the client's doing. A 201 alone would also come back from a server that stored
+    // the event and dropped its cap or its pools.
+    const stored = await findEventByName(director, tournamentId, RR_KO_EVENT)
+    expect(stored.draw_type).toBe('rr-then-ko')
+    expect(stored.qualifiers_per_pool).toBe(STORED_QUALIFIERS_PER_POOL)
+
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    // `toContainText`, not `toHaveText`: the hero sets its own full stop after the name.
+    // The long timeout is for the FIRST navigation only, and it is about the stack rather
+    // than the app — the composed web-client is a Vite *dev* server, so the first request
+    // for a route pays for transforming it on demand.
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    // ----- open the two-stage event's editor, and its fifth tab --------------
+    const editor = await detail.openEvent(RR_KO_EVENT)
+    const drawStructure = await editor.openDrawStructure()
+    await expect(drawStructure.section).toBeVisible()
+    await expect(drawStructure.heading).toHaveText(
+      'Set what matters. We’ll work out the rest.',
+    )
+
+    // ----- the field the whole tab is derived against ------------------------
+    // The cap, as a number and in words. Everything below is a consequence of it, so a
+    // wrong field here would make every later assertion a report of the same one fault.
+    await expect(drawStructure.fieldSize).toHaveText(String(FIELD_CAP))
+    await expect(drawStructure.previewBasis).toHaveText(PREVIEW_BASIS)
+
+    // ----- the equation: the whole draw in one line --------------------------
+    await expect(drawStructure.previewEquation).toHaveText(EQUATION)
+
+    // ----- four pools of eight, two out of each ------------------------------
+    await expect(drawStructure.previewPoolCards).toHaveCount(POOL_COUNT)
+    for (const letter of ['A', 'B', 'C', 'D']) {
+      const card = drawStructure.previewPoolCard(letter)
+      // One fact per assertion: `textContent` puts no space between block elements, so
+      // the card reads `Pool A8playerstop 2 advance` as one string and a whole-card
+      // `toHaveText` would be pinning that concatenation instead of the copy.
+      await expect(card).toContainText(`${POOL_SIZE}`)
+      await expect(card).toContainText('players')
+      await expect(card).toContainText(`top ${QUALIFIERS_ADVANCING} advance`)
+      // The negative half: a pool that cannot be played says so in words, and none of
+      // these can be — eight players supplying two qualifiers is comfortable.
+      await expect(card).not.toContainText('Too small')
+    }
+
+    // ----- …feeding a bracket that needs no byes -----------------------------
+    await expect(drawStructure.previewKnockout).toContainText(
+      `${BRACKET_SIZE}-player bracket`,
+    )
+    // Eight qualifiers into an eight-slot bracket. The `No …` wording is the state, not
+    // an absence of text: a bracket that took byes says `{n} first-round byes` here.
+    await expect(drawStructure.previewKnockout).toContainText('No first-round byes')
+    // `4 × C(8,2)`. The one number on this screen that no other surface states, and the
+    // reference's own worked example.
+    await expect(drawStructure.previewKnockout).toContainText(
+      `${POOL_MATCHES} pool matches`,
+    )
+
+    // ----- the verdict, which is the tab's one summary -----------------------
+    // Read together, because the heading and the badge are one decision: a `Sound` badge
+    // over `This draw can’t work yet` would be worse than either alone.
+    await expect(drawStructure.previewVerdict).toHaveText('Ready to save')
+    await expect(drawStructure.previewBadge).toHaveText('Sound')
+
+    // ----- and the Pool count row says where its number came from ------------
+    // The row a director looks at to learn that nobody chose this: the value, the badge
+    // that says the system owns it, and the sentence naming the pool rows it was read
+    // off. Addressed by the setting's name, which is the row's accessible name.
+    await expect(drawStructure.settingValue('Pool count')).toHaveText(
+      String(POOL_COUNT),
+    )
+    await expect(drawStructure.settingUnit('Pool count')).toHaveText('pools')
+    await expect(drawStructure.settingOwnership('Pool count')).toHaveText('Automatic')
+    await expect(drawStructure.settingSource('Pool count')).toHaveText(
+      POOL_COUNT_SOURCE,
+    )
+    // The pools are even, so the size row reads one number and not a `{min}–{max}` range
+    // — the fact that keeps the equation above from being an average.
+    await expect(drawStructure.settingValue('Pool size')).toHaveText(String(POOL_SIZE))
+    await expect(drawStructure.settingUnit('Pool size')).toHaveText('players per pool')
+
+    // ----- the control: a plain round-robin is offered NO such tab -----------
+    // Reloaded rather than closing the sheet: the editor is a modal, so its overlay
+    // covers the second event's card until it is gone, and a fresh page is the shortest
+    // way to be sure of that.
+    await detail.reload(tournamentId)
+    const plainEditor = await detail.openEvent(ROUND_ROBIN_EVENT)
+    // FIRST that the sheet is open at all. Without this, a click that missed would leave
+    // a page with no tabs on it, and "no Draw structure tab" would pass for free.
+    await expect(plainEditor.tab('Basics')).toBeVisible()
+    await expect(plainEditor.tab('Table pools')).toBeVisible()
+    await expect(plainEditor.tab('Draw structure')).toHaveCount(0)
+    // …and no panel left behind either: the trigger and its content are rendered
+    // together, so a tab that vanished while its content stayed would be a blank fifth
+    // section a director could still be sent to.
+    await expect(plainEditor.drawStructure.section).toHaveCount(0)
+  })
+})

--- a/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
+++ b/web-client/e2e/page-objects/tournaments/tournament-detail.page.ts
@@ -464,8 +464,17 @@ export class TournamentDetailPage {
     return this.page.getByRole('button', { name: /Create event|Save changes/ })
   }
 
-  /** One of the editor's four section tabs. */
-  editorTab(name: 'Basics' | 'Eligibility' | 'Match settings' | 'Table pools'): Locator {
+  /** One of the editor's section tabs. `Draw structure` is the **conditional** one: it
+   * exists only while the event's draw type is `rr-then-ko` (ADR 20260808), so a spec
+   * that reaches for it on any other format is asking for a tab that is not there. */
+  editorTab(
+    name:
+      | 'Basics'
+      | 'Eligibility'
+      | 'Match settings'
+      | 'Table pools'
+      | 'Draw structure',
+  ): Locator {
     return this.page.getByRole('tab', { name })
   }
 

--- a/web-client/src/components/tournaments/data/draw-structure.test.ts
+++ b/web-client/src/components/tournaments/data/draw-structure.test.ts
@@ -1,0 +1,787 @@
+// **The vector table IS the contract** (ADR
+// 20260808-draw-structure-derivation-runs-on-both-sides-and-shares-its-vectors). The same
+// cases are asserted against the Python derivation that guards the API, with identical
+// inputs and identical expected numbers, so a change to the maths that lands on one side
+// and not the other fails a test.
+//
+// Three rules keep it transcribable:
+//
+// 1. **Every vector states all eight inputs.** No defaults builder, no shared base object.
+//    A hidden `poolCountMode: 'automatic'` is a guess the Python author would have to
+//    make, and DRY is worth less here than being readable as a spec.
+// 2. **Every vector states the whole result**, including all three source sentences. One
+//    `toEqual` per vector. That is what pins the copy — a sentence asserted nowhere is a
+//    sentence free to drift.
+// 3. **One loop, no per-case `it` blocks with inline numbers.** A reviewer reads the two
+//    tables side by side; they cannot do that if the cases are scattered through
+//    assertions.
+//
+// ## What crosses the language boundary, and what does not
+//
+// The ADR shares the **numbers**, not the **copy**: the API keeps its own `DegenerateDraw`
+// strings (`api/app/draws.py`), and it has no setting rows to write a source sentence
+// under. So the Python table asserts a subset of each `expected`, and the split is not
+// something a reader should have to infer:
+//
+// - **Shared, and must match exactly:** `poolCount`, `poolSizes`, `qualifiersPerPool`,
+//   `totalQualifiers`, `knockoutBracketSize`, `firstRoundByes`, `poolMatchCount`, the
+//   numbers on `disagreement`, and the `kind` of each entry in `impossibleProblems`.
+//   Those are the derivation, and a difference in any of them is drift.
+// - **Client-only, and deliberately not ported:** `sources` in full (there are no rows on
+//   the server), `unevenDistribution` (a notice, not a refusal — the API does not object
+//   to unequal pools), and the `title` / `body` on each impossible problem.
+//
+// The `input` side crosses whole: all eight numbers, unchanged.
+
+import {
+  deriveDrawStructure,
+  poolLetter,
+  type DrawStructure,
+  type DrawStructureOptions,
+} from './draw-structure'
+
+interface DrawStructureVector {
+  /** What the case is about, in the domain's words. */
+  name: string
+  input: DrawStructureOptions
+  expected: DrawStructure
+}
+
+/** The shared contract. Mirrored in the Python derivation's own table. */
+export const DRAW_STRUCTURE_VECTORS: DrawStructureVector[] = [
+  // ---------------------------------------------------------------------------------
+  // The reference's own five states, plus the ones it does not draw.
+  // ---------------------------------------------------------------------------------
+
+  {
+    // The reference's "Nothing set" screen. One pool per reservation row — today's
+    // behaviour, kept as the automatic answer.
+    name: 'nothing set: 32 players across 4 pool reservations',
+    input: {
+      previewFieldSize: 32,
+      poolReservationCount: 4,
+      poolCountMode: 'automatic',
+      manualPoolCount: null,
+      poolSizeMode: 'automatic',
+      manualPoolSize: null,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 4,
+      poolSizes: [8, 8, 8, 8],
+      qualifiersPerPool: 2,
+      totalQualifiers: 8,
+      knockoutBracketSize: 8,
+      firstRoundByes: 0,
+      poolMatchCount: 112,
+      sources: {
+        poolCount: {
+          ownership: 'automatic',
+          sentence: "4 pool reservations · today's behaviour",
+        },
+        poolSize: { ownership: 'automatic', sentence: '32 players ÷ 4 pools' },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 4 pools.',
+        },
+      },
+      disagreement: null,
+      unevenDistribution: null,
+      impossibleProblems: [],
+    },
+  },
+
+  {
+    // Pool count is the director's, pool size is ours: the balanced split, remainder to
+    // the EARLIEST pools.
+    name: 'manual pool count only: 40 players across 6 pools',
+    input: {
+      previewFieldSize: 40,
+      poolReservationCount: 4,
+      poolCountMode: 'manual',
+      manualPoolCount: 6,
+      poolSizeMode: 'automatic',
+      manualPoolSize: null,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 6,
+      poolSizes: [7, 7, 7, 7, 6, 6],
+      qualifiersPerPool: 2,
+      totalQualifiers: 12,
+      knockoutBracketSize: 12,
+      firstRoundByes: 4,
+      poolMatchCount: 114,
+      sources: {
+        poolCount: {
+          ownership: 'manual',
+          sentence: 'You set this. Each pool also gets a reservation.',
+        },
+        poolSize: { ownership: 'automatic', sentence: '40 players ÷ 6 pools' },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 6 pools.',
+        },
+      },
+      disagreement: null,
+      unevenDistribution: [
+        { pools: 4, size: 7 },
+        { pools: 2, size: 6 },
+      ],
+      impossibleProblems: [],
+    },
+  },
+
+  {
+    // The other way round: the director's target size derives the count, and 40 divides
+    // exactly, so nothing is left over.
+    name: 'manual pool size only: 40 players in pools of 5',
+    input: {
+      previewFieldSize: 40,
+      poolReservationCount: 4,
+      poolCountMode: 'automatic',
+      manualPoolCount: null,
+      poolSizeMode: 'manual',
+      manualPoolSize: 5,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 8,
+      poolSizes: [5, 5, 5, 5, 5, 5, 5, 5],
+      qualifiersPerPool: 1,
+      totalQualifiers: 8,
+      knockoutBracketSize: 8,
+      firstRoundByes: 0,
+      poolMatchCount: 80,
+      sources: {
+        poolCount: { ownership: 'automatic', sentence: '40 players ÷ about 5 per pool' },
+        poolSize: {
+          ownership: 'manual',
+          sentence: 'You set the target. We derived the pool count.',
+        },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 8 pools.',
+        },
+      },
+      disagreement: null,
+      unevenDistribution: null,
+      impossibleProblems: [],
+    },
+  },
+
+  {
+    // The reference's "Numbers disagree" screen. BOTH numbers stand — the sizes stay at
+    // the six fives the director asked for, and the ten players with nowhere to go are
+    // reported rather than seated by moving somebody's number.
+    name: 'both manual and disagreeing: 6 pools of 5 seat 30 of a 40 field',
+    input: {
+      previewFieldSize: 40,
+      poolReservationCount: 6,
+      poolCountMode: 'manual',
+      manualPoolCount: 6,
+      poolSizeMode: 'manual',
+      manualPoolSize: 5,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 6,
+      poolSizes: [5, 5, 5, 5, 5, 5],
+      qualifiersPerPool: 2,
+      totalQualifiers: 12,
+      knockoutBracketSize: 12,
+      firstRoundByes: 4,
+      poolMatchCount: 60,
+      sources: {
+        poolCount: {
+          ownership: 'manual',
+          sentence: 'You set this. Each pool also gets a reservation.',
+        },
+        poolSize: { ownership: 'manual', sentence: 'You set this.' },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 6 pools.',
+        },
+      },
+      disagreement: {
+        poolCount: 6,
+        poolSize: 5,
+        seats: 30,
+        fieldSize: 40,
+        direction: 'unseated',
+        count: 10,
+      },
+      unevenDistribution: null,
+      // A disagreement is a call for the director, NOT an impossible competition. Every
+      // pool here is playable.
+      impossibleProblems: [],
+    },
+  },
+
+  {
+    // The disagreement running the other way: more seats than players.
+    name: 'both manual, seats to spare: 8 pools of 5 seat 40 of a 30 field',
+    input: {
+      previewFieldSize: 30,
+      poolReservationCount: 8,
+      poolCountMode: 'manual',
+      manualPoolCount: 8,
+      poolSizeMode: 'manual',
+      manualPoolSize: 5,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 8,
+      poolSizes: [5, 5, 5, 5, 5, 5, 5, 5],
+      qualifiersPerPool: 1,
+      totalQualifiers: 8,
+      knockoutBracketSize: 8,
+      firstRoundByes: 0,
+      poolMatchCount: 80,
+      sources: {
+        poolCount: {
+          ownership: 'manual',
+          sentence: 'You set this. Each pool also gets a reservation.',
+        },
+        poolSize: { ownership: 'manual', sentence: 'You set this.' },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 8 pools.',
+        },
+      },
+      disagreement: {
+        poolCount: 8,
+        poolSize: 5,
+        seats: 40,
+        fieldSize: 30,
+        direction: 'empty-seats',
+        count: 10,
+      },
+      unevenDistribution: null,
+      impossibleProblems: [],
+    },
+  },
+
+  {
+    // The reference's "Uneven field" screen. Legal, and said out loud — the bigger pools
+    // play more matches, and nothing has been silently reshaped.
+    name: 'uneven but legal: 22 players across 4 pools',
+    input: {
+      previewFieldSize: 22,
+      poolReservationCount: 4,
+      poolCountMode: 'automatic',
+      manualPoolCount: null,
+      poolSizeMode: 'automatic',
+      manualPoolSize: null,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 4,
+      poolSizes: [6, 6, 5, 5],
+      qualifiersPerPool: 2,
+      totalQualifiers: 8,
+      knockoutBracketSize: 8,
+      firstRoundByes: 0,
+      poolMatchCount: 50,
+      sources: {
+        poolCount: {
+          ownership: 'automatic',
+          sentence: "4 pool reservations · today's behaviour",
+        },
+        poolSize: { ownership: 'automatic', sentence: '22 players ÷ 4 pools' },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 4 pools.',
+        },
+      },
+      disagreement: null,
+      unevenDistribution: [
+        { pools: 2, size: 6 },
+        { pools: 2, size: 5 },
+      ],
+      impossibleProblems: [],
+    },
+  },
+
+  // ---------------------------------------------------------------------------------
+  // The three impossible competitions.
+  // ---------------------------------------------------------------------------------
+
+  {
+    // The reference's "Field too small" screen — and the ORDERING case. Four pools of one
+    // means the pool rule fires, and the automatic two qualifiers out of a pool of one
+    // means the qualifier rule would fire too. Only the pool problem is reported: it is
+    // the one the director can act on, and the other is its echo.
+    name: 'field too small: 8 players across 6 pools reports the pool, not the qualifier',
+    input: {
+      previewFieldSize: 8,
+      poolReservationCount: 6,
+      poolCountMode: 'manual',
+      manualPoolCount: 6,
+      poolSizeMode: 'automatic',
+      manualPoolSize: null,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 6,
+      poolSizes: [2, 2, 1, 1, 1, 1],
+      qualifiersPerPool: 2,
+      totalQualifiers: 12,
+      knockoutBracketSize: 12,
+      firstRoundByes: 4,
+      poolMatchCount: 2,
+      sources: {
+        poolCount: {
+          ownership: 'manual',
+          sentence: 'You set this. Each pool also gets a reservation.',
+        },
+        poolSize: { ownership: 'automatic', sentence: '8 players ÷ 6 pools' },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 6 pools.',
+        },
+      },
+      disagreement: null,
+      unevenDistribution: [
+        { pools: 2, size: 2 },
+        { pools: 4, size: 1 },
+      ],
+      // Pool C, because C is the FIRST pool under two — not the last, and not "four pools".
+      impossibleProblems: [
+        {
+          kind: 'pool',
+          title: 'Pool C would have one player',
+          body: 'They would have nobody to play. Use fewer pools or raise the player limit.',
+        },
+      ],
+    },
+  },
+
+  {
+    // One pool taking one qualifier. The pools are fine, so the BRACKET rule is the one
+    // that fires — and this is the only vector that catches a missing `max(2, …)` in the
+    // byes formula: `2 ^ ceil(log2(max(2, 1))) - 1` is one bye, not none.
+    name: 'one-player knockout: 1 pool taking its top 1',
+    input: {
+      previewFieldSize: 8,
+      poolReservationCount: 1,
+      poolCountMode: 'manual',
+      manualPoolCount: 1,
+      poolSizeMode: 'automatic',
+      manualPoolSize: null,
+      qualifiersMode: 'manual',
+      manualQualifiers: 1,
+    },
+    expected: {
+      poolCount: 1,
+      poolSizes: [8],
+      qualifiersPerPool: 1,
+      totalQualifiers: 1,
+      knockoutBracketSize: 1,
+      firstRoundByes: 1,
+      poolMatchCount: 28,
+      sources: {
+        poolCount: {
+          ownership: 'manual',
+          sentence: 'You set this. Each pool also gets a reservation.',
+        },
+        poolSize: { ownership: 'automatic', sentence: '8 players ÷ 1 pools' },
+        qualifiers: { ownership: 'manual', sentence: 'You set this.' },
+      },
+      disagreement: null,
+      unevenDistribution: null,
+      impossibleProblems: [
+        {
+          kind: 'bracket',
+          title: 'The knockout would have one player',
+          body: 'One player has nobody to play. Take more qualifiers or run more pools.',
+        },
+      ],
+    },
+  },
+
+  {
+    // Three through from a pool that only holds two.
+    name: 'too many qualifiers: top 3 from a pool of 2',
+    input: {
+      previewFieldSize: 10,
+      poolReservationCount: 4,
+      poolCountMode: 'manual',
+      manualPoolCount: 4,
+      poolSizeMode: 'automatic',
+      manualPoolSize: null,
+      qualifiersMode: 'manual',
+      manualQualifiers: 3,
+    },
+    expected: {
+      poolCount: 4,
+      poolSizes: [3, 3, 2, 2],
+      qualifiersPerPool: 3,
+      totalQualifiers: 12,
+      knockoutBracketSize: 12,
+      firstRoundByes: 4,
+      poolMatchCount: 8,
+      sources: {
+        poolCount: {
+          ownership: 'manual',
+          sentence: 'You set this. Each pool also gets a reservation.',
+        },
+        poolSize: { ownership: 'automatic', sentence: '10 players ÷ 4 pools' },
+        qualifiers: { ownership: 'manual', sentence: 'You set this.' },
+      },
+      disagreement: null,
+      unevenDistribution: [
+        { pools: 2, size: 3 },
+        { pools: 2, size: 2 },
+      ],
+      impossibleProblems: [
+        {
+          kind: 'qualifier',
+          title: "You can't take 3 qualifiers from a pool of 2",
+          body: 'Take 2 or fewer, or make the smallest pool bigger.',
+        },
+      ],
+    },
+  },
+
+  {
+    // The SECOND ordering case, and the complete set with the one above: a field of one
+    // trips the pool rule and the bracket rule at once, and the pool wins. (There is no
+    // reachable bracket-over-qualifier case: `bracket < 2` forces one pool taking one,
+    // and one qualifier can only exceed a pool of zero, which trips the pool rule first.)
+    name: 'ordering: a field of one is a pool problem, not a bracket problem',
+    input: {
+      previewFieldSize: 1,
+      poolReservationCount: 1,
+      poolCountMode: 'manual',
+      manualPoolCount: 1,
+      poolSizeMode: 'automatic',
+      manualPoolSize: null,
+      qualifiersMode: 'manual',
+      manualQualifiers: 1,
+    },
+    expected: {
+      poolCount: 1,
+      poolSizes: [1],
+      qualifiersPerPool: 1,
+      totalQualifiers: 1,
+      knockoutBracketSize: 1,
+      firstRoundByes: 1,
+      poolMatchCount: 0,
+      sources: {
+        poolCount: {
+          ownership: 'manual',
+          sentence: 'You set this. Each pool also gets a reservation.',
+        },
+        poolSize: { ownership: 'automatic', sentence: '1 players ÷ 1 pools' },
+        qualifiers: { ownership: 'manual', sentence: 'You set this.' },
+      },
+      disagreement: null,
+      unevenDistribution: null,
+      impossibleProblems: [
+        {
+          kind: 'pool',
+          title: 'Pool A would have one player',
+          body: 'They would have nobody to play. Use fewer pools or raise the player limit.',
+        },
+      ],
+    },
+  },
+
+  {
+    // THE GREEDY EDGE. Nine pools, the ninth holding the one player 41 does not divide
+    // into eight fives. A balanced split would give `5,5,5,5,5,5,5,4,4` and hide the
+    // problem by editing a number the director typed — so the fill stays greedy and the
+    // pool of one is reported.
+    name: 'greedy fill: 41 players in pools of 5 leaves a pool of one',
+    input: {
+      previewFieldSize: 41,
+      poolReservationCount: 4,
+      poolCountMode: 'automatic',
+      manualPoolCount: null,
+      poolSizeMode: 'manual',
+      manualPoolSize: 5,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 9,
+      poolSizes: [5, 5, 5, 5, 5, 5, 5, 5, 1],
+      qualifiersPerPool: 1,
+      totalQualifiers: 9,
+      knockoutBracketSize: 9,
+      firstRoundByes: 7,
+      poolMatchCount: 80,
+      sources: {
+        poolCount: { ownership: 'automatic', sentence: '41 players ÷ about 5 per pool' },
+        poolSize: {
+          ownership: 'manual',
+          sentence: 'You set the target. We derived the pool count.',
+        },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 9 pools.',
+        },
+      },
+      disagreement: null,
+      unevenDistribution: [
+        { pools: 8, size: 5 },
+        { pools: 1, size: 1 },
+      ],
+      // The ninth pool, so Pool I — past the single-letter cases the earlier vectors pin.
+      impossibleProblems: [
+        {
+          kind: 'pool',
+          title: 'Pool I would have one player',
+          body: 'They would have nobody to play. Use fewer pools or raise the player limit.',
+        },
+      ],
+    },
+  },
+
+  // ---------------------------------------------------------------------------------
+  // The edges the reference does not draw.
+  // ---------------------------------------------------------------------------------
+
+  {
+    // An event with NO cap previews against 16 players. The derivation just takes the
+    // number — the honest "16 players because this event has no cap" basis label is the
+    // renderer's job — and the pool-size sentence is where the 16 shows up.
+    name: 'no cap: the uncapped preview field of 16 players',
+    input: {
+      previewFieldSize: 16,
+      poolReservationCount: 4,
+      poolCountMode: 'automatic',
+      manualPoolCount: null,
+      poolSizeMode: 'automatic',
+      manualPoolSize: null,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 4,
+      poolSizes: [4, 4, 4, 4],
+      qualifiersPerPool: 2,
+      totalQualifiers: 8,
+      knockoutBracketSize: 8,
+      firstRoundByes: 0,
+      poolMatchCount: 24,
+      sources: {
+        poolCount: {
+          ownership: 'automatic',
+          sentence: "4 pool reservations · today's behaviour",
+        },
+        poolSize: { ownership: 'automatic', sentence: '16 players ÷ 4 pools' },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 4 pools.',
+        },
+      },
+      disagreement: null,
+      unevenDistribution: null,
+      impossibleProblems: [],
+    },
+  },
+
+  {
+    // An event with no pool rows yet. The count clamps to one, and the sentence reports
+    // the number the derivation USED — `1 pool reservations`, unpluralised, because the
+    // sentence explains the division that happened and the reference does not pluralise.
+    name: 'no pool reservations yet: the count clamps to one and the sentence says so',
+    input: {
+      previewFieldSize: 16,
+      poolReservationCount: 0,
+      poolCountMode: 'automatic',
+      manualPoolCount: null,
+      poolSizeMode: 'automatic',
+      manualPoolSize: null,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 1,
+      poolSizes: [16],
+      qualifiersPerPool: 8,
+      totalQualifiers: 8,
+      knockoutBracketSize: 8,
+      firstRoundByes: 0,
+      poolMatchCount: 120,
+      sources: {
+        poolCount: {
+          ownership: 'automatic',
+          sentence: "1 pool reservations · today's behaviour",
+        },
+        poolSize: { ownership: 'automatic', sentence: '16 players ÷ 1 pools' },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 1 pools.',
+        },
+      },
+      disagreement: null,
+      unevenDistribution: null,
+      impossibleProblems: [],
+    },
+  },
+
+  {
+    // A director typing a zero into the pool-size box. It clamps to one, and — the same
+    // rule as the reservation sentence above — the copy reports the clamped value, not
+    // the zero, because that is the division that was actually done.
+    name: 'a manual pool size of zero clamps to one, in the maths and in the copy',
+    input: {
+      previewFieldSize: 3,
+      poolReservationCount: 4,
+      poolCountMode: 'automatic',
+      manualPoolCount: null,
+      poolSizeMode: 'manual',
+      manualPoolSize: 0,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 3,
+      poolSizes: [1, 1, 1],
+      qualifiersPerPool: 3,
+      totalQualifiers: 9,
+      knockoutBracketSize: 9,
+      firstRoundByes: 7,
+      poolMatchCount: 0,
+      sources: {
+        poolCount: { ownership: 'automatic', sentence: '3 players ÷ about 1 per pool' },
+        poolSize: {
+          ownership: 'manual',
+          sentence: 'You set the target. We derived the pool count.',
+        },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 3 pools.',
+        },
+      },
+      disagreement: null,
+      unevenDistribution: null,
+      impossibleProblems: [
+        {
+          kind: 'pool',
+          title: 'Pool A would have one player',
+          body: 'They would have nobody to play. Use fewer pools or raise the player limit.',
+        },
+      ],
+    },
+  },
+
+  {
+    // A field of nobody — the state a brand-new event with a zero cap would preview. The
+    // pool refusal has a second sentence for it: `no players`, not `one player`.
+    name: 'an empty field: the pools have no players at all',
+    input: {
+      previewFieldSize: 0,
+      poolReservationCount: 3,
+      poolCountMode: 'automatic',
+      manualPoolCount: null,
+      poolSizeMode: 'automatic',
+      manualPoolSize: null,
+      qualifiersMode: 'automatic',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 3,
+      poolSizes: [0, 0, 0],
+      qualifiersPerPool: 3,
+      totalQualifiers: 9,
+      knockoutBracketSize: 9,
+      firstRoundByes: 7,
+      poolMatchCount: 0,
+      sources: {
+        poolCount: {
+          ownership: 'automatic',
+          sentence: "3 pool reservations · today's behaviour",
+        },
+        poolSize: { ownership: 'automatic', sentence: '0 players ÷ 3 pools' },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 3 pools.',
+        },
+      },
+      disagreement: null,
+      unevenDistribution: null,
+      impossibleProblems: [
+        {
+          kind: 'pool',
+          title: 'Pool A would have no players',
+          body: 'They would have nobody to play. Use fewer pools or raise the player limit.',
+        },
+      ],
+    },
+  },
+
+  {
+    // A director who clears every input. The mode still says `manual`, but there is no
+    // number, so nothing has been set: the derivation falls back to automatic AND reports
+    // the ownership as automatic, so the `Yours` badge can never sit above a sentence
+    // saying we worked the number out. Byte-identical to the "nothing set" vector.
+    name: 'a manual mode with no number is automatic, badge and all',
+    input: {
+      previewFieldSize: 32,
+      poolReservationCount: 4,
+      poolCountMode: 'manual',
+      manualPoolCount: null,
+      poolSizeMode: 'manual',
+      manualPoolSize: null,
+      qualifiersMode: 'manual',
+      manualQualifiers: null,
+    },
+    expected: {
+      poolCount: 4,
+      poolSizes: [8, 8, 8, 8],
+      qualifiersPerPool: 2,
+      totalQualifiers: 8,
+      knockoutBracketSize: 8,
+      firstRoundByes: 0,
+      poolMatchCount: 112,
+      sources: {
+        poolCount: {
+          ownership: 'automatic',
+          sentence: "4 pool reservations · today's behaviour",
+        },
+        poolSize: { ownership: 'automatic', sentence: '32 players ÷ 4 pools' },
+        qualifiers: {
+          ownership: 'automatic',
+          sentence: 'Aiming at an 8-player knockout across 4 pools.',
+        },
+      },
+      disagreement: null,
+      unevenDistribution: null,
+      impossibleProblems: [],
+    },
+  },
+]
+
+describe('deriveDrawStructure', () => {
+  it.each(DRAW_STRUCTURE_VECTORS)('$name', ({ input, expected }) => {
+    expect(deriveDrawStructure(input)).toEqual(expected)
+  })
+})
+
+describe('poolLetter', () => {
+  // The naming the pool refusal and the preview cards both read off. Past Z it keeps
+  // naming pools instead of printing punctuation — `String.fromCharCode(65 + 26)` is `[`.
+  it('names pools A onwards, and keeps going past Z', () => {
+    expect([0, 2, 8, 25, 26, 27, 51, 52].map(poolLetter)).toEqual([
+      'A',
+      'C',
+      'I',
+      'Z',
+      'AA',
+      'AB',
+      'AZ',
+      'BA',
+    ])
+  })
+})

--- a/web-client/src/components/tournaments/data/draw-structure.ts
+++ b/web-client/src/components/tournaments/data/draw-structure.ts
@@ -1,0 +1,386 @@
+// The whole **round-robin-then-knockout draw structure**, derived from the eight numbers
+// a director can set (#1320). Pool count, pool sizes, qualifiers, the bracket, the byes,
+// the pool-match total, the source sentence under each row, and the three notices —
+// disagreement, uneven, impossible.
+//
+// **This module renders nothing and fetches nothing.** It is a pure function, and that is
+// load-bearing rather than tidy: the tab recomputes on every keystroke, so the number a
+// director reads must never lag the input that produced it (ADR
+// 20260808-draw-structure-derivation-runs-on-both-sides-and-shares-its-vectors).
+//
+// **The same arithmetic also runs in Python, and neither side is generated from the
+// other.** The API owns the refusals, because a rule enforced only in React is not
+// enforced — `ios/` and the MCP server write events too. What ties the two copies together
+// is one table of vectors, asserted on both sides with identical inputs and identical
+// expected numbers (`./draw-structure.test.ts`). A reviewer should read the two tables
+// side by side before reading either implementation. **Anything added here that the
+// vectors do not pin is drift waiting to happen**, which is why the result carries only
+// the fields the tab actually reads.
+//
+// The spec is `docs/designs/rr-then-ko-draw-structure/README.md` — its "The derivation"
+// section for the maths, its "Row copy" and "Impossible" sections for the strings. The
+// strings are **verbatim**, including the `÷` and `·` glyphs and including
+// `1 pool reservations`: this module does not pluralise copy the reference does not
+// pluralise, because a silent improvement here reds the Python vectors later and the diff
+// looks like a Python bug.
+
+/** The knockout the automatic qualifier count aims at. **A constant, not stored state**
+ * (ADR 20260808-a-structural-setting-is-owned-by-the-director-or-derived-by-the-system):
+ * nothing in the reference writes it, so no UI exposes it. A director who wants a
+ * different bracket sets the qualifiers themselves, which is a setting they own. */
+export const TARGET_BRACKET_SIZE = 8
+
+/** Who a structural setting belongs to: the system derived it, or the director typed it.
+ * The row's `Automatic` / `Yours` badge is this, and nothing else. */
+export type SettingOwnership = 'automatic' | 'manual'
+
+/** One setting row's provenance: who owns the number, and the one line under it saying
+ * where the number came from. The sentence is derived here rather than in the row, so the
+ * copy cannot fork across three components that each know a little of the derivation. */
+export interface SettingSource {
+  ownership: SettingOwnership
+  sentence: string
+}
+
+/** The provenance of all three numeric settings. Membership is not here: it has no
+ * number, so it is not derived — the row reads its mode straight off the event. */
+export interface DrawStructureSources {
+  poolCount: SettingSource
+  poolSize: SettingSource
+  qualifiers: SettingSource
+}
+
+/** A run of same-sized pools, for the uneven notice's tally (`2 pools of 6 · 2 pools of
+ * 5`). Largest size first. */
+export interface PoolSizeTally {
+  /** How many pools hold this many players. */
+  pools: number
+  /** How many players those pools hold. */
+  size: number
+}
+
+/**
+ * The director's two manual numbers do not multiply out to their field.
+ *
+ * **This is not an error and it is not corrected.** Both numbers were typed on purpose, so
+ * the app states the arithmetic and offers fixes rather than quietly reshaping one of them
+ * — hence `direction` and `count` instead of a signed difference nobody would read aloud.
+ *
+ * Only the numbers live here. The panel's title, body and three fixes are the renderer's,
+ * because the fixes are buttons and a button is not a derivation.
+ */
+export interface DrawStructureDisagreement {
+  /** The manual pool count, as the derivation used it. */
+  poolCount: number
+  /** The manual pool size, as the derivation used it. */
+  poolSize: number
+  /** `poolCount * poolSize` — the seats the structure actually has. */
+  seats: number
+  /** The field the preview is derived against. */
+  fieldSize: number
+  /** Which way the shortfall runs: more players than seats, or more seats than players. */
+  direction: 'unseated' | 'empty-seats'
+  /** How many entrants have nowhere to go, or how many seats would be empty. Always
+   * positive — the direction carries the sign. */
+  count: number
+}
+
+/** Which of the three impossible competitions a configuration produces. */
+export type ImpossibleProblemKind = 'pool' | 'bracket' | 'qualifier'
+
+/** A competition that cannot be played, in the words the panel shows. The API refuses the
+ * same three conditions in its own, longer copy (`api/app/draws.py`); this is the client's
+ * shorter version, because the panel also offers fixes and the API cannot. */
+export interface ImpossibleProblem {
+  kind: ImpossibleProblemKind
+  title: string
+  body: string
+}
+
+/** The eight inputs. Every one of them is stated at each call site and in every vector —
+ * there is no defaults builder, because the Python side transcribes this table by hand and
+ * a hidden default is a guess waiting to be made wrong. */
+export interface DrawStructureOptions {
+  /** The field the preview derives against: the event's cap, or the uncapped default. */
+  previewFieldSize: number
+  /** How many pool rows the event already has — today's behaviour for the pool count. */
+  poolReservationCount: number
+  poolCountMode: SettingOwnership
+  manualPoolCount: number | null
+  poolSizeMode: SettingOwnership
+  manualPoolSize: number | null
+  qualifiersMode: SettingOwnership
+  manualQualifiers: number | null
+}
+
+/** Everything the Draw structure tab renders, derived once. */
+export interface DrawStructure {
+  poolCount: number
+  /** One entry per pool, in pool order — **not** a single size, because the pools are
+   * routinely unequal and the uneven case is a first-class state, not an edge. */
+  poolSizes: number[]
+  qualifiersPerPool: number
+  /** `poolCount * qualifiersPerPool`: how many players come out of the pool stage. */
+  totalQualifiers: number
+  /** The knockout's entry list. The same number as `totalQualifiers` by construction —
+   * they are two different questions with one answer, and both are named because the tab
+   * asks both. */
+  knockoutBracketSize: number
+  firstRoundByes: number
+  /** Every all-play-all match the pool stage plays, across all pools. */
+  poolMatchCount: number
+  sources: DrawStructureSources
+  // ⚠️ The next three are reported **independently**, and more than one can be non-empty
+  // at once — a pool of one is routinely also an uneven split. The reference shows only
+  // ONE panel at a time (impossible, then disagreement, then uneven), and that precedence
+  // belongs to whatever renders them. It is not encoded here: a derivation that suppressed
+  // the uneven tally because a pool was impossible would be deciding a layout question.
+  /** `null` when the numbers agree, or when only one of them is the director's. */
+  disagreement: DrawStructureDisagreement | null
+  /** The size tally, largest first, or `null` when every pool is the same size. */
+  unevenDistribution: PoolSizeTally[] | null
+  /** **At most one problem**, and always the first in `pool` → `bracket` → `qualifier`
+   * order. One impossible competition is one thing to fix; listing the two further
+   * conditions that a pool of one also trips would bury it. */
+  impossibleProblems: ImpossibleProblem[]
+}
+
+/** `Pool A`, `Pool B`, … and past `Pool Z` the spreadsheet's `AA`, so a hundred-pool field
+ * names its pools instead of printing punctuation. */
+export function poolLetter(index: number): string {
+  let letters = ''
+  for (let n = index; n >= 0; n = Math.floor(n / 26) - 1) {
+    letters = String.fromCharCode(65 + (n % 26)) + letters
+  }
+  return letters
+}
+
+/** The README's `2 ^ ceil(log2(n))`, computed by doubling. Same answer, minus the chance
+ * that a float `log2` puts an exact power of two on the wrong side of a `ceil`. */
+function nextPowerOfTwo(n: number): number {
+  let size = 1
+  while (size < n) size *= 2
+  return size
+}
+
+/** The `max(1, …)` the README puts on every director-supplied number. A zero or a negative
+ * is not a smaller structure, it is no structure — and every sentence that reports the
+ * number reports **this** value, so the copy explains the division that actually happened.
+ */
+const atLeastOne = (value: number) => Math.max(1, value)
+
+/** The balanced split: `base = floor(field / count)`, and the remainder goes to the
+ * EARLIEST pools. 22 across 4 is `6, 6, 5, 5`. */
+function balancedSizes(fieldSize: number, poolCount: number): number[] {
+  const base = Math.floor(fieldSize / poolCount)
+  const extra = fieldSize % poolCount
+  return Array.from({ length: poolCount }, (_, i) => base + (i < extra ? 1 : 0))
+}
+
+/**
+ * The **greedy** fill, used when the director set the pool size but not the pool count:
+ * each pool takes the target in turn and the last pool takes what is left.
+ *
+ * ⚠️ **This is deliberately not a balanced split, and must not be "fixed" into one.** 41
+ * players in pools of 5 gives `5,5,5,5,5,5,5,5,1` — and that pool of one is then an
+ * impossible competition the director is told about. Rebalancing to `5,5,5,5,5,5,5,4,4`
+ * would silently reshape a number they typed, which is the exact behaviour #1320 exists to
+ * remove: the app states the consequence of the input, it does not edit the input.
+ */
+function greedySizes(fieldSize: number, poolCount: number, poolSize: number): number[] {
+  let remaining = fieldSize
+  return Array.from({ length: poolCount }, () => {
+    const take = Math.min(poolSize, remaining)
+    remaining -= take
+    return take
+  })
+}
+
+/** The size tally the uneven notice reads out, largest pool first. */
+function tallySizes(sizes: number[]): PoolSizeTally[] {
+  const counts = new Map<number, number>()
+  for (const size of sizes) counts.set(size, (counts.get(size) ?? 0) + 1)
+  return [...counts.entries()]
+    .sort(([a], [b]) => b - a)
+    .map(([size, pools]) => ({ pools, size }))
+}
+
+/**
+ * Derive the whole draw structure from the eight inputs.
+ *
+ * **A mode of `manual` with no number is automatic.** A director who clears the input has
+ * not set anything, and the row must go on showing a real number rather than a blank or a
+ * one. The reported ownership is therefore the *effective* one, so the `Yours` badge and
+ * the source sentence can never disagree with each other.
+ */
+export function deriveDrawStructure(options: DrawStructureOptions): DrawStructure {
+  const {
+    previewFieldSize: fieldSize,
+    poolReservationCount,
+    poolCountMode,
+    manualPoolCount,
+    poolSizeMode,
+    manualPoolSize,
+    qualifiersMode,
+    manualQualifiers,
+  } = options
+
+  const setCount = poolCountMode === 'manual' && manualPoolCount !== null
+  const setSize = poolSizeMode === 'manual' && manualPoolSize !== null
+  const setQualifiers = qualifiersMode === 'manual' && manualQualifiers !== null
+
+  const targetSize = setSize ? atLeastOne(manualPoolSize) : null
+
+  // Pool count: the director's, else derived from their pool size, else today's behaviour
+  // — one reservation row is one pool.
+  const poolCount = setCount
+    ? atLeastOne(manualPoolCount)
+    : targetSize !== null
+      ? atLeastOne(Math.ceil(fieldSize / targetSize))
+      : atLeastOne(poolReservationCount)
+
+  // Pool sizes. Both manual means both numbers stand, product be damned — that standoff is
+  // reported as a disagreement below, never resolved by moving one of them.
+  const poolSizes =
+    targetSize === null
+      ? balancedSizes(fieldSize, poolCount)
+      : setCount
+        ? Array.from({ length: poolCount }, () => targetSize)
+        : greedySizes(fieldSize, poolCount, targetSize)
+
+  const smallestPool = Math.min(...poolSizes)
+  const largestPool = Math.max(...poolSizes)
+
+  const qualifiersPerPool = setQualifiers
+    ? atLeastOne(manualQualifiers)
+    : atLeastOne(Math.ceil(TARGET_BRACKET_SIZE / poolCount))
+
+  const knockoutBracketSize = poolCount * qualifiersPerPool
+  // `max(2, …)` is what makes a one-player knockout report ONE bye rather than none: the
+  // smallest bracket that can be drawn holds two, so the missing player is a bye.
+  const firstRoundByes = nextPowerOfTwo(Math.max(2, knockoutBracketSize)) - knockoutBracketSize
+  const poolMatchCount = poolSizes.reduce((total, n) => total + (n * (n - 1)) / 2, 0)
+
+  const seats = poolCount * (targetSize ?? 0)
+  const conflict = setCount && setSize && seats !== fieldSize
+  const disagreement: DrawStructureDisagreement | null =
+    conflict && targetSize !== null
+      ? {
+          poolCount,
+          poolSize: targetSize,
+          seats,
+          fieldSize,
+          direction: fieldSize > seats ? 'unseated' : 'empty-seats',
+          count: Math.abs(fieldSize - seats),
+        }
+      : null
+
+  // The `not conflict` guard mirrors the README and the Python. No input can distinguish
+  // it: a disagreement needs both modes manual, and both manual gives every pool the same
+  // size, so `min === max` already. It stays because the two implementations must read the
+  // same, not because a vector reaches it.
+  const unevenDistribution =
+    !conflict && smallestPool !== largestPool ? tallySizes(poolSizes) : null
+
+  return {
+    poolCount,
+    poolSizes,
+    qualifiersPerPool,
+    totalQualifiers: knockoutBracketSize,
+    knockoutBracketSize,
+    firstRoundByes,
+    poolMatchCount,
+    sources: {
+      poolCount: {
+        ownership: setCount ? 'manual' : 'automatic',
+        sentence: setCount
+          ? 'You set this. Each pool also gets a reservation.'
+          : targetSize !== null
+            ? `${fieldSize} players ÷ about ${targetSize} per pool`
+            : `${poolCount} pool reservations · today's behaviour`,
+      },
+      poolSize: {
+        ownership: setSize ? 'manual' : 'automatic',
+        sentence: setSize
+          ? setCount
+            ? 'You set this.'
+            : 'You set the target. We derived the pool count.'
+          : `${fieldSize} players ÷ ${poolCount} pools`,
+      },
+      qualifiers: {
+        ownership: setQualifiers ? 'manual' : 'automatic',
+        sentence: setQualifiers
+          ? 'You set this.'
+          : `Aiming at an ${TARGET_BRACKET_SIZE}-player knockout across ${poolCount} pools.`,
+      },
+    },
+    disagreement,
+    unevenDistribution,
+    impossibleProblems: impossibleProblemsFor({
+      poolSizes,
+      smallestPool,
+      knockoutBracketSize,
+      qualifiersPerPool,
+    }),
+  }
+}
+
+/**
+ * The three impossible competitions, **tested in order, first hit only**.
+ *
+ * The order is not arbitrary. A pool of one trips the qualifier rule too, and a field of
+ * one trips all three — but "Pool C would have one player" is the fact the director can
+ * act on, and the other two are echoes of it. Reporting the echoes alongside it would make
+ * one mistake look like three.
+ */
+function impossibleProblemsFor({
+  poolSizes,
+  smallestPool,
+  knockoutBracketSize,
+  qualifiersPerPool,
+}: {
+  poolSizes: number[]
+  smallestPool: number
+  knockoutBracketSize: number
+  qualifiersPerPool: number
+}): ImpossibleProblem[] {
+  // 1. A pool nobody can play in. Named by the FIRST such pool, because that is the one a
+  //    director looking down the preview will see first.
+  const emptyIndex = poolSizes.findIndex((size) => size < 2)
+  if (emptyIndex !== -1) {
+    const size = poolSizes[emptyIndex]
+    return [
+      {
+        kind: 'pool',
+        title: `Pool ${poolLetter(emptyIndex)} would have ${size === 1 ? 'one player' : 'no players'}`,
+        body: 'They would have nobody to play. Use fewer pools or raise the player limit.',
+      },
+    ]
+  }
+
+  // 2. A knockout of one. Reachable only from one pool taking one qualifier, and the
+  //    winner of that pool would be handed a title without playing for it.
+  if (knockoutBracketSize < 2) {
+    return [
+      {
+        kind: 'bracket',
+        title: 'The knockout would have one player',
+        body: 'One player has nobody to play. Take more qualifiers or run more pools.',
+      },
+    ]
+  }
+
+  // 3. More qualifiers than the smallest pool holds — the pool would advance players it
+  //    does not have.
+  if (qualifiersPerPool > smallestPool) {
+    return [
+      {
+        kind: 'qualifier',
+        title: `You can't take ${qualifiersPerPool} qualifiers from a pool of ${smallestPool}`,
+        body: `Take ${smallestPool} or fewer, or make the smallest pool bigger.`,
+      },
+    ]
+  }
+
+  return []
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
@@ -4,11 +4,26 @@ import { render, screen, type Container } from '@/test/utilities'
 
 import { EventEditor, type EventEditorProps } from './event-editor'
 import { buildEventEditorProps } from './event-editor.factory'
+import { drawStructureSectionPage } from './event-editor/draw-structure-section.page'
 
 const scoped = (container: Container) => ({
   getSectionTab(label: string) {
     return container.getByRole('tab', { name: label })
   },
+  /** …and its `query` twin, for the claim that a tab is **not on the list at all** —
+   * the Draw structure tab exists only for `rr-then-ko` (ADR 20260808). */
+  querySectionTab(label: string) {
+    return container.queryByRole('tab', { name: label })
+  },
+  /** Every tab's label, in the order the list renders them. */
+  getSectionTabLabels(): string[] {
+    return container
+      .queryAllByRole('tab')
+      .map((tab: HTMLElement) => (tab.textContent ?? '').trim())
+  },
+  /** The Draw structure tab's panel, and the queries inside it. Reused from the
+   * section's own page object, scoped to the editor. */
+  drawStructure: drawStructureSectionPage.within(container),
   /** The sheet itself — present exactly while the editor is open. The claim
    * "a refused save does not close the editor" is a claim about this node. */
   querySheet() {

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -13,6 +13,7 @@ import {
   buildPool,
   buildPredicate,
   buildRrThenKoEvent,
+  buildSwissEvent,
   buildTournament,
 } from '../data/seed.factory'
 import { eventEditorPage } from './event-editor.page'
@@ -141,6 +142,120 @@ describe('EventEditor', () => {
       eventEditorPage.render({ event: buildRrThenKoEvent({ qualifiersPerPool: 3 }) })
 
       expect(eventEditorPage.getQualifiersInput()).toHaveValue(3)
+    })
+  })
+
+  /**
+   * **The Draw structure tab is conditional** (ADR 20260808, #1320). Only `rr-then-ko`
+   * has a pool stage feeding a knockout, so only `rr-then-ko` has a structure to set:
+   * for the other three formats the tab is *absent*, not empty and not disabled.
+   *
+   * The section's own tests pin what the tab says. These pin the three things only the
+   * editor can: that the tab is on the list, that it is off the list for every other
+   * draw type, and that switching format out from under a director standing on it does
+   * not leave them looking at a blank sheet.
+   */
+  describe('the Draw structure tab', () => {
+    it('is the fifth tab for a two-stage event', () => {
+      eventEditorPage.render({ event: buildRrThenKoEvent() })
+
+      expect(eventEditorPage.getSectionTabLabels()).toEqual([
+        'Basics',
+        'Eligibility',
+        'Match settings',
+        'Table pools',
+        'Draw structure',
+      ])
+    })
+
+    it.each([
+      ['round-robin', () => buildEvent({ drawType: 'round-robin' })],
+      ['single-elim', () => buildEvent({ drawType: 'single-elim', pools: [] })],
+      ['swiss', () => buildSwissEvent()],
+    ] as const)('is absent for %s', (_drawType, build) => {
+      eventEditorPage.render({ event: build() })
+
+      expect(eventEditorPage.querySectionTab('Draw structure')).toBeNull()
+      expect(eventEditorPage.getSectionTabLabels()).toHaveLength(4)
+    })
+
+    it('opens onto the four settings, derived from the draft', async () => {
+      eventEditorPage.render({
+        event: buildRrThenKoEvent({
+          maxPlayers: 32,
+          pools: [
+            buildPool({ id: 'p-a', name: 'Pool A', position: 0 }),
+            buildPool({ id: 'p-b', name: 'Pool B', position: 1 }),
+          ],
+        }),
+      })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+
+      // Wiring only: every value and sentence is pinned by the section's own tests.
+      expect(eventEditorPage.drawStructure.getSettingNames()).toEqual([
+        'Pool count',
+        'Pool size',
+        'Membership',
+        'Qualifiers per pool',
+      ])
+      expect(
+        eventEditorPage.drawStructure.setting('Pool size').getSource(),
+      ).toHaveTextContent('32 players ÷ 2 pools')
+    })
+
+    // The draft is what the tab is keyed on, so the picker reveals and hides it live —
+    // the same claim the qualifier-count row makes one tab over.
+    it('appears when the director picks the two-stage format', async () => {
+      eventEditorPage.render({ event: buildEvent({ drawType: 'round-robin' }) })
+      expect(eventEditorPage.querySectionTab('Draw structure')).toBeNull()
+
+      await eventEditorPage.chooseDrawType('Round-robin then knockout')
+
+      expect(
+        await screen.findByRole('tab', { name: 'Draw structure' }),
+      ).toBeInTheDocument()
+    })
+
+    /**
+     * …and goes again when they change their mind — the round trip, and the case that
+     * leaves a director looking at a blank sheet if the tab list and the panel ever
+     * disagree (Radix renders no panel for a `value` that matches no trigger).
+     *
+     * The picker lives on Basics, so a director necessarily walks back there to switch
+     * format: the assertion is that they are still standing on a real tab afterwards.
+     */
+    it('goes again when the director switches away, leaving them on a live tab', async () => {
+      eventEditorPage.render({ event: buildRrThenKoEvent() })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      await userEvent.click(eventEditorPage.getSectionTab('Basics'))
+      await eventEditorPage.chooseDrawType('Round robin')
+
+      await waitFor(() =>
+        expect(eventEditorPage.querySectionTab('Draw structure')).toBeNull(),
+      )
+      expect(eventEditorPage.getSectionTab('Basics')).toHaveAttribute(
+        'aria-selected',
+        'true',
+      )
+      expect(eventEditorPage.getNameInput()).toBeInTheDocument()
+    })
+
+    // The tab reaches back to the tab that owns the number it derives against.
+    it('takes the director to Basics from the preview-field block', async () => {
+      eventEditorPage.render({ event: buildRrThenKoEvent() })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      await userEvent.click(
+        eventEditorPage.drawStructure.getChangeInBasicsButton(),
+      )
+
+      expect(eventEditorPage.getSectionTab('Basics')).toHaveAttribute(
+        'aria-selected',
+        'true',
+      )
+      expect(eventEditorPage.getPlayerLimitInput()).toBeInTheDocument()
     })
   })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -31,6 +31,7 @@ import type {
   TournamentTable,
 } from '../data/types'
 import { BasicsSection } from './event-editor/basics-section'
+import { DrawStructureSection } from './event-editor/draw-structure-section'
 import { EligibilitySection } from './event-editor/eligibility-section'
 import { MatchSection } from './event-editor/match-section'
 import { PoolsSection } from './event-editor/pools-section'
@@ -86,12 +87,21 @@ export interface EventEditorProps {
   saving?: boolean
 }
 
+/** The four tabs every event has, whatever its format. */
 const SECTIONS = [
   { value: 'basics', label: 'Basics' },
   { value: 'eligibility', label: 'Eligibility' },
   { value: 'match', label: 'Match settings' },
   { value: 'pools', label: 'Table pools' },
 ]
+
+/** The fifth tab, and the only **conditional** one: a draw structure is the shape of a
+ * pool stage feeding a knockout, and only `rr-then-ko` has both (ADR 20260808 — "the
+ * Draw structure tab is conditional"). A round-robin has no bracket to aim at, a
+ * single-elimination has no pools to split, and swiss has neither, so for those three
+ * the tab is *absent* rather than empty: a tab that opened onto settings the format
+ * cannot hold would invite a director to configure a draw their event will never cut. */
+const DRAW_STRUCTURE_SECTION = { value: 'draw-structure', label: 'Draw structure' }
 
 /** The slide-in event editor — a side sheet with four sections (Basics,
  * Eligibility, Match settings, Table pools) over ONE React-Hook-Form draft. The form
@@ -280,6 +290,26 @@ export const EventEditor = ({
   const poolsFreeze = event ? poolSetFreeze(event) : OPEN
   const drawTypeLock = event ? drawTypeFreeze(event, drawTypes) : OPEN
 
+  // ⚠️ Keyed off the **draft's** draw type, not the saved event's. The Basics picker
+  // writes the draft, so the tab appears the moment a director picks the two-stage
+  // format and disappears the moment they pick something else — before anything is
+  // saved, which is when they are deciding.
+  const hasDrawStructure = draft?.drawType === 'rr-then-ko'
+  const sections = hasDrawStructure
+    ? [...SECTIONS, DRAW_STRUCTURE_SECTION]
+    : SECTIONS
+  // …and that disappearance is why the active tab is DERIVED rather than read straight
+  // out of state. A `Tabs` whose `value` matches no trigger renders no panel at all —
+  // a blank sheet with nothing selected. Today nothing reaches that: the draw-type
+  // picker is on Basics, so a director necessarily leaves this tab before they can
+  // remove it. It is three lines of insurance against the next thing that sets the
+  // section (chore 3e moves a field onto this tab, and a refused save jumps to the tab
+  // holding it). Adjusted at render, never in an effect — the render already knows
+  // (https://react.dev/learn/you-might-not-need-an-effect).
+  const activeSection = sections.some((s) => s.value === section)
+    ? section
+    : 'basics'
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
@@ -310,14 +340,28 @@ export const EventEditor = ({
             data-testid="event-editor-body"
             className="flex-1 overflow-y-auto px-6 py-5"
           >
-            <Tabs value={section} onValueChange={setSection}>
-              <TabsList className="mb-6 w-full">
-                {SECTIONS.map((s) => (
-                  <TabsTrigger key={s.value} value={s.value} className="flex-1">
-                    {s.label}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
+            <Tabs value={activeSection} onValueChange={setSection}>
+              {/* The scroll wrapper is the FIFTH tab's doing. Every trigger is
+                  `whitespace-nowrap`, so the list cannot shrink below its own min-content
+                  width — and "Basics · Eligibility · Match settings · Table pools · Draw
+                  structure" is wider than a 375px phone. Left to overflow it would widen
+                  the sheet's scroll container instead, which is the sideways-hiding bug
+                  this editor has already shipped twice (`expectNoHorizontalScroll`, the
+                  phone spec). Scrolling the LIST keeps every tab reachable and keeps the
+                  overflow out of the body. */}
+              <div className="mb-6 overflow-x-auto">
+                <TabsList className="w-full min-w-max">
+                  {sections.map((s) => (
+                    <TabsTrigger
+                      key={s.value}
+                      value={s.value}
+                      className="flex-1"
+                    >
+                      {s.label}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+              </div>
               <TabsContent value="basics">
                 <BasicsSection
                   event={draft}
@@ -351,6 +395,18 @@ export const EventEditor = ({
                   nameIssues={isSubmitted ? poolIssues : undefined}
                 />
               </TabsContent>
+              {/* Rendered only alongside its trigger, so the panel and the tab appear
+                  and vanish together — Radix keeps no content for a tab that is not on
+                  the list. Fed the DRAFT, so the structure recomputes as the director
+                  edits the player limit on Basics or adds a pool on Table pools. */}
+              {hasDrawStructure && (
+                <TabsContent value="draw-structure">
+                  <DrawStructureSection
+                    event={draft}
+                    onGoToBasics={() => setSection('basics')}
+                  />
+                </TabsContent>
+              )}
             </Tabs>
           </div>
         )}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.factory.tsx
@@ -1,0 +1,46 @@
+import { buildPool, buildRrThenKoEvent } from '../../data/seed.factory'
+import { poolLetter } from '../../data/draw-structure'
+import type { TournamentEvent } from '../../data/types'
+import type { DrawStructureSectionProps } from './draw-structure-section'
+
+/**
+ * The reference's **"Nothing set"** state
+ * (`docs/designs/rr-then-ko-draw-structure/nothing-set.png`): a two-stage event capped
+ * at **32 players** with **four** pool reservations, so the tab derives 4 pools of 8 and
+ * 2 qualifiers apiece, and every setting is the system's.
+ *
+ * ⚠️ **Both numbers are stated here rather than inherited**, because two of the four
+ * source sentences read them out — `32 players ÷ 4 pools` and
+ * `4 pool reservations · today's behaviour`. A cap or a pool count that moved under this
+ * factory would move the copy the tests pin, and the red would look like a copy bug.
+ *
+ * The split is deliberately **even** (32 ÷ 4 = 8), so the uneven case is something a
+ * test asks for rather than something it gets by accident.
+ */
+export function buildDrawStructureEvent(
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+): TournamentEvent {
+  return buildRrThenKoEvent({
+    maxPlayers: 32,
+    pools: Array.from({ length: 4 }, (_, i) =>
+      buildPool({
+        id: `p-${poolLetter(i).toLowerCase()}`,
+        name: `Pool ${poolLetter(i)}`,
+        position: i,
+      }),
+    ),
+    ...overrides,
+  })
+}
+
+/** Props for `DrawStructureSection` — the "Nothing set" event above, and a spy-able
+ * way back to Basics. */
+export function buildDrawStructureSectionProps(
+  overrides: Partial<DrawStructureSectionProps> = {},
+): DrawStructureSectionProps {
+  return {
+    event: buildDrawStructureEvent(),
+    onGoToBasics: () => {},
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.page.tsx
@@ -5,6 +5,7 @@ import {
   type DrawStructureSectionProps,
 } from './draw-structure-section'
 import { buildDrawStructureSectionProps } from './draw-structure-section.factory'
+import { drawIssuePanelPage } from './draw-structure-section/draw-issue-panel.page'
 import { drawPreviewPage } from './draw-structure-section/draw-preview.page'
 import { settingRowPage } from './draw-structure-section/setting-row.page'
 
@@ -51,6 +52,12 @@ const scoped = (container: Container) => ({
   /** The live preview's own accessors (`drawPreviewPage`), scoped to the tab. The
    * preview's content is pinned by its own tests — the tab asserts it wired it in. */
   preview: drawPreviewPage.within(container),
+  /** The one notice's own accessors (`drawIssuePanelPage`), scoped to the tab.
+   *
+   * ⚠️ Addressed by test id, never by `getByRole('status')`: the preview is a polite live
+   * region too, so at tab scope a role query matches two elements and throws. The role is
+   * asserted in the panel's own test, where it is the only candidate. */
+  issuePanel: drawIssuePanelPage.within(container),
 })
 
 /** Test page-object for `DrawStructureSection`, the event editor's fifth tab. */

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.page.tsx
@@ -1,0 +1,63 @@
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import {
+  DrawStructureSection,
+  type DrawStructureSectionProps,
+} from './draw-structure-section'
+import { buildDrawStructureSectionProps } from './draw-structure-section.factory'
+import { settingRowPage } from './draw-structure-section/setting-row.page'
+
+const scoped = (container: Container) => ({
+  getSection() {
+    return container.getByTestId('draw-structure-section')
+  },
+  /** The tab's heading — the one sentence that says what the tab is for. */
+  getHeading() {
+    return container.getByTestId('draw-structure-heading')
+  },
+  /** The field every number on the tab is derived from. */
+  getPreviewFieldSize() {
+    return container.getByTestId('draw-structure-field-size')
+  },
+  /** Where that field came from: the event's cap, or the honest "no cap" sentence. */
+  getPreviewBasis() {
+    return container.getByTestId('draw-structure-preview-basis')
+  },
+  /** The way back to the tab that sets the player limit. */
+  getChangeInBasicsButton() {
+    return container.getByRole('button', { name: 'Change in Basics' })
+  },
+  /** Every setting's name, **in the order the rows render** — the claim that the four
+   * settings read top to bottom as Pool count, Pool size, Membership, Qualifiers per
+   * pool, which no name-addressed accessor can state. */
+  getSettingNames(): string[] {
+    return container
+      .queryAllByTestId('draw-setting-name')
+      .map((node: HTMLElement) => (node.textContent ?? '').trim())
+  },
+  /** One setting's row, addressed by the setting it holds — the four rows are
+   * otherwise identical markup. Returns the row's own accessors
+   * (`settingRowPage`), scoped to it. */
+  setting(name: string) {
+    return settingRowPage.within(
+      within(container.getByRole('region', { name })),
+    )
+  },
+  /** The column chore 2c fills with the live preview. Present and empty this chore. */
+  getPreviewSlot() {
+    return container.getByTestId('draw-structure-preview-slot')
+  },
+})
+
+/** Test page-object for `DrawStructureSection`, the event editor's fifth tab. */
+export const drawStructureSectionPage = {
+  render(overrides: Partial<DrawStructureSectionProps> = {}) {
+    render(<DrawStructureSection {...buildDrawStructureSectionProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.page.tsx
@@ -5,6 +5,7 @@ import {
   type DrawStructureSectionProps,
 } from './draw-structure-section'
 import { buildDrawStructureSectionProps } from './draw-structure-section.factory'
+import { drawPreviewPage } from './draw-structure-section/draw-preview.page'
 import { settingRowPage } from './draw-structure-section/setting-row.page'
 
 const scoped = (container: Container) => ({
@@ -43,10 +44,13 @@ const scoped = (container: Container) => ({
       within(container.getByRole('region', { name })),
     )
   },
-  /** The column chore 2c fills with the live preview. Present and empty this chore. */
+  /** The right column, which holds the live preview. */
   getPreviewSlot() {
     return container.getByTestId('draw-structure-preview-slot')
   },
+  /** The live preview's own accessors (`drawPreviewPage`), scoped to the tab. The
+   * preview's content is pinned by its own tests — the tab asserts it wired it in. */
+  preview: drawPreviewPage.within(container),
 })
 
 /** Test page-object for `DrawStructureSection`, the event editor's fifth tab. */

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
@@ -220,4 +220,62 @@ describe('DrawStructureSection', () => {
       )
     })
   })
+
+  /**
+   * Wiring and precedence. The panel's copy and its role are pinned by
+   * `draw-issue-panel.test.tsx`; what the tab owns is which notice appears, and where.
+   */
+  describe('the one notice', () => {
+    it('says nothing about a draw that divides — 32 across 4', () => {
+      drawStructureSectionPage.render()
+
+      expect(drawStructureSectionPage.issuePanel.queryPanel()).toBeNull()
+    })
+
+    // The reference's "Uneven field" state: 22 across 4 is 6, 6, 5, 5.
+    it('reads out an uneven split, under the settings that produced it', () => {
+      drawStructureSectionPage.render({
+        event: buildDrawStructureEvent({ maxPlayers: 22 }),
+      })
+
+      const panel = drawStructureSectionPage.issuePanel.getPanel()
+      expect(drawStructureSectionPage.issuePanel.getTitle()).toHaveTextContent(
+        '2 pools of 6 · 2 pools of 5',
+      )
+      // The left column, beside the preview and not inside it.
+      expect(drawStructureSectionPage.getPreviewSlot()).not.toContainElement(
+        panel,
+      )
+    })
+
+    /**
+     * ⚠️ The case the precedence exists for, and the reference's "Field too small" state:
+     * 8 players over 6 pool reservations splits `2, 2, 1, 1, 1, 1`. That is an uneven
+     * tally AND four pools nobody can play in, both reported at once — and
+     * `Legal, but uneven` is not the thing to say about a pool of one.
+     *
+     * The Pool size row proves the tally really is there. Without it this test would
+     * also pass on a draw that is not uneven at all, and prove nothing about the order.
+     */
+    it('drops the uneven notice when a pool cannot be played — 8 across 6', () => {
+      drawStructureSectionPage.render({
+        event: buildDrawStructureEvent({
+          maxPlayers: 8,
+          pools: Array.from({ length: 6 }, (_, i) =>
+            buildPool({ id: `p-${i}`, name: `Pool ${i}`, position: i }),
+          ),
+        }),
+      })
+
+      const row = drawStructureSectionPage.setting('Pool size')
+      expect(row.getValue()).toHaveTextContent('1–2')
+      expect(row.queryUnit()).toHaveTextContent('players · uneven')
+
+      expect(drawStructureSectionPage.issuePanel.queryPanel()).toBeNull()
+      // …and the director is not left guessing: the preview says so.
+      expect(drawStructureSectionPage.preview.getVerdict()).toHaveTextContent(
+        'This draw can’t work yet',
+      )
+    })
+  })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
@@ -1,0 +1,180 @@
+import userEvent from '@testing-library/user-event'
+
+import { buildPool } from '../../data/seed.factory'
+import { buildDrawStructureEvent } from './draw-structure-section.factory'
+import { drawStructureSectionPage } from './draw-structure-section.page'
+
+describe('DrawStructureSection', () => {
+  it('says what the tab is for, in the reference’s words', () => {
+    drawStructureSectionPage.render()
+
+    expect(drawStructureSectionPage.getHeading()).toHaveTextContent(
+      'Set what matters. We’ll work out the rest.',
+    )
+    expect(drawStructureSectionPage.getSection()).toHaveTextContent(
+      'Pools play all-play-all. The top finishers move into a knockout bracket.',
+    )
+  })
+
+  // The order is the reference's, and it is the order a director reads the draw in:
+  // how many pools, how big, who is in them, how many come out.
+  it('lists the four settings in order', () => {
+    drawStructureSectionPage.render()
+
+    expect(drawStructureSectionPage.getSettingNames()).toEqual([
+      'Pool count',
+      'Pool size',
+      'Membership',
+      'Qualifiers per pool',
+    ])
+  })
+
+  /**
+   * The reference's "Nothing set" state: 32 players over 4 pool reservations. Every
+   * value AND every source sentence, because the sentence is what makes the number
+   * checkable — `8` alone cannot tell a director whether the app divided their field or
+   * invented a target.
+   */
+  describe('the reference’s "Nothing set" state — 32 players, 4 reservations', () => {
+    it('derives 4 pools, and says the reservations are where that came from', () => {
+      drawStructureSectionPage.render()
+
+      const row = drawStructureSectionPage.setting('Pool count')
+      expect(row.getValue()).toHaveTextContent('4')
+      expect(row.queryUnit()).toHaveTextContent('pools')
+      expect(row.getSource()).toHaveTextContent(
+        "4 pool reservations · today's behaviour",
+      )
+    })
+
+    it('derives 8 per pool, and shows the division it did', () => {
+      drawStructureSectionPage.render()
+
+      const row = drawStructureSectionPage.setting('Pool size')
+      expect(row.getValue()).toHaveTextContent('8')
+      expect(row.queryUnit()).toHaveTextContent('players per pool')
+      expect(row.getSource()).toHaveTextContent('32 players ÷ 4 pools')
+    })
+
+    it('deals membership by snake, and says how the seeds spread', () => {
+      drawStructureSectionPage.render()
+
+      const row = drawStructureSectionPage.setting('Membership')
+      expect(row.getValue()).toHaveTextContent('Snake automatically')
+      expect(row.getSource()).toHaveTextContent('Seeds spread 1, 2, 3, 3, 2, 1.')
+      // No number, so no unit — the value is already a sentence.
+      expect(row.queryUnit()).toBeNull()
+    })
+
+    it('takes 2 through from each pool, aiming at the 8-player knockout', () => {
+      drawStructureSectionPage.render()
+
+      const row = drawStructureSectionPage.setting('Qualifiers per pool')
+      expect(row.getValue()).toHaveTextContent('2')
+      expect(row.queryUnit()).toHaveTextContent('through from each pool')
+      expect(row.getSource()).toHaveTextContent(
+        'Aiming at an 8-player knockout across 4 pools.',
+      )
+    })
+
+    // ADR 20260808: the owner is readable as TEXT on every row, never as a shade.
+    it('marks all four values Automatic, in words', () => {
+      drawStructureSectionPage.render()
+
+      for (const name of [
+        'Pool count',
+        'Pool size',
+        'Membership',
+        'Qualifiers per pool',
+      ]) {
+        expect(
+          drawStructureSectionPage.setting(name).getOwnershipBadge(),
+        ).toHaveTextContent('Automatic')
+      }
+    })
+  })
+
+  // Row copy, not the 2d notice panel: an all-automatic split is uneven whenever the
+  // field does not divide, and the row has to say so rather than round.
+  it('reads an uneven split as a range, and says "uneven" in the unit', () => {
+    drawStructureSectionPage.render({
+      event: buildDrawStructureEvent({
+        pools: [
+          buildPool({ id: 'p-a', name: 'Pool A', position: 0 }),
+          buildPool({ id: 'p-b', name: 'Pool B', position: 1 }),
+          buildPool({ id: 'p-c', name: 'Pool C', position: 2 }),
+        ],
+      }),
+    })
+
+    // 32 across 3 is 11, 11, 10.
+    const row = drawStructureSectionPage.setting('Pool size')
+    expect(row.getValue()).toHaveTextContent('10–11')
+    expect(row.queryUnit()).toHaveTextContent('players · uneven')
+  })
+
+  it('says "pool", singular, when the field runs in one', () => {
+    drawStructureSectionPage.render({
+      event: buildDrawStructureEvent({ pools: [buildPool()] }),
+    })
+
+    const row = drawStructureSectionPage.setting('Pool count')
+    expect(row.getValue()).toHaveTextContent('1')
+    expect(row.queryUnit()).toHaveTextContent('pool')
+  })
+
+  describe('the field the preview derives against', () => {
+    it('is the cap the director set, and says so', () => {
+      drawStructureSectionPage.render()
+
+      expect(drawStructureSectionPage.getPreviewFieldSize()).toHaveTextContent(
+        '32',
+      )
+      expect(drawStructureSectionPage.getPreviewBasis()).toHaveTextContent(
+        '32-player cap',
+      )
+    })
+
+    /**
+     * ⚠️ The deviation #1320 requires. The reference labels the basis `{n}-player cap`
+     * in every state, which for an uncapped event names a cap nobody set — and would
+     * send a director to the Basics tab looking for a number that is not there.
+     */
+    it('falls back to 16 for an uncapped event, and does NOT call the 16 a cap', () => {
+      drawStructureSectionPage.render({
+        event: buildDrawStructureEvent({ maxPlayers: null }),
+      })
+
+      expect(drawStructureSectionPage.getPreviewFieldSize()).toHaveTextContent(
+        '16',
+      )
+      expect(drawStructureSectionPage.getPreviewBasis()).toHaveTextContent(
+        '16 players because this event has no cap',
+      )
+      expect(drawStructureSectionPage.getPreviewBasis()).not.toHaveTextContent(
+        '16-player cap',
+      )
+      // …and the whole tab is derived against it: 16 over 4 pools is 4 apiece.
+      expect(
+        drawStructureSectionPage.setting('Pool size').getSource(),
+      ).toHaveTextContent('16 players ÷ 4 pools')
+    })
+
+    it('sends the director to Basics to change it', async () => {
+      const onGoToBasics = vi.fn()
+      drawStructureSectionPage.render({ onGoToBasics })
+
+      await userEvent.click(drawStructureSectionPage.getChangeInBasicsButton())
+
+      expect(onGoToBasics).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // Chore 2c fills this. It is present so the two-column layout is the layout the
+  // preview will land in, rather than one it forces a re-shuffle of.
+  it('leaves the preview column empty', () => {
+    drawStructureSectionPage.render()
+
+    expect(drawStructureSectionPage.getPreviewSlot()).toBeEmptyDOMElement()
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
@@ -170,11 +170,54 @@ describe('DrawStructureSection', () => {
     })
   })
 
-  // Chore 2c fills this. It is present so the two-column layout is the layout the
-  // preview will land in, rather than one it forces a re-shuffle of.
-  it('leaves the preview column empty', () => {
-    drawStructureSectionPage.render()
+  /**
+   * Wiring only: the preview's copy, states and arithmetic are pinned by
+   * `draw-preview.test.tsx`. What the tab owns is that the preview sits in the right
+   * column and is fed the same derivation the rows read.
+   */
+  describe('the live preview', () => {
+    it('fills the right-hand column', () => {
+      drawStructureSectionPage.render()
 
-    expect(drawStructureSectionPage.getPreviewSlot()).toBeEmptyDOMElement()
+      expect(drawStructureSectionPage.getPreviewSlot()).toContainElement(
+        drawStructureSectionPage.preview.getPreview(),
+      )
+    })
+
+    it('is derived from the same numbers the rows read out', () => {
+      drawStructureSectionPage.render()
+
+      expect(drawStructureSectionPage.preview.getEquation()).toHaveTextContent(
+        '32 players ÷ 4 pools = 8 per pool',
+      )
+      expect(
+        drawStructureSectionPage.preview.getFact('Pool reservations'),
+      ).toHaveTextContent('4')
+    })
+
+    // One call to `previewBasisLabel`, two readers — so the heading block and the
+    // preview can never come to say different things about the same number.
+    it('says the same thing about the preview field as the heading block does', () => {
+      drawStructureSectionPage.render({
+        event: buildDrawStructureEvent({ maxPlayers: null }),
+      })
+
+      const basis = '16 players because this event has no cap'
+      expect(drawStructureSectionPage.getPreviewBasis()).toHaveTextContent(basis)
+      expect(
+        drawStructureSectionPage.preview.getFact('Preview basis'),
+      ).toHaveTextContent(basis)
+    })
+
+    // There is exactly one verdict on this tab. A second summary would give a director
+    // two places to look and let one of them go stale.
+    it('is the tab’s only summary of the draw', () => {
+      drawStructureSectionPage.render()
+
+      expect(drawStructureSectionPage.preview.queryAllPreviews()).toHaveLength(1)
+      expect(drawStructureSectionPage.preview.getVerdict()).toHaveTextContent(
+        'Ready to save',
+      )
+    })
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
@@ -113,7 +113,11 @@ export const DrawStructureSection = ({
           `auto`, so `minmax(0, …)` on both tracks is what keeps a long source sentence
           from widening the column past the sheet and hiding behind a horizontal
           scrollbar nothing advertises (the bug this editor has shipped twice). */}
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-[minmax(0,1fr)_minmax(0,280px)]">
+      {/* 320px, not 280: at 280 the knockout card's `{n}-player bracket` wraps onto a
+          second line beside its byes/matches column, which the reference keeps on one.
+          Verified in a browser at the 1280px desktop width — jsdom does no layout, so
+          no unit test can hold this number. */}
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-[minmax(0,1fr)_minmax(0,320px)]">
         <div className="flex min-w-0 flex-col">
           <Overline className="text-[color:var(--ball-500)]">
             Draw structure

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button'
 
 import { deriveDrawStructure } from '../../data/draw-structure'
 import type { TournamentEvent } from '../../data/types'
+import { DrawPreview } from './draw-structure-section/draw-preview'
 import {
   previewBasisLabel,
   previewFieldSize,
@@ -51,10 +52,12 @@ export interface DrawStructureSectionProps {
  * input arrive with the ownership modes (chore 3c) — and they are *absent* until then,
  * never a disabled box, which is the unexplained dead end ADR-0015 forbids.
  *
- * The right column is a **slot for the live preview** (chore 2c), and the uneven /
- * disagreement / impossible notices are chore 2d. What this tab already carries of them
- * is the Pool size row's own copy: an uneven split reads `{min}–{max} players · uneven`,
- * because that is row copy and not a panel.
+ * The right column carries the live preview (`DrawPreview`) — **the tab's one verdict**,
+ * and the only summary of the draw anywhere on it. The uneven / disagreement /
+ * impossible *notices*, which explain those states and offer fixes, are chores 2d, 5a
+ * and 4c and land in this left column. What this tab already carries of them is the Pool
+ * size row's own copy: an uneven split reads `{min}–{max} players · uneven`, because that
+ * is row copy and not a panel.
  *
  * ## The arithmetic is not here
  *
@@ -68,6 +71,10 @@ export const DrawStructureSection = ({
   onGoToBasics,
 }: DrawStructureSectionProps) => {
   const fieldSize = previewFieldSize(event.maxPlayers)
+  // ONE call, two readers — the heading block and the preview's `Preview basis` fact.
+  // Called twice they could eventually be called with different arguments, and two
+  // sentences about the same number is exactly the confusion #1320 removes.
+  const previewBasis = previewBasisLabel(event.maxPlayers)
   const structure = deriveDrawStructure({
     previewFieldSize: fieldSize,
     // One pool reservation is one pool — today's behaviour, and the automatic source of
@@ -136,7 +143,7 @@ export const DrawStructureSection = ({
               data-testid="draw-structure-preview-basis"
               className="mt-1 text-[11px] text-[color:var(--fg-3)]"
             >
-              {previewBasisLabel(event.maxPlayers)}
+              {previewBasis}
             </p>
             <Button
               variant="link"
@@ -200,10 +207,22 @@ export const DrawStructureSection = ({
           </div>
         </div>
 
-        {/* The live preview's column (chore 2c). Empty on purpose and empty to a screen
-            reader too — a placeholder that said "coming soon" would be a promise this
-            tab is not making to a director. */}
-        <div className="min-w-0" data-testid="draw-structure-preview-slot" />
+        {/* The live preview's column. The preview is sticky inside it, so the draw stays
+            on screen while the director scrolls the settings that change it — which
+            works because a grid item stretches to the row's height by default. */}
+        <div className="min-w-0" data-testid="draw-structure-preview-slot">
+          <DrawPreview
+            structure={structure}
+            fieldSize={fieldSize}
+            // ⚠️ The event's real pool ROWS, not `max(rows, derived)` as the reference
+            // shows (ADR 20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-
+            // count-is-a-projection). Nothing sets a manual pool count this chore, so
+            // the two are equal today; taking the max would hide the gap the moment
+            // chore 3c lets a director type one.
+            poolReservationCount={event.pools.length}
+            previewBasis={previewBasis}
+          />
+        </div>
       </div>
     </div>
   )

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
@@ -3,6 +3,8 @@ import { Button } from '@/components/ui/button'
 
 import { deriveDrawStructure } from '../../data/draw-structure'
 import type { TournamentEvent } from '../../data/types'
+import { drawIssueFor } from './draw-structure-section/draw-issue'
+import { DrawIssuePanel } from './draw-structure-section/draw-issue-panel'
 import { DrawPreview } from './draw-structure-section/draw-preview'
 import {
   previewBasisLabel,
@@ -54,10 +56,11 @@ export interface DrawStructureSectionProps {
  *
  * The right column carries the live preview (`DrawPreview`) — **the tab's one verdict**,
  * and the only summary of the draw anywhere on it. The uneven / disagreement /
- * impossible *notices*, which explain those states and offer fixes, are chores 2d, 5a
- * and 4c and land in this left column. What this tab already carries of them is the Pool
- * size row's own copy: an uneven split reads `{min}–{max} players · uneven`, because that
- * is row copy and not a panel.
+ * impossible *notices*, which explain those states and offer fixes, land under the
+ * settings in this left column as one `DrawIssuePanel`. **Only the uneven one is built**:
+ * `Can’t save` is chore 4c and `Needs your call` is chore 5a, and both come with `Apply`
+ * fixes. The Pool size row carries its own uneven copy either way (`{min}–{max} players ·
+ * uneven`), because that is row copy and not a panel.
  *
  * ## The arithmetic is not here
  *
@@ -95,6 +98,13 @@ export const DrawStructureSection = ({
   const smallestPool = Math.min(...structure.poolSizes)
   const largestPool = Math.max(...structure.poolSizes)
   const uneven = smallestPool !== largestPool
+
+  // The ONE notice the tab shows, chosen in the reference's order — impossible, then
+  // disagreement, then uneven. The derivation reports all three independently and more
+  // than one can hold at once (8 players across 6 reservations is an uneven split whose
+  // last four pools have one player each), so the choice is `drawIssueFor`'s and this tab
+  // never re-derives it.
+  const issue = drawIssueFor(structure)
 
   return (
     <div className="flex flex-col gap-6" data-testid="draw-structure-section">
@@ -205,6 +215,15 @@ export const DrawStructureSection = ({
               source={structure.sources.qualifiers.sentence}
             />
           </div>
+
+          {/* Under the settings, in the left column: the notice is about the numbers
+              directly above it. The preview in the right column states what the draw IS;
+              this states the one thing worth saying about it. */}
+          {issue !== null && (
+            <div className="mt-5">
+              <DrawIssuePanel issue={issue} />
+            </div>
+          )}
         </div>
 
         {/* The live preview's column. The preview is sticky inside it, so the draw stays

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
@@ -1,0 +1,210 @@
+import { Overline } from '@/components/overline'
+import { Button } from '@/components/ui/button'
+
+import { deriveDrawStructure } from '../../data/draw-structure'
+import type { TournamentEvent } from '../../data/types'
+import {
+  previewBasisLabel,
+  previewFieldSize,
+} from './draw-structure-section/preview-field'
+import { SettingRow } from './draw-structure-section/setting-row'
+
+export interface DrawStructureSectionProps {
+  /**
+   * The event as the editor's **live draft** has it, so the tab recomputes as the
+   * director edits the player limit or adds a pool on the tabs next door.
+   *
+   * ⚠️ Only two fields are read — `maxPlayers` and `pools.length` — and the second is
+   * read as a *count* deliberately. The editor's draft carries the form's `pools`, which
+   * are `PoolEntry` diffs rather than the read model's `Pool` rows (ADR 20260801); the
+   * length is the same either way, and nothing else here may touch a pool's insides.
+   */
+  event: TournamentEvent
+  /**
+   * Take the director to the Basics tab, where the player limit that sizes this preview
+   * lives.
+   *
+   * A button, not a `<Link>`: Basics is a sibling tab inside this same sheet, so "go
+   * there" is editor state and not navigation. A link would leave the page and lose the
+   * unsaved draft.
+   */
+  onGoToBasics: () => void
+}
+
+/**
+ * The event editor's **Draw structure** tab (#1320) — the four structural settings of a
+ * round-robin-then-knockout draw, read out as the system currently derives them.
+ *
+ * ## Why the tab exists
+ *
+ * A director controls one and a half of these four settings today, and nothing on any
+ * tab states the other two (ADR 20260808). #1320 records a real director who set one
+ * pool and one qualifier per pool, sent one player to the bracket, and was refused with
+ * a message that named the wrong cause. This tab states every number and says where it
+ * came from, so the shape of the draw is readable before it is cut.
+ *
+ * ## What this chore renders, and what it does not
+ *
+ * **Every setting is `Automatic`, and every value is text.** Nothing stores an ownership
+ * mode yet, so the derivation is fed all-automatic and the rows read out what today's
+ * behaviour already does. The `Set myself` / `Use automatic` action and the numeric
+ * input arrive with the ownership modes (chore 3c) — and they are *absent* until then,
+ * never a disabled box, which is the unexplained dead end ADR-0015 forbids.
+ *
+ * The right column is a **slot for the live preview** (chore 2c), and the uneven /
+ * disagreement / impossible notices are chore 2d. What this tab already carries of them
+ * is the Pool size row's own copy: an uneven split reads `{min}–{max} players · uneven`,
+ * because that is row copy and not a panel.
+ *
+ * ## The arithmetic is not here
+ *
+ * Every number and every source sentence comes from `deriveDrawStructure`
+ * (`data/draw-structure`), whose vectors are asserted against a Python twin. A component
+ * that recomputed even one of them would be a second implementation with no vector
+ * holding it to the first.
+ */
+export const DrawStructureSection = ({
+  event,
+  onGoToBasics,
+}: DrawStructureSectionProps) => {
+  const fieldSize = previewFieldSize(event.maxPlayers)
+  const structure = deriveDrawStructure({
+    previewFieldSize: fieldSize,
+    // One pool reservation is one pool — today's behaviour, and the automatic source of
+    // the pool count (ADR 20260808).
+    poolReservationCount: event.pools.length,
+    // All four settings are the system's this chore: nothing writes an ownership mode
+    // yet, so there is no manual number for any of them to hold.
+    poolCountMode: 'automatic',
+    manualPoolCount: null,
+    poolSizeMode: 'automatic',
+    manualPoolSize: null,
+    qualifiersMode: 'automatic',
+    manualQualifiers: null,
+  })
+
+  // Read off the derived sizes rather than divided out again — the pools are routinely
+  // unequal (22 across 4 is `6, 6, 5, 5`) and the uneven case is a first-class state.
+  const smallestPool = Math.min(...structure.poolSizes)
+  const largestPool = Math.max(...structure.poolSizes)
+  const uneven = smallestPool !== largestPool
+
+  return (
+    <div className="flex flex-col gap-6" data-testid="draw-structure-section">
+      {/* **Stacked below `sm`, side by side above it** — the same breakpoint the sheet
+          itself switches on (`w-full sm:w-[820px]`). A grid item's `min-width` is
+          `auto`, so `minmax(0, …)` on both tracks is what keeps a long source sentence
+          from widening the column past the sheet and hiding behind a horizontal
+          scrollbar nothing advertises (the bug this editor has shipped twice). */}
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-[minmax(0,1fr)_minmax(0,280px)]">
+        <div className="flex min-w-0 flex-col">
+          <Overline className="text-[color:var(--ball-500)]">
+            Draw structure
+          </Overline>
+          <h3
+            data-testid="draw-structure-heading"
+            className="mt-1.5 text-[22px] leading-tight font-semibold text-[color:var(--fg-1)]"
+          >
+            Set what matters. We’ll work out the rest.
+          </h3>
+          <p className="mt-1.5 text-[13px] text-[color:var(--fg-3)]">
+            Pools play all-play-all. The top finishers move into a knockout
+            bracket.
+          </p>
+
+          {/* The field every number below is derived from, stated before the numbers
+              are. It is the one input to this tab that is not set on this tab, which is
+              why it carries the way back to the tab that does set it. */}
+          <div className="mt-4 w-fit rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--bg-raised)] px-4 py-3">
+            <div className="text-[11px] font-semibold tracking-[0.14em] text-[color:var(--fg-3)] uppercase">
+              Preview field
+            </div>
+            <p className="mt-1 flex items-baseline gap-2">
+              <span
+                data-testid="draw-structure-field-size"
+                className="font-mono text-[20px] leading-none font-semibold text-[color:var(--fg-1)]"
+              >
+                {fieldSize}
+              </span>
+              <span className="text-[13px] text-[color:var(--fg-2)]">
+                players
+              </span>
+            </p>
+            {/* Honest about where the number came from, which for an uncapped event
+                means NOT calling it a cap (`previewBasisLabel`). */}
+            <p
+              data-testid="draw-structure-preview-basis"
+              className="mt-1 text-[11px] text-[color:var(--fg-3)]"
+            >
+              {previewBasisLabel(event.maxPlayers)}
+            </p>
+            <Button
+              variant="link"
+              size="sm"
+              className="mt-1 h-auto p-0 text-[12px]"
+              onClick={onGoToBasics}
+            >
+              Change in Basics
+            </Button>
+          </div>
+
+          {/* ONE list with dividers, not one card per row. The divider is the list's, so
+              a row contributes no border of its own and the four settings read as one
+              draw rather than as four unrelated panels. */}
+          <div className="mt-5 divide-y divide-[color:var(--border-subtle)] border-t border-[color:var(--border-subtle)]">
+            <SettingRow
+              name="Pool count"
+              hint="How many pools the field splits into. Each pool also books its tables and time window."
+              value={String(structure.poolCount)}
+              kind="number"
+              unit={structure.poolCount === 1 ? 'pool' : 'pools'}
+              ownership={structure.sources.poolCount.ownership}
+              source={structure.sources.poolCount.sentence}
+            />
+            {/* The uneven split is this row's own copy, not the 2d notice: `{min}–{max}`
+                with the unit saying so out loud. An en dash, and a middle dot before
+                `uneven` — both the reference's glyphs. */}
+            <SettingRow
+              name="Pool size"
+              hint="The target number of players in each pool."
+              value={uneven ? `${smallestPool}–${largestPool}` : String(smallestPool)}
+              kind="number"
+              unit={uneven ? 'players · uneven' : 'players per pool'}
+              ownership={structure.sources.poolSize.ownership}
+              source={structure.sources.poolSize.sentence}
+            />
+            {/* Membership has no number, so `deriveDrawStructure` says nothing about it
+                (its `DrawStructureSources` omits it by design). The row reads its mode
+                off the event — and nothing stores one yet, so it is the snake, which is
+                what `_snake()` in `api/app/draws.py` already does on every cut. */}
+            <SettingRow
+              name="Membership"
+              hint="Who lands in each pool. Entrants do not exist until you cut the draw."
+              value="Snake automatically"
+              kind="phrase"
+              ownership="automatic"
+              source="Seeds spread 1, 2, 3, 3, 2, 1."
+            />
+            {/* ⚠️ Still on Basics as well, this slice. Chore 3e moves it here for good;
+                until then the director sees the stored K on Basics and the DERIVED one
+                here, and the two can disagree. That is deliberate and temporary. */}
+            <SettingRow
+              name="Qualifiers per pool"
+              hint="How many finishers from each pool reach the knockout."
+              value={String(structure.qualifiersPerPool)}
+              kind="number"
+              unit="through from each pool"
+              ownership={structure.sources.qualifiers.ownership}
+              source={structure.sources.qualifiers.sentence}
+            />
+          </div>
+        </div>
+
+        {/* The live preview's column (chore 2c). Empty on purpose and empty to a screen
+            reader too — a placeholder that said "coming soon" would be a promise this
+            tab is not making to a director. */}
+        <div className="min-w-0" data-testid="draw-structure-preview-slot" />
+      </div>
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.factory.tsx
@@ -1,0 +1,37 @@
+import type { DrawIssue } from './draw-issue'
+import type { DrawIssuePanelProps } from './draw-issue-panel'
+
+/**
+ * The reference's **"Uneven field"** state
+ * (`docs/designs/rr-then-ko-draw-structure/uneven-field-panel.png`): 22 players across 4
+ * pools, which the balanced split makes `6, 6, 5, 5` and the tally reads out as
+ * `2 pools of 6 · 2 pools of 5`.
+ *
+ * ⚠️ **Largest first**, because that is the order `tallySizes` produces and the order the
+ * title states. A fixture written the other way round would pass a test that only counts
+ * the entries and hide the one claim worth making.
+ */
+export function buildUnevenDrawIssue(
+  overrides: Partial<Extract<DrawIssue, { kind: 'uneven' }>> = {},
+): DrawIssue {
+  return {
+    kind: 'uneven',
+    distribution: [
+      { pools: 2, size: 6 },
+      { pools: 2, size: 5 },
+    ],
+    ...overrides,
+  }
+}
+
+/** Props for `DrawIssuePanel` — the uneven notice above, which is the only variant this
+ * chore renders. The impossible and disagreement kinds are built inline by the tests that
+ * assert the panel stays silent for them (chores 4c and 5a). */
+export function buildDrawIssuePanelProps(
+  overrides: Partial<DrawIssuePanelProps> = {},
+): DrawIssuePanelProps {
+  return {
+    issue: buildUnevenDrawIssue(),
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.page.tsx
@@ -1,0 +1,43 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { DrawIssuePanel, type DrawIssuePanelProps } from './draw-issue-panel'
+import { buildDrawIssuePanelProps } from './draw-issue-panel.factory'
+
+const scoped = (container: Container) => ({
+  /** The panel. */
+  getPanel() {
+    return container.getByTestId('draw-issue-panel')
+  },
+  /** The panel, or `null` — **the accessor the precedence claims use**. Only one notice
+   * shows at a time, and the two unbuilt kinds (chores 4c and 5a) show none at all, so
+   * "there is no panel" is a state a test has to be able to state. */
+  queryPanel() {
+    return container.queryByTestId('draw-issue-panel')
+  },
+  /** The topline — `Legal, but uneven`. Read as TEXT: the dot beside it is decoration,
+   * and a notice whose meaning is a colour has no meaning to a screen reader. */
+  getTopline() {
+    return container.getByText('Legal, but uneven')
+  },
+  /** The size tally — `2 pools of 6 · 2 pools of 5`. */
+  getTitle() {
+    return container.getByTestId('draw-issue-panel-title')
+  },
+  /** The line under it, saying what uneven costs and what was not done to it. */
+  getBody() {
+    return container.getByTestId('draw-issue-panel-body')
+  },
+})
+
+/** Test page-object for `DrawIssuePanel`, the Draw structure tab's one notice. */
+export const drawIssuePanelPage = {
+  render(overrides: Partial<DrawIssuePanelProps> = {}) {
+    render(<DrawIssuePanel {...buildDrawIssuePanelProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.test.tsx
@@ -1,0 +1,110 @@
+import { buildUnevenDrawIssue } from './draw-issue-panel.factory'
+import { drawIssuePanelPage } from './draw-issue-panel.page'
+
+// Which kind reaches the panel is `drawIssueFor`'s call, and `./draw-issue.test.ts` pins
+// it. This file pins what the panel does with the kind it is handed.
+describe('DrawIssuePanel', () => {
+  describe('the uneven notice', () => {
+    it('says the split is legal, in words rather than in a colour', () => {
+      drawIssuePanelPage.render()
+
+      expect(drawIssuePanelPage.getTopline()).toBeInTheDocument()
+    })
+
+    // The reference's "Uneven field" state: 22 across 4 is 6, 6, 5, 5.
+    it('reads the tally out largest pool first', () => {
+      drawIssuePanelPage.render()
+
+      expect(drawIssuePanelPage.getTitle()).toHaveTextContent(
+        '2 pools of 6 · 2 pools of 5',
+      )
+    })
+
+    /**
+     * A deviation from the reference, which shows only a two-and-two tally. `1 pool` is
+     * reachable today — a field of 7 over 2 pool reservations splits 4, 3 — and unlike
+     * the `1 pool reservations` sentence next door this title has no Python twin
+     * transcribing it against shared vectors, so pluralising it drifts nothing.
+     */
+    it('says "pool", singular, for a run of one', () => {
+      drawIssuePanelPage.render({
+        issue: buildUnevenDrawIssue({
+          distribution: [
+            { pools: 1, size: 4 },
+            { pools: 1, size: 3 },
+          ],
+        }),
+      })
+
+      expect(drawIssuePanelPage.getTitle()).toHaveTextContent(
+        '1 pool of 4 · 1 pool of 3',
+      )
+    })
+
+    it('says what uneven costs, and what was not done to the numbers', () => {
+      drawIssuePanelPage.render()
+
+      expect(drawIssuePanelPage.getBody()).toHaveTextContent(
+        'The bigger pools play more matches. Nothing has been silently reshaped.',
+      )
+    })
+
+    /**
+     * `status`, not `alert`. An uneven split is legal: it disables nothing and saving
+     * stays available, so it must be announced when the reader reaches it rather than
+     * interrupt whatever they were reading.
+     */
+    it('announces itself politely, as a status and not an alert', () => {
+      drawIssuePanelPage.render()
+
+      expect(drawIssuePanelPage.getPanel()).toHaveAttribute('role', 'status')
+      expect(drawIssuePanelPage.getPanel()).not.toHaveAttribute('role', 'alert')
+    })
+
+    it('offers nothing to click — an uneven split has nothing to fix', () => {
+      drawIssuePanelPage.render()
+
+      expect(
+        drawIssuePanelPage.getPanel().querySelectorAll('button, a, input'),
+      ).toHaveLength(0)
+    })
+  })
+
+  // Both panels come with fixes and `Apply` buttons no derivation can supply, so the tab
+  // shows nothing rather than half of one. The live preview beside it already reads
+  // `This draw can’t work yet` / `Your numbers disagree`, so neither state is silent.
+  describe('the two variants that are not built yet', () => {
+    it('renders nothing for the impossible kind (chore 4c)', () => {
+      drawIssuePanelPage.render({
+        issue: {
+          kind: 'impossible',
+          problem: {
+            kind: 'pool',
+            title: 'Pool C would have one player',
+            body: 'They would have nobody to play. Use fewer pools or raise the player limit.',
+          },
+        },
+      })
+
+      expect(drawIssuePanelPage.queryPanel()).toBeNull()
+    })
+
+    it('renders nothing for the disagreement kind (chore 5a)', () => {
+      drawIssuePanelPage.render({
+        issue: {
+          kind: 'disagreement',
+          disagreement: {
+            poolCount: 6,
+            poolSize: 5,
+            seats: 30,
+            fieldSize: 40,
+            direction: 'unseated',
+            count: 10,
+          },
+        },
+      })
+
+      expect(drawIssuePanelPage.queryPanel()).toBeNull()
+    })
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.tsx
@@ -1,0 +1,106 @@
+import { Fragment } from 'react'
+
+import { Overline } from '@/components/overline'
+
+import type { DrawIssue } from './draw-issue'
+
+export interface DrawIssuePanelProps {
+  /** The issue to state, already chosen by `drawIssueFor`. The panel never picks: given
+   * one it renders one, which is what keeps the precedence in a single place. */
+  issue: DrawIssue
+}
+
+/**
+ * The Draw structure tab's **issue panel** (#1320): one notice under the settings list,
+ * saying the one thing that is true of the director's numbers.
+ *
+ * **It never picks.** Which of the three kinds is on screen is `drawIssueFor`'s
+ * (`./draw-issue`), so the precedence lives in one place and this renders what it is
+ * handed.
+ *
+ * ## Why it is not an `Alert`
+ *
+ * The reference gives `Can’t save` the role `alert` and gives the other two the role
+ * `status`, so **the role is variant data** — a field of the same table that carries the
+ * topline and the dot, exactly as `VERDICTS` works in `draw-preview.tsx`. `Alert`
+ * (`components/ui/alert`) hardcodes `role="alert"`. Passing `role` through its prop
+ * spread would work, and would leave the role as a default being fought rather than a
+ * field being set. After overriding its `bg-card`, its padding and its two slot faces to
+ * reach the tab's tokens there is about three utility classes of it left, so this is a
+ * small purpose-built panel instead. It still composes the tab's primitives: `Overline`
+ * for the topline, and the `--border-subtle` / `--bg-raised` / `--info` tokens the
+ * preview beside it already uses.
+ *
+ * ## The meaning is the words, never the dot
+ *
+ * `Legal, but uneven` is visible text. The coloured dot is `aria-hidden` decoration on
+ * top of it, so a reader who cannot separate blue from yellow reads the same notice
+ * everyone else does.
+ *
+ * ## What this chore renders
+ *
+ * **Only the uneven variant.** `Can’t save` is chore 4c and `Needs your call` is chore
+ * 5a — both come with fixes and `Apply` buttons that no derivation can supply, so
+ * inventing their copy here would be inventing the fixes too.
+ */
+export const DrawIssuePanel = ({ issue }: DrawIssuePanelProps) => {
+  // Chores 4c (impossible, role `alert`, red dot, up to two fixes) and 5a (disagreement,
+  // role `status`, yellow dot, three fixes) render here. Until then the tab shows nothing
+  // in those states rather than a half-written panel: the live preview beside it already
+  // reads `This draw can’t work yet` / `Your numbers disagree`, so neither state is
+  // silent.
+  if (issue.kind !== 'uneven') return null
+
+  return (
+    // `status`, not `alert`: an uneven split is legal. It is announced when the reader
+    // gets to it and never interrupts, it disables nothing, and saving and cutting stay
+    // available — so it wears none of the warning tokens either.
+    <div
+      role="status"
+      data-testid="draw-issue-panel"
+      data-issue-kind={issue.kind}
+      className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--bg-raised)] px-4 py-3"
+    >
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden="true"
+          className="size-1.5 shrink-0 rounded-full bg-[color:var(--info)]"
+        />
+        {/* No colour of its own: `.fortymm-theme .fortymm-overline` is unlayered and
+            beats a Tailwind text-colour utility set here anyway. */}
+        <Overline as="span">Legal, but uneven</Overline>
+      </div>
+
+      {/* The tally the derivation counted, largest pool first. Each string literal
+          carries its own spaces — JSX drops the whitespace around a line break, and
+          `2pools of6` is one reformat away from a text node written the other way. */}
+      <p
+        data-testid="draw-issue-panel-title"
+        className="mt-1.5 text-[15px] leading-snug font-semibold text-[color:var(--fg-1)]"
+      >
+        {issue.distribution.map((tally, index) => (
+          // Keyed by size: `tallySizes` counts each size once, so a size is unique in
+          // the list and index keys would reorder wrongly as the field changes.
+          <Fragment key={tally.size}>
+            {index > 0 && ' · '}
+            <span className="font-mono">{tally.pools}</span>
+            {/* Pluralised, unlike `1 pool reservations` next door. That sentence stays
+                unpluralised because a Python twin transcribes it against shared vectors;
+                this title is built here from a `PoolSizeTally[]` and has no twin, and
+                `1 pool of 4 · 1 pool of 3` (a field of 7 over 2 reservations) ships
+                today. */}
+            {tally.pools === 1 ? ' pool of ' : ' pools of '}
+            <span className="font-mono">{tally.size}</span>
+          </Fragment>
+        ))}
+      </p>
+
+      <p
+        data-testid="draw-issue-panel-body"
+        className="mt-1 text-[13px] leading-snug text-[color:var(--fg-3)]"
+      >
+        The bigger pools play more matches. Nothing has been silently reshaped.
+      </p>
+    </div>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue.test.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue.test.ts
@@ -1,0 +1,86 @@
+import {
+  deriveDrawStructure,
+  type DrawStructureOptions,
+} from '../../../data/draw-structure'
+import { drawIssueFor } from './draw-issue'
+
+/** The eight derivation inputs, all-automatic, so a case states only what it changes.
+ * Structures are **derived, never hand-written**: a `DrawStructure` typed out by hand can
+ * hold a tally the arithmetic never produces, and then the precedence is proved against a
+ * state no director can reach. */
+const structureFor = (overrides: Partial<DrawStructureOptions>) =>
+  deriveDrawStructure({
+    previewFieldSize: 32,
+    poolReservationCount: 4,
+    poolCountMode: 'automatic',
+    manualPoolCount: null,
+    poolSizeMode: 'automatic',
+    manualPoolSize: null,
+    qualifiersMode: 'automatic',
+    manualQualifiers: null,
+    ...overrides,
+  })
+
+/**
+ * The precedence the derivation deliberately does not encode. It reports the three
+ * conditions independently and more than one can hold at once, so **this is the only
+ * place that decides which one a director reads** — chores 4c and 5a extend the panel's
+ * renderer and leave this alone.
+ */
+describe('drawIssueFor', () => {
+  it('has nothing to say about a draw that divides — 32 across 4', () => {
+    expect(drawIssueFor(structureFor({}))).toBeNull()
+  })
+
+  it('reports the uneven tally when that is all that is wrong — 22 across 4', () => {
+    expect(drawIssueFor(structureFor({ previewFieldSize: 22 }))).toEqual({
+      kind: 'uneven',
+      distribution: [
+        { pools: 2, size: 6 },
+        { pools: 2, size: 5 },
+      ],
+    })
+  })
+
+  /**
+   * ⚠️ The case the ordering exists for. 8 across 6 reservations splits `2, 2, 1, 1, 1,
+   * 1`, so the derivation reports an uneven tally AND a pool nobody can play in — both
+   * non-empty, at once. "Legal, but uneven" is not the thing to say about a pool of one.
+   */
+  it('puts an unplayable pool ahead of the uneven tally it comes with', () => {
+    const structure = structureFor({
+      previewFieldSize: 8,
+      poolReservationCount: 6,
+    })
+    // Both really are set — otherwise this asserts precedence against a state that never
+    // had two answers to choose between.
+    expect(structure.unevenDistribution).not.toBeNull()
+    expect(structure.impossibleProblems).toHaveLength(1)
+
+    expect(drawIssueFor(structure)).toEqual({
+      kind: 'impossible',
+      problem: structure.impossibleProblems[0],
+    })
+  })
+
+  /**
+   * The reference's "Numbers disagree" state: 6 manual pools of 5 manual against a field
+   * of 40. No input can put a disagreement and an uneven tally on screen together — both
+   * modes manual gives every pool the same size — so this pins the middle rung of the
+   * order rather than a contest, and it is what chore 5a extends.
+   */
+  it('reports the disagreement when the director’s two numbers do not multiply out', () => {
+    const structure = structureFor({
+      previewFieldSize: 40,
+      poolCountMode: 'manual',
+      manualPoolCount: 6,
+      poolSizeMode: 'manual',
+      manualPoolSize: 5,
+    })
+
+    expect(drawIssueFor(structure)).toEqual({
+      kind: 'disagreement',
+      disagreement: structure.disagreement,
+    })
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue.ts
@@ -1,0 +1,48 @@
+// **Which of the three notices the Draw structure tab shows.**
+//
+// `deriveDrawStructure` (`../../../data/draw-structure`) reports the three conditions
+// independently and says out loud that it will not order them: more than one holds at
+// once routinely, and picking between them is a layout question a derivation has no
+// business answering. This module is the answer, and it is the ONLY place the answer
+// exists — `DrawIssuePanel` renders whichever kind it is handed, and chores 4c and 5a add
+// their variants to that renderer without touching this file.
+
+import type {
+  DrawStructure,
+  DrawStructureDisagreement,
+  ImpossibleProblem,
+  PoolSizeTally,
+} from '../../../data/draw-structure'
+
+/**
+ * The one thing the tab is telling the director about their numbers.
+ *
+ * A discriminated union rather than three nullable fields, because the tab shows exactly
+ * one notice and a shape that can hold two would let a caller render both.
+ */
+export type DrawIssue =
+  | { kind: 'impossible'; problem: ImpossibleProblem }
+  | { kind: 'disagreement'; disagreement: DrawStructureDisagreement }
+  | { kind: 'uneven'; distribution: PoolSizeTally[] }
+
+/**
+ * Pick the one issue, in the reference's order: impossible, then disagreement, then
+ * uneven.
+ *
+ * The order is the order a director can act in. A draw that cannot be played is not
+ * "your call", and an uneven split is not worth reading while a pool has one player in
+ * it. A field of 8 across 6 pool reservations splits `2, 2, 1, 1, 1, 1` — an uneven tally
+ * AND four unplayable pools, both reported — so this is a live case and not a defensive
+ * one.
+ */
+export function drawIssueFor(structure: DrawStructure): DrawIssue | null {
+  const [problem] = structure.impossibleProblems
+  if (problem !== undefined) return { kind: 'impossible', problem }
+  if (structure.disagreement !== null) {
+    return { kind: 'disagreement', disagreement: structure.disagreement }
+  }
+  if (structure.unevenDistribution !== null) {
+    return { kind: 'uneven', distribution: structure.unevenDistribution }
+  }
+  return null
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.factory.tsx
@@ -1,0 +1,62 @@
+import {
+  deriveDrawStructure,
+  type DrawStructureOptions,
+} from '../../../data/draw-structure'
+import type { DrawPreviewProps } from './draw-preview'
+import { previewBasisLabel } from './preview-field'
+
+/**
+ * The eight derivation inputs of the reference's **"Nothing set"** state
+ * (`docs/designs/rr-then-ko-draw-structure/nothing-set.png`): 32 players across 4 pool
+ * reservations, every setting the system's. That derives 4 pools of 8, 2 qualifiers
+ * apiece, an 8-player bracket with no byes, and 112 pool matches.
+ *
+ * The split is deliberately **even** and the draw deliberately **sound**, so an uneven,
+ * disagreeing or impossible preview is something a test asks for by overriding an input
+ * rather than something it gets by accident.
+ */
+export function buildDrawPreviewOptions(
+  overrides: Partial<DrawStructureOptions> = {},
+): DrawStructureOptions {
+  return {
+    previewFieldSize: 32,
+    poolReservationCount: 4,
+    poolCountMode: 'automatic',
+    manualPoolCount: null,
+    poolSizeMode: 'automatic',
+    manualPoolSize: null,
+    qualifiersMode: 'automatic',
+    manualQualifiers: null,
+    ...overrides,
+  }
+}
+
+/**
+ * Props for `DrawPreview` **derived from the eight inputs**, so a test states the
+ * director's settings and gets the preview that follows from them.
+ *
+ * This is the builder to reach for: hand-writing a `DrawStructure` would let a test pin
+ * a bracket size the arithmetic never produces, and the preview's whole job is to report
+ * that arithmetic.
+ */
+export function buildDrawPreviewPropsFor(
+  optionOverrides: Partial<DrawStructureOptions> = {},
+): DrawPreviewProps {
+  const options = buildDrawPreviewOptions(optionOverrides)
+  return {
+    structure: deriveDrawStructure(options),
+    fieldSize: options.previewFieldSize,
+    poolReservationCount: options.poolReservationCount,
+    // The default builder treats the field as a cap the director set, which is the
+    // reference's state. The uncapped sentence is a prop a test overrides.
+    previewBasis: previewBasisLabel(options.previewFieldSize),
+  }
+}
+
+/** Props for `DrawPreview` — the "Nothing set" state above, with any prop replaced
+ * outright. */
+export function buildDrawPreviewProps(
+  overrides: Partial<DrawPreviewProps> = {},
+): DrawPreviewProps {
+  return { ...buildDrawPreviewPropsFor(), ...overrides }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.page.tsx
@@ -1,0 +1,104 @@
+import { render, screen, within, type Container } from '@/test/utilities'
+
+import { DrawPreview, type DrawPreviewProps } from './draw-preview'
+import { buildDrawPreviewProps } from './draw-preview.factory'
+import { poolCardPage } from './draw-preview/pool-card.page'
+
+const scoped = (container: Container) => {
+  const getPoolList = () =>
+    container.getByRole('list', { name: 'Projected pools' })
+  const getPoolCards = () =>
+    within(getPoolList()).queryAllByTestId('draw-preview-pool-card')
+
+  return {
+    /** The preview panel. */
+    getPreview() {
+      return container.getByTestId('draw-preview')
+    },
+    /** Every preview panel in scope. There is exactly one verdict on the tab, so a
+     * caller asserting "one" is asserting the design rule, not counting markup. */
+    queryAllPreviews() {
+      return container.queryAllByTestId('draw-preview')
+    },
+    /** The one-line verdict — `Ready to save`, `Your numbers disagree`,
+     * `This draw can’t work yet`. */
+    getVerdict() {
+      return container.getByTestId('draw-preview-verdict')
+    },
+    /** The badge beside it — `Sound`, `Your call`, `Impossible`. Read as TEXT: the tint
+     * is the second signal, never the only one. */
+    getBadge() {
+      return container.getByTestId('draw-preview-badge')
+    },
+    /** `{field} players ÷ {count} pools = {size} per pool`. */
+    getEquation() {
+      return container.getByTestId('draw-preview-equation')
+    },
+    /** The pool-card group. Named, so a screen reader can introduce it before reading
+     * eight identically-shaped cards. */
+    getPoolList,
+    /** Every pool card, **in the order it renders** — the claim that the cards read
+     * A, B, C, …, which no letter-addressed accessor can state. */
+    getPoolCards,
+    /** Every card's pool name, **in the order it renders** — `Pool A`, `Pool B`, …
+     * The one claim a letter-addressed accessor cannot make. */
+    getPoolNames(): string[] {
+      return getPoolCards().map(
+        (card) => (card.textContent ?? '').match(/Pool [A-Z]+/)?.[0] ?? '',
+      )
+    },
+    /** One pool's card, addressed by its letter. Returns the card's own accessors
+     * (`poolCardPage`), scoped to it — with `getCard` re-bound to the card itself,
+     * since `within` searches a node's descendants and not the node. */
+    pool(letter: string) {
+      const card = getPoolCards().find((node) =>
+        (node.textContent ?? '').includes(`Pool ${letter}`),
+      )
+      if (!card) throw new Error(`No preview card for Pool ${letter}`)
+      return { ...poolCardPage.within(within(card)), getCard: () => card }
+    },
+    /** The knockout card: bracket size, byes and the pool-match total. */
+    getKnockout() {
+      return container.getByTestId('draw-preview-knockout')
+    },
+    /** One of the three facts under the picture, addressed by its term. Returns the
+     * value beside it. */
+    getFact(term: string) {
+      const dt = container.getByText(term, { selector: 'dt' })
+      const value = dt.nextElementSibling
+      if (!(value instanceof HTMLElement)) {
+        throw new Error(`No value beside the "${term}" fact`)
+      }
+      return value
+    },
+    /** The closing line about when entrants are placed. */
+    getFoot() {
+      return container.getByTestId('draw-preview-foot')
+    },
+    /** The polite live region the derived numbers sit in, so a recompute is announced
+     * rather than silently swapped. */
+    getLiveRegion() {
+      return container.getByRole('status')
+    },
+    /** Any link out of the preview. The reference's `Preview cut-time assignment →`
+     * belongs to #1324, so there must be none. */
+    queryAllLinks() {
+      return container.queryAllByRole('link')
+    },
+  }
+}
+
+/** Test page-object for `DrawPreview`, the Draw structure tab's live preview. Build a
+ * state with `buildDrawPreviewPropsFor` (the eight derivation inputs) and pass it to
+ * `render`, rather than hand-writing a `DrawStructure` the arithmetic never produces. */
+export const drawPreviewPage = {
+  render(overrides: Partial<DrawPreviewProps> = {}) {
+    render(<DrawPreview {...buildDrawPreviewProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.test.tsx
@@ -1,0 +1,318 @@
+import { buildDrawPreviewPropsFor } from './draw-preview.factory'
+import { drawPreviewPage } from './draw-preview.page'
+
+describe('DrawPreview', () => {
+  /**
+   * The reference's **"Nothing set"** state
+   * (`docs/designs/rr-then-ko-draw-structure/nothing-set.png`): 32 players across 4 pool
+   * reservations, every setting the system's.
+   */
+  describe('the reference’s "Nothing set" state — 32 players, 4 reservations', () => {
+    it('says the draw is ready, in words and on the badge', () => {
+      drawPreviewPage.render()
+
+      expect(drawPreviewPage.getVerdict()).toHaveTextContent('Ready to save')
+      expect(drawPreviewPage.getBadge()).toHaveTextContent('Sound')
+    })
+
+    it('states the division it did', () => {
+      drawPreviewPage.render()
+
+      expect(drawPreviewPage.getEquation()).toHaveTextContent(
+        '32 players ÷ 4 pools = 8 per pool',
+      )
+    })
+
+    it('draws one card per pool, lettered in order', () => {
+      drawPreviewPage.render()
+
+      expect(drawPreviewPage.getPoolNames()).toEqual([
+        'Pool A',
+        'Pool B',
+        'Pool C',
+        'Pool D',
+      ])
+      for (const letter of ['A', 'B', 'C', 'D']) {
+        const card = drawPreviewPage.pool(letter).getCard()
+        expect(card).toHaveTextContent('8')
+        expect(card).toHaveTextContent('players')
+        expect(card).toHaveTextContent('top 2 advance')
+      }
+    })
+
+    it('reads the knockout out of the pools it feeds', () => {
+      drawPreviewPage.render()
+
+      const knockout = drawPreviewPage.getKnockout()
+      expect(knockout).toHaveTextContent('Knockout')
+      expect(knockout).toHaveTextContent('8-player bracket')
+      expect(knockout).toHaveTextContent('No first-round byes')
+      expect(knockout).toHaveTextContent('112 pool matches')
+    })
+
+    it('deals membership by snake', () => {
+      drawPreviewPage.render()
+
+      expect(drawPreviewPage.getFact('Membership')).toHaveTextContent('Snake')
+    })
+
+    it('says where the field it derived against came from', () => {
+      drawPreviewPage.render()
+
+      expect(drawPreviewPage.getFact('Preview basis')).toHaveTextContent(
+        '32-player cap',
+      )
+    })
+
+    it('says when entrants actually get placed', () => {
+      drawPreviewPage.render()
+
+      expect(drawPreviewPage.getFoot()).toHaveTextContent(
+        'Entrants are placed only when registration closes and you cut the draw.',
+      )
+    })
+  })
+
+  // An all-automatic split is uneven whenever the field does not divide, and the
+  // equation has to say so rather than round to a number no pool holds.
+  it('reads an uneven split as a range', () => {
+    drawPreviewPage.render(
+      buildDrawPreviewPropsFor({
+        previewFieldSize: 22,
+        poolReservationCount: 4,
+      }),
+    )
+
+    // 22 across 4 is 6, 6, 5, 5.
+    expect(drawPreviewPage.getEquation()).toHaveTextContent(
+      '22 players ÷ 4 pools = 5–6 per pool',
+    )
+  })
+
+  /**
+   * The reference's **"Numbers disagree"** state
+   * (`docs/designs/rr-then-ko-draw-structure/numbers-disagree.png`): 6 pools of 5 seat
+   * 30, and the field is 40.
+   */
+  describe('when the director’s two numbers disagree', () => {
+    const disagreeing = () =>
+      buildDrawPreviewPropsFor({
+        previewFieldSize: 40,
+        poolReservationCount: 6,
+        poolCountMode: 'manual',
+        manualPoolCount: 6,
+        poolSizeMode: 'manual',
+        manualPoolSize: 5,
+        qualifiersMode: 'manual',
+        manualQualifiers: 1,
+      })
+
+    it('hands the call back to the director rather than picking a number', () => {
+      drawPreviewPage.render(disagreeing())
+
+      expect(drawPreviewPage.getVerdict()).toHaveTextContent(
+        'Your numbers disagree',
+      )
+      expect(drawPreviewPage.getBadge()).toHaveTextContent('Your call')
+    })
+
+    it('still draws the structure those numbers describe', () => {
+      drawPreviewPage.render(disagreeing())
+
+      expect(drawPreviewPage.getPoolCards()).toHaveLength(6)
+      expect(drawPreviewPage.getKnockout()).toHaveTextContent(
+        '6-player bracket',
+      )
+      expect(drawPreviewPage.getKnockout()).toHaveTextContent('60 pool matches')
+    })
+
+    it('counts more than one bye in the plural', () => {
+      drawPreviewPage.render(disagreeing())
+
+      expect(drawPreviewPage.getKnockout()).toHaveTextContent(
+        '2 first-round byes',
+      )
+    })
+  })
+
+  // A bracket of three needs one player to sit out the first round, and "1 first-round
+  // byes" is the kind of copy a director reads as a bug in the arithmetic.
+  it('counts a single bye in the singular', () => {
+    drawPreviewPage.render(
+      buildDrawPreviewPropsFor({
+        previewFieldSize: 32,
+        poolReservationCount: 3,
+        poolCountMode: 'manual',
+        manualPoolCount: 3,
+        qualifiersMode: 'manual',
+        manualQualifiers: 1,
+      }),
+    )
+
+    expect(drawPreviewPage.getKnockout()).toHaveTextContent(
+      '1 first-round bye',
+    )
+    expect(drawPreviewPage.getKnockout()).not.toHaveTextContent(
+      '1 first-round byes',
+    )
+  })
+
+  /**
+   * The reference's **"Field too small"** state: 8 players across 6 manual pools is
+   * 2, 2, 1, 1, 1, 1 — four pools with nobody to play.
+   */
+  describe('when the draw cannot be played', () => {
+    const tooSmall = () =>
+      buildDrawPreviewPropsFor({
+        previewFieldSize: 8,
+        poolReservationCount: 6,
+        poolCountMode: 'manual',
+        manualPoolCount: 6,
+        qualifiersMode: 'manual',
+        manualQualifiers: 1,
+      })
+
+    it('refuses to call it ready', () => {
+      drawPreviewPage.render(tooSmall())
+
+      expect(drawPreviewPage.getVerdict()).toHaveTextContent(
+        'This draw can’t work yet',
+      )
+      expect(drawPreviewPage.getBadge()).toHaveTextContent('Impossible')
+    })
+
+    // The derivation names only the FIRST unplayable pool. The cards name every one of
+    // them, because that is what a director has to fix.
+    /**
+     * The precedence, pinned. Four manual pools of one against a field of 32 trips
+     * BOTH conditions at once: the seats do not add up (a disagreement) and every pool
+     * has one player in it (impossible). `data/draw-structure.ts` reports the two
+     * independently and says the order belongs to whatever renders them — so it is this
+     * component's, and a draw nobody can play is not "your call".
+     */
+    it('calls a draw that is both impossible and disagreeing impossible', () => {
+      drawPreviewPage.render(
+        buildDrawPreviewPropsFor({
+          previewFieldSize: 32,
+          poolReservationCount: 4,
+          poolCountMode: 'manual',
+          manualPoolCount: 4,
+          poolSizeMode: 'manual',
+          manualPoolSize: 1,
+        }),
+      )
+
+      expect(drawPreviewPage.getVerdict()).toHaveTextContent(
+        'This draw can’t work yet',
+      )
+      expect(drawPreviewPage.getBadge()).toHaveTextContent('Impossible')
+      expect(drawPreviewPage.getBadge()).not.toHaveTextContent('Your call')
+    })
+
+    it('marks each unplayable pool, not just the first', () => {
+      drawPreviewPage.render(tooSmall())
+
+      expect(drawPreviewPage.pool('A').queryTooSmall()).toBeNull()
+      expect(drawPreviewPage.pool('B').queryTooSmall()).toBeNull()
+      for (const letter of ['C', 'D', 'E', 'F']) {
+        expect(drawPreviewPage.pool(letter).queryTooSmall()).toBeInTheDocument()
+      }
+    })
+  })
+
+  /**
+   * ⚠️ The ADR's departure from the reference
+   * (`20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-count-is-a-projection`).
+   * The reference renders this fact as `max(reservations, derived)`, which for this very
+   * state would print `8` and hide the gap. Both halves are asserted together, because
+   * the gap — not either number — is the thing being reported.
+   */
+  it('states the event’s real pool rows, even when the structure needs more', () => {
+    drawPreviewPage.render(
+      buildDrawPreviewPropsFor({
+        previewFieldSize: 40,
+        poolReservationCount: 4,
+        poolSizeMode: 'manual',
+        manualPoolSize: 5,
+      }),
+    )
+
+    // 40 in pools of 5 needs 8 pools. The event has 4 rows.
+    expect(drawPreviewPage.getEquation()).toHaveTextContent('8 pools')
+    expect(drawPreviewPage.getFact('Pool reservations')).toHaveTextContent('4')
+  })
+
+  // The cards are a shape, not an inventory: the equation above them keeps the real
+  // count, so a big draw does not turn the column into a wall of cards.
+  it('draws at most eight cards, and still states the true pool count', () => {
+    drawPreviewPage.render(
+      buildDrawPreviewPropsFor({
+        previewFieldSize: 48,
+        poolReservationCount: 12,
+      }),
+    )
+
+    expect(drawPreviewPage.getPoolCards()).toHaveLength(8)
+    expect(drawPreviewPage.getEquation()).toHaveTextContent('12 pools')
+  })
+
+  it('shows the preview basis it was given, cap or no cap', () => {
+    drawPreviewPage.render({
+      previewBasis: '16 players because this event has no cap',
+    })
+
+    expect(drawPreviewPage.getFact('Preview basis')).toHaveTextContent(
+      '16 players because this event has no cap',
+    )
+  })
+
+  describe('reading the preview without seeing it', () => {
+    // The numbers move on every keystroke next door. A preview that swaps its text
+    // silently is a preview a screen-reader user never learns changed.
+    it('puts the derived numbers in a polite live region', () => {
+      drawPreviewPage.render()
+
+      const live = drawPreviewPage.getLiveRegion()
+      expect(live).toContainElement(drawPreviewPage.getVerdict())
+      expect(live).toContainElement(drawPreviewPage.getEquation())
+      expect(live).toContainElement(drawPreviewPage.getKnockout())
+    })
+
+    // Atomic, it would re-read the equation, all eight pools, the knockout and the three
+    // facts every time one digit moved.
+    it('announces only the part that changed', () => {
+      drawPreviewPage.render()
+
+      expect(drawPreviewPage.getLiveRegion()).toHaveAttribute(
+        'aria-atomic',
+        'false',
+      )
+    })
+
+    it('names the panel and the pool group', () => {
+      drawPreviewPage.render()
+
+      expect(drawPreviewPage.getPreview()).toHaveAccessibleName(
+        'The draw as it stands',
+      )
+      expect(drawPreviewPage.getPoolList()).toHaveAccessibleName(
+        'Projected pools',
+      )
+    })
+  })
+
+  // The draw stays on screen while the director scrolls the settings that change it.
+  it('sticks to the top of its column', () => {
+    drawPreviewPage.render()
+
+    expect(drawPreviewPage.getPreview()).toHaveClass('sticky')
+  })
+
+  // The reference ends with `Preview cut-time assignment →`. That screen is #1324, and a
+  // link to nowhere is the unexplained dead end ADR-0015 forbids.
+  it('offers no way out to a screen that does not exist yet', () => {
+    drawPreviewPage.render()
+
+    expect(drawPreviewPage.queryAllLinks()).toHaveLength(0)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.tsx
@@ -1,0 +1,268 @@
+import { useId } from 'react'
+
+import { Overline } from '@/components/overline'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+import { poolLetter, type DrawStructure } from '../../../data/draw-structure'
+import { PoolCard } from './draw-preview/pool-card'
+
+/** How many pool cards the preview draws. The reference stops at eight, and so does
+ * this: the equation directly above already states the pool count, so a twelve-pool draw
+ * reads `12 pools` over eight cards rather than losing the number. The cards are a shape,
+ * not an inventory. */
+const MAX_POOL_CARDS = 8
+
+/** The three states the preview can be in, in the words the reference uses. **The
+ * heading and the badge are one decision**, so they are one table — split across two
+ * conditionals they would eventually disagree, and a `Sound` badge over
+ * `This draw can’t work yet` is worse than either alone. */
+const VERDICTS = {
+  impossible: {
+    heading: 'This draw can’t work yet',
+    badge: 'Impossible',
+    badgeClass: 'border-[color:var(--loss)]/50 text-[color:var(--loss)]',
+  },
+  disagreement: {
+    heading: 'Your numbers disagree',
+    badge: 'Your call',
+    badgeClass: 'border-[color:var(--warn)]/50 text-[color:var(--warn)]',
+  },
+  sound: {
+    heading: 'Ready to save',
+    badge: 'Sound',
+    badgeClass: 'border-[color:var(--serve-500)]/50 text-[color:var(--serve-500)]',
+  },
+} as const
+
+export interface DrawPreviewProps {
+  /** The whole derivation, already done. **Every number the preview shows is read off
+   * this** — nothing here divides, rounds or counts. */
+  structure: DrawStructure
+  /** The field the derivation ran against, so the equation states its own left-hand
+   * side. */
+  fieldSize: number
+  /**
+   * How many pool rows the event actually has.
+   *
+   * ⚠️ **Not `max(reservations, derived)`.** The reference shows the larger of the two
+   * and moves on; ADR
+   * `20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-count-is-a-projection`
+   * refuses that, because the `max()` hides the one thing worth reporting. A director
+   * with four pool rows whose structure needs eight must read `8 pools` in the equation
+   * and `4` in this fact, and see the gap.
+   */
+  poolReservationCount: number
+  /** Where the preview field came from, in words — `32-player cap`, or the honest
+   * sentence for an event with no cap. Built by `previewBasisLabel` **at the caller**, so
+   * the heading block and this fact are one call and cannot come apart. */
+  previewBasis: string
+}
+
+/**
+ * The Draw structure tab's **live preview** (#1320): the draw as it stands, in one
+ * sticky column beside the settings that produce it.
+ *
+ * ## Why it is one panel
+ *
+ * There is exactly one verdict on this tab, and it is here. The left column's notices
+ * (uneven, disagreement, impossible) explain and offer fixes; this says what the draw
+ * currently *is*. A second summary anywhere would give a director two places to look and
+ * one of them would be stale.
+ *
+ * ## Why it announces itself
+ *
+ * The numbers move on every keystroke in the settings next door, and a preview that
+ * silently swaps its text is a preview a screen-reader user never learns changed. The
+ * body is therefore a `status` region — polite, and **not** atomic: an atomic region
+ * would re-read the equation, all eight pools, the knockout and the three facts every
+ * time a single digit moved.
+ *
+ * ## What is not here
+ *
+ * The reference ends with a `Preview cut-time assignment →` link. That screen is #1324,
+ * so the link is absent rather than stubbed — a dead link is the unexplained dead end
+ * ADR-0015 forbids. Membership reads `Snake` because nothing stores the manual mode yet
+ * (chore 3c).
+ */
+export const DrawPreview = ({
+  structure,
+  fieldSize,
+  poolReservationCount,
+  previewBasis,
+}: DrawPreviewProps) => {
+  const overlineId = useId()
+
+  // The precedence is the reference's, and it is the order a director can act in: a draw
+  // that cannot be played is not "your call".
+  const verdict =
+    structure.impossibleProblems.length > 0
+      ? VERDICTS.impossible
+      : structure.disagreement !== null
+        ? VERDICTS.disagreement
+        : VERDICTS.sound
+
+  // Read off the derived sizes rather than divided out again — the pools are routinely
+  // unequal, and `8` where the draw holds `6–5` would be the silent reshaping #1320
+  // exists to remove.
+  const smallestPool = Math.min(...structure.poolSizes)
+  const largestPool = Math.max(...structure.poolSizes)
+  const sizeLabel =
+    smallestPool === largestPool
+      ? String(smallestPool)
+      : `${smallestPool}–${largestPool}`
+
+  const byes = structure.firstRoundByes
+  const byesLine =
+    byes === 0
+      ? 'No first-round byes'
+      : `${byes} first-round ${byes === 1 ? 'bye' : 'byes'}`
+
+  // Three facts about the draw that are not in the picture above it. Only a bare figure
+  // takes the mono face: `Preview basis` is `32-player cap` for a capped event but a
+  // whole sentence for an uncapped one, and the heading block already sets that same
+  // sentence in the UI face.
+  const facts = [
+    {
+      term: 'Pool reservations',
+      value: String(poolReservationCount),
+      mono: true,
+    },
+    { term: 'Membership', value: 'Snake', mono: false },
+    { term: 'Preview basis', value: previewBasis, mono: false },
+  ]
+
+  return (
+    // Sticky, so the draw stays on screen while the director scrolls the four settings
+    // that change it — the whole point of putting the two side by side.
+    <section
+      aria-labelledby={overlineId}
+      data-testid="draw-preview"
+      className="sticky top-0 flex flex-col gap-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)] p-4"
+    >
+      <div
+        role="status"
+        aria-atomic="false"
+        className="flex min-w-0 flex-col gap-3"
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            {/* No colour of its own: `.fortymm-theme .fortymm-overline` is unlayered,
+                so it beats any Tailwind text-colour utility set here, and the muted
+                grey it gives is the one the reference uses. */}
+            <Overline id={overlineId}>The draw as it stands</Overline>
+            <h4
+              data-testid="draw-preview-verdict"
+              className="mt-1 text-[17px] leading-tight font-semibold text-[color:var(--fg-1)]"
+            >
+              {verdict.heading}
+            </h4>
+          </div>
+          <Badge
+            data-testid="draw-preview-badge"
+            variant="outline"
+            className={cn(
+              'shrink-0 text-[10px] font-semibold tracking-[0.1em] uppercase',
+              verdict.badgeClass,
+            )}
+          >
+            {verdict.badge}
+          </Badge>
+        </div>
+
+        {/* The whole draw in one line. Each string literal carries its own spaces —
+            JSX drops the whitespace around a line break, and `32players` is one
+            reformat away from a text node written the other way. */}
+        <p
+          data-testid="draw-preview-equation"
+          className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--bg-raised)] px-3 py-2 text-center text-[12px] text-[color:var(--fg-3)]"
+        >
+          <span className="font-mono text-[15px] font-semibold text-[color:var(--fg-1)]">
+            {fieldSize}
+          </span>
+          {' players ÷ '}
+          <span className="font-mono text-[15px] font-semibold text-[color:var(--fg-1)]">
+            {structure.poolCount}
+          </span>
+          {' pools = '}
+          <span className="font-mono text-[15px] font-semibold text-[color:var(--fg-1)]">
+            {sizeLabel}
+          </span>
+          {' per pool'}
+        </p>
+
+        {/* Named, because eight identically-shaped cards are otherwise a wall of
+            numbers a screen reader cannot introduce. */}
+        {/* Two across: the preview column is 280px at its widest, and a third card
+            would squeeze the figures below the size the mono face is set at. */}
+        <ul aria-label="Projected pools" className="grid grid-cols-2 gap-2">
+          {structure.poolSizes.slice(0, MAX_POOL_CARDS).map((size, index) => (
+            <PoolCard
+              key={poolLetter(index)}
+              letter={poolLetter(index)}
+              size={size}
+              qualifiers={structure.qualifiersPerPool}
+            />
+          ))}
+        </ul>
+
+        {/* Decorative: the pools feeding the knockout is already said in words below. */}
+        <p
+          aria-hidden="true"
+          className="text-center text-[13px] leading-none text-[color:var(--fg-3)]"
+        >
+          ↓
+        </p>
+
+        <div
+          data-testid="draw-preview-knockout"
+          className="flex items-start justify-between gap-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--bg-raised)] px-3 py-2"
+        >
+          <div className="min-w-0">
+            <div className="text-[10px] font-semibold tracking-[0.14em] text-[color:var(--fg-3)] uppercase">
+              Knockout
+            </div>
+            <p className="mt-0.5 font-mono text-[15px] font-semibold text-[color:var(--fg-1)]">
+              {structure.knockoutBracketSize}-player bracket
+            </p>
+          </div>
+          <div className="shrink-0 text-right text-[11px] text-[color:var(--fg-3)]">
+            <p>{byesLine}</p>
+            {/* Not pluralised, deliberately: the reference does not pluralise this line
+                and `data/draw-structure.ts` records why an unasked-for improvement here
+                is drift against the Python twin. */}
+            <p>{structure.poolMatchCount} pool matches</p>
+          </div>
+        </div>
+
+        <dl className="mt-1 border-t border-[color:var(--border-subtle)]">
+          {facts.map(({ term, value, mono }) => (
+            <div
+              key={term}
+              className="flex items-baseline justify-between gap-3 border-b border-[color:var(--border-subtle)] py-1.5"
+            >
+              <dt className="text-[12px] text-[color:var(--fg-3)]">{term}</dt>
+              <dd
+                className={cn(
+                  'text-[12px] text-[color:var(--fg-1)]',
+                  mono && 'font-mono',
+                )}
+              >
+                {value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      {/* Outside the live region: it never changes, and a region that re-read it on
+          every keystroke would bury the numbers that did. */}
+      <p
+        data-testid="draw-preview-foot"
+        className="text-[11px] leading-snug text-[color:var(--fg-3)]"
+      >
+        Entrants are placed only when registration closes and you cut the draw.
+      </p>
+    </section>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview/pool-card.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview/pool-card.factory.tsx
@@ -1,0 +1,18 @@
+import type { PoolCardProps } from './pool-card'
+
+/**
+ * `Pool A` in the reference's **"Nothing set"** state
+ * (`docs/designs/rr-then-ko-draw-structure/nothing-set.png`): eight players, two of them
+ * advancing — a pool that can be played, so the bad state is something a test asks for
+ * rather than something it gets by accident.
+ */
+export function buildPoolCardProps(
+  overrides: Partial<PoolCardProps> = {},
+): PoolCardProps {
+  return {
+    letter: 'A',
+    size: 8,
+    qualifiers: 2,
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview/pool-card.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview/pool-card.page.tsx
@@ -1,0 +1,39 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { PoolCard, type PoolCardProps } from './pool-card'
+import { buildPoolCardProps } from './pool-card.factory'
+
+const scoped = (container: Container) => ({
+  /** The card itself. */
+  getCard() {
+    return container.getByTestId('draw-preview-pool-card')
+  },
+  /** The `Too small` line — **absent** on a pool that can be played. The bad state is
+   * read as text on purpose: a colour is no state at all to a screen reader. */
+  queryTooSmall() {
+    return container.queryByText('Too small')
+  },
+  /** The `top {q} advance` line, which wears the advancing green only on a pool that can
+   * actually supply those qualifiers. */
+  getAdvanceLine() {
+    return container.getByText(/^top \d+ advance$/)
+  },
+})
+
+/** Test page-object for `PoolCard`. The card is an `<li>`, so `render` puts it in a list
+ * — the same parent `DrawPreview` gives it. */
+export const poolCardPage = {
+  render(overrides: Partial<PoolCardProps> = {}) {
+    render(
+      <ul>
+        <PoolCard {...buildPoolCardProps(overrides)} />
+      </ul>,
+    )
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview/pool-card.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview/pool-card.test.tsx
@@ -1,0 +1,60 @@
+import { poolCardPage } from './pool-card.page'
+
+describe('PoolCard', () => {
+  it('names the pool, sizes it, and says how many advance', () => {
+    poolCardPage.render({ letter: 'A', size: 8, qualifiers: 2 })
+
+    const card = poolCardPage.getCard()
+    expect(card).toHaveTextContent('Pool A')
+    expect(card).toHaveTextContent('8')
+    expect(card).toHaveTextContent('players')
+    expect(card).toHaveTextContent('top 2 advance')
+  })
+
+  it('reads as playable when the pool can supply its qualifiers', () => {
+    poolCardPage.render({ size: 8, qualifiers: 2 })
+
+    expect(poolCardPage.queryTooSmall()).toBeNull()
+  })
+
+  // A pool of one has nobody to play. The derivation calls the whole draw impossible for
+  // it; the card says which pool.
+  it('says "Too small" when the pool holds fewer than two players', () => {
+    poolCardPage.render({ letter: 'C', size: 1, qualifiers: 1 })
+
+    expect(poolCardPage.queryTooSmall()).toBeInTheDocument()
+  })
+
+  // The second, independent condition: the pool is playable but cannot send four players
+  // to a knockout when only three are in it.
+  it('says "Too small" when the pool holds fewer players than it must advance', () => {
+    poolCardPage.render({ letter: 'C', size: 3, qualifiers: 4 })
+
+    expect(poolCardPage.queryTooSmall()).toBeInTheDocument()
+  })
+
+  // The boundary the two conditions meet at: a pool of two taking two is legal.
+  it('leaves a pool that advances every player alone', () => {
+    poolCardPage.render({ size: 2, qualifiers: 2 })
+
+    expect(poolCardPage.queryTooSmall()).toBeNull()
+  })
+
+  // Green is the advancing state, and a pool that cannot advance anybody must not wear
+  // it — the tint is the second signal, never the only one.
+  it('drops the advancing colour from a pool that is too small', () => {
+    poolCardPage.render({ size: 1, qualifiers: 1 })
+
+    expect(poolCardPage.getAdvanceLine()).not.toHaveClass(
+      'text-[color:var(--serve-500)]',
+    )
+  })
+
+  it('keeps the advancing colour on a pool that can supply its qualifiers', () => {
+    poolCardPage.render({ size: 8, qualifiers: 2 })
+
+    expect(poolCardPage.getAdvanceLine()).toHaveClass(
+      'text-[color:var(--serve-500)]',
+    )
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview/pool-card.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview/pool-card.tsx
@@ -1,0 +1,67 @@
+import { cn } from '@/lib/utils'
+
+export interface PoolCardProps {
+  /** The pool's letter — `A`, `B`, … — from `poolLetter`. The card never derives it,
+   * because the letter is the pool's *position* and only the list knows that. */
+  letter: string
+  /** How many players the derivation lands in this pool. */
+  size: number
+  /** How many of them reach the knockout. The same number for every pool, and the card
+   * needs it to know whether it can supply them. */
+  qualifiers: number
+}
+
+/**
+ * One pool in the live preview: how big it is, and how many of it advance.
+ *
+ * **The card owns one branch — whether this pool can be played.** A pool of one has
+ * nobody to play, and a pool of three cannot send four players to the knockout, so the
+ * card reads as bad when its size is under two or under the qualifier count. The
+ * derivation reports the same two conditions as *impossible problems*
+ * (`data/draw-structure.ts`), but it reports only the FIRST one it hits, for the whole
+ * draw. A director looking at eight cards needs to see which pools are the problem, so
+ * the card asks the question again of itself.
+ *
+ * **The bad state is a word, not a colour.** `Too small` is visible text, and the tint
+ * is on top of it. A red border alone says nothing to a screen reader and little to a
+ * reader who cannot separate the two shades.
+ */
+export const PoolCard = ({ letter, size, qualifiers }: PoolCardProps) => {
+  const tooSmall = size < 2 || size < qualifiers
+  return (
+    <li
+      data-testid="draw-preview-pool-card"
+      className={cn(
+        'rounded-lg border px-2.5 py-2',
+        tooSmall
+          ? 'border-[color:var(--loss)]/50 bg-[color:var(--loss)]/10'
+          : 'border-[color:var(--border-subtle)] bg-[color:var(--bg-raised)]',
+      )}
+    >
+      <div className="text-[10px] font-semibold tracking-[0.14em] text-[color:var(--fg-3)] uppercase">
+        Pool {letter}
+      </div>
+      <p className="mt-1 font-mono text-[20px] leading-none font-semibold text-[color:var(--fg-1)]">
+        {size}
+      </p>
+      <p className="mt-0.5 text-[11px] text-[color:var(--fg-3)]">players</p>
+      {/* Green is the advancing state, and it is only honest on a pool that can supply
+          the qualifiers it promises. */}
+      <p
+        className={cn(
+          'mt-1.5 text-[11px]',
+          tooSmall
+            ? 'text-[color:var(--fg-3)]'
+            : 'text-[color:var(--serve-500)]',
+        )}
+      >
+        top {qualifiers} advance
+      </p>
+      {tooSmall && (
+        <p className="mt-1 text-[11px] font-semibold text-[color:var(--loss)]">
+          Too small
+        </p>
+      )}
+    </li>
+  )
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/preview-field.test.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/preview-field.test.ts
@@ -1,0 +1,32 @@
+import {
+  DEFAULT_UNCAPPED_FIELD,
+  previewBasisLabel,
+  previewFieldSize,
+} from './preview-field'
+
+describe('previewFieldSize', () => {
+  it('derives against the cap the director set', () => {
+    expect(previewFieldSize(32)).toBe(32)
+  })
+
+  it('falls back to the uncapped default when the event has no cap', () => {
+    expect(previewFieldSize(null)).toBe(16)
+    expect(DEFAULT_UNCAPPED_FIELD).toBe(16)
+  })
+})
+
+describe('previewBasisLabel', () => {
+  it('names the cap the field came from', () => {
+    expect(previewBasisLabel(32)).toBe('32-player cap')
+  })
+
+  // The deviation #1320 requires: the reference says `16-player cap` here, which is a
+  // cap nobody set. A director who read that would go looking for it on Basics.
+  it('says why the field is 16 when the event has no cap — never calls it a cap', () => {
+    expect(previewBasisLabel(null)).toBe(
+      '16 players because this event has no cap',
+    )
+    expect(previewBasisLabel(null)).not.toContain('cap.')
+    expect(previewBasisLabel(null)).not.toMatch(/16-player cap/)
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/preview-field.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/preview-field.ts
@@ -1,0 +1,45 @@
+// The **field a draw-structure preview is derived against** (#1320), and the one
+// sentence that says where that field came from.
+//
+// It lives here rather than in `data/draw-structure.ts` on purpose. That module's
+// numbers are pinned vector-for-vector against a Python twin, and it says out loud that
+// anything the vectors do not pin is drift waiting to happen. This is not one of the
+// eight derivation inputs — it is the question of *which* field the derivation is fed,
+// and the answer is a fact about the EVENT (does it have a cap?), not about the draw.
+//
+// Both this module and the live preview (chore 2c) read the label from here, so the
+// heading block and the preview's "Preview basis" fact cannot come to say different
+// things about the same number.
+
+/**
+ * The field a preview assumes when the event has **no cap**.
+ *
+ * `maxPlayers: null` is "no cap" and never zero (ADR-0935), so there is no number to
+ * divide into pools — and a preview of nothing is not a preview. Sixteen is the
+ * synthetic field we invent instead.
+ *
+ * ⚠️ **Mirrors `DEFAULT_UNCAPPED_FIELD` in `api/app/schedule_preview.py`**, which invents
+ * the same synthetic field for the same reason. Neither copy is generated from the
+ * other: change one and change this.
+ */
+export const DEFAULT_UNCAPPED_FIELD = 16
+
+/** The field the Draw structure tab derives against: the director's cap, or the
+ * uncapped default above. */
+export const previewFieldSize = (maxPlayers: number | null): number =>
+  maxPlayers ?? DEFAULT_UNCAPPED_FIELD
+
+/**
+ * Where that field came from, **in words a director can check**.
+ *
+ * ⚠️ This is the one place the implementation departs from the reference
+ * (`docs/designs/rr-then-ko-draw-structure/README.md`), which labels the basis
+ * `{n}-player cap` in *every* state — the uncapped one included. That sentence is false
+ * for an uncapped event: nobody typed 16, there is no cap, and a director reading
+ * "16-player cap" would go hunting the Basics tab for a number that is not there. #1320
+ * requires the honest label, and the README records the deviation.
+ */
+export const previewBasisLabel = (maxPlayers: number | null): string =>
+  maxPlayers === null
+    ? `${DEFAULT_UNCAPPED_FIELD} players because this event has no cap`
+    : `${maxPlayers}-player cap`

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.factory.tsx
@@ -1,0 +1,25 @@
+import type { SettingRowProps } from './setting-row'
+
+/**
+ * The reference's **Pool count** row in its "Nothing set" state
+ * (`docs/designs/rr-then-ko-draw-structure/nothing-set.png`): four pools, derived from
+ * four pool reservations, so every part of the row is populated — a numeric value, a
+ * unit, an `Automatic` badge and a source sentence.
+ *
+ * The Membership row (no number, no unit) is built by overriding
+ * `kind: 'phrase'` and dropping the unit.
+ */
+export function buildSettingRowProps(
+  overrides: Partial<SettingRowProps> = {},
+): SettingRowProps {
+  return {
+    name: 'Pool count',
+    hint: 'How many pools the field splits into. Each pool also books its tables and time window.',
+    value: '4',
+    kind: 'number',
+    unit: 'pools',
+    ownership: 'automatic',
+    source: "4 pool reservations · today's behaviour",
+    ...overrides,
+  }
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.page.tsx
@@ -1,0 +1,51 @@
+import { render, screen, type Container } from '@/test/utilities'
+
+import { SettingRow, type SettingRowProps } from './setting-row'
+import { buildSettingRowProps } from './setting-row.factory'
+
+const scoped = (container: Container) => ({
+  /** The row itself — a `region` named by the setting it holds. */
+  getRow() {
+    return container.getByRole('region')
+  },
+  /** The setting's name. */
+  getName() {
+    return container.getByTestId('draw-setting-name')
+  },
+  /** The one line under the name. */
+  getHint() {
+    return container.getByTestId('draw-setting-hint')
+  },
+  /** The value as the director reads it — a figure, or Membership's phrase. */
+  getValue() {
+    return container.getByTestId('draw-setting-value')
+  },
+  /** The plain words after the value. **Absent on a `phrase` row**: Membership's
+   * value is already a sentence, so there is nothing to unit. */
+  queryUnit() {
+    return container.queryByTestId('draw-setting-unit')
+  },
+  /** The ownership badge — `Automatic` or `Yours`. Read as TEXT: a colour-only
+   * signal would be no signal at all to a screen reader (ADR 20260808). */
+  getOwnershipBadge() {
+    return container.getByTestId('draw-setting-ownership')
+  },
+  /** The line saying where the value came from. */
+  getSource() {
+    return container.getByTestId('draw-setting-source')
+  },
+})
+
+/** Test page-object for `SettingRow`. Composed by `drawStructureSectionPage`, which
+ * scopes these accessors to one row at a time. */
+export const settingRowPage = {
+  render(overrides: Partial<SettingRowProps> = {}) {
+    render(<SettingRow {...buildSettingRowProps(overrides)} />)
+  },
+
+  within(container: Container = screen) {
+    return scoped(container)
+  },
+
+  ...scoped(screen),
+}

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.test.tsx
@@ -1,0 +1,70 @@
+import { settingRowPage } from './setting-row.page'
+
+describe('SettingRow', () => {
+  it('reads out the setting, what it means, what it says and where that came from', () => {
+    settingRowPage.render()
+
+    expect(settingRowPage.getName()).toHaveTextContent('Pool count')
+    expect(settingRowPage.getHint()).toHaveTextContent(
+      'How many pools the field splits into. Each pool also books its tables and time window.',
+    )
+    expect(settingRowPage.getValue()).toHaveTextContent('4')
+    expect(settingRowPage.queryUnit()).toHaveTextContent('pools')
+    expect(settingRowPage.getSource()).toHaveTextContent(
+      "4 pool reservations · today's behaviour",
+    )
+  })
+
+  // The row is addressable by the thing it sets, not by its position in the list — four
+  // rows of identical markup are otherwise indistinguishable to a screen reader.
+  it('names the region after the setting', () => {
+    settingRowPage.render({ name: 'Qualifiers per pool' })
+
+    expect(settingRowPage.getRow()).toHaveAccessibleName('Qualifiers per pool')
+  })
+
+  // ADR 20260808: the owner is stated in WORDS. A badge that differed only by colour
+  // would be no badge at all to a screen reader.
+  it('says "Automatic" in text when the system owns the value', () => {
+    settingRowPage.render({ ownership: 'automatic' })
+
+    expect(settingRowPage.getOwnershipBadge()).toHaveTextContent('Automatic')
+  })
+
+  it('says "Yours" in text when the director owns the value', () => {
+    settingRowPage.render({ ownership: 'manual' })
+
+    expect(settingRowPage.getOwnershipBadge()).toHaveTextContent('Yours')
+  })
+
+  it('renders a figure in the mono face', () => {
+    settingRowPage.render({ kind: 'number', value: '4' })
+
+    expect(settingRowPage.getValue()).toHaveClass('font-mono')
+  })
+
+  // Membership: the value is prose, so there is no unit and no mono figure.
+  it('renders a phrase with no unit and no mono face', () => {
+    settingRowPage.render({
+      name: 'Membership',
+      kind: 'phrase',
+      value: 'Snake automatically',
+      unit: undefined,
+      source: 'Seeds spread 1, 2, 3, 3, 2, 1.',
+    })
+
+    expect(settingRowPage.getValue()).toHaveTextContent('Snake automatically')
+    expect(settingRowPage.getValue()).not.toHaveClass('font-mono')
+    expect(settingRowPage.queryUnit()).toBeNull()
+  })
+
+  // This chore is read-only: the `Set myself` action and the numeric input are 3c, and
+  // they are absent rather than disabled.
+  it('renders no control — the value is text', () => {
+    settingRowPage.render()
+
+    expect(settingRowPage.getRow().querySelectorAll('input, button')).toHaveLength(
+      0,
+    )
+  })
+})

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.tsx
@@ -1,0 +1,141 @@
+import { useId } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+import type { SettingOwnership } from '../../../data/draw-structure'
+
+/** The word on the badge, and the only place ownership is put into words.
+ *
+ * **Ownership is text, not a colour.** A director must be able to read who owns a number
+ * without comparing two shades of grey (ADR 20260808 — "the editor states the owner in
+ * words, not only in colour"), and a screen reader has no shades at all. */
+const OWNERSHIP_LABEL: Record<SettingOwnership, string> = {
+  automatic: 'Automatic',
+  manual: 'Yours',
+}
+
+export interface SettingRowProps {
+  /** The setting's name — `Pool count`, `Pool size`, `Membership`,
+   * `Qualifiers per pool`. It is also the row's accessible name, so a test (and a
+   * screen reader) addresses the row by the thing it sets. */
+  name: string
+  /** One short line under the name, saying what the setting means. */
+  hint: string
+  /**
+   * The value the director reads. Already formatted by the caller, because only the
+   * caller knows what the number means: `4`, or `6–10` when the pools are uneven, or a
+   * whole phrase for Membership.
+   */
+  value: string
+  /**
+   * How the value reads, which is also how it is set:
+   *
+   * - `number` — a figure, in the mono face at display size, beside its `unit`.
+   * - `phrase` — prose (`Snake automatically`), in the UI face, with no unit. Membership
+   *   is the only setting with no number, so it is the only row that takes this.
+   */
+  kind: 'number' | 'phrase'
+  /** Plain words after the value (`pools`, `players per pool`). A `phrase` row has
+   * none: its value is already a sentence. */
+  unit?: string
+  /** Who owns the value — the badge is this and nothing else (ADR 20260808). */
+  ownership: SettingOwnership
+  /** One line saying where the value came from, e.g. `32 players ÷ 4 pools`. Derived
+   * by `deriveDrawStructure` for the three numeric settings, so the copy cannot fork
+   * away from the arithmetic it describes. */
+  source: string
+}
+
+/**
+ * One row of the Draw structure tab's setting list: what the setting is called, what it
+ * means, what it currently says, **who owns it**, and where that value came from.
+ *
+ * The four settings share one pattern because they are one kind of thing — a structural
+ * setting, owned by the director or derived by the system (ADR 20260808). Written out
+ * four times, the badge and the source line would be four places to get the same
+ * ownership story right.
+ *
+ * **The rows share one list with dividers, not one card each.** The divider is the
+ * parent's (`divide-y`), so a row contributes no border of its own and the list reads as
+ * one draw rather than as four unrelated panels.
+ *
+ * This chore renders the value as text only. The `Set myself` / `Use automatic` action
+ * and the numeric input are chore 3c — and they are *absent*, not disabled: a dead box
+ * is the unexplained dead end ADR-0015 forbids.
+ */
+export const SettingRow = ({
+  name,
+  hint,
+  value,
+  kind,
+  unit,
+  ownership,
+  source,
+}: SettingRowProps) => {
+  const nameId = useId()
+  return (
+    // A named `region`, so the row is addressable by the setting it holds rather than by
+    // its position in the list — the four rows are otherwise identical markup.
+    <section
+      aria-labelledby={nameId}
+      data-testid="draw-setting-row"
+      className="grid grid-cols-1 gap-x-6 gap-y-2 py-4 sm:grid-cols-[minmax(0,160px)_minmax(0,1fr)]"
+    >
+      <div className="min-w-0">
+        <h4
+          id={nameId}
+          data-testid="draw-setting-name"
+          className="text-[15px] font-semibold text-[color:var(--fg-1)]"
+        >
+          {name}
+        </h4>
+        <p
+          data-testid="draw-setting-hint"
+          className="mt-1 text-[12px] leading-snug text-[color:var(--fg-3)]"
+        >
+          {hint}
+        </p>
+      </div>
+
+      <div className="min-w-0">
+        <p className="flex flex-wrap items-baseline gap-x-2">
+          <span
+            data-testid="draw-setting-value"
+            className={cn(
+              'text-[color:var(--fg-1)]',
+              kind === 'number'
+                ? 'font-mono text-[22px] leading-none font-semibold'
+                : 'text-[15px] font-semibold',
+            )}
+          >
+            {value}
+          </span>
+          {unit && (
+            <span
+              data-testid="draw-setting-unit"
+              className="text-[13px] text-[color:var(--fg-2)]"
+            >
+              {unit}
+            </span>
+          )}
+        </p>
+        <p className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1">
+          <Badge
+            data-testid="draw-setting-ownership"
+            variant="outline"
+            className="text-[10px] font-semibold tracking-[0.1em] uppercase"
+          >
+            {OWNERSHIP_LABEL[ownership]}
+          </Badge>
+          <span
+            data-testid="draw-setting-source"
+            className="text-[12px] text-[color:var(--fg-3)]"
+          >
+            {source}
+          </span>
+        </p>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
Slice 2 of the #1320 arc, stacked on #1325. Web client only. No API change, no schema change, no regen.

A director editing a round-robin-then-knockout event gets a fifth tab, **Draw structure**, which states the draw their pool rows already imply. Everything on it is read-only and badged `Automatic`. Typing your own numbers is slice 3.

## What a director sees

Four setting rows in one list — pool count, pool size, membership, qualifiers per pool — each with the value, the unit, an `Automatic` badge, and a sentence saying where the number came from. Beside them, one sticky preview: the equation, a card per pool with the qualifiers it sends on, the knockout bracket with its byes, and the pool match count.

An event with four pools and a 32-player cap reads `32 players ÷ 4 pools = 8 per pool`, four pools of 8 at top 2, an 8-player knockout, no first-round byes, 112 pool matches.

Pools that differ by one player get a `Legal, but uneven` notice. It is a status, not a warning: nothing is disabled, and neither the red nor the yellow token appears.

## How it is built

The arithmetic is one pure module with no React and no fetch, so the tab recomputes on a keystroke without asking the server. Its tests are a single exported table of 16 vectors rather than scattered assertions, because chore 4a asserts the same table in Python — a header block marks which fields cross that boundary.

Two traps are pinned by their own vectors. The fill is greedy when the director sets a pool size, so 41 players in pools of five ends in a pool of one, which is an impossible competition rather than something to silently rebalance. The byes formula clamps the bracket to two before taking the next power of two, without which a one-player knockout reports no byes instead of one.

The panel that carries the uneven notice is the one slices 4 and 5 extend. All three variants are in the type, and the precedence between them lives in one function, so the refusal and the disagreement plug in without re-deriving which wins. That precedence is load-bearing: a field of eight across six pools produces an uneven tally *and* a pool of one at the same time, and the director must read the refusal.

## Two departures from the reference, both deliberate

- The reference labels the preview basis `{n}-player cap` even when the 16 it used is a default nobody chose. An uncapped event now says so in words.
- The reference renders `Pool reservations` as `max(rows, derived)`. This shows the true row count, because that maximum hides the mismatch slices 4 and 5 exist to report (ADR `20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-count-is-a-projection`).

The `Preview cut-time assignment →` link is omitted. That screen is #1324.

## Verification

- vitest **333 files / 3709 tests**, collected equal to ran. `tsc -b` clean, `eslint` clean.
- Root e2e **32/32**, including a new spec that seeds a real event through the API and reads the tab in a browser. The numbers it asserts — 112 matches, the 8-player bracket, the absent byes — are produced by the derivation and stored nowhere, so a tab reading the payload instead would red. It also opens a plain round-robin event and proves the tab is *not* there, after first proving two tabs that are.
- Opened in a browser at the desktop width, which caught one thing no unit test could: `8-player bracket` wrapped onto two lines at the 280px preview width. jsdom performs no layout, so every test was green while it wrapped.

Qualifiers per pool still appears on Basics as well. Chore 3e moves it.

Refs #1320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcvZ6Zh6w6vxj6uAaizmuF
