### PR TITLE
Slice 3: a director sets a structural number themselves, and the app keeps it (#1320)

### DIFF
--- a/api/app/schemas/tournament.py
+++ b/api/app/schemas/tournament.py
@@ -1,9 +1,10 @@
+import enum
 import uuid
 from collections import Counter
 from collections.abc import Mapping
 from datetime import date, datetime, time
 from decimal import ROUND_DOWN, Decimal
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pydantic import (
@@ -184,6 +185,138 @@ not become
 unwritable when a player withdraws."""
 
 
+MAX_MANUAL_POOL_DIMENSION = MAX_EVENT_PLAYERS
+"""The ceiling on a pool count and on a pool size the **director types**.
+
+The same kind of bound ``MAX_QUALIFIERS_PER_POOL`` is, and not the domain rule either:
+the rules that decide whether a structure is playable move with the field and belong to
+the derivation (chore 4b), not to this boundary. This is the boundary refusing numbers
+that are nonsense on their face. ``MAX_EVENT_PLAYERS`` is the largest field this API
+holds, so more pools than that — or more players in one pool than that — is not a
+structure whatever else is set, and the derivation that builds one list entry per pool
+never has to size a list from a number a client chose."""
+
+ManualPoolCount = Annotated[int, Field(ge=1, le=MAX_MANUAL_POOL_DIMENSION)]
+"""How many pools the director says the field splits into, when they own the count.
+
+``1 <= n <= MAX_MANUAL_POOL_DIMENSION`` is a **representational** floor and ceiling, in
+the sense ``QualifiersPerPool``'s is: a draw of zero pools is not a draw, and a negative
+count is not a count. Whether the number the director typed *fits their field* is a
+different question with a different answer — the app reports the disagreement and keeps
+both numbers (ADR "a structural setting is owned by the director or derived by the
+system"), so it is deliberately NOT refused here."""
+
+ManualPoolSize = Annotated[int, Field(ge=1, le=MAX_MANUAL_POOL_DIMENSION)]
+"""How many players the director targets in each pool, when they own the size. The same
+representational bounds :data:`ManualPoolCount` carries, for the same reasons — a pool
+of one player is a real refusal, but it is the *cut's* (``DegenerateDraw``), not this
+boundary's."""
+
+
+class StructuralSettingOwner(enum.Enum):
+    # Who owns one of an ``rr-then-ko`` draw's numeric structural settings (ADR "a
+    # structural setting is owned by the director or derived by the system"): the system
+    # derives it from the event, or the director typed it.
+    #
+    # Stored as its own mode, NEVER inferred from whether a value is present. A derived
+    # value is a number too, so reading ownership off "is the field filled in" would
+    # make every derived draw look director-owned the moment it was shown — and the two
+    # states must behave differently the next time the field changes.
+    #
+    # No docstring on purpose: Pydantic emits an enum's ``__doc__`` as the OpenAPI
+    # ``description``, so prose here would cross the wire into both generated clients.
+    automatic = "automatic"
+    manual = "manual"
+
+
+class PoolMembershipMode(enum.Enum):
+    # How entrants land in the pools of an ``rr-then-ko`` draw. Ownership again, but its
+    # two values are named for what they DO rather than for who chose them, because the
+    # automatic answer is a specific algorithm the director can read: ``snake`` is the
+    # 1, 2, 3, 3, 2, 1 deal ``_snake()`` in ``app.draws`` already performs on every cut.
+    #
+    # ``manual`` is "assign at cut time" — the director places entrants themselves once
+    # registration closes. Storing the mode is all this does: the cut screen that
+    # honours it is #1324, and until then a ``manual`` event still cuts by snake.
+    #
+    # No docstring on purpose — see :class:`StructuralSettingOwner`.
+    snake = "snake"
+    manual = "manual"
+
+
+# ``DrawStructure``'s rationale lives out here, in comments, and only its contract lives
+# in the docstring below. A model's ``__doc__`` becomes the OpenAPI ``description`` and
+# crosses into both generated clients, so the reasoning a reviewer of THIS file wants is
+# noise in ``schema.d.ts`` and ``Types.swift`` — the same reason the two enums above
+# carry no docstring at all.
+#
+# **Every mode has a default, and the defaults are today's behaviour.** An event that
+# predates this work stores ``{"qualifiers_per_pool": K}`` with no ``draw_structure``
+# key, and it parses into this model's defaults: every mode automatic, no manual
+# numbers. That is what makes the change need no migration — "not set" and "set to
+# automatic" are the same event, which is exactly what the ADR asks for.
+#
+# **A manual number is KEPT when its mode is automatic**, and that pairing is a legal
+# state on purpose. It is the director's number, remembered: a director who switches a
+# row back to Automatic to see what the system would say, and then switches back, gets
+# their own number returned rather than a blank box. Nothing derives anything from a
+# manual number whose mode is automatic — the mode is the only thing a reader asks. The
+# alternative, clearing the number, would make "Use automatic" a destructive act.
+#
+# **What "automatic qualifiers" means for a value that is always stored.**
+# ``qualifiers_per_pool`` is required on every ``rr-then-ko`` event and always has been,
+# so unlike the two pool numbers it has no absent state to fall back to. The reading
+# this work commits to: the stored K is the **manual slot** for qualifiers — the
+# director's number, kept — and ``qualifiers_mode`` says whether anybody should read it.
+# When the mode is ``automatic``, a reader derives ``ceil(8 / pool count)`` from the
+# target bracket size and ignores the stored number, which is what the client already
+# does (``web-client/src/components/tournaments/data/draw-structure.ts``).
+#
+# That leaves one gap, named here rather than papered over: ``app.draws`` still cuts
+# from the **stored** K whatever the mode says, so an automatic event can display a
+# derived qualifier count and cut a different one. Closing it is the API-side
+# derivation's job (chores 4a/5c); this model only records the ownership the cut will
+# later have to honour.
+#
+# One model for the write and the read, unlike ``AddressInput``/``Address``: every value
+# in here was written through this same model, so the read boundary is not being asked
+# to stay permissive about history it could not have produced.
+class DrawStructure(BaseModel):
+    """Which of a round-robin-then-knockout draw's structural settings the **director
+    owns**, and the numbers they chose.
+
+    Four settings, each with its ownership stored rather than guessed: the pool count,
+    the pool size, the qualifier count (whose value is the event's own
+    ``qualifiers_per_pool``), and how entrants reach their pools. Every mode defaults to
+    the derived answer, so an event that sets nothing behaves exactly as it does today.
+
+    A manual number is kept while its mode is ``automatic``: it is the director's
+    number, remembered for the next time they take the setting back.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    #: Who owns the pool count. ``automatic`` derives it — from the event's pool rows,
+    #: or from the field and a manual pool size (ADR "an event's pool count is its pool
+    #: rows and a derived count is a projection").
+    pool_count_mode: StructuralSettingOwner = StructuralSettingOwner.automatic
+    #: The pool count the director typed, or ``None`` if they never typed one. Read only
+    #: when ``pool_count_mode`` is ``manual``; kept either way.
+    manual_pool_count: ManualPoolCount | None = None
+    #: Who owns the pool size. ``automatic`` splits the field across the pool count.
+    pool_size_mode: StructuralSettingOwner = StructuralSettingOwner.automatic
+    #: The per-pool target the director typed, or ``None``. Read only when
+    #: ``pool_size_mode`` is ``manual``; kept either way.
+    manual_pool_size: ManualPoolSize | None = None
+    #: Who owns the qualifier count. Its **value** is the arm's ``qualifiers_per_pool``,
+    #: because that key already exists on every event and a second copy would be a field
+    #: and its own derivation in one object (api/CLAUDE.md).
+    qualifiers_mode: StructuralSettingOwner = StructuralSettingOwner.automatic
+    #: How entrants reach their pools: the snake, or the director placing them at cut
+    #: time. There is no automatic/manual pair here because there is no number to own.
+    membership_mode: PoolMembershipMode = PoolMembershipMode.snake
+
+
 class DrawSettingsWriteBase(BaseModel):
     """What every arm of the draw-settings union shares: ``extra="forbid"``, and the
     serialization onto the settings column.
@@ -212,6 +345,51 @@ class DrawSettingsWriteBase(BaseModel):
         representation of "no configuration" — never ``NULL``.
         """
         return self.model_dump(mode="json", exclude={"draw_type"})
+
+    def carrying_unstated_settings_of(self, stored: "DrawSettingsWriteBase") -> Self:
+        """This configuration with any setting the caller **did not state** taken from
+        ``stored`` — what the edit path writes.
+
+        A PATCH leaves an omitted field alone: ``update_event`` builds its change set
+        with ``model_dump(exclude_unset=True)``, so a key the caller never sent is not
+        in it. The draw configuration cannot follow that rule by omission alone,
+        because it is rebuilt as a whole arm from the loose fields beside
+        ``draw_type`` — and a rebuilt arm fills every field the caller left out with
+        the arm's own default. For ``draw_structure`` that default is "every mode
+        automatic", so a rename sent by a client that has never heard of the field
+        would silently discard the director's ownership modes. The ADR forbids exactly
+        that ("the system never silently changes a director's number"), and it would
+        have been every iOS and MCP edit.
+
+        So the omission is repaired here, against what the event already has. **A
+        stated structure still replaces wholesale** — that is the editor's save, and it
+        is how a director returns a setting to automatic.
+
+        ``self`` on the three arms with no unstateable setting. The ``rr-then-ko`` arm
+        overrides it.
+        """
+        return self
+
+    def configuration_the_draw_was_dealt_from(self) -> "DrawSettingsWriteBase":
+        """This configuration with the settings a **standing draw does not depend on**
+        normalized away — what the edit path's freeze compares (ADR-0786).
+
+        The freeze asks one question: would this patch contradict fixtures that already
+        exist? The draw type dealt them, and both configured counts sized them, so those
+        are frozen. The four ownership modes size nothing that is already on the table —
+        the pool count a cut draw has is its pool rows, which their own freeze already
+        holds, and membership is dealt by the snake either way until the cut screen
+        exists (#1324).
+
+        So this is not an exemption granted for convenience: comparing whole arms would
+        answer a ``membership_mode`` toggle with
+        ``_qualifiers_per_pool_frozen_detail``'s sentence, which is a refusal naming a
+        cause the director did not touch — the exact defect #1320 was filed about.
+
+        ``self`` on the three arms that carry no structure. The ``rr-then-ko`` arm
+        overrides it.
+        """
+        return self
 
 
 class RoundRobinDrawSettingsWrite(DrawSettingsWriteBase):
@@ -246,6 +424,14 @@ class RoundRobinDrawSettingsWrite(DrawSettingsWriteBase):
         question, and the field's absence is what refuses the key on the wire."""
         return None
 
+    @property
+    def draw_structure(self) -> DrawStructure | None:
+        """``None`` — a plain round-robin has no knockout stage to aim at, so it has no
+        structural settings to own (ADR "a structural setting is owned by the director
+        or derived by the system" is scoped to ``rr-then-ko``). A property for the
+        reason :meth:`qualifiers_per_pool` is one."""
+        return None
+
 
 class SingleElimDrawSettingsWrite(DrawSettingsWriteBase):
     """A single-elimination event's draw configuration: the draw type, and nothing else.
@@ -264,6 +450,12 @@ class SingleElimDrawSettingsWrite(DrawSettingsWriteBase):
         """``None`` — a bracket's depth is derived from the field, not chosen."""
         return None
 
+    @property
+    def draw_structure(self) -> DrawStructure | None:
+        """``None`` — a bracket has no pools, so it has none of the pool-to-knockout
+        settings a director can own."""
+        return None
+
 
 class RrThenKoDrawSettingsWrite(DrawSettingsWriteBase):
     """A round-robin-then-knockout event's draw configuration: the draw type **and** its
@@ -276,6 +468,24 @@ class RrThenKoDrawSettingsWrite(DrawSettingsWriteBase):
 
     draw_type: Literal[DrawType.rr_then_ko] = DrawType.rr_then_ko
     qualifiers_per_pool: QualifiersPerPool
+    # Which structural settings the director owns, and the numbers they typed (ADR "a
+    # structural setting is owned by the director or derived by the system"). The ONE
+    # arm that carries them: the ADR is scoped to this draw type, and ``extra="forbid"``
+    # on the others is what makes a pool-size mode on a swiss event a 422 rather than a
+    # key nothing will ever read.
+    #
+    # ``default_factory``, so an event stored before this work —
+    # ``{"qualifiers_per_pool": K}``, no ``draw_structure`` key — parses into "every
+    # mode automatic, no manual numbers", which is precisely today's behaviour. That is
+    # the whole of the migration: there isn't one (ADR "a draw type's settings are one
+    # NOT NULL JSON object" made the settings a JSON object so that adding keys costs no
+    # DDL).
+    #
+    # It is a ``default_factory`` rather than a shared default instance for the ordinary
+    # reason — a mutable default shared by every arm ever parsed — and it also keeps the
+    # emitted JSON schema free of a ``default`` key, so the generated TypeScript reads
+    # ``draw_structure?:`` rather than making it required (api/CLAUDE.md).
+    draw_structure: DrawStructure = Field(default_factory=DrawStructure)
 
     @property
     def rounds(self) -> int | None:
@@ -283,6 +493,43 @@ class RrThenKoDrawSettingsWrite(DrawSettingsWriteBase):
         the pools are dealt by the circle method and the bracket's depth follows from
         the qualifier count."""
         return None
+
+    def carrying_unstated_settings_of(self, stored: "DrawSettingsWriteBase") -> Self:
+        """This arm with ``draw_structure`` taken from ``stored`` — the repair the base
+        method describes, and the one arm that needs it.
+
+        The ownership modes are the only setting a caller can leave out of a draw
+        configuration and still send a valid one: ``qualifiers_per_pool`` and ``rounds``
+        are required by the arms that have them, so an omission there is already a 422.
+
+        ``stored`` is whatever the event currently holds, which is **not** always an
+        ``rr-then-ko`` arm — a patch may be switching the draw type *to* this one. There
+        is nothing to carry forward from a round-robin event, and the arm's own defaults
+        (every mode automatic) are the right answer for a structure the event has never
+        had.
+
+        "Stated" is ``model_fields_set``, which is exact rather than approximate here:
+        :func:`_draw_settings_write` puts ``draw_structure`` into the payload it
+        validates only when the request carried one, so the field is in this arm's
+        ``model_fields_set`` if and only if the caller sent it. An explicit ``null`` is
+        an absent one — the schema turns both into "not stated" — because ``null`` is
+        what a client sends when it has nothing to say about a field, and reading it as
+        "reset the director's modes" would be the same silent discard by another route.
+        """
+        stated = "draw_structure" in self.model_fields_set
+        if stated or not isinstance(stored, RrThenKoDrawSettingsWrite):
+            return self
+        return self.model_copy(update={"draw_structure": stored.draw_structure})
+
+    def configuration_the_draw_was_dealt_from(self) -> "DrawSettingsWriteBase":
+        """This arm with its structural settings back at their defaults — the draw type
+        and the qualifier count, which are the two facts a cut ``rr-then-ko`` draw's
+        fixtures were actually dealt from.
+
+        See the base method for why the modes are left out of the freeze. The defaults
+        are substituted rather than the field being excluded from a dump, so what the
+        freeze compares stays a parsed arm and equality stays the union's own."""
+        return self.model_copy(update={"draw_structure": DrawStructure()})
 
 
 class SwissDrawSettingsWrite(DrawSettingsWriteBase):
@@ -304,6 +551,12 @@ class SwissDrawSettingsWrite(DrawSettingsWriteBase):
     def qualifiers_per_pool(self) -> int | None:
         """``None`` — swiss is pool-less and eliminates nobody, so there is nothing to
         qualify out of or into."""
+        return None
+
+    @property
+    def draw_structure(self) -> DrawStructure | None:
+        """``None`` — swiss is pool-less, so it has no pool count, no pool size and no
+        membership to own."""
         return None
 
 
@@ -346,10 +599,13 @@ _DRAW_SETTINGS_WRITE: TypeAdapter[DrawSettingsWriteArm] = TypeAdapter(DrawSettin
 
 
 def _draw_settings_write(
-    draw_type: DrawType, qualifiers_per_pool: int | None, rounds: int | None
+    draw_type: DrawType,
+    qualifiers_per_pool: int | None,
+    rounds: int | None,
+    draw_structure: DrawStructure | None = None,
 ) -> DrawSettingsWriteArm:
-    """Parse a ``(draw_type, qualifiers_per_pool, rounds)`` triple into the union arm it
-    names, or raise :class:`ValueError` — a 422 — when it names none.
+    """Parse a ``(draw_type, qualifiers_per_pool, rounds, draw_structure)`` payload into
+    the union arm it names, or raise :class:`ValueError` — a 422 — when it names none.
 
     The settings are **flat on the wire** and a union in the interior. Nesting them
     (``draw: {…}``) would express the union in the generated clients too, at the cost of
@@ -369,12 +625,22 @@ def _draw_settings_write(
     The refusal text is the **union's own**, re-raised as a ``ValueError`` so FastAPI
     renders it as an ordinary 422 body. Composing a friendlier sentence here would be a
     second statement of a rule the arms already make, and the two would drift.
+
+    An omitted ``draw_structure`` therefore lands on the arm's **default** — every mode
+    automatic — which is the right answer on a create, where the event has no history to
+    keep. On a patch it is not: the event may already carry modes the director chose,
+    and this function cannot see them. The edit path repairs that afterwards, against
+    the stored arm (:meth:`TournamentEventUpdate.draw_settings_over`). The omission is
+    still visible to it, because a field this function did not put in the payload is not
+    in the resulting arm's ``model_fields_set``.
     """
     payload: dict[str, object] = {"draw_type": draw_type}
     if qualifiers_per_pool is not None:
         payload["qualifiers_per_pool"] = qualifiers_per_pool
     if rounds is not None:
         payload["rounds"] = rounds
+    if draw_structure is not None:
+        payload["draw_structure"] = draw_structure
     try:
         return _DRAW_SETTINGS_WRITE.validate_python(payload)
     except ValidationError as exc:
@@ -1754,6 +2020,23 @@ class TournamentEventRead(BaseModel):
     # it and has no default. ``null`` for every other draw type, and that is a fact
     # rather than missing data — none of them has a chosen round count.
     rounds: int | None
+    # Which structural settings this event's director owns, and the numbers they typed —
+    # off the same parsed arm the two counts above come from, so the modes and the
+    # qualifier count cannot be read from two places and disagree.
+    #
+    # ``null`` for every draw type but ``rr-then-ko``, and a *fact* rather than missing
+    # data: the ownership ADR is scoped to that one draw type, so a round-robin event
+    # has no structural setting to own. For an ``rr-then-ko`` event it is never null —
+    # an event stored before this work reads back as every mode automatic, which is what
+    # it has always behaved as.
+    #
+    # It is on the read for the reason the qualifier count is: the editor patches the
+    # draw configuration as a unit, so it has to be able to send back what the event
+    # already has — a director who edits one mode is sending all four. A caller that
+    # omits it does not lose the stored modes (the patch path carries them forward,
+    # ``TournamentEventUpdate.draw_settings_over``), but it cannot CHANGE one without
+    # first reading them, which is what this field is for.
+    draw_structure: DrawStructure | None
     # ``null`` means the event is uncapped — there is no entrant limit (ADR-0935).
     max_players: int | None
     # Typed ``float`` so JSON emits a number, not a Decimal string. The
@@ -2165,6 +2448,18 @@ class TournamentEventCreate(BaseModel):
     # ``SwissRounds`` restates the ``1 <= R <= 32`` bound the arm carries so both reach
     # the generated clients.
     rounds: SwissRounds | None = None
+    # Which structural settings the director owns, and only for the one draw type that
+    # has any — flat beside ``draw_type`` exactly as the two counts above are, and
+    # parsed into the same union by the validator below, so a pool-size mode on a swiss
+    # event is a 422 here (ADR "a structural setting is owned by the director or derived
+    # by the system").
+    #
+    # Omitted is "every mode automatic", which is what an event created before this work
+    # has and what a client that knows nothing about draw structure keeps producing. It
+    # is a nested object rather than six more flat fields because the four settings are
+    # one thing a director sets on one tab, and the group has to be replaceable as a
+    # unit.
+    draw_structure: DrawStructure | None = None
     # ``None`` (or omitted) is the uncapped event — the "no cap" sentinel of ADR-0935,
     # not a cap of zero. When a cap IS supplied it is an ``EventMaxPlayers``: ``gt=0``
     # (a cap of zero admits nobody, which is not an event) and ``le=512`` (the column
@@ -2227,7 +2522,7 @@ class TournamentEventCreate(BaseModel):
         (:attr:`_draw_settings`) rather than discarded — parse once, at the boundary,
         and carry the parsed value inward."""
         self._draw_settings = _draw_settings_write(
-            self.draw_type, self.qualifiers_per_pool, self.rounds
+            self.draw_type, self.qualifiers_per_pool, self.rounds, self.draw_structure
         )
         return self
 
@@ -2267,6 +2562,22 @@ class TournamentEventUpdate(BaseModel):
     # is — and ``null`` means the same thing here as absent does ("this draw type takes
     # no round count"), which is what patching a swiss event back to a round-robin says.
     rounds: SwissRounds | None = None
+    # The ownership modes, patched with their draw type and never alone, exactly as the
+    # two counts are — but with the opposite reading of an omission. ``null`` and absent
+    # both mean **unchanged**: the event keeps the structure it already has
+    # (:meth:`draw_settings_over`, which is how this verb honours the same
+    # "omitted is untouched" rule ``model_dump(exclude_unset=True)`` gives every other
+    # field). A structure that IS sent replaces the stored one wholesale, which is how a
+    # director returns a setting to automatic.
+    #
+    # The asymmetry with ``qualifiers_per_pool`` is not an inconsistency, it is what the
+    # two fields' histories force. Every event has a stored qualifier count and the arm
+    # requires one, so the editor must send it on every patch; nothing can be inferred
+    # from its absence because there is no valid patch that omits it. A structure can be
+    # omitted by any caller that predates the field — today's iOS app and the MCP server
+    # — and reading that as "reset every mode to automatic" would let a rename discard a
+    # director's choices, which the ownership ADR forbids outright.
+    draw_structure: DrawStructure | None = None
     max_players: EventMaxPlayers | None = None
     entry_fee: EventEntryFee | None = None
     # The same validated IANA zone create requires — correcting the venue timezone is a
@@ -2318,13 +2629,39 @@ class TournamentEventUpdate(BaseModel):
 
     @property
     def draw_settings(self) -> DrawSettingsWriteArm | None:
-        """The parsed draw configuration this patch asks for, or ``None`` when it is not
+        """The draw configuration this patch **stated**, or ``None`` when it is not
         patching the draw configuration at all.
 
         Total by the time anybody can call it, exactly as the create schema's is and
         for the same reason: :meth:`_parse_draw_settings` ran the parse during
-        validation and kept the arm."""
+        validation and kept the arm.
+
+        **This is not the configuration to write.** A setting the caller left out is
+        filled in here with the arm's default, which for ``draw_structure`` means "every
+        mode automatic" — a value nobody asked for. :meth:`draw_settings_over` is what
+        resolves that against the event; writers take it, and this stays the record of
+        what the request actually said."""
         return self._draw_settings
+
+    def draw_settings_over(
+        self, stored: DrawSettingsWriteArm
+    ) -> DrawSettingsWriteArm | None:
+        """The draw configuration to **write**, resolved against the one the event has
+        — or ``None`` when this patch does not touch the draw configuration at all.
+
+        A PATCH leaves omitted fields alone (``model_dump(exclude_unset=True)``), and
+        this is how the draw configuration keeps that promise even though it is rebuilt
+        as a whole arm rather than field by field. See
+        :meth:`DrawSettingsWriteBase.carrying_unstated_settings_of` for what "unstated"
+        covers and why the alternative — defaulting the modes on every patch — would let
+        a rename from an older client discard a director's ownership.
+
+        Both readers on the edit path (the freeze, then the write) take this same
+        resolved arm, so the configuration that is judged is the configuration that
+        lands."""
+        if self._draw_settings is None:
+            return None
+        return self._draw_settings.carrying_unstated_settings_of(stored)
 
     @model_validator(mode="after")
     def _parse_draw_settings(self) -> "TournamentEventUpdate":
@@ -2350,9 +2687,17 @@ class TournamentEventUpdate(BaseModel):
                 "rounds is part of an event's draw configuration and is patched with "
                 "it: send draw_type alongside it."
             )
+        if self.draw_type is None and self.draw_structure is not None:
+            raise ValueError(
+                "draw_structure is part of an event's draw configuration and is "
+                "patched with it: send draw_type alongside it."
+            )
         if self.draw_type is not None:
             self._draw_settings = _draw_settings_write(
-                self.draw_type, self.qualifiers_per_pool, self.rounds
+                self.draw_type,
+                self.qualifiers_per_pool,
+                self.rounds,
+                self.draw_structure,
             )
         return self
 

--- a/api/app/tournament_events.py
+++ b/api/app/tournament_events.py
@@ -396,7 +396,11 @@ async def _enforce_pool_set_frozen(
 
 
 async def _enforce_draw_settings_frozen(
-    db: AsyncSession, event: TournamentEvent, updates: TournamentEventUpdate
+    db: AsyncSession,
+    event: TournamentEvent,
+    *,
+    stored: DrawSettingsWriteArm,
+    incoming: DrawSettingsWriteArm | None,
 ) -> None:
     """Raise :class:`DrawTypeFrozenError` once a draw-configuration payload would change
     the **draw type or the setting that goes with it** — rr-then-ko's qualifier count,
@@ -425,22 +429,33 @@ async def _enforce_draw_settings_frozen(
     the freeze exists to permit. Asked **before** anything is written, under the
     tournament's row lock the verb holds.
 
-    What the event *currently* has is read off its ``draw_settings`` row — the one home
-    of that fact (ADR "an event's draw configuration is a row, not a column") — and read
-    once, before the caller's ``setattr`` loop, so what is compared is the stored
-    configuration and not the one the payload is asking for. Both sides of the
-    comparison are the **parsed arm**, so "did the configuration move" is one equality
+    Both configurations are handed in rather than read here, and both come from the
+    caller's single read: ``stored`` is the event's own row parsed once (ADR "an event's
+    draw configuration is a row, not a column"), and ``incoming`` is the payload
+    **already resolved against it**
+    (:meth:`~app.schemas.tournament.TournamentEventUpdate.draw_settings_over`). That
+    sharing is the point — the arm this guard judges has to be the arm the write lands,
+    or the freeze is answering a question about a configuration nobody is asking for.
+    Both sides are the **parsed arm**, so "did the configuration move" is one equality
     over the whole union rather than a field-by-field walk that a new setting could fall
     out of.
+
+    ``incoming`` is ``None`` when the patch does not touch the draw configuration at
+    all: the schema refuses an explicit ``null`` on ``draw_type`` (422) and refuses a
+    ``qualifiers_per_pool`` with no ``draw_type`` beside it, so an absent draw type
+    means an absent configuration.
     """
-    # ``None`` is "this patch does not touch the draw configuration": the schema refuses
-    # an explicit ``null`` on ``draw_type`` (422) and refuses a ``qualifiers_per_pool``
-    # with no ``draw_type`` beside it, so an absent draw type means an absent pair.
-    incoming = updates.draw_settings
     if incoming is None:
         return
-    stored = draw_settings_of(event.draw_settings)
-    if incoming == stored:
+    # Compared as the DRAW WAS DEALT, not field for field: an ``rr-then-ko`` event's
+    # ownership modes size nothing the cut already put on the table, so changing one is
+    # not a contradiction and must not be refused — least of all by the qualifier-count
+    # sentence, which would name a number the director never touched. See
+    # ``DrawSettingsWriteBase.configuration_the_draw_was_dealt_from``.
+    if (
+        incoming.configuration_the_draw_was_dealt_from()
+        == stored.configuration_the_draw_was_dealt_from()
+    ):
         return
     current = stored.draw_type
     # Only now the query — and only for a payload that really moves the configuration.
@@ -615,10 +630,26 @@ async def update_event(
     # adapter so the read it shapes need not re-query that column.
     tournament = await _load_owned_tournament_for_update(db, tournament_id, actor)
     event = await _load_event(db, tournament_id, event_id)
+    # The event's stored draw configuration, parsed ONCE — off the settings row that
+    # rides along with the event (``lazy="joined"``), so this is no query. Both the
+    # freeze below and the write further down take what this resolves to, which is what
+    # keeps "the configuration that was judged" and "the configuration that landed" the
+    # same object.
+    stored_draw_settings = draw_settings_of(event.draw_settings)
+    # The configuration to WRITE, not the one the payload literally stated: a patch that
+    # names the draw type without a ``draw_structure`` keeps the modes the event already
+    # has, exactly as omitting any other field leaves it alone (that rule is
+    # ``model_dump(exclude_unset=True)`` below; the draw configuration cannot use it,
+    # because it is rebuilt as a whole arm). Reading ``updates.draw_settings`` here
+    # instead would reset a director's ownership on every edit sent by a client that has
+    # not been taught the field.
+    draw_settings = updates.draw_settings_over(stored_draw_settings)
     # 404 → 403 → 409: the freezes are asked before the setattr loop below, so a
     # refusal writes nothing at all.
     await _enforce_pool_set_frozen(db, event, updates)
-    await _enforce_draw_settings_frozen(db, event, updates)
+    await _enforce_draw_settings_frozen(
+        db, event, stored=stored_draw_settings, incoming=draw_settings
+    )
     facts_before = _event_scheduling_facts(event)
     # Captured BEFORE the setattr loop overwrites it: a timezone edit preserves the
     # wall-clock of already-placed fixtures, which needs the zone they were placed IN to
@@ -641,6 +672,11 @@ async def update_event(
     # settings row's JSON object, not on the event, so the loop would bind an unmapped
     # attribute and drop the edit silently.
     changes.pop("rounds", None)
+    # And the ownership modes, which are one more key inside that same JSON object. Left
+    # in the loop, ``setattr(event, "draw_structure", …)`` would bind a plain Python
+    # attribute the mapper never persists: the PATCH would answer 200 with the structure
+    # the director sent and the next GET would answer with the old one.
+    changes.pop("draw_structure", None)
     # Pools are rows, so they are taken OUT of the generic setattr loop entirely and
     # applied as a diff (:func:`app.tournament_pools.apply_event_pools`) — assigning the
     # dumped payload would put dicts where the relationship expects
@@ -655,12 +691,13 @@ async def update_event(
     # a clear for an absence. The applying happens after the loop below, with the other
     # writes, so a payload that touches nothing else still reaches it.
     changes.pop("pools", None)
-    # The parsed union arm, not the loose keys: it is ``None`` exactly when the patch
-    # does not touch the draw configuration, and when it is not, the pair it carries is
-    # one the write union accepted at the request boundary (ADR 20260727). That union is
-    # the only thing that checks the pairing now — the settings table's ``CASE``
-    # ``CHECK`` was dropped with the column it named.
-    draw_settings = updates.draw_settings
+    # ``draw_settings`` — the resolved union arm, not the loose keys — was worked out at
+    # the top of this verb, beside the stored configuration it was resolved against, so
+    # that the freeze and this write share one value. It is ``None`` exactly when the
+    # patch does not touch the draw configuration, and when it is not, the pair it
+    # carries is one the write union accepted at the request boundary (ADR 20260727).
+    # That union is the only thing that checks the pairing now — the settings table's
+    # ``CASE`` ``CHECK`` was dropped with the column it named.
     for key, value in changes.items():
         setattr(event, key, value)
     if updates.pools is not None:

--- a/api/app/tournament_serialization.py
+++ b/api/app/tournament_serialization.py
@@ -686,6 +686,11 @@ def serialize_event(
             # rule: a property on the arms that have no round count, so this line asks
             # every arm one question rather than deciding which draw types have one.
             "rounds": draw_settings.rounds,
+            # And the ownership modes, off the same arm and by the same rule — ``None``
+            # on the three draw types that have no structural settings, because that is
+            # what their arms answer, not because this line decided it (ADR "a
+            # structural setting is owned by the director or derived by the system").
+            "draw_structure": draw_settings.draw_structure,
             "max_players": e.max_players,
             "entry_fee": e.entry_fee,
             # The event's venue timezone anchors its wall-clock ``Slot`` windows to

--- a/api/tests/_helpers.py
+++ b/api/tests/_helpers.py
@@ -42,7 +42,7 @@ from app.notifications.dependencies import get_push_sender
 from app.notifications.jobs import DELIVER_NOTIFICATION_JOB
 from app.scheduling import ScheduleSnapshot, SolveResult
 from app.schemas.notification import NotificationJob
-from app.schemas.tournament import draw_settings_from_storage
+from app.schemas.tournament import DrawStructure, draw_settings_from_storage
 from app.sessions import CSRF_COOKIE_NAME, CSRF_HEADER_NAME, CSRF_SAFE_METHODS
 from app.tournament_draw_settings import draw_settings_row
 
@@ -157,12 +157,16 @@ def event_draw_settings(
     *,
     qualifiers_per_pool: int | None = None,
     rounds: int | None = None,
+    draw_structure: DrawStructure | None = None,
 ) -> TournamentEventDrawSettings:
     """The draw-settings row for an event a test seeds straight through the ORM, built
-    from the draw type and whichever setting that draw type carries — the qualifier
-    count for ``rr-then-ko``, the round count for ``swiss``.
+    from the draw type and whichever settings that draw type carries — the qualifier
+    count and the ownership modes for ``rr-then-ko``, the round count for ``swiss``.
 
-    Neither is a column any more — both are keys inside the row's ``settings`` JSON
+    ``draw_structure`` omitted seeds the row the way an event written before #1320 is
+    stored: no such key at all, which reads back as every mode automatic.
+
+    None of them is a column — all three are keys inside the row's ``settings`` JSON
     object (ADR "a draw type's settings are one NOT NULL JSON object") — so this is the
     one translation from the values the tests speak to the stored shape, and it goes
     through the same parse and the same writer the request boundary uses. Which means a
@@ -172,11 +176,13 @@ def event_draw_settings(
 
     Both ``None`` is "this draw type takes no configuration", and it stores ``{}``.
     """
-    settings: dict[str, int] = {}
+    settings: dict[str, Any] = {}
     if qualifiers_per_pool is not None:
         settings["qualifiers_per_pool"] = qualifiers_per_pool
     if rounds is not None:
         settings["rounds"] = rounds
+    if draw_structure is not None:
+        settings["draw_structure"] = draw_structure.model_dump(mode="json")
     return draw_settings_row(draw_settings_from_storage(draw_type, settings))
 
 

--- a/api/tests/test_tournament_event_draw_settings.py
+++ b/api/tests/test_tournament_event_draw_settings.py
@@ -30,6 +30,7 @@ column on ``tournament_events`` to cross-check it against, which is the point.
 
 import uuid
 from collections.abc import AsyncIterator
+from itertools import product
 from typing import Any, get_args
 
 import pytest
@@ -50,9 +51,12 @@ from app.models import (
 from app.schemas.tournament import (
     DrawSettingsWrite,
     DrawSettingsWriteArm,
+    DrawStructure,
+    PoolMembershipMode,
     RoundRobinDrawSettingsWrite,
     RrThenKoDrawSettingsWrite,
     SingleElimDrawSettingsWrite,
+    StructuralSettingOwner,
     SwissDrawSettingsWrite,
     draw_settings_from_storage,
 )
@@ -647,3 +651,316 @@ async def test_a_seeded_draw_type_cannot_be_deleted_while_an_event_uses_it(
             sa.text("DELETE FROM draw_types WHERE key = 'round-robin'")
         )
     await db_session.rollback()
+
+
+# ----- the draw structure: who owns each setting (#1320) --------------------
+#
+# ADR "a structural setting is owned by the director or derived by the system". The
+# ownership modes are four more keys inside the SAME settings object, which is what
+# makes them free of a migration (ADR "a draw type's settings are one NOT NULL JSON
+# object"). So the two claims that matter here are storage claims: an event written
+# before the keys existed still reads, and every combination of the keys survives the
+# round trip.
+
+#: The two ownership modes, and the two membership modes — spelled as tuples so the
+#: combination sweep below is a ``product`` over them rather than sixteen literals.
+OWNERS = (StructuralSettingOwner.automatic, StructuralSettingOwner.manual)
+MEMBERSHIPS = (PoolMembershipMode.snake, PoolMembershipMode.manual)
+
+#: Three DIFFERENT numbers, on purpose. A sweep that used one number for the pool count,
+#: the pool size and the qualifier count would stay green against an encoder that wrote
+#: any of them into the wrong key.
+MANUAL_POOL_COUNT = 6
+MANUAL_POOL_SIZE = 5
+MANUAL_QUALIFIERS = 3
+
+
+async def test_an_event_stored_before_the_draw_structure_reads_as_all_automatic(
+    db_session: AsyncSession,
+) -> None:
+    """**The no-migration claim.** A settings object carrying none of the ownership keys
+    — which is every ``rr-then-ko`` event written before #1320 — parses into every mode
+    automatic and no manual numbers.
+
+    That is not a convenience. ADR "a structural setting is owned by the director or
+    derived by the system" says setting nothing must reproduce today's behaviour, and
+    today's behaviour IS all-automatic: the pool count is the pool row count, the pool
+    size is the field split across those rows, membership is the snake, and the
+    qualifier count is the one the director already typed. So an existing event needs no
+    backfill and gets none — the row is left exactly as it was written, which this test
+    asserts of the stored blob as well as of the parse.
+
+    Both halves are asserted separately. A default change on the ``manual_*`` fields
+    would slip past a test that only checked the modes, and vice versa.
+    """
+    parsed = draw_settings_from_storage(
+        DrawType.rr_then_ko, {"qualifiers_per_pool": MANUAL_QUALIFIERS}
+    )
+    assert isinstance(parsed, RrThenKoDrawSettingsWrite)
+    structure = parsed.draw_structure
+    assert structure.pool_count_mode is StructuralSettingOwner.automatic
+    assert structure.pool_size_mode is StructuralSettingOwner.automatic
+    assert structure.qualifiers_mode is StructuralSettingOwner.automatic
+    assert structure.membership_mode is PoolMembershipMode.snake
+    assert structure.manual_pool_count is None
+    assert structure.manual_pool_size is None
+
+    # And through a real row written the way a pre-#1320 event's row was written: the
+    # raw-mapping door, which does not parse (see ``for_draw_type``'s docstring). What
+    # comes back out of Postgres is the object that went in, with nothing added to it.
+    row = TournamentEventDrawSettings.for_draw_type(
+        DrawType.rr_then_ko, settings={"qualifiers_per_pool": MANUAL_QUALIFIERS}
+    )
+    db_session.add(row)
+    await db_session.flush()
+    settings_id = row.id
+    db_session.expire_all()
+
+    stored = (
+        await db_session.execute(
+            select(TournamentEventDrawSettings).where(
+                TournamentEventDrawSettings.id == settings_id
+            )
+        )
+    ).scalar_one()
+    assert stored.settings == {"qualifiers_per_pool": MANUAL_QUALIFIERS}, (
+        "an event that predates this work must not be rewritten by reading it: the "
+        "absent keys ARE the automatic modes"
+    )
+    assert draw_settings_of(stored) == RrThenKoDrawSettingsWrite(
+        qualifiers_per_pool=MANUAL_QUALIFIERS
+    )
+
+    await db_session.rollback()
+
+
+async def test_every_combination_of_ownership_modes_round_trips(
+    db_session: AsyncSession,
+) -> None:
+    """What is written is what is read, for all sixteen combinations of the four modes.
+
+    Every combination carries **both** manual numbers, including the combinations whose
+    modes are automatic. That is deliberate: a manual number is kept while its mode is
+    automatic (see
+    :func:`test_a_manual_number_is_kept_while_its_mode_is_automatic`), so a sweep that
+    only attached numbers to manual modes would never exercise the pairing the product
+    actually stores.
+
+    The rows are flushed and expired before the read, so what is parsed is what Postgres
+    holds rather than the dict the encoder left in memory.
+    """
+    structures = [
+        DrawStructure(
+            pool_count_mode=count_mode,
+            manual_pool_count=MANUAL_POOL_COUNT,
+            pool_size_mode=size_mode,
+            manual_pool_size=MANUAL_POOL_SIZE,
+            qualifiers_mode=qualifiers_mode,
+            membership_mode=membership,
+        )
+        for count_mode, size_mode, qualifiers_mode, membership in product(
+            OWNERS, OWNERS, OWNERS, MEMBERSHIPS
+        )
+    ]
+    assert len(structures) == 16, "2 × 2 × 2 ownership modes × 2 membership modes"
+
+    arms = [
+        RrThenKoDrawSettingsWrite(
+            qualifiers_per_pool=MANUAL_QUALIFIERS, draw_structure=structure
+        )
+        for structure in structures
+    ]
+    rows = [draw_settings_row(arm) for arm in arms]
+    db_session.add_all(rows)
+    await db_session.flush()
+    ids = [row.id for row in rows]
+    db_session.expire_all()
+
+    for arm, settings_id in zip(arms, ids, strict=True):
+        stored = (
+            await db_session.execute(
+                select(TournamentEventDrawSettings).where(
+                    TournamentEventDrawSettings.id == settings_id
+                )
+            )
+        ).scalar_one()
+        assert draw_settings_of(stored) == arm, arm.draw_structure
+
+    # The stored shape itself, asserted once: the modes are their wire slugs inside one
+    # nested object beside the qualifier count, not enum reprs and not six flat keys. An
+    # equality over the whole blob is what would red if a key were renamed, since the
+    # round trip above would go on agreeing with itself.
+    all_manual = (
+        await db_session.execute(
+            select(TournamentEventDrawSettings).where(
+                TournamentEventDrawSettings.id == ids[-1]
+            )
+        )
+    ).scalar_one()
+    assert all_manual.settings == {
+        "qualifiers_per_pool": MANUAL_QUALIFIERS,
+        "draw_structure": {
+            "pool_count_mode": "manual",
+            "manual_pool_count": MANUAL_POOL_COUNT,
+            "pool_size_mode": "manual",
+            "manual_pool_size": MANUAL_POOL_SIZE,
+            "qualifiers_mode": "manual",
+            "membership_mode": "manual",
+        },
+    }
+
+    await db_session.rollback()
+
+
+async def test_a_manual_number_is_kept_while_its_mode_is_automatic(
+    db_session: AsyncSession,
+) -> None:
+    """**The retention decision, stated as a test.** A pool count and a pool size the
+    director typed are kept when their modes go back to automatic. They are not dropped.
+
+    A manual number with an automatic mode is therefore a legal stored state, and it
+    means one thing only: this is the director's number, remembered. Nothing derives
+    anything from it while the mode is automatic — the mode is the only thing a reader
+    asks — so the pair cannot contradict itself.
+
+    The alternative (clear the number when the mode goes automatic) was rejected because
+    a director who switches a row to Automatic to see what the system would say, and
+    then switches back, would be handed an empty box instead of their own number.
+    """
+    remembered = DrawStructure(
+        pool_count_mode=StructuralSettingOwner.automatic,
+        manual_pool_count=MANUAL_POOL_COUNT,
+        pool_size_mode=StructuralSettingOwner.automatic,
+        manual_pool_size=MANUAL_POOL_SIZE,
+    )
+    row = draw_settings_row(
+        RrThenKoDrawSettingsWrite(
+            qualifiers_per_pool=MANUAL_QUALIFIERS, draw_structure=remembered
+        )
+    )
+    db_session.add(row)
+    await db_session.flush()
+    settings_id = row.id
+    db_session.expire_all()
+
+    stored = (
+        await db_session.execute(
+            select(TournamentEventDrawSettings).where(
+                TournamentEventDrawSettings.id == settings_id
+            )
+        )
+    ).scalar_one()
+    parsed = draw_settings_of(stored)
+    assert isinstance(parsed, RrThenKoDrawSettingsWrite)
+    assert parsed.draw_structure.manual_pool_count == MANUAL_POOL_COUNT
+    assert parsed.draw_structure.manual_pool_size == MANUAL_POOL_SIZE
+    assert parsed.draw_structure.pool_count_mode is StructuralSettingOwner.automatic
+    assert parsed.draw_structure.pool_size_mode is StructuralSettingOwner.automatic
+
+    await db_session.rollback()
+
+
+async def test_a_directors_structure_survives_create_patch_and_re_read(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The whole seam, over HTTP: a structure sent on create reads back on create, is
+    still there in the database, and a PATCH replaces it.
+
+    The PATCH half is the one a storage-level round trip cannot cover. The ownership
+    modes are a key inside the settings row's JSON object and not a column on the event,
+    so an edit routed through the update verb's generic ``setattr`` loop would bind an
+    attribute the mapper never persists — accepted, and dropped. This asserts the
+    database after the edit, not the response body the edit returned.
+    """
+    client, _ = authed_client
+    created_structure = {
+        "pool_count_mode": "manual",
+        "manual_pool_count": MANUAL_POOL_COUNT,
+        "pool_size_mode": "automatic",
+        "manual_pool_size": None,
+        "qualifiers_mode": "manual",
+        "membership_mode": "snake",
+    }
+    tournament = await client.post("/v1/tournaments", json=_tournament_payload())
+    assert tournament.status_code == 201, tournament.text
+    tournament_id = tournament.json()["id"]
+    created = await client.post(
+        f"/v1/tournaments/{tournament_id}/events",
+        json=_event_payload(
+            draw_type="rr-then-ko",
+            qualifiers_per_pool=MANUAL_QUALIFIERS,
+            draw_structure=created_structure,
+        ),
+    )
+    assert created.status_code == 201, created.text
+    assert created.json()["draw_structure"] == created_structure
+    event_id = uuid.UUID(created.json()["id"])
+
+    (event,) = await _load_events(db_session, event_id)
+    assert draw_settings_of(event.draw_settings) == RrThenKoDrawSettingsWrite(
+        qualifiers_per_pool=MANUAL_QUALIFIERS,
+        draw_structure=DrawStructure(
+            pool_count_mode=StructuralSettingOwner.manual,
+            manual_pool_count=MANUAL_POOL_COUNT,
+            qualifiers_mode=StructuralSettingOwner.manual,
+        ),
+    )
+
+    # The editor patches the draw configuration as a unit — type, count and structure
+    # together — which is the shape the event form already sends.
+    patched_structure = {
+        "pool_count_mode": "automatic",
+        "manual_pool_count": MANUAL_POOL_COUNT,
+        "pool_size_mode": "manual",
+        "manual_pool_size": MANUAL_POOL_SIZE,
+        "qualifiers_mode": "automatic",
+        "membership_mode": "manual",
+    }
+    patched = await client.patch(
+        f"/v1/tournaments/{tournament_id}/events/{event_id}",
+        json={
+            "draw_type": "rr-then-ko",
+            "qualifiers_per_pool": MANUAL_QUALIFIERS,
+            "draw_structure": patched_structure,
+        },
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["draw_structure"] == patched_structure
+
+    (event,) = await _load_events(db_session, event_id)
+    assert event.draw_settings.settings["draw_structure"] == patched_structure
+
+
+async def test_a_draw_type_with_no_structure_refuses_one_and_reads_back_null(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """The ownership ADR is scoped to ``rr-then-ko``, and the union is what scopes it.
+
+    A round-robin event has no knockout stage to aim at, so it has no pool-to-knockout
+    settings: sending some is a 422 at the boundary (``extra="forbid"`` on the arm, the
+    same refusal a qualifier count on a round-robin gets), and reading one back gives
+    ``null`` — a fact about the draw type, not missing data.
+    """
+    client, _ = authed_client
+    tournament = await client.post("/v1/tournaments", json=_tournament_payload())
+    assert tournament.status_code == 201, tournament.text
+    tournament_id = tournament.json()["id"]
+
+    refused = await client.post(
+        f"/v1/tournaments/{tournament_id}/events",
+        json=_event_payload(
+            draw_type="round-robin",
+            draw_structure={"pool_count_mode": "manual", "manual_pool_count": 6},
+        ),
+    )
+    assert refused.status_code == 422, refused.text
+    assert "draw_structure" in refused.text
+
+    created = await client.post(
+        f"/v1/tournaments/{tournament_id}/events",
+        json=_event_payload(draw_type="round-robin"),
+    )
+    assert created.status_code == 201, created.text
+    assert created.json()["draw_structure"] is None

--- a/api/tests/test_tournament_events.py
+++ b/api/tests/test_tournament_events.py
@@ -37,7 +37,15 @@ from app.models import (
     TournamentStatus,
     User,
 )
-from app.schemas.tournament import Address, TournamentEventCreate, TournamentEventUpdate
+from app.schemas.tournament import (
+    Address,
+    DrawStructure,
+    PoolMembershipMode,
+    StructuralSettingOwner,
+    TournamentEventCreate,
+    TournamentEventUpdate,
+)
+from app.tournament_draw_settings import draw_settings_of
 from app.tournament_errors import (
     DrawTypeFrozenError,
     EventNotFoundError,
@@ -48,6 +56,7 @@ from app.tournament_errors import (
 from app.tournament_events import create_event, delete_event, update_event
 from app.tournament_pools import pool_read
 from tests._helpers import (
+    event_draw_settings,
     event_pools,
     make_user,
     venue_tables,
@@ -662,6 +671,8 @@ async def _add_cut_event(
     tournament: Tournament,
     *,
     draw_type: DrawType = DrawType.round_robin,
+    qualifiers_per_pool: int | None = None,
+    draw_structure: DrawStructure | None = None,
     timezone: str = "America/Chicago",
     scheduled_start: datetime | None = None,
 ) -> TournamentEvent:
@@ -670,12 +681,21 @@ async def _add_cut_event(
     ``scheduled_start`` placement, for the timezone-reanchor path.
 
     The pool's id is minted here (``event_pools``) rather than by the column's default,
-    because the fixture below has to name it before either row is flushed."""
+    because the fixture below has to name it before either row is flushed.
+
+    The settings row goes through ``event_draw_settings``, which routes the pair through
+    the same parse the request boundary uses — so a draw type that REQUIRES a setting
+    (``rr-then-ko``'s qualifier count) reds here when the seed omits it, rather than
+    writing a row the app could not have made and failing at the next read."""
     event = TournamentEvent(
         tournament_id=tournament.id,
         name="Cut Singles",
         format=EventFormat.singles,
-        draw_settings=TournamentEventDrawSettings.for_draw_type(draw_type),
+        draw_settings=event_draw_settings(
+            draw_type,
+            qualifiers_per_pool=qualifiers_per_pool,
+            draw_structure=draw_structure,
+        ),
         max_players=None,
         entry_fee=Decimal("0.00"),
         timezone=timezone,
@@ -889,6 +909,247 @@ async def test_update_event_re_sending_the_same_draw_type_is_not_frozen(
     assert league_id == default_league.id
     assert updated.name == "Renamed Under Draw"
     assert updated.draw_settings.draw_type is DrawType.round_robin
+
+
+async def test_update_event_changing_only_an_ownership_mode_is_not_frozen(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A cut draw does NOT freeze the ownership modes: a director may say who owns the
+    pool count, or that they will place entrants at cut time, while fixtures stand.
+
+    The freeze exists to stop a payload contradicting fixtures that already exist (ADR-
+    0786). The modes contradict none: the pools a cut draw has are its pool rows, which
+    their own freeze already holds, and membership is dealt by the snake either way
+    until the cut screen exists (#1324). What the fixtures WERE dealt from — the draw
+    type and the qualifier count — is still frozen, and the test above and its neighbour
+    say so.
+
+    Without the exemption this edit would be refused, and refused in the qualifier
+    count's words: ``_draw_settings_frozen_detail`` asks the arm which setting moved,
+    and the ``rr-then-ko`` arm answers "the number of qualifiers per pool is frozen" for
+    any change at all. A refusal naming a number the director never touched is the
+    defect
+    #1320 was filed about, so this is the test that keeps
+    ``configuration_the_draw_was_dealt_from`` from being deleted as dead weight.
+    """
+    owner = await make_user(db_session, "events-update-modes-owner")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event = await _add_cut_event(
+        db_session,
+        tournament,
+        draw_type=DrawType.rr_then_ko,
+        qualifiers_per_pool=2,
+    )
+    event_id = event.id
+
+    updated, _ = await update_event(
+        db_session,
+        tournament_id=tournament.id,
+        event_id=event_id,
+        actor=owner,
+        updates=TournamentEventUpdate.model_validate(
+            {
+                "draw_type": "rr-then-ko",
+                "qualifiers_per_pool": 2,
+                "draw_structure": {
+                    "pool_count_mode": "manual",
+                    "manual_pool_count": 4,
+                    "membership_mode": "manual",
+                },
+            }
+        ),
+    )
+
+    stored = draw_settings_of(updated.draw_settings)
+    assert stored.draw_structure == DrawStructure(
+        pool_count_mode=StructuralSettingOwner.manual,
+        manual_pool_count=4,
+        membership_mode=PoolMembershipMode.manual,
+    )
+    # The qualifier count is untouched by the edit, which is what makes this a test
+    # about the modes rather than about a configuration that happened to be equal
+    # anyway.
+    assert stored.qualifiers_per_pool == 2
+
+
+#: What a director owns on the events the two tests below edit: a pool count they typed,
+#: a pool size they typed and then handed back to the system, and hand assignment at cut
+#: time. Three different numbers and one non-default membership, so a patch that lost or
+#: swapped any of them reds.
+_DIRECTOR_OWNED_STRUCTURE = DrawStructure(
+    pool_count_mode=StructuralSettingOwner.manual,
+    manual_pool_count=6,
+    pool_size_mode=StructuralSettingOwner.automatic,
+    manual_pool_size=5,
+    membership_mode=PoolMembershipMode.manual,
+)
+
+
+async def test_update_event_omitting_the_structure_leaves_the_stored_modes_alone(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """A patch that names the draw configuration but sends **no** ``draw_structure``
+    leaves the director's ownership exactly as it was. Omitted is unchanged.
+
+    This is the rule every other field on this verb already follows — ``changes`` is
+    ``model_dump(exclude_unset=True)``, so a key the caller never sent is not in it and
+    nothing is written. The draw configuration cannot get that for free, because it is
+    rebuilt as a whole arm from the loose fields beside ``draw_type``, and a rebuilt
+    arm fills ``draw_structure`` with the model's default of all-automatic. So the
+    patch path resolves the omission against the stored arm
+    (``TournamentEventUpdate.draw_settings_over``).
+
+    Without that, the damage would not have been theoretical or rare. Today's iOS app
+    and the MCP server both patch events and neither knows this field exists, so **a
+    rename would have discarded a pool count the director typed on the web** — the
+    silent change the ownership ADR forbids outright. It would also have slipped past
+    the freeze on a cut draw, because the modes are deliberately not part of what the
+    freeze compares.
+
+    A cut event is used here for exactly that reason: it is the case with no second line
+    of defence.
+    """
+    owner = await make_user(db_session, "events-update-structure-kept-owner")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event = await _add_cut_event(
+        db_session,
+        tournament,
+        draw_type=DrawType.rr_then_ko,
+        qualifiers_per_pool=2,
+        draw_structure=_DIRECTOR_OWNED_STRUCTURE,
+    )
+    event_id = event.id
+    # The seed is asserted before the edit. Without this the test would pass against an
+    # event that never had a manual mode to lose, which is the shape of "green because
+    # nothing happened".
+    seeded = draw_settings_of(event.draw_settings)
+    assert seeded.draw_structure == _DIRECTOR_OWNED_STRUCTURE
+
+    updated, _ = await update_event(
+        db_session,
+        tournament_id=tournament.id,
+        event_id=event_id,
+        actor=owner,
+        updates=TournamentEventUpdate.model_validate(
+            {
+                "name": "Renamed By An Older Client",
+                "draw_type": "rr-then-ko",
+                "qualifiers_per_pool": 2,
+            }
+        ),
+    )
+
+    assert updated.name == "Renamed By An Older Client"
+    stored = draw_settings_of(updated.draw_settings)
+    assert stored.draw_structure == _DIRECTOR_OWNED_STRUCTURE, (
+        "a patch that never mentioned draw_structure must not touch it: the director's "
+        "pool count, their remembered pool size and their membership choice all survive"
+    )
+
+    # Persisted, not merely returned — the resolved arm reached the settings row.
+    db_session.expire_all()
+    row = (
+        await db_session.execute(
+            select(TournamentEvent).where(TournamentEvent.id == event_id)
+        )
+    ).scalar_one()
+    assert draw_settings_of(row.draw_settings).draw_structure == (
+        _DIRECTOR_OWNED_STRUCTURE
+    )
+
+
+async def test_update_event_sending_a_structure_replaces_the_stored_one_wholesale(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """The other half of the rule: a structure that IS sent replaces the stored one
+    entirely, mode by mode, including back to automatic.
+
+    Both semantics have to be pinned together, because the fix for the omission case is
+    a carry-forward and the obvious over-correction is to merge the two structures
+    instead of replacing. A merge would make "Use automatic" unsendable — the click
+    that returns a setting to the system would arrive as a field with nothing in it and
+    be read as "unstated".
+
+    So the sent structure wins in full: the manual pool count is gone because this
+    payload says pool count is automatic, and the remembered pool size is gone with it
+    because this payload does not carry one.
+    """
+    owner = await make_user(db_session, "events-update-structure-replaced-owner")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event = await _add_cut_event(
+        db_session,
+        tournament,
+        draw_type=DrawType.rr_then_ko,
+        qualifiers_per_pool=2,
+        draw_structure=_DIRECTOR_OWNED_STRUCTURE,
+    )
+    event_id = event.id
+
+    updated, _ = await update_event(
+        db_session,
+        tournament_id=tournament.id,
+        event_id=event_id,
+        actor=owner,
+        updates=TournamentEventUpdate.model_validate(
+            {
+                "draw_type": "rr-then-ko",
+                "qualifiers_per_pool": 2,
+                "draw_structure": {
+                    "pool_size_mode": "manual",
+                    "manual_pool_size": 8,
+                },
+            }
+        ),
+    )
+
+    stored = draw_settings_of(updated.draw_settings)
+    assert stored.draw_structure == DrawStructure(
+        pool_size_mode=StructuralSettingOwner.manual,
+        manual_pool_size=8,
+    ), (
+        "a sent structure is the whole structure: pool count is back to automatic with "
+        "no remembered number, and membership is back to the snake"
+    )
+
+
+async def test_update_event_changing_the_qualifier_count_is_still_frozen(
+    db_session: AsyncSession,
+    default_league: League,
+) -> None:
+    """The other side of the exemption above: the qualifier count a cut bracket was
+    sized from is still frozen, and a patch that moves it is still refused (ADR
+    20260727).
+
+    Sent with a structure alongside it, because that is the shape the editor sends and
+    because the exemption must not become "any payload carrying a structure passes"."""
+    owner = await make_user(db_session, "events-update-frozen-k-owner")
+    tournament = await _make_tournament(db_session, owner=owner, league=default_league)
+    event = await _add_cut_event(
+        db_session,
+        tournament,
+        draw_type=DrawType.rr_then_ko,
+        qualifiers_per_pool=2,
+    )
+    event_id = event.id
+
+    with pytest.raises(DrawTypeFrozenError) as refusal:
+        await update_event(
+            db_session,
+            tournament_id=tournament.id,
+            event_id=event_id,
+            actor=owner,
+            updates=TournamentEventUpdate.model_validate(
+                {
+                    "draw_type": "rr-then-ko",
+                    "qualifiers_per_pool": 3,
+                    "draw_structure": {"membership_mode": "manual"},
+                }
+            ),
+        )
+    assert "qualifiers per pool is frozen" in str(refusal.value)
 
 
 async def test_update_event_timezone_change_reanchors_placements(

--- a/e2e/page-objects/tournament-detail-page/event-editor.page.ts
+++ b/e2e/page-objects/tournament-detail-page/event-editor.page.ts
@@ -36,18 +36,20 @@ export class EventEditorPage {
     return this.page.getByRole('combobox', { name: 'Draw type' })
   }
 
-  /** **K** — the per-pool qualifier count. Present for `rr-then-ko` and for nothing
-   * else: the control is ABSENT, not disabled, for a draw type with no knockout stage
-   * to qualify for, so its visibility is itself the assertion that the picker's choice
-   * reached the form. */
-  get qualifiersInput(): Locator {
-    return this.page.getByLabel('Qualifiers per pool')
-  }
+  // **K has no box on this tab, and that absence is deliberate.** The per-pool qualifier
+  // count is a structural setting, so it moved onto the Draw structure tab beside the
+  // other three (ADR 20260808) — and there it has a box only once the director takes it
+  // (`DrawStructureTabPage.setManually`). A `qualifiersInput` getter left here would still
+  // *resolve*, because the tab's box takes its accessible name from the same words, so it
+  // would quietly find a control on a different tab and only in one of its two states.
+  // The surface that is now present for `rr-then-ko` and for nothing else is the **tab**:
+  // `tab('Draw structure')`, which is what a spec asserts to prove the picker's choice
+  // reached the form.
 
   /** **R** — the round count a `swiss` event plays. Present for `swiss` and for nothing
-   * else, exactly as `qualifiersInput` is present only for `rr-then-ko`: a round count is
-   * a question the other three formats do not ask, and the server's draw-settings union
-   * says the same by refusing the key on their arms.
+   * else, exactly as the Draw structure tab is present only for `rr-then-ko`: a round
+   * count is a question the other three formats do not ask, and the server's
+   * draw-settings union says the same by refusing the key on their arms.
    *
    * Matched by a `^Rounds` regex rather than an exact label, because the row is `required`
    * and the `Field` renders its asterisk into the accessible name. */
@@ -75,16 +77,9 @@ export class EventEditorPage {
     await expect(this.drawTypeSelect).toContainText(label)
   }
 
-  /** Type the qualifier count. A blank box is a *missing answer* for this draw type
-   * (never `0`), so it is filled with a real number and read back. */
-  async setQualifiersPerPool(count: number): Promise<void> {
-    await this.qualifiersInput.fill(String(count))
-    await expect(this.qualifiersInput).toHaveValue(String(count))
-  }
-
   /** Type the round count. A blank box is a *missing answer* for this draw type (never
    * `0`, which would be a swiss that plays nothing), so it is filled with a real number
-   * and read back — the same shape `setQualifiersPerPool` takes. */
+   * and read back — the same shape `DrawStructureTabPage.setManually` takes. */
   async setRounds(rounds: number): Promise<void> {
     await this.roundsInput.fill(String(rounds))
     await expect(this.roundsInput).toHaveValue(String(rounds))
@@ -165,5 +160,32 @@ export class EventEditorPage {
    * for an existing one — the same button, so a spec names the act it is performing. */
   get createEventButton(): Locator {
     return this.page.getByRole('button', { name: 'Create event' })
+  }
+
+  /** The same button on an **existing** event's sheet. Named apart from
+   * `createEventButton` for the reason that one is named: the word on it says which act
+   * the spec is performing, and a spec that meant to save an edit and got a create is a
+   * spec that opened the wrong sheet. */
+  get saveChangesButton(): Locator {
+    return this.page.getByRole('button', { name: 'Save changes' })
+  }
+
+  /**
+   * Save an existing event's changes and wait for the sheet to **close**.
+   *
+   * The close is the success signal, and it is the editor's own contract: it awaits the
+   * update and closes itself only when the promise RESOLVES, staying open over a rejection
+   * so a refused save is reported instead of binning what was typed (#933, #934). So a
+   * spec that reloads without waiting here would read the server before the write landed,
+   * and blame the *reload* for a save that had merely not finished.
+   *
+   * The refusal alert is asserted absent first, because "the sheet is still open with a
+   * red banner in it" is a far more legible failure than a number that did not survive a
+   * reload three steps later.
+   */
+  async saveChanges(): Promise<void> {
+    await this.saveChangesButton.click()
+    await expect(this.errorAlert).toHaveCount(0)
+    await expect(this.saveChangesButton).toHaveCount(0)
   }
 }

--- a/e2e/page-objects/tournament-detail-page/event-editor/draw-structure-tab.page.ts
+++ b/e2e/page-objects/tournament-detail-page/event-editor/draw-structure-tab.page.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from '@playwright/test'
+import { expect, Locator, Page } from '@playwright/test'
 
 /**
  * The event editor's **Draw structure** tab (#1320) — the four structural settings of a
@@ -61,9 +61,51 @@ export class DrawStructureTabPage {
     return this.page.getByRole('region', { name, exact: true })
   }
 
-  /** The number (or phrase) the row currently reads. */
+  /** The number (or phrase) the row currently reads, **as text**.
+   *
+   * ⚠️ Present only while the value is the system's — a setting the director owns renders
+   * a box instead, so this locator resolves nothing there and `settingInput` is what reads
+   * the number. The two are never both present, which is what makes
+   * `expect(settingInput(name)).toHaveCount(0)` a real statement that the setting went
+   * back to being automatic. */
   settingValue(name: string): Locator {
     return this.settingRow(name).getByTestId('draw-setting-value')
+  }
+
+  /** The **manual box**, present only while the director owns this setting and may edit
+   * it (there is no disabled box on this tab — ADR-0015).
+   *
+   * Addressed by the row's own heading, which is the box's accessible name
+   * (`aria-labelledby` onto the setting's name): a box whose only label were the unit
+   * after it would announce as `pools`, which is four indistinguishable boxes. Scoped to
+   * the row as well, so a spec naming the wrong setting resolves nothing rather than
+   * something. */
+  settingInput(name: string): Locator {
+    return this.settingRow(name).getByRole('textbox', { name, exact: true })
+  }
+
+  /**
+   * The row's one action — the quiet text button that hands the setting over or gives it
+   * back.
+   *
+   * **The label is an argument, not a return value**, so asking for the button is also a
+   * statement about which way the row currently points: `Set myself` on a row the director
+   * already owns resolves nothing, and the spec fails at the click rather than three
+   * assertions later.
+   *
+   * Matched on the **whole** accessible name, `{label} {name}`. Three rows offer
+   * `Set myself`, so the visible words alone name no setting, and the button's `aria-label`
+   * says both — an `aria-label` replaces the text content for name matching, so a locator
+   * asking for `Set myself` alone would resolve nothing at all.
+   */
+  settingAction(
+    name: string,
+    label: 'Set myself' | 'Use automatic' | 'Assign myself' | 'Use snake',
+  ): Locator {
+    return this.settingRow(name).getByRole('button', {
+      name: `${label} ${name}`,
+      exact: true,
+    })
   }
 
   /** The plain words after the value — `pools`, `players per pool`. A `Membership` row
@@ -83,6 +125,28 @@ export class DrawStructureTabPage {
    * the number it describes, so this string and the value above it cannot fork. */
   settingSource(name: string): Locator {
     return this.settingRow(name).getByTestId('draw-setting-source')
+  }
+
+  /**
+   * **Take a numeric setting and type a number into it** — the two-step act that is now
+   * the only way to author one of these numbers, performed as one call for a spec that
+   * wants the end state rather than the steps.
+   *
+   * ⚠️ **`Set myself` seeds the box from what the row was already showing**, so a caller
+   * that wanted a particular number must always type it afterwards — which is what this
+   * does. The seeded value is a live derivation, so it moves with the rest of the draft:
+   * the qualifier count seeds at `ceil(8 / pool count)`, which is a different number
+   * before and after the pools are added. **Set the pools first**, or the number typed
+   * here is the only thing standing between the spec and a draw it did not ask for.
+   *
+   * Reads the value back for the reason `EventEditorPage.setRounds` does: a box that
+   * dropped the keystroke leaves a spec asserting three screens later on a number the
+   * form never held.
+   */
+  async setManually(name: string, value: number): Promise<void> {
+    await this.settingAction(name, 'Set myself').click()
+    await this.settingInput(name).fill(String(value))
+    await expect(this.settingInput(name)).toHaveValue(String(value))
   }
 
   // ----- the live preview ----------------------------------------------------

--- a/e2e/support/tournament-api.ts
+++ b/e2e/support/tournament-api.ts
@@ -625,10 +625,37 @@ export async function enterPlayer(
  * they are read as a pair. Reading them back is what turns "the create request did not
  * 422" into "the server holds the configuration the director typed" — a 201 alone would
  * also be returned by a server that had quietly dropped K. */
+/** **Who owns each of an `rr-then-ko` draw's structural settings, as the server stores
+ * it** — the event's `draw_structure` object (ADR 20260808).
+ *
+ * The two pool numbers are named beside their modes because the pair is the whole fact: a
+ * `manual` mode with the number dropped, and an `automatic` mode with the director's number
+ * discarded, are both silent losses of work the ADR forbids and neither is visible from a
+ * mode alone.
+ *
+ * There is no manual *qualifier* number, and that absence is the wire's: the event's own
+ * `qualifiers_per_pool` is the manual slot, and `qualifiers_mode` says whether anybody
+ * should read it. */
+export interface StoredDrawStructure {
+  readonly pool_count_mode: 'automatic' | 'manual'
+  readonly manual_pool_count: number | null
+  readonly pool_size_mode: 'automatic' | 'manual'
+  readonly manual_pool_size: number | null
+  readonly qualifiers_mode: 'automatic' | 'manual'
+  readonly membership_mode: 'snake' | 'manual'
+}
+
 export interface EventDrawConfig {
   readonly id: string
   readonly name: string
   readonly draw_type: string
+  /** The ownership record above, or **`null` for every draw type that has no pool stage
+   * to structure** — only the `rr-then-ko` arm carries one.
+   *
+   * Read back for the reason `qualifiers_per_pool` is: a 200 on the save would also come
+   * back from a server that stored the event and dropped the modes, and the modes are
+   * exactly what the Draw structure tab's badge is rendered from. */
+  readonly draw_structure: StoredDrawStructure | null
   /** **K**. `null` for every draw type that has no knockout stage to qualify for. */
   readonly qualifiers_per_pool: number | null
   /** **R** — how many rounds a `swiss` event plays. `null` for every other draw type,

--- a/e2e/tests/tournament-draw-structure.spec.ts
+++ b/e2e/tests/tournament-draw-structure.spec.ts
@@ -1,14 +1,15 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { faker } from '@faker-js/faker'
 
 import { TournamentDetailPage } from '../page-objects/tournament-detail.page'
-import { guestFromContext } from '../support/match-api'
+import { guestFromContext, type Guest } from '../support/match-api'
 import { grantBetaTester } from '../support/rbac-grant'
 import {
   addEvent,
   createTournament,
   findEventByName,
   type PoolSpec,
+  type StoredTable,
 } from '../support/tournament-api'
 
 /** The two-stage event, and the handle every reading below finds it by. */
@@ -71,6 +72,82 @@ const POOL_COUNT_SOURCE = `${POOL_COUNT} pool reservations · today's behaviour`
  * and belongs to a different event than this one. */
 const PREVIEW_BASIS = `${FIELD_CAP}-player cap`
 
+/** The source line under the Pool size row while nobody owns it: the division that
+ * produced it, from the same derivation that produced the number. */
+const AUTOMATIC_POOL_SIZE_SOURCE = `${FIELD_CAP} players ÷ ${POOL_COUNT} pools`
+
+// ----- the second spec's numbers: a pool size the DIRECTOR sets ---------------
+//
+// Kept apart from the four constants above, and not one of them is reused. The whole
+// point of the manual scenario is that **every derived number moves**, so a shared
+// constant would be a place for the two scenarios to quietly become one.
+
+/** The size the director types over the `8` the row was showing. Sixteen because it
+ * halves the pool count rather than nudging it: `2` is unmistakably not the `4` pool
+ * rows the event still has, so a reload that showed the old automatic split could not be
+ * mistaken for a coincidence. */
+const MANUAL_POOL_SIZE = 16
+/** What the pool count becomes once the size is the director's: `ceil(32 / 16)`. Still an
+ * **automatic** number — taking one setting does not take the one below it. */
+const DERIVED_POOL_COUNT = 2
+/** `ceil(8 / 2)`, the automatic qualifier count aimed at an eight-player knockout across
+ * two pools. Note it is **not** the event's stored K, which is still 2: an automatic
+ * qualifier count ignores the stored number, so this is a live reading of the derivation
+ * rather than an echo of the seed. */
+const DERIVED_QUALIFIERS_ADVANCING = 4
+/** `2 × 4` — the same eight-player bracket the automatic draw produced, reached by a
+ * different route. Asserted anyway: a bracket that moved would mean the qualifier count
+ * and the pool count had not moved together. */
+const MANUAL_BRACKET_SIZE = 8
+/** `2 × C(16,2)`. The number that says loudest that the manual size took: the automatic
+ * draw plays 112 pool matches and this one plays more than twice that. */
+const MANUAL_POOL_MATCHES = 240
+
+/** The equation once the director owns the size. */
+const MANUAL_EQUATION = `${FIELD_CAP} players ÷ ${DERIVED_POOL_COUNT} pools = ${MANUAL_POOL_SIZE} per pool`
+/** The source line under the Pool size row when the director set the target and the
+ * system worked out the rest — **verbatim**, right single quote and all. */
+const MANUAL_POOL_SIZE_SOURCE = 'You set the target. We derived the pool count.'
+/** …and the line under the Pool count row, which now names the division it did rather
+ * than the pool rows it used to read off. The `about` is the reference's: a greedy fill
+ * does not promise every pool that size. */
+const DERIVED_POOL_COUNT_SOURCE = `${FIELD_CAP} players ÷ about ${MANUAL_POOL_SIZE} per pool`
+
+/**
+ * The tournament both specs are about: one `rr-then-ko` event, capped at 32, over four
+ * pool rows that reserve no tables — the state the whole tab is derived from.
+ *
+ * The director **is** the browser's own session (`guestFromContext`), so page navigations
+ * run as them and the event card carries the owner's `Edit …` open target rather than a
+ * viewer's `View …`.
+ *
+ * The tournament name is returned because it is the only handle a spec has on the page
+ * having rendered at all — the hero's `h1` — and the catalogue because a second event is
+ * added against it.
+ */
+async function seedTwoStageTournament(page: Page): Promise<{
+  director: Guest
+  tournamentId: string
+  tables: ReadonlyArray<StoredTable>
+  name: string
+}> {
+  const director = await guestFromContext(page.request)
+  grantBetaTester(director.username)
+
+  const name = `Draw structure ${faker.string.alphanumeric(8)}`
+  const { tournamentId, tables } = await createTournament(director, name)
+
+  await addEvent(director, tournamentId, tables, {
+    name: RR_KO_EVENT,
+    drawType: 'rr-then-ko',
+    qualifiersPerPool: STORED_QUALIFIERS_PER_POOL,
+    maxPlayers: FIELD_CAP,
+    pools: POOLS,
+  })
+
+  return { director, tournamentId, tables, name }
+}
+
 /**
  * **The Draw structure tab, through the whole composed stack** (#1320).
  *
@@ -117,22 +194,10 @@ test.describe('Tournament — the rr-then-ko draw structure', () => {
   }) => {
     expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
 
-    // The director IS the browser's own session, so page navigations run as them and the
-    // event cards carry the owner's `Edit …` open target rather than a viewer's `View …`.
-    const director = await guestFromContext(page.request)
-    grantBetaTester(director.username)
-
     // ----- the shell, over the API: two events, one tournament ---------------
-    const name = `Draw structure ${faker.string.alphanumeric(8)}`
-    const { tournamentId, tables } = await createTournament(director, name)
+    const { director, tournamentId, tables, name } =
+      await seedTwoStageTournament(page)
 
-    await addEvent(director, tournamentId, tables, {
-      name: RR_KO_EVENT,
-      drawType: 'rr-then-ko',
-      qualifiersPerPool: STORED_QUALIFIERS_PER_POOL,
-      maxPlayers: FIELD_CAP,
-      pools: POOLS,
-    })
     // The control, and the reason it is on the SAME tournament: two events one click
     // apart is the sharpest form of "this format has the tab and that one does not".
     await addEvent(director, tournamentId, tables, {
@@ -238,5 +303,167 @@ test.describe('Tournament — the rr-then-ko draw structure', () => {
     // together, so a tab that vanished while its content stayed would be a blank fifth
     // section a director could still be sent to.
     await expect(plainEditor.drawStructure.section).toHaveCount(0)
+  })
+
+  /**
+   * **A pool size the director sets is theirs after a reload — and giving it back sticks
+   * too.**
+   *
+   * ## What only this suite can say
+   *
+   * That the ownership *mode* is stored. Every other test of this tab hands the tab a
+   * mode: `draw-structure-section.test.tsx` renders a fixture that already has one, and
+   * the MSW store keeps whatever it is handed. Neither can tell "the director owns this
+   * setting" from "the number happens to be that". Only a real PATCH into Postgres and a
+   * real `GET` back out can, and the discriminator is the **badge**: a `16` that survived
+   * a reload under an `Automatic` badge is a number the system will silently re-derive the
+   * next time the field moves — the director's work, lost quietly, which is exactly what
+   * ADR 20260808 forbids and what #1320 was filed about.
+   *
+   * So the badge is asserted every time the number is, and the reload is a real one: a new
+   * page, a re-opened editor, a re-opened tab, and nothing left of the first visit but
+   * what the server kept.
+   *
+   * ## Both directions, one test, one seed
+   *
+   * `Set myself` and `Use automatic` are one setting's two edges, and the second only
+   * means anything from a state the first produced. Driving both here keeps every
+   * transition the browser's — an API-seeded manual mode would prove the server accepts a
+   * body this test composed, which is the thing `tournament-api.ts` declines to do — and
+   * pays the tournament seed and the first navigation once.
+   *
+   * ## The API read-backs are corroboration, not the assertion
+   *
+   * Two of them, around the two saves, in the shape this file already uses for
+   * `draw_type`: they say *where* a failure is (the server dropped it / the client never
+   * sent it) rather than leaving a wrong badge to be argued about. The second one carries
+   * the ADR's own non-destructive rule — `Use automatic` keeps the director's number and
+   * only stops reading it — which no screen states, because the point of it is that the
+   * screen goes back to the derived number.
+   */
+  test('a pool size the director sets survives a save and a reload, badge and all', async ({
+    page,
+    baseURL,
+  }) => {
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    const { director, tournamentId, name } = await seedTwoStageTournament(page)
+
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    // The long timeout is the composed web-client's first compile of this route, not the
+    // app — see the same wait in the spec above.
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    // ----- 1. nobody owns the pool size yet ----------------------------------
+    const editor = await detail.openEvent(RR_KO_EVENT)
+    const drawStructure = await editor.openDrawStructure()
+    await expect(drawStructure.section).toBeVisible()
+    await expect(drawStructure.settingValue('Pool size')).toHaveText(String(POOL_SIZE))
+    await expect(drawStructure.settingOwnership('Pool size')).toHaveText('Automatic')
+    await expect(drawStructure.settingSource('Pool size')).toHaveText(
+      AUTOMATIC_POOL_SIZE_SOURCE,
+    )
+    // No box while the system owns it — a read-only row here is text, never a disabled
+    // input (ADR-0015). It is also what makes the same assertion at the very end mean
+    // something.
+    await expect(drawStructure.settingInput('Pool size')).toHaveCount(0)
+
+    // ----- 2. the director takes it, and types a different number ------------
+    await drawStructure.settingAction('Pool size', 'Set myself').click()
+    // Taking a setting changes the OWNER, not the number: the box is seeded with the `8`
+    // the row was already showing, so the first click moves nothing.
+    await expect(drawStructure.settingInput('Pool size')).toHaveValue(String(POOL_SIZE))
+    await expect(drawStructure.settingOwnership('Pool size')).toHaveText('Yours')
+
+    await drawStructure.settingInput('Pool size').fill(String(MANUAL_POOL_SIZE))
+
+    // ----- 3. …and the rest of the draw moves with it, before the save -------
+    // Asserted here as well as after the reload, so a reload that shows the wrong numbers
+    // is a persistence failure rather than a derivation one.
+    await expect(drawStructure.settingValue('Pool count')).toHaveText(
+      String(DERIVED_POOL_COUNT),
+    )
+    await expect(drawStructure.previewEquation).toHaveText(MANUAL_EQUATION)
+
+    await editor.saveChanges()
+
+    // ----- 4. the SERVER holds the mode, not just the number -----------------
+    const stored = await findEventByName(director, tournamentId, RR_KO_EVENT)
+    expect(stored.draw_structure).not.toBeNull()
+    expect(stored.draw_structure?.pool_size_mode).toBe('manual')
+    expect(stored.draw_structure?.manual_pool_size).toBe(MANUAL_POOL_SIZE)
+    // The setting below it was never touched, and a save that took ownership of every row
+    // it rendered would be a save that quietly froze three numbers.
+    expect(stored.draw_structure?.pool_count_mode).toBe('automatic')
+
+    // ----- 5. reload, and read the whole tab back ----------------------------
+    await detail.reload(tournamentId)
+    await expect(detail.title).toContainText(name)
+    const reopened = await detail.openEvent(RR_KO_EVENT)
+    const reloaded = await reopened.openDrawStructure()
+    await expect(reloaded.section).toBeVisible()
+
+    // The number **and** its owner. A `16` under an `Automatic` badge is the bug this
+    // spec exists to catch, so the badge is not an extra — it is the assertion.
+    await expect(reloaded.settingInput('Pool size')).toHaveValue(String(MANUAL_POOL_SIZE))
+    await expect(reloaded.settingOwnership('Pool size')).toHaveText('Yours')
+    await expect(reloaded.settingSource('Pool size')).toHaveText(MANUAL_POOL_SIZE_SOURCE)
+
+    // The derived consequences came back with it, rather than the tab re-deriving the
+    // automatic split off the four pool rows the event still has.
+    await expect(reloaded.settingValue('Pool count')).toHaveText(
+      String(DERIVED_POOL_COUNT),
+    )
+    await expect(reloaded.settingOwnership('Pool count')).toHaveText('Automatic')
+    await expect(reloaded.settingSource('Pool count')).toHaveText(
+      DERIVED_POOL_COUNT_SOURCE,
+    )
+    await expect(reloaded.previewEquation).toHaveText(MANUAL_EQUATION)
+    await expect(reloaded.previewPoolCards).toHaveCount(DERIVED_POOL_COUNT)
+    for (const letter of ['A', 'B']) {
+      const card = reloaded.previewPoolCard(letter)
+      // One fact per assertion — the card's own text runs together (see the page object).
+      await expect(card).toContainText(String(MANUAL_POOL_SIZE))
+      await expect(card).toContainText(`top ${DERIVED_QUALIFIERS_ADVANCING} advance`)
+      await expect(card).not.toContainText('Too small')
+    }
+    await expect(reloaded.previewKnockout).toContainText(
+      `${MANUAL_BRACKET_SIZE}-player bracket`,
+    )
+    // 240, against the automatic draw's 112. The loudest number on the screen, and the
+    // one no fixture chose.
+    await expect(reloaded.previewKnockout).toContainText(
+      `${MANUAL_POOL_MATCHES} pool matches`,
+    )
+    await expect(reloaded.previewVerdict).toHaveText('Ready to save')
+    await expect(reloaded.previewBadge).toHaveText('Sound')
+
+    // ----- 6. the other direction: giving the setting back sticks too --------
+    await reloaded.settingAction('Pool size', 'Use automatic').click()
+    await expect(reloaded.settingOwnership('Pool size')).toHaveText('Automatic')
+    await expect(reloaded.settingValue('Pool size')).toHaveText(String(POOL_SIZE))
+    await reopened.saveChanges()
+
+    // The number is KEPT while its mode is automatic (ADR 20260808) — `Use automatic` is
+    // the opposite of destructive. Nothing on screen can say this, because the point of it
+    // is that the screen goes back to the derived number.
+    const returned = await findEventByName(director, tournamentId, RR_KO_EVENT)
+    expect(returned.draw_structure?.pool_size_mode).toBe('automatic')
+    expect(returned.draw_structure?.manual_pool_size).toBe(MANUAL_POOL_SIZE)
+
+    await detail.reload(tournamentId)
+    await expect(detail.title).toContainText(name)
+    const finalEditor = await detail.openEvent(RR_KO_EVENT)
+    const handedBack = await finalEditor.openDrawStructure()
+    await expect(handedBack.settingOwnership('Pool size')).toHaveText('Automatic')
+    await expect(handedBack.settingValue('Pool size')).toHaveText(String(POOL_SIZE))
+    // The discriminator that the MODE came back, not merely the number: an automatic row
+    // renders text, so a box here would mean the setting was still the director's and had
+    // simply re-derived to the same `8`.
+    await expect(handedBack.settingInput('Pool size')).toHaveCount(0)
+    // …and the whole draw is the automatic one again: four pools of eight, off the four
+    // pool rows the event has had all along.
+    await expect(handedBack.previewEquation).toHaveText(EQUATION)
+    await expect(handedBack.previewPoolCards).toHaveCount(POOL_COUNT)
   })
 })

--- a/e2e/tests/tournament-rr-then-ko.spec.ts
+++ b/e2e/tests/tournament-rr-then-ko.spec.ts
@@ -27,7 +27,12 @@ const DRAW_TYPE_LABEL = 'Round-robin then knockout'
  * is nearly free). */
 const POOL_COUNT = 3
 /** `K` — the qualifiers per pool. The number this whole spec exists to get onto the
- * wire: an `rr-then-ko` create body without it is a **422** at the request boundary. */
+ * wire: an `rr-then-ko` create body without it is a **422** at the request boundary.
+ *
+ * **Two, and the director types it.** The form supplies the derived `ceil(8 / P)` for an
+ * event that carries no count the server would accept, so this event would go in with 3
+ * if nobody touched the row — and three out of a pool of three is every entrant
+ * advancing. Half the assertions below are about the three who do *not*. */
 const QUALIFIERS_PER_POOL = 2
 /** `N` — nine entrants, dealt three to a pool. Enough to satisfy the cut's two
  * entrant-dependent refusals (`K ≤ ⌊N/P⌋` = 3, and `P × K ≥ 2`) with room to spare, and
@@ -218,12 +223,27 @@ test.describe('Tournament — rr-then-ko draw', () => {
     const editor = await detail.openNewEvent()
     await editor.nameInput.fill(EVENT_NAME)
     await editor.chooseDrawType(DRAW_TYPE_LABEL)
-    // The qualifier box exists ONLY for this draw type — it is absent, not disabled,
-    // for a format with no knockout stage to qualify for. So its appearance is the
-    // proof the picker's choice reached the form, before anything is submitted.
-    await expect(editor.qualifiersInput).toBeVisible()
-    await editor.setQualifiersPerPool(QUALIFIERS_PER_POOL)
+    // The **Draw structure tab** exists ONLY for this draw type — it is absent, not
+    // disabled, for a format with no knockout stage to qualify for (ADR 20260808). So its
+    // appearance is the proof the picker's choice reached the form, before anything is
+    // submitted. The qualifier box on Basics used to carry that proof; the setting moved
+    // onto this tab, and the tab inherited it.
+    await expect(editor.tab('Draw structure')).toBeVisible()
+
+    // **The pools FIRST**, because the qualifier count is derived from them.
     await editor.addPools(POOL_COUNT)
+
+    // **K is typed, and this spec is about the typed one.** A director who never touches
+    // the row now gets the derived count, which across three pools is `ceil(8 / 3)` = 3 —
+    // and 3 qualifiers out of a pool of three is every entrant advancing. That draw has no
+    // eliminated three for the bracket to exclude and a pool stage that decides nothing,
+    // which is precisely the claim below (`the bracket names exactly the six who qualified
+    // and none of the three who did not`). So the director takes the setting and types 2.
+    //
+    // Taking it also seeds the box with that 3, which is why the number is typed *after*
+    // the pools exist and not before: seeded against one pool it would have been 8.
+    const drawStructure = await editor.openDrawStructure()
+    await drawStructure.setManually('Qualifiers per pool', QUALIFIERS_PER_POOL)
 
     // THE 422 GATE. The create body is the client's own, and its status is asserted
     // directly: a body missing `qualifiers_per_pool` is refused at the request boundary,

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -4347,6 +4347,99 @@ internal enum Components {
                 case registered
             }
         }
+        /// Which of a round-robin-then-knockout draw's structural settings the **director
+        /// owns**, and the numbers they chose.
+        ///
+        /// Four settings, each with its ownership stored rather than guessed: the pool count,
+        /// the pool size, the qualifier count (whose value is the event's own
+        /// ``qualifiers_per_pool``), and how entrants reach their pools. Every mode defaults to
+        /// the derived answer, so an event that sets nothing behaves exactly as it does today.
+        ///
+        /// A manual number is kept while its mode is ``automatic``: it is the director's
+        /// number, remembered for the next time they take the setting back.
+        ///
+        /// - Remark: Generated from `#/components/schemas/DrawStructure`.
+        internal struct DrawStructure: Codable, Hashable, Sendable {
+            /// - Remark: Generated from `#/components/schemas/DrawStructure/pool_count_mode`.
+            internal var poolCountMode: Components.Schemas.StructuralSettingOwner?
+            /// - Remark: Generated from `#/components/schemas/DrawStructure/manual_pool_count`.
+            internal var manualPoolCount: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/DrawStructure/pool_size_mode`.
+            internal var poolSizeMode: Components.Schemas.StructuralSettingOwner?
+            /// - Remark: Generated from `#/components/schemas/DrawStructure/manual_pool_size`.
+            internal var manualPoolSize: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/DrawStructure/qualifiers_mode`.
+            internal var qualifiersMode: Components.Schemas.StructuralSettingOwner?
+            /// - Remark: Generated from `#/components/schemas/DrawStructure/membership_mode`.
+            internal var membershipMode: Components.Schemas.PoolMembershipMode?
+            /// Creates a new `DrawStructure`.
+            ///
+            /// - Parameters:
+            ///   - poolCountMode:
+            ///   - manualPoolCount:
+            ///   - poolSizeMode:
+            ///   - manualPoolSize:
+            ///   - qualifiersMode:
+            ///   - membershipMode:
+            internal init(
+                poolCountMode: Components.Schemas.StructuralSettingOwner? = nil,
+                manualPoolCount: Swift.Int? = nil,
+                poolSizeMode: Components.Schemas.StructuralSettingOwner? = nil,
+                manualPoolSize: Swift.Int? = nil,
+                qualifiersMode: Components.Schemas.StructuralSettingOwner? = nil,
+                membershipMode: Components.Schemas.PoolMembershipMode? = nil
+            ) {
+                self.poolCountMode = poolCountMode
+                self.manualPoolCount = manualPoolCount
+                self.poolSizeMode = poolSizeMode
+                self.manualPoolSize = manualPoolSize
+                self.qualifiersMode = qualifiersMode
+                self.membershipMode = membershipMode
+            }
+            internal enum CodingKeys: String, CodingKey {
+                case poolCountMode = "pool_count_mode"
+                case manualPoolCount = "manual_pool_count"
+                case poolSizeMode = "pool_size_mode"
+                case manualPoolSize = "manual_pool_size"
+                case qualifiersMode = "qualifiers_mode"
+                case membershipMode = "membership_mode"
+            }
+            internal init(from decoder: any Swift.Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.poolCountMode = try container.decodeIfPresent(
+                    Components.Schemas.StructuralSettingOwner.self,
+                    forKey: .poolCountMode
+                )
+                self.manualPoolCount = try container.decodeIfPresent(
+                    Swift.Int.self,
+                    forKey: .manualPoolCount
+                )
+                self.poolSizeMode = try container.decodeIfPresent(
+                    Components.Schemas.StructuralSettingOwner.self,
+                    forKey: .poolSizeMode
+                )
+                self.manualPoolSize = try container.decodeIfPresent(
+                    Swift.Int.self,
+                    forKey: .manualPoolSize
+                )
+                self.qualifiersMode = try container.decodeIfPresent(
+                    Components.Schemas.StructuralSettingOwner.self,
+                    forKey: .qualifiersMode
+                )
+                self.membershipMode = try container.decodeIfPresent(
+                    Components.Schemas.PoolMembershipMode.self,
+                    forKey: .membershipMode
+                )
+                try decoder.ensureNoAdditionalProperties(knownKeys: [
+                    "pool_count_mode",
+                    "manual_pool_count",
+                    "pool_size_mode",
+                    "manual_pool_size",
+                    "qualifiers_mode",
+                    "membership_mode"
+                ])
+            }
+        }
         /// - Remark: Generated from `#/components/schemas/DrawType`.
         internal enum DrawType: String, Codable, Hashable, Sendable, CaseIterable {
             case singleElim = "single-elim"
@@ -7824,6 +7917,11 @@ internal enum Components {
                 case reservation
             }
         }
+        /// - Remark: Generated from `#/components/schemas/PoolMembershipMode`.
+        internal enum PoolMembershipMode: String, Codable, Hashable, Sendable, CaseIterable {
+            case snake = "snake"
+            case manual = "manual"
+        }
         /// A pool whose aggregate match-time (``required_min``) exceeds the
         /// table-minutes its window offers (``capacity_min`` = window span ×
         /// ``table_count``). Resolved: the pool ``name``, which kind of ``reservation``
@@ -9990,6 +10088,11 @@ internal enum Components {
             case live = "live"
             case final = "final"
         }
+        /// - Remark: Generated from `#/components/schemas/StructuralSettingOwner`.
+        internal enum StructuralSettingOwner: String, Codable, Hashable, Sendable, CaseIterable {
+            case automatic = "automatic"
+            case manual = "manual"
+        }
         /// One entry's line in a **swiss** table: every column a pool's row carries, plus
         /// the **Buchholz** figure that ordered it.
         ///
@@ -10606,6 +10709,26 @@ internal enum Components {
             internal var qualifiersPerPool: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/rounds`.
             internal var rounds: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/draw_structure`.
+            internal struct DrawStructurePayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/draw_structure/value1`.
+                internal var value1: Components.Schemas.DrawStructure
+                /// Creates a new `DrawStructurePayload`.
+                ///
+                /// - Parameters:
+                ///   - value1:
+                internal init(value1: Components.Schemas.DrawStructure) {
+                    self.value1 = value1
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    self.value1 = try .init(from: decoder)
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    try self.value1.encode(to: encoder)
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/draw_structure`.
+            internal var drawStructure: Components.Schemas.TournamentEventCreate.DrawStructurePayload?
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/max_players`.
             internal var maxPlayers: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventCreate/entry_fee`.
@@ -10628,6 +10751,7 @@ internal enum Components {
             ///   - drawType:
             ///   - qualifiersPerPool:
             ///   - rounds:
+            ///   - drawStructure:
             ///   - maxPlayers:
             ///   - entryFee:
             ///   - timezone:
@@ -10641,6 +10765,7 @@ internal enum Components {
                 drawType: Components.Schemas.DrawType,
                 qualifiersPerPool: Swift.Int? = nil,
                 rounds: Swift.Int? = nil,
+                drawStructure: Components.Schemas.TournamentEventCreate.DrawStructurePayload? = nil,
                 maxPlayers: Swift.Int? = nil,
                 entryFee: Swift.Double,
                 timezone: Swift.String,
@@ -10654,6 +10779,7 @@ internal enum Components {
                 self.drawType = drawType
                 self.qualifiersPerPool = qualifiersPerPool
                 self.rounds = rounds
+                self.drawStructure = drawStructure
                 self.maxPlayers = maxPlayers
                 self.entryFee = entryFee
                 self.timezone = timezone
@@ -10668,6 +10794,7 @@ internal enum Components {
                 case drawType = "draw_type"
                 case qualifiersPerPool = "qualifiers_per_pool"
                 case rounds
+                case drawStructure = "draw_structure"
                 case maxPlayers = "max_players"
                 case entryFee = "entry_fee"
                 case timezone
@@ -10697,6 +10824,10 @@ internal enum Components {
                 self.rounds = try container.decodeIfPresent(
                     Swift.Int.self,
                     forKey: .rounds
+                )
+                self.drawStructure = try container.decodeIfPresent(
+                    Components.Schemas.TournamentEventCreate.DrawStructurePayload.self,
+                    forKey: .drawStructure
                 )
                 self.maxPlayers = try container.decodeIfPresent(
                     Swift.Int.self,
@@ -10732,6 +10863,7 @@ internal enum Components {
                     "draw_type",
                     "qualifiers_per_pool",
                     "rounds",
+                    "draw_structure",
                     "max_players",
                     "entry_fee",
                     "timezone",
@@ -10758,6 +10890,26 @@ internal enum Components {
             internal var qualifiersPerPool: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/rounds`.
             internal var rounds: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/TournamentEventRead/draw_structure`.
+            internal struct DrawStructurePayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/TournamentEventRead/draw_structure/value1`.
+                internal var value1: Components.Schemas.DrawStructure
+                /// Creates a new `DrawStructurePayload`.
+                ///
+                /// - Parameters:
+                ///   - value1:
+                internal init(value1: Components.Schemas.DrawStructure) {
+                    self.value1 = value1
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    self.value1 = try .init(from: decoder)
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    try self.value1.encode(to: encoder)
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/TournamentEventRead/draw_structure`.
+            internal var drawStructure: Components.Schemas.TournamentEventRead.DrawStructurePayload?
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/max_players`.
             internal var maxPlayers: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventRead/entry_fee`.
@@ -10894,6 +11046,7 @@ internal enum Components {
             ///   - drawType:
             ///   - qualifiersPerPool:
             ///   - rounds:
+            ///   - drawStructure:
             ///   - maxPlayers:
             ///   - entryFee:
             ///   - timezone:
@@ -10916,6 +11069,7 @@ internal enum Components {
                 drawType: Components.Schemas.DrawType,
                 qualifiersPerPool: Swift.Int? = nil,
                 rounds: Swift.Int? = nil,
+                drawStructure: Components.Schemas.TournamentEventRead.DrawStructurePayload? = nil,
                 maxPlayers: Swift.Int? = nil,
                 entryFee: Swift.Double,
                 timezone: Swift.String,
@@ -10938,6 +11092,7 @@ internal enum Components {
                 self.drawType = drawType
                 self.qualifiersPerPool = qualifiersPerPool
                 self.rounds = rounds
+                self.drawStructure = drawStructure
                 self.maxPlayers = maxPlayers
                 self.entryFee = entryFee
                 self.timezone = timezone
@@ -10961,6 +11116,7 @@ internal enum Components {
                 case drawType = "draw_type"
                 case qualifiersPerPool = "qualifiers_per_pool"
                 case rounds
+                case drawStructure = "draw_structure"
                 case maxPlayers = "max_players"
                 case entryFee = "entry_fee"
                 case timezone
@@ -11045,6 +11201,26 @@ internal enum Components {
             internal var qualifiersPerPool: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/rounds`.
             internal var rounds: Swift.Int?
+            /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/draw_structure`.
+            internal struct DrawStructurePayload: Codable, Hashable, Sendable {
+                /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/draw_structure/value1`.
+                internal var value1: Components.Schemas.DrawStructure
+                /// Creates a new `DrawStructurePayload`.
+                ///
+                /// - Parameters:
+                ///   - value1:
+                internal init(value1: Components.Schemas.DrawStructure) {
+                    self.value1 = value1
+                }
+                internal init(from decoder: any Swift.Decoder) throws {
+                    self.value1 = try .init(from: decoder)
+                }
+                internal func encode(to encoder: any Swift.Encoder) throws {
+                    try self.value1.encode(to: encoder)
+                }
+            }
+            /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/draw_structure`.
+            internal var drawStructure: Components.Schemas.TournamentEventUpdate.DrawStructurePayload?
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/max_players`.
             internal var maxPlayers: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/TournamentEventUpdate/entry_fee`.
@@ -11103,6 +11279,7 @@ internal enum Components {
             ///   - drawType:
             ///   - qualifiersPerPool:
             ///   - rounds:
+            ///   - drawStructure:
             ///   - maxPlayers:
             ///   - entryFee:
             ///   - timezone:
@@ -11116,6 +11293,7 @@ internal enum Components {
                 drawType: Components.Schemas.TournamentEventUpdate.DrawTypePayload? = nil,
                 qualifiersPerPool: Swift.Int? = nil,
                 rounds: Swift.Int? = nil,
+                drawStructure: Components.Schemas.TournamentEventUpdate.DrawStructurePayload? = nil,
                 maxPlayers: Swift.Int? = nil,
                 entryFee: Swift.Double? = nil,
                 timezone: Swift.String? = nil,
@@ -11129,6 +11307,7 @@ internal enum Components {
                 self.drawType = drawType
                 self.qualifiersPerPool = qualifiersPerPool
                 self.rounds = rounds
+                self.drawStructure = drawStructure
                 self.maxPlayers = maxPlayers
                 self.entryFee = entryFee
                 self.timezone = timezone
@@ -11143,6 +11322,7 @@ internal enum Components {
                 case drawType = "draw_type"
                 case qualifiersPerPool = "qualifiers_per_pool"
                 case rounds
+                case drawStructure = "draw_structure"
                 case maxPlayers = "max_players"
                 case entryFee = "entry_fee"
                 case timezone
@@ -11172,6 +11352,10 @@ internal enum Components {
                 self.rounds = try container.decodeIfPresent(
                     Swift.Int.self,
                     forKey: .rounds
+                )
+                self.drawStructure = try container.decodeIfPresent(
+                    Components.Schemas.TournamentEventUpdate.DrawStructurePayload.self,
+                    forKey: .drawStructure
                 )
                 self.maxPlayers = try container.decodeIfPresent(
                     Swift.Int.self,
@@ -11207,6 +11391,7 @@ internal enum Components {
                     "draw_type",
                     "qualifiers_per_pool",
                     "rounds",
+                    "draw_structure",
                     "max_players",
                     "entry_fee",
                     "timezone",

--- a/web-client/e2e/page-objects/tournaments/tournaments-store.ts
+++ b/web-client/e2e/page-objects/tournaments/tournaments-store.ts
@@ -1082,16 +1082,20 @@ function poolSetFrozenDetail(
 }
 
 /** Why this event PATCH is refused by a standing draw — or `null` when it is not
- * (`_enforce_pool_set_frozen` / `_enforce_draw_type_frozen`, both a 409).
+ * (`_enforce_pool_set_frozen` / `_enforce_draw_settings_frozen`, both a 409).
  *
  * Two facts are frozen while fixtures exist, and **only** these two:
  * - the **set of pool ids**, because a fixture names the pool it was dealt into — remove
  *   one and its fixtures point at nothing, add one and it arrives with no fixtures;
- * - the **draw type**, because it is not a label on an event but the strategy that DEALT
- *   these fixtures.
+ * - the **configuration the draw was dealt from**, which is the draw type *and* the number
+ *   that sized it: an `rr-then-ko` bracket is cut upfront for `P × K`, and a swiss draw
+ *   writes all `R` rounds at the cut. A count the fixtures were not cut for is exactly as
+ *   contradictory as a type they were not dealt by, and much quieter.
  *
  * Everything else about a pool — its name, its tables, its window, its place in the order
- * — stays editable, and so does the rest of the event.
+ * — stays editable, and so does the rest of the event, **including the ownership modes**:
+ * the server excludes `draw_structure` from this comparison on purpose, because a mode
+ * sizes nothing the cut already put on the table.
  *
  * **Re-identifying a pool is no longer one of the refusals**, because it is no longer a
  * payload a client can send (ADR 20260801): a pool id is minted by the server, so an
@@ -1103,6 +1107,8 @@ function frozenDetail(event: TournamentEventRead, body: unknown): string | null 
   const patch = body as {
     pools?: { id?: string | null }[] | null
     draw_type?: string | null
+    qualifiers_per_pool?: number | null
+    rounds?: number | null
   } | null
 
   if (patch?.pools) {
@@ -1117,11 +1123,53 @@ function frozenDetail(event: TournamentEventRead, body: unknown): string | null 
     if (!same) return poolSetFrozenDetail(event, patch.pools)
   }
 
-  if (patch?.draw_type && patch.draw_type !== event.draw_type) {
+  // An absent draw type means the patch is not touching the configuration at all: the
+  // schema refuses an explicit `null` there, and refuses a count with no type beside it.
+  if (!patch?.draw_type) return null
+
+  if (patch.draw_type !== event.draw_type) {
     return (
       "This event's draw is already cut, so its draw type is frozen: its fixtures were " +
       `dealt as a “${event.draw_type}” draw, and changing the type would leave the event ` +
       'claiming a shape its draw does not have. To change the draw type, remove the draw ' +
+      'first, then cut it again.'
+    )
+  }
+
+  // Same type, so the only thing left that can have moved is the setting that sized the
+  // draw. The MSW store enforces the same rule, in the same words
+  // (`drawSettingsFrozenDetail`, `src/mocks/tournaments-store.ts`) — this stub is the one
+  // the browser specs run against, and a stub laxer than the server hides the 409 rather
+  // than reporting it.
+  // ⚠️ **An ABSENT setting reads as unchanged, not as `null`.** On the server an arm
+  // missing its own setting never reaches this guard — `rr-then-ko` requires
+  // `qualifiers_per_pool` and `swiss` requires `rounds`, both with no default, so the
+  // schema answers 422 first. A 409 here for that body would make this stub stricter than
+  // the server, which drives a client to disable work the API allows.
+  if (
+    event.draw_type === 'rr-then-ko' &&
+    'qualifiers_per_pool' in patch &&
+    (patch.qualifiers_per_pool ?? null) !== event.qualifiers_per_pool
+  ) {
+    return (
+      "This event's draw is already cut, so the number of qualifiers per pool is " +
+      `frozen: its knockout bracket was cut for the top ${event.qualifiers_per_pool} out of each ` +
+      `pool of a “${event.draw_type}” draw, and changing that count would leave ` +
+      'qualifiers with no slot to be seated into. To change it, remove the draw ' +
+      'first, then cut it again.'
+    )
+  }
+
+  if (
+    event.draw_type === 'swiss' &&
+    'rounds' in patch &&
+    (patch.rounds ?? null) !== event.rounds
+  ) {
+    const roundNoun = event.rounds === 1 ? 'round' : 'rounds'
+    return (
+      "This event's draw is already cut, so its number of rounds is frozen: all " +
+      `${event.rounds} ${roundNoun} were cut at once, and changing the count would leave ` +
+      'the draw with rounds it has no fixtures for. To change it, remove the draw ' +
       'first, then cut it again.'
     )
   }

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -2277,6 +2277,33 @@ export interface components {
             registered: boolean;
         };
         /**
+         * DrawStructure
+         * @description Which of a round-robin-then-knockout draw's structural settings the **director
+         *     owns**, and the numbers they chose.
+         *
+         *     Four settings, each with its ownership stored rather than guessed: the pool count,
+         *     the pool size, the qualifier count (whose value is the event's own
+         *     ``qualifiers_per_pool``), and how entrants reach their pools. Every mode defaults to
+         *     the derived answer, so an event that sets nothing behaves exactly as it does today.
+         *
+         *     A manual number is kept while its mode is ``automatic``: it is the director's
+         *     number, remembered for the next time they take the setting back.
+         */
+        DrawStructure: {
+            /** @default automatic */
+            pool_count_mode: components["schemas"]["StructuralSettingOwner"];
+            /** Manual Pool Count */
+            manual_pool_count?: number | null;
+            /** @default automatic */
+            pool_size_mode: components["schemas"]["StructuralSettingOwner"];
+            /** Manual Pool Size */
+            manual_pool_size?: number | null;
+            /** @default automatic */
+            qualifiers_mode: components["schemas"]["StructuralSettingOwner"];
+            /** @default snake */
+            membership_mode: components["schemas"]["PoolMembershipMode"];
+        };
+        /**
          * DrawType
          * @enum {string}
          */
@@ -3737,6 +3764,11 @@ export interface components {
             reservation: "pool" | "event";
         };
         /**
+         * PoolMembershipMode
+         * @enum {string}
+         */
+        PoolMembershipMode: "snake" | "manual";
+        /**
          * PoolOverCapacityRead
          * @description A pool whose aggregate match-time (``required_min``) exceeds the
          *     table-minutes its window offers (``capacity_min`` = window span ×
@@ -4630,6 +4662,11 @@ export interface components {
          */
         Status: "scheduled" | "live" | "final";
         /**
+         * StructuralSettingOwner
+         * @enum {string}
+         */
+        StructuralSettingOwner: "automatic" | "manual";
+        /**
          * SwissStandingRowRead
          * @description One entry's line in a **swiss** table: every column a pool's row carries, plus
          *     the **Buchholz** figure that ordered it.
@@ -4911,6 +4948,7 @@ export interface components {
             qualifiers_per_pool?: number | null;
             /** Rounds */
             rounds?: number | null;
+            draw_structure?: components["schemas"]["DrawStructure"] | null;
             /** Max Players */
             max_players?: number | null;
             /** Entry Fee */
@@ -4944,6 +4982,7 @@ export interface components {
             qualifiers_per_pool: number | null;
             /** Rounds */
             rounds: number | null;
+            draw_structure: components["schemas"]["DrawStructure"] | null;
             /** Max Players */
             max_players: number | null;
             /** Entry Fee */
@@ -5015,6 +5054,7 @@ export interface components {
             qualifiers_per_pool?: number | null;
             /** Rounds */
             rounds?: number | null;
+            draw_structure?: components["schemas"]["DrawStructure"] | null;
             /** Max Players */
             max_players?: number | null;
             /** Entry Fee */

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -950,6 +950,11 @@ describe('eventToCreateBody', () => {
       // …and the round count the same way, for the same reason: omitted on the way out for
       // a round-robin event, an explicit `null` on the way back.
       rounds: null,
+      // …and the structural-ownership block the same way once more (ADR 20260808). A
+      // round-robin event has no pool count, pool size, qualifier count or membership rule
+      // for a director to take, so the read carries `null` — only an `rr-then-ko` event
+      // comes back with a structure at all.
+      draw_structure: null,
       id: event.id,
       tournament_id: 't-1',
       // The registrations are server-owned and absent from the create body;

--- a/web-client/src/components/tournaments/data/api.test.ts
+++ b/web-client/src/components/tournaments/data/api.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from 'vitest'
 
 import type { components } from '@/api/schema'
 import {
+  EVERY_SETTING_AUTOMATIC,
   buildTournamentDetailRead,
   buildTournamentEntrantRead,
   buildTournamentEntrantReads,
   buildTournamentEventRead,
   buildTournamentFixtureRead,
 } from '@/mocks/factories/tournaments/tournament.factory'
+import { everySettingAutomatic } from './draw-ownership'
 import {
   apiToEntrant,
   apiToEntryState,
@@ -820,6 +822,10 @@ const event: TournamentEvent = {
   // round count either (the swiss ADR). Same rule as the qualifier count above: the write
   // bodies must OMIT the key, not send this `null`.
   rounds: null,
+  // …and it has no pool stage to own the structure of, so it carries no ownership record
+  // either (ADR 20260808). `null` again, and the write bodies must OMIT `draw_structure`
+  // for the same `extra="forbid"` reason.
+  drawOwnership: null,
   maxPlayers: 48,
   entryFee: 30,
   timezone: 'America/Chicago',
@@ -1144,6 +1150,139 @@ describe('eventToUpdateBody', () => {
       })
 
       expect(apiToEvent(stored).qualifiersPerPool).toBe(2)
+    })
+  })
+
+  /**
+   * The **ownership record** on the wire (ADR 20260808) — `draw_structure`, the modes and
+   * the two manual pool numbers.
+   *
+   * The same claim as the qualifier count's, and it fails the same silent way: a director
+   * who took the pool count and typed 6, whose modes a mapper dropped, gets an event that
+   * looks saved and cuts four pools. The record travels on the `rr-then-ko` arm and **only**
+   * that arm, because the other three are `extra="forbid"`.
+   */
+  describe('the ownership record on the wire (ADR 20260808)', () => {
+    const twoStage: TournamentEvent = {
+      ...event,
+      drawType: 'rr-then-ko',
+      qualifiersPerPool: 2,
+      drawOwnership: {
+        ...everySettingAutomatic(),
+        poolCountMode: 'manual',
+        manualPoolCount: 6,
+        poolSizeMode: 'manual',
+        manualPoolSize: 5,
+        membershipMode: 'manual',
+      },
+    }
+
+    it('SENDS what the director owns, on both verbs', () => {
+      const expected = {
+        pool_count_mode: 'manual',
+        manual_pool_count: 6,
+        pool_size_mode: 'manual',
+        manual_pool_size: 5,
+        qualifiers_mode: 'automatic',
+        membership_mode: 'manual',
+      }
+
+      expect(eventToCreateBody(asEditedEvent(twoStage)).draw_structure).toEqual(
+        expected,
+      )
+      expect(eventToUpdateBody(asEditedEvent(twoStage)).draw_structure).toEqual(
+        expected,
+      )
+    })
+
+    // An event that has never seen the tab has no record, and the editor still sends one:
+    // it puts back what it rendered, which is every setting the system's. (The same
+    // structure the server's own `default_factory` would have written — so this is the
+    // honest form of the request, not a different one.)
+    it('sends the all-automatic record for an event that has never had one', () => {
+      const body = eventToUpdateBody(asEditedEvent({ ...twoStage, drawOwnership: null }))
+
+      expect(body.draw_structure).toEqual({
+        pool_count_mode: 'automatic',
+        manual_pool_count: null,
+        pool_size_mode: 'automatic',
+        manual_pool_size: null,
+        qualifiers_mode: 'automatic',
+        membership_mode: 'snake',
+      })
+    })
+
+    // The three structure-less arms declare no `draw_structure` field at all, so the key
+    // is a **422** there — not a `null` politely ignored. `toBeNull()` would pass against
+    // the payload that gets refused.
+    it.each(['round-robin', 'single-elim'] as const)(
+      'OMITS the key entirely for %s — where sending it is a 422, not a no-op',
+      (drawType) => {
+        const create = eventToCreateBody(asEditedEvent({ ...event, drawType }))
+        const update = eventToUpdateBody(asEditedEvent({ ...event, drawType }))
+
+        expect('draw_structure' in create).toBe(false)
+        expect('draw_structure' in update).toBe(false)
+      },
+    )
+
+    // The near half of the round trip: what the server stored comes back in this client's
+    // vocabulary, and reaches the tab.
+    it('reads a stored record back off the wire', () => {
+      const read = apiToEvent(
+        buildTournamentEventRead({
+          draw_type: 'rr-then-ko',
+          qualifiers_per_pool: 2,
+          draw_structure: {
+            ...EVERY_SETTING_AUTOMATIC,
+            pool_count_mode: 'manual',
+            manual_pool_count: 6,
+          },
+        }),
+      )
+
+      expect(read.drawOwnership).toEqual({
+        ...everySettingAutomatic(),
+        poolCountMode: 'manual',
+        manualPoolCount: 6,
+      })
+    })
+
+    it('reads a structure-less draw type back as null, never as a record', () => {
+      const read = apiToEvent(buildTournamentEventRead({ draw_type: 'round-robin' }))
+
+      expect(read.drawOwnership).toBeNull()
+    })
+
+    // PARSED, not cast (`.claude/rules/parse-at-boundaries.md`). A manual `0` is a number
+    // the server's `ge=1` could never have stored, and it is the exact value a cleared box
+    // would author on the way back out — a 422 three components from here. It fails
+    // INSIDE the mapper, where the payload is.
+    it('throws on a manual number the server could never have stored', () => {
+      expect(() =>
+        apiToEvent(
+          buildTournamentEventRead({
+            draw_type: 'rr-then-ko',
+            qualifiers_per_pool: 2,
+            draw_structure: {
+              ...EVERY_SETTING_AUTOMATIC,
+              pool_count_mode: 'manual',
+              manual_pool_count: 0,
+            },
+          }),
+        ),
+      ).toThrow()
+    })
+
+    it('round-trips a taken setting: type 6 pools, send 6, read 6 back', () => {
+      const sent = eventToUpdateBody(asEditedEvent(twoStage))
+      const stored = buildTournamentEventRead({
+        draw_type: 'rr-then-ko',
+        qualifiers_per_pool: 2,
+        draw_structure: sent.draw_structure,
+      })
+
+      expect(apiToEvent(stored).drawOwnership).toEqual(twoStage.drawOwnership)
     })
   })
 

--- a/web-client/src/components/tournaments/data/api.ts
+++ b/web-client/src/components/tournaments/data/api.ts
@@ -19,6 +19,7 @@ import { z } from 'zod'
 import { ApiError, api, unwrap } from '@/api/client'
 import { notifyError } from '@/lib/notify-error'
 import type { components } from '@/api/schema'
+import { apiToDrawOwnership, drawOwnershipToApi } from './draw-ownership'
 import { parseDrawTypeCatalogue } from './draw-types'
 import { entryRefusalNotice } from './entry-refusal'
 import { hasVenue } from './helpers'
@@ -149,6 +150,13 @@ export function apiToEvent(e: TournamentEventRead): TournamentEvent {
     // is what the three round-count-less draw types store, not missing data, and inventing
     // a `ceil(log2 n)` here would author a body the server 422s on the way back out.
     rounds: e.rounds,
+    // PARSED, not cast (`./draw-ownership`, `.claude/rules/parse-at-boundaries.md`): these
+    // modes decide what the Draw structure tab renders AND what the next save puts back on
+    // the wire, so a mode this client does not know, or a manual number the server's
+    // `ge=1, le=512` could never have stored, must fail here rather than surface as an
+    // empty box the director then saves. `null` — every draw type but `rr-then-ko` — parses
+    // straight through to `null`.
+    drawOwnership: apiToDrawOwnership(e.draw_structure),
     maxPlayers: e.max_players,
     entryFee: e.entry_fee,
     timezone: e.timezone,
@@ -470,11 +478,26 @@ function poolEntriesToApi(
  * **compile error here** until somebody says which settings it puts on the wire.
  */
 function drawSettingsToApi(
-  ev: Pick<TournamentEvent, 'drawType' | 'qualifiersPerPool' | 'rounds'>,
+  ev: Pick<
+    TournamentEvent,
+    'drawType' | 'qualifiersPerPool' | 'rounds' | 'drawOwnership'
+  >,
 ) {
   switch (ev.drawType) {
     case 'rr-then-ko':
-      return { draw_type: ev.drawType, qualifiers_per_pool: ev.qualifiersPerPool }
+      return {
+        draw_type: ev.drawType,
+        qualifiers_per_pool: ev.qualifiersPerPool,
+        // **The ownership record travels with the pair**, on this arm and only this arm
+        // (ADR 20260808): it is part of the draw configuration, so the server refuses one
+        // sent without a `draw_type` beside it and 422s one sent alongside any other type.
+        //
+        // It is sent on EVERY save, never omitted as "unchanged": the editor puts back
+        // what it rendered. An event that has never had a record renders — and therefore
+        // sends — the all-automatic one (`drawOwnershipToApi`), which is the same
+        // structure the server's own default would have written.
+        draw_structure: drawOwnershipToApi(ev.drawOwnership),
+      }
     case 'swiss':
       return { draw_type: ev.drawType, rounds: ev.rounds }
     case 'round-robin':

--- a/web-client/src/components/tournaments/data/draw-ownership.test.ts
+++ b/web-client/src/components/tournaments/data/draw-ownership.test.ts
@@ -1,0 +1,197 @@
+import { EVERY_SETTING_AUTOMATIC } from '@/mocks/factories/tournaments/tournament.factory'
+
+import {
+  MANUAL_POOL_DIMENSION_MAX,
+  acceptedManualEntry,
+  apiToDrawOwnership,
+  drawOwnershipToApi,
+  everySettingAutomatic,
+  type DrawOwnership,
+} from './draw-ownership'
+import type { SettingOwnership } from './draw-structure'
+
+/** Compile-time, not a runtime assertion: the three numeric settings' modes ARE the
+ * derivation's `SettingOwnership`, so a row hands its stored mode straight to
+ * `deriveDrawStructure` with no cast and there is no second enum to drift. Both
+ * directions, because one alone would admit a mode the derivation cannot read. */
+const _modeIsOwnership: SettingOwnership = 'manual' satisfies DrawOwnership['poolCountMode']
+const _ownershipIsMode: DrawOwnership['poolSizeMode'] =
+  'automatic' satisfies SettingOwnership
+void _modeIsOwnership
+void _ownershipIsMode
+
+describe('everySettingAutomatic', () => {
+  it('is today’s behaviour: nothing taken, and the snake deals', () => {
+    expect(everySettingAutomatic()).toEqual({
+      poolCountMode: 'automatic',
+      manualPoolCount: null,
+      poolSizeMode: 'automatic',
+      manualPoolSize: null,
+      qualifiersMode: 'automatic',
+      membershipMode: 'snake',
+    })
+  })
+
+  /**
+   * ⚠️ The reason it is a function. A shared constant would be one object every event's
+   * toggle rewrote — and `as const`'s readonly modifiers are **not** checked on
+   * assignment, so nothing in the type system would have said so. The failure would be an
+   * unrelated event's pool count turning `Yours` on a page nobody edited.
+   */
+  it('mints a fresh record every call, so one event’s toggle is one event’s', () => {
+    const mine = everySettingAutomatic()
+    const yours = everySettingAutomatic()
+
+    mine.poolCountMode = 'manual'
+    mine.manualPoolCount = 6
+
+    expect(yours.poolCountMode).toBe('automatic')
+    expect(yours.manualPoolCount).toBeNull()
+  })
+})
+
+describe('apiToDrawOwnership', () => {
+  it('renames the wire’s keys into this client’s vocabulary', () => {
+    expect(
+      apiToDrawOwnership({
+        pool_count_mode: 'manual',
+        manual_pool_count: 6,
+        pool_size_mode: 'manual',
+        manual_pool_size: 5,
+        qualifiers_mode: 'manual',
+        membership_mode: 'manual',
+      }),
+    ).toEqual({
+      poolCountMode: 'manual',
+      manualPoolCount: 6,
+      poolSizeMode: 'manual',
+      manualPoolSize: 5,
+      qualifiersMode: 'manual',
+      membershipMode: 'manual',
+    })
+  })
+
+  // The three draw types with no pool stage send `null`, and a payload that omits the key
+  // means the same thing. Absent and null are one state — no structure — so a reader
+  // models one thing rather than three.
+  it.each([null, undefined])('reads %s as no structure at all', (missing) => {
+    expect(apiToDrawOwnership(missing)).toBeNull()
+  })
+
+  it('fills in a manual number the server left out', () => {
+    const parsed = apiToDrawOwnership({
+      pool_count_mode: 'automatic',
+      pool_size_mode: 'automatic',
+      qualifiers_mode: 'automatic',
+      membership_mode: 'snake',
+    })
+
+    expect(parsed?.manualPoolCount).toBeNull()
+    expect(parsed?.manualPoolSize).toBeNull()
+  })
+
+  /**
+   * PARSED, not cast. The three payloads below are ones `schema.d.ts` says cannot exist —
+   * which is the point: it is a compile-time claim about a server this client does not
+   * control, and each of these would otherwise surface far from the response that carried
+   * it. A `0` is the sharpest: it is what a cleared box authors through `Number('')`, and
+   * it is a 422 on the way back out.
+   */
+  it.each([
+    ['a manual count of zero', { manual_pool_count: 0 }],
+    ['a manual size past the server’s ceiling', { manual_pool_size: 513 }],
+    ['a fractional manual count', { manual_pool_count: 3.5 }],
+    ['a mode this client does not know', { pool_count_mode: 'inherited' }],
+    ['a membership mode this client does not know', { membership_mode: 'random' }],
+  ])('refuses %s, at the boundary', (_case, broken) => {
+    expect(() =>
+      apiToDrawOwnership({
+        ...EVERY_SETTING_AUTOMATIC,
+        ...broken,
+      } as Parameters<typeof apiToDrawOwnership>[0]),
+    ).toThrow()
+  })
+})
+
+describe('drawOwnershipToApi', () => {
+  it('renames this client’s keys back onto the wire', () => {
+    expect(
+      drawOwnershipToApi({
+        ...everySettingAutomatic(),
+        poolSizeMode: 'manual',
+        manualPoolSize: 5,
+      }),
+    ).toEqual({
+      pool_count_mode: 'automatic',
+      manual_pool_count: null,
+      pool_size_mode: 'manual',
+      manual_pool_size: 5,
+      qualifiers_mode: 'automatic',
+      membership_mode: 'snake',
+    })
+  })
+
+  // An event that never had a record still sends one: the editor puts back what it
+  // rendered, and what it rendered is every setting the system's.
+  it('sends the all-automatic record for an event that has none', () => {
+    expect(drawOwnershipToApi(null)).toEqual(EVERY_SETTING_AUTOMATIC)
+  })
+
+  it('round-trips: everything the wire holds survives both mappers', () => {
+    const taken: DrawOwnership = {
+      poolCountMode: 'manual',
+      manualPoolCount: 6,
+      poolSizeMode: 'automatic',
+      // Kept while the mode is automatic — the director's number, remembered.
+      manualPoolSize: 5,
+      qualifiersMode: 'manual',
+      membershipMode: 'manual',
+    }
+
+    expect(apiToDrawOwnership(drawOwnershipToApi(taken))).toEqual(taken)
+  })
+})
+
+/**
+ * The **keystroke boundary** — the reason nothing downstream has to defend against a `0`,
+ * and the reason the box needs no error slot.
+ */
+describe('acceptedManualEntry', () => {
+  it('reads a typed number the server’s bounds admit', () => {
+    expect(acceptedManualEntry('6', MANUAL_POOL_DIMENSION_MAX)).toBe(6)
+    expect(acceptedManualEntry('512', MANUAL_POOL_DIMENSION_MAX)).toBe(512)
+  })
+
+  // ⚠️ `Number('')` is `0`, and a `0` is a 422 AND a draw of no pools. A cleared box is a
+  // director who has not set this, which is `null` and a real state.
+  it('reads a cleared box as null, never as a zero', () => {
+    expect(acceptedManualEntry('', MANUAL_POOL_DIMENSION_MAX)).toBeNull()
+    expect(acceptedManualEntry('   ', MANUAL_POOL_DIMENSION_MAX)).toBeNull()
+  })
+
+  /**
+   * `undefined` is "not a value this box may hold", so the keystroke is dropped and the
+   * box keeps the number the director last chose.
+   *
+   * ⚠️ It is deliberately NOT clamped to the bound: turning a pasted `600` into `512`
+   * would be the system silently changing a director's number, which is the one thing ADR
+   * 20260808 says it never does.
+   */
+  it.each([
+    ['a typed zero', '0'],
+    ['past the ceiling', '600'],
+    ['a fraction', '3.5'],
+    ['a negative', '-4'],
+    ['exponent notation', '1e3'],
+    ['words', 'six'],
+  ])('refuses %s, and does not clamp it', (_case, typed) => {
+    expect(acceptedManualEntry(typed, MANUAL_POOL_DIMENSION_MAX)).toBeUndefined()
+  })
+
+  // The ceiling is the caller's, because the two settings have different ones: 512 for a
+  // pool dimension, 1,000 for a qualifier count.
+  it('bounds against the ceiling it was given', () => {
+    expect(acceptedManualEntry('600', 1000)).toBe(600)
+    expect(acceptedManualEntry('600', 512)).toBeUndefined()
+  })
+})

--- a/web-client/src/components/tournaments/data/draw-ownership.test.ts
+++ b/web-client/src/components/tournaments/data/draw-ownership.test.ts
@@ -2,10 +2,12 @@ import { EVERY_SETTING_AUTOMATIC } from '@/mocks/factories/tournaments/tournamen
 
 import {
   MANUAL_POOL_DIMENSION_MAX,
+  MEMBERSHIP_MANUAL_VALUE,
   acceptedManualEntry,
   apiToDrawOwnership,
   drawOwnershipToApi,
   everySettingAutomatic,
+  ownedStructureSettings,
   type DrawOwnership,
 } from './draw-ownership'
 import type { SettingOwnership } from './draw-structure'
@@ -193,5 +195,108 @@ describe('acceptedManualEntry', () => {
   it('bounds against the ceiling it was given', () => {
     expect(acceptedManualEntry('600', 1000)).toBe(600)
     expect(acceptedManualEntry('600', 512)).toBeUndefined()
+  })
+})
+
+/**
+ * **What the director owns right now** — the list a draw-type change has to price before
+ * it discards it (ADR 20260808).
+ *
+ * The claim under every case is one sentence: this names exactly the settings whose badge
+ * reads `Yours`. The badge is `deriveDrawStructure`'s (`./draw-structure`), and this
+ * restates its rule rather than calling it, so the cases below are where the two are held
+ * together.
+ */
+describe('ownedStructureSettings', () => {
+  /** An event that has never seen the tab, and the three draw types that have no tab at
+   * all. Both mean the same thing: no record, so nothing is anybody's. */
+  it('finds nothing on an event with no record at all', () => {
+    expect(ownedStructureSettings(null, 2)).toEqual([])
+  })
+
+  it('finds nothing while every setting is the system’s', () => {
+    expect(ownedStructureSettings(everySettingAutomatic(), 2)).toEqual([])
+  })
+
+  /** #1320's own example, read back: a pool count of 6 and a pool size of 5. */
+  it('reads back the numbers the director set, in the tab’s row order', () => {
+    expect(
+      ownedStructureSettings(
+        {
+          ...everySettingAutomatic(),
+          poolCountMode: 'manual',
+          manualPoolCount: 6,
+          poolSizeMode: 'manual',
+          manualPoolSize: 5,
+        },
+        2,
+      ),
+    ).toEqual([
+      { label: 'Pool count', value: '6' },
+      { label: 'Pool size', value: '5' },
+    ])
+  })
+
+  /** Membership is the director's choice too, and the one setting with no number: the
+   * mode IS the setting, so a manual mode is owned on its own. */
+  it('counts membership, and names the phrase the row shows', () => {
+    expect(
+      ownedStructureSettings(
+        { ...everySettingAutomatic(), membershipMode: 'manual' },
+        2,
+      ),
+    ).toEqual([{ label: 'Membership', value: MEMBERSHIP_MANUAL_VALUE }])
+  })
+
+  /** K's value is the EVENT's count — there is no `manual_qualifiers` on the wire, the
+   * stored number is the manual slot — which is why it arrives as a second argument. */
+  it('reads the qualifier count off the event, not off the record', () => {
+    expect(
+      ownedStructureSettings(
+        { ...everySettingAutomatic(), qualifiersMode: 'manual' },
+        3,
+      ),
+    ).toEqual([{ label: 'Qualifiers per pool', value: '3' }])
+  })
+
+  /**
+   * ⚠️ **A manual mode with an empty box owns nothing**, and this is the case that keeps
+   * the list honest against the badge. `deriveDrawStructure` reads a manual mode with no
+   * number as automatic and says `Automatic` on the row — so naming it here would price a
+   * loss the director cannot see anywhere on screen.
+   */
+  it.each([
+    [
+      'a cleared pool count',
+      { poolCountMode: 'manual', manualPoolCount: null } as const,
+      2,
+    ],
+    [
+      'a cleared pool size',
+      { poolSizeMode: 'manual', manualPoolSize: null } as const,
+      2,
+    ],
+    ['a cleared qualifier count', { qualifiersMode: 'manual' } as const, null],
+  ] as const)('finds nothing for %s', (_case, patch, qualifiers) => {
+    expect(
+      ownedStructureSettings({ ...everySettingAutomatic(), ...patch }, qualifiers),
+    ).toEqual([])
+  })
+
+  /** All four at once, which is also the order the Draw structure tab lists them in. */
+  it('lists all four in row order', () => {
+    expect(
+      ownedStructureSettings(
+        {
+          poolCountMode: 'manual',
+          manualPoolCount: 4,
+          poolSizeMode: 'manual',
+          manualPoolSize: 8,
+          qualifiersMode: 'manual',
+          membershipMode: 'manual',
+        },
+        2,
+      ).map((setting) => setting.label),
+    ).toEqual(['Pool count', 'Pool size', 'Membership', 'Qualifiers per pool'])
   })
 })

--- a/web-client/src/components/tournaments/data/draw-ownership.ts
+++ b/web-client/src/components/tournaments/data/draw-ownership.ts
@@ -142,6 +142,65 @@ export function drawOwnershipToApi(ownership: DrawOwnership | null): ApiDrawStru
   }
 }
 
+/** What the Membership row reads when the director places entrants themselves. Exported
+ * so the row and the confirm that reads it back cannot word it two ways — a director who
+ * chose `Assign at cut time` must see those three words again in the dialog that is about
+ * to take them away. */
+export const MEMBERSHIP_MANUAL_VALUE = 'Assign at cut time'
+
+/** One structural setting the director owns **right now**, read back the way the Draw
+ * structure tab shows it: the row's own name, and the value they set. */
+export interface OwnedStructureSetting {
+  /** The setting's name, spelled as the tab's row spells it. */
+  label: string
+  /** What the director set it to, in words. */
+  value: string
+}
+
+/**
+ * **Exactly the settings whose badge reads `Yours`**, in the order the tab lists them.
+ * Empty when every setting is the system's, which is the whole question a caller asks it:
+ * an event with nothing owned has nothing to lose, so a draw-type switch costs nothing and
+ * is silent (ADR 20260808 — "switching away from `rr-then-ko` can discard a director's
+ * work").
+ *
+ * **A manual mode with no number counts as nothing owned**, and that is not a shortcut. It
+ * is the rule `deriveDrawStructure` (`./draw-structure`) already applies to the badge: a
+ * director who cleared the box has not set anything, so the row derives and reports itself
+ * as automatic. Naming a setting here that the tab calls `Automatic` would price a loss the
+ * director cannot see, and skipping one the tab calls `Yours` would discard work in
+ * silence. The predicate is restated rather than called, because the derivation needs a
+ * field size and eight inputs to answer a question this one asks of six.
+ *
+ * The qualifier count's value is the **event's own K** — there is no `manual_qualifiers` on
+ * the wire, the stored count is the manual slot — which is why it arrives as a second
+ * argument rather than off the record.
+ */
+export function ownedStructureSettings(
+  ownership: DrawOwnership | null,
+  qualifiersPerPool: number | null,
+): OwnedStructureSetting[] {
+  if (ownership === null) return []
+  const owned: OwnedStructureSetting[] = []
+  if (ownership.poolCountMode === 'manual' && ownership.manualPoolCount !== null) {
+    owned.push({ label: 'Pool count', value: String(ownership.manualPoolCount) })
+  }
+  if (ownership.poolSizeMode === 'manual' && ownership.manualPoolSize !== null) {
+    owned.push({ label: 'Pool size', value: String(ownership.manualPoolSize) })
+  }
+  // Membership has no number to be missing: the mode IS the setting, so a manual mode is
+  // owned on its own. It counts for the same reason the other three do — placing entrants
+  // by hand is the director's choice, and a switch that dropped it silently would drop a
+  // decision they made.
+  if (ownership.membershipMode === 'manual') {
+    owned.push({ label: 'Membership', value: MEMBERSHIP_MANUAL_VALUE })
+  }
+  if (ownership.qualifiersMode === 'manual' && qualifiersPerPool !== null) {
+    owned.push({ label: 'Qualifiers per pool', value: String(qualifiersPerPool) })
+  }
+  return owned
+}
+
 /**
  * Read what a director typed into a manual box — **the keystroke boundary**, and the
  * reason nothing downstream has to defend against a `0`.

--- a/web-client/src/components/tournaments/data/draw-ownership.ts
+++ b/web-client/src/components/tournaments/data/draw-ownership.ts
@@ -1,0 +1,172 @@
+// **Who owns each of a round-robin-then-knockout draw's four structural settings**, as the
+// event stores it — the wire's `draw_structure` object (ADR
+// 20260808-a-structural-setting-is-owned-by-the-director-or-derived-by-the-system).
+//
+// ⚠️ **This is not `./draw-structure`, and the two must not be confused.** That module
+// *derives* the draw — the pool count, the sizes, the qualifiers, the source sentences and
+// the three notices. This one is the small record of **who owns what**, which is the only
+// part of it the server keeps. One is an input to the other, and they are named apart on
+// purpose: `DrawStructure` is the derived answer, `DrawOwnership` is the stored question.
+//
+// The domain field is `TournamentEvent.drawOwnership` while the wire key is
+// `draw_structure`, the same rename `match_settings` → `match` already makes: the client
+// names a value for what it holds, and the two mappers below are the one place the two
+// vocabularies meet.
+//
+// **A manual number is kept while its mode is `automatic`** (the ADR, and the API's own
+// comment on `DrawStructure`). `Use automatic` is therefore not destructive: the
+// director's number is remembered, and taking the setting back returns it rather than an
+// empty box.
+
+import { z } from 'zod'
+
+import type { components } from '@/api/schema'
+import { PLAYERS_MAX } from './event-validation'
+
+type ApiDrawStructure = components['schemas']['DrawStructure']
+
+/** How entrants reach their pools. Ownership again, but its two values are named for what
+ * they DO rather than for who chose them (the API's `PoolMembershipMode`): `snake` is the
+ * 1, 2, 3, 3, 2, 1 deal `_snake()` already performs on every cut, and `manual` is the
+ * director placing entrants themselves once registration closes. */
+export type PoolMembershipMode = 'snake' | 'manual'
+
+/** The ceiling on a manual pool count or pool size — the server's
+ * `MAX_MANUAL_POOL_DIMENSION`, which is `MAX_EVENT_PLAYERS`, which is the number this
+ * client already states as `PLAYERS_MAX`. Read off that constant rather than re-typed, so
+ * the two bounds cannot come apart: a draw of more pools than the field can hold players
+ * is not a draw. */
+export const MANUAL_POOL_DIMENSION_MAX = PLAYERS_MAX
+
+/** The floor on every manual number: the server's `ge=1`, and the reason a cleared box
+ * must send `null`. **A `0` is a 422**, not a smaller structure — no pools is not a draw —
+ * and `Number('')` is `0`, which is precisely how a cleared box authors one. */
+export const MANUAL_MIN = 1
+
+/** A manual pool dimension: a whole number the server's `ge=1, le=512` admits, or `null`
+ * for a box the director has cleared. `null` is a real state and not an error — the
+ * derivation reads a manual mode with no number as automatic — so it is never coerced. */
+const manualDimensionSchema = z
+  .number()
+  .int()
+  .min(MANUAL_MIN)
+  .max(MANUAL_POOL_DIMENSION_MAX)
+  .nullable()
+
+/**
+ * The stored ownership record. Mirrors the API's `DrawStructure` field for field, in this
+ * client's vocabulary, and **carries its bounds**: every number that crosses this schema
+ * is one the server's `ManualPoolCount` / `ManualPoolSize` would accept.
+ *
+ * There is no manual *qualifier* number here, and that absence is the wire's: the
+ * qualifier count's value is the event's own `qualifiersPerPool`, which every `rr-then-ko`
+ * event already carries, and `qualifiersMode` says whether anybody should read it. A
+ * second copy would be a field and its own derivation in one object.
+ */
+export const drawOwnershipSchema = z.object({
+  poolCountMode: z.enum(['automatic', 'manual']),
+  manualPoolCount: manualDimensionSchema,
+  poolSizeMode: z.enum(['automatic', 'manual']),
+  manualPoolSize: manualDimensionSchema,
+  qualifiersMode: z.enum(['automatic', 'manual']),
+  membershipMode: z.enum(['snake', 'manual']),
+})
+
+export type DrawOwnership = z.infer<typeof drawOwnershipSchema>
+
+/**
+ * What an `rr-then-ko` event holds before a director takes any setting for themselves:
+ * every mode the system's, no manual numbers, membership by snake. It is also what every
+ * event that predates the Draw structure tab reads back as — the ADR's "an event that sets
+ * nothing behaves exactly as it does today".
+ *
+ * ⚠️ **A function, not a constant.** `as const` gives readonly modifiers TypeScript does
+ * **not** check on assignment, so one shared object handed to every event would be one
+ * object every event's toggle rewrote. A fresh record per event is also what the database
+ * holds. (The wire-side twin, `EVERY_SETTING_AUTOMATIC` in the mock factory, states the
+ * same thing about itself and is spread at every use site.)
+ */
+export function everySettingAutomatic(): DrawOwnership {
+  return {
+    poolCountMode: 'automatic',
+    manualPoolCount: null,
+    poolSizeMode: 'automatic',
+    manualPoolSize: null,
+    qualifiersMode: 'automatic',
+    membershipMode: 'snake',
+  }
+}
+
+/**
+ * PARSED, not cast (`.claude/rules/parse-at-boundaries.md`): the modes drive what the tab
+ * renders and what the next save puts on the wire, so a payload holding a mode this client
+ * does not know — or a manual `0` the server could never have stored — must fail here,
+ * inside the fetch, rather than surface as an empty box three components away.
+ *
+ * **Absent and `null` are the same thing**: no structure. Only an `rr-then-ko` event has
+ * one at all, the other three arms send `null`, and a fixture or stub that omits the key
+ * means exactly what a `null` does.
+ */
+export function apiToDrawOwnership(
+  structure: ApiDrawStructure | null | undefined,
+): DrawOwnership | null {
+  if (structure == null) return null
+  return drawOwnershipSchema.parse({
+    poolCountMode: structure.pool_count_mode,
+    manualPoolCount: structure.manual_pool_count ?? null,
+    poolSizeMode: structure.pool_size_mode,
+    manualPoolSize: structure.manual_pool_size ?? null,
+    qualifiersMode: structure.qualifiers_mode,
+    membershipMode: structure.membership_mode,
+  })
+}
+
+/**
+ * The record as the `rr-then-ko` write arm takes it.
+ *
+ * **An event with no stored record sends the all-automatic one**, rather than omitting the
+ * key: the editor sends what it rendered, and what it rendered for a structure-less event
+ * is every setting the system's. (The server would default an omitted key to the same
+ * thing — `default_factory=DrawStructure` — so this is the honest form of the same
+ * request, not a different one.)
+ */
+export function drawOwnershipToApi(ownership: DrawOwnership | null): ApiDrawStructure {
+  const stated = ownership ?? everySettingAutomatic()
+  return {
+    pool_count_mode: stated.poolCountMode,
+    manual_pool_count: stated.manualPoolCount,
+    pool_size_mode: stated.poolSizeMode,
+    manual_pool_size: stated.manualPoolSize,
+    qualifiers_mode: stated.qualifiersMode,
+    membership_mode: stated.membershipMode,
+  }
+}
+
+/**
+ * Read what a director typed into a manual box — **the keystroke boundary**, and the
+ * reason nothing downstream has to defend against a `0`.
+ *
+ * Three answers, because there are three things a keystroke can mean:
+ *
+ * - `null` — the box is **empty**. A real answer ("I have not set this"), never a zero:
+ *   `Number('')` is `0`, and a `0` is both a 422 and a draw of no pools.
+ * - a number — a value the server's bounds admit, ready to store.
+ * - `undefined` — **not a value this box may hold**, so the keystroke is ignored and the
+ *   box keeps the number the director last chose. It is not clamped to the bound: ADR
+ *   20260808 is that the system never silently changes a director's number, and turning a
+ *   pasted `600` into `512` would be exactly that edit.
+ */
+export function acceptedManualEntry(
+  raw: string,
+  max: number,
+): number | null | undefined {
+  const typed = raw.trim()
+  if (typed === '') return null
+  // Digits only, asked before the schema: it is what refuses `-1`, `3.5` and `1e3` as the
+  // *characters* they are, rather than as numbers a `z.number().int()` would have to
+  // reason about — and `z.number()` accepts `NaN` under the ESM build this app runs
+  // (measured, Zod 4.4.3; see `entryFeeSchema`), so `Number('abc')` must never reach it.
+  if (!/^\d+$/.test(typed)) return undefined
+  const bounded = z.number().int().min(MANUAL_MIN).max(max).safeParse(Number(typed))
+  return bounded.success ? bounded.data : undefined
+}

--- a/web-client/src/components/tournaments/data/draw.test.ts
+++ b/web-client/src/components/tournaments/data/draw.test.ts
@@ -6,6 +6,7 @@ import {
   drawTypeFreeze,
   drawVerbFreeze,
   poolSetFreeze,
+  qualifiersPerPoolFreeze,
   unpooledShape,
   type DrawState,
   type FixtureSide,
@@ -22,6 +23,7 @@ import {
   buildMaterializedDrawnEvent,
   buildPlayedDrawnEvent,
   buildPool,
+  buildRrThenKoEvent,
   buildSwissDrawnEvent,
   buildSwissOddDrawnEvent,
   buildSwissOddMidEvent,
@@ -602,6 +604,55 @@ describe('drawTypeFreeze', () => {
     expect(freeze.reason).not.toContain('dealt as')
     expect(freeze.reason).toContain('its draw type is frozen')
     expect(freeze.reason).toContain('Delete the draw to change the type')
+  })
+})
+
+/**
+ * The draw type's other half, one column over (ADR 20260727, chore 3e). The server freezes
+ * the whole configuration its draw was dealt from, and for a two-stage event K is half of
+ * it: the bracket is cut upfront for `P × K`, so a moved count leaves qualifiers with no
+ * slot to be seated into (`_qualifiers_per_pool_frozen_detail`, a 409).
+ */
+describe('qualifiersPerPoolFreeze', () => {
+  it('is open while no draw is cut', () => {
+    expect(qualifiersPerPoolFreeze(buildRrThenKoEvent()).kind).toBe('open')
+  })
+
+  it('freezes once the draw is cut, naming the count the bracket was cut for', () => {
+    const freeze = qualifiersPerPoolFreeze(
+      buildTwoStageDrawnEvent({ qualifiersPerPool: 2 }),
+    )
+    if (freeze.kind !== 'frozen') throw new Error('expected a frozen qualifier count')
+
+    expect(freeze.reason).toContain('the top 2 out of each pool')
+    // A refusal with no way out is a dead end; this one has an exit and names it.
+    expect(freeze.reason).toContain('Delete the draw')
+    expect(freeze.reason).toContain('cut it again')
+  })
+
+  /** No stored count on a cut event is a state the server does not allow (K is required on
+   * the `rr-then-ko` write arm), so this is the same belt `drawTypeFreeze` wears over a
+   * missing label: the clause naming the number is dropped, and the half that gets a stuck
+   * director unstuck is still there. Never `top null`. */
+  it('drops the number rather than printing a null', () => {
+    const freeze = qualifiersPerPoolFreeze(
+      buildTwoStageDrawnEvent({ qualifiersPerPool: null }),
+    )
+    if (freeze.kind !== 'frozen') throw new Error('expected a frozen qualifier count')
+
+    expect(freeze.reason).not.toContain('null')
+    expect(freeze.reason).not.toContain('out of each pool')
+    expect(freeze.reason).toContain('qualifiers per pool is frozen')
+    expect(freeze.reason).toContain('Delete the draw')
+  })
+
+  /** It rides the DRAW, not the play, exactly as the draw type's does: the bracket exists
+   * from the cut, and a K it was not cut for contradicts it whether or not anybody has
+   * played yet. (`drawVerbFreeze` is the one that waits for evidence.) */
+  it('freezes on a cut draw that nobody has played', () => {
+    const cut = buildTwoStageDrawnEvent({ qualifiersPerPool: 2 })
+    expect(drawVerbFreeze(cut).kind).toBe('open')
+    expect(qualifiersPerPoolFreeze(cut).kind).toBe('frozen')
   })
 })
 

--- a/web-client/src/components/tournaments/data/draw.ts
+++ b/web-client/src/components/tournaments/data/draw.ts
@@ -551,6 +551,58 @@ export function drawTypeFreeze(
 }
 
 /**
+ * May the director change this event's **qualifier count** — K, the number of finishers
+ * each pool sends to the knockout?
+ *
+ * Frozen the moment a draw exists, and by the server's own guard rather than a new one:
+ * `_enforce_draw_settings_frozen` compares the whole *dealt configuration*, of which K is
+ * half for an `rr-then-ko` event. A bracket is cut **upfront** for `P × K` and the
+ * qualifiers are seated into predetermined slots as each pool finishes, so a bracket cut
+ * at `K = 2` and advanced at `K = 3` has three pools' worth of thirds with nowhere to sit
+ * (`_qualifiers_per_pool_frozen_detail`, a 409).
+ *
+ * **The whole row is frozen, and only some of it by the server.** Three things on the
+ * Draw structure tab's qualifiers row could change K's story, and they are not all
+ * refused by the same authority:
+ *
+ * - typing in the manual box writes K — the server's 409;
+ * - `Set myself` seeds the box from the DERIVED count, which on a cut event is routinely
+ *   not the stored one, so it too writes K — the same 409, and the defect this freeze was
+ *   written for;
+ * - `Use automatic` writes the **mode** and nothing else. The server explicitly permits
+ *   it: ownership modes are excluded from `configuration_the_draw_was_dealt_from`, so the
+ *   PATCH would be a 200.
+ *
+ * The client declines to offer that third one anyway, and **not** because the server would
+ * refuse it — do not "fix" this against the API. It is offered nowhere because it is a
+ * one-way door onto a lie: handing the setting back makes the row report the *derived*
+ * count, which is not the count this event's bracket was cut for, and `Set myself` — the
+ * only way back — is frozen. Ownership of a number that cannot move is not a choice worth
+ * offering.
+ *
+ * Asked of the two-stage event's row only: the row exists for no other draw type
+ * (`DrawStructureSection`), which is what lets the reason name a knockout bracket.
+ */
+export function qualifiersPerPoolFreeze(event: TournamentEvent): EditFreeze {
+  if (!hasDraw(event)) return { kind: 'open' }
+  // The count the bracket was actually cut for, when the event has one to name. `null` is
+  // not a state a cut `rr-then-ko` event can be in (the server requires K on that arm), so
+  // this is the same belt `drawTypeFreeze` wears over its missing label: the way out is
+  // what a stuck director needs, and that half never depended on the number.
+  const cutFor =
+    event.qualifiersPerPool === null
+      ? ''
+      : ` — its knockout bracket was cut for the top ${event.qualifiersPerPool} out of each pool`
+  return {
+    kind: 'frozen',
+    reason:
+      `This event’s draw is cut, so the number of qualifiers per pool is frozen${cutFor}. ` +
+      `A qualifier the bracket has no slot for has nowhere to be seated. Delete the draw ` +
+      `to change the count, then cut it again.`,
+  }
+}
+
+/**
  * May the director **re-cut or remove** this event's draw?
  *
  * The third freeze, and the one whose refusal has **no way out**. Its two siblings are

--- a/web-client/src/components/tournaments/data/event-validation.ts
+++ b/web-client/src/components/tournaments/data/event-validation.ts
@@ -367,8 +367,16 @@ export const swissRoundsSchema = z
     error: `A Swiss event plays at most ${SWISS_ROUNDS_MAX} rounds.`,
   })
 
-/** The editor's four tabs, of which three can hold something invalid (Match settings
+/** The editor's five tabs, of which four can hold something invalid (Match settings
  * comes off closed pickers). A sum type rather than a `string`, so "which tab do I
  * open?" is answered from a closed set the editor's `TabsContent` values are checked
- * against. */
-export type EventSection = 'basics' | 'eligibility' | 'pools'
+ * against.
+ *
+ * `draw-structure` is the conditional fifth (ADR 20260808) — present only on an
+ * `rr-then-ko` event, and safe to name even when it is absent: the editor falls back to
+ * Basics for a section no trigger matches. */
+export type EventSection =
+  | 'basics'
+  | 'eligibility'
+  | 'pools'
+  | 'draw-structure'

--- a/web-client/src/components/tournaments/data/helpers.ts
+++ b/web-client/src/components/tournaments/data/helpers.ts
@@ -485,6 +485,11 @@ export function emptyEvent(t: Tournament): TournamentEvent {
     // swiss ADR). A new event that pre-filled a number here would be one whose create body
     // the API 422s the moment the director never touched the draw type.
     rounds: null,
+    // …and no structural settings to own: a bracket has no pool stage, so `null` is the
+    // only value the server's `single-elim` arm admits for `draw_structure` too (ADR
+    // 20260808). A director who picks the two-stage format on Basics gets the
+    // all-automatic record from the Draw structure tab itself.
+    drawOwnership: null,
     maxPlayers: 32,
     entryFee: 30,
     // Anchor the wall-clock windows in the director's own timezone (ADR 20260719):

--- a/web-client/src/components/tournaments/data/pool-reconciliation.test.ts
+++ b/web-client/src/components/tournaments/data/pool-reconciliation.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+
+import { addedPool, keepPool } from './pool-entries'
+import { poolNameAt, reconcilePoolsToCount } from './pool-reconciliation'
+import { buildPool } from './seed.factory'
+import type { PoolEntry, Slot } from './types'
+
+/** The event's own window — what a first pool inherits when there is no pool to copy. */
+const EVENT_SLOT: Slot = { date: '2026-06-13', start: '08:00', end: '20:00' }
+/** A window a director has already narrowed on the last pool card, so "the new row takes
+ * the LAST pool's window" is distinguishable from "the new row takes the event's". */
+const LAST_SLOT: Slot = { date: '2026-06-14', start: '13:00', end: '16:30' }
+
+/** `n` stored pools, named and slotted as the Table pools tab would have them. */
+const storedPools = (n: number): PoolEntry[] =>
+  Array.from({ length: n }, (_, i) =>
+    keepPool(
+      buildPool({
+        id: `p-${i + 1}`,
+        name: poolNameAt(i),
+        slot: i === n - 1 ? LAST_SLOT : EVENT_SLOT,
+        tableIds: [`t${i + 1}`],
+        position: i,
+      }),
+    ),
+  )
+
+describe('poolNameAt', () => {
+  it('names the letter sequence, and keeps naming it past Z', () => {
+    expect(poolNameAt(0)).toBe('Pool A')
+    expect(poolNameAt(1)).toBe('Pool B')
+    // The 27th pool, reachable now that the Pool count box admits 512 — `Pool AA`, and
+    // not the `Pool [` a raw `String.fromCharCode(65 + n)` prints.
+    expect(poolNameAt(26)).toBe('Pool AA')
+  })
+})
+
+describe('reconcilePoolsToCount — raising the count', () => {
+  it('appends rows until the list is the count the director typed', () => {
+    const { pools, removed } = reconcilePoolsToCount(storedPools(4), 6, EVENT_SLOT)
+
+    expect(pools).toHaveLength(6)
+    expect(removed).toEqual([])
+  })
+
+  /** The four pools the event already had are the SAME entries — same arm, same id. A
+   * reconciliation that rebuilt them would remove and recreate every pool of the event
+   * on a keystroke. */
+  it('leaves every existing pool exactly as it was', () => {
+    const before = storedPools(4)
+    const { pools } = reconcilePoolsToCount(before, 6, EVENT_SLOT)
+
+    expect(pools.slice(0, 4)).toEqual(before)
+  })
+
+  /** ⚠️ **No id, ever.** `PoolWrite` is `extra="forbid"` and has no `id` field, so a
+   * client-minted one is a 422 naming the entry (ADR 20260801). The `added` arm is what
+   * makes that unsayable, and this is the assertion that the append uses it. */
+  it('mints the new rows with no id at all', () => {
+    const { pools } = reconcilePoolsToCount(storedPools(4), 6, EVENT_SLOT)
+
+    for (const entry of pools.slice(4)) {
+      expect(entry.kind).toBe('added')
+      expect('id' in entry).toBe(false)
+    }
+  })
+
+  it('continues the letter sequence rather than restarting it', () => {
+    const { pools } = reconcilePoolsToCount(storedPools(4), 6, EVENT_SLOT)
+
+    expect(pools.map((p) => p.name)).toEqual([
+      'Pool A',
+      'Pool B',
+      'Pool C',
+      'Pool D',
+      'Pool E',
+      'Pool F',
+    ])
+  })
+
+  /** The director is not handed a blank card to complete (ADR 20260808): a new row takes
+   * the window the last pool already runs in. */
+  it('takes the last existing pool’s date and window', () => {
+    const { pools } = reconcilePoolsToCount(storedPools(4), 6, EVENT_SLOT)
+
+    expect(pools[4].slot).toEqual(LAST_SLOT)
+    expect(pools[5].slot).toEqual(LAST_SLOT)
+  })
+
+  /** Copied, never shared. Two entries holding one `Slot` by reference is one window that
+   * two pool cards edit at once. */
+  it('gives each new row a window of its own', () => {
+    const before = storedPools(4)
+    const { pools } = reconcilePoolsToCount(before, 6, EVENT_SLOT)
+
+    expect(pools[4].slot).not.toBe(before[3].slot)
+    expect(pools[4].slot).not.toBe(pools[5].slot)
+  })
+
+  /** **No tables**, because the ADR says so: an empty pool is a known, reported state
+   * (#1072), and a table selection the director never made is a reservation invented on
+   * their behalf. */
+  it('reserves no tables', () => {
+    const { pools } = reconcilePoolsToCount(storedPools(4), 6, EVENT_SLOT)
+
+    expect(pools[4].tableIds).toEqual([])
+    expect(pools[5].tableIds).toEqual([])
+  })
+
+  /** With nothing to copy from, the fallback is the Table pools tab's own first-pool
+   * behaviour — `Pool A`, the event's window, no tables — and not a second convention. */
+  it('falls back to the event’s own window for a first pool', () => {
+    const { pools } = reconcilePoolsToCount([], 2, EVENT_SLOT)
+
+    expect(pools).toHaveLength(2)
+    expect(pools.map((p) => p.name)).toEqual(['Pool A', 'Pool B'])
+    expect(pools[0].slot).toEqual(EVENT_SLOT)
+    expect(pools[1].slot).toEqual(EVENT_SLOT)
+  })
+})
+
+describe('reconcilePoolsToCount — lowering the count', () => {
+  /** From the END, which is where `append` puts a new pool and therefore the order the
+   * director built. */
+  it('drops rows from the end and names the ones it dropped', () => {
+    const before = storedPools(6)
+    const { pools, removed } = reconcilePoolsToCount(before, 4, EVENT_SLOT)
+
+    expect(pools).toEqual(before.slice(0, 4))
+    expect(removed).toEqual(before.slice(4))
+    expect(removed.map((p) => p.name)).toEqual(['Pool E', 'Pool F'])
+  })
+
+  /** The surviving pools go on citing the ids the server minted. A `slice` preserves the
+   * arms; anything that rebuilt them would be an id-keyed diff removing four pools and
+   * adding four back. */
+  it('keeps the survivors’ server ids', () => {
+    const { pools } = reconcilePoolsToCount(storedPools(6), 4, EVENT_SLOT)
+
+    expect(pools.every((p) => p.kind === 'kept')).toBe(true)
+    expect(pools.map((p) => (p.kind === 'kept' ? p.id : null))).toEqual([
+      'p-1',
+      'p-2',
+      'p-3',
+      'p-4',
+    ])
+  })
+
+  /** A pool the server has never seen is dropped like any other — the last one added is
+   * the first one to go. */
+  it('drops an unsaved pool the same way', () => {
+    const before: PoolEntry[] = [
+      ...storedPools(1),
+      addedPool({ name: 'Pool B', slot: EVENT_SLOT, tableIds: [] }),
+    ]
+    const { pools, removed } = reconcilePoolsToCount(before, 1, EVENT_SLOT)
+
+    expect(pools).toEqual(before.slice(0, 1))
+    expect(removed).toEqual(before.slice(1))
+  })
+})
+
+describe('reconcilePoolsToCount — the count already holds', () => {
+  it('changes nothing and removes nothing', () => {
+    const before = storedPools(4)
+    const { pools, removed } = reconcilePoolsToCount(before, 4, EVENT_SLOT)
+
+    expect(pools).toEqual(before)
+    expect(removed).toEqual([])
+  })
+})
+
+describe('reconcilePoolsToCount — the floor', () => {
+  /** The same `max(1, …)` every other reader of a manual number applies. A cleared box
+   * sends `null` and never reaches here, but no pools is not a smaller draw. */
+  it('never reconciles an event down to no pools', () => {
+    const { pools, removed } = reconcilePoolsToCount(storedPools(3), 0, EVENT_SLOT)
+
+    expect(pools).toHaveLength(1)
+    expect(removed).toHaveLength(2)
+  })
+})

--- a/web-client/src/components/tournaments/data/pool-reconciliation.ts
+++ b/web-client/src/components/tournaments/data/pool-reconciliation.ts
@@ -1,0 +1,90 @@
+// **A pool count is a number of pool ROWS** (ADR
+// 20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-count-is-a-projection):
+// nothing stores a pool count of its own, so a director who types `6` on the Draw
+// structure tab is asking for six rows, and this module is what turns that number into the
+// list the editor already sends.
+//
+// **It is a pure function, and it renders nothing.** Two callers need the same answer and
+// must not each work it out: the Pool count row (typing a number), and — next — the
+// disagreement panel's `Use {n} pools of {size}` resolution, which the ADR describes as
+// the same append through the same seam. A second implementation would be a second way to
+// mint a pool, which is exactly what point 3 of the ADR's decision forbids.
+//
+// **What it never does is write.** It returns the new list *and* the rows that list drops,
+// because dropping a row discards a reservation — its window and its table selections —
+// and the caller has to be able to name what will go before it goes (ADR
+// 20260806-a-confirm-prices-an-irreversible-act-a-freeze-explains-an-illegal-one).
+
+import { poolLetter } from './draw-structure'
+import { addedPool } from './pool-entries'
+import type { PoolEntry, Slot } from './types'
+
+/** What a pool joining at `index` is called — `Pool A`, `Pool B`, … and past `Pool Z` the
+ * spreadsheet's `Pool AA` (`poolLetter`).
+ *
+ * **The ONE place a default pool name is minted**, shared with the Table pools tab's own
+ * `Add pool`, because the ADR's "continuing the existing letter sequence" is a promise
+ * about one sequence and not about two that happen to agree for the first 26. (They did
+ * not agree past it: the tab used to spell the letter `String.fromCharCode(65 + n)`, which
+ * prints `Pool [` for the 27th pool — reachable now that the Pool count box admits 512.) */
+export const poolNameAt = (index: number): string => `Pool ${poolLetter(index)}`
+
+/** The result of reconciling a pool list to a count: the list to write, and — when the
+ * count went **down** — the rows it drops.
+ *
+ * The two are returned together rather than derived twice, because the caller needs both
+ * halves of the same decision: what to save, and what to warn about first. `removed` is
+ * empty for every non-destructive reconciliation, so "is this destructive?" is
+ * `removed.length > 0` and never a comparison of two lengths done a second time. */
+export interface PoolReconciliation {
+  /** The pools the event should have, in order — what the editor sends. */
+  pools: PoolEntry[]
+  /** The rows this drops, in the order they sit in today (so the copy names them the way
+   * the Table pools tab lists them). Empty unless the count went down. */
+  removed: PoolEntry[]
+}
+
+/**
+ * Reconcile an event's pool rows to a director-typed pool **count**.
+ *
+ * **Raising it appends.** New rows continue the letter sequence, take the **last existing
+ * pool's** date and window — so the director is not handed a blank card to complete — and
+ * reserve **no tables**. A pool with no tables is a known, reported state (#1072), which is
+ * why nothing here invents a table selection the director never made.
+ *
+ * With no pool to copy from, the fallback is the Table pools tab's own first-pool
+ * behaviour: the **event's** window. One convention, stated once — this module and
+ * `PoolsSection.addPool` mint a pool the same way or they mint two kinds of pool.
+ *
+ * **Lowering it drops from the END**, which is where `append` puts new pools and therefore
+ * the order the director built. The survivors are the *same entries*, arms and all: a
+ * `kept` pool goes on citing the id the server minted, so lowering a count and raising it
+ * again does not silently remove and recreate every pool of the event (and orphan nothing,
+ * because a cut event's pool set is frozen before this can be reached).
+ *
+ * `count` is the director's, already through the box's own bounds
+ * (`acceptedManualEntry`: an integer in `1 … 512`, or `null` for a cleared box, which is
+ * not a count and never reaches here). `Math.max(1, …)` is the same floor every other
+ * reader of a manual number applies — no pools is not a smaller draw, it is no draw.
+ */
+export function reconcilePoolsToCount(
+  pools: readonly PoolEntry[],
+  count: number,
+  eventSlot: Slot,
+): PoolReconciliation {
+  const target = Math.max(1, Math.trunc(count))
+  if (target < pools.length) {
+    return { pools: pools.slice(0, target), removed: pools.slice(target) }
+  }
+  // The window a new pool inherits: the last pool's, else the event's. Copied, never
+  // shared — a `Slot` handed to two entries by reference is one window both cards edit.
+  const source = pools.length > 0 ? pools[pools.length - 1].slot : eventSlot
+  const appended = Array.from({ length: target - pools.length }, (_, i) =>
+    addedPool({
+      name: poolNameAt(pools.length + i),
+      slot: { ...source },
+      tableIds: [],
+    }),
+  )
+  return { pools: [...pools, ...appended], removed: [] }
+}

--- a/web-client/src/components/tournaments/data/seed.factory.ts
+++ b/web-client/src/components/tournaments/data/seed.factory.ts
@@ -5,6 +5,7 @@
 
 import { DRAW_TYPE_CATALOGUE } from '@/mocks/factories/tournaments/tournament.factory'
 
+import { everySettingAutomatic } from './draw-ownership'
 import { parseDrawTypeCatalogue } from './draw-types'
 import type { ConflictFixture, PlacementConflict, ScheduleSolve } from './solve'
 import { keepPools } from './pool-entries'
@@ -188,6 +189,21 @@ export function buildEvent(
     // the qualifier count is: `Partial<…>` admits an explicit `undefined` while the field is
     // required-and-nullable (`number | null`).
     rounds: overrides.rounds ?? null,
+    // **Every structural setting derived**, which is what an event that has never seen the
+    // Draw structure tab holds (ADR 20260808) — and only an `rr-then-ko` event holds one
+    // at all, the other three arms having no pool stage to own. DERIVED from the draw type
+    // rather than stated, so a fixture cannot describe a shape the API never sends.
+    //
+    // Stated AFTER the spread for the reason the two fields above are: the field is
+    // required-and-nullable while `Partial<…>` admits an explicit `undefined`. A FRESH
+    // record per event (`everySettingAutomatic()`), never a shared constant — the toggle
+    // writes through this field, and one object shared by every fixture would be one
+    // object every test rewrote.
+    drawOwnership:
+      overrides.drawOwnership ??
+      ((overrides.drawType ?? 'round-robin') === 'rr-then-ko'
+        ? everySettingAutomatic()
+        : null),
   } satisfies Omit<TournamentEvent, 'entered'>
   // An **uncapped** event (`maxPlayers: null`, ADR-0935) is never `event_full` —
   // the server guarantees it, and so does the fixture. The null check is the whole

--- a/web-client/src/components/tournaments/data/types.ts
+++ b/web-client/src/components/tournaments/data/types.ts
@@ -6,6 +6,7 @@
 // here, but nothing crosses back at runtime.
 import type { MatchStatus } from '@/api/matches'
 
+import type { DrawOwnership } from './draw-ownership'
 import type { DrawType, DrawTypeOption } from './draw-types'
 import type { PredicateOp } from './options'
 import type { ScheduleSolve } from './solve'
@@ -19,6 +20,11 @@ export type EventFormat = 'singles' | 'doubles' | 'teams'
  * here so the domain modules that read every tournament type from `./types` keep doing
  * so — there is no second declaration to drift. */
 export type { DrawType, DrawTypeOption }
+
+/** The stored ownership record is declared **once**, next to its Zod schema and the two
+ * wire mappers (`./draw-ownership`), for the reason the draw-type vocabulary is.
+ * Re-exported here so a reader of `TournamentEvent.drawOwnership` has the type to hand. */
+export type { DrawOwnership }
 
 export type MatchLength = 1 | 3 | 5 | 7
 
@@ -623,6 +629,19 @@ export interface TournamentEvent {
    * what sizes the draw (`R × ⌊n/2⌋` fixtures, all cut up front), which is why it is
    * carried on the read model at all. */
   rounds: number | null
+  /** **Who owns each of this draw's four structural settings** — the wire's
+   * `draw_structure` (ADR 20260808), parsed at the boundary by `./draw-ownership`.
+   *
+   * ⚠️ `null` is not "unset": it is what the three draw types with no pool stage store,
+   * and only an `rr-then-ko` event carries a record at all. An `rr-then-ko` event that has
+   * never seen the Draw structure tab carries the all-automatic one
+   * (`everySettingAutomatic`), which is today's behaviour written down.
+   *
+   * It holds the **modes and the two manual pool numbers** — not the qualifier count,
+   * whose value is this event's own `qualifiersPerPool` above with `qualifiersMode` saying
+   * whether anybody should read it. What each mode *means* for the numbers on screen is
+   * `deriveDrawStructure` (`./draw-structure`), which takes this as its input. */
+  drawOwnership: DrawOwnership | null
   /** The entrant cap, or `null` for an uncapped event. `null` means "no cap",
    * never zero (ADR-0935): a blank player-limit field submits `null`, and every
    * reader must handle the no-cap branch rather than dividing by it. */

--- a/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.factory.tsx
@@ -60,6 +60,22 @@ export function buildEndTournamentConsequence(
   }
 }
 
+/** The **lowered pool count** consequence — two of `Men's Singles`' pool reservations
+ * going, with the windows and the tables they hold (ADR 20260808). Two names rather than
+ * one, because the plural is the ordinary case and the singular is the edge. */
+export function buildRemovePoolReservationsConsequence(
+  overrides: Partial<
+    Extract<IrreversibleActConsequence, { variant: 'remove-pool-reservations' }>
+  > = {},
+): IrreversibleActConsequence {
+  return {
+    variant: 'remove-pool-reservations',
+    eventName: "Men's Singles",
+    poolNames: ['Pool E', 'Pool F'],
+    ...overrides,
+  }
+}
+
 /** Props for `ConfirmIrreversibleActDialog` — an open **re-cut** confirm on
  * `Men's Singles`. A test that wants the delete act passes a `consequence` of its own. */
 export function buildConfirmIrreversibleActDialogProps(

--- a/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.factory.tsx
@@ -76,6 +76,27 @@ export function buildRemovePoolReservationsConsequence(
   }
 }
 
+/** The **draw type change** consequence — `Men's Singles` leaving `rr-then-ko`, with two
+ * of its four structural settings the director's own (ADR 20260808). Two settings rather
+ * than one, because the plural is the ordinary case; and two pool reservations, because
+ * the sentence that says they stay is the whole reason the count is on the consequence. */
+export function buildDiscardDrawStructureConsequence(
+  overrides: Partial<
+    Extract<IrreversibleActConsequence, { variant: 'discard-draw-structure' }>
+  > = {},
+): IrreversibleActConsequence {
+  return {
+    variant: 'discard-draw-structure',
+    eventName: "Men's Singles",
+    settings: [
+      { label: 'Pool count', value: '6' },
+      { label: 'Pool size', value: '5' },
+    ],
+    poolReservationCount: 2,
+    ...overrides,
+  }
+}
+
 /** Props for `ConfirmIrreversibleActDialog` — an open **re-cut** confirm on
  * `Men's Singles`. A test that wants the delete act passes a `consequence` of its own. */
 export function buildConfirmIrreversibleActDialogProps(

--- a/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.test.tsx
@@ -3,6 +3,7 @@ import {
   buildEndTournamentConsequence,
   buildPublishTournamentConsequence,
   buildRecutDrawConsequence,
+  buildRemovePoolReservationsConsequence,
   buildStartTournamentConsequence,
 } from './confirm-irreversible-act-dialog.factory'
 import { confirmIrreversibleActDialogPage as page } from './confirm-irreversible-act-dialog.page'
@@ -115,7 +116,85 @@ describe('ConfirmIrreversibleActDialog', () => {
     expect(page.getConfirmButton()).toHaveTextContent('End the tournament')
   })
 
-  // Said the other way round, across all five: the sum type exists so that a variant
+  /**
+   * The **pool-count** act (ADR 20260808): an event's pool count is its pool rows, so
+   * lowering it removes rows — and a row is a reservation with a window and a set of
+   * tables somebody chose.
+   *
+   * The names are the point. "2 pools" would leave a director counting cards on the other
+   * tab to find out which two they are about to lose.
+   */
+  it('prices a LOWERED POOL COUNT: the named pools, with the windows and tables they hold', () => {
+    page.render({
+      consequence: buildRemovePoolReservationsConsequence({
+        eventName: 'Under 15s',
+        poolNames: ['Pool E', 'Pool F'],
+      }),
+    })
+
+    const dialog = page.getDialog()
+    expect(dialog).toHaveTextContent('Remove 2 pool reservations?')
+    expect(dialog).toHaveTextContent('Lowering the pool count for Under 15s')
+    expect(dialog).toHaveTextContent('removes Pool E and Pool F')
+    expect(dialog).toHaveTextContent(
+      'Each one takes its time window and its reserved tables with it.',
+    )
+    expect(page.getConfirmButton()).toHaveTextContent('Remove 2 pools')
+  })
+
+  /** One pool is one reservation — the count, the noun and the button's object all move
+   * together, so the dialog never reads "Remove 1 pool reservations?". */
+  it('says a single removed pool in the singular, all the way to the button', () => {
+    page.render({
+      consequence: buildRemovePoolReservationsConsequence({ poolNames: ['Pool D'] }),
+    })
+
+    expect(page.getDialog()).toHaveTextContent('Remove 1 pool reservation?')
+    expect(page.getDialog()).toHaveTextContent('removes Pool D.')
+    expect(page.getConfirmButton()).toHaveTextContent('Remove the pool')
+  })
+
+  /** Three names read as a list. */
+  it('lists three removed pools with a comma and an “and”', () => {
+    page.render({
+      consequence: buildRemovePoolReservationsConsequence({
+        poolNames: ['Pool D', 'Pool E', 'Pool F'],
+      }),
+    })
+
+    expect(page.getDialog()).toHaveTextContent('removes Pool D, Pool E and Pool F.')
+  })
+
+  /** The box admits 512, so "name every pool that goes" is a sentence that can run to
+   * hundreds of names. Past the cap it names three and counts the rest. */
+  it('caps the list rather than reading out every one of a long removal', () => {
+    page.render({
+      consequence: buildRemovePoolReservationsConsequence({
+        poolNames: ['Pool C', 'Pool D', 'Pool E', 'Pool F', 'Pool G', 'Pool H'],
+      }),
+    })
+
+    const dialog = page.getDialog()
+    expect(dialog).toHaveTextContent('Remove 6 pool reservations?')
+    expect(dialog).toHaveTextContent('removes Pool C, Pool D, Pool E and 3 more.')
+    expect(dialog).not.toHaveTextContent('Pool H')
+  })
+
+  /** A pool's name is the one thing on its card a director can *clear*, and the confirm
+   * comes before the save that refuses it. "removes  and Pool F" names nothing. */
+  it('calls a pool with an emptied name box what it is', () => {
+    page.render({
+      consequence: buildRemovePoolReservationsConsequence({
+        poolNames: ['   ', 'Pool F'],
+      }),
+    })
+
+    expect(page.getDialog()).toHaveTextContent(
+      'removes an unnamed pool and Pool F.',
+    )
+  })
+
+  // Said the other way round, across all six: the sum type exists so that a variant
   // cannot render another act's sentence, and "X is present" alone would never catch a
   // dialog that also said everything else — or a generic "This cannot be undone" that
   // said nothing in particular.
@@ -125,6 +204,7 @@ describe('ConfirmIrreversibleActDialog', () => {
     'publish-tournament': 'puts it in front of everybody',
     'start-tournament': 'closes registration for good',
     'end-tournament': 'archived is the last thing a tournament is',
+    'remove-pool-reservations': 'Lowering the pool count for',
   } as const
 
   it.each([
@@ -136,6 +216,10 @@ describe('ConfirmIrreversibleActDialog', () => {
     },
     { variant: 'start-tournament', consequence: buildStartTournamentConsequence() },
     { variant: 'end-tournament', consequence: buildEndTournamentConsequence() },
+    {
+      variant: 'remove-pool-reservations',
+      consequence: buildRemovePoolReservationsConsequence(),
+    },
   ] as const)(
     'gives $variant a sentence no other act says',
     ({ variant, consequence }) => {
@@ -151,8 +235,9 @@ describe('ConfirmIrreversibleActDialog', () => {
   /**
    * The button treatment, per act — decided in the same switch that writes the copy.
    *
-   * `destructive` is for the two verbs that throw work away (pairings, and the schedule
-   * solved on them). The three lifecycle edges destroy nothing: publishing opens a door,
+   * `destructive` is for the three acts that throw work away — the two draw verbs (pairings,
+   * and the schedule solved on them) and a lowered pool count (reservations, with their
+   * windows and their tables). The three lifecycle edges destroy nothing: publishing opens a door,
    * starting mints matches, ending archives. They are one-way, which is what earns them
    * the dialog — not destructive, which is what would earn them the red. It also keeps
    * them off `variant="destructive"`, which fails AA colour contrast (#1039, open) and
@@ -172,6 +257,11 @@ describe('ConfirmIrreversibleActDialog', () => {
       destructive: false,
     },
     { name: 'an end', consequence: buildEndTournamentConsequence(), destructive: false },
+    {
+      name: 'a lowered pool count',
+      consequence: buildRemovePoolReservationsConsequence(),
+      destructive: true,
+    },
   ])('paints the confirm for $name', ({ consequence, destructive }) => {
     page.render({ consequence })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.test.tsx
@@ -1,5 +1,6 @@
 import {
   buildDeleteDrawConsequence,
+  buildDiscardDrawStructureConsequence,
   buildEndTournamentConsequence,
   buildPublishTournamentConsequence,
   buildRecutDrawConsequence,
@@ -194,7 +195,111 @@ describe('ConfirmIrreversibleActDialog', () => {
     )
   })
 
-  // Said the other way round, across all six: the sum type exists so that a variant
+  /**
+   * **The settings, with the values the director typed** — the whole difference between
+   * this confirm and a generic "you will lose your settings" warning. A director who set
+   * six pools of five reads those two numbers back before they spend them.
+   */
+  it('prices a DRAW TYPE CHANGE: the settings the director owns, read back with their values', () => {
+    page.render({
+      consequence: buildDiscardDrawStructureConsequence({
+        eventName: 'Under 15s',
+        settings: [
+          { label: 'Pool count', value: '6' },
+          { label: 'Pool size', value: '5' },
+        ],
+        poolReservationCount: 6,
+      }),
+    })
+
+    const dialog = page.getDialog()
+    expect(dialog).toHaveTextContent('Discard these draw structure settings?')
+    expect(dialog).toHaveTextContent('changing the draw type for Under 15s')
+    expect(dialog).toHaveTextContent(
+      'hands Pool count (6) and Pool size (5) back to automatic',
+    )
+    // Why the settings go at all, said in the format's own terms.
+    expect(dialog).toHaveTextContent(
+      'Only a round-robin-then-knockout draw has a pool stage',
+    )
+    // The confirm carries the act's own verb, not a bare "OK".
+    expect(page.getConfirmButton()).toHaveTextContent('Change the draw type')
+  })
+
+  /**
+   * ⚠️ **The pools survive, and the copy has to say so.** A pool is a venue reservation as
+   * much as a group, and a pool restricts scheduling whatever the draw type (ADR
+   * 20260807) — so the tables and windows a director booked are not the draw type's to
+   * spend. A dialog that stayed silent here would leave them guessing, and one that
+   * claimed the pools go would be lying.
+   */
+  it('promises the pool reservations stay, and counts them', () => {
+    page.render({
+      consequence: buildDiscardDrawStructureConsequence({ poolReservationCount: 6 }),
+    })
+
+    expect(page.getDialog()).toHaveTextContent(
+      'The 6 pools you booked stay exactly as they are.',
+    )
+  })
+
+  it('says a single surviving pool in the singular', () => {
+    page.render({
+      consequence: buildDiscardDrawStructureConsequence({ poolReservationCount: 1 }),
+    })
+
+    expect(page.getDialog()).toHaveTextContent(
+      'The pool you booked stays exactly as it is.',
+    )
+  })
+
+  /** An event with no pool rows at all — reachable, since the pool count can be the
+   * director's while the reservations are still to be made. The sentence goes rather than
+   * reading `The 0 pools you booked`. */
+  it('says nothing about pools when the event has none', () => {
+    page.render({
+      consequence: buildDiscardDrawStructureConsequence({ poolReservationCount: 0 }),
+    })
+
+    expect(page.getDialog()).not.toHaveTextContent('you booked')
+  })
+
+  /** One setting is one setting, in the title as well as in the list. */
+  it('says a single discarded setting in the singular', () => {
+    page.render({
+      consequence: buildDiscardDrawStructureConsequence({
+        settings: [{ label: 'Membership', value: 'Assign at cut time' }],
+      }),
+    })
+
+    expect(page.getDialog()).toHaveTextContent('Discard this draw structure setting?')
+    // ⚠️ The whole sentence, membership included: the snake DEALS entrants rather than
+    // deriving them from a field size, so a promise phrased "we work those out again from
+    // the field" would be false on the one setting with no number.
+    expect(page.getDialog()).toHaveTextContent(
+      'hands Membership (Assign at cut time) back to automatic. We work them out again.',
+    )
+  })
+
+  /** All four read as a list, the same punctuation the pool list uses. */
+  it('lists four discarded settings with commas and an “and”', () => {
+    page.render({
+      consequence: buildDiscardDrawStructureConsequence({
+        settings: [
+          { label: 'Pool count', value: '4' },
+          { label: 'Pool size', value: '8' },
+          { label: 'Membership', value: 'Assign at cut time' },
+          { label: 'Qualifiers per pool', value: '3' },
+        ],
+      }),
+    })
+
+    expect(page.getDialog()).toHaveTextContent(
+      'hands Pool count (4), Pool size (8), Membership (Assign at cut time) and Qualifiers per pool (3) back to automatic',
+    )
+  })
+
+  // Said the other way round, across all seven: the sum type exists so that a variant
   // cannot render another act's sentence, and "X is present" alone would never catch a
   // dialog that also said everything else — or a generic "This cannot be undone" that
   // said nothing in particular.
@@ -205,6 +310,7 @@ describe('ConfirmIrreversibleActDialog', () => {
     'start-tournament': 'closes registration for good',
     'end-tournament': 'archived is the last thing a tournament is',
     'remove-pool-reservations': 'Lowering the pool count for',
+    'discard-draw-structure': 'back to automatic',
   } as const
 
   it.each([
@@ -219,6 +325,10 @@ describe('ConfirmIrreversibleActDialog', () => {
     {
       variant: 'remove-pool-reservations',
       consequence: buildRemovePoolReservationsConsequence(),
+    },
+    {
+      variant: 'discard-draw-structure',
+      consequence: buildDiscardDrawStructureConsequence(),
     },
   ] as const)(
     'gives $variant a sentence no other act says',
@@ -235,9 +345,10 @@ describe('ConfirmIrreversibleActDialog', () => {
   /**
    * The button treatment, per act — decided in the same switch that writes the copy.
    *
-   * `destructive` is for the three acts that throw work away — the two draw verbs (pairings,
-   * and the schedule solved on them) and a lowered pool count (reservations, with their
-   * windows and their tables). The three lifecycle edges destroy nothing: publishing opens a door,
+   * `destructive` is for the four acts that throw work away — the two draw verbs (pairings,
+   * and the schedule solved on them), a lowered pool count (reservations, with their
+   * windows and their tables) and a changed draw type (the settings a director typed).
+   * The three lifecycle edges destroy nothing: publishing opens a door,
    * starting mints matches, ending archives. They are one-way, which is what earns them
    * the dialog — not destructive, which is what would earn them the red. It also keeps
    * them off `variant="destructive"`, which fails AA colour contrast (#1039, open) and
@@ -260,6 +371,11 @@ describe('ConfirmIrreversibleActDialog', () => {
     {
       name: 'a lowered pool count',
       consequence: buildRemovePoolReservationsConsequence(),
+      destructive: true,
+    },
+    {
+      name: 'a changed draw type',
+      consequence: buildDiscardDrawStructureConsequence(),
       destructive: true,
     },
   ])('paints the confirm for $name', ({ consequence, destructive }) => {

--- a/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.tsx
@@ -18,10 +18,13 @@ import {
  * act without the tournament it moves (ADR "a confirm prices an irreversible act, a
  * freeze explains an illegal one").
  *
- * Five acts, of two kinds. The two **draw** acts discard a standing draw and the schedule
+ * Six acts, of three kinds. The two **draw** acts discard a standing draw and the schedule
  * solved on it. The three **lifecycle** edges are the forward-only path a tournament walks
  * — `draft → published → live → archived` — with no edge back and `archived` terminal, so
- * every one of them is one-way too.
+ * every one of them is one-way too. The one **pool-count** act discards reservations: a
+ * lowered pool count on the Draw structure tab removes pool rows, and a removed row takes
+ * its time window and its table selections with it (ADR 20260808 — "lowering a manual pool
+ * count removes rows, which is destructive").
  *
  * The `never` default in the body switch is what keeps the union honest: a variant added
  * here is a **type error** until it has copy of its own, rather than a dialog that
@@ -51,9 +54,26 @@ export type LifecycleActConsequence =
   | { variant: 'start-tournament'; tournamentName: string }
   | { variant: 'end-tournament'; tournamentName: string }
 
+/** The act that belongs to the Draw structure tab's **pool count** — narrow for the third
+ * time, and for the same reason: the tab can price exactly this one, so its state must be
+ * unable to hold a draw verb or a lifecycle edge it has no way to perform.
+ *
+ * It carries the pool **names**, not a count, because the copy names them: a director
+ * about to lose `Pool E` and `Pool F` needs to know which two reservations go, and a bare
+ * "2 pools" would make them count the cards on the other tab to find out. */
+export type PoolCountActConsequence = {
+  variant: 'remove-pool-reservations'
+  eventName: string
+  /** The pools that would go, in the order the Table pools tab lists them. Never empty:
+   * a reconciliation that removes nothing is not an act worth pricing, and the tab does
+   * not open the dialog for one. */
+  poolNames: string[]
+}
+
 export type IrreversibleActConsequence =
   | DrawActConsequence
   | LifecycleActConsequence
+  | PoolCountActConsequence
 
 export interface ConfirmIrreversibleActDialogProps {
   open: boolean
@@ -65,6 +85,29 @@ export interface ConfirmIrreversibleActDialogProps {
 const Strong = ({ children }: { children: React.ReactNode }) => (
   <span className="font-semibold text-[color:var(--fg-1)]">{children}</span>
 )
+
+/** What a pool with an emptied name box is called in this sentence. Reachable: the name is
+ * the one thing on a pool card a director can *clear*, and the save is refused for it
+ * later (`poolNameIssues`) — but the confirm comes first, and "removes  and Pool F" names
+ * nothing. */
+const UNNAMED_POOL = 'an unnamed pool'
+
+/** How many pools the sentence names before it starts counting them. Three is enough for
+ * the ordinary case (a director nudging six pools down to four) and the cap is what keeps
+ * a drop from 512 to 1 from reading out 511 names. */
+const MAX_NAMED_POOLS = 3
+
+/** `Pool E`, `Pool E and Pool F`, `Pool D, Pool E and Pool F`, and past the cap
+ * `Pool D, Pool E, Pool F and 8 more`. */
+const removedPoolList = (names: string[]): string => {
+  const shown = names
+    .slice(0, MAX_NAMED_POOLS)
+    .map((name) => name.trim() || UNNAMED_POOL)
+  const unshown = names.length - shown.length
+  const parts = unshown > 0 ? [...shown, `${unshown} more`] : shown
+  if (parts.length < 2) return parts[0] ?? ''
+  return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`
+}
 
 /**
  * The consequence-stating confirm on an act a director **cannot undo**: the two draw acts
@@ -92,12 +135,13 @@ const Strong = ({ children }: { children: React.ReactNode }) => (
  * Focus is trapped, and Radix's own `onOpenAutoFocus` lands it on **Go back** — the safe
  * default when the other button spends something that does not come back.
  *
- * ## Why only two of the five wear the destructive treatment
+ * ## Why only three of the six wear the destructive treatment
  *
  * The confirm's `variant` is decided by the same `switch` that writes the copy, so a new
  * variant cannot acquire a sentence without also answering for how its button looks.
  * `destructive` is reserved for the acts that **throw work away** — the two draw verbs
- * discard pairings and the schedule solved on them. The three lifecycle edges destroy
+ * discard pairings and the schedule solved on them, and a lowered pool count discards
+ * reservations with their windows and their tables. The three lifecycle edges destroy
  * nothing: publishing opens a door, starting mints matches, ending archives. They are
  * consequential and one-way, which is what earns them a dialog — not destructive, which
  * is what would earn them the red.
@@ -197,6 +241,31 @@ export const ConfirmIrreversibleActDialog = ({
           confirmLabel: 'End the tournament',
           confirmVariant: 'default' as const,
         }
+      // The pool count is the pool ROWS (ADR 20260808), so lowering it removes rows — and
+      // a row is a reservation, with a window and a set of tables somebody chose. The
+      // sentence names which pools go, because that is the part the director cannot work
+      // out from the number they just typed.
+      //
+      // It deliberately does NOT say "there is no undoing this": the removal lands in the
+      // editor's draft, and closing the sheet without saving really does put the pools
+      // back. What does not come back is the work — raising the count again mints blank
+      // rows with no tables — so the copy prices the work and claims nothing more.
+      case 'remove-pool-reservations': {
+        const count = consequence.poolNames.length
+        return {
+          title: `Remove ${count} pool ${count === 1 ? 'reservation' : 'reservations'}?`,
+          description: (
+            <>
+              Lowering the pool count for <Strong>{consequence.eventName}</Strong>{' '}
+              removes <Strong>{removedPoolList(consequence.poolNames)}</Strong>.
+              Each one takes its time window and its reserved tables with it.
+            </>
+          ),
+          confirmLabel: count === 1 ? 'Remove the pool' : `Remove ${count} pools`,
+          // Red, by the rule above: this throws away work a director did on another tab.
+          confirmVariant: 'destructive' as const,
+        }
+      }
       default: {
         // A variant without copy of its own is a TYPE error here, not a dialog that
         // prices the wrong act.

--- a/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/confirm-irreversible-act-dialog.tsx
@@ -11,6 +11,8 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 
+import type { OwnedStructureSetting } from '../data/draw-ownership'
+
 /**
  * What confirming would SPEND — the dialog's whole content, as a sum type (no bag of
  * optional props): each variant carries exactly the context its copy names, so a draw
@@ -18,13 +20,15 @@ import {
  * act without the tournament it moves (ADR "a confirm prices an irreversible act, a
  * freeze explains an illegal one").
  *
- * Six acts, of three kinds. The two **draw** acts discard a standing draw and the schedule
+ * Seven acts, of four kinds. The two **draw** acts discard a standing draw and the schedule
  * solved on it. The three **lifecycle** edges are the forward-only path a tournament walks
  * — `draft → published → live → archived` — with no edge back and `archived` terminal, so
  * every one of them is one-way too. The one **pool-count** act discards reservations: a
  * lowered pool count on the Draw structure tab removes pool rows, and a removed row takes
  * its time window and its table selections with it (ADR 20260808 — "lowering a manual pool
- * count removes rows, which is destructive").
+ * count removes rows, which is destructive"). The one **draw-structure** act discards
+ * ownership: leaving `rr-then-ko` leaves the pool stage those settings shape, so the
+ * settings the director took go back to the system (the same ADR).
  *
  * The `never` default in the body switch is what keeps the union honest: a variant added
  * here is a **type error** until it has copy of its own, rather than a dialog that
@@ -70,10 +74,33 @@ export type PoolCountActConsequence = {
   poolNames: string[]
 }
 
+/** The act that belongs to the Basics tab's **draw type** — narrow for the fourth time,
+ * and for the same reason as the three above.
+ *
+ * Only a `rr-then-ko` draw has a pool stage feeding a knockout, so leaving that draw type
+ * leaves the settings behind (ADR 20260808 — "switching away from `rr-then-ko` can discard
+ * a director's work"). The dialog is opened **only** when something is actually the
+ * director's: an all-automatic event loses nothing, and a confirm that priced nothing would
+ * be the ceremony ADR 20260806 refuses. */
+export type DrawStructureActConsequence = {
+  variant: 'discard-draw-structure'
+  eventName: string
+  /** The settings the director owns, read back with the values they set. **Never empty** —
+   * see above. Carried as label/value pairs rather than as a pre-joined sentence, so the
+   * copy that reads them out lives here with the rest of the dialog's words. */
+  settings: OwnedStructureSetting[]
+  /** How many pool rows the event has. The switch does **not** touch them, and the copy
+   * says so — a pool restricts scheduling whatever the draw type (ADR 20260807), so the
+   * tables and windows a director booked survive a change of format. Zero is a real
+   * answer, and the sentence is dropped for it rather than reading `0 pools`. */
+  poolReservationCount: number
+}
+
 export type IrreversibleActConsequence =
   | DrawActConsequence
   | LifecycleActConsequence
   | PoolCountActConsequence
+  | DrawStructureActConsequence
 
 export interface ConfirmIrreversibleActDialogProps {
   open: boolean
@@ -97,6 +124,13 @@ const UNNAMED_POOL = 'an unnamed pool'
  * a drop from 512 to 1 from reading out 511 names. */
 const MAX_NAMED_POOLS = 3
 
+/** `A`, `A and B`, `A, B and C` — the one place this dialog turns a list into a phrase,
+ * so its two list-reading variants cannot punctuate differently. */
+const andList = (parts: string[]): string => {
+  if (parts.length < 2) return parts[0] ?? ''
+  return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`
+}
+
 /** `Pool E`, `Pool E and Pool F`, `Pool D, Pool E and Pool F`, and past the cap
  * `Pool D, Pool E, Pool F and 8 more`. */
 const removedPoolList = (names: string[]): string => {
@@ -104,10 +138,15 @@ const removedPoolList = (names: string[]): string => {
     .slice(0, MAX_NAMED_POOLS)
     .map((name) => name.trim() || UNNAMED_POOL)
   const unshown = names.length - shown.length
-  const parts = unshown > 0 ? [...shown, `${unshown} more`] : shown
-  if (parts.length < 2) return parts[0] ?? ''
-  return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`
+  return andList(unshown > 0 ? [...shown, `${unshown} more`] : shown)
 }
+
+/** `Pool count (6), Pool size (5) and Membership (Assign at cut time)` — every setting
+ * read back with the value the director set, because "your draw structure settings" names
+ * nothing a director can check against what they typed. **No cap**, unlike the pool list:
+ * there are four settings in all, so the longest this can run is four. */
+const ownedSettingList = (settings: OwnedStructureSetting[]): string =>
+  andList(settings.map((setting) => `${setting.label} (${setting.value})`))
 
 /**
  * The consequence-stating confirm on an act a director **cannot undo**: the two draw acts
@@ -135,13 +174,14 @@ const removedPoolList = (names: string[]): string => {
  * Focus is trapped, and Radix's own `onOpenAutoFocus` lands it on **Go back** — the safe
  * default when the other button spends something that does not come back.
  *
- * ## Why only three of the six wear the destructive treatment
+ * ## Why only four of the seven wear the destructive treatment
  *
  * The confirm's `variant` is decided by the same `switch` that writes the copy, so a new
  * variant cannot acquire a sentence without also answering for how its button looks.
  * `destructive` is reserved for the acts that **throw work away** — the two draw verbs
- * discard pairings and the schedule solved on them, and a lowered pool count discards
- * reservations with their windows and their tables. The three lifecycle edges destroy
+ * discard pairings and the schedule solved on them, a lowered pool count discards
+ * reservations with their windows and their tables, and a changed draw type discards the
+ * structural settings a director typed. The three lifecycle edges destroy
  * nothing: publishing opens a door, starting mints matches, ending archives. They are
  * consequential and one-way, which is what earns them a dialog — not destructive, which
  * is what would earn them the red.
@@ -263,6 +303,53 @@ export const ConfirmIrreversibleActDialog = ({
           ),
           confirmLabel: count === 1 ? 'Remove the pool' : `Remove ${count} pools`,
           // Red, by the rule above: this throws away work a director did on another tab.
+          confirmVariant: 'destructive' as const,
+        }
+      }
+      // Leaving `rr-then-ko` leaves the pool stage, and the settings that shape it go with
+      // it (ADR 20260808). The sentence names them with their values, because "your draw
+      // structure settings" is the generic warning a confirm is supposed to replace.
+      //
+      // It says the settings go back to **automatic**, not that their numbers are deleted,
+      // and that is the honest verb for what happens: the ownership record is dropped, and
+      // the app derives every number again. The qualifier count keeps its stored value —
+      // K is required on a two-stage event, and clearing it would refuse the next save.
+      //
+      // `We work them out again` rather than `from the field`, because membership is one of
+      // the four and the snake is not derived from a field size — it deals entrants. One
+      // sentence has to be true of all four settings the list can hold.
+      //
+      // And it says the **pools stay**, because a pool is a venue reservation as much as a
+      // group, and a pool restricts scheduling whatever the draw type (ADR 20260807). The
+      // director booked those tables and windows deliberately, so a change of format is not
+      // a reason to hand them back.
+      case 'discard-draw-structure': {
+        const count = consequence.settings.length
+        const pools = consequence.poolReservationCount
+        return {
+          title:
+            count === 1
+              ? 'Discard this draw structure setting?'
+              : 'Discard these draw structure settings?',
+          description: (
+            <>
+              Only a round-robin-then-knockout draw has a pool stage, so changing the
+              draw type for <Strong>{consequence.eventName}</Strong> hands{' '}
+              <Strong>{ownedSettingList(consequence.settings)}</Strong> back to
+              automatic. We work them out again.
+              {pools > 0 && (
+                <>
+                  {' '}
+                  {pools === 1
+                    ? 'The pool you booked stays exactly as it is.'
+                    : `The ${pools} pools you booked stay exactly as they are.`}
+                </>
+              )}
+            </>
+          ),
+          confirmLabel: 'Change the draw type',
+          // Red, by the rule in the component doc: a setting the director typed is work,
+          // and this throws it away.
           confirmVariant: 'destructive' as const,
         }
       }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
@@ -95,13 +95,16 @@ const scoped = (container: Container) => ({
   getEntryFeeInput() {
     return container.getByLabelText(/Entry fee/)
   },
-  /** **K** — the qualifier-count box on Basics, which exists only while the draft's draw
-   * type is `rr-then-ko` (ADR 20260727). */
-  getQualifiersInput() {
-    return container.getByLabelText(/Qualifiers per pool/)
-  },
-  /** …and its `query` twin, for the claim that the row is not on screen at all for a
-   * draw type with no knockout stage. */
+  /** **K** — the qualifier count's box, on the **Draw structure** tab since chore 3e.
+   *
+   * It is reached through `drawStructure.setting('Qualifiers per pool')` like every other
+   * setting on that tab; what is left here is the editor-scoped `query`, for the one claim
+   * this level makes — that no box for K is on screen.
+   *
+   * ⚠️ It proves *absence only where a box could be*. Radix unmounts an inactive tab's
+   * panel, so this is null for a two-stage event standing on Basics too — which is exactly
+   * what makes it the right query for "Basics does not render one", and the wrong one for
+   * "the tab is gone". Pair it with `querySectionTab('Draw structure')` for that. */
   queryQualifiersInput() {
     return container.queryByLabelText(/Qualifiers per pool/)
   },

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
@@ -55,6 +55,17 @@ const scoped = (container: Container) => ({
   getPoolNameInputs() {
     return container.queryAllByLabelText('Pool name')
   },
+  /** The Table pools tab's **header** add action. Editor-scoped, like the pool name boxes
+   * above, for the tests whose claim is about the whole sheet: a pool reservation is what
+   * the Draw structure tab derives its pool count from, so adding one is how a test states
+   * a two-pool event the way a director makes one.
+   *
+   * ⚠️ The exact name, not `/Add (first )?pool/`: an event with no pools renders the empty
+   * state's `Add first pool` **as well as** this one, and a pattern matching both throws on
+   * the very click a from-nothing test starts with. */
+  getAddPoolButton() {
+    return container.getByRole('button', { name: 'Add pool' })
+  },
   /** The red messages under the pool name boxes, in card order — the Table pools
    * counterpart of `queryFieldError` on Basics and `getRuleErrors()` on Eligibility. */
   getPoolNameErrors(): (string | null)[] {

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.page.tsx
@@ -2,6 +2,7 @@ import userEvent from '@testing-library/user-event'
 
 import { render, screen, type Container } from '@/test/utilities'
 
+import { confirmIrreversibleActDialogPage } from './confirm-irreversible-act-dialog.page'
 import { EventEditor, type EventEditorProps } from './event-editor'
 import { buildEventEditorProps } from './event-editor.factory'
 import { drawStructureSectionPage } from './event-editor/draw-structure-section.page'
@@ -24,6 +25,15 @@ const scoped = (container: Container) => ({
   /** The Draw structure tab's panel, and the queries inside it. Reused from the
    * section's own page object, scoped to the editor. */
   drawStructure: drawStructureSectionPage.within(container),
+  /** The confirm the editor itself opens — today the one a **draw-type change** buys, when
+   * the director owns a structural setting the switch would discard (ADR 20260808).
+   *
+   * At SCREEN scope on purpose, exactly as the section's own `confirm` is: an `AlertDialog`
+   * portals to the body, so a container-scoped query would find nothing and pass while
+   * checking nothing. There is only ever one `alertdialog` on screen, so this and
+   * `drawStructure.confirm` reach the same node — they are named apart because the acts
+   * they price are. */
+  confirm: confirmIrreversibleActDialogPage,
   /** The sheet itself — present exactly while the editor is open. The claim
    * "a refused save does not close the editor" is a claim about this node. */
   querySheet() {
@@ -148,7 +158,17 @@ const scoped = (container: Container) => ({
  */
 export const eventEditorPage = {
   render(overrides: Partial<EventEditorProps> = {}) {
-    render(<EventEditor {...buildEventEditorProps(overrides)} />)
+    const view = render(<EventEditor {...buildEventEditorProps(overrides)} />)
+    return {
+      ...view,
+      /** Hand the **same mounted editor** a new set of props — how a director opens it on
+       * another event, and the only way to say that: a second `render` mounts a second
+       * editor, so state the first one was holding is still there, in a component the
+       * assertions can no longer tell apart from the new one. */
+      rerenderWith(next: Partial<EventEditorProps> = {}) {
+        view.rerender(<EventEditor {...buildEventEditorProps(next)} />)
+      },
+    }
   },
 
   within(container: Container = screen) {

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -439,6 +439,211 @@ describe('EventEditor', () => {
   })
 
   /**
+   * **The Draw structure tab's pool count and the Table pools tab's cards are ONE list**
+   * (ADR 20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-count-is-a-
+   * projection). An event's pool count is the number of pool rows it has; nothing stores a
+   * second number, so the two tabs cannot report different ones.
+   *
+   * This is the claim only the *editor* can make. The section's own tests prove what a
+   * keystroke asks for — these prove the ask lands in the same form field the other tab
+   * reads and the save sends, which is the whole of "the two tabs cannot drift".
+   */
+  describe('the pool count and the pool cards are one list', () => {
+    /** The box takes the whole value at once, as a director replacing a number does. */
+    const typePoolCount = (value: string) =>
+      fireEvent.change(
+        eventEditorPage.drawStructure.setting('Pool count').getInput(),
+        { target: { value } },
+      )
+
+    /** …and this is the director saying they are done with it. A **lowered** count is
+     * priced here rather than on the keystroke — see the multi-digit spec below. */
+    const finishTypingPoolCount = () =>
+      fireEvent.blur(eventEditorPage.drawStructure.setting('Pool count').getInput())
+
+    it('gives Table pools the number of cards the director typed on Draw structure', async () => {
+      // Two pool reservations, so the tab derives 2 and taking the count seeds 2.
+      eventEditorPage.render({ event: buildRrThenKoEvent() })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      await userEvent.click(
+        eventEditorPage.drawStructure.setting('Pool count').getAction(),
+      )
+      typePoolCount('5')
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      // Named by continuing the sequence, and each new card is a real, editable pool —
+      // not a number the other tab is keeping to itself.
+      expect(
+        eventEditorPage
+          .getPoolNameInputs()
+          .map((input: HTMLElement) => (input as HTMLInputElement).value),
+      ).toEqual(['Pool A', 'Pool B', 'Pool C', 'Pool D', 'Pool E'])
+    })
+
+    /** …and the reverse, which is the half a stored count could never honour: a card added
+     * on Table pools raises the automatic count, its source sentence and the preview's
+     * fact, because all three read the one list. */
+    it('raises the automatic pool count when a card is added on Table pools', async () => {
+      eventEditorPage.render({ event: buildRrThenKoEvent() })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      await userEvent.click(screen.getByRole('button', { name: 'Add pool' }))
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+
+      const row = eventEditorPage.drawStructure.setting('Pool count')
+      expect(row.getValue()).toHaveTextContent('3')
+      expect(row.getSource()).toHaveTextContent(
+        "3 pool reservations · today's behaviour",
+      )
+      expect(
+        eventEditorPage.drawStructure.preview.getFact('Pool reservations'),
+      ).toHaveTextContent('3')
+    })
+
+    /** ⚠️ THE CLAIM IS ABOUT THE REQUEST. A lowered count is a removal under an id-keyed
+     * diff: the surviving pool goes on citing the id the server minted, and the pool no
+     * entry cites is the one that goes (ADR 20260801). */
+    it('sends the shortened pool list once the removal is confirmed', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({ event: buildRrThenKoEvent(), onSave })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      await userEvent.click(
+        eventEditorPage.drawStructure.setting('Pool count').getAction(),
+      )
+      typePoolCount('1')
+      finishTypingPoolCount()
+      expect(eventEditorPage.drawStructure.confirm.getDialog()).toHaveTextContent(
+        'removes Pool B',
+      )
+      eventEditorPage.drawStructure.confirm.confirm()
+
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      const body = eventToUpdateBody(onSave.mock.calls[0][0])
+      expect(body.pools).toEqual([expect.objectContaining({ id: 'p-a', name: 'Pool A' })])
+      expect(body.draw_structure).toEqual(
+        expect.objectContaining({ manual_pool_count: 1 }),
+      )
+    })
+
+    /** Go back leaves the other tab exactly as it was. Asserted on the CARDS rather than
+     * on a callback: a confirm that only failed to fire a spy would still be a confirm
+     * that had already removed the pool. */
+    it('leaves both tabs alone when the removal is refused', async () => {
+      eventEditorPage.render({ event: buildRrThenKoEvent() })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      await userEvent.click(
+        eventEditorPage.drawStructure.setting('Pool count').getAction(),
+      )
+      typePoolCount('1')
+      finishTypingPoolCount()
+      eventEditorPage.drawStructure.confirm.cancel()
+
+      expect(
+        eventEditorPage.drawStructure.setting('Pool count').getInput(),
+      ).toHaveValue('2')
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      expect(eventEditorPage.getPoolNameInputs()).toHaveLength(2)
+    })
+
+    /**
+     * ⚠️ **A count whose leading digit is below the row count must still be typeable.**
+     * Against two pools, `12` produces the value `1` first — and a confirm priced on that
+     * keystroke opens a modal dialog, moves focus out of the box, and eats the `2`. In a
+     * box whose ceiling is 512 that would make most three-digit counts unreachable.
+     *
+     * Typed with `userEvent`, one character at a time, deliberately: this claim is about
+     * what happens *between* keystrokes, and a whole-value `fireEvent.change` cannot see
+     * it — that spelling passes whether the confirm is priced on the keystroke or on the
+     * commit.
+     */
+    it('lets a director type a count whose first digit is a removal', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({ event: buildRrThenKoEvent(), onSave })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      await userEvent.click(
+        eventEditorPage.drawStructure.setting('Pool count').getAction(),
+      )
+      await userEvent.clear(
+        eventEditorPage.drawStructure.setting('Pool count').getInput(),
+      )
+      await userEvent.type(
+        eventEditorPage.drawStructure.setting('Pool count').getInput(),
+        '12',
+      )
+
+      expect(eventEditorPage.drawStructure.confirm.queryDialog()).toBeNull()
+      expect(
+        eventEditorPage.drawStructure.setting('Pool count').getInput(),
+      ).toHaveValue('12')
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      expect(eventEditorPage.getPoolNameInputs()).toHaveLength(12)
+    })
+
+    /**
+     * The removal, with the pool cards **already mounted**.
+     *
+     * The order is the point: every other spec here either raises the count or never
+     * leaves the Draw structure tab, so the pool cards were registered *after* the write.
+     * `setValue` on a field-array name republishes the array, but it is not
+     * `useFieldArray.remove()` — a dropped index that stayed registered would go on
+     * reaching the save.
+     */
+    it('removes a mounted pool card, and the removal reaches the request', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({ event: buildRrThenKoEvent(), onSave })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      expect(eventEditorPage.getPoolNameInputs()).toHaveLength(2)
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      await userEvent.click(
+        eventEditorPage.drawStructure.setting('Pool count').getAction(),
+      )
+      typePoolCount('1')
+      finishTypingPoolCount()
+      eventEditorPage.drawStructure.confirm.confirm()
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      expect(eventEditorPage.getPoolNameInputs()).toHaveLength(1)
+
+      await userEvent.click(eventEditorPage.getSaveButton())
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      expect(eventToUpdateBody(onSave.mock.calls[0][0]).pools).toHaveLength(1)
+    })
+
+    /** The pool set is frozen once a draw is cut — every fixture names the pool it was
+     * dealt into — so the row that now creates and removes pool rows is frozen with it,
+     * by the same `poolSetFreeze` the Table pools tab already used. */
+    it('freezes the pool count row on an event whose draw is cut', async () => {
+      eventEditorPage.render({
+        event: buildRrThenKoEvent({
+          drawOwnership: {
+            ...everySettingAutomatic(),
+            poolCountMode: 'manual',
+            manualPoolCount: 2,
+          },
+          fixtures: [buildFixture({ poolId: 'p-a' })],
+        }),
+      })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+
+      const row = eventEditorPage.drawStructure.setting('Pool count')
+      expect(row.getInput()).toBeDisabled()
+      expect(row.getAction()).toBeDisabled()
+      expect(row.queryFreezeReason()).toHaveTextContent(
+        'Every fixture names the pool it was dealt into',
+      )
+    })
+  })
+
+  /**
    * A rule with no value is not a rule. It used to go to the server anyway — where
    * a scalar one was ACCEPTED (201) and came back onto the event card as the chip
    * `Rating < ?`, a restriction on nobody wearing the clothes of a real one, while a

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -7,6 +7,7 @@ import { screen, waitFor } from '@/test/utilities'
 
 import { emptyEvent } from '../data/helpers'
 import { eventToCreateBody, eventToUpdateBody } from '../data/api'
+import { everySettingAutomatic } from '../data/draw-ownership'
 import {
   buildEvent,
   buildFixture,
@@ -256,6 +257,94 @@ describe('EventEditor', () => {
         'true',
       )
       expect(eventEditorPage.getPlayerLimitInput()).toBeInTheDocument()
+    })
+  })
+
+  /**
+   * **The ownership record, end to end** (ADR 20260808) — the toggle, the box, the form
+   * and the body that leaves the client.
+   *
+   * The section's own tests prove what a click asks for; these prove the two things only
+   * the *editor* can. That a setting taken on the tab is **form state**, so it survives a
+   * walk to another tab and reaches the object handed to `onSave` — a tab that kept a
+   * draft of its own would look identical on screen and save nothing. And that a record
+   * the server already stored comes back onto the tab, which is the other half of the
+   * round trip.
+   */
+  describe('the draw structure a director owns, end to end', () => {
+    it('SENDS what the director took and typed — it reaches the request body', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      // Two pool reservations, so the tab derives 2 pools and taking the count seeds 2.
+      eventEditorPage.render({ event: buildRrThenKoEvent(), onSave })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      const row = eventEditorPage.drawStructure.setting('Pool count')
+      await userEvent.click(row.getAction())
+
+      // The first click changed the owner, not the number.
+      expect(eventEditorPage.drawStructure.setting('Pool count').getInput()).toHaveValue(
+        '2',
+      )
+
+      await userEvent.clear(eventEditorPage.drawStructure.setting('Pool count').getInput())
+      await userEvent.type(
+        eventEditorPage.drawStructure.setting('Pool count').getInput(),
+        '6',
+      )
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      // ⚠️ THE CLAIM IS ABOUT THE REQUEST. `onSave` receives the event the page maps with
+      // `eventToUpdateBody`, so mapping it here is what the client would really send.
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      expect(eventToUpdateBody(onSave.mock.calls[0][0]).draw_structure).toEqual(
+        expect.objectContaining({
+          pool_count_mode: 'manual',
+          manual_pool_count: 6,
+        }),
+      )
+    })
+
+    // The other half: what the server stored is what the director sees when they come
+    // back. A tab that always started all-automatic would look right on the first visit
+    // and silently discard every setting on the second.
+    it('shows a setting the director took last time as still theirs', async () => {
+      eventEditorPage.render({
+        event: buildRrThenKoEvent({
+          drawOwnership: {
+            ...everySettingAutomatic(),
+            poolCountMode: 'manual',
+            manualPoolCount: 6,
+          },
+        }),
+      })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+
+      const row = eventEditorPage.drawStructure.setting('Pool count')
+      expect(row.getInput()).toHaveValue('6')
+      expect(row.getOwnershipBadge()).toHaveTextContent('Yours')
+    })
+
+    // A save that never opened the tab still sends the record — the editor puts back
+    // what it rendered, and an omitted key would be a mock/server disagreement waiting
+    // to happen the day something reads it as "reset the director's modes".
+    it('sends the all-automatic record for an event that has never had one', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({
+        event: buildRrThenKoEvent({ drawOwnership: null }),
+        onSave,
+      })
+
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      expect(eventToUpdateBody(onSave.mock.calls[0][0]).draw_structure).toEqual(
+        expect.objectContaining({
+          pool_count_mode: 'automatic',
+          manual_pool_count: null,
+          membership_mode: 'snake',
+        }),
+      )
     })
   })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -47,26 +47,53 @@ describe('EventEditor', () => {
    * **K**, through the whole editor (ADR 20260727) — the picker, the resolver, and the
    * body that leaves the client.
    *
-   * The section's own tests prove the row is conditional; these prove the three things
-   * only the *editor* can: that switching the served picker reveals and hides it, that a
-   * bad count is refused BEFORE anything is sent, and — the one that matters most — that
-   * the value a director types is on the object handed to `onSave`, which is what
-   * `eventToUpdateBody` turns into the request. A test that stopped at form state would
-   * pass just as happily against a mapper that dropped the field on the floor.
+   * ⚠️ **The box is on the Draw structure tab** (chore 3e, ADR 20260808): the qualifier
+   * count is a structural setting, and it moved off Basics to sit with the other three.
+   * So every test here opens that tab first, and the two claims about *Basics* are that
+   * the box is not there.
+   *
+   * The section's own tests prove what the row says. These prove the things only the
+   * *editor* can: that a bad count is refused BEFORE anything is sent, that a refused save
+   * opens the tab holding the box, and — the one that matters most — that the value a
+   * director types is on the object handed to `onSave`, which is what `eventToUpdateBody`
+   * turns into the request. A test that stopped at form state would pass just as happily
+   * against a mapper that dropped the field on the floor.
    */
   describe('the qualifier count, end to end', () => {
-    it('reveals the control when the director picks the two-stage format, and hides it again', async () => {
+    /** The qualifiers row, reached the way a director reaches it. */
+    const openQualifiersRow = async () => {
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      return eventEditorPage.drawStructure.setting('Qualifiers per pool')
+    }
+
+    /** A two-stage event whose director already **owns** the count, which is what puts a
+     * direct-entry box on the row rather than a derived number read out as text. */
+    const ownsQualifiers = (qualifiersPerPool: number) =>
+      buildRrThenKoEvent({
+        qualifiersPerPool,
+        drawOwnership: {
+          ...everySettingAutomatic(),
+          qualifiersMode: 'manual',
+        },
+      })
+
+    it('is nowhere on the sheet for a draw type with no knockout stage', () => {
       eventEditorPage.render({ event: buildEvent({ drawType: 'round-robin' }) })
+
+      expect(eventEditorPage.queryQualifiersInput()).toBeNull()
+      expect(eventEditorPage.querySectionTab('Draw structure')).toBeNull()
+    })
+
+    // The move itself, at the level that can see both tabs at once: Basics opens with no
+    // box for K, and the box is one tab over. A control in both places is the state chore
+    // 3e ended — two boxes over one field, showing the stored count and the derived one.
+    it('is set on the Draw structure tab, and not on Basics', async () => {
+      eventEditorPage.render({ event: ownsQualifiers(2) })
+
       expect(eventEditorPage.queryQualifiersInput()).toBeNull()
 
-      // The label is the SERVER's (`draw_type_catalogue`), not a string this client keeps.
-      await eventEditorPage.chooseDrawType('Round-robin then knockout')
-      expect(await screen.findByLabelText(/Qualifiers per pool/)).toBeInTheDocument()
-
-      await eventEditorPage.chooseDrawType('Round robin')
-      await waitFor(() =>
-        expect(eventEditorPage.queryQualifiersInput()).toBeNull(),
-      )
+      const row = await openQualifiersRow()
+      expect(row.getInput()).toHaveValue('2')
     })
 
     // ⚠️ THE CLAIM IS ABOUT THE REQUEST, not the box. `onSave` receives the event the
@@ -74,14 +101,10 @@ describe('EventEditor', () => {
     // really put on the wire — and 2 is neither the planner's fallback (1) nor absent.
     it('SENDS the configured count — the value reaches the request body', async () => {
       const onSave = vi.fn().mockResolvedValue(undefined)
-      eventEditorPage.render({
-        event: buildRrThenKoEvent({ qualifiersPerPool: 1 }),
-        onSave,
-      })
+      eventEditorPage.render({ event: ownsQualifiers(1), onSave })
 
-      fireEvent.change(eventEditorPage.getQualifiersInput(), {
-        target: { value: '2' },
-      })
+      const row = await openQualifiersRow()
+      fireEvent.change(row.getInput(), { target: { value: '2' } })
       await userEvent.click(eventEditorPage.getSaveButton())
 
       await waitFor(() => expect(onSave).toHaveBeenCalled())
@@ -109,40 +132,107 @@ describe('EventEditor', () => {
       expect('qualifiers_per_pool' in body).toBe(false)
     })
 
-    // Refused HERE, so nothing was sent — `onSave` not called at all is the assertion
-    // that separates "told the director" from "asked the server and read the answer out".
-    it.each([
-      ['0', 'At least 1 player must advance from each pool.'],
-      ['-1', 'At least 1 player must advance from each pool.'],
-      ['', 'Say how many players advance from each pool.'],
-    ])(
-      'refuses %s inline and sends NOTHING',
-      async (typed, message) => {
-        const onSave = vi.fn()
-        eventEditorPage.render({
-          event: buildRrThenKoEvent({ qualifiersPerPool: 2 }),
-          onSave,
-        })
+    /**
+     * Refused HERE, so nothing was sent — `onSave` not called at all is the assertion that
+     * separates "told the director" from "asked the server and read the answer out".
+     *
+     * **An emptied box is the only way in now**, and that is a tightening the move brought
+     * with it: the row's box parses each keystroke (`acceptedManualEntry`), so `0` and `-1`
+     * are dropped as characters and never become form state. The old Basics box was an
+     * `<input type=number>` that accepted both. Only "the director cleared it" is left,
+     * and it is exactly the case a required count must still refuse.
+     */
+    it('refuses an emptied count inline and sends NOTHING', async () => {
+      const onSave = vi.fn()
+      eventEditorPage.render({ event: ownsQualifiers(2), onSave })
 
-        fireEvent.change(eventEditorPage.getQualifiersInput(), {
-          target: { value: typed },
-        })
-        await userEvent.click(eventEditorPage.getSaveButton())
+      const row = await openQualifiersRow()
+      fireEvent.change(row.getInput(), { target: { value: '' } })
+      await userEvent.click(eventEditorPage.getSaveButton())
 
-        await waitFor(() =>
-          expect(eventEditorPage.queryFieldError(message)).toBeInTheDocument(),
-        )
-        expect(onSave).not.toHaveBeenCalled()
-      },
-    )
+      await waitFor(() =>
+        expect(row.queryError()).toHaveTextContent(
+          'Say how many players advance from each pool.',
+        ),
+      )
+      expect(onSave).not.toHaveBeenCalled()
+      // The red is UNDER the box and pointed at by it — the channel a screen reader has.
+      expect(row.getInput()).toHaveAttribute('aria-invalid', 'true')
+      expect(row.describedNodeOf(row.getInput())).toHaveTextContent(
+        'Say how many players advance from each pool.',
+      )
+    })
+
+    /**
+     * …and the refusal opens **the tab the box is on** — the field-to-tab map, end to end
+     * (`firstInvalidSection`).
+     *
+     * This is the assertion the move can break in silence. Leave `qualifiersPerPool`
+     * mapped to `basics` and everything above still passes: the save is still refused,
+     * nothing is still sent, the red is still rendered on a tab the director was walked
+     * away from. A message on a tab you cannot see is indistinguishable from a Save button
+     * that does nothing, which is the whole reason that map exists. So the test starts on
+     * Basics deliberately, and the claim is *which tab is selected afterwards*.
+     */
+    it('opens the Draw structure tab when the save is refused for the count', async () => {
+      eventEditorPage.render({ event: ownsQualifiers(2), onSave: vi.fn() })
+
+      const row = await openQualifiersRow()
+      fireEvent.change(row.getInput(), { target: { value: '' } })
+      await userEvent.click(eventEditorPage.getSectionTab('Basics'))
+      expect(eventEditorPage.getSectionTab('Basics')).toHaveAttribute(
+        'aria-selected',
+        'true',
+      )
+
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() =>
+        expect(eventEditorPage.getSectionTab('Draw structure')).toHaveAttribute(
+          'aria-selected',
+          'true',
+        ),
+      )
+    })
 
     // The far half of the round trip (chores 3c/3d): what the SERVER stored is what the
     // control opens on. Without this the editor could show a default while the event ran
     // at a different K — the quiet failure the whole server-side detour was to prevent.
-    it('opens on the count the server sent back', () => {
-      eventEditorPage.render({ event: buildRrThenKoEvent({ qualifiersPerPool: 3 }) })
+    it('opens on the count the server sent back', async () => {
+      eventEditorPage.render({ event: ownsQualifiers(3) })
 
-      expect(eventEditorPage.getQualifiersInput()).toHaveValue(3)
+      const row = await openQualifiersRow()
+      expect(row.getInput()).toHaveValue('3')
+    })
+
+    /**
+     * **A cut event refuses the row, and says why** — the defect chore 3c surfaced.
+     *
+     * The server freezes the configuration its draw was dealt from, and K is half of it
+     * for a two-stage event: a bracket cut for `P × K` and advanced at a different K has
+     * qualifiers with no slot to sit in, so the PATCH is a 409. `Set myself` seeds the box
+     * from the DERIVED count, which on a cut event is routinely not the stored one — so
+     * the click that looked harmless was the click that authored the refusal.
+     *
+     * The editor derives the freeze from the SAVED event (`qualifiersPerPoolFreeze`) and
+     * hands it to the tab; this is the wiring, and the row's own test pins what frozen
+     * looks like.
+     */
+    it('freezes the row once the draw is cut, with the reason the box points at', async () => {
+      eventEditorPage.render({
+        event: buildRrThenKoEvent({
+          qualifiersPerPool: 2,
+          drawOwnership: { ...everySettingAutomatic(), qualifiersMode: 'manual' },
+          fixtures: [buildFixture()],
+        }),
+      })
+
+      const row = await openQualifiersRow()
+      expect(row.getInput()).toBeDisabled()
+      expect(row.getAction()).toBeDisabled()
+      expect(row.describedNodeOf(row.getInput())).toHaveTextContent(
+        /qualifiers per pool is frozen/i,
+      )
     })
   })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -133,6 +133,126 @@ describe('EventEditor', () => {
     })
 
     /**
+     * ⚠️ **THE #1320 DEFECT, end to end: a count the SYSTEM owns must not block a create.**
+     *
+     * Chore 3e moved K onto the Draw structure tab, where an automatic setting renders its
+     * derived number as **text** — there is no box until the director clicks `Set myself`.
+     * The resolver went on requiring a typed count, so a director who authored an ordinary
+     * two-stage event was refused, client-side, with "Say how many players advance from
+     * each pool." pointing at a row they could not type into. That is the very shape of
+     * refusal #1320 was filed about, reissued by its own fix.
+     *
+     * The claim here is BOTH halves, because either alone passes against a broken client:
+     *
+     * - the create is not refused (`onSave` is reached, and no red is on the row), and
+     * - the body carries the **derived** count. The API's `rr-then-ko` arm requires
+     *   `qualifiers_per_pool`, so a create that sent nothing would be a 422 one layer
+     *   later; automatic means "send the derived one".
+     *
+     * Built the way a director builds it: an empty event, the two-stage format picked on
+     * Basics, two pool reservations added on Table pools — and the qualifiers row never
+     * touched. Two pools of a 32-player field derive `ceil(8 / 2)` = **4**, which is none
+     * of the numbers a bug lands on by accident: not the pool count, not the target
+     * bracket, not a floor of one.
+     */
+    it('creates a two-stage event whose count the system owns, and sends the derived number', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({
+        event: emptyEvent(buildTournament()),
+        onSave,
+      })
+
+      await userEvent.type(eventEditorPage.getNameInput(), 'Two-stage Singles')
+      await eventEditorPage.chooseDrawType('Round-robin then knockout')
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      await userEvent.click(eventEditorPage.getAddPoolButton())
+      await userEvent.click(eventEditorPage.getAddPoolButton())
+
+      // The row as the director leaves it: a derived number, badged the system's, with no
+      // box — which is what makes an imperative to type one unanswerable.
+      const row = await openQualifiersRow()
+      expect(row.getValue()).toHaveTextContent('4')
+      expect(row.getOwnershipBadge()).toHaveTextContent('Automatic')
+      expect(row.queryInput()).toBeNull()
+
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      // ⚠️ ONE wait, and the red is asked about FIRST on purpose. A refused create simply
+      // never calls `onSave`, so a wait on the spy alone reds with "number of calls: 0"
+      // after ten seconds — a timeout that cannot tell "the resolver refused it" from "the
+      // harness never got there" (`.claude/rules/verify-the-artifact-under-test.md`).
+      // Reading the row's text into the assertion makes the refusal name itself: the last
+      // error `waitFor` reports is the sentence the director was shown.
+      await waitFor(() => {
+        expect(row.queryError()?.textContent ?? null).toBeNull()
+        expect(onSave).toHaveBeenCalled()
+      })
+      expect(eventToCreateBody(onSave.mock.calls[0][0]).qualifiers_per_pool).toBe(4)
+    })
+
+    // …and the same hole on the SAVE of an event that already exists, which is reached one
+    // step differently: the count is `null` on the three arms with no knockout stage, so a
+    // director changing an existing round-robin event into a two-stage one has never had a
+    // count either — and the ownership record is still `null`, because only the Draw
+    // structure tab writes one.
+    it('saves an existing event switched to rr-then-ko, with the derived count', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({
+        event: buildEvent({
+          drawType: 'round-robin',
+          maxPlayers: 32,
+          pools: [
+            buildPool({ id: 'p-a', name: 'Pool A' }),
+            buildPool({ id: 'p-b', name: 'Pool B', position: 1 }),
+          ],
+        }),
+        onSave,
+      })
+
+      await eventEditorPage.chooseDrawType('Round-robin then knockout')
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      // The red first, for the reason the create above gives: a refused save is otherwise
+      // an unnamed "the spy was never called".
+      await waitFor(() => {
+        expect(
+          eventEditorPage.queryError(/Say how many players advance/)?.textContent ?? null,
+        ).toBeNull()
+        expect(onSave).toHaveBeenCalled()
+      })
+      expect(eventToUpdateBody(onSave.mock.calls[0][0]).qualifiers_per_pool).toBe(4)
+    })
+
+    /**
+     * ⚠️ **…and a count the event ALREADY has is sent back unchanged**, even when the
+     * derived one differs. The fix supplies a number that is missing; it does not
+     * re-configure a draw.
+     *
+     * This event's bracket was cut for the top 2 out of each pool while its two pools of a
+     * 32-player field derive 4. The server freezes the configuration a cut draw was dealt
+     * from and compares `qualifiers_per_pool` inside it, so a save of the event's *name*
+     * that quietly carried 4 would come back a 409 naming a count the director never
+     * touched — #1320's own bug, reintroduced by its fix.
+     */
+    it('sends the stored count for a CUT event whose qualifiers are automatic', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({
+        event: buildRrThenKoEvent({
+          qualifiersPerPool: 2,
+          fixtures: [buildFixture()],
+        }),
+        onSave,
+      })
+
+      await userEvent.type(eventEditorPage.getNameInput(), ' II')
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      expect(eventToUpdateBody(onSave.mock.calls[0][0]).qualifiers_per_pool).toBe(2)
+    })
+
+    /**
      * Refused HERE, so nothing was sent — `onSave` not called at all is the assertion that
      * separates "told the director" from "asked the server and read the answer out".
      *

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -512,6 +512,12 @@ describe('EventEditor', () => {
           manual_pool_count: 6,
         }),
       )
+      // ⚠️ **The rows travel with the number, in the same request.** The Save click is
+      // what blurs the box, so the count is written *during* that click — and
+      // `writePoolCount` fires two callbacks. A body carrying `manual_pool_count: 6` over
+      // two pools would be a count without its reservations, which is the one act ADR
+      // 20260808 forbids splitting.
+      expect(eventToUpdateBody(onSave.mock.calls[0][0]).pools).toHaveLength(6)
     })
 
     // The other half: what the server stored is what the director sees when they come
@@ -576,8 +582,8 @@ describe('EventEditor', () => {
         { target: { value } },
       )
 
-    /** …and this is the director saying they are done with it. A **lowered** count is
-     * priced here rather than on the keystroke — see the multi-digit spec below. */
+    /** …and this is the director saying they are done with it. **No count is written
+     * before it**, up or down — see the two multi-digit specs below. */
     const finishTypingPoolCount = () =>
       fireEvent.blur(eventEditorPage.drawStructure.setting('Pool count').getInput())
 
@@ -590,6 +596,7 @@ describe('EventEditor', () => {
         eventEditorPage.drawStructure.setting('Pool count').getAction(),
       )
       typePoolCount('5')
+      finishTypingPoolCount()
 
       await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
       // Named by continuing the sequence, and each new card is a real, editable pool —
@@ -680,6 +687,9 @@ describe('EventEditor', () => {
      * what happens *between* keystrokes, and a whole-value `fireEvent.change` cannot see
      * it — that spelling passes whether the confirm is priced on the keystroke or on the
      * commit.
+     *
+     * The number the director **finished** typing is then the one that lands, on the
+     * commit and in one act — which is why the tail asserts twelve cards and not one.
      */
     it('lets a director type a count whose first digit is a removal', async () => {
       const onSave = vi.fn().mockResolvedValue(undefined)
@@ -701,8 +711,88 @@ describe('EventEditor', () => {
       expect(
         eventEditorPage.drawStructure.setting('Pool count').getInput(),
       ).toHaveValue('12')
+
+      finishTypingPoolCount()
+
       await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
       expect(eventEditorPage.getPoolNameInputs()).toHaveLength(12)
+    })
+
+    /**
+     * ⚠️ **…and a count whose first digit RAISES must not mint its rows either.** Against
+     * two pools, `55` produces the value `5` first: written on that keystroke it creates
+     * three reservations, and the `55` then creates fifty more — so a director correcting
+     * the number back down is met by a confirm naming pools the app invented for them.
+     *
+     * Typed one character at a time, and read off the preview's `Pool reservations` fact
+     * rather than the Table pools cards: the fact counts the very list the cards render,
+     * and reading it needs no click, so the claim is about the state *between* keystrokes
+     * and not about what a blur then did.
+     */
+    it('creates no pool row for the first digit of a raised count', async () => {
+      eventEditorPage.render({ event: buildRrThenKoEvent() })
+      const poolReservations = () =>
+        eventEditorPage.drawStructure.preview.getFact('Pool reservations')
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      await userEvent.click(
+        eventEditorPage.drawStructure.setting('Pool count').getAction(),
+      )
+      await userEvent.clear(
+        eventEditorPage.drawStructure.setting('Pool count').getInput(),
+      )
+
+      await userEvent.type(
+        eventEditorPage.drawStructure.setting('Pool count').getInput(),
+        '5',
+      )
+      expect(poolReservations()).toHaveTextContent('2')
+
+      await userEvent.type(
+        eventEditorPage.drawStructure.setting('Pool count').getInput(),
+        '5',
+      )
+      expect(
+        eventEditorPage.drawStructure.setting('Pool count').getInput(),
+      ).toHaveValue('55')
+      expect(poolReservations()).toHaveTextContent('2')
+
+      finishTypingPoolCount()
+
+      expect(poolReservations()).toHaveTextContent('55')
+      expect(eventEditorPage.drawStructure.confirm.queryDialog()).toBeNull()
+    })
+
+    /**
+     * **A count the director never finished is discarded when they leave the tab** — and
+     * this is a *pinned* consequence of the commit, not an accident.
+     *
+     * A Radix tab switches on `mousedown`, so React unmounts the panel — box and all —
+     * before focus ever moves: no blur fires, and nothing is committed. The same has been
+     * true of a held *lowering* since the confirm was added, and it is what keeps the two
+     * directions one rule.
+     *
+     * ⚠️ It is also why an unmount-time flush would be wrong: a lowering cannot be priced
+     * from a panel that is gone, so flushing would write the raise and drop the removal —
+     * the very asymmetry this box no longer has. If that is ever reconsidered, this spec
+     * is the one that must be answered first.
+     */
+    it('discards a count the director never finished before leaving the tab', async () => {
+      eventEditorPage.render({ event: buildRrThenKoEvent() })
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      await userEvent.click(
+        eventEditorPage.drawStructure.setting('Pool count').getAction(),
+      )
+      typePoolCount('5')
+
+      await userEvent.click(eventEditorPage.getSectionTab('Table pools'))
+      expect(eventEditorPage.getPoolNameInputs()).toHaveLength(2)
+
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      expect(
+        eventEditorPage.drawStructure.setting('Pool count').getInput(),
+      ).toHaveValue('2')
     })
 
     /**

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.test.tsx
@@ -644,6 +644,192 @@ describe('EventEditor', () => {
   })
 
   /**
+   * **Leaving `rr-then-ko` asks first, but only when there is something to lose** (ADR
+   * 20260808 — "switching away from `rr-then-ko` can discard a director's work", priced as
+   * ADR 20260806 means the word).
+   *
+   * Only the editor can make these claims: the picker is on Basics, the settings it spends
+   * are on the Draw structure tab, and the pools it does *not* spend are on a third. A
+   * section-level test can see one of the three.
+   */
+  describe('changing the draw type away from rr-then-ko', () => {
+    /** A two-stage event whose director owns two settings — #1320's own example, six
+     * pools of five, over the fixture's two pool reservations. */
+    const ownsPoolCountAndSize = () =>
+      buildRrThenKoEvent({
+        drawOwnership: {
+          ...everySettingAutomatic(),
+          poolCountMode: 'manual',
+          manualPoolCount: 6,
+          poolSizeMode: 'manual',
+          manualPoolSize: 5,
+        },
+      })
+
+    /** The two-stage label, off the served catalogue (ADR 20260726) — the value the
+     * picker must go back to reading after a cancel. */
+    const TWO_STAGE_LABEL = 'Round-robin then knockout'
+
+    /**
+     * Nothing was the director's, so nothing is discarded and nothing is asked. The
+     * all-automatic record is what every event that has never opened the tab holds, so
+     * this is the ordinary path and it must stay silent — a confirm here would be the
+     * ceremony that trains a director to click through the one that matters.
+     */
+    it('switches silently while every setting is the system’s', async () => {
+      eventEditorPage.render({ event: buildRrThenKoEvent() })
+
+      await eventEditorPage.chooseDrawType('Round robin')
+
+      expect(eventEditorPage.confirm.queryDialog()).toBeNull()
+      expect(eventEditorPage.getDrawTypeTrigger()).toHaveTextContent('Round robin')
+      await waitFor(() =>
+        expect(eventEditorPage.querySectionTab('Draw structure')).toBeNull(),
+      )
+    })
+
+    /** …and a setting whose box the director **cleared** is the system's too: the tab
+     * badges it `Automatic`, so pricing it would name a loss they cannot see on screen. */
+    it('switches silently when a manual setting has an empty box', async () => {
+      eventEditorPage.render({
+        event: buildRrThenKoEvent({
+          drawOwnership: {
+            ...everySettingAutomatic(),
+            poolCountMode: 'manual',
+            manualPoolCount: null,
+          },
+        }),
+      })
+
+      await eventEditorPage.chooseDrawType('Round robin')
+
+      expect(eventEditorPage.confirm.queryDialog()).toBeNull()
+      expect(eventEditorPage.getDrawTypeTrigger()).toHaveTextContent('Round robin')
+    })
+
+    /** The confirm **names the settings**, with the numbers the director typed. A generic
+     * "you will lose your draw settings" is the warning this replaces. */
+    it('names the settings it is about to discard, before discarding them', async () => {
+      eventEditorPage.render({ event: ownsPoolCountAndSize() })
+
+      await eventEditorPage.chooseDrawType('Round robin')
+
+      const dialog = eventEditorPage.confirm.getDialog()
+      expect(dialog).toHaveTextContent('Discard these draw structure settings?')
+      expect(dialog).toHaveTextContent(
+        'hands Pool count (6) and Pool size (5) back to automatic',
+      )
+      // The pools are not the draw type's to spend, and the copy says so — the fixture
+      // has two reservations.
+      expect(dialog).toHaveTextContent(
+        'The 2 pools you booked stay exactly as they are.',
+      )
+    })
+
+    /** Membership is the director's choice too, and it is the one setting with no number
+     * — so a switch that only asked about numbers would drop it in silence. */
+    it('asks for a hand-dealt membership on its own', async () => {
+      eventEditorPage.render({
+        event: buildRrThenKoEvent({
+          drawOwnership: { ...everySettingAutomatic(), membershipMode: 'manual' },
+        }),
+      })
+
+      await eventEditorPage.chooseDrawType('Round robin')
+
+      expect(eventEditorPage.confirm.getDialog()).toHaveTextContent(
+        'hands Membership (Assign at cut time) back to automatic',
+      )
+    })
+
+    /**
+     * ⚠️ **Go back leaves the draw type and every setting exactly as they were.**
+     *
+     * Both halves are asserted, and the first is the bug this chore exists to avoid: a
+     * confirm that wrote the new draw type and offered to undo it leaves the picker
+     * reading `Round robin` while the event is still two-stage. It cannot happen here
+     * because nothing was written — the picker is controlled off the draft — and the
+     * second assertion is what proves the record survived with it.
+     */
+    it('leaves the picker and the settings alone when the switch is refused', async () => {
+      eventEditorPage.render({ event: ownsPoolCountAndSize() })
+
+      await eventEditorPage.chooseDrawType('Round robin')
+      eventEditorPage.confirm.cancel()
+
+      expect(eventEditorPage.getDrawTypeTrigger()).toHaveTextContent(TWO_STAGE_LABEL)
+      await userEvent.click(eventEditorPage.getSectionTab('Draw structure'))
+      const row = eventEditorPage.drawStructure.setting('Pool count')
+      expect(row.getOwnershipBadge()).toHaveTextContent('Yours')
+      expect(row.getInput()).toHaveValue('6')
+      expect(
+        eventEditorPage.drawStructure.setting('Pool size').getInput(),
+      ).toHaveValue('5')
+    })
+
+    /**
+     * The confirm path, proved by **coming back**: switch away, switch back, and the two
+     * settings are the system's again with no box to type in. A test that stopped at "the
+     * dialog closed and the tab went" would pass against a switch that kept the record.
+     */
+    it('discards the record once the switch is confirmed', async () => {
+      eventEditorPage.render({ event: ownsPoolCountAndSize() })
+
+      await eventEditorPage.chooseDrawType('Round robin')
+      eventEditorPage.confirm.confirm()
+
+      await waitFor(() =>
+        expect(eventEditorPage.querySectionTab('Draw structure')).toBeNull(),
+      )
+      expect(eventEditorPage.getDrawTypeTrigger()).toHaveTextContent('Round robin')
+
+      await eventEditorPage.chooseDrawType(TWO_STAGE_LABEL)
+      await userEvent.click(
+        await screen.findByRole('tab', { name: 'Draw structure' }),
+      )
+      const row = eventEditorPage.drawStructure.setting('Pool count')
+      expect(row.getOwnershipBadge()).toHaveTextContent('Automatic')
+      expect(row.queryInput()).toBeNull()
+    })
+
+    /**
+     * ⚠️ **The pools stay, and the request is where that claim is settled.** The confirm
+     * promises the reservations survive, so the body a save produces must still carry
+     * them — a pool is a venue booking as much as a group, and a pool restricts scheduling
+     * whatever the draw type (ADR 20260807).
+     */
+    it('sends the pools untouched, and no structure record, after the switch', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      eventEditorPage.render({ event: ownsPoolCountAndSize(), onSave })
+
+      await eventEditorPage.chooseDrawType('Round robin')
+      eventEditorPage.confirm.confirm()
+      await userEvent.click(eventEditorPage.getSaveButton())
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      const body = eventToUpdateBody(onSave.mock.calls[0][0])
+      expect(body.draw_type).toBe('round-robin')
+      expect(body.pools).toHaveLength(2)
+      // The record travels on the `rr-then-ko` arm and nowhere else, so a round-robin
+      // body carrying one would be a 422.
+      expect('draw_structure' in body).toBe(false)
+    })
+
+    /** A question nobody answered does not follow the editor to the next event. The
+     * editor stays mounted between opens, so this state is the editor's to clear. */
+    it('drops an unanswered confirm when the editor opens on another event', async () => {
+      const view = eventEditorPage.render({ event: ownsPoolCountAndSize() })
+
+      await eventEditorPage.chooseDrawType('Round robin')
+      expect(eventEditorPage.confirm.queryDialog()).not.toBeNull()
+
+      view.rerenderWith({ event: buildEvent({ name: 'Open Singles' }) })
+
+      expect(eventEditorPage.confirm.queryDialog()).toBeNull()
+    })
+  })
+
+  /**
    * A rule with no value is not a rule. It used to go to the server anyway — where
    * a scalar one was ACCEPTED (201) and came back onto the event card as the chip
    * `Rating < ?`, a restriction on nobody wearing the clothes of a real one, while a

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -229,6 +229,11 @@ export const EventEditor = ({
     // resolver judges `(drawType, rounds)` as one pair too, so a draw type set without its
     // round count would be validated against a stale R.
     form.setValue('rounds', next.rounds, opts)
+    // …and the ownership record with them (ADR 20260808), for the third time the same
+    // reason: it is part of the draw configuration the server parses as one union arm, and
+    // it is what the Draw structure tab writes through. A tab that kept its own state
+    // instead would be a second draft the save never read.
+    form.setValue('drawOwnership', next.drawOwnership, opts)
     form.setValue('maxPlayers', next.maxPlayers, opts)
     form.setValue('entryFee', next.entryFee, opts)
     form.setValue('timezone', next.timezone, opts)
@@ -403,6 +408,8 @@ export const EventEditor = ({
                 <TabsContent value="draw-structure">
                   <DrawStructureSection
                     event={draft}
+                    canEdit={canEdit}
+                    onChange={applyChange}
                     onGoToBasics={() => setSection('basics')}
                   />
                 </TabsContent>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -32,6 +32,7 @@ import {
 import type {
   DrawTypeOption,
   EditedEvent,
+  PoolEntry,
   TournamentEvent,
   TournamentTable,
 } from '../data/types'
@@ -246,6 +247,25 @@ export const EventEditor = ({
     form.setValue('match', next.match, opts)
   }
 
+  /**
+   * Write the **pool list** back — the one field `applyChange` above cannot carry.
+   *
+   * `TournamentEvent.pools` is the read model's `Pool[]`, while the form holds the
+   * organizer's `PoolEntry[]` diff (ADR 20260801), so the pools travel on a channel of
+   * their own rather than riding a bridged draft that would have to lie about their type.
+   *
+   * It writes the **same `pools` field the Table pools tab drives** through its
+   * `useFieldArray` — RHF's `setValue` on a field-array name republishes the array, so the
+   * cards over there re-render from this list. That is what makes the two tabs one list:
+   * the Draw structure tab's pool count and the Table pools tab's cards cannot report
+   * different numbers, because there is only one number (ADR 20260808).
+   */
+  const applyPoolsChange = (pools: PoolEntry[]) =>
+    form.setValue('pools', pools, {
+      shouldDirty: true,
+      shouldValidate: isSubmitted,
+    })
+
   const submit = form.handleSubmit(
     async (formValues) => {
       if (!event) return
@@ -422,10 +442,19 @@ export const EventEditor = ({
                 <TabsContent value="draw-structure">
                   <DrawStructureSection
                     event={draft}
+                    // The pool ENTRIES, off the same watch the pool-name reds read — not
+                    // `draft.pools`, which is typed as the read model's rows and is these
+                    // entries at runtime. This tab now writes the list, so it is given the
+                    // shape it writes.
+                    pools={watchedPools ?? []}
                     canEdit={canEdit}
                     errors={drawStructureErrors}
                     qualifiersFreeze={qualifiersLock}
+                    // The SAME freeze the Table pools tab is given, threaded to the second
+                    // control that can now change the pool set (a typed pool count).
+                    poolSetFreeze={poolsFreeze}
                     onChange={applyChange}
+                    onPoolsChange={applyPoolsChange}
                     onGoToBasics={() => setSection('basics')}
                   />
                 </TabsContent>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -21,6 +21,10 @@ import {
   qualifiersPerPoolFreeze,
   type EditFreeze,
 } from '../data/draw'
+import {
+  ownedStructureSettings,
+  type OwnedStructureSetting,
+} from '../data/draw-ownership'
 import { poolNameIssues } from '../data/event-validation'
 import { eligibilityIssues } from '../data/predicate-validation'
 import {
@@ -36,6 +40,10 @@ import type {
   TournamentEvent,
   TournamentTable,
 } from '../data/types'
+import {
+  ConfirmIrreversibleActDialog,
+  type DrawStructureActConsequence,
+} from './confirm-irreversible-act-dialog'
 import { BasicsSection } from './event-editor/basics-section'
 import { DrawStructureSection } from './event-editor/draw-structure-section'
 import { EligibilitySection } from './event-editor/eligibility-section'
@@ -109,6 +117,11 @@ const SECTIONS = [
  * cannot hold would invite a director to configure a draw their event will never cut. */
 const DRAW_STRUCTURE_SECTION = { value: 'draw-structure', label: 'Draw structure' }
 
+/** What an event with no name yet is called — in the sheet's own title, and in the one
+ * dialog whose sentence names the event. One name for one thing: a director reading
+ * "Untitled event" in the header must read the same two words in the confirm. */
+const UNTITLED_EVENT = 'Untitled event'
+
 /** The slide-in event editor — a side sheet with four sections (Basics,
  * Eligibility, Match settings, Table pools) over ONE React-Hook-Form draft. The form
  * is the single source of truth: the scalar Basics/Match fields write back through
@@ -153,6 +166,21 @@ export const EventEditor = ({
   /** How the last save was refused, or `null`. A classified failure — never a raw
    * server string (see `data/save-failure`). Never a reason to close. */
   const [failure, setFailure] = useState<SaveFailure | null>(null)
+  /**
+   * The **draw-type change awaiting its answer**: the whole edited event the picker asked
+   * for, and the settings that answer would discard. `null` whenever no dialog is up.
+   *
+   * The edit is held rather than applied, which is the entire cancel path: the form still
+   * holds `rr-then-ko`, and the picker is controlled off it, so Go back leaves the select
+   * reading the two-stage format without anything having to put it back. A version that
+   * wrote first and reverted on cancel would look identical for one frame and be wrong in
+   * every way that matters — the tab would flicker away, and a `Set myself` in flight would
+   * be gone.
+   */
+  const [pendingDrawType, setPendingDrawType] = useState<{
+    next: TournamentEvent
+    settings: OwnedStructureSetting[]
+  } | null>(null)
 
   const form = useForm<EventFormValues>({
     resolver: zodResolver(eventSchema),
@@ -167,6 +195,10 @@ export const EventEditor = ({
     setSection('basics')
     // A fresh event starts clean: last time's red belongs to last time's draft.
     setFailure(null)
+    // …and so does last time's unanswered question. Unlike the pool-count confirm one tab
+    // over, this state is the EDITOR's, and the editor is not unmounted between events —
+    // left standing it would price a draw-type change on an event nobody just edited.
+    setPendingDrawType(null)
   }
 
   // Re-seed the form to the new event's values (and clear any prior errors). The
@@ -218,7 +250,7 @@ export const EventEditor = ({
   const watchedPools = useWatch({ control: form.control, name: 'pools' })
   const poolIssues = poolNameIssues(watchedPools ?? [])
 
-  const applyChange = (next: TournamentEvent) => {
+  const writeChange = (next: TournamentEvent) => {
     // Don't validate until the user has tried to save once — otherwise a new
     // event (whose name starts empty) would flash "required" on the first
     // keystroke in any field. After a rejected submit, re-validate live so the
@@ -245,6 +277,41 @@ export const EventEditor = ({
     form.setValue('timezone', next.timezone, opts)
     form.setValue('slot', next.slot, opts)
     form.setValue('match', next.match, opts)
+  }
+
+  /**
+   * Every scalar edit any tab makes, and the one place a **draw-type change is priced**.
+   *
+   * Leaving `rr-then-ko` leaves the pool stage the structural settings shape, so the
+   * ownership record goes with it (ADR 20260808). Two paths, decided by whether the
+   * director owns anything at all:
+   *
+   * - **Nothing is theirs** — every mode automatic, or manual with an empty box, which the
+   *   tab already badges `Automatic`. The switch is silent, and the record is left exactly
+   *   as it is: nothing was discarded, so nothing is written. A dormant record never
+   *   reaches the wire — `drawSettingsToApi` sends `draw_structure` on the `rr-then-ko` arm
+   *   and nowhere else — and leaving it alone is what keeps a number remembered under
+   *   `Use automatic` remembered.
+   * - **Something is theirs** — the edit is held and the confirm names it. This is the
+   *   confirm ADR 20260806 describes: it prices the act, in the settings' own values, and
+   *   it is asked BEFORE anything is written.
+   *
+   * The comparison is against the **draft**, not the saved event: a director who picked
+   * `rr-then-ko` this session, took the pool count, and then changed their mind again is
+   * losing the same work as one who saved it last week.
+   */
+  const applyChange = (next: TournamentEvent) => {
+    if (draft && draft.drawType === 'rr-then-ko' && next.drawType !== 'rr-then-ko') {
+      const settings = ownedStructureSettings(
+        draft.drawOwnership,
+        draft.qualifiersPerPool,
+      )
+      if (settings.length > 0) {
+        setPendingDrawType({ next, settings })
+        return
+      }
+    }
+    writeChange(next)
   }
 
   /**
@@ -350,7 +417,16 @@ export const EventEditor = ({
     : 'basics'
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
+    <Sheet
+      open={open}
+      onOpenChange={(next) => {
+        // A closed sheet holds no unanswered question. The editor stays mounted between
+        // opens, so a confirm left standing here would greet the next director with the
+        // price of a change the last one walked away from.
+        if (!next) setPendingDrawType(null)
+        onOpenChange(next)
+      }}
+    >
       <SheetContent
         side="right"
         className="w-full gap-0 p-0 sm:w-[820px] sm:max-w-[820px]"
@@ -363,7 +439,7 @@ export const EventEditor = ({
             {overline}
           </SheetDescription>
           <SheetTitle className="truncate text-[20px]">
-            {draft?.name || 'Untitled event'}
+            {draft?.name || UNTITLED_EVENT}
           </SheetTitle>
         </SheetHeader>
 
@@ -461,6 +537,37 @@ export const EventEditor = ({
               )}
             </Tabs>
           </div>
+        )}
+
+        {/* The price of leaving `rr-then-ko`, asked before anything is written: the form
+            still holds the two-stage draw type and the whole ownership record, so Go back
+            — or Escape — leaves the picker and all four settings exactly as they were.
+            Rendered only while an act is awaiting its answer. */}
+        {pendingDrawType && draft && (
+          <ConfirmIrreversibleActDialog
+            open
+            consequence={
+              {
+                variant: 'discard-draw-structure',
+                eventName: draft.name || UNTITLED_EVENT,
+                settings: pendingDrawType.settings,
+                // The pools the switch does NOT touch, off the same watched list the Table
+                // pools tab edits — so the sentence counts the draft's rows rather than the
+                // ones the event was loaded with.
+                poolReservationCount: (watchedPools ?? []).length,
+              } satisfies DrawStructureActConsequence
+            }
+            onConfirm={() => {
+              // The switch, and the reset the confirm bought — in one write, so the form
+              // can never hold a draw type with no pool stage beside a record of who owns
+              // it. `null` is what every other pool-stage-less draw type carries
+              // (`EMPTY_FORM_VALUES`), and it is what `drawSettingsToApi` would drop
+              // anyway; the point is that coming back to `rr-then-ko` starts clean.
+              writeChange({ ...pendingDrawType.next, drawOwnership: null })
+              setPendingDrawType(null)
+            }}
+            onCancel={() => setPendingDrawType(null)}
+          />
         )}
 
         {/* The refusal, where the work is. An `Alert` rather than a toast on

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -53,6 +53,7 @@ import {
   eventSchema,
   eventToFormValues,
   firstInvalidSection,
+  withSuppliedQualifiers,
   type EventFormValues,
 } from './event-form'
 
@@ -341,7 +342,14 @@ export const EventEditor = ({
       // `TournamentEvent`: the form holds entries, and an entry is not a pool. Handing
       // the read model's pools back instead would re-send the ids on a create (a 422) and
       // lose the added/kept distinction on a patch.
-      const saved: EditedEvent = { ...event, ...formValues }
+      //
+      // …and with the **qualifier count the system owes** filled in
+      // (`withSuppliedQualifiers`, `./event-form`). An `rr-then-ko` event must carry a K,
+      // the resolver deliberately asks the director for one only when they own the setting,
+      // and this is what closes that pair: automatic means the derived count goes on the
+      // wire, not that nothing does. The two halves live in one module so neither can be
+      // changed without the other in view.
+      const saved: EditedEvent = { ...event, ...withSuppliedQualifiers(formValues) }
       setFailure(null)
       try {
         await onSave(saved)

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor.tsx
@@ -15,7 +15,12 @@ import {
 } from '@/components/ui/sheet'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
-import { drawTypeFreeze, poolSetFreeze, type EditFreeze } from '../data/draw'
+import {
+  drawTypeFreeze,
+  poolSetFreeze,
+  qualifiersPerPoolFreeze,
+  type EditFreeze,
+} from '../data/draw'
 import { poolNameIssues } from '../data/event-validation'
 import { eligibilityIssues } from '../data/predicate-validation'
 import {
@@ -274,11 +279,17 @@ export const EventEditor = ({
 
   const basicsErrors = {
     name: errors.name?.message,
-    qualifiersPerPool: errors.qualifiersPerPool?.message,
     rounds: errors.rounds?.message,
     maxPlayers: errors.maxPlayers?.message,
     entryFee: errors.entryFee?.message,
     timezone: errors.timezone?.message,
+  }
+
+  // …and the qualifier count's red, on the tab the count now lives on (chore 3e). It is
+  // the same `errors` object read one field over — the resolver has one verdict, and the
+  // tab that holds the box is the tab that shows it.
+  const drawStructureErrors = {
+    qualifiersPerPool: errors.qualifiersPerPool?.message,
   }
 
   // **What a cut draw freezes** (ADR-0786), derived from the SAVED event and never from
@@ -287,13 +298,16 @@ export const EventEditor = ({
   // still being created (`event === null`) has no draw, and cannot: there is nobody
   // entered to deal.
   //
-  // Two freezes, two controls, two different tabs — so they are two values, not one
-  // `frozen: boolean` handed to both. The pools section may not add or remove a pool;
-  // the Basics tab may not re-label the draw type. Everything else on both tabs stays
-  // live, including — pointedly — a pool's tables, window and name.
+  // THREE freezes, three controls, three different tabs — so they are three values, not
+  // one `frozen: boolean` handed to all of them. The pools section may not add or remove a
+  // pool; the Basics tab may not re-label the draw type; the Draw structure tab may not
+  // move the qualifier count the bracket was cut for. Everything else on all three tabs
+  // stays live, including — pointedly — a pool's tables, window and name, and the other
+  // three structural settings, whose ownership the server excludes from its own freeze.
   const OPEN: EditFreeze = { kind: 'open' }
   const poolsFreeze = event ? poolSetFreeze(event) : OPEN
   const drawTypeLock = event ? drawTypeFreeze(event, drawTypes) : OPEN
+  const qualifiersLock = event ? qualifiersPerPoolFreeze(event) : OPEN
 
   // ⚠️ Keyed off the **draft's** draw type, not the saved event's. The Basics picker
   // writes the draft, so the tab appears the moment a director picks the two-stage
@@ -304,12 +318,12 @@ export const EventEditor = ({
     ? [...SECTIONS, DRAW_STRUCTURE_SECTION]
     : SECTIONS
   // …and that disappearance is why the active tab is DERIVED rather than read straight
-  // out of state. A `Tabs` whose `value` matches no trigger renders no panel at all —
-  // a blank sheet with nothing selected. Today nothing reaches that: the draw-type
-  // picker is on Basics, so a director necessarily leaves this tab before they can
-  // remove it. It is three lines of insurance against the next thing that sets the
-  // section (chore 3e moves a field onto this tab, and a refused save jumps to the tab
-  // holding it). Adjusted at render, never in an effect — the render already knows
+  // out of state. A `Tabs` whose `value` matches no trigger renders no panel at all — a
+  // blank sheet with nothing selected. Two things now set the section, and the second one
+  // is why this is not merely insurance: the draw-type picker (on Basics, so a director
+  // necessarily leaves this tab before they can remove it), and a REFUSED SAVE, which
+  // since chore 3e jumps to `draw-structure` for a bad qualifier count. Adjusted at
+  // render, never in an effect — the render already knows
   // (https://react.dev/learn/you-might-not-need-an-effect).
   const activeSection = sections.some((s) => s.value === section)
     ? section
@@ -409,6 +423,8 @@ export const EventEditor = ({
                   <DrawStructureSection
                     event={draft}
                     canEdit={canEdit}
+                    errors={drawStructureErrors}
+                    qualifiersFreeze={qualifiersLock}
                     onChange={applyChange}
                     onGoToBasics={() => setSection('basics')}
                   />

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.page.tsx
@@ -21,23 +21,23 @@ const scoped = (container: Container) => ({
   getEntryFeeInput() {
     return container.getByLabelText(/Entry fee/)
   },
-  /** **K** — the qualifier-count box, which exists only for an `rr-then-ko` event
-   * (ADR 20260727). `get` for the case that expects it. */
-  getQualifiersInput() {
-    return container.getByLabelText(/Qualifiers per pool/)
-  },
-  /** …and the `query` twin, because "this control is NOT on screen" is the claim for
-   * every other draw type: a qualifier count is not a blank field a round-robin event
-   * has, it is a question that format does not ask. Asked by LABEL rather than by
-   * `getFormElements().length`, so it discriminates "the row is absent" from "some other
-   * row went missing too". */
-  queryQualifiersInput() {
+  /** **K** — kept as a `query` and nothing else, because the only claim this tab has left
+   * to make about the qualifier count is that it is **not here** (chore 3e). It moved to
+   * the Draw structure tab, and a box that came back would be a second control writing one
+   * field: the two would disagree the moment either changed.
+   *
+   * Asked by LABEL, and by the WHOLE row rather than by `getFormElements().length`, so it
+   * discriminates "the qualifier count is gone" from "some other row went missing too".
+   * There is deliberately no `get` twin: no test on this tab should be able to demand it. */
+  queryQualifiersControl() {
     return container.queryByLabelText(/Qualifiers per pool/)
   },
-  /** The qualifier count as a **reader** sees it — the `Field` read-only branch's value
-   * under its label (ADR 0015). Use `queryQualifiersInput` for the "row absent" claim. */
-  getQualifiersValue() {
-    return fieldPage.within(container).getFieldValue('Qualifiers per pool')
+  /** …and the same claim one level out, which is the one a READER needs: a read-only row
+   * has no control to query for, only a label and a value (ADR 0015), so "the control is
+   * gone" would pass on a row that is still there in text. The LABEL is what both branches
+   * of the row share. */
+  queryQualifiersRow() {
+    return container.queryByText('Qualifiers per pool', { selector: 'label' })
   },
   /** **R** — the round-count box, which exists only for a `swiss` event (the swiss ADR).
    * `get` for the case that expects it. */

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.test.tsx
@@ -237,147 +237,45 @@ describe('BasicsSection', () => {
   })
 
   /**
-   * **K** — the qualifier count (ADR 20260727). Its whole design is that it belongs to
-   * the `(draw_type, K)` PAIR and not to the event: the server parses the two into a
-   * union tagged by the draw type, whose `rr-then-ko` arm requires a count and whose
-   * other two arms are `extra="forbid"` and refuse the key outright.
+   * **K left this tab** (chore 3e, ADR 20260808). The qualifier count is a *structural*
+   * setting, and the other three structural settings live together on the Draw structure
+   * tab — with a derivation behind them, an ownership badge, and a cut-draw freeze of
+   * their own. Its behaviour is pinned there now (`draw-structure-section.test.tsx`), so
+   * what is left for this tab to say is that the box did not stay behind.
    *
-   * So the claim worth pinning is not "there is a number box" — it is that the box is
-   * **on screen for exactly one draw type**, and absent (not disabled, not em-dashed) for
-   * the rest. A control rendered unconditionally would invite a director to answer a
-   * question their event cannot hold the answer to, and would author a 422.
+   * It is worth a test rather than an absence, because a second control over one field is
+   * exactly the state the move ended: for one slice both tabs rendered a box for K, and
+   * the Basics one showed the stored count while the other showed the derived one. Two
+   * boxes disagreeing about one number is worse than either box alone.
    */
-  describe('the qualifier count (rr-then-ko only)', () => {
-    it('renders the control for a two-stage event', () => {
-      basicsSectionPage.render({ event: buildRrThenKoEvent({ qualifiersPerPool: 2 }) })
+  describe('the qualifier count, which is not on this tab', () => {
+    it.each([
+      ['rr-then-ko', () => buildRrThenKoEvent({ qualifiersPerPool: 2 })],
+      ['round-robin', () => buildEvent({ drawType: 'round-robin' })],
+    ] as const)('renders no box for it — %s', (_drawType, build) => {
+      basicsSectionPage.render({ event: build() })
 
-      expect(basicsSectionPage.getQualifiersInput()).toHaveValue(2)
+      expect(basicsSectionPage.queryQualifiersControl()).toBeNull()
+      expect(basicsSectionPage.queryQualifiersRow()).toBeNull()
+      // …and the rest of the tab is untouched, so this is "one row moved out" rather than
+      // "the section failed to render".
+      expect(basicsSectionPage.getNameInput()).toBeInTheDocument()
+      expect(basicsSectionPage.getDrawTypeTrigger()).toBeInTheDocument()
     })
 
-    // The falsification for the conditional: render it unconditionally and these red.
-    it.each(['round-robin', 'single-elim'] as const)(
-      'does not render it at all for %s — a format with no knockout stage to qualify for',
-      (drawType) => {
-        basicsSectionPage.render({
-          event: buildEvent({ drawType, qualifiersPerPool: null }),
-        })
-
-        expect(basicsSectionPage.queryQualifiersInput()).toBeNull()
-        // …and the rest of the tab is untouched, so this is "one row is absent" rather
-        // than "the section failed to render".
-        expect(basicsSectionPage.getNameInput()).toBeInTheDocument()
-        expect(basicsSectionPage.getDrawTypeTrigger()).toBeInTheDocument()
-      },
-    )
-
-    // Switching the picker is what a director actually does, and the row has to follow
-    // the DRAFT they are building, not the event as it was loaded. (The editor bridges
-    // live form state into `event`, so this is the same value that reaches the section;
-    // the picker-driven version of this claim is in `event-editor.test.tsx`.)
-    //
-    // ⚠️ `rerenderWith`, never a second `render`: Testing Library APPENDS a second tree
-    // rather than replacing the first, and `screen` spans the whole body — so a second
-    // `render` leaves the old rr-then-ko section mounted and "the control is gone" fails
-    // against a component that unmounts it correctly. Measured while writing this: two
-    // renders → 2 `basics-section` roots and the stale input still found; one
-    // `rerenderWith` → 1 root and 0 inputs.
-    it('appears and disappears with the draw type the director picks', () => {
-      const { rerenderWith } = basicsSectionPage.render({
-        event: buildRrThenKoEvent({ qualifiersPerPool: 2 }),
-      })
-      expect(basicsSectionPage.getQualifiersInput()).toBeInTheDocument()
-
-      rerenderWith({
-        event: buildRrThenKoEvent({ drawType: 'round-robin', qualifiersPerPool: null }),
-      })
-
-      expect(basicsSectionPage.queryQualifiersInput()).toBeNull()
-      // One tree, so the absence above is a real unmount and not a query that missed.
-      expect(screen.getAllByTestId('basics-section')).toHaveLength(1)
-    })
-
-    it('emits the typed count', () => {
-      const onChange = vi.fn()
+    // A reader's rows are values, not controls (ADR 0015), so "no box" is only half the
+    // claim: a read-only row left behind here would still print the count under a label
+    // on a tab that no longer owns it.
+    it('leaves no read-only row behind for a reader either', () => {
       basicsSectionPage.render({
         event: buildRrThenKoEvent({ qualifiersPerPool: 2 }),
-        onChange,
+        canEdit: false,
       })
 
-      fireEvent.change(basicsSectionPage.getQualifiersInput(), {
-        target: { value: '3' },
-      })
-
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({ qualifiersPerPool: 3 }),
-      )
-    })
-
-    // Blank is **missing**, not zero — `Number('')` is `0`, and a bracket nobody advances
-    // into is not what an emptied box means. The resolver turns the `null` into the
-    // required error; a `0` would sail past a "did they answer?" check and be refused
-    // later, by the server, in Pydantic's words.
-    it('emits null — never 0 — when the box is cleared', () => {
-      const onChange = vi.fn()
-      basicsSectionPage.render({
-        event: buildRrThenKoEvent({ qualifiersPerPool: 2 }),
-        onChange,
-      })
-
-      fireEvent.change(basicsSectionPage.getQualifiersInput(), {
-        target: { value: '' },
-      })
-
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({ qualifiersPerPool: null }),
-      )
-    })
-
-    it('prints the form’s message under the box, and marks it invalid', () => {
-      basicsSectionPage.render({
-        event: buildRrThenKoEvent(),
-        errors: {
-          qualifiersPerPool: 'At least 1 player must advance from each pool.',
-        },
-      })
-
-      expect(basicsSectionPage.getQualifiersInput()).toHaveAttribute(
-        'aria-invalid',
-        'true',
-      )
-      expect(
-        basicsSectionPage.queryFieldError(
-          'At least 1 player must advance from each pool.',
-        ),
-      ).toBeInTheDocument()
-    })
-
-    // The count rides the SAME freeze as the draw type, because on the server it is the
-    // same guard: `_enforce_draw_settings_frozen` compares the whole configuration, since
-    // a bracket cut for `P × K` is exactly as contradicted by a changed K as by a changed
-    // type. A live box here would author a 409.
-    it('freezes with the draw type once the draw is cut, pointing at the reason', () => {
-      basicsSectionPage.render({
-        event: buildRrThenKoEvent({
-          fixtures: buildDrawnEvent().fixtures,
-        }),
-      })
-
-      const input = basicsSectionPage.getQualifiersInput()
-      expect(input).toBeDisabled()
-      const describedBy = input.getAttribute('aria-describedby')
-      expect(describedBy).toBeTruthy()
-      expect(document.getElementById(describedBy!)).toHaveTextContent(
-        /Delete the draw/i,
-      )
-    })
-
-    it('leaves it live, with its hint, when no draw is cut', () => {
-      basicsSectionPage.render({ event: buildRrThenKoEvent() })
-
-      expect(basicsSectionPage.getQualifiersInput()).toBeEnabled()
-      expect(
-        basicsSectionPage.queryFieldError(/advance to the knockout stage/i),
-      ).toBeInTheDocument()
+      expect(basicsSectionPage.queryQualifiersRow()).toBeNull()
+      // The tab still renders its own read-only rows, so the absence above is the row and
+      // not the view.
+      expect(basicsSectionPage.getFieldValue('Draw type')).toBeInTheDocument()
     })
   })
 
@@ -724,11 +622,10 @@ describe('BasicsSection', () => {
       expect(basicsSectionPage.getFormElements()).toHaveLength(0)
     })
 
-    // …and the same sweep over the ONE draw type that renders an extra row. The default
-    // fixture is round-robin, whose qualifier-count row is not rendered at all — so the
-    // guard above passes whether or not that row honours `readOnly`, and a live
-    // `<input type=number>` (a `spinbutton`, invisible to a role-only sweep) could ship
-    // behind it. The DOM sweep over a two-stage event is what actually covers it.
+    // …and the same sweep over a two-stage event. It no longer renders an extra row —
+    // the qualifier count moved to the Draw structure tab (chore 3e) — so this is now
+    // the pin that the move left nothing live behind: with a box still here, the DOM
+    // sweep finds a `spinbutton` a role-only sweep would not.
     it('renders no interactive controls for a two-stage event either', () => {
       basicsSectionPage.render({
         event: buildRrThenKoEvent({ qualifiersPerPool: 2 }),
@@ -736,16 +633,12 @@ describe('BasicsSection', () => {
       })
 
       expect(basicsSectionPage.getFormElements()).toHaveLength(0)
-      expect(basicsSectionPage.queryQualifiersInput()).toBeNull()
-      // The value is still THERE — a viewer reads the count, they just cannot type it.
-      // (`Field` requires a `value` beside `readOnly` precisely so a row cannot vanish
-      // into an em-dash and be mistaken for one the organizer left blank.)
-      expect(basicsSectionPage.getQualifiersValue()).toHaveTextContent('2')
+      expect(basicsSectionPage.queryQualifiersRow()).toBeNull()
     })
 
-    // …and the same sweep over the OTHER draw type that renders an extra row. The two
-    // guards above are both blind to it: the default fixture is round-robin and the
-    // two-stage one renders the qualifier count, so neither ever mounts the swiss branch —
+    // …and the same sweep over the ONE draw type that still renders an extra row here.
+    // The two guards above are both blind to it: the default fixture is round-robin and
+    // the two-stage one has no extra row left, so neither ever mounts the swiss branch —
     // and a live `<input type=number>` there is a `spinbutton`, which a role-only sweep
     // does not see at all (`web-client/CLAUDE.md`). The DOM sweep over a swiss event is
     // what actually covers it.

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/basics-section.tsx
@@ -4,8 +4,6 @@ import type { EditFreeze } from '../../data/draw'
 import {
   ENTRY_FEE_MAX,
   PLAYERS_MAX,
-  QUALIFIERS_PER_POOL_MAX,
-  QUALIFIERS_PER_POOL_MIN,
   SWISS_ROUNDS_MAX,
   SWISS_ROUNDS_MIN,
 } from '../../data/event-validation'
@@ -28,10 +26,6 @@ import { TimezoneSelect } from './timezone-select'
  * drops the hint slot in its read-only branch (ADR 0015). */
 export interface BasicsFieldErrors {
   name?: string
-  /** The qualifier count's inline red — only ever present for an `rr-then-ko` event,
-   * since that is the only draw type the resolver asks the question of (and the only one
-   * whose control is on screen). */
-  qualifiersPerPool?: string
   /** The round count's inline red — only ever present for a `swiss` event, since that is
    * the only draw type the resolver asks the question of (and the only one whose control
    * is on screen). */
@@ -90,14 +84,16 @@ const numericValue = (n: number | null): number | null =>
   n === null || Number.isNaN(n) ? null : n
 
 /**
- * One **draw setting** the director types a number into — `rr-then-ko`'s qualifiers per
- * pool (K) and swiss's round count (R) are the same row, twice.
+ * One **draw setting** the director types a number into — today only swiss's round count
+ * (R). `rr-then-ko`'s qualifiers per pool (K) used to be its second call site, and moved
+ * to the Draw structure tab in chore 3e: K is a *structural* setting, and the other three
+ * structural settings live together there (ADR 20260808).
  *
- * They are the same row because they are the same *kind of fact*: a number the chosen draw
+ * **The component stays, with one caller.** It is the shape of "a number the chosen draw
  * type asks for, that the planner deals the fixtures by, and that the server freezes the
- * moment a draw exists. Written out twice, they were two places to get the same freeze
- * wiring right — and this tab has already got that wiring wrong once: its draw-type select
- * carried the freeze while describing nothing. So the mechanics live here, once:
+ * moment a draw exists" — and this tab has got that wiring wrong once already: its
+ * draw-type select carried the freeze while describing nothing. Inlining it back into the
+ * one row would put those mechanics somewhere they read as incidental:
  *
  * - **The freeze is the draw type's** (`drawTypeFreeze`, `data/draw`), because on the server
  *   it is the same guard: `_enforce_draw_settings_frozen` compares the whole configuration,
@@ -294,40 +290,23 @@ export const BasicsSection = ({
             />
           )}
         </Field>
-        {/* **K**, and only for the one draw type that has a knockout stage to qualify
-            for (ADR 20260727). Not disabled, not em-dashed — ABSENT: a qualifier count
-            is not a field a round-robin event leaves blank, it is a question that format
-            does not ask, and the server says the same thing by refusing the key outright
-            on that arm of its draw-settings union (`extra="forbid"` — a 422, not a
-            silently dropped value). A control that stayed on screen would invite a
-            director to answer a question whose answer their event cannot hold.
+        {/* ⚠️ **The qualifier count is NOT here** (chore 3e). It is a structural setting,
+            so it sits with the other three on the Draw structure tab — the fifth tab, and
+            the only one that has the derivation, the ownership badge and the cut-draw
+            freeze that a two-stage draw's numbers need. This tab keeps the draw TYPE, the
+            player limit and the swiss round count, and a box for K here would be a second
+            control writing one field.
 
-            The freeze, the advisory bounds and the blank-is-null handling are
-            `DrawSettingField`'s — this row says only what is true of K. */}
-        {event.drawType === 'rr-then-ko' && (
-          <DrawSettingField
-            label="Qualifiers per pool"
-            value={event.qualifiersPerPool}
-            min={QUALIFIERS_PER_POOL_MIN}
-            max={QUALIFIERS_PER_POOL_MAX}
-            hint="How many of each pool’s finishers advance to the knockout stage."
-            error={errors.qualifiersPerPool}
-            freeze={drawTypeFreeze}
-            readOnly={readOnly}
-            onChange={(qualifiersPerPool) => set({ qualifiersPerPool })}
-          />
-        )}
-        {/* **R**, and only for the one draw type whose round count anybody chooses (ADR
+            **R**, and only for the one draw type whose round count anybody chooses (ADR
             "swiss pre-cuts every round and pairs each one on advance"). Absent for the
-            other three, exactly as the qualifier count above is absent for theirs, and for
-            the same reason: a round-robin's rounds are dealt by the circle method and a
+            other three: a round-robin's rounds are dealt by the circle method and a
             bracket's depth follows from the field, so this is not a box those formats leave
             blank — it is a question they do not ask. The server says the same thing by
             refusing the key outright on their arms of the draw-settings union
             (`extra="forbid"` — a 422, not a silently dropped value).
 
             Everything else about the row — the freeze it rides, its advisory bounds, its
-            blank-is-null handling — is `DrawSettingField`'s, shared with K above. */}
+            blank-is-null handling — is `DrawSettingField`'s. */}
         {event.drawType === 'swiss' && (
           <DrawSettingField
             label="Rounds"

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.factory.tsx
@@ -45,6 +45,11 @@ export function buildDrawStructureSectionProps(
   return {
     event: buildDrawStructureEvent(),
     canEdit: true,
+    // **Open by default, and stated rather than defaulted in the component**: the "Nothing
+    // set" event has no draw, so the qualifier count is a setting a director may still
+    // move. The freeze test asks for the other state explicitly, which is what makes "a
+    // cut event refuses the row" a claim a test makes rather than one it inherits.
+    qualifiersFreeze: { kind: 'open' },
     onChange: () => {},
     onGoToBasics: () => {},
     ...overrides,

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.factory.tsx
@@ -1,5 +1,6 @@
 import { buildPool, buildRrThenKoEvent } from '../../data/seed.factory'
 import { poolLetter } from '../../data/draw-structure'
+import { keepPools } from '../../data/pool-entries'
 import type { TournamentEvent } from '../../data/types'
 import type { DrawStructureSectionProps } from './draw-structure-section'
 
@@ -42,15 +43,26 @@ export function buildDrawStructureEvent(
 export function buildDrawStructureSectionProps(
   overrides: Partial<DrawStructureSectionProps> = {},
 ): DrawStructureSectionProps {
+  // ONE list of pools, cited as the form would hold it. ⚠️ Derived from the event's own
+  // rows rather than built beside them: an event with four pools and a `pools` prop holding
+  // three is the very drift ADR 20260808 exists to remove, and a test given both could pin
+  // `4 pool reservations` off the event while the reconciliation read a different list.
+  const event = overrides.event ?? buildDrawStructureEvent()
   return {
-    event: buildDrawStructureEvent(),
+    event,
+    pools: keepPools(event.pools),
     canEdit: true,
     // **Open by default, and stated rather than defaulted in the component**: the "Nothing
     // set" event has no draw, so the qualifier count is a setting a director may still
     // move. The freeze test asks for the other state explicitly, which is what makes "a
     // cut event refuses the row" a claim a test makes rather than one it inherits.
     qualifiersFreeze: { kind: 'open' },
+    // …and the same for the pool set, for the same reason: the "Nothing set" event has no
+    // draw, so its pool count is a setting a director may still move. A cut event's frozen
+    // row is a state a test asks for.
+    poolSetFreeze: { kind: 'open' },
     onChange: () => {},
+    onPoolsChange: () => {},
     onGoToBasics: () => {},
     ...overrides,
   }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.factory.tsx
@@ -33,13 +33,19 @@ export function buildDrawStructureEvent(
   })
 }
 
-/** Props for `DrawStructureSection` — the "Nothing set" event above, and a spy-able
- * way back to Basics. */
+/** Props for `DrawStructureSection` — the "Nothing set" event above, editable by the
+ * director looking at it, and spy-able ways to write a setting back and to get to Basics.
+ *
+ * `canEdit: true` is the default because it is the state the tab is *for*; the guard test
+ * asks for the other one explicitly, which is what makes "a reader sees no control" a
+ * claim a test states rather than a default it inherits. */
 export function buildDrawStructureSectionProps(
   overrides: Partial<DrawStructureSectionProps> = {},
 ): DrawStructureSectionProps {
   return {
     event: buildDrawStructureEvent(),
+    canEdit: true,
+    onChange: () => {},
     onGoToBasics: () => {},
     ...overrides,
   }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.page.tsx
@@ -1,3 +1,4 @@
+import { interactiveElementsIn } from '@/test/read-only'
 import { render, screen, within, type Container } from '@/test/utilities'
 
 import {
@@ -28,6 +29,15 @@ const scoped = (container: Container) => ({
   /** The way back to the tab that sets the player limit. */
   getChangeInBasicsButton() {
     return container.getByRole('button', { name: 'Change in Basics' })
+  },
+  queryChangeInBasicsButton() {
+    return container.queryByRole('button', { name: 'Change in Basics' })
+  },
+  /** Every interactive control on the tab — the one sweep (`@/test/read-only`),
+   * composed rather than re-typed. A reader's tab has none: the boxes, the four
+   * actions and the way back to Basics are all *absent*, never disabled (ADR-0015). */
+  getFormElements() {
+    return interactiveElementsIn(container.getByTestId('draw-structure-section'))
   },
   /** Every setting's name, **in the order the rows render** — the claim that the four
    * settings read top to bottom as Pool count, Pool size, Membership, Qualifiers per

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.page.tsx
@@ -1,6 +1,7 @@
 import { interactiveElementsIn } from '@/test/read-only'
 import { render, screen, within, type Container } from '@/test/utilities'
 
+import { confirmIrreversibleActDialogPage } from '../confirm-irreversible-act-dialog.page'
 import {
   DrawStructureSection,
   type DrawStructureSectionProps,
@@ -68,6 +69,11 @@ const scoped = (container: Container) => ({
    * region too, so at tab scope a role query matches two elements and throws. The role is
    * asserted in the panel's own test, where it is the only candidate. */
   issuePanel: drawIssuePanelPage.within(container),
+  /** The confirm a **lowered pool count** opens — the dialog's own accessors
+   * (`confirmIrreversibleActDialogPage`), at SCREEN scope on purpose: an `AlertDialog`
+   * portals to the body, so it is not a descendant of the tab and a container-scoped
+   * query would never find it. */
+  confirm: confirmIrreversibleActDialogPage,
 })
 
 /** Test page-object for `DrawStructureSection`, the event editor's fifth tab. */

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
@@ -1,8 +1,10 @@
 import userEvent from '@testing-library/user-event'
 
+import { fireEvent } from '@/test/utilities'
+
 import { everySettingAutomatic } from '../../data/draw-ownership'
 import { buildPool } from '../../data/seed.factory'
-import type { DrawOwnership, TournamentEvent } from '../../data/types'
+import type { DrawOwnership, PoolEntry, TournamentEvent } from '../../data/types'
 import { buildDrawStructureEvent } from './draw-structure-section.factory'
 import { drawStructureSectionPage } from './draw-structure-section.page'
 
@@ -422,7 +424,10 @@ describe('DrawStructureSection', () => {
       expect(onChange).not.toHaveBeenCalled()
     })
 
-    it.each(['Pool count', 'Pool size', 'Membership'])(
+    // Pool count is NOT in this list, and it is not an omission: it freezes on a cut event
+    // too, for a different reason and by a different freeze (the pool SET freeze — its row
+    // now creates and removes pool rows). See `the pool set is frozen` below.
+    it.each(['Pool size', 'Membership'])(
       'leaves %s alone — the server does not freeze its ownership',
       (name) => {
         drawStructureSectionPage.render({
@@ -435,6 +440,451 @@ describe('DrawStructureSection', () => {
         expect(row.queryFreezeReason()).toBeNull()
       },
     )
+  })
+
+  /**
+   * **A pool count the director types IS a number of pool rows** (ADR
+   * 20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-count-is-a-projection).
+   * Nothing stores a second number, so typing `6` asks for six rows — created or removed
+   * through the very list the Table pools tab edits and the save already sends.
+   *
+   * Asserted on the two writes together, because the ADR's demand is that they are one
+   * act: the number and the rows change in one save, or neither does.
+   */
+  describe('typing a pool count', () => {
+    /** The "Nothing set" event — **4 pool reservations** — with the count already taken,
+     * so the row renders a box. */
+    const owningFourPools = () =>
+      eventOwning({ poolCountMode: 'manual', manualPoolCount: 4 })
+
+    const renderOwningCount = (
+      overrides: Parameters<typeof drawStructureSectionPage.render>[0] = {},
+    ) => {
+      const onChange = vi.fn()
+      const onPoolsChange = vi.fn()
+      drawStructureSectionPage.render({
+        event: owningFourPools(),
+        onChange,
+        onPoolsChange,
+        ...overrides,
+      })
+      return { onChange, onPoolsChange }
+    }
+
+    /** The box takes the whole value at once — a director correcting a count selects the
+     * number and replaces it, and `acceptedManualEntry` reads what the box then holds.
+     *
+     * ⚠️ `fireEvent` rather than `userEvent.type` **at this level only**: these props are
+     * spies, so nothing feeds a new `value` back into the controlled box, and typing would
+     * append to the number already in it. The multi-digit claim is asserted where real
+     * form state closes that loop — `event-editor.test.tsx`. */
+    const typeCount = (value: string) =>
+      fireEvent.change(drawStructureSectionPage.setting('Pool count').getInput(), {
+        target: { value },
+      })
+
+    /** The director says they are done — they left the box. A *lowered* count is priced
+     * here rather than on the keystroke, because `12` begins with `1`. */
+    const finishTyping = () =>
+      fireEvent.blur(drawStructureSectionPage.setting('Pool count').getInput())
+
+    describe('raising it', () => {
+      it('appends rows until the event has the count that was typed', () => {
+        const { onChange, onPoolsChange } = renderOwningCount()
+
+        typeCount('6')
+
+        // ONE act: the stored number and the rows, written together.
+        expect(onChange.mock.lastCall?.[0].drawOwnership.manualPoolCount).toBe(6)
+        expect(onPoolsChange.mock.lastCall?.[0]).toHaveLength(6)
+      })
+
+      it('continues the letter sequence rather than restarting it', () => {
+        const { onPoolsChange } = renderOwningCount()
+
+        typeCount('6')
+
+        expect(
+          onPoolsChange.mock.lastCall?.[0].map((pool: PoolEntry) => pool.name),
+        ).toEqual(['Pool A', 'Pool B', 'Pool C', 'Pool D', 'Pool E', 'Pool F'])
+      })
+
+      /** The director is not left completing a blank card: a new row runs when the last
+       * one does. The factory's pools run 09:00–12:30 while the *event* runs 09:00–18:00,
+       * so "the last pool's window" and "the event's window" are distinguishable here. */
+      it('takes the last existing pool’s date and window, and reserves no tables', () => {
+        const { onPoolsChange } = renderOwningCount()
+
+        typeCount('5')
+
+        const appended = onPoolsChange.mock.lastCall?.[0].at(-1)
+        expect(appended.slot).toEqual({
+          date: '2026-06-13',
+          start: '09:00',
+          end: '12:30',
+        })
+        // #1072 already reports an empty pool. A table selection the director never made
+        // would be a reservation invented for them (ADR 20260808).
+        expect(appended.tableIds).toEqual([])
+      })
+
+      /** ⚠️ `PoolWrite` is `extra="forbid"` and has no `id`, so a client-minted one is a
+       * 422 naming the entry. The `added` arm is what makes that unsayable. */
+      it('mints the new rows with no id, and leaves the stored ones citing theirs', () => {
+        const { onPoolsChange } = renderOwningCount()
+
+        typeCount('6')
+
+        const written: PoolEntry[] = onPoolsChange.mock.lastCall?.[0]
+        expect(written.slice(0, 4).map((pool) => pool.kind)).toEqual([
+          'kept',
+          'kept',
+          'kept',
+          'kept',
+        ])
+        expect(written.slice(4).map((pool) => pool.kind)).toEqual([
+          'added',
+          'added',
+        ])
+        expect(written.slice(4).every((pool) => !('id' in pool))).toBe(true)
+      })
+
+      /** Constructive: nothing is discarded, so nothing is priced (ADR 20260806 — the
+       * first cut is exempt for the same reason). */
+      it('asks no confirm', () => {
+        renderOwningCount()
+
+        typeCount('6')
+
+        expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
+      })
+    })
+
+    describe('lowering it', () => {
+      /**
+       * **Nothing is written on the keystroke.** Asserted with no query for the dialog in
+       * it, deliberately: a test that reached for the dialog first would red with "unable
+       * to find an alertdialog" the moment the confirm was removed, which cannot tell
+       * "the write is gated" from "the dialog moved". This one reds on the write.
+       */
+      it('writes neither the count nor the rows until the removal is confirmed', () => {
+        const { onChange, onPoolsChange } = renderOwningCount()
+
+        typeCount('2')
+        finishTyping()
+
+        expect(onChange).not.toHaveBeenCalled()
+        expect(onPoolsChange).not.toHaveBeenCalled()
+      })
+
+      /**
+       * ⚠️ **A lowered count is not priced until the director has finished typing it**,
+       * and this is the assertion that says why. Against four pools, `12` produces the
+       * value `1` first; a confirm on that keystroke traps focus in a modal dialog and the
+       * `2` never lands. The box shows what was typed and holds it.
+       */
+      it('holds a lower keystroke without pricing it, so a longer number can still be typed', () => {
+        const { onChange, onPoolsChange } = renderOwningCount()
+
+        typeCount('1')
+
+        expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
+        expect(drawStructureSectionPage.setting('Pool count').getInput()).toHaveValue('1')
+        expect(onChange).not.toHaveBeenCalled()
+        expect(onPoolsChange).not.toHaveBeenCalled()
+      })
+
+      /** …and the next digit takes it back above the row count, which writes at once —
+       * nothing is discarded, so nothing is priced. */
+      it('writes the moment the number typed is no longer a removal', () => {
+        const { onChange, onPoolsChange } = renderOwningCount()
+
+        typeCount('1')
+        typeCount('12')
+
+        expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
+        expect(onChange.mock.lastCall?.[0].drawOwnership.manualPoolCount).toBe(12)
+        expect(onPoolsChange.mock.lastCall?.[0]).toHaveLength(12)
+      })
+
+      /** Destructive: two reservations go, with their windows and their tables. The
+       * director is told **which** before it happens. */
+      it('names the pools that would go', () => {
+        renderOwningCount()
+
+        typeCount('2')
+        finishTyping()
+
+        const dialog = drawStructureSectionPage.confirm.getDialog()
+        expect(dialog).toHaveTextContent('Remove 2 pool reservations?')
+        expect(dialog).toHaveTextContent('removes Pool C and Pool D')
+      })
+
+      it('names the event, so a director running several knows which one', () => {
+        renderOwningCount()
+
+        typeCount('3')
+        finishTyping()
+
+        expect(drawStructureSectionPage.confirm.getDialog()).toHaveTextContent(
+          'Lowering the pool count for Two-stage Singles',
+        )
+      })
+
+      /** Enter is the other way to say "done", for a director who never leaves the
+       * keyboard. */
+      it('prices it on Enter as well as on leaving the box', () => {
+        renderOwningCount()
+
+        typeCount('2')
+        fireEvent.keyDown(
+          drawStructureSectionPage.setting('Pool count').getInput(),
+          { key: 'Enter' },
+        )
+
+        expect(drawStructureSectionPage.confirm.getDialog()).toHaveTextContent(
+          'Remove 2 pool reservations?',
+        )
+      })
+
+      it('drops the rows from the END on the confirm, and stores the count with them', () => {
+        const { onChange, onPoolsChange } = renderOwningCount()
+
+        typeCount('2')
+        finishTyping()
+        drawStructureSectionPage.confirm.confirm()
+
+        expect(onChange.mock.lastCall?.[0].drawOwnership.manualPoolCount).toBe(2)
+        expect(
+          onPoolsChange.mock.lastCall?.[0].map((pool: PoolEntry) => pool.name),
+        ).toEqual(['Pool A', 'Pool B'])
+      })
+
+      /**
+       * **Go back changes nothing at all** — and the box says so.
+       *
+       * Asserting only that the callbacks did not fire would pass while the box went on
+       * showing the `2` the director typed, which is a row claiming a pool count the event
+       * does not have. The box reads the held number while the dialog is up and the stored
+       * one the moment it is dropped.
+       */
+      it('restores the stored count on Go back, and touches no pool row', () => {
+        const { onChange, onPoolsChange } = renderOwningCount()
+        const row = drawStructureSectionPage.setting('Pool count')
+
+        typeCount('2')
+        finishTyping()
+        expect(row.getInput()).toHaveValue('2')
+
+        drawStructureSectionPage.confirm.cancel()
+
+        expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
+        expect(row.getInput()).toHaveValue('4')
+        expect(onChange).not.toHaveBeenCalled()
+        expect(onPoolsChange).not.toHaveBeenCalled()
+      })
+
+      /** Escape is the cancel, through the dialog's own channel. */
+      it('reads Escape as Go back', () => {
+        const { onPoolsChange } = renderOwningCount()
+
+        typeCount('2')
+        finishTyping()
+        drawStructureSectionPage.confirm.pressEscape()
+
+        expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
+        expect(onPoolsChange).not.toHaveBeenCalled()
+      })
+
+      /** Leaving the box with nothing held asks nothing. A director who tabs through the
+       * tab without typing must not meet a dialog. */
+      it('asks nothing when the director leaves a box they never edited', () => {
+        const { onChange, onPoolsChange } = renderOwningCount()
+
+        finishTyping()
+
+        expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
+        expect(onChange).not.toHaveBeenCalled()
+        expect(onPoolsChange).not.toHaveBeenCalled()
+      })
+    })
+
+    /** A cleared box is **not** a count of none. The derivation reads a manual mode with
+     * no number as automatic, so the count goes back to being the row count — and the rows
+     * stay exactly where they are. Reconciling to `0` here would delete every pool of the
+     * event because somebody selected the number to retype it. */
+    it('clears to automatic without removing a single pool', () => {
+      const { onChange, onPoolsChange } = renderOwningCount()
+
+      typeCount('')
+
+      expect(onChange.mock.lastCall?.[0].drawOwnership.manualPoolCount).toBeNull()
+      expect(onPoolsChange).not.toHaveBeenCalled()
+      expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
+    })
+
+    /** Typing the count the event's rows already have removes nothing, so it is priced by
+     * nothing. Reachable, and worth pinning, from the one state where the stored count and
+     * the row count legitimately differ: `Set myself` seeded 6 against 4 reservations, and
+     * the director types the 4 they actually have. */
+    it('asks no confirm when the typed count is the row count already', () => {
+      const { onChange, onPoolsChange } = renderOwningCount({
+        event: eventOwning({ poolCountMode: 'manual', manualPoolCount: 6 }),
+      })
+
+      typeCount('4')
+
+      expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
+      expect(onChange.mock.lastCall?.[0].drawOwnership.manualPoolCount).toBe(4)
+      expect(
+        onPoolsChange.mock.lastCall?.[0].map((pool: PoolEntry) => pool.name),
+      ).toEqual(['Pool A', 'Pool B', 'Pool C', 'Pool D'])
+    })
+
+    /**
+     * **`Set myself` creates no row**, and that is the ADR's point 3 rather than an
+     * oversight: the count it seeds from is a *projection* against a field the app
+     * invented, and a projection in excess of the rows is reported, never materialised.
+     * Here 32 players in pools of 5 projects 7 pools over 4 reservations.
+     *
+     * Chore 5b's disagreement panel is what reports the gap, and its
+     * `Use {n} pools of {size}` is what appends the rows — through the same
+     * `reconcilePoolsToCount` the box types through.
+     */
+    it('creates no pool row when the director merely takes the setting', async () => {
+      const onPoolsChange = vi.fn()
+      drawStructureSectionPage.render({
+        event: eventOwning({ poolSizeMode: 'manual', manualPoolSize: 5 }),
+        onPoolsChange,
+      })
+
+      await userEvent.click(drawStructureSectionPage.setting('Pool count').getAction())
+
+      expect(onPoolsChange).not.toHaveBeenCalled()
+    })
+
+    /** …and neither does handing it back. The automatic count IS the row count, so
+     * `Use automatic` changes who owns the number and not how many pools exist. */
+    it('creates and removes nothing when the director hands the setting back', async () => {
+      const { onPoolsChange } = renderOwningCount()
+
+      await userEvent.click(drawStructureSectionPage.setting('Pool count').getAction())
+
+      expect(onPoolsChange).not.toHaveBeenCalled()
+    })
+  })
+
+  /**
+   * **The pool SET freeze reaches this tab too** (ADR 20260808's consequence, and the
+   * server's `_enforce_pool_set_frozen`): once a draw is cut every fixture names the pool
+   * it was dealt into, so a row this tab creates or removes is a 409. It is the *same*
+   * freeze the Table pools tab is given — no second rule about the same fact.
+   */
+  describe('the pool set is frozen', () => {
+    const FROZEN = {
+      kind: 'frozen',
+      reason:
+        'Every fixture names the pool it was dealt into, so a pool can’t be added or ' +
+        'removed while the draw stands.',
+    } as const
+
+    it('disables the pool count box and its action, and states why', () => {
+      drawStructureSectionPage.render({
+        event: eventOwning({ poolCountMode: 'manual', manualPoolCount: 4 }),
+        poolSetFreeze: FROZEN,
+      })
+
+      const row = drawStructureSectionPage.setting('Pool count')
+      expect(row.getInput()).toBeDisabled()
+      expect(row.getAction()).toBeDisabled()
+      expect(row.queryFreezeReason()).toHaveTextContent(FROZEN.reason)
+    })
+
+    /** A disabled control is not focusable and carries no tooltip, so the only channel
+     * left is the description it points at (#1223, the bug in the frozen draw-type
+     * select). */
+    it('points both dead controls at the reason', () => {
+      drawStructureSectionPage.render({
+        event: eventOwning({ poolCountMode: 'manual', manualPoolCount: 4 }),
+        poolSetFreeze: FROZEN,
+      })
+
+      const row = drawStructureSectionPage.setting('Pool count')
+      expect(row.describedNodeOf(row.getInput())).toHaveTextContent(FROZEN.reason)
+      expect(row.describedNodeOf(row.getAction())).toHaveTextContent(FROZEN.reason)
+    })
+
+    /** ⚠️ `Use automatic` alone would be a 200 — the server excludes ownership modes from
+     * its freeze — so this half is the CLIENT's choice, exactly as the qualifiers row's is.
+     * It is a one-way door: the automatic count is the row count, and `Set myself`, the
+     * only way back, is frozen. */
+    it('refuses the mode flip on that row too', async () => {
+      const onChange = vi.fn()
+      drawStructureSectionPage.render({
+        event: eventOwning({ poolCountMode: 'manual', manualPoolCount: 4 }),
+        poolSetFreeze: FROZEN,
+        onChange,
+      })
+
+      await userEvent.click(drawStructureSectionPage.setting('Pool count').getAction())
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    /**
+     * ⚠️ **The commonest cut event, and the one the tests above cannot reach.** An event
+     * whose director never opened this tab stores no ownership record at all, so the pool
+     * count is automatic: the row renders a *value* and a `Set myself`, and there is no box
+     * to disable. That click seeds a manual count — the first step toward creating or
+     * removing a row — so it is frozen too, and says why.
+     */
+    it('freezes Set myself on a cut event whose pool count is still automatic', () => {
+      drawStructureSectionPage.render({
+        event: buildDrawStructureEvent({ drawOwnership: null }),
+        poolSetFreeze: FROZEN,
+      })
+
+      const row = drawStructureSectionPage.setting('Pool count')
+      expect(row.queryInput()).toBeNull()
+      expect(row.getAction()).toHaveTextContent('Set myself')
+      expect(row.getAction()).toBeDisabled()
+      expect(row.describedNodeOf(row.getAction())).toHaveTextContent(FROZEN.reason)
+    })
+
+    it.each(['Pool size', 'Membership', 'Qualifiers per pool'])(
+      'leaves %s alone — a frozen pool set says nothing about it',
+      (name) => {
+        drawStructureSectionPage.render({
+          event: eventOwning({ poolSizeMode: 'manual', manualPoolSize: 8 }),
+          poolSetFreeze: FROZEN,
+        })
+
+        const row = drawStructureSectionPage.setting(name)
+        expect(row.getAction()).toBeEnabled()
+        expect(row.queryFreezeReason()).toBeNull()
+      },
+    )
+  })
+
+  /** The row's automatic source sentence and the preview's `Pool reservations` fact are
+   * two readings of ONE list, so they can never name two different numbers. */
+  it('counts the same pool list in the source sentence and in the preview', () => {
+    drawStructureSectionPage.render({
+      event: buildDrawStructureEvent({
+        pools: [
+          buildPool({ id: 'p-a', name: 'Pool A', position: 0 }),
+          buildPool({ id: 'p-b', name: 'Pool B', position: 1 }),
+          buildPool({ id: 'p-c', name: 'Pool C', position: 2 }),
+        ],
+      }),
+    })
+
+    expect(
+      drawStructureSectionPage.setting('Pool count').getSource(),
+    ).toHaveTextContent("3 pool reservations · today's behaviour")
+    expect(
+      drawStructureSectionPage.preview.getFact('Pool reservations'),
+    ).toHaveTextContent('3')
   })
 
   /**

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
@@ -369,6 +369,100 @@ describe('DrawStructureSection', () => {
   })
 
   /**
+   * **A cut draw freezes the qualifier count, and nothing else on this tab** (chore 3e,
+   * the defect chore 3c surfaced).
+   *
+   * The knockout bracket is cut upfront for `P × K` and the qualifiers are seated into
+   * predetermined slots as each pool finishes, so a K the fixtures were not cut for leaves
+   * qualifiers with nowhere to sit — a 409 (`_qualifiers_per_pool_frozen_detail`). The
+   * click that authored it looked harmless: `Set myself` seeds the box from the DERIVED
+   * count, which on a cut event is routinely not the stored one.
+   *
+   * ⚠️ The **asymmetry is the point, and it is not symmetric on the server either.** The
+   * other three settings' ownership modes are excluded from the server's freeze
+   * (`configuration_the_draw_was_dealt_from`) because they size nothing the cut already put
+   * on the table, so a director may still take the pool count on a cut event. Freezing the
+   * whole tab would refuse work the server allows.
+   */
+  describe('a cut draw', () => {
+    const FROZEN = {
+      kind: 'frozen',
+      reason: 'This event’s draw is cut, so the number of qualifiers per pool is frozen.',
+    } as const
+
+    it('disables the qualifier box and its action, and states why', () => {
+      drawStructureSectionPage.render({
+        event: eventOwning({ qualifiersMode: 'manual' }),
+        qualifiersFreeze: FROZEN,
+      })
+
+      const row = drawStructureSectionPage.setting('Qualifiers per pool')
+      expect(row.getInput()).toBeDisabled()
+      expect(row.getAction()).toBeDisabled()
+      expect(row.queryFreezeReason()).toHaveTextContent(FROZEN.reason)
+    })
+
+    // `Use automatic` writes the MODE and nothing else, which the server permits outright —
+    // so this row is frozen by the CLIENT's choice, not by a 409. It is refused because it
+    // is a one-way door: hand the setting back and the row reports the derived count rather
+    // than the one the bracket was cut for, and `Set myself` — the only way back — is
+    // frozen. The comment on `qualifiersPerPoolFreeze` says so; this pins the behaviour.
+    it('refuses even the mode flip on that row', async () => {
+      const onChange = vi.fn()
+      drawStructureSectionPage.render({
+        event: eventOwning({ qualifiersMode: 'manual' }),
+        qualifiersFreeze: FROZEN,
+        onChange,
+      })
+
+      await userEvent.click(
+        drawStructureSectionPage.setting('Qualifiers per pool').getAction(),
+      )
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it.each(['Pool count', 'Pool size', 'Membership'])(
+      'leaves %s alone — the server does not freeze its ownership',
+      (name) => {
+        drawStructureSectionPage.render({
+          event: eventOwning({ qualifiersMode: 'manual' }),
+          qualifiersFreeze: FROZEN,
+        })
+
+        const row = drawStructureSectionPage.setting(name)
+        expect(row.getAction()).toBeEnabled()
+        expect(row.queryFreezeReason()).toBeNull()
+      },
+    )
+  })
+
+  /**
+   * **K is the one setting on this tab that can be left in a state the save refuses**, and
+   * so the one with a red. It is required on every `rr-then-ko` event, and its box is the
+   * only one a director can empty (the other three boxes drop a keystroke the schema would
+   * reject rather than storing it).
+   *
+   * The row it moved from carried the same slot. Without it, a save refused for the count
+   * would open this tab — `firstInvalidSection` sends it here now — with nothing red on it.
+   */
+  it('prints the resolver’s red on the qualifier row, and nowhere else', () => {
+    drawStructureSectionPage.render({
+      event: eventOwning({ qualifiersMode: 'manual' }, { qualifiersPerPool: null }),
+      errors: { qualifiersPerPool: 'Say how many players advance from each pool.' },
+    })
+
+    const row = drawStructureSectionPage.setting('Qualifiers per pool')
+    expect(row.queryError()).toHaveTextContent(
+      'Say how many players advance from each pool.',
+    )
+    expect(row.getInput()).toHaveAttribute('aria-invalid', 'true')
+    expect(
+      drawStructureSectionPage.setting('Pool count').queryError(),
+    ).toBeNull()
+  })
+
+  /**
    * A non-creator gets a **view** (ADR-0015): every value as text, and not one control —
    * no box, no action, and no imperative sending them to a tab where the cap is not
    * theirs to change either. Swept by `@/test/read-only`, which is the one sweep, never a
@@ -400,6 +494,25 @@ describe('DrawStructureSection', () => {
       const row = drawStructureSectionPage.setting('Pool count')
       expect(row.getValue()).toHaveTextContent('6')
       expect(row.getOwnershipBadge()).toHaveTextContent('Yours')
+    })
+
+    /** …and the **qualifier count** by name, because it is the row that moved here (chore
+     * 3e) and the claim came with it: a reader used to read K off the Basics tab, and a
+     * move that dropped the read-only half would leave them with no way to see it at all.
+     *
+     * It also tightens the sweep above, which never sets `qualifiersMode` — so that guard
+     * passes today whether or not this row honours `canEdit`. */
+    it('reads out the qualifier count a director owns, as a value and not a box', () => {
+      drawStructureSectionPage.render({
+        event: eventOwning({ qualifiersMode: 'manual' }, { qualifiersPerPool: 3 }),
+        canEdit: false,
+      })
+
+      const row = drawStructureSectionPage.setting('Qualifiers per pool')
+      expect(row.getValue()).toHaveTextContent('3')
+      expect(row.getOwnershipBadge()).toHaveTextContent('Yours')
+      expect(row.queryInput()).toBeNull()
+      expect(row.queryAction()).toBeNull()
     })
   })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
@@ -483,8 +483,9 @@ describe('DrawStructureSection', () => {
         target: { value },
       })
 
-    /** The director says they are done — they left the box. A *lowered* count is priced
-     * here rather than on the keystroke, because `12` begins with `1`. */
+    /** The director says they are done — they left the box. **Nothing is written before
+     * this**, whichever way the count moved: a keystroke is only a prefix of the number
+     * being typed, and `55` begins with `5` exactly as `12` begins with `1`. */
     const finishTyping = () =>
       fireEvent.blur(drawStructureSectionPage.setting('Pool count').getInput())
 
@@ -493,16 +494,49 @@ describe('DrawStructureSection', () => {
         const { onChange, onPoolsChange } = renderOwningCount()
 
         typeCount('6')
+        finishTyping()
 
         // ONE act: the stored number and the rows, written together.
         expect(onChange.mock.lastCall?.[0].drawOwnership.manualPoolCount).toBe(6)
         expect(onPoolsChange.mock.lastCall?.[0]).toHaveLength(6)
       })
 
+      /**
+       * ⚠️ **A raised count is held until the director finishes typing it**, and this is
+       * the assertion that says why. Against four pools, `55` produces the value `5`
+       * first: written on that keystroke it mints a fifth pool, and the `55` then mints
+       * fifty more — so backspacing to the `5` the director meant is a *removal*, priced
+       * by a confirm naming fifty reservations they never asked for.
+       *
+       * The pool list must be untouched until the number is finished, and then written
+       * **once**, for the number that was finished.
+       */
+      it('mints no row for the prefix of a longer number, and writes the finished one once', () => {
+        const { onChange, onPoolsChange } = renderOwningCount()
+
+        typeCount('5')
+
+        expect(onChange).not.toHaveBeenCalled()
+        expect(onPoolsChange).not.toHaveBeenCalled()
+
+        typeCount('55')
+
+        expect(onPoolsChange).not.toHaveBeenCalled()
+        expect(drawStructureSectionPage.setting('Pool count').getInput()).toHaveValue('55')
+
+        finishTyping()
+
+        expect(onPoolsChange).toHaveBeenCalledTimes(1)
+        expect(onPoolsChange.mock.lastCall?.[0]).toHaveLength(55)
+        expect(onChange.mock.lastCall?.[0].drawOwnership.manualPoolCount).toBe(55)
+        expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
+      })
+
       it('continues the letter sequence rather than restarting it', () => {
         const { onPoolsChange } = renderOwningCount()
 
         typeCount('6')
+        finishTyping()
 
         expect(
           onPoolsChange.mock.lastCall?.[0].map((pool: PoolEntry) => pool.name),
@@ -516,6 +550,7 @@ describe('DrawStructureSection', () => {
         const { onPoolsChange } = renderOwningCount()
 
         typeCount('5')
+        finishTyping()
 
         const appended = onPoolsChange.mock.lastCall?.[0].at(-1)
         expect(appended.slot).toEqual({
@@ -534,6 +569,7 @@ describe('DrawStructureSection', () => {
         const { onPoolsChange } = renderOwningCount()
 
         typeCount('6')
+        finishTyping()
 
         const written: PoolEntry[] = onPoolsChange.mock.lastCall?.[0]
         expect(written.slice(0, 4).map((pool) => pool.kind)).toEqual([
@@ -555,6 +591,7 @@ describe('DrawStructureSection', () => {
         renderOwningCount()
 
         typeCount('6')
+        finishTyping()
 
         expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
       })
@@ -594,16 +631,25 @@ describe('DrawStructureSection', () => {
         expect(onPoolsChange).not.toHaveBeenCalled()
       })
 
-      /** …and the next digit takes it back above the row count, which writes at once —
-       * nothing is discarded, so nothing is priced. */
-      it('writes the moment the number typed is no longer a removal', () => {
+      /** …and the next digit takes it back above the row count, so the number the
+       * director finished typing is the one that lands — with no confirm, because it
+       * discards nothing. The `1` that was on its way there is priced by nothing and
+       * writes nothing. */
+      it('writes the finished number when a later digit undoes the removal', () => {
         const { onChange, onPoolsChange } = renderOwningCount()
 
         typeCount('1')
         typeCount('12')
 
         expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
+        expect(onChange).not.toHaveBeenCalled()
+        expect(onPoolsChange).not.toHaveBeenCalled()
+
+        finishTyping()
+
+        expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
         expect(onChange.mock.lastCall?.[0].drawOwnership.manualPoolCount).toBe(12)
+        expect(onPoolsChange).toHaveBeenCalledTimes(1)
         expect(onPoolsChange.mock.lastCall?.[0]).toHaveLength(12)
       })
 
@@ -733,6 +779,7 @@ describe('DrawStructureSection', () => {
       })
 
       typeCount('4')
+      finishTyping()
 
       expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
       expect(onChange.mock.lastCall?.[0].drawOwnership.manualPoolCount).toBe(4)

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
@@ -1,8 +1,21 @@
 import userEvent from '@testing-library/user-event'
 
+import { everySettingAutomatic } from '../../data/draw-ownership'
 import { buildPool } from '../../data/seed.factory'
+import type { DrawOwnership, TournamentEvent } from '../../data/types'
 import { buildDrawStructureEvent } from './draw-structure-section.factory'
 import { drawStructureSectionPage } from './draw-structure-section.page'
+
+/** The "Nothing set" event with some of its settings already taken — the state a
+ * director comes back to, and the one the round trip has to reproduce. */
+const eventOwning = (
+  taken: Partial<DrawOwnership>,
+  overrides: Partial<Omit<TournamentEvent, 'entered'>> = {},
+) =>
+  buildDrawStructureEvent({
+    drawOwnership: { ...everySettingAutomatic(), ...taken },
+    ...overrides,
+  })
 
 describe('DrawStructureSection', () => {
   it('says what the tab is for, in the reference’s words', () => {
@@ -91,6 +104,302 @@ describe('DrawStructureSection', () => {
           drawStructureSectionPage.setting(name).getOwnershipBadge(),
         ).toHaveTextContent('Automatic')
       }
+    })
+  })
+
+  /**
+   * **Taking a setting changes the owner, not the number** (ADR 20260808). The first
+   * click seeds the box from what the row was already showing, so a director who wants to
+   * nudge a number by one does not first have to work out what it currently is.
+   *
+   * Asserted on `onChange`, because that is the whole of the tab's write: the form is the
+   * draft, and a tab holding state of its own would be a second one the save never read.
+   */
+  describe('taking a setting for yourself', () => {
+    const takeSetting = async (name: string, event = buildDrawStructureEvent()) => {
+      const onChange = vi.fn()
+      drawStructureSectionPage.render({ event, onChange })
+
+      await userEvent.click(drawStructureSectionPage.setting(name).getAction())
+
+      return onChange
+    }
+
+    it('seeds the pool count from the count the row was showing', async () => {
+      // 4 pool reservations, so the row reads 4 — and taking it types 4.
+      const onChange = await takeSetting('Pool count')
+
+      expect(onChange.mock.lastCall?.[0].drawOwnership).toEqual({
+        ...everySettingAutomatic(),
+        poolCountMode: 'manual',
+        manualPoolCount: 4,
+      })
+    })
+
+    /**
+     * ⚠️ Deliberately an **uneven** field, and this is the case the seeding rule exists
+     * for: 22 across 4 splits `6, 6, 5, 5`, so the largest pool is 6 and the smallest is
+     * 5. On the even default fixture (32 across 4, every pool 8) the two are the same
+     * number and a wrong rule would sail through.
+     *
+     * The largest is the target the split was aiming at. Seeding the smallest would
+     * shrink the draw on the first click — the silent reshaping #1320 exists to remove.
+     */
+    it('seeds the pool size from the LARGEST derived pool, not the smallest', async () => {
+      const onChange = await takeSetting(
+        'Pool size',
+        buildDrawStructureEvent({ maxPlayers: 22 }),
+      )
+
+      expect(onChange.mock.lastCall?.[0].drawOwnership).toEqual({
+        ...everySettingAutomatic(),
+        poolSizeMode: 'manual',
+        manualPoolSize: 6,
+      })
+    })
+
+    /**
+     * The qualifier count has no manual slot of its own on the wire: **the event's K is
+     * the slot**, and the mode says whether anybody should read it. So taking this
+     * setting writes the event's own number — and writes the DERIVED one, which is what
+     * the row, the preview and every pool card have been showing.
+     *
+     * Three pool reservations derive `ceil(8 / 3)` = 3, while the event stores 2. The two
+     * numbers are different on purpose: a fixture where they agreed could not tell "the
+     * derived count was written" from "nothing was written at all".
+     */
+    it('seeds the qualifier count onto the event’s own K', async () => {
+      const onChange = await takeSetting(
+        'Qualifiers per pool',
+        buildDrawStructureEvent({
+          qualifiersPerPool: 2,
+          pools: [
+            buildPool({ id: 'p-a', name: 'Pool A', position: 0 }),
+            buildPool({ id: 'p-b', name: 'Pool B', position: 1 }),
+            buildPool({ id: 'p-c', name: 'Pool C', position: 2 }),
+          ],
+        }),
+      )
+
+      const saved = onChange.mock.lastCall?.[0]
+      expect(saved.qualifiersPerPool).toBe(3)
+      expect(saved.drawOwnership.qualifiersMode).toBe('manual')
+    })
+
+    it('hands membership over without touching a number', async () => {
+      const onChange = await takeSetting('Membership')
+
+      expect(onChange.mock.lastCall?.[0].drawOwnership).toEqual({
+        ...everySettingAutomatic(),
+        membershipMode: 'manual',
+      })
+    })
+
+    it('changes nothing else about the event', async () => {
+      const event = buildDrawStructureEvent()
+      const onChange = await takeSetting('Pool count', event)
+
+      expect(onChange.mock.lastCall?.[0]).toEqual({
+        ...event,
+        drawOwnership: {
+          ...everySettingAutomatic(),
+          poolCountMode: 'manual',
+          manualPoolCount: 4,
+        },
+      })
+    })
+  })
+
+  /**
+   * **Giving a setting back is not destructive.** `Use automatic` sets the mode and keeps
+   * the number, so a director who looks at what the system would say and comes back gets
+   * their own number returned rather than an empty box (ADR 20260808, and the API's own
+   * comment on `DrawStructure`).
+   */
+  describe('giving a setting back', () => {
+    it('keeps the director’s pool count, remembered, for the next time', async () => {
+      const onChange = vi.fn()
+      drawStructureSectionPage.render({
+        event: eventOwning({ poolCountMode: 'manual', manualPoolCount: 6 }),
+        onChange,
+      })
+
+      await userEvent.click(drawStructureSectionPage.setting('Pool count').getAction())
+
+      expect(onChange.mock.lastCall?.[0].drawOwnership).toEqual({
+        ...everySettingAutomatic(),
+        poolCountMode: 'automatic',
+        manualPoolCount: 6,
+      })
+    })
+
+    /**
+     * ⚠️ The qualifier count is the one that could be destroyed, because its value is the
+     * event's own **required** K. Clearing it here would be both a destructive
+     * `Use automatic` and an unsaveable event — the resolver refuses a two-stage event
+     * with no count, and would send the director off to fix a number they never touched.
+     */
+    it('leaves the event’s K alone when qualifiers go back to automatic', async () => {
+      const onChange = vi.fn()
+      drawStructureSectionPage.render({
+        event: eventOwning({ qualifiersMode: 'manual' }, { qualifiersPerPool: 3 }),
+        onChange,
+      })
+
+      await userEvent.click(
+        drawStructureSectionPage.setting('Qualifiers per pool').getAction(),
+      )
+
+      const saved = onChange.mock.lastCall?.[0]
+      expect(saved.qualifiersPerPool).toBe(3)
+      expect(saved.drawOwnership.qualifiersMode).toBe('automatic')
+    })
+  })
+
+  /** What the tab looks like once a director owns a setting: a box instead of a figure,
+   * `Yours` instead of `Automatic`, and a source sentence saying who set it. */
+  describe('a setting the director owns', () => {
+    it('reads the director’s number out of a box, and says it is theirs', () => {
+      drawStructureSectionPage.render({
+        event: eventOwning({ poolCountMode: 'manual', manualPoolCount: 6 }),
+      })
+
+      const row = drawStructureSectionPage.setting('Pool count')
+      expect(row.getInput()).toHaveValue('6')
+      expect(row.getOwnershipBadge()).toHaveTextContent('Yours')
+      expect(row.getSource()).toHaveTextContent(
+        'You set this. Each pool also gets a reservation.',
+      )
+      expect(row.getAction()).toHaveTextContent('Use automatic')
+    })
+
+    it('offers a box on the size row too, and derives the count from it', () => {
+      drawStructureSectionPage.render({
+        event: eventOwning({ poolSizeMode: 'manual', manualPoolSize: 5 }),
+      })
+
+      const row = drawStructureSectionPage.setting('Pool size')
+      expect(row.getInput()).toHaveValue('5')
+      expect(row.getSource()).toHaveTextContent(
+        'You set the target. We derived the pool count.',
+      )
+      // 32 players in pools of 5 needs 7 pools, and the count row says so.
+      expect(drawStructureSectionPage.setting('Pool count').getValue()).toHaveTextContent(
+        '7',
+      )
+    })
+
+    it('puts the event’s own K in the qualifiers box', () => {
+      drawStructureSectionPage.render({
+        event: eventOwning({ qualifiersMode: 'manual' }, { qualifiersPerPool: 3 }),
+      })
+
+      const row = drawStructureSectionPage.setting('Qualifiers per pool')
+      expect(row.getInput()).toHaveValue('3')
+      expect(row.getSource()).toHaveTextContent('You set this.')
+    })
+
+    /**
+     * ⚠️ The subtle state, and the reason the badge and the box read two different
+     * things: a director can own a setting and have cleared its box. The derivation reads
+     * that as automatic and reports the ownership it actually used, so the badge and the
+     * source sentence can never disagree — while the box and the action follow the stored
+     * mode, so the row stays theirs and can still be handed back.
+     */
+    it('reports the EFFECTIVE owner when the box is empty, and still offers it back', () => {
+      drawStructureSectionPage.render({
+        event: eventOwning({ poolCountMode: 'manual', manualPoolCount: null }),
+      })
+
+      const row = drawStructureSectionPage.setting('Pool count')
+      expect(row.getInput()).toHaveValue('')
+      expect(row.getOwnershipBadge()).toHaveTextContent('Automatic')
+      expect(row.getSource()).toHaveTextContent(
+        "4 pool reservations · today's behaviour",
+      )
+      expect(row.getAction()).toHaveTextContent('Use automatic')
+    })
+  })
+
+  /** Membership is the one setting with no number, so it is the one row that changes its
+   * words rather than its figure. */
+  describe('membership', () => {
+    it('says the snake deals, and offers to hand it over', () => {
+      drawStructureSectionPage.render()
+
+      const row = drawStructureSectionPage.setting('Membership')
+      expect(row.getValue()).toHaveTextContent('Snake automatically')
+      expect(row.getSource()).toHaveTextContent('Seeds spread 1, 2, 3, 3, 2, 1.')
+      expect(row.getAction()).toHaveTextContent('Assign myself')
+      expect(row.queryNote()).toBeNull()
+      // No number to own, so no box either.
+      expect(row.queryInput()).toBeNull()
+    })
+
+    it('says the director will place the field, and what that costs', () => {
+      drawStructureSectionPage.render({
+        event: eventOwning({ membershipMode: 'manual' }),
+      })
+
+      const row = drawStructureSectionPage.setting('Membership')
+      expect(row.getValue()).toHaveTextContent('Assign at cut time')
+      expect(row.getOwnershipBadge()).toHaveTextContent('Yours')
+      expect(row.getSource()).toHaveTextContent(
+        'You’ll place entrants once registration closes.',
+      )
+      expect(row.queryNote()).toHaveTextContent(
+        'Repeat protection turns off when you assign pools by hand.',
+      )
+      expect(row.getAction()).toHaveTextContent('Use snake')
+    })
+
+    // The preview's fact follows the row, in the preview's own shorter words.
+    it.each([
+      ['snake', 'Snake'],
+      ['manual', 'By hand at cut'],
+    ] as const)('reports %s membership in the preview as "%s"', (mode, fact) => {
+      drawStructureSectionPage.render({
+        event: eventOwning({ membershipMode: mode }),
+      })
+
+      expect(
+        drawStructureSectionPage.preview.getFact('Membership'),
+      ).toHaveTextContent(fact)
+    })
+  })
+
+  /**
+   * A non-creator gets a **view** (ADR-0015): every value as text, and not one control —
+   * no box, no action, and no imperative sending them to a tab where the cap is not
+   * theirs to change either. Swept by `@/test/read-only`, which is the one sweep, never a
+   * selector re-typed here.
+   */
+  describe('a reader', () => {
+    it('sees no interactive control anywhere on the tab', () => {
+      drawStructureSectionPage.render({
+        // Two settings already taken, so a live tab would render two boxes and four
+        // actions here. A guard against an empty tab is a guard against nothing.
+        event: eventOwning({
+          poolCountMode: 'manual',
+          manualPoolCount: 6,
+          membershipMode: 'manual',
+        }),
+        canEdit: false,
+      })
+
+      expect(drawStructureSectionPage.getFormElements()).toHaveLength(0)
+      expect(drawStructureSectionPage.queryChangeInBasicsButton()).toBeNull()
+    })
+
+    it('still reads out every number and who owns it', () => {
+      drawStructureSectionPage.render({
+        event: eventOwning({ poolCountMode: 'manual', manualPoolCount: 6 }),
+        canEdit: false,
+      })
+
+      const row = drawStructureSectionPage.setting('Pool count')
+      expect(row.getValue()).toHaveTextContent('6')
+      expect(row.getOwnershipBadge()).toHaveTextContent('Yours')
     })
   })
 
@@ -246,6 +555,46 @@ describe('DrawStructureSection', () => {
       expect(drawStructureSectionPage.getPreviewSlot()).not.toContainElement(
         panel,
       )
+    })
+
+    /**
+     * ⚠️ **The reference's "Numbers disagree" state, reachable for the first time in this
+     * chore** — a disagreement needs pool count AND pool size both manual, which nothing
+     * could set until now. 40 players over 6 pools of 5 seats 30.
+     *
+     * The panel for it is chore 5a, so the tab shows **nothing** rather than a
+     * half-written notice — and the director is not left guessing, because the preview
+     * beside it says so in the reference's words. This test is the guard on that split:
+     * it reds the day a panel appears here without its `Apply` fixes, and it reds the day
+     * the preview stops saying it.
+     */
+    it('leaves the disagreement to the preview — 6 pools of 5, 40 players', () => {
+      drawStructureSectionPage.render({
+        event: eventOwning(
+          {
+            poolCountMode: 'manual',
+            manualPoolCount: 6,
+            poolSizeMode: 'manual',
+            manualPoolSize: 5,
+          },
+          { maxPlayers: 40 },
+        ),
+      })
+
+      expect(drawStructureSectionPage.preview.getVerdict()).toHaveTextContent(
+        'Your numbers disagree',
+      )
+      expect(drawStructureSectionPage.issuePanel.queryPanel()).toBeNull()
+      // Both of the director's numbers stand, unedited — the app states the arithmetic
+      // rather than moving one of them (ADR 20260808).
+      expect(drawStructureSectionPage.preview.getEquation()).toHaveTextContent(
+        '40 players ÷ 6 pools = 5 per pool',
+      )
+      // …and the gap the reference's `max(reservations, derived)` would have hidden: the
+      // draw needs six pools and the event has four rows.
+      expect(
+        drawStructureSectionPage.preview.getFact('Pool reservations'),
+      ).toHaveTextContent('4')
     })
 
     /**

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import { Overline } from '@/components/overline'
 import { Button } from '@/components/ui/button'
 
@@ -9,7 +11,12 @@ import {
 } from '../../data/draw-ownership'
 import { deriveDrawStructure } from '../../data/draw-structure'
 import { QUALIFIERS_PER_POOL_MAX } from '../../data/event-validation'
-import type { TournamentEvent } from '../../data/types'
+import { reconcilePoolsToCount } from '../../data/pool-reconciliation'
+import type { PoolEntry, TournamentEvent } from '../../data/types'
+import {
+  ConfirmIrreversibleActDialog,
+  type PoolCountActConsequence,
+} from '../confirm-irreversible-act-dialog'
 import { drawIssueFor } from './draw-structure-section/draw-issue'
 import { DrawIssuePanel } from './draw-structure-section/draw-issue-panel'
 import { DrawPreview } from './draw-structure-section/draw-preview'
@@ -31,14 +38,36 @@ export interface DrawStructureFieldErrors {
 export interface DrawStructureSectionProps {
   /**
    * The event as the editor's **live draft** has it, so the tab recomputes as the
-   * director edits the player limit or adds a pool on the tabs next door.
+   * director edits the player limit or the qualifier count on the tabs next door.
    *
-   * ⚠️ `pools` is read as a *count* deliberately. The editor's draft carries the form's
-   * `pools`, which are `PoolEntry` diffs rather than the read model's `Pool` rows (ADR
-   * 20260801); the length is the same either way, and nothing here may touch a pool's
-   * insides.
+   * ⚠️ **Its `pools` are not read here** — the `pools` prop below is, and it is the honest
+   * shape. The draft's copy is the read model's `Pool[]` by type and the form's
+   * `PoolEntry[]` at runtime (ADR 20260801), which was fine while this tab only ever
+   * counted them and is not fine now that it writes them. `event.slot` *is* read: it is
+   * the window a first pool inherits.
    */
   event: TournamentEvent
+  /**
+   * The event's pool rows as the **form** holds them — the `PoolEntry` diff the Table
+   * pools tab edits and the save puts on the wire.
+   *
+   * **An event's pool count IS the number of these** (ADR
+   * 20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-count-is-a-projection).
+   * There is no second stored number, so the automatic pool count is `pools.length`, the
+   * preview's `Pool reservations` fact is `pools.length`, and a director who types a pool
+   * count is asking for that many rows.
+   */
+  pools: PoolEntry[]
+  /**
+   * Write the reconciled pool list back to the editor's form — the **same** `pools` field
+   * the Table pools tab drives through its `useFieldArray`, which is what makes the two
+   * tabs incapable of drifting: they are one list, read and written from two places.
+   *
+   * Called only alongside `onChange`, in the same handler, so the number and the rows
+   * change together or neither does (the ADR's point 2). There is no second endpoint and
+   * no second way to mint a pool.
+   */
+  onPoolsChange: (pools: PoolEntry[]) => void
   /** When false (a non-creator), the tab is a **view**: every value is text, and there
    * is no action, no box and no way to Basics. Not a disabled form (ADR-0015). */
   canEdit: boolean
@@ -77,6 +106,21 @@ export interface DrawStructureSectionProps {
    * **Required, not optional.** A freeze a call site can forget is a freeze that silently
    * does not happen, and this one guards a 409. */
   qualifiersFreeze: EditFreeze
+  /** Whether the event's **set of pools** may still change (`poolSetFreeze`, `data/draw`)
+   * — the *same* freeze the Table pools tab is given, not a second rule about the same
+   * fact. It has to reach this tab because the Pool count row now creates and removes pool
+   * rows: a cut event's fixtures each name the pool they were dealt into, so the server
+   * refuses the write with a 409 (`_enforce_pool_set_frozen`) and this row declines to
+   * build it.
+   *
+   * **The whole row freezes**, box and action alike, exactly as the qualifiers row does.
+   * `Use automatic` alone would be a 200 — the server excludes ownership modes from its
+   * freeze — but it is a one-way door: the automatic count is the row count, `Set myself`
+   * is the only way back, and it is frozen. Ownership of a number that cannot move is not
+   * a choice worth offering.
+   *
+   * **Required, not optional**, for the reason its sibling above is. */
+  poolSetFreeze: EditFreeze
 }
 
 /**
@@ -110,6 +154,32 @@ export interface DrawStructureSectionProps {
  * each other. The box and the action read the stored mode instead, so the row the
  * director took stays theirs and can still be handed back.
  *
+ * ## A typed pool count IS a number of pool rows
+ *
+ * Nothing stores a pool count of its own (ADR 20260808-an-events-pool-count-is-its-pool-
+ * rows-and-a-derived-count-is-a-projection). So a director who types `6` into the Pool
+ * count box gets six pool rows, reconciled through the list the Table pools tab already
+ * edits and the save already sends — one write, one save, and no way for the two tabs to
+ * disagree about how many pools the event has.
+ *
+ * Raising the count **appends** rows that continue the letter sequence and inherit the
+ * last pool's window, with no tables, and it writes on the keystroke like every other box
+ * here — it spends nothing. Lowering it **removes** rows from the end, which discards
+ * reservations, so it is *held* until the director finishes typing and then priced by a
+ * confirm that names them (ADR 20260806). Held rather than priced per keystroke because
+ * `12` begins with `1`: see `typedPoolCount`.
+ *
+ * Two things deliberately do *not* reconcile:
+ *
+ * - **Clearing the box.** A manual mode with no number is automatic, so an emptied box
+ *   hands the count back to the row count rather than asking for none.
+ * - **`Set myself`.** It seeds the box from the *derived* count, which is a projection —
+ *   and a projection in excess of the rows is reported, never materialised (the ADR's
+ *   point 3). Creating four reservations off a field the app invented is precisely what
+ *   that rule forbids. The gap is chore 5b's disagreement panel to report, and its
+ *   `Use {n} pools of {size}` resolution appends through `reconcilePoolsToCount` — the
+ *   same seam this row types through.
+ *
  * ## The arithmetic is not here
  *
  * Every number and every source sentence comes from `deriveDrawStructure`
@@ -119,11 +189,14 @@ export interface DrawStructureSectionProps {
  */
 export const DrawStructureSection = ({
   event,
+  pools,
   canEdit,
   onChange,
+  onPoolsChange,
   onGoToBasics,
   errors = {},
   qualifiersFreeze,
+  poolSetFreeze,
 }: DrawStructureSectionProps) => {
   const fieldSize = previewFieldSize(event.maxPlayers)
   // ONE call, two readers — the heading block and the preview's `Preview basis` fact.
@@ -140,8 +213,11 @@ export const DrawStructureSection = ({
   const structure = deriveDrawStructure({
     previewFieldSize: fieldSize,
     // One pool reservation is one pool — today's behaviour, and the automatic source of
-    // the pool count (ADR 20260808).
-    poolReservationCount: event.pools.length,
+    // the pool count (ADR 20260808). Read off the FORM's pool list, which is what the
+    // reconciliation below writes, so the source sentence
+    // (`{n} pool reservations · today's behaviour`) states a number that is true of the
+    // draft the director is looking at.
+    poolReservationCount: pools.length,
     poolCountMode: ownership.poolCountMode,
     manualPoolCount: ownership.manualPoolCount,
     poolSizeMode: ownership.poolSizeMode,
@@ -163,6 +239,78 @@ export const DrawStructureSection = ({
       qualifiersPerPool,
       drawOwnership: { ...ownership, ...next },
     })
+
+  /**
+   * A pool count the director has typed but **not finished typing** — one below the rows
+   * the event has, so it is not written yet. `null` the rest of the time.
+   *
+   * ⚠️ **This is why the confirm is not opened on the keystroke**, and the reason is
+   * arithmetic rather than taste. Against six pools, typing `12` produces the value `1`
+   * first: priced per keystroke, that `1` opens a modal dialog, focus leaves the box, and
+   * the `2` never lands. Every count with a smaller leading digit than the event has pools
+   * would be unreachable in a box whose ceiling is 512.
+   *
+   * So a lowered count is *held* — the box shows what was typed, nothing is written — and
+   * priced when the director says they are done (`commitPoolCount`, off blur or Enter). A
+   * *raised* count needs none of this: it spends nothing, so it writes on the keystroke
+   * like every other box on the tab.
+   */
+  const [typedPoolCount, setTypedPoolCount] = useState<number | null>(null)
+
+  /**
+   * The removal awaiting its answer: the count that produced it and the rows it would
+   * drop. `null` whenever no dialog is on screen.
+   */
+  const [pendingRemoval, setPendingRemoval] = useState<{
+    count: number
+    removed: PoolEntry[]
+  } | null>(null)
+
+  /** Write a pool count — **the number and the rows, in one act** (ADR 20260808). Not an
+   * effect on the stored count: a saved event may legitimately hold a manual count its row
+   * count does not match (that is what `Set myself` leaves behind, and the ADR permits
+   * saving it), and an effect would silently reshape it the moment the tab was opened. */
+  const writePoolCount = (count: number) => {
+    own({ manualPoolCount: count })
+    onPoolsChange(reconcilePoolsToCount(pools, count, event.slot).pools)
+    setTypedPoolCount(null)
+    setPendingRemoval(null)
+  }
+
+  /** What the Pool count box does with a keystroke the bounds admitted. */
+  const takePoolCount = (value: number | null) => {
+    // A cleared box is **not** a count of none. The derivation reads a manual mode with no
+    // number as automatic, so the count goes back to being the row count — and no row is
+    // touched. Reconciling to `0` here would delete every pool of the event because
+    // somebody selected the number to retype it.
+    if (value === null) {
+      setTypedPoolCount(null)
+      own({ manualPoolCount: null })
+      return
+    }
+    // Below the rows the event has: destructive, so it is held rather than written, and
+    // the next keystroke may well raise it back above them.
+    if (value < pools.length) {
+      setTypedPoolCount(value)
+      return
+    }
+    writePoolCount(value)
+  }
+
+  /** The director is done typing (they left the box, or pressed Enter). A held count is
+   * priced now: the confirm names the reservations that would go before any of them does
+   * (ADR 20260806). */
+  const commitPoolCount = () => {
+    // Nothing held, or a dialog already asking about it — the confirm's own focus move
+    // blurs the box a second time, and one question is enough.
+    if (typedPoolCount === null || pendingRemoval !== null) return
+    const { removed } = reconcilePoolsToCount(pools, typedPoolCount, event.slot)
+    if (removed.length > 0) {
+      setPendingRemoval({ count: typedPoolCount, removed })
+      return
+    }
+    writePoolCount(typedPoolCount)
+  }
 
   // Read off the derived sizes rather than divided out again — the pools are routinely
   // unequal (22 across 4 is `6, 6, 5, 5`) and the uneven case is a first-class state.
@@ -259,12 +407,21 @@ export const DrawStructureSection = ({
               unit={structure.poolCount === 1 ? 'pool' : 'pools'}
               ownership={structure.sources.poolCount.ownership}
               source={structure.sources.poolCount.sentence}
+              // The pool SET freeze, not a rule of this row's own: a cut event's fixtures
+              // each name the pool they were dealt into, so creating or removing a pool row
+              // is a 409 (`poolSetFreeze`, `data/draw`) — and this row now does exactly
+              // that. Box and action both, for the reason on the prop.
+              freeze={poolSetFreeze}
               entry={
                 canEdit && ownership.poolCountMode === 'manual'
                   ? {
-                      value: ownership.manualPoolCount,
+                      // The held number while one is being typed, else the stored one.
+                      // Going back drops the held value, and the box is the stored number
+                      // again.
+                      value: typedPoolCount ?? ownership.manualPoolCount,
                       max: MANUAL_POOL_DIMENSION_MAX,
-                      onChange: (value) => own({ manualPoolCount: value }),
+                      onChange: takePoolCount,
+                      onCommit: commitPoolCount,
                     }
                   : undefined
               }
@@ -274,12 +431,20 @@ export const DrawStructureSection = ({
                     ? {
                         label: 'Use automatic',
                         // The mode only: the number stays, remembered for the next time
-                        // they take the setting back.
+                        // they take the setting back — and **no row is touched**. The
+                        // automatic count is the row count, so handing the setting back
+                        // changes who owns the number, not how many pools the event has.
                         onClick: () => own({ poolCountMode: 'automatic' }),
                       }
                     : {
                         label: 'Set myself',
-                        // Seeded from the count the row was already showing.
+                        // Seeded from the count the row was already showing — and, again,
+                        // **no row is created**. That count is a projection while pool size
+                        // is manual, and a projection in excess of the rows is reported,
+                        // never materialised (ADR 20260808, point 3). Chore 5b's
+                        // disagreement panel is what reports it, and its
+                        // `Use {n} pools of {size}` is what appends the rows, through the
+                        // same `reconcilePoolsToCount` this row types through.
                         onClick: () =>
                           own({
                             poolCountMode: 'manual',
@@ -447,13 +612,38 @@ export const DrawStructureSection = ({
             // shows (ADR 20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-
             // count-is-a-projection). A director who takes the pool count and types 8
             // over four reservations must read `8 pools` in the equation and `4` in the
-            // fact, and see the gap.
-            poolReservationCount={event.pools.length}
+            // fact, and see the gap. The same list the derivation counts, so the fact and
+            // the row's source sentence can never name two different numbers.
+            poolReservationCount={pools.length}
             membershipMode={ownership.membershipMode}
             previewBasis={previewBasis}
           />
         </div>
       </div>
+
+      {/* The price of a lowered pool count, asked before anything is written: the rows are
+          still in the form, the ownership record still holds the old number, and Go back —
+          or Escape — leaves both exactly as they are. Rendered only while an act is
+          awaiting its answer, so the dialog cannot be on screen with nothing behind it. */}
+      {pendingRemoval && (
+        <ConfirmIrreversibleActDialog
+          open
+          consequence={
+            {
+              variant: 'remove-pool-reservations',
+              eventName: event.name,
+              poolNames: pendingRemoval.removed.map((pool) => pool.name),
+            } satisfies PoolCountActConsequence
+          }
+          onConfirm={() => writePoolCount(pendingRemoval.count)}
+          onCancel={() => {
+            // BOTH: the held number goes with the dialog, so the box reads the stored
+            // count again rather than a number the event does not have.
+            setTypedPoolCount(null)
+            setPendingRemoval(null)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import type { EditFreeze } from '../../data/draw'
 import {
   MANUAL_POOL_DIMENSION_MAX,
+  MEMBERSHIP_MANUAL_VALUE,
   everySettingAutomatic,
   type DrawOwnership,
 } from '../../data/draw-ownership'
@@ -505,7 +506,10 @@ export const DrawStructureSection = ({
             <SettingRow
               name="Membership"
               hint="Who lands in each pool. Entrants do not exist until you cut the draw."
-              value={membershipManual ? 'Assign at cut time' : 'Snake automatically'}
+              // The manual phrase is a shared constant (`MEMBERSHIP_MANUAL_VALUE`): the
+              // confirm that discards this setting reads the same three words back, and
+              // two copies of one phrase is one of them going stale.
+              value={membershipManual ? MEMBERSHIP_MANUAL_VALUE : 'Snake automatically'}
               kind="phrase"
               ownership={membershipManual ? 'manual' : 'automatic'}
               source={

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
@@ -1,6 +1,7 @@
 import { Overline } from '@/components/overline'
 import { Button } from '@/components/ui/button'
 
+import type { EditFreeze } from '../../data/draw'
 import {
   MANUAL_POOL_DIMENSION_MAX,
   everySettingAutomatic,
@@ -17,6 +18,15 @@ import {
   previewFieldSize,
 } from './draw-structure-section/preview-field'
 import { SettingRow } from './draw-structure-section/setting-row'
+
+/** Inline validation messages for the settings this tab owns, mapped from the editor's
+ * React-Hook-Form state. Only the qualifier count can carry one: the other three settings
+ * are typed through boxes that refuse a keystroke the schema would reject
+ * (`acceptedManualEntry`), while K is a value the event must have and a box the director
+ * can empty. Never shown to a reader — a reader has no box to be wrong in. */
+export interface DrawStructureFieldErrors {
+  qualifiersPerPool?: string
+}
 
 export interface DrawStructureSectionProps {
   /**
@@ -51,6 +61,22 @@ export interface DrawStructureSectionProps {
    * unsaved draft.
    */
   onGoToBasics: () => void
+  /** The resolver's red for the qualifier count, surfaced on its row. The tab does not
+   * *decide* it: the editor resolves the whole form on submit and hands each tab its share,
+   * so "may I save?" and "what does this row say in red?" are one answer computed once —
+   * exactly as the Basics tab already works. */
+  errors?: DrawStructureFieldErrors
+  /** Whether the **qualifier count** may still be changed (`qualifiersPerPoolFreeze`,
+   * `data/draw`). Frozen once the event's draw is cut: the knockout bracket was cut
+   * upfront for `P × K`, so a moved K leaves qualifiers with no slot to be seated into — a
+   * 409 on the server. Frozen means a disabled box and a disabled action, both pointing at
+   * the reason (ADR 20260806); it does not mean a hidden row. The other three settings are
+   * untouched by it — their modes size nothing the cut already put on the table, and the
+   * server excludes them from the freeze on purpose.
+   *
+   * **Required, not optional.** A freeze a call site can forget is a freeze that silently
+   * does not happen, and this one guards a 409. */
+  qualifiersFreeze: EditFreeze
 }
 
 /**
@@ -96,6 +122,8 @@ export const DrawStructureSection = ({
   canEdit,
   onChange,
   onGoToBasics,
+  errors = {},
+  qualifiersFreeze,
 }: DrawStructureSectionProps) => {
   const fieldSize = previewFieldSize(event.maxPlayers)
   // ONE call, two readers — the heading block and the preview's `Preview basis` fact.
@@ -342,9 +370,13 @@ export const DrawStructureSection = ({
                   : undefined
               }
             />
-            {/* ⚠️ Still on Basics as well, this slice. Chore 3e moves it here for good;
-                until then the director sees the stored K on Basics and the DERIVED one
-                here, and the two can disagree. That is deliberate and temporary. */}
+            {/* **K, and this is now the only place it is set** (chore 3e): it is a
+                structural setting, so it moved off the Basics tab and in beside the other
+                three (ADR 20260808). Which is why this row carries two slots the other
+                three do not — the resolver's red, and the cut-draw freeze — both of which
+                the Basics row it replaced already had. Dropping either in the move would
+                have sent a refused save to a tab with nothing red on it, or offered a
+                director a click that can only 409. */}
             <SettingRow
               name="Qualifiers per pool"
               hint="How many finishers from each pool reach the knockout."
@@ -353,11 +385,13 @@ export const DrawStructureSection = ({
               unit="through from each pool"
               ownership={structure.sources.qualifiers.ownership}
               source={structure.sources.qualifiers.sentence}
+              error={errors.qualifiersPerPool}
+              freeze={qualifiersFreeze}
               entry={
                 canEdit && ownership.qualifiersMode === 'manual'
                   ? {
-                      // The event's own K — the manual slot for this setting, and the
-                      // number the Basics box shows too until chore 3e moves it here.
+                      // The event's own K — the manual slot for this setting. There is no
+                      // `manual_qualifiers` on the wire: the stored count IS the slot.
                       value: event.qualifiersPerPool,
                       max: QUALIFIERS_PER_POOL_MAX,
                       onChange: (value) => own({}, value),

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
@@ -163,12 +163,16 @@ export interface DrawStructureSectionProps {
  * edits and the save already sends — one write, one save, and no way for the two tabs to
  * disagree about how many pools the event has.
  *
- * Raising the count **appends** rows that continue the letter sequence and inherit the
- * last pool's window, with no tables, and it writes on the keystroke like every other box
- * here — it spends nothing. Lowering it **removes** rows from the end, which discards
- * reservations, so it is *held* until the director finishes typing and then priced by a
- * confirm that names them (ADR 20260806). Held rather than priced per keystroke because
- * `12` begins with `1`: see `typedPoolCount`.
+ * **The box is held while the director types**, in both directions, and written when they
+ * say they are done — off blur or Enter. A keystroke is only a prefix of the number being
+ * typed (`55` begins with `5`, `12` begins with `1`), and this box mints and drops real
+ * pool rows, so acting on a prefix reshapes the event around a count nobody asked for:
+ * see `typedPoolCount`.
+ *
+ * The committed count then **appends** rows that continue the letter sequence and inherit
+ * the last pool's window, with no tables, or **removes** rows from the end. A removal
+ * discards reservations, so it is priced first by a confirm that names them (ADR
+ * 20260806) — priced on the committed number, never on a keystroke.
  *
  * Two things deliberately do *not* reconcile:
  *
@@ -242,19 +246,28 @@ export const DrawStructureSection = ({
     })
 
   /**
-   * A pool count the director has typed but **not finished typing** — one below the rows
-   * the event has, so it is not written yet. `null` the rest of the time.
+   * A pool count the director has typed but **not finished typing**. `null` whenever
+   * nothing is held — which is also what a cleared box leaves behind, since an empty box
+   * is not a count at all.
    *
-   * ⚠️ **This is why the confirm is not opened on the keystroke**, and the reason is
-   * arithmetic rather than taste. Against six pools, typing `12` produces the value `1`
-   * first: priced per keystroke, that `1` opens a modal dialog, focus leaves the box, and
-   * the `2` never lands. Every count with a smaller leading digit than the event has pools
-   * would be unreachable in a box whose ceiling is 512.
+   * ⚠️ **Every typed count is held, in both directions**, and written once the director
+   * says they are done (`commitPoolCount`, off blur or Enter). The reason is arithmetic
+   * rather than taste: a keystroke is a *prefix* of the number being typed, and this box
+   * materialises pool rows, so acting on a prefix acts on a number nobody asked for.
    *
-   * So a lowered count is *held* — the box shows what was typed, nothing is written — and
-   * priced when the director says they are done (`commitPoolCount`, off blur or Enter). A
-   * *raised* count needs none of this: it spends nothing, so it writes on the keystroke
-   * like every other box on the tab.
+   * - Lowering. Against six pools, typing `12` produces the value `1` first. Priced per
+   *   keystroke, that `1` opens a modal dialog, focus leaves the box, and the `2` never
+   *   lands — every count with a smaller leading digit than the event has pools would be
+   *   unreachable in a box whose ceiling is 512.
+   * - Raising. Against four pools, typing `55` produces `5` first. Written per keystroke,
+   *   that `5` mints a pool row and the `55` then mints fifty more, so backspacing to the
+   *   `5` that was meant is now a removal, priced by a confirm naming fifty reservations
+   *   the director never asked for.
+   *
+   * One box, one rule: the box shows what was typed, nothing is written, and the number
+   * the director finished typing is the only one the event ever sees. A lowering that
+   * drops reservations is still priced by the confirm at that point, on the committed
+   * value (ADR 20260806).
    */
   const [typedPoolCount, setTypedPoolCount] = useState<number | null>(null)
 
@@ -289,18 +302,15 @@ export const DrawStructureSection = ({
       own({ manualPoolCount: null })
       return
     }
-    // Below the rows the event has: destructive, so it is held rather than written, and
-    // the next keystroke may well raise it back above them.
-    if (value < pools.length) {
-      setTypedPoolCount(value)
-      return
-    }
-    writePoolCount(value)
+    // Held, whichever way it moves: a keystroke is a prefix, and a prefix of `55` is a
+    // `5` that would mint a pool row nobody asked for. The box shows it, the event does
+    // not get it until `commitPoolCount`.
+    setTypedPoolCount(value)
   }
 
-  /** The director is done typing (they left the box, or pressed Enter). A held count is
-   * priced now: the confirm names the reservations that would go before any of them does
-   * (ADR 20260806). */
+  /** The director is done typing (they left the box, or pressed Enter). The held count is
+   * written now — and priced first if it drops reservations: the confirm names the ones
+   * that would go before any of them does (ADR 20260806). */
   const commitPoolCount = () => {
     // Nothing held, or a dialog already asking about it — the confirm's own focus move
     // blurs the box a second time, and one question is enough.

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
@@ -1,7 +1,13 @@
 import { Overline } from '@/components/overline'
 import { Button } from '@/components/ui/button'
 
+import {
+  MANUAL_POOL_DIMENSION_MAX,
+  everySettingAutomatic,
+  type DrawOwnership,
+} from '../../data/draw-ownership'
 import { deriveDrawStructure } from '../../data/draw-structure'
+import { QUALIFIERS_PER_POOL_MAX } from '../../data/event-validation'
 import type { TournamentEvent } from '../../data/types'
 import { drawIssueFor } from './draw-structure-section/draw-issue'
 import { DrawIssuePanel } from './draw-structure-section/draw-issue-panel'
@@ -17,12 +23,25 @@ export interface DrawStructureSectionProps {
    * The event as the editor's **live draft** has it, so the tab recomputes as the
    * director edits the player limit or adds a pool on the tabs next door.
    *
-   * ⚠️ Only two fields are read — `maxPlayers` and `pools.length` — and the second is
-   * read as a *count* deliberately. The editor's draft carries the form's `pools`, which
-   * are `PoolEntry` diffs rather than the read model's `Pool` rows (ADR 20260801); the
-   * length is the same either way, and nothing else here may touch a pool's insides.
+   * ⚠️ `pools` is read as a *count* deliberately. The editor's draft carries the form's
+   * `pools`, which are `PoolEntry` diffs rather than the read model's `Pool` rows (ADR
+   * 20260801); the length is the same either way, and nothing here may touch a pool's
+   * insides.
    */
   event: TournamentEvent
+  /** When false (a non-creator), the tab is a **view**: every value is text, and there
+   * is no action, no box and no way to Basics. Not a disabled form (ADR-0015). */
+  canEdit: boolean
+  /**
+   * Write the edited event back to the editor's form — the same `onChange` the Basics
+   * and Match settings tabs take, so a setting taken here is form state and not a
+   * second draft this tab keeps to itself.
+   *
+   * The two fields it ever changes are `drawOwnership` and — when the director takes the
+   * qualifier count — `qualifiersPerPool`, whose value is the qualifiers row's number
+   * (the wire has no `manual_qualifiers`: the stored K *is* the manual slot).
+   */
+  onChange: (event: TournamentEvent) => void
   /**
    * Take the director to the Basics tab, where the player limit that sizes this preview
    * lives.
@@ -36,31 +55,34 @@ export interface DrawStructureSectionProps {
 
 /**
  * The event editor's **Draw structure** tab (#1320) — the four structural settings of a
- * round-robin-then-knockout draw, read out as the system currently derives them.
+ * round-robin-then-knockout draw, each one the director's or the system's.
  *
  * ## Why the tab exists
  *
- * A director controls one and a half of these four settings today, and nothing on any
- * tab states the other two (ADR 20260808). #1320 records a real director who set one
- * pool and one qualifier per pool, sent one player to the bracket, and was refused with
- * a message that named the wrong cause. This tab states every number and says where it
- * came from, so the shape of the draw is readable before it is cut.
+ * A director controlled one and a half of these four settings, and nothing on any tab
+ * stated the other two (ADR 20260808). #1320 records a real director who set one pool and
+ * one qualifier per pool, sent one player to the bracket, and was refused with a message
+ * that named the wrong cause. This tab states every number, says where it came from, and
+ * lets a director take any of them for themselves — or give it back.
  *
- * ## What this chore renders, and what it does not
+ * ## Taking a setting changes the owner, not the number
  *
- * **Every setting is `Automatic`, and every value is text.** Nothing stores an ownership
- * mode yet, so the derivation is fed all-automatic and the rows read out what today's
- * behaviour already does. The `Set myself` / `Use automatic` action and the numeric
- * input arrive with the ownership modes (chore 3c) — and they are *absent* until then,
- * never a disabled box, which is the unexplained dead end ADR-0015 forbids.
+ * `Set myself` seeds the box from what the row was already showing: the derived pool
+ * count, the **largest** derived pool, the derived qualifier count. So the first click
+ * moves nothing, and a director who wants to nudge a number by one does not first have to
+ * work out what it currently is (ADR 20260808).
  *
- * The right column carries the live preview (`DrawPreview`) — **the tab's one verdict**,
- * and the only summary of the draw anywhere on it. The uneven / disagreement /
- * impossible *notices*, which explain those states and offer fixes, land under the
- * settings in this left column as one `DrawIssuePanel`. **Only the uneven one is built**:
- * `Can’t save` is chore 4c and `Needs your call` is chore 5a, and both come with `Apply`
- * fixes. The Pool size row carries its own uneven copy either way (`{min}–{max} players ·
- * uneven`), because that is row copy and not a panel.
+ * `Use automatic` is the exact opposite of destructive: it sets the mode and **keeps the
+ * number**, so a director who looks at what the system would say and comes back gets
+ * their own number returned rather than an empty box.
+ *
+ * ## The badge follows the EFFECTIVE owner, the box follows the stored mode
+ *
+ * A director can own a setting and have cleared its box. The derivation reads that as
+ * automatic — a manual mode with no number derives — and reports the ownership it
+ * actually used, so the `Yours` badge and the source sentence can never disagree with
+ * each other. The box and the action read the stored mode instead, so the row the
+ * director took stays theirs and can still be handed back.
  *
  * ## The arithmetic is not here
  *
@@ -71,6 +93,8 @@ export interface DrawStructureSectionProps {
  */
 export const DrawStructureSection = ({
   event,
+  canEdit,
+  onChange,
   onGoToBasics,
 }: DrawStructureSectionProps) => {
   const fieldSize = previewFieldSize(event.maxPlayers)
@@ -78,26 +102,47 @@ export const DrawStructureSection = ({
   // Called twice they could eventually be called with different arguments, and two
   // sentences about the same number is exactly the confusion #1320 removes.
   const previewBasis = previewBasisLabel(event.maxPlayers)
+  // An `rr-then-ko` event that has never seen this tab stores no record, and the
+  // all-automatic one is what that means (ADR 20260808 — "an event that sets nothing
+  // behaves exactly as it does today"). A FRESH record, never a shared constant: it is
+  // what every write below is built from, and a shared object would be one object every
+  // event's toggle rewrote.
+  const ownership = event.drawOwnership ?? everySettingAutomatic()
+
   const structure = deriveDrawStructure({
     previewFieldSize: fieldSize,
     // One pool reservation is one pool — today's behaviour, and the automatic source of
     // the pool count (ADR 20260808).
     poolReservationCount: event.pools.length,
-    // All four settings are the system's this chore: nothing writes an ownership mode
-    // yet, so there is no manual number for any of them to hold.
-    poolCountMode: 'automatic',
-    manualPoolCount: null,
-    poolSizeMode: 'automatic',
-    manualPoolSize: null,
-    qualifiersMode: 'automatic',
-    manualQualifiers: null,
+    poolCountMode: ownership.poolCountMode,
+    manualPoolCount: ownership.manualPoolCount,
+    poolSizeMode: ownership.poolSizeMode,
+    manualPoolSize: ownership.manualPoolSize,
+    qualifiersMode: ownership.qualifiersMode,
+    // **The event's own K is the manual slot.** There is no `manual_qualifiers` on the
+    // wire: every `rr-then-ko` event already carries a qualifier count, and the mode is
+    // what says whether anybody should read it. Passed unconditionally, exactly as the
+    // API's comment describes, so the derivation's own `qualifiersMode` check decides.
+    manualQualifiers: event.qualifiersPerPool,
   })
+
+  /** Write a changed ownership record — always a **replacement**, never a mutation. The
+   * `as const` on the wire-side twin gives readonly modifiers TypeScript does not check
+   * on assignment, so a record edited in place would be one record every event shared. */
+  const own = (next: Partial<DrawOwnership>, qualifiersPerPool = event.qualifiersPerPool) =>
+    onChange({
+      ...event,
+      qualifiersPerPool,
+      drawOwnership: { ...ownership, ...next },
+    })
 
   // Read off the derived sizes rather than divided out again — the pools are routinely
   // unequal (22 across 4 is `6, 6, 5, 5`) and the uneven case is a first-class state.
   const smallestPool = Math.min(...structure.poolSizes)
   const largestPool = Math.max(...structure.poolSizes)
   const uneven = smallestPool !== largestPool
+
+  const membershipManual = ownership.membershipMode === 'manual'
 
   // The ONE notice the tab shows, chosen in the reference's order — impossible, then
   // disagreement, then uneven. The derivation reports all three independently and more
@@ -159,14 +204,19 @@ export const DrawStructureSection = ({
             >
               {previewBasis}
             </p>
-            <Button
-              variant="link"
-              size="sm"
-              className="mt-1 h-auto p-0 text-[12px]"
-              onClick={onGoToBasics}
-            >
-              Change in Basics
-            </Button>
+            {/* HIDDEN from a reader, not disabled (ADR-0015): "Change in Basics" is an
+                imperative addressed to somebody who can change it, and the cap is not
+                theirs to change. */}
+            {canEdit && (
+              <Button
+                variant="link"
+                size="sm"
+                className="mt-1 h-auto p-0 text-[12px]"
+                onClick={onGoToBasics}
+              >
+                Change in Basics
+              </Button>
+            )}
           </div>
 
           {/* ONE list with dividers, not one card per row. The divider is the list's, so
@@ -181,6 +231,35 @@ export const DrawStructureSection = ({
               unit={structure.poolCount === 1 ? 'pool' : 'pools'}
               ownership={structure.sources.poolCount.ownership}
               source={structure.sources.poolCount.sentence}
+              entry={
+                canEdit && ownership.poolCountMode === 'manual'
+                  ? {
+                      value: ownership.manualPoolCount,
+                      max: MANUAL_POOL_DIMENSION_MAX,
+                      onChange: (value) => own({ manualPoolCount: value }),
+                    }
+                  : undefined
+              }
+              action={
+                canEdit
+                  ? ownership.poolCountMode === 'manual'
+                    ? {
+                        label: 'Use automatic',
+                        // The mode only: the number stays, remembered for the next time
+                        // they take the setting back.
+                        onClick: () => own({ poolCountMode: 'automatic' }),
+                      }
+                    : {
+                        label: 'Set myself',
+                        // Seeded from the count the row was already showing.
+                        onClick: () =>
+                          own({
+                            poolCountMode: 'manual',
+                            manualPoolCount: structure.poolCount,
+                          }),
+                      }
+                  : undefined
+              }
             />
             {/* The uneven split is this row's own copy, not the 2d notice: `{min}–{max}`
                 with the unit saying so out loud. An en dash, and a middle dot before
@@ -193,18 +272,75 @@ export const DrawStructureSection = ({
               unit={uneven ? 'players · uneven' : 'players per pool'}
               ownership={structure.sources.poolSize.ownership}
               source={structure.sources.poolSize.sentence}
+              entry={
+                canEdit && ownership.poolSizeMode === 'manual'
+                  ? {
+                      value: ownership.manualPoolSize,
+                      max: MANUAL_POOL_DIMENSION_MAX,
+                      onChange: (value) => own({ manualPoolSize: value }),
+                    }
+                  : undefined
+              }
+              action={
+                canEdit
+                  ? ownership.poolSizeMode === 'manual'
+                    ? {
+                        label: 'Use automatic',
+                        onClick: () => own({ poolSizeMode: 'automatic' }),
+                      }
+                    : {
+                        label: 'Set myself',
+                        // **The LARGEST derived pool**, which is the target the split was
+                        // aiming at: 22 across 4 is `6, 6, 5, 5`, and a director taking
+                        // that setting is taking pools of six with a short one, not pools
+                        // of five with a long one. Seeding the smallest would shrink the
+                        // draw on the first click, which is the silent reshaping #1320
+                        // exists to remove.
+                        onClick: () =>
+                          own({
+                            poolSizeMode: 'manual',
+                            manualPoolSize: largestPool,
+                          }),
+                      }
+                  : undefined
+              }
             />
             {/* Membership has no number, so `deriveDrawStructure` says nothing about it
                 (its `DrawStructureSources` omits it by design). The row reads its mode
-                off the event — and nothing stores one yet, so it is the snake, which is
-                what `_snake()` in `api/app/draws.py` already does on every cut. */}
+                straight off the event — and the automatic answer is not a shrug, it is
+                `_snake()` in `api/app/draws.py`, which already deals every cut. */}
             <SettingRow
               name="Membership"
               hint="Who lands in each pool. Entrants do not exist until you cut the draw."
-              value="Snake automatically"
+              value={membershipManual ? 'Assign at cut time' : 'Snake automatically'}
               kind="phrase"
-              ownership="automatic"
-              source="Seeds spread 1, 2, 3, 3, 2, 1."
+              ownership={membershipManual ? 'manual' : 'automatic'}
+              source={
+                membershipManual
+                  ? 'You’ll place entrants once registration closes.'
+                  : 'Seeds spread 1, 2, 3, 3, 2, 1.'
+              }
+              // What placing entrants by hand COSTS, said on the row that costs it: the
+              // snake keeps two players who met in a pool apart in the first knockout
+              // round, and a hand-dealt pool cannot promise that.
+              note={
+                membershipManual
+                  ? 'Repeat protection turns off when you assign pools by hand.'
+                  : undefined
+              }
+              action={
+                canEdit
+                  ? membershipManual
+                    ? {
+                        label: 'Use snake',
+                        onClick: () => own({ membershipMode: 'snake' }),
+                      }
+                    : {
+                        label: 'Assign myself',
+                        onClick: () => own({ membershipMode: 'manual' }),
+                      }
+                  : undefined
+              }
             />
             {/* ⚠️ Still on Basics as well, this slice. Chore 3e moves it here for good;
                 until then the director sees the stored K on Basics and the DERIVED one
@@ -217,6 +353,42 @@ export const DrawStructureSection = ({
               unit="through from each pool"
               ownership={structure.sources.qualifiers.ownership}
               source={structure.sources.qualifiers.sentence}
+              entry={
+                canEdit && ownership.qualifiersMode === 'manual'
+                  ? {
+                      // The event's own K — the manual slot for this setting, and the
+                      // number the Basics box shows too until chore 3e moves it here.
+                      value: event.qualifiersPerPool,
+                      max: QUALIFIERS_PER_POOL_MAX,
+                      onChange: (value) => own({}, value),
+                    }
+                  : undefined
+              }
+              action={
+                canEdit
+                  ? ownership.qualifiersMode === 'manual'
+                    ? {
+                        label: 'Use automatic',
+                        // ⚠️ The mode, and ONLY the mode. Clearing K here would be a
+                        // destructive `Use automatic` *and* an unsaveable event: the
+                        // count is required on every `rr-then-ko` event, so the resolver
+                        // would refuse the save and send the director to Basics.
+                        onClick: () => own({ qualifiersMode: 'automatic' }),
+                      }
+                    : {
+                        label: 'Set myself',
+                        // Seeded from the derived count, which for a stored K the system
+                        // was ignoring is a real change to the event's number — and the
+                        // right one: it is what the row, the preview and the pool cards
+                        // have all been showing.
+                        onClick: () =>
+                          own(
+                            { qualifiersMode: 'manual' },
+                            structure.qualifiersPerPool,
+                          ),
+                      }
+                  : undefined
+              }
             />
           </div>
 
@@ -239,10 +411,11 @@ export const DrawStructureSection = ({
             fieldSize={fieldSize}
             // ⚠️ The event's real pool ROWS, not `max(rows, derived)` as the reference
             // shows (ADR 20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-
-            // count-is-a-projection). Nothing sets a manual pool count this chore, so
-            // the two are equal today; taking the max would hide the gap the moment
-            // chore 3c lets a director type one.
+            // count-is-a-projection). A director who takes the pool count and types 8
+            // over four reservations must read `8 pools` in the equation and `4` in the
+            // fact, and see the gap.
             poolReservationCount={event.pools.length}
+            membershipMode={ownership.membershipMode}
             previewBasis={previewBasis}
           />
         </div>

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.factory.tsx
@@ -47,6 +47,10 @@ export function buildDrawPreviewPropsFor(
     structure: deriveDrawStructure(options),
     fieldSize: options.previewFieldSize,
     poolReservationCount: options.poolReservationCount,
+    // The snake, which is the "Nothing set" state and what every cut already deals. The
+    // hand-dealt mode is a prop a test overrides — it is not one of the eight derivation
+    // inputs, because membership has no number to derive.
+    membershipMode: 'snake',
     // The default builder treats the field as a cap the director set, which is the
     // reference's state. The uncapped sentence is a prop a test overrides.
     previewBasis: previewBasisLabel(options.previewFieldSize),

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.test.tsx
@@ -56,6 +56,16 @@ describe('DrawPreview', () => {
       expect(drawPreviewPage.getFact('Membership')).toHaveTextContent('Snake')
     })
 
+    // …and says so in its own, shorter words when the director takes it: the setting row
+    // one column over reads `Assign at cut time`, this fact reads `By hand at cut`.
+    it('says when the director will place the field themselves', () => {
+      drawPreviewPage.render({ membershipMode: 'manual' })
+
+      expect(drawPreviewPage.getFact('Membership')).toHaveTextContent(
+        'By hand at cut',
+      )
+    })
+
     it('says where the field it derived against came from', () => {
       drawPreviewPage.render()
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-preview.tsx
@@ -4,8 +4,16 @@ import { Overline } from '@/components/overline'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 
+import type { PoolMembershipMode } from '../../../data/draw-ownership'
 import { poolLetter, type DrawStructure } from '../../../data/draw-structure'
 import { PoolCard } from './draw-preview/pool-card'
+
+/** The `Membership` fact, in the reference's words — two of them, because the fact is a
+ * summary and the setting row one column over is where the sentence is. */
+const MEMBERSHIP_FACT: Record<PoolMembershipMode, string> = {
+  snake: 'Snake',
+  manual: 'By hand at cut',
+}
 
 /** How many pool cards the preview draws. The reference stops at eight, and so does
  * this: the equation directly above already states the pool count, so a twelve-pool draw
@@ -53,6 +61,11 @@ export interface DrawPreviewProps {
    * and `4` in this fact, and see the gap.
    */
   poolReservationCount: number
+  /** How entrants will reach their pools — the event's stored mode (ADR 20260808). The
+   * mode itself rather than a label, because the fact's two words are the preview's own
+   * copy (`MEMBERSHIP_FACT`) and shorter than the setting row's: the row says
+   * `Snake automatically`, the fact says `Snake`. */
+  membershipMode: PoolMembershipMode
   /** Where the preview field came from, in words — `32-player cap`, or the honest
    * sentence for an event with no cap. Built by `previewBasisLabel` **at the caller**, so
    * the heading block and this fact are one call and cannot come apart. */
@@ -82,13 +95,15 @@ export interface DrawPreviewProps {
  *
  * The reference ends with a `Preview cut-time assignment →` link. That screen is #1324,
  * so the link is absent rather than stubbed — a dead link is the unexplained dead end
- * ADR-0015 forbids. Membership reads `Snake` because nothing stores the manual mode yet
- * (chore 3c).
+ * ADR-0015 forbids. The reference also carries a `Repeat protection is off` block under
+ * the facts when membership is manual; the Membership setting row states that cost
+ * already, and the block is a later chore.
  */
 export const DrawPreview = ({
   structure,
   fieldSize,
   poolReservationCount,
+  membershipMode,
   previewBasis,
 }: DrawPreviewProps) => {
   const overlineId = useId()
@@ -128,7 +143,7 @@ export const DrawPreview = ({
       value: String(poolReservationCount),
       mono: true,
     },
-    { term: 'Membership', value: 'Snake', mono: false },
+    { term: 'Membership', value: MEMBERSHIP_FACT[membershipMode], mono: false },
     { term: 'Preview basis', value: previewBasis, mono: false },
   ]
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.page.tsx
@@ -1,10 +1,15 @@
+import { interactiveElementsIn } from '@/test/read-only'
 import { render, screen, type Container } from '@/test/utilities'
 
 import { SettingRow, type SettingRowProps } from './setting-row'
 import { buildSettingRowProps } from './setting-row.factory'
 
 const scoped = (container: Container) => ({
-  /** The row itself — a `region` named by the setting it holds. */
+  /** The row itself — a `region` named by the setting it holds.
+   *
+   * ⚠️ Only available at *screen* scope: a container already scoped **to** the region
+   * cannot then find it, since a `within` query searches descendants. The section's page
+   * object scopes each row this way, so it sweeps the whole tab instead. */
   getRow() {
     return container.getByRole('region')
   },
@@ -16,9 +21,22 @@ const scoped = (container: Container) => ({
   getHint() {
     return container.getByTestId('draw-setting-hint')
   },
-  /** The value as the director reads it — a figure, or Membership's phrase. */
+  /** The value as the director reads it — a figure, or Membership's phrase. **Absent
+   * when the director owns the setting and may edit it**: the box is the value then, and
+   * a row that showed both would be showing one number twice. */
   getValue() {
     return container.getByTestId('draw-setting-value')
+  },
+  queryValue() {
+    return container.queryByTestId('draw-setting-value')
+  },
+  /** The direct-entry box, when the director owns this setting. `<input type="text"
+   * inputMode="numeric">` — there is no spinner and there are no plus/minus buttons. */
+  getInput() {
+    return container.getByTestId('draw-setting-input')
+  },
+  queryInput() {
+    return container.queryByTestId('draw-setting-input')
   },
   /** The plain words after the value. **Absent on a `phrase` row**: Membership's
    * value is already a sentence, so there is nothing to unit. */
@@ -33,6 +51,25 @@ const scoped = (container: Container) => ({
   /** The line saying where the value came from. */
   getSource() {
     return container.getByTestId('draw-setting-source')
+  },
+  /** The one quiet text action — `Set myself` / `Use automatic`, or Membership's
+   * `Assign myself` / `Use snake`. Absent for a reader. */
+  getAction() {
+    return container.getByTestId('draw-setting-action')
+  },
+  queryAction() {
+    return container.queryByTestId('draw-setting-action')
+  },
+  /** The extra line under the source, for a consequence the setting carries. Absent on
+   * every row but a hand-dealt Membership. */
+  queryNote() {
+    return container.queryByTestId('draw-setting-note')
+  },
+  /** The row's interactive controls — the one sweep (`@/test/read-only`), composed
+   * rather than re-typed. Screen scope only, for the reason `getRow` gives; the tab's
+   * own guard sweeps the whole tab (`drawStructureSectionPage.getFormElements`). */
+  getFormElements() {
+    return interactiveElementsIn(container.getByTestId('draw-setting-row'))
   },
 })
 

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.page.tsx
@@ -65,6 +65,25 @@ const scoped = (container: Container) => ({
   queryNote() {
     return container.queryByTestId('draw-setting-note')
   },
+  /** The resolver's red for this row's value. Distinct test id from the freeze reason
+   * below, even though the two share one slot, so a test cannot pass on a freeze rendered
+   * where an error belongs. */
+  queryError() {
+    return container.queryByTestId('draw-setting-error')
+  },
+  /** The reason this row is frozen — a cut draw's refusal, in words (ADR 20260806). */
+  queryFreezeReason() {
+    return container.queryByTestId('draw-setting-freeze')
+  },
+  /** Whatever the box or the action POINTS at (`aria-describedby`), resolved to the node
+   * itself. A disabled control is not focusable and carries no tooltip, so this is the
+   * only channel its reason has left — and asserting the text sits *somewhere* on the row
+   * would pass on a reason nothing points at (#1223, the bug in the frozen draw-type
+   * select). `null` when the control describes nothing. */
+  describedNodeOf(control: HTMLElement) {
+    const id = control.getAttribute('aria-describedby')
+    return id === null ? null : document.getElementById(id)
+  },
   /** The row's interactive controls — the one sweep (`@/test/read-only`), composed
    * rather than re-typed. Screen scope only, for the reason `getRow` gives; the tab's
    * own guard sweeps the whole tab (`drawStructureSectionPage.getFormElements`). */

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.test.tsx
@@ -218,4 +218,99 @@ describe('SettingRow', () => {
 
     expect(settingRowPage.queryNote()).toBeNull()
   })
+
+  /**
+   * The two things a row can say about why it is not simply working: the resolver's red,
+   * and the reason it is frozen. They share one slot and the error outranks the freeze —
+   * the same order the Basics row this pattern came from used, and the same reason: the
+   * thing that is wrong outranks the thing that is merely worth knowing.
+   */
+  describe('the message slot', () => {
+    it('says nothing when the value is accepted and the setting is open', () => {
+      settingRowPage.render({ freeze: { kind: 'open' } })
+
+      expect(settingRowPage.queryError()).toBeNull()
+      expect(settingRowPage.queryFreezeReason()).toBeNull()
+    })
+
+    it('prints the resolver’s red, and marks the box invalid', () => {
+      settingRowPage.render({
+        entry: { value: null, max: 1000, onChange: vi.fn() },
+        error: 'Say how many players advance from each pool.',
+      })
+
+      expect(settingRowPage.queryError()).toHaveTextContent(
+        'Say how many players advance from each pool.',
+      )
+      const input = settingRowPage.getInput()
+      expect(input).toHaveAttribute('aria-invalid', 'true')
+      // POINTED at, not merely printed nearby — the channel a screen reader has.
+      expect(settingRowPage.describedNodeOf(input)).toHaveTextContent(
+        'Say how many players advance from each pool.',
+      )
+    })
+
+    /**
+     * A frozen row: the box and the action stay on screen, **disabled, with the reason**
+     * (ADR 20260806). Not hidden — what changed is the state of the event, not who the
+     * director is, and a control that vanishes from under somebody entitled to it asks a
+     * loud question and answers none of it.
+     *
+     * The action is asserted too, and deliberately: on a cut event `Set myself` seeds the
+     * box from the DERIVED count, so it writes K just as typing does. A freeze that left
+     * it live would leave the 409 exactly one click away.
+     */
+    it('disables the box and the action, and points both at the reason', () => {
+      settingRowPage.render({
+        entry: { value: 2, max: 1000, onChange: vi.fn() },
+        action: { label: 'Use automatic', onClick: vi.fn() },
+        freeze: { kind: 'frozen', reason: 'The bracket was cut for the top 2.' },
+      })
+
+      const input = settingRowPage.getInput()
+      const action = settingRowPage.getAction()
+      expect(input).toBeDisabled()
+      expect(action).toBeDisabled()
+      expect(settingRowPage.queryFreezeReason()).toHaveTextContent(
+        'The bracket was cut for the top 2.',
+      )
+      expect(settingRowPage.describedNodeOf(input)).toHaveTextContent(
+        'The bracket was cut for the top 2.',
+      )
+      expect(settingRowPage.describedNodeOf(action)).toHaveTextContent(
+        'The bracket was cut for the top 2.',
+      )
+    })
+
+    // …and a frozen box takes no input, which is the whole point of the freeze. The
+    // disabled attribute is what stops it, so this is the behaviour behind the attribute
+    // rather than a second reading of it.
+    it('writes nothing while frozen', async () => {
+      const onChange = vi.fn()
+      settingRowPage.render({
+        entry: { value: 2, max: 1000, onChange },
+        freeze: { kind: 'frozen', reason: 'The bracket was cut for the top 2.' },
+      })
+
+      await userEvent.type(settingRowPage.getInput(), '3')
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    // One slot, and the error wins it: a row cannot be both refused and frozen in
+    // practice — a frozen row holds the value the draw was cut from, which the resolver
+    // accepts — so the slot states the one that is actionable.
+    it('shows the error rather than the freeze when both are given', () => {
+      settingRowPage.render({
+        entry: { value: null, max: 1000, onChange: vi.fn() },
+        error: 'Say how many players advance from each pool.',
+        freeze: { kind: 'frozen', reason: 'The bracket was cut for the top 2.' },
+      })
+
+      expect(settingRowPage.queryError()).toHaveTextContent(
+        'Say how many players advance from each pool.',
+      )
+      expect(settingRowPage.queryFreezeReason()).toBeNull()
+    })
+  })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.test.tsx
@@ -1,3 +1,10 @@
+import { useState } from 'react'
+import userEvent from '@testing-library/user-event'
+
+import { render } from '@/test/utilities'
+
+import { SettingRow } from './setting-row'
+import { buildSettingRowProps } from './setting-row.factory'
 import { settingRowPage } from './setting-row.page'
 
 describe('SettingRow', () => {
@@ -58,13 +65,157 @@ describe('SettingRow', () => {
     expect(settingRowPage.queryUnit()).toBeNull()
   })
 
-  // This chore is read-only: the `Set myself` action and the numeric input are 3c, and
-  // they are absent rather than disabled.
-  it('renders no control — the value is text', () => {
+  // A row with neither an `entry` nor an `action` is what a READER sees, and it renders
+  // no control at all — not a disabled one, which is the unexplained dead end ADR-0015
+  // forbids. Swept by `@/test/read-only`, never by a selector re-typed here.
+  it('renders no control at all without an entry or an action', () => {
+    settingRowPage.render({ entry: undefined, action: undefined })
+
+    expect(settingRowPage.getFormElements()).toHaveLength(0)
+  })
+
+  describe('the quiet text action', () => {
+    it('offers the caller’s words, and calls back when pressed', async () => {
+      const onClick = vi.fn()
+      settingRowPage.render({ action: { label: 'Set myself', onClick } })
+
+      expect(settingRowPage.getAction()).toHaveTextContent('Set myself')
+      await userEvent.click(settingRowPage.getAction())
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    // Three rows offer `Set myself`, so the visible words alone name no setting. The
+    // button carries the row's name for a reader browsing by button.
+    it('names the setting it acts on, for a screen reader', () => {
+      settingRowPage.render({
+        name: 'Qualifiers per pool',
+        action: { label: 'Set myself', onClick: () => {} },
+      })
+
+      expect(settingRowPage.getAction()).toHaveAccessibleName(
+        'Set myself Qualifiers per pool',
+      )
+    })
+  })
+
+  /**
+   * The manual box. `<input type="text" inputMode="numeric">` and **no spinner** — the
+   * reference is explicit that there are no plus or minus buttons anywhere, and a
+   * `type="number"` would bring a scroll-wheel that silently changes a saved number.
+   */
+  describe('the direct-entry box', () => {
+    const entry = (overrides: Partial<{ value: number | null }> = {}) => ({
+      value: 6,
+      max: 512,
+      onChange: vi.fn(),
+      ...overrides,
+    })
+
+    it('shows the director’s number, in a numeric text box', () => {
+      settingRowPage.render({ entry: entry() })
+
+      const box = settingRowPage.getInput()
+      expect(box).toHaveValue('6')
+      expect(box).toHaveAttribute('type', 'text')
+      expect(box).toHaveAttribute('inputMode', 'numeric')
+      // No spinner, and nothing to press: the row's only button is its action.
+      expect(box).not.toHaveAttribute('type', 'number')
+    })
+
+    // The visible words to its left are its label, so the accessible name is what a
+    // sighted director reads. A box labelled only by the unit after it would announce as
+    // "pools", which is indistinguishable across three rows.
+    it('is named by the setting it holds', () => {
+      settingRowPage.render({ name: 'Pool size', entry: entry() })
+
+      expect(settingRowPage.getInput()).toHaveAccessibleName('Pool size')
+    })
+
+    // One number, one place. A row showing the derived text AND the box would be showing
+    // the same setting twice, and the two would drift the moment one was typed into.
+    it('replaces the read-out value rather than sitting beside it', () => {
+      settingRowPage.render({ entry: entry() })
+
+      expect(settingRowPage.queryValue()).toBeNull()
+      expect(settingRowPage.queryUnit()).toHaveTextContent('pools')
+    })
+
+    it('hands back a number the bounds admit', async () => {
+      const onChange = vi.fn()
+      settingRowPage.render({ entry: { value: null, max: 512, onChange } })
+
+      await userEvent.type(settingRowPage.getInput(), '8')
+
+      expect(onChange).toHaveBeenCalledWith(8)
+    })
+
+    // ⚠️ `Number('')` is `0`, and a `0` is a 422 — the exact silent authorship the
+    // player-limit box shipped once already (ADR-0935).
+    it('hands back null for a cleared box, never a zero', async () => {
+      const onChange = vi.fn()
+      settingRowPage.render({ entry: { value: 6, max: 512, onChange } })
+
+      await userEvent.clear(settingRowPage.getInput())
+
+      expect(onChange).toHaveBeenCalledWith(null)
+      expect(onChange).not.toHaveBeenCalledWith(0)
+    })
+
+    // Dropped, not clamped: the system never silently changes a director's number (ADR
+    // 20260808), so the box keeps the one they last chose and nothing is written.
+    it('drops a keystroke that would author a number the server refuses', async () => {
+      const onChange = vi.fn()
+      settingRowPage.render({ entry: { value: 51, max: 512, onChange } })
+
+      // 51 → 513, one past the server's ceiling.
+      await userEvent.type(settingRowPage.getInput(), '3')
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    /**
+     * ⚠️ Rendered against **real state**, unlike every other case here. A box whose
+     * `value` prop never moves is restored by React after each keystroke, so "select all
+     * and type 4" would read `64` however well the row behaved — the harness, not the
+     * component, would be what the test measured. With the value round-tripping, `64` is
+     * the genuine failure: the selection was not replaced.
+     */
+    it('lets the director select the value and replace it outright', async () => {
+      const Editing = () => {
+        const [value, setValue] = useState<number | null>(6)
+        return (
+          <SettingRow
+            {...buildSettingRowProps({ entry: { value, max: 512, onChange: setValue } })}
+          />
+        )
+      }
+      render(<Editing />)
+
+      // Select all, then type — the correction a spinner-less box has to support.
+      // `keyboard`, not `type`: `type` clicks the box first, which would collapse the
+      // very selection this is about.
+      await userEvent.tripleClick(settingRowPage.getInput())
+      await userEvent.keyboard('4')
+
+      expect(settingRowPage.getInput()).toHaveValue('4')
+    })
+  })
+
+  // Membership's, and only when it is hand-dealt: what placing entrants yourself costs.
+  it('carries a note under the source when the caller gives one', () => {
+    settingRowPage.render({
+      note: 'Repeat protection turns off when you assign pools by hand.',
+    })
+
+    expect(settingRowPage.queryNote()).toHaveTextContent(
+      'Repeat protection turns off when you assign pools by hand.',
+    )
+  })
+
+  it('has no note otherwise', () => {
     settingRowPage.render()
 
-    expect(settingRowPage.getRow().querySelectorAll('input, button')).toHaveLength(
-      0,
-    )
+    expect(settingRowPage.queryNote()).toBeNull()
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 
+import type { EditFreeze } from '../../../data/draw'
 import { acceptedManualEntry } from '../../../data/draw-ownership'
 import type { SettingOwnership } from '../../../data/draw-structure'
 
@@ -90,6 +91,27 @@ export interface SettingRowProps {
   /** One more line under the source, for a consequence the setting carries — today only
    * Membership's `Repeat protection turns off when you assign pools by hand.` */
   note?: string
+  /**
+   * The inline red, when the resolver (or the server) rejected the value this row holds.
+   *
+   * Only the qualifier count can produce one today: it is the one setting on this tab the
+   * event *must* carry a value for (the server's `rr-then-ko` arm requires K), so it is
+   * the one whose box can be left in a state the save is refused for. The row it moved
+   * from carried the same slot; a row that dropped it would send a refused save to a tab
+   * with nothing red on it — the dead end `firstInvalidSection` exists to prevent.
+   */
+  error?: string
+  /**
+   * Whether this setting may still be changed at all (`EditFreeze`, `data/draw`) — a cut
+   * draw freezes the qualifier count, because the bracket was cut for it.
+   *
+   * Frozen means the box and the action are **present, disabled, and pointing at the
+   * reason** (`aria-describedby`), never absent: what changed is the state of the event,
+   * not who the director is, so the fix for the dead end is the explanation and not a
+   * vanishing control (ADR 20260806, the freeze/confirm table). A disabled control is not
+   * focusable and carries no tooltip, so the description is the only channel it has left.
+   */
+  freeze?: EditFreeze
 }
 
 /**
@@ -113,6 +135,13 @@ export interface SettingRowProps {
  * would bring a spinner, a scroll-wheel that silently changes a saved number, and a
  * control a screen reader calls a `spinbutton`; a director setting six pools types `6`
  * and a director correcting it selects the number and replaces it outright.
+ *
+ * ## One message slot, and the error outranks the freeze
+ *
+ * A row has at most one thing to say about why it is not simply working: the resolver's
+ * red, or the reason it is frozen. They cannot both be true — a frozen row's value is the
+ * one the draw was cut from, which is by construction a value the resolver accepts — so
+ * they share a slot, in that order, exactly as the Basics row this one replaced did.
  */
 export const SettingRow = ({
   name,
@@ -125,8 +154,18 @@ export const SettingRow = ({
   entry,
   action,
   note,
+  error,
+  freeze,
 }: SettingRowProps) => {
   const nameId = useId()
+  const messageId = useId()
+  const frozen = freeze?.kind === 'frozen'
+  const message = error ?? (frozen ? freeze.reason : undefined)
+  // The box and the action POINT at the message, they do not merely sit above it — and a
+  // disabled control has no other channel left. Undefined rather than an empty string when
+  // there is nothing to point at: an `aria-describedby` naming an empty node is a
+  // description a screen reader reads as silence.
+  const describedBy = message === undefined ? undefined : messageId
   return (
     // A named `region`, so the row is addressable by the setting it holds rather than by
     // its position in the list — the four rows are otherwise identical markup.
@@ -163,6 +202,9 @@ export const SettingRow = ({
               inputMode="numeric"
               data-testid="draw-setting-input"
               aria-labelledby={nameId}
+              aria-invalid={!!error}
+              aria-describedby={describedBy}
+              disabled={frozen}
               className="w-[84px] shrink-0 py-1.5 text-center font-mono text-[20px] leading-none font-semibold"
               // `''` for a cleared box, never a `0`: the two are different answers, and
               // one of them is a 422.
@@ -221,6 +263,22 @@ export const SettingRow = ({
             {note}
           </p>
         )}
+        {/* The red, or the reason — one slot, and the test id says which, so a test
+            cannot pass on a freeze reason rendered where an error belongs. */}
+        {message !== undefined && (
+          <p
+            id={messageId}
+            data-testid={error ? 'draw-setting-error' : 'draw-setting-freeze'}
+            className={cn(
+              'mt-1.5 text-[12px] leading-snug',
+              error
+                ? 'text-[color:var(--loss)]'
+                : 'text-[color:var(--fg-3)]',
+            )}
+          >
+            {message}
+          </p>
+        )}
       </div>
 
       {action && (
@@ -230,6 +288,8 @@ export const SettingRow = ({
             size="sm"
             data-testid="draw-setting-action"
             className="h-auto p-0 text-[13px]"
+            disabled={frozen}
+            aria-describedby={describedBy}
             // Three rows offer `Set myself`, so the visible words alone name no setting —
             // and a list of buttons is how a screen-reader user meets them, where the
             // row's own region label is nowhere in earshot. The visible words come FIRST,

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.tsx
@@ -32,6 +32,17 @@ export interface SettingRowEntry {
    * for a cleared box — a keystroke that would author neither is ignored, so nothing
    * downstream has to defend against a `0`. */
   onChange: (value: number | null) => void
+  /**
+   * The director has **finished** typing this number — they left the box, or pressed
+   * Enter. Optional, because only one setting needs the distinction.
+   *
+   * `onChange` fires per keystroke, which is right for a number that merely gets stored
+   * and wrong for one that **spends** something. The pool count is the second kind: it is
+   * a number of pool rows (ADR 20260808), so lowering it discards reservations and has to
+   * be priced by a confirm first. Priced per keystroke, `12` would be unreachable — the
+   * `1` opens a modal dialog, focus leaves the box, and the `2` never lands.
+   */
+  onCommit?: () => void
 }
 
 /** The row's one quiet text action — `Set myself` / `Use automatic`, or Membership's
@@ -216,6 +227,15 @@ export const SettingRow = ({
                 // NOT clamped to the bound: the system never silently changes a
                 // director's number (ADR 20260808).
                 if (accepted !== undefined) entry.onChange(accepted)
+              }}
+              // The two ways a director says they are **done typing** this number (see
+              // `onCommit`). Both, not one: leaving the box is how a mouse user finishes,
+              // and Enter is how somebody who never leaves the keyboard does. Enter
+              // submits nothing — the editor's Save is a button, not a form submit — so
+              // there is no default to prevent.
+              onBlur={entry.onCommit}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') entry.onCommit?.()
               }}
             />
           ) : (

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.tsx
@@ -37,10 +37,12 @@ export interface SettingRowEntry {
    * Enter. Optional, because only one setting needs the distinction.
    *
    * `onChange` fires per keystroke, which is right for a number that merely gets stored
-   * and wrong for one that **spends** something. The pool count is the second kind: it is
-   * a number of pool rows (ADR 20260808), so lowering it discards reservations and has to
-   * be priced by a confirm first. Priced per keystroke, `12` would be unreachable — the
-   * `1` opens a modal dialog, focus leaves the box, and the `2` never lands.
+   * and wrong for one that **materialises** something. The pool count is the second kind:
+   * it is a number of pool rows (ADR 20260808), so a keystroke would mint or drop real
+   * reservations for a value that is only a prefix of the number being typed. Against four
+   * pools, `55` would mint one row and then fifty more, and `12` would open the removal
+   * confirm on its `1` — focus leaves the box, and the `2` never lands. So the whole
+   * number waits for this signal, whichever way it moves.
    */
   onCommit?: () => void
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/setting-row.tsx
@@ -1,8 +1,11 @@
 import { useId } from 'react'
 
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 
+import { acceptedManualEntry } from '../../../data/draw-ownership'
 import type { SettingOwnership } from '../../../data/draw-structure'
 
 /** The word on the badge, and the only place ownership is put into words.
@@ -13,6 +16,28 @@ import type { SettingOwnership } from '../../../data/draw-structure'
 const OWNERSHIP_LABEL: Record<SettingOwnership, string> = {
   automatic: 'Automatic',
   manual: 'Yours',
+}
+
+/** The manual box, when the director owns the setting. */
+export interface SettingRowEntry {
+  /** The number in the box, or `null` for a box the director has cleared. `null` is a
+   * real state — the derivation reads a manual setting with no number as automatic — and
+   * it is emphatically not a `0`, which the API refuses. */
+  value: number | null
+  /** The largest number this box may hold: the server's own ceiling for this setting
+   * (512 for a pool dimension, 1,000 for a qualifier count). */
+  max: number
+  /** Store what the director typed. Called only with a value the bounds admit, or `null`
+   * for a cleared box — a keystroke that would author neither is ignored, so nothing
+   * downstream has to defend against a `0`. */
+  onChange: (value: number | null) => void
+}
+
+/** The row's one quiet text action — `Set myself` / `Use automatic`, or Membership's
+ * `Assign myself` / `Use snake`. */
+export interface SettingRowAction {
+  label: string
+  onClick: () => void
 }
 
 export interface SettingRowProps {
@@ -26,6 +51,9 @@ export interface SettingRowProps {
    * The value the director reads. Already formatted by the caller, because only the
    * caller knows what the number means: `4`, or `6–10` when the pools are uneven, or a
    * whole phrase for Membership.
+   *
+   * Shown as text whenever there is no `entry` — a setting the system owns, or one being
+   * read by somebody who cannot edit it.
    */
   value: string
   /**
@@ -45,11 +73,29 @@ export interface SettingRowProps {
    * by `deriveDrawStructure` for the three numeric settings, so the copy cannot fork
    * away from the arithmetic it describes. */
   source: string
+  /**
+   * The direct-entry box, when the director owns this setting **and** may edit it.
+   * Absent means the value is read out as text — there is no disabled box anywhere, which
+   * is the unexplained dead end ADR-0015 forbids.
+   */
+  entry?: SettingRowEntry
+  /**
+   * The one way to change who owns this setting. Absent for a reader.
+   *
+   * A quiet text button, never a segmented control: four `Automatic / Manual` switches
+   * stacked down a column read as a settings panel rather than as a draw, which ADR
+   * 20260808 considered and rejected.
+   */
+  action?: SettingRowAction
+  /** One more line under the source, for a consequence the setting carries — today only
+   * Membership's `Repeat protection turns off when you assign pools by hand.` */
+  note?: string
 }
 
 /**
  * One row of the Draw structure tab's setting list: what the setting is called, what it
- * means, what it currently says, **who owns it**, and where that value came from.
+ * means, what it currently says, **who owns it**, where that value came from, and the one
+ * action that hands it over or gives it back.
  *
  * The four settings share one pattern because they are one kind of thing — a structural
  * setting, owned by the director or derived by the system (ADR 20260808). Written out
@@ -60,9 +106,13 @@ export interface SettingRowProps {
  * parent's (`divide-y`), so a row contributes no border of its own and the list reads as
  * one draw rather than as four unrelated panels.
  *
- * This chore renders the value as text only. The `Set myself` / `Use automatic` action
- * and the numeric input are chore 3c — and they are *absent*, not disabled: a dead box
- * is the unexplained dead end ADR-0015 forbids.
+ * ## The box has no spinner
+ *
+ * `<input type="text" inputMode="numeric">`, deliberately, and there are **no plus or
+ * minus buttons anywhere** — the reference is explicit about both. A `type="number"`
+ * would bring a spinner, a scroll-wheel that silently changes a saved number, and a
+ * control a screen reader calls a `spinbutton`; a director setting six pools types `6`
+ * and a director correcting it selects the number and replaces it outright.
  */
 export const SettingRow = ({
   name,
@@ -72,6 +122,9 @@ export const SettingRow = ({
   unit,
   ownership,
   source,
+  entry,
+  action,
+  note,
 }: SettingRowProps) => {
   const nameId = useId()
   return (
@@ -80,7 +133,7 @@ export const SettingRow = ({
     <section
       aria-labelledby={nameId}
       data-testid="draw-setting-row"
-      className="grid grid-cols-1 gap-x-6 gap-y-2 py-4 sm:grid-cols-[minmax(0,160px)_minmax(0,1fr)]"
+      className="grid grid-cols-1 gap-x-6 gap-y-2 py-4 sm:grid-cols-[minmax(0,160px)_minmax(0,1fr)_auto]"
     >
       <div className="min-w-0">
         <h4
@@ -100,17 +153,42 @@ export const SettingRow = ({
 
       <div className="min-w-0">
         <p className="flex flex-wrap items-baseline gap-x-2">
-          <span
-            data-testid="draw-setting-value"
-            className={cn(
-              'text-[color:var(--fg-1)]',
-              kind === 'number'
-                ? 'font-mono text-[22px] leading-none font-semibold'
-                : 'text-[15px] font-semibold',
-            )}
-          >
-            {value}
-          </span>
+          {entry ? (
+            // Labelled by the row's own heading — the visible words directly to its left,
+            // so the accessible name IS what a sighted director reads. A box whose only
+            // label were the unit after it would announce as "pools", which is four
+            // indistinguishable boxes to a screen reader.
+            <Input
+              type="text"
+              inputMode="numeric"
+              data-testid="draw-setting-input"
+              aria-labelledby={nameId}
+              className="w-[84px] shrink-0 py-1.5 text-center font-mono text-[20px] leading-none font-semibold"
+              // `''` for a cleared box, never a `0`: the two are different answers, and
+              // one of them is a 422.
+              value={entry.value === null ? '' : String(entry.value)}
+              onChange={(e) => {
+                const accepted = acceptedManualEntry(e.target.value, entry.max)
+                // `undefined` is "not a value this box may hold" — the keystroke is
+                // dropped and the box keeps the number the director last chose. It is
+                // NOT clamped to the bound: the system never silently changes a
+                // director's number (ADR 20260808).
+                if (accepted !== undefined) entry.onChange(accepted)
+              }}
+            />
+          ) : (
+            <span
+              data-testid="draw-setting-value"
+              className={cn(
+                'text-[color:var(--fg-1)]',
+                kind === 'number'
+                  ? 'font-mono text-[22px] leading-none font-semibold'
+                  : 'text-[15px] font-semibold',
+              )}
+            >
+              {value}
+            </span>
+          )}
           {unit && (
             <span
               data-testid="draw-setting-unit"
@@ -135,7 +213,34 @@ export const SettingRow = ({
             {source}
           </span>
         </p>
+        {note && (
+          <p
+            data-testid="draw-setting-note"
+            className="mt-1.5 text-[12px] leading-snug text-[color:var(--warn)]"
+          >
+            {note}
+          </p>
+        )}
       </div>
+
+      {action && (
+        <div className="sm:pt-0.5 sm:text-right">
+          <Button
+            variant="link"
+            size="sm"
+            data-testid="draw-setting-action"
+            className="h-auto p-0 text-[13px]"
+            // Three rows offer `Set myself`, so the visible words alone name no setting —
+            // and a list of buttons is how a screen-reader user meets them, where the
+            // row's own region label is nowhere in earshot. The visible words come FIRST,
+            // so what a director says out loud to a voice-control tool still matches.
+            aria-label={`${action.label} ${name}`}
+            onClick={action.onClick}
+          >
+            {action.label}
+          </Button>
+        </div>
+      )}
     </section>
   )
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/pools-section.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import type { EditFreeze } from '../../data/draw'
 import { findPoolConflicts } from '../../data/helpers'
 import { addedPool, poolEntryKey } from '../../data/pool-entries'
+import { poolNameAt } from '../../data/pool-reconciliation'
 import type { PoolEntry, TournamentTable } from '../../data/types'
 import { EmptyState } from '../../empty-state'
 import type { EventFormValues } from '../event-form'
@@ -142,10 +143,16 @@ export const PoolsSection = ({
   //
   // It joins at the END, which is where `append` puts it and where the server will
   // therefore position it: the array order is the pool order, and nothing else is.
+  //
+  // The name comes from `poolNameAt` — the ONE place a default pool name is minted, shared
+  // with the Draw structure tab's pool-count reconciliation (`data/pool-reconciliation`),
+  // because "continuing the letter sequence" is a promise about one sequence. This used to
+  // spell the letter `String.fromCharCode(65 + n)` here, which prints `Pool [` for the 27th
+  // pool — reachable now that a director can type a pool count of up to 512.
   const addPool = () =>
     append(
       addedPool({
-        name: `Pool ${String.fromCharCode(65 + fields.length)}`,
+        name: poolNameAt(fields.length),
         slot: { ...eventSlot },
         tableIds: [],
       }),

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
@@ -1,8 +1,10 @@
+import { everySettingAutomatic } from '../data/draw-ownership'
 import { buildEvent, buildPool, buildPredicate } from '../data/seed.factory'
 import {
   eventSchema,
   eventToFormValues,
   firstInvalidSection,
+  withSuppliedQualifiers,
   type EventFormValues,
 } from './event-form'
 
@@ -45,8 +47,20 @@ describe('eventSchema', () => {
    * under a control that is not even rendered.
    */
   describe('the qualifier count', () => {
+    /**
+     * A two-stage event whose director **owns** the count (ADR 20260808).
+     *
+     * ⚠️ The ownership is the fixture's load-bearing half, not decoration: every rule below
+     * is asked of a director's number, and only of a director's number. A setting the
+     * SYSTEM owns has an answer already — the derived one — so the resolver asks nothing of
+     * it (the case its own test states, straight after this block's bounds).
+     */
     const twoStage = (qualifiersPerPool: number | null) =>
-      formFor({ drawType: 'rr-then-ko', qualifiersPerPool })
+      formFor({
+        drawType: 'rr-then-ko',
+        qualifiersPerPool,
+        drawOwnership: { ...everySettingAutomatic(), qualifiersMode: 'manual' },
+      })
 
     it('requires a count for rr-then-ko, and blames the field by name', () => {
       expect(rejectedFields(twoStage(null))).toEqual(['qualifiersPerPool'])
@@ -107,6 +121,115 @@ describe('eventSchema', () => {
         rejectedFields(formFor({ drawType: 'round-robin', qualifiersPerPool: 2 })),
       ).toEqual([])
     })
+
+    /**
+     * ⚠️ **A count the SYSTEM owns is never refused** (ADR 20260808, #1320) — the defect
+     * chore 3e shipped, and the one this whole pair of rules exists to keep shut.
+     *
+     * An automatic setting already has an answer: the derived count the Draw structure tab
+     * is displaying, which `withSuppliedQualifiers` puts on the wire. Refusing the save for
+     * a missing number therefore refuses it for nothing — and says so with an imperative
+     * ("Say how many players advance from each pool.") pointing at a row that renders
+     * **text**, because an automatic setting has no box. That is exactly the unactionable
+     * refusal #1320 was filed about, which is why this case is stated twice: once here at
+     * the resolver, and once end to end in the editor's own test.
+     */
+    it.each([
+      ['a record that says automatic', everySettingAutomatic()],
+      // The state a director is really in the second they pick the two-stage format on
+      // Basics: nothing has written a record yet, and no record means nothing was taken
+      // from the system.
+      ['no ownership record at all', null],
+    ] as const)('asks nothing of a count the system owns — %s', (_case, drawOwnership) => {
+      expect(
+        rejectedFields(
+          formFor({ drawType: 'rr-then-ko', qualifiersPerPool: null, drawOwnership }),
+        ),
+      ).toEqual([])
+    })
+  })
+
+  /**
+   * **What the save sends for a count nobody typed** (`withSuppliedQualifiers`) — the other
+   * half of the rule above, and the reason relaxing it is safe.
+   *
+   * The server's `rr-then-ko` arm requires `qualifiers_per_pool`, so "the resolver asks
+   * nothing" only works if something else answers. These are the four states it can be in.
+   */
+  describe('the qualifier count the system supplies', () => {
+    /** Two pools of a 32-player field: the derived count is `ceil(8 / 2)` = **4**, which is
+     * none of the numbers a bug would land on by accident — not the pool count (2), not the
+     * target bracket (8), not the planner's floor (1), and not the fixtures' usual K (2). */
+    const twoPools = (overrides: Parameters<typeof buildEvent>[0] = {}) =>
+      formFor({
+        drawType: 'rr-then-ko',
+        maxPlayers: 32,
+        pools: [
+          buildPool({ id: 'p-a', name: 'Pool A' }),
+          buildPool({ id: 'p-b', name: 'Pool B', position: 1 }),
+        ],
+        ...overrides,
+      })
+
+    it('derives the count for an event that has none', () => {
+      const values = twoPools({ qualifiersPerPool: null })
+
+      expect(withSuppliedQualifiers(values).qualifiersPerPool).toBe(4)
+    })
+
+    // …and it is the DERIVATION's number, not a constant: change the pools and the supplied
+    // count moves with the row the tab is showing.
+    it('derives it from the pool count the tab derived it from', () => {
+      const values = twoPools({
+        qualifiersPerPool: null,
+        pools: [
+          buildPool({ id: 'p-a', name: 'Pool A' }),
+          buildPool({ id: 'p-b', name: 'Pool B', position: 1 }),
+          buildPool({ id: 'p-c', name: 'Pool C', position: 2 }),
+        ],
+      })
+
+      // `ceil(8 / 3)`, the number the row reads out — never `8 / 3`, and never the target.
+      expect(withSuppliedQualifiers(values).qualifiersPerPool).toBe(3)
+    })
+
+    /**
+     * ⚠️ **A stored count is LEFT ALONE**, and this is the assertion that keeps it so.
+     *
+     * Under an automatic mode the stored K is the count the event's bracket was cut for,
+     * and the server freezes the configuration its draw was dealt from
+     * (`_enforce_draw_settings_frozen`). Supplying the derived number here instead would
+     * turn a save of the event's *name* into a 409 naming a qualifier count the director
+     * never touched — #1320's own bug, wearing the fix's clothes.
+     */
+    it('leaves a stored count alone, so a cut event is not re-configured behind the director', () => {
+      const values = twoPools({ qualifiersPerPool: 2 })
+
+      expect(withSuppliedQualifiers(values).qualifiersPerPool).toBe(2)
+    })
+
+    // The director's number is theirs, right or wrong: the resolver refuses a broken one
+    // and nothing is sent, so a substitute here would be a save of a count they did not ask
+    // for — quietly, past a red they never saw.
+    it('leaves a count the director owns alone, even when they have cleared it', () => {
+      const values = twoPools({
+        qualifiersPerPool: null,
+        drawOwnership: { ...everySettingAutomatic(), qualifiersMode: 'manual' },
+      })
+
+      expect(withSuppliedQualifiers(values).qualifiersPerPool).toBeNull()
+    })
+
+    // The three arms with no knockout stage carry `null` and send no key at all
+    // (`drawSettingsToApi`), so there is nothing here to answer.
+    it.each(['round-robin', 'single-elim', 'swiss'] as const)(
+      'supplies nothing to %s, which has no qualifiers',
+      (drawType) => {
+        const values = formFor({ drawType, qualifiersPerPool: null, rounds: 3 })
+
+        expect(withSuppliedQualifiers(values).qualifiersPerPool).toBeNull()
+      },
+    )
   })
 
   /**

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.test.ts
@@ -314,15 +314,43 @@ describe('firstInvalidSection', () => {
     )
   })
 
-  // It lives on Basics, beside the draw type that decides whether it is asked at all —
-  // and a save refused on a tab you cannot see is indistinguishable from a dead button.
-  it('sends a broken qualifier count to Basics', () => {
+  /**
+   * **The count moved tabs, and this map moved with it** (chore 3e). K is a structural
+   * setting, so its box is on Draw structure now, and a save refused for it has to open
+   * the tab holding the box.
+   *
+   * This is the assertion the move can break silently: leave the field mapped to `basics`
+   * and every other test still passes — the resolver still refuses, the sheet still stays
+   * open, the red is still rendered. It is rendered on a tab the director is not looking
+   * at, which is indistinguishable from a dead Save button.
+   */
+  it('sends a broken qualifier count to Draw structure — the tab its box is on', () => {
     expect(
       firstInvalidSection({ qualifiersPerPool: { type: 'custom', message: 'x' } }),
-    ).toBe('basics')
+    ).toBe('draw-structure')
   })
 
-  // …and the round count, which lives on the same tab beside the same picker.
+  // The manual pool numbers land on the same tab, from the same arm.
+  it('sends a broken ownership record to Draw structure', () => {
+    expect(
+      firstInvalidSection({ drawOwnership: { type: 'custom', message: 'x' } }),
+    ).toBe('draw-structure')
+  })
+
+  // …and the ORDER: Draw structure is the fifth tab, so a form broken there and on an
+  // earlier tab opens the earlier one. Landing on the last tab would leave the empty name
+  // behind them, unseen — the same rule the name/rule pair below states.
+  it('prefers an earlier tab when the qualifier count is broken too', () => {
+    expect(
+      firstInvalidSection({
+        pools: { type: 'custom', message: 'x' },
+        qualifiersPerPool: { type: 'custom', message: 'x' },
+      }),
+    ).toBe('pools')
+  })
+
+  // The round count, which stays on Basics beside the picker that decides whether it is
+  // asked at all — the half of the pair that did NOT move.
   it('sends a broken round count to Basics', () => {
     expect(firstInvalidSection({ rounds: { type: 'custom', message: 'x' } })).toBe(
       'basics',

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
@@ -206,7 +206,7 @@ export const eventSchema = z.object({
   // rather than on the field.
   //
   // Only the `rr-then-ko` arm is asked at all: for the other two, `qualifiersPerPool` is
-  // `null`, there is no control on screen (the Basics tab renders it only for the
+  // `null`, there is no control on screen (the Draw structure tab exists only for the
   // two-stage type), and the write body omits the key entirely (`eventToApiFields`,
   // `data/api`) — so a rule that fired there would refuse a save for a reason the
   // director cannot see, let alone fix. The issue is raised **at the field's own path**,
@@ -338,20 +338,20 @@ export function eventToFormValues(event: TournamentEvent | null): EventFormValue
  * A message on a tab you cannot see is indistinguishable from a button that does
  * nothing, which is exactly what Save looked like before this existed.
  *
- * Basics before Eligibility before Table pools, deliberately: that is the order the
- * tabs are in, and with more than one broken, the name is the field they are most
- * likely to have simply not filled in — landing on a *later* tab would leave the empty
- * name behind them, unseen.
+ * Basics before Eligibility before Table pools before Draw structure, deliberately: that
+ * is the order the tabs are in, and with more than one broken, the name is the field they
+ * are most likely to have simply not filled in — landing on a *later* tab would leave the
+ * empty name behind them, unseen.
  */
 export function firstInvalidSection(
   errors: FieldErrors<EventFormValues>,
 ): EventSection | null {
-  // `qualifiersPerPool` and `rounds` both live on Basics beside the draw type that decides
-  // whether either is asked at all, so a refused two-stage or swiss save opens the tab
-  // holding the empty box.
+  // `rounds` lives on Basics beside the draw type that decides whether it is asked at all,
+  // so a refused swiss save opens the tab holding the empty box. `qualifiersPerPool` used
+  // to be asked here too, and is asked LAST now — it moved tabs in chore 3e, and this map
+  // has to move with it or a refused two-stage save lands on a tab with nothing red on it.
   if (
     errors.name ||
-    errors.qualifiersPerPool ||
     errors.rounds ||
     errors.maxPlayers ||
     errors.entryFee ||
@@ -359,17 +359,21 @@ export function firstInvalidSection(
   )
     return 'basics'
   if (errors.predicates) return 'eligibility'
-  // The manual pool numbers, on the tab that sets them. **Insurance, not a path a director
-  // can walk today**: the boxes parse each keystroke (`acceptedManualEntry`,
-  // `data/draw-ownership`) and never accept a value `drawOwnershipSchema` would reject, so
-  // this arm exists for the day something else writes the record. Without it a refusal
-  // here would land the director on Basics with no red anywhere, which is the dead end
-  // this function exists to prevent.
-  if (errors.drawOwnership) return 'draw-structure'
   // A pool with a cleared name (`poolNameSchema`). RHF reports it per row
   // (`errors.pools[2].name`) *and* sets the array key, so the truthiness of `pools` is
   // the whole question here — which row it is, the card itself says, in red, under the
   // box. Match settings has no arm: every control on it is a closed picker.
   if (errors.pools) return 'pools'
+  // The FIFTH tab, so it is asked last (`SECTIONS` + `DRAW_STRUCTURE_SECTION`,
+  // `./event-editor`). Two fields land here, and they are reached very differently:
+  //
+  // - **`qualifiersPerPool`** is the one a director walks into. K is required on every
+  //   `rr-then-ko` event, its box is on this tab, and emptying that box is a refused save
+  //   — which has to open the tab holding the box, with the red under it.
+  // - **`drawOwnership`** is insurance. The manual boxes parse each keystroke
+  //   (`acceptedManualEntry`, `data/draw-ownership`) and never accept a value
+  //   `drawOwnershipSchema` would reject, so this arm exists for the day something else
+  //   writes the record.
+  if (errors.qualifiersPerPool || errors.drawOwnership) return 'draw-structure'
   return null
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import type { FieldErrors } from 'react-hook-form'
 
+import { drawOwnershipSchema } from '../data/draw-ownership'
 import { drawTypeSchema } from '../data/draw-types'
 import {
   entryFeeSchema,
@@ -156,6 +157,12 @@ export const eventSchema = z.object({
   // three draw types whose round count nobody chooses, and it is the *blank box* for the
   // one whose director does.
   rounds: z.number().nullable(),
+  // **Who owns each structural setting**, and the two manual pool numbers (ADR 20260808).
+  // The schema is the domain's own (`data/draw-ownership`), imported rather than restated
+  // for the reason every other field rule here is: it already carries the server's
+  // `ge=1, le=512` on the manual numbers, and a second copy would be a second thing to
+  // drift. `null` is the honest value for the three draw types with no pool stage.
+  drawOwnership: drawOwnershipSchema.nullable(),
   maxPlayers: maxPlayersSchema,
   entryFee: entryFeeSchema,
   // The IANA timezone anchoring the wall-clock windows (ADR 20260719). `NOT NULL`
@@ -256,6 +263,9 @@ const EMPTY_FORM_VALUES: EventFormValues = {
   // count either (the swiss ADR). `null` is the only value the server's `single-elim` arm
   // admits.
   rounds: null,
+  // …and a bracket has no pool stage, so no structural settings to own either (ADR
+  // 20260808). `null` is the only value the server's `single-elim` arm admits.
+  drawOwnership: null,
   // A new event starts **uncapped**, not at an invented number: `null` is a valid,
   // saveable answer (ADR-0935), so an organizer who never touches the box gets an
   // event with no cap — rather than a form that silently refuses to submit.
@@ -289,6 +299,10 @@ export function eventToFormValues(event: TournamentEvent | null): EventFormValue
     // …and the round count the same way, the near half of the round trip the read shape's
     // `rounds` exists for.
     rounds: event.rounds,
+    // The ownership record the SERVER sent back, straight onto the tab — the near half of
+    // the round trip `draw_structure` exists for, and what makes a setting a director took
+    // last week still read `Yours` when they reopen the event.
+    drawOwnership: event.drawOwnership,
     maxPlayers: event.maxPlayers,
     entryFee: event.entryFee,
     timezone: event.timezone,
@@ -345,6 +359,13 @@ export function firstInvalidSection(
   )
     return 'basics'
   if (errors.predicates) return 'eligibility'
+  // The manual pool numbers, on the tab that sets them. **Insurance, not a path a director
+  // can walk today**: the boxes parse each keystroke (`acceptedManualEntry`,
+  // `data/draw-ownership`) and never accept a value `drawOwnershipSchema` would reject, so
+  // this arm exists for the day something else writes the record. Without it a refusal
+  // here would land the director on Basics with no red anywhere, which is the dead end
+  // this function exists to prevent.
+  if (errors.drawOwnership) return 'draw-structure'
   // A pool with a cleared name (`poolNameSchema`). RHF reports it per row
   // (`errors.pools[2].name`) *and* sets the array key, so the truthiness of `pools` is
   // the whole question here — which row it is, the card itself says, in red, under the

--- a/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-form.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod'
 import type { FieldErrors } from 'react-hook-form'
 
-import { drawOwnershipSchema } from '../data/draw-ownership'
+import { drawOwnershipSchema, everySettingAutomatic } from '../data/draw-ownership'
+import { deriveDrawStructure } from '../data/draw-structure'
 import { drawTypeSchema } from '../data/draw-types'
 import {
   entryFeeSchema,
@@ -22,6 +23,7 @@ import type {
   PredicateValue,
   TournamentEvent,
 } from '../data/types'
+import { previewFieldSize } from './event-editor/draw-structure-section/preview-field'
 
 /** A `YYYY-MM-DD` date with `HH:MM` start/end — the shape both an event and a
  * pool carry (mirrors `Slot` in `data/types`). */
@@ -212,8 +214,21 @@ export const eventSchema = z.object({
   // director cannot see, let alone fix. The issue is raised **at the field's own path**,
   // so React-Hook-Form reports it as `errors.qualifiersPerPool` and the red lands under
   // the box, exactly as a field-level rule's would.
+  //
+  // ⚠️ **And it is asked only of a count the DIRECTOR owns** (ADR 20260808). A count whose
+  // mode is `automatic` already has an answer — the derived one the Draw structure tab is
+  // showing — and `withSuppliedQualifiers` below is what puts that answer on the wire. So
+  // there is nothing missing there and nothing to refuse. Asking anyway was the shape of
+  // refusal #1320 exists to remove: "Say how many players advance from each pool." under a
+  // row rendering **text**, because an automatic setting has no box, addressed to a
+  // director whose only way to comply is to first guess that `Set myself` exists. An event
+  // with no ownership record has had nothing taken from the system, so it reads as
+  // automatic too (`everySettingAutomatic`) — and `drawOwnership: null` is exactly what a
+  // director gets the moment they pick the two-stage format on Basics.
   .superRefine((values, ctx) => {
     if (values.drawType !== 'rr-then-ko') return
+    const ownership = values.drawOwnership ?? everySettingAutomatic()
+    if (ownership.qualifiersMode !== 'manual') return
     const result = qualifiersPerPoolSchema.safeParse(values.qualifiersPerPool)
     if (result.success) return
     ctx.addIssue({
@@ -328,6 +343,61 @@ export function eventToFormValues(event: TournamentEvent | null): EventFormValue
     // list they were looking at has to be the list that goes on the wire.
     pools: keepPools(poolsInOrder(event.pools)),
   }
+}
+
+/**
+ * The form's values **as the save sends them** — the other half of the rule the resolver
+ * stops short of (ADR 20260808, #1320).
+ *
+ * The server's `rr-then-ko` arm requires `qualifiers_per_pool` and always has: there is no
+ * absent state for it, and a `null` on that arm is a 422. So a count the director does not
+ * own still has to be a number on the wire — **automatic means "send the derived one", not
+ * "send nothing"**. This is where that number is supplied, and it is called on the way out
+ * of the editor so the invariant reads in one place: *no `rr-then-ko` save leaves this
+ * client without a count `qualifiersPerPoolSchema` accepts.* The resolver refuses a count
+ * the director broke; this supplies the one they never gave.
+ *
+ * **The number comes from `deriveDrawStructure` and is never recomputed here.** It is the
+ * same call the Draw structure tab renders from, with the same eight inputs, so the count
+ * that is saved is the count the row was showing — the whole point of the tab. A second
+ * `ceil(8 / poolCount)` written beside it would be a second derivation with no vector
+ * holding it to the Python twin (`data/draw-structure`).
+ *
+ * ⚠️ **A stored count is left alone**, and that narrowing is deliberate. When the mode is
+ * automatic the stored K is the director's remembered number and — more to the point —
+ * **the count the event's bracket was cut for**: the server freezes the configuration the
+ * draw was dealt from and compares `qualifiers_per_pool` inside it
+ * (`_enforce_draw_settings_frozen`, `api/app/tournament_events.py`). Rewriting a cut
+ * event's K to a derived one behind the director's back would 409 a save of something else
+ * entirely, naming a number they never touched — #1320's own bug, reintroduced by its fix.
+ * The pool size row is not frozen, so a derived count really does move under a cut event.
+ * Closing the gap between a displayed count and the count the API cuts from is the
+ * **server's** derivation to do (`api/app/schemas/tournament.py`, chores 4a/5c); it is not
+ * this client's to paper over with a silent write.
+ */
+export function withSuppliedQualifiers(values: EventFormValues): EventFormValues {
+  // The three count-less arms send no `qualifiers_per_pool` at all (`drawSettingsToApi`,
+  // `data/api`), so there is nothing to supply and a stale value is already dropped.
+  if (values.drawType !== 'rr-then-ko') return values
+  const ownership = values.drawOwnership ?? everySettingAutomatic()
+  // The director's own count, already judged by the resolver above. Theirs to be right or
+  // wrong about, never ours to replace.
+  if (ownership.qualifiersMode === 'manual') return values
+  // A count the server would take: the remembered one, or the one the draw was cut for.
+  if (qualifiersPerPoolSchema.safeParse(values.qualifiersPerPool).success) return values
+  const { qualifiersPerPool } = deriveDrawStructure({
+    // Exactly the arguments `DrawStructureSection` derives from, read off the same live
+    // form. The tab reads the cap through the draft and the pools through this very field.
+    previewFieldSize: previewFieldSize(values.maxPlayers),
+    poolReservationCount: values.pools.length,
+    poolCountMode: ownership.poolCountMode,
+    manualPoolCount: ownership.manualPoolCount,
+    poolSizeMode: ownership.poolSizeMode,
+    manualPoolSize: ownership.manualPoolSize,
+    qualifiersMode: ownership.qualifiersMode,
+    manualQualifiers: values.qualifiersPerPool,
+  })
+  return { ...values, qualifiersPerPool }
 }
 
 /**

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -1126,6 +1126,29 @@ export function entryStateFor(
     : { state: 'open' }
 }
 
+/** What an `rr-then-ko` event holds before a director takes any setting for
+ * themselves: the system owns all three numbers and deals membership by snake. It is
+ * also what every event that predates the Draw structure tab reads back as, which is
+ * the ADR's "an event that sets nothing behaves exactly as it does today".
+ *
+ * Exported because the MSW store (`src/mocks/tournaments-store.ts`) seeds and mints
+ * `rr-then-ko` events too, and "all-automatic" is one value, not two literals that
+ * would have to be kept agreeing as the settings list grows.
+ *
+ * ⚠️ **Spread it at every use site**, never hand the object itself to an event. `as const`
+ * makes the properties readonly, and TypeScript does not check readonly modifiers on
+ * assignment — so the moment anything writes a mode through an event (which is exactly
+ * what the ownership toggle will do), an unspread constant would rewrite the structure of
+ * every other event sharing it. A row per event is also what the database holds. */
+export const EVERY_SETTING_AUTOMATIC = {
+  pool_count_mode: 'automatic',
+  manual_pool_count: null,
+  pool_size_mode: 'automatic',
+  manual_pool_size: null,
+  qualifiers_mode: 'automatic',
+  membership_mode: 'snake',
+} as const satisfies NonNullable<TournamentEventRead['draw_structure']>
+
 /**
  * A rated Bo5 "Open Singles" event with one morning pool, as returned by the
  * tournament detail/list endpoints. Defaults are internally consistent so a
@@ -1203,6 +1226,17 @@ export function buildTournamentEventRead(
     // for the reason the qualifier count is — the field is required-and-nullable on the read
     // shape while `Partial<…>` admits an explicit `undefined`.
     rounds: overrides.rounds ?? null,
+    // **Every structural setting derived**, which is what an event that has never seen
+    // the Draw structure tab holds (ADR 20260808). Only an `rr-then-ko` event carries
+    // one at all — the other three arms have no structure to own, and the read says so
+    // with `null`. Stated AFTER the spread for the reason the two fields above are: it
+    // is required-and-nullable on the read shape while `Partial<…>` admits an explicit
+    // `undefined`.
+    draw_structure:
+      overrides.draw_structure ??
+      ((overrides.draw_type ?? 'round-robin') === 'rr-then-ko'
+        ? { ...EVERY_SETTING_AUTOMATIC }
+        : null),
   } satisfies Omit<TournamentEventRead, 'entered'>
   return {
     ...event,

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildFixtureTimeRead,
   DRAW_TYPE_CATALOGUE,
+  EVERY_SETTING_AUTOMATIC,
   planDraw,
 } from '@/mocks/factories/tournaments/tournament.factory'
 import {
@@ -602,6 +603,43 @@ describe('the rest of the event surface still holds', () => {
     })
     if (!result.ok) throw new Error('create failed')
     expect(result.event.max_players).toBeNull()
+  })
+
+  /**
+   * **A created event's structural ownership follows its draw type** (ADR 20260808).
+   *
+   * Both arms in one test, because the claim is the *branch*, not either value: only an
+   * `rr-then-ko` event has a pool count, a pool size, a qualifier count and a membership
+   * rule for a director to take, so it is born owning none of them, and every other draw
+   * type is born with no structure at all. Asserted against the factory's own
+   * `EVERY_SETTING_AUTOMATIC` rather than a re-typed literal — a second copy of the
+   * settings list here would simply agree with itself while the two drifted.
+   */
+  it('gives a created event the structure its draw type implies, and no other', () => {
+    const twoStage = createEvent(TOURNAMENT, {
+      name: 'Two-stage Singles',
+      format: 'singles',
+      draw_type: 'rr-then-ko',
+      // Required on this arm of the write union — the count the bracket is sized from.
+      qualifiers_per_pool: 2,
+      entry_fee: 0,
+      timezone: 'America/Chicago',
+      slot: SLOT,
+      match_settings: { rated: false, length_games: 3 },
+    })
+    const bracketOnly = createEvent(TOURNAMENT, {
+      name: 'Bracket Singles',
+      format: 'singles',
+      draw_type: 'single-elim',
+      entry_fee: 0,
+      timezone: 'America/Chicago',
+      slot: SLOT,
+      match_settings: { rated: false, length_games: 3 },
+    })
+    if (!twoStage.ok || !bracketOnly.ok) throw new Error('create failed')
+
+    expect(twoStage.event.draw_structure).toEqual(EVERY_SETTING_AUTOMATIC)
+    expect(bracketOnly.event.draw_structure).toBeNull()
   })
 
   // An explicit null clears the cap; `??` would have kept the old value. This is

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -37,6 +37,7 @@ import type { components } from '@/api/schema'
 type TournamentStatus = components['schemas']['TournamentStatus']
 type TournamentTable = components['schemas']['TournamentTable']
 type TournamentTableUpsert = components['schemas']['TournamentTableUpsert']
+type TournamentEventUpdate = components['schemas']['TournamentEventUpdate']
 
 const TOURNAMENT = 'bay-area-open-2026' // seeded `published`, owned
 const DRAFT_TOURNAMENT = 'summer-slam-2026' // seeded `draft`, owned, one drawn event
@@ -640,6 +641,85 @@ describe('the rest of the event surface still holds', () => {
 
     expect(twoStage.event.draw_structure).toEqual(EVERY_SETTING_AUTOMATIC)
     expect(bracketOnly.event.draw_structure).toBeNull()
+  })
+
+  /**
+   * **The ownership record is patched as part of the draw configuration** (ADR 20260808),
+   * exactly as the qualifier count and the round count are — and with one rule of its own
+   * the other two do not need.
+   *
+   * A mock more permissive, or more forgetful, than the server is a trap: a director's
+   * settings that survived in `npm run dev` and vanished in production would look like a
+   * client bug for as long as it took to find the mock.
+   */
+  describe('patching the ownership record', () => {
+    const takingTheCount = {
+      ...EVERY_SETTING_AUTOMATIC,
+      pool_count_mode: 'manual',
+      manual_pool_count: 6,
+    } as const
+
+    const asTwoStage = (draw_structure?: TournamentEventUpdate['draw_structure']) =>
+      updateEvent(TOURNAMENT, EMPTY_SINGLES, {
+        draw_type: 'rr-then-ko',
+        qualifiers_per_pool: 2,
+        ...(draw_structure === undefined ? {} : { draw_structure }),
+      })
+
+    it('stores what the editor sent', () => {
+      const patched = asTwoStage(takingTheCount)
+      if (!patched.ok) throw new Error('update failed')
+
+      expect(patched.event.draw_structure).toEqual(takingTheCount)
+    })
+
+    /**
+     * ⚠️ The rule the other two settings do not have (`carrying_unstated_settings_of`,
+     * `api/app/schemas/tournament.py`). The modes are the only part of a draw
+     * configuration a caller may leave out and still send a valid one — `qualifiers_per_pool`
+     * and `rounds` are required by the arms that have them — so reading an absent key as
+     * "every mode automatic" would silently discard a director's settings on any save
+     * that did not mention them.
+     */
+    it('keeps the stored record when a patch says nothing about it', () => {
+      expect(asTwoStage(takingTheCount).ok).toBe(true)
+
+      const patched = asTwoStage()
+      if (!patched.ok) throw new Error('update failed')
+
+      expect(patched.event.draw_structure).toEqual(takingTheCount)
+    })
+
+    it('starts an event that never had one at every setting automatic', () => {
+      const patched = asTwoStage()
+      if (!patched.ok) throw new Error('update failed')
+
+      expect(patched.event.draw_structure).toEqual(EVERY_SETTING_AUTOMATIC)
+    })
+
+    // A draw type with no pool stage has no structure to own, and the settings table has
+    // no row that could hold one. The record goes with the configuration it belonged to.
+    it('drops the record when the event is re-typed to a structure-less draw', () => {
+      expect(asTwoStage(takingTheCount).ok).toBe(true)
+
+      const patched = updateEvent(TOURNAMENT, EMPTY_SINGLES, {
+        draw_type: 'single-elim',
+      })
+      if (!patched.ok) throw new Error('update failed')
+
+      expect(patched.event.draw_structure).toBeNull()
+    })
+
+    // A patch that names no draw type is not touching the configuration at all — the
+    // rename case, which is most of them.
+    it('leaves the record alone when the patch is about something else', () => {
+      expect(asTwoStage(takingTheCount).ok).toBe(true)
+
+      const patched = updateEvent(TOURNAMENT, EMPTY_SINGLES, { name: 'Renamed' })
+      if (!patched.ok) throw new Error('update failed')
+
+      expect(patched.event.draw_structure).toEqual(takingTheCount)
+    })
   })
 
   // An explicit null clears the cap; `??` would have kept the old value. This is

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -2253,6 +2253,95 @@ describe('the draw type freezes while a draw exists', () => {
     expect(result.ok).toBe(true)
     expect(eventOf(ROUND_ROBIN).draw_type).toBe('single-elim')
   })
+
+  /**
+   * **The other half of the same configuration** (ADR 20260727, chore 3e). The server
+   * freezes what the draw was DEALT from, not just its label: an `rr-then-ko` bracket is
+   * cut upfront for `P × K`, so a K the fixtures were not cut for leaves qualifiers with no
+   * slot to be seated into — a 409 with its own sentence.
+   *
+   * ⚠️ This mock **could not produce that refusal** until now: it compared `draw_type`
+   * alone, so the Draw structure tab's `Set myself` — which seeds the count from the
+   * DERIVED value, routinely not the stored one on a cut event — looked fine in
+   * `npm run dev` and in vitest, and 409'd against the real server. A stub laxer than the
+   * server it stands in for is a trap, and this is the shape the trap took.
+   */
+  describe('and so does the number the draw was sized by', () => {
+    const drawnTwoStage = () => {
+      expect(uncutDraw(TOURNAMENT, FULL_SINGLES).ok).toBe(true)
+      const patched = updateEvent(TOURNAMENT, FULL_SINGLES, {
+        draw_type: 'rr-then-ko',
+        qualifiers_per_pool: 2,
+        pools: [
+          { name: 'Pool 1', slot: SLOT, table_ids: [] },
+          { name: 'Pool 2', slot: SLOT, table_ids: [] },
+        ],
+      })
+      expect(patched.ok).toBe(true)
+      expect(cutDraw(TOURNAMENT, FULL_SINGLES).ok).toBe(true)
+    }
+
+    it('refuses a PATCH that moves the qualifier count of a cut draw', () => {
+      drawnTwoStage()
+
+      const result = updateEvent(TOURNAMENT, FULL_SINGLES, {
+        draw_type: 'rr-then-ko',
+        qualifiers_per_pool: 3,
+      })
+
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.status).toBe(409)
+      // The count's own sentence, not the draw type's: the type did not move, and naming
+      // it would send the director looking for a change they never made.
+      expect(result.status === 409 && result.detail).toContain(
+        'the number of qualifiers per pool is frozen',
+      )
+      expect(result.status === 409 && result.detail).toContain('remove the draw')
+      // A refused write writes nothing.
+      expect(eventOf(FULL_SINGLES).qualifiers_per_pool).toBe(2)
+    })
+
+    // The whole-form save again, one field over: the editor PATCHes the count back
+    // unchanged on every save, so re-sending it must stay a 200.
+    it('ALLOWS a PATCH that re-sends the SAME count', () => {
+      drawnTwoStage()
+
+      const result = updateEvent(TOURNAMENT, FULL_SINGLES, {
+        draw_type: 'rr-then-ko',
+        qualifiers_per_pool: 2,
+        name: 'Renamed',
+      })
+
+      expect(result.ok).toBe(true)
+      expect(eventOf(FULL_SINGLES).name).toBe('Renamed')
+    })
+
+    /** ⚠️ The **asymmetry**, and the server's own: ownership modes are excluded from
+     * `configuration_the_draw_was_dealt_from`, because they size nothing the cut already
+     * put on the table. A director may still take the pool count on a cut event, and a mock
+     * that refused it would be *stricter* than the server — which drives a client to
+     * disable work the API allows. */
+    it('leaves the ownership modes free on a cut draw', () => {
+      drawnTwoStage()
+
+      const result = updateEvent(TOURNAMENT, FULL_SINGLES, {
+        draw_type: 'rr-then-ko',
+        qualifiers_per_pool: 2,
+        draw_structure: {
+          pool_count_mode: 'manual',
+          manual_pool_count: 6,
+          pool_size_mode: 'automatic',
+          manual_pool_size: null,
+          membership_mode: 'snake',
+          qualifiers_mode: 'automatic',
+        },
+      })
+
+      expect(result.ok).toBe(true)
+      expect(eventOf(FULL_SINGLES).draw_structure?.manual_pool_count).toBe(6)
+    })
+  })
 })
 
 // ----- the solve tick's calling pass (ADR "the schedule is solved; the call is

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -24,6 +24,7 @@ import {
   buildTournamentFixtureRead,
   DRAW_TYPE_CATALOGUE,
   entryStateFor,
+  EVERY_SETTING_AUTOMATIC,
   planDraw,
   planRoundRobinFixtures,
   type DrawPlan,
@@ -111,7 +112,16 @@ type ScheduleSolveRead = components['schemas']['ScheduleSolveRead']
  * draw at the cut (`R × ⌊n/2⌋` fixtures, all of them written up front), it is `null` for
  * every draw type but `swiss`, and `null` is not "unset" there either — a round-robin's
  * rounds come off the circle method and a bracket's depth follows from the field, so
- * neither is a number anybody chooses. */
+ * neither is a number anybody chooses.
+ *
+ * `draw_structure` — **who owns each of a two-stage draw's structural settings** (ADR
+ * 20260808) — is stored on those same terms once more, and it is `null` for every draw
+ * type but `rr-then-ko`: the other three arms have no pool count, pool size, qualifier
+ * count or membership rule to hand anybody, so there is no structure for them to own.
+ * The two `rr-then-ko` rows below hold `EVERY_SETTING_AUTOMATIC` — the factory's one
+ * declaration of "the director has taken nothing", which is what an event that has never
+ * seen the Draw structure tab reads back as. Same discipline as the two fields above:
+ * the seed states the bare value and says no more. */
 type StoredEvent = Omit<TournamentEventRead, 'entered' | 'entry_state'> & {
   /** Seeded: the dev user is refused by this rule, at this rating. */
   ineligible?: { predicate_id: string; rating: number }
@@ -573,6 +583,7 @@ function seed(): StoredTournament[] {
           draw_type: 'round-robin',
           qualifiers_per_pool: null,
           rounds: null,
+          draw_structure: null,
           max_players: 64,
           entry_fee: 45,
           timezone: 'America/Chicago',
@@ -621,6 +632,7 @@ function seed(): StoredTournament[] {
           draw_type: 'round-robin',
           qualifiers_per_pool: null,
           rounds: null,
+          draw_structure: null,
           max_players: 48,
           entry_fee: 30,
           timezone: 'America/Los_Angeles',
@@ -646,6 +658,7 @@ function seed(): StoredTournament[] {
           draw_type: 'single-elim',
           qualifiers_per_pool: null,
           rounds: null,
+          draw_structure: null,
           max_players: 16,
           entry_fee: 60,
           timezone: 'America/Los_Angeles',
@@ -682,6 +695,7 @@ function seed(): StoredTournament[] {
           draw_type: 'round-robin',
           qualifiers_per_pool: null,
           rounds: null,
+          draw_structure: null,
           max_players: 24,
           entry_fee: 20,
           timezone: 'America/Los_Angeles',
@@ -747,6 +761,7 @@ function seed(): StoredTournament[] {
           draw_type: 'single-elim',
           qualifiers_per_pool: null,
           rounds: null,
+          draw_structure: null,
           max_players: 32,
           entry_fee: 25,
           timezone: 'America/Los_Angeles',
@@ -807,6 +822,7 @@ function seed(): StoredTournament[] {
           draw_type: 'round-robin',
           qualifiers_per_pool: null,
           rounds: null,
+          draw_structure: null,
           max_players: 16,
           entry_fee: 20,
           timezone: 'America/New_York',
@@ -870,6 +886,7 @@ function seed(): StoredTournament[] {
           draw_type: 'single-elim',
           qualifiers_per_pool: null,
           rounds: null,
+          draw_structure: null,
           max_players: 32,
           entry_fee: 40,
           timezone: 'America/Los_Angeles',
@@ -968,6 +985,7 @@ function seed(): StoredTournament[] {
           draw_type: 'round-robin',
           qualifiers_per_pool: null,
           rounds: null,
+          draw_structure: null,
           max_players: 8,
           entry_fee: 0,
           timezone: 'America/Los_Angeles',
@@ -1038,6 +1056,10 @@ function seed(): StoredTournament[] {
           // for is exactly what this draw type has.
           qualifiers_per_pool: 2,
           rounds: null,
+          // Nothing taken by the director (ADR 20260808) — the system owns all three
+          // numbers and deals membership by snake, which is what this event's pools and
+          // bracket were dealt as. Spread, so this event owns its row (see the constant).
+          draw_structure: { ...EVERY_SETTING_AUTOMATIC },
           max_players: 8,
           entry_fee: 35,
           timezone: 'America/Los_Angeles',
@@ -1128,6 +1150,9 @@ function seed(): StoredTournament[] {
           // exists purely to seed (ADR 20260727).
           qualifiers_per_pool: 2,
           rounds: null,
+          // All-automatic here too: this seed shows the two-stage results states, not a
+          // director's structural choices.
+          draw_structure: { ...EVERY_SETTING_AUTOMATIC },
           max_players: 6,
           entry_fee: 25,
           timezone: 'America/Los_Angeles',
@@ -2236,6 +2261,15 @@ export function createEvent(
     // choose, which is `null`, never `undefined` and never an invented number — the day
     // this event's draw is cut, this is how many rounds get written.
     rounds: body.rounds ?? null,
+    // **Who owns each structural setting** (ADR 20260808), DERIVED from the draw type the
+    // caller sent rather than stated: only an `rr-then-ko` event has a structure to own,
+    // and a new one has had nothing taken from the system yet — which is the ADR's "an
+    // event that sets nothing behaves exactly as it does today". Hardcoding either arm
+    // would make the mock disagree with the server about a designed state: a `null` on a
+    // two-stage event would leave the Draw structure tab reading a shape the API never
+    // sends, and a structure on any other type is a row the settings table cannot hold.
+    draw_structure:
+      body.draw_type === 'rr-then-ko' ? { ...EVERY_SETTING_AUTOMATIC } : null,
     // A missing cap is "no cap" (ADR-0935), stored as null — never undefined.
     max_players: body.max_players ?? null,
     entry_fee: body.entry_fee,

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -2334,7 +2334,8 @@ export function updateEvent(
   // reason a stranger's request is refused. (The *schema's* 422s come before all of it —
   // the handler asks them at the boundary; see `validateEventBody`. The diff's own 422,
   // below, comes after, so a cut event answers the freeze.)
-  const frozen = poolSetFrozenDetail(event, patch) ?? drawTypeFrozenDetail(event, patch)
+  const frozen =
+    poolSetFrozenDetail(event, patch) ?? drawSettingsFrozenDetail(event, patch)
   if (frozen !== null) return { ok: false, status: 409, detail: frozen }
   // The diff runs BEFORE anything is written, so an entry citing an unknown id leaves the
   // event exactly as it was — never written, not merely rolled back.
@@ -2525,29 +2526,116 @@ function poolSetFrozenDetail(
   )
 }
 
-/** Why this event's `draw_type` may not be replaced right now, or `null` when it may be
- * (`_enforce_draw_type_frozen`, ADR-0786). The pool-set freeze's sibling, one field over:
- * a draw type is not a label on an event, it is the strategy that DEALT its fixtures, and
- * re-labelling it under a standing draw leaves the event claiming a shape its draw does
- * not have (a `single-elim` event holding pooled round-robin fixtures — the PATCH the
- * server used to answer **200**).
+/**
+ * **The configuration a draw was DEALT from**, as one comparable value — the mock's twin
+ * of `DrawSettingsWriteBase.configuration_the_draw_was_dealt_from`.
+ *
+ * A draw type is not a label on an event, it is the strategy that dealt its fixtures — and
+ * for two of the four types a *number* is part of that strategy: an `rr-then-ko` bracket is
+ * cut upfront for `P × K`, and a swiss draw writes all `R` rounds at the cut. So the thing
+ * a standing draw freezes is the type **and** the setting that sized it, together, in one
+ * comparison rather than a field-by-field walk a new setting could fall out of.
+ *
+ * ⚠️ The ownership modes (`draw_structure`) are deliberately **not** in it, exactly as they
+ * are not on the server: they size nothing the cut already put on the table, so taking the
+ * pool count on a cut event is a legal PATCH and must not be refused — least of all by the
+ * qualifier-count sentence, which would name a number the director never touched.
+ */
+function dealtConfiguration(
+  drawType: StoredEvent['draw_type'],
+  qualifiersPerPool: number | null,
+  rounds: number | null,
+): string {
+  switch (drawType) {
+    case 'rr-then-ko':
+      return `rr-then-ko:${qualifiersPerPool}`
+    case 'swiss':
+      return `swiss:${rounds}`
+    case 'round-robin':
+    case 'single-elim':
+      // No setting of their own — the type IS the configuration.
+      return drawType
+    default: {
+      const exhaustive: never = drawType
+      return exhaustive
+    }
+  }
+}
+
+/** Why this event's **draw configuration** may not be replaced right now, or `null` when
+ * it may be (`_enforce_draw_settings_frozen`, ADR-0786 / ADR 20260727 / the swiss ADR).
+ * The pool-set freeze's sibling: re-labelling the type under a standing draw leaves the
+ * event claiming a shape its draw does not have (a `single-elim` event holding pooled
+ * round-robin fixtures — the PATCH the server used to answer **200**), and moving the
+ * number the draw was sized by is exactly as contradictory and much quieter.
+ *
+ * ⚠️ **It used to compare `draw_type` alone, and that gap hid a real defect.** The Draw
+ * structure tab's `Set myself` seeds the qualifier count from the DERIVED value, which on a
+ * cut event is routinely not the stored one — so the click authored a 409 the server would
+ * answer and this mock would not, which is precisely the "looks perfect in `npm run dev`"
+ * trap the rest of this file exists to avoid. A stub that cannot produce the server's
+ * refusal is a stub no test can catch the refusal with.
  *
  * **Presence is not enough — the CHANGE is what is refused.** The editor PATCHes the
- * whole form back, `draw_type` included, to move a pool's tables; a mock that fired on
- * the mere presence of the key would refuse the very edit the freeze exists to permit,
- * and the pools editor would look broken in `npm run dev` against a server that allows
- * it. */
-function drawTypeFrozenDetail(
+ * whole form back, `draw_type` and count included, to move a pool's tables; a mock that
+ * fired on the mere presence of the key would refuse the very edit the freeze exists to
+ * permit, and the pools editor would look broken against a server that allows it. */
+function drawSettingsFrozenDetail(
   event: StoredEvent,
   patch: TournamentEventUpdate,
 ): string | null {
+  // The schema refuses an explicit `null` on `draw_type`, and refuses a count with no draw
+  // type beside it — so an absent draw type means the patch is not touching the
+  // configuration at all.
   if (patch.draw_type === undefined || patch.draw_type === null) return null
-  if (patch.draw_type === event.draw_type) return null
+  const stored = dealtConfiguration(
+    event.draw_type,
+    event.qualifiers_per_pool,
+    event.rounds,
+  )
+  // ⚠️ **An ABSENT setting reads as unchanged, not as `null`.** On the server an arm
+  // missing its own setting never reaches this guard: `rr-then-ko` requires
+  // `qualifiers_per_pool` and `swiss` requires `rounds`, both with no default, so such a
+  // body is a **422 at the schema** (`validateEventBody`, `mocks/handlers`) and the freeze
+  // is never asked about it. Reading the absence as a moved setting would make this mock
+  // answer 409 where the server answers 422 — the mirror image of the laxness this guard
+  // was tightened to fix, and just as misleading.
+  const incoming = dealtConfiguration(
+    patch.draw_type,
+    'qualifiers_per_pool' in patch
+      ? (patch.qualifiers_per_pool ?? null)
+      : event.qualifiers_per_pool,
+    'rounds' in patch ? (patch.rounds ?? null) : event.rounds,
+  )
+  if (stored === incoming) return null
   if (event.fixtures.length === 0) return null
+  // The draw type is named first when both moved: it is the bigger claim, and the
+  // qualifier-count sentence would be describing a bracket the event is no longer asking
+  // to have.
+  if (patch.draw_type !== event.draw_type) {
+    return (
+      "This event's draw is already cut, so its draw type is frozen: its fixtures were " +
+      `dealt as a “${event.draw_type}” draw, and changing the type would leave the event ` +
+      'claiming a shape its draw does not have. To change the draw type, remove the draw ' +
+      'first, then cut it again.'
+    )
+  }
+  // Same type, moved setting — the server's own sentence for each, verbatim, because the
+  // editor shows a refusal's detail verbatim in its inline banner.
+  if (event.draw_type === 'rr-then-ko') {
+    return (
+      "This event's draw is already cut, so the number of qualifiers per pool is " +
+      `frozen: its knockout bracket was cut for the top ${event.qualifiers_per_pool} out of each ` +
+      `pool of a “${event.draw_type}” draw, and changing that count would leave ` +
+      'qualifiers with no slot to be seated into. To change it, remove the draw ' +
+      'first, then cut it again.'
+    )
+  }
+  const roundNoun = event.rounds === 1 ? 'round' : 'rounds'
   return (
-    "This event's draw is already cut, so its draw type is frozen: its fixtures were " +
-    `dealt as a “${event.draw_type}” draw, and changing the type would leave the event ` +
-    'claiming a shape its draw does not have. To change the draw type, remove the draw ' +
+    "This event's draw is already cut, so its number of rounds is frozen: all " +
+    `${event.rounds} ${roundNoun} were cut at once, and changing the count would leave ` +
+    'the draw with rounds it has no fixtures for. To change it, remove the draw ' +
     'first, then cut it again.'
   )
 }

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -2364,6 +2364,21 @@ export function updateEvent(
       patch.draw_type === undefined || patch.draw_type === null
         ? event.rounds
         : (patch.rounds ?? null),
+    // …and the **ownership record** moves with the same unit again (ADR 20260808), with
+    // one addition the other two do not have: an omitted `draw_structure` on a patch that
+    // *does* name `rr-then-ko` is CARRIED FORWARD, not reset. That is the server's
+    // `carrying_unstated_settings_of` — the modes are the only part of a draw
+    // configuration a caller may leave out and still send a valid one, so reading an
+    // absent key as "every mode automatic" would silently discard a director's settings
+    // on any save that did not mention them. A patch naming any other draw type has no
+    // structure to own, and says so with `null`.
+    draw_structure:
+      patch.draw_type === undefined || patch.draw_type === null
+        ? event.draw_structure
+        : patch.draw_type === 'rr-then-ko'
+          ? (patch.draw_structure ??
+            event.draw_structure ?? { ...EVERY_SETTING_AUTOMATIC })
+          : null,
     // An explicit `null` clears the cap (ADR-0935); only an *absent* key leaves
     // the stored cap untouched. `??` would conflate the two, silently keeping a
     // cap the editor meant to remove.


### PR DESCRIPTION
Slice 3 of the #1320 arc, stacked on #1334.

A director can now take any structural setting for themselves and give it back, and the choice survives a save. Slice 2 made the tab readable; this makes it editable.

## What a director can do

Each row offers a quiet `Set myself`, and a row they own offers `Use automatic`. There is no segmented control and no stepper: a manual number goes into a plain text box with a numeric input mode. Taking a setting seeds the box from the number the row already showed, so the first click moves the owner and not the value. Giving one back keeps the number, so looking at the system's answer and returning is not destructive.

The badge follows the *effective* owner while the box follows the stored mode, so `Yours` can never sit above a number the system chose.

`Qualifiers per pool` leaves Basics and joins the other three, appearing once instead of twice against one form field. A refused save follows it to the right tab.

A typed pool count creates or removes real pool rows, through the list the Table pools tab already edits — so the count and the reservations it names cannot drift (ADR `20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-count-is-a-projection`). Removing pools is priced by the repo's existing confirm, which names the reservations that will go.

Changing draw type away from `rr-then-ko` asks first, listing the settings it will discard, and only when something is actually owned. Cancelling changes nothing and the picker returns to `rr-then-ko`. The reservations stay: a pool is a venue booking as much as a group, and a round robin has pools too.

## On the server

The ownership modes and the director's numbers are new keys in the draw-settings JSON the event already has — no column, no migration. Ownership is stored, never inferred from whether a value is present, because a derived number and a typed one look identical. An event that predates this reads back all-automatic, which is today's behaviour exactly.

## Three defects found and fixed on the way, none of them by a test

**Omitting `draw_structure` on a PATCH reset every mode to automatic.** iOS and the MCP server both patch events and neither knows the field exists, so a rename from the phone would have wiped a pool count typed on the web — the silent change the ownership ADR forbids. Omission now means unchanged; sending a structure still replaces it wholesale. Both semantics are pinned.

**The pool-removal confirm, priced per keystroke, ate digits.** Against four pools, typing `12` produces `1` first: a modal opened, focus left the box, and the `2` was lost, making most three-digit counts unreachable. Now priced on commit.

**An automatic qualifier count blocked creating an event at all.** The row showed the derived number as text, because that is what automatic looks like, and the create was refused with "Say how many players advance from each pool." pointing at a row with no box. That is the shape of failure #1320 exists to remove, so the rule changed rather than the wording: an automatic setting already has an answer, and the form supplies it.

The freeze needed the same care. The ownership modes are exempt from the server's frozen-configuration check because a cut draw does not depend on them, but taking the qualifier count also rewrites the K the fixtures *were* dealt from. Without that distinction, toggling a mode on a cut event was refused by a message naming a number the director never touched — #1320's own bug by another route. The qualifiers row is therefore frozen after a cut, with its reason stated.

## Verification

- vitest **335 files / 3886 tests**, `tsc -b --force` clean, `eslint` clean.
- Root e2e **33/33** against the composed stack, including a new spec that sets a pool size, reloads, and asserts the **badge** as well as the number — a value that survived under an `Automatic` badge would mean the mode never persisted.
- The `rr-then-ko` e2e spec was repaired, not accommodated: it takes the qualifier count by hand, because the derived count at three pools is three, which would advance every entrant and quietly empty its claim that the eliminated are absent from the bracket. The stale Basics accessors were removed rather than left pointing at a control that now answers on another tab.
- Both generated OpenAPI files verified drift-free against the live spec.

Refs #1320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcvZ6Zh6w6vxj6uAaizmuF
