### PR TITLE
Slice 5: the app reports a disagreement and offers three ways out (#1320)

### DIFF
--- a/api/app/draw_structure.py
+++ b/api/app/draw_structure.py
@@ -26,12 +26,14 @@ pinned by five test modules. They live here now, as
 :func:`pool_too_small_message`, :data:`ONE_PLAYER_KNOCKOUT_MESSAGE` and
 :func:`too_many_qualifiers_message`, and :mod:`app.draws` imports them — so the cut and
 the derivation refuse in the same words by construction rather than by two authors
-agreeing. **One sentence is this module's own**, because the cut has no state that
-reaches it: :func:`pool_too_small_for_pool_size_message` is the pool refusal for a pool
-size the *director* set, which the snake deal cannot produce. The import runs this way
-round because this module must stay a leaf:
-:mod:`app.draws` pulls in the ORM enums and the request schemas, and nothing that
-imports *this* should have to.
+agreeing. **Two sentences are this module's own**, because the cut had no state that
+reached them: :func:`pool_too_small_for_pool_size_message` is the pool refusal for a
+pool size the *director* set, which the snake deal cannot produce, and
+:func:`unseated_entrants_message` is the cut-time refusal for a structure that seats
+fewer players than have entered (#1320, chore 5c). The import runs this way round
+because this module
+must stay a leaf: :mod:`app.draws` pulls in the ORM enums and the request schemas, and
+nothing that imports *this* should have to.
 
 The spec is ``docs/designs/rr-then-ko-draw-structure/README.md``, section "The
 derivation".
@@ -178,6 +180,48 @@ class DrawStructureDisagreement:
     #: How many entrants have nowhere to go, or how many seats would be empty. Always
     #: positive: :attr:`direction` carries the sign.
     count: int
+
+
+def unseated_entrants_message(disagreement: DrawStructureDisagreement) -> str:
+    """The **cut's** refusal for a structure that seats fewer players than have entered
+    — the arithmetic in the order the ADR states it (``20260808-a-structural-setting-is-
+    owned-by-the-director-or-derived-by-the-system``): what the structure seats, what
+    the field is, and how many entrants have nowhere to go.
+
+    It sits beside the value object rather than up in the copy section because it takes
+    the whole :class:`DrawStructureDisagreement`: every number in the sentence is one
+    the derivation already computed, and re-deriving ``seats`` from loose arguments here
+    would be a second copy of the arithmetic the vectors pin.
+
+    **One direction only, and the asymmetry is the point — do not tidy it into
+    symmetry.** A disagreement runs both ways (:class:`DisagreementDirection`), but only
+    :attr:`~DisagreementDirection.unseated` stops a cut, so this sentence words only
+    that direction and its caller
+    (``app.event_draw_structure.entrants_with_nowhere_to_go``) hands it nothing else.
+    Empty seats are not a problem: seven pools of six against a real field of forty
+    deals ``6,6,6,6,6,6,4``, which is the legal uneven split the app already calls legal
+    one slice over — and refusing it would dead-end the director hardest of all, because
+    the reference's own resolution ``Use ceil(field / size) pools of {size}`` (labelled
+    "Everyone gets a seat.") rounds *up* and therefore lands them exactly there.
+
+    **Deliberately not the impossible-competition wording.** A pool of one is a
+    competition nobody can play, and the director fixes it by making the numbers
+    playable; this is two playable numbers that do not cover the field, and the director
+    fixes it by deciding which of the two they meant. The tail says so: the cut will not
+    choose for them.
+    """
+    pool_noun = "pool" if disagreement.pool_count == 1 else "pools"
+    seat_verb = "seats" if disagreement.pool_count == 1 else "seat"
+    field_noun = "entrant" if disagreement.field_size == 1 else "entrants"
+    unseated_noun = "entrant has" if disagreement.count == 1 else "entrants have"
+    return (
+        f"{disagreement.pool_count} {pool_noun} of {disagreement.pool_size} "
+        f"{seat_verb} {disagreement.seats}, and this event has "
+        f"{disagreement.field_size} {field_noun} — {disagreement.count} "
+        f"{unseated_noun} nowhere to go. Cutting would have "
+        "to change one of those numbers for you, so change the pool count or the "
+        "pool size, then cut again."
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/api/app/draws.py
+++ b/api/app/draws.py
@@ -118,11 +118,24 @@ class UnsupportedDrawType(DrawError):
 
 
 class DegenerateDraw(DrawError):
-    """The requested cut would produce a draw that isn't a competition.
+    """The requested cut would produce a draw that isn't a competition, **or one the
+    director's own numbers do not describe**.
 
     A pool holding a single entrant has nobody to play (and a pool holding none is a
     ghost), so we refuse the cut rather than silently emit a pool of one. The director
     fixes the input — fewer pools, or more entrants — and re-cuts.
+
+    The second reason is #1320's, and it is not "unplayable": a saved draw structure
+    whose two manual numbers seat **fewer** players than have entered describes a
+    perfectly playable competition that is simply **not the one this field needs**, and
+    cutting it would mean changing a number the director typed. Only that direction is
+    refused — seats to spare deal a legal uneven split — and the argument for the
+    asymmetry lives with the guard. It is this class rather than a new one on purpose:
+    both HTTP (``app.tournaments._draw_refusal``) and MCP
+    (``app.mcp_server._map_draw_refusal_tool_error``) pass a ``DegenerateDraw``'s
+    domain-authored copy through untouched, and a new subclass would land in their
+    deliberately vague fallback arms. See
+    ``app.tournament_draws._refuse_a_structure_that_leaves_entrants_unseated``.
     """
 
 

--- a/api/app/event_draw_structure.py
+++ b/api/app/event_draw_structure.py
@@ -7,42 +7,70 @@ two callers — ``create_event`` and ``update_event`` — need the same answer a
 same event, and assembled twice the two would eventually disagree about which pool list
 or which field size they meant.
 
-It answers **one** question, ``is this configuration playable``, and it answers it about
-the state the request would produce rather than the fields the request carries (ADR
+It answers **two** questions — ``is this configuration playable`` (the write's, chore
+4b) and ``does this configuration leave entrants with nowhere to go`` (the cut's, chore
+5c) — and it answers both about the state the caller is judging rather than the
+fields a request carries (ADR
 ``20260808-draw-structure-derivation-runs-on-both-sides-and-shares-its-vectors``). That
 is what lets the director in #1320 escape: their event is already impossible, and one
 request that changes the pool count and the qualifiers together has to be accepted.
 
-Pure, and a leaf: it takes the parsed write arm, a pool-row count and a player cap, and
-imports no session, no FastAPI and no ORM.
+**The two questions are asked against two different fields, on purpose.** See
+:func:`preview_field_size` and :func:`entrants_with_nowhere_to_go` — the assembly of the
+eight inputs is shared (:func:`_derived`), and the field is the one input that differs.
+
+Pure, and a leaf: it takes the parsed settings arm, a pool-row count and a field, and
+imports no session, no FastAPI and no ORM. :data:`DEFAULT_UNCAPPED_FIELD` lives here
+rather than in :mod:`app.schedule_preview` (which re-exports it, so every existing
+reference to ``schedule_preview.DEFAULT_UNCAPPED_FIELD`` still resolves) for exactly
+that reason: the preview imports :mod:`app.tournament_draws`, and the cut needs this
+module, so a constant borrowed the other way round would close an import cycle.
 """
 
 from app.draw_structure import (
+    DisagreementDirection,
+    DrawStructure,
+    DrawStructureDisagreement,
     DrawStructureOptions,
     ImpossibleProblem,
     SettingOwnership,
     derive_draw_structure,
 )
-from app.schedule_preview import DEFAULT_UNCAPPED_FIELD
 from app.schemas.tournament import (
     DrawSettingsWriteArm,
     RrThenKoDrawSettingsWrite,
     StructuralSettingOwner,
 )
 
-__all__ = ["impossible_draw_structure", "preview_field_size"]
+__all__ = [
+    "DEFAULT_UNCAPPED_FIELD",
+    "entrants_with_nowhere_to_go",
+    "impossible_draw_structure",
+    "preview_field_size",
+]
+
+#: The synthetic field size for an *uncapped* event (``max_players IS NULL``,
+#: ADR-0935). An uncapped event has no natural number to auto-fill to, so a
+#: configuration-time derivation needs a stand-in; the schedule preview's caller may
+#: always override it. Sixteen is a plausible club-night field the ADR names as the
+#: default. Re-exported by :mod:`app.schedule_preview`, which invents that many
+#: entrants for its snapshot.
+DEFAULT_UNCAPPED_FIELD = 16
 
 
 def preview_field_size(max_players: int | None) -> int:
-    """The field the derivation runs against: the event's cap, or
-    :data:`~app.schedule_preview.DEFAULT_UNCAPPED_FIELD` when it has none.
+    """The field a **configuration-time** derivation runs against: the event's cap, or
+    :data:`DEFAULT_UNCAPPED_FIELD` when it has none.
 
     The **same** number the schedule preview invents for an uncapped event
     (``schedule_preview._field_size``) and the same one the client's
-    ``previewFieldSize`` labels its basis with, imported rather than restated so the
-    three cannot drift. A director configures an event before registration opens, so
-    there is no real field to judge — the refusals below are about the competition the
-    numbers describe, not about anybody who has entered.
+    ``previewFieldSize`` labels its basis with, shared rather than restated so the three
+    cannot drift. A director configures an event before registration opens, so there is
+    no real field to judge — the write's refusals are about the competition the numbers
+    describe, not about anybody who has entered.
+
+    **The cut does not use this.** By then the entrants exist, and
+    :func:`entrants_with_nowhere_to_go` judges them instead.
     """
     if max_players is not None:
         return max_players
@@ -62,6 +90,92 @@ def _ownership(owner: StructuralSettingOwner) -> SettingOwnership:
             return SettingOwnership.automatic
         case StructuralSettingOwner.manual:
             return SettingOwnership.manual
+
+
+def _derived(
+    draw_settings: DrawSettingsWriteArm, *, pool_count: int, field_size: int
+) -> DrawStructure | None:
+    """This configuration's whole derived structure, or ``None`` when the draw type has
+    no pool stage feeding a knockout.
+
+    **The eight inputs, assembled once** — the module's whole reason for existing. The
+    write asks it about a preview field and the cut asks it about a real one, and two
+    assemblies would eventually disagree about which pool list or which ownership mode
+    they meant.
+
+    The event's stored ``qualifiers_per_pool`` is passed as the *manual* qualifier
+    number unconditionally, exactly as the client passes it: there is no second field
+    for it, and ``qualifiers_mode`` is what decides whether anybody reads it.
+    """
+    if not isinstance(draw_settings, RrThenKoDrawSettingsWrite):
+        return None
+    structure = draw_settings.draw_structure
+    return derive_draw_structure(
+        DrawStructureOptions(
+            preview_field_size=field_size,
+            pool_reservation_count=pool_count,
+            pool_count_mode=_ownership(structure.pool_count_mode),
+            manual_pool_count=structure.manual_pool_count,
+            pool_size_mode=_ownership(structure.pool_size_mode),
+            manual_pool_size=structure.manual_pool_size,
+            qualifiers_mode=_ownership(structure.qualifiers_mode),
+            manual_qualifiers=draw_settings.qualifiers_per_pool,
+        )
+    )
+
+
+def entrants_with_nowhere_to_go(
+    *,
+    draw_settings: DrawSettingsWriteArm,
+    pool_count: int,
+    field_size: int,
+) -> DrawStructureDisagreement | None:
+    """The disagreement by which this configuration seats **fewer** players than
+    ``field_size``, or ``None``.
+
+    The cut's question, and the reason a cut is refused where a save is not: a
+    disagreement is two numbers the director typed on purpose, so the app keeps both and
+    the event saves (ADR ``20260808-a-structural-setting-is-owned-by-the-director-or-
+    derived-by-the-system``, "A disagreement is not a refusal"). A *cut* has to seat
+    every entrant somewhere, so it would have to answer a question the director has not
+    settled.
+
+    **Only the ``unseated`` direction. Empty seats are answered ``None``, and that
+    asymmetry is deliberate — do not tidy it into symmetry.** Seven pools of six against
+    a real field of forty deals ``6,6,6,6,6,6,4``: an uneven split, which this app calls
+    legal and previews as legal. Refusing it would also close the last door on the
+    director, because the reference's own resolution for a disagreement —
+    ``Use ceil(field / size) pools of {size}``, labelled "Everyone gets a seat." —
+    rounds **up**, so applying the fix the app itself offers lands on seats to spare
+    every time the size does not divide the field.
+
+    **``field_size`` is the real registered field, and the caller passes it — this is
+    not :func:`preview_field_size`.** Three reasons, in the order they decide it:
+
+    * The ADR's disagreement is about the cut having to invent an answer. What the cut
+      actually deals is the event's active entrants, so that is the only field whose
+      arithmetic can force an invention. A cap is a limit nobody may have reached, and
+      the uncapped default is a number nobody has entered.
+    * Judged against the preview field the guard would get both cases backwards: it
+      would refuse a structure that seats the real field exactly (six pools of five
+      against thirty entrants deals exactly the pools the director asked for), and wave
+      through one that does not.
+    * A refusal quotes numbers a director has to be able to check. At cut time the
+      entrant list is on screen; the preview field is not.
+
+    ``pool_count`` is the number of pool **rows** the event has, and it is read only
+    when the pool count is *automatic* — an event's pool count is its pool rows (ADR
+    ``20260808-an-events-pool-count-is-its-pool-rows-and-a-derived-count-is-a-
+    projection``). Whether a *manual* pool count that disagrees with the pool rows is
+    itself worth refusing is a separate question, and this guard does not answer it: it
+    compares seats against the field, nothing else.
+    """
+    derived = _derived(draw_settings, pool_count=pool_count, field_size=field_size)
+    if derived is None or derived.disagreement is None:
+        return None
+    if derived.disagreement.direction is not DisagreementDirection.unseated:
+        return None
+    return derived.disagreement
 
 
 def impossible_draw_structure(
@@ -87,30 +201,17 @@ def impossible_draw_structure(
     * **``impossible_problems`` only.** A **disagreement** is not a refusal: six pools
       of five seat thirty, a field of forty does not fit, and both numbers were typed on
       purpose, so the event saves (ADR ``20260808-a-structural-setting-is-owned-by-the-
-      director-or-derived-by-the-system``). Only the *cut* is unavailable.
+      director-or-derived-by-the-system``). Only the *cut* is unavailable, and only when
+      the field is the bigger of the two — :func:`entrants_with_nowhere_to_go`.
     * **At most one problem**, which is the derivation's own rule — one impossible
       competition is one thing to fix.
-
-    The event's stored ``qualifiers_per_pool`` is passed as the *manual* qualifier
-    number unconditionally, exactly as the client passes it: there is no second field
-    for it, and ``qualifiers_mode`` is what decides whether anybody reads it.
     """
-    if not isinstance(draw_settings, RrThenKoDrawSettingsWrite):
-        return None
-    structure = draw_settings.draw_structure
-    derived = derive_draw_structure(
-        DrawStructureOptions(
-            preview_field_size=preview_field_size(max_players),
-            pool_reservation_count=pool_count,
-            pool_count_mode=_ownership(structure.pool_count_mode),
-            manual_pool_count=structure.manual_pool_count,
-            pool_size_mode=_ownership(structure.pool_size_mode),
-            manual_pool_size=structure.manual_pool_size,
-            qualifiers_mode=_ownership(structure.qualifiers_mode),
-            manual_qualifiers=draw_settings.qualifiers_per_pool,
-        )
+    derived = _derived(
+        draw_settings,
+        pool_count=pool_count,
+        field_size=preview_field_size(max_players),
     )
-    if not derived.is_impossible:
+    if derived is None or not derived.is_impossible:
         return None
     # Guarded by the line above, so this is not an index into a possibly-empty tuple:
     # ``is_impossible`` IS "there is a problem", and the derivation reports at most one.

--- a/api/app/schedule_preview.py
+++ b/api/app/schedule_preview.py
@@ -114,6 +114,7 @@ from app.draws import (
     PlannedFixture,
     UnsupportedDrawType,
 )
+from app.event_draw_structure import DEFAULT_UNCAPPED_FIELD as _DEFAULT_UNCAPPED_FIELD
 from app.models.tournament import DrawType, Tournament, TournamentEvent
 from app.scheduling import (
     EventId,
@@ -131,11 +132,13 @@ from app.schemas.tournament import MatchSettings, Pool, TournamentTable
 from app.tournament_draws import draw_config, event_pools, strategy_for_event
 from app.venue_time import anchor_wallclock
 
-#: The synthetic field size for an *uncapped* event (``max_players IS NULL``,
-#: ADR-0935). An uncapped event has no natural number to auto-fill to, so a
-#: preview needs a stand-in; the director may always override it. Sixteen is a
-#: plausible club-night field the ADR names as the default.
-DEFAULT_UNCAPPED_FIELD = 16
+#: The synthetic field size for an *uncapped* event, **defined in**
+#: :mod:`app.event_draw_structure` and imported here rather than the other way round:
+#: that module is a leaf the *cut* now depends on (#1320), and this one imports
+#: :mod:`app.tournament_draws`, so borrowing the constant the other way would close an
+#: import cycle. Re-exported under its original name, which every caller and every
+#: ``:data:`DEFAULT_UNCAPPED_FIELD``` reference below still uses.
+DEFAULT_UNCAPPED_FIELD = _DEFAULT_UNCAPPED_FIELD
 
 
 #: The prefix every synthetic entrant's ``PlayerId`` carries — ``placeholder-{k}``

--- a/api/app/tournament_draws.py
+++ b/api/app/tournament_draws.py
@@ -20,7 +20,10 @@ and leaves this module with only the three things a database is actually needed 
 - **the currency** (``draw_currency_by_event``) — whether each event's draw still
   describes the field it was cut from. The fact the ``published → live`` precondition
   is decided on (ADR-0786).
-- **the write** (``cut_draw`` / ``uncut_draw``).
+- **the write** (``cut_draw`` / ``uncut_draw``), and the one refusal the write owns
+  that the pure half cannot: a saved draw structure that seats fewer players than
+  the field the cut is about to deal
+  (``_refuse_a_structure_that_leaves_entrants_unseated``, #1320).
 
 Neither write commits. The caller owns the transaction, because a cut is only safe
 inside the tournament's row lock: the field it reads and the fixtures it derives from
@@ -34,7 +37,9 @@ from collections.abc import Collection, Mapping, Sequence
 from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.draw_structure import unseated_entrants_message
 from app.draws import (
+    DegenerateDraw,
     DrawConfig,
     DrawStrategy,
     Entrant,
@@ -49,6 +54,7 @@ from app.draws import (
     strategy_for,
     unseated_entrant_allowance,
 )
+from app.event_draw_structure import entrants_with_nowhere_to_go
 from app.models import (
     DrawType,
     EventFormat,
@@ -571,6 +577,45 @@ def _covers_the_field(
     )
 
 
+def _refuse_a_structure_that_leaves_entrants_unseated(
+    event: TournamentEvent, *, pool_count: int, field_size: int
+) -> None:
+    """Raise :class:`~app.draws.DegenerateDraw` when this event's **saved** draw
+    structure seats fewer players than the field the cut is about to deal (#1320).
+
+    **A disagreement is not a refusal — of the save** (ADR ``20260808-a-structural-
+    setting-is-owned-by-the-director-or-derived-by-the-system``). Six pools of five seat
+    thirty; a field of forty leaves ten entrants with nowhere to go. Both numbers were
+    typed on purpose and the director may be mid-thought, so the write keeps them
+    (``app.event_draw_structure.impossible_draw_structure`` deliberately looks at the
+    impossible problems alone). The **cut** is the act that cannot proceed: it has to
+    seat every entrant somewhere, and every somewhere available to it contradicts one of
+    the two numbers.
+
+    **Seats to spare are not refused**, and that asymmetry is load-bearing rather than
+    an oversight — see ``entrants_with_nowhere_to_go``, which is where the reasoning
+    lives and which answers ``None`` for that direction.
+
+    The arithmetic is not re-implemented here. It is the same derivation the Draw
+    structure tab runs as the director types, assembled from the event by
+    :func:`app.event_draw_structure.entrants_with_nowhere_to_go` and worded by
+    :func:`app.draw_structure.unseated_entrants_message`, so the sentence a director
+    reads when the cut refuses carries the same numbers the tab was showing them.
+
+    ``field_size`` is the **real** active field, not the preview's cap-or-16 — see
+    ``entrants_with_nowhere_to_go`` for why the cut judges the field it actually deals.
+    Answers ``None`` for every draw type without a pool stage feeding a knockout, so
+    nothing but ``rr-then-ko`` can be refused here.
+    """
+    unseated = entrants_with_nowhere_to_go(
+        draw_settings=draw_settings_of(event.draw_settings),
+        pool_count=pool_count,
+        field_size=field_size,
+    )
+    if unseated is not None:
+        raise DegenerateDraw(unseated_entrants_message(unseated))
+
+
 async def cut_draw(db: AsyncSession, event: TournamentEvent) -> None:
     """Cut (or re-cut) this event's draw: plan the fixtures its draw type prescribes for
     its active field, and make them the event's fixtures — **all of them, and only
@@ -619,12 +664,25 @@ async def cut_draw(db: AsyncSession, event: TournamentEvent) -> None:
     lands without reading the field of an event that has no business being cut. It is
     the only "this event cannot be cut" refusal left at this seam — ``strategy_for`` is
     total now that the enum holds only what runs (ADR 20260726), so it refuses nothing.
+
+    Refuses a **structure that leaves entrants unseated** with
+    :class:`~app.draws.DegenerateDraw` too (#1320, and
+    :func:`_refuse_a_structure_that_leaves_entrants_unseated` for the whole argument): a
+    director's two manual numbers may be saved while they think, but a cut would have to
+    change one of them for them. It is asked **after** the strategy has planned and
+    before the DELETE — after, because an impossible competition outranks a
+    disagreement, which is the precedence the Draw structure tab's one-panel-at-a-time
+    rule already shows a director, and planning is pure so a plan thrown away costs
+    nothing.
     """
     if event.format is not EventFormat.singles:
         raise NonSinglesDraw(event.format)
     strategy = strategy_for_event(event)
-    planned = strategy.plan_initial(
-        draw_config(event), order_entrants(await active_draw_entrants(db, event.id))
+    config = draw_config(event)
+    entrants = order_entrants(await active_draw_entrants(db, event.id))
+    planned = strategy.plan_initial(config, entrants)
+    _refuse_a_structure_that_leaves_entrants_unseated(
+        event, pool_count=len(config.pool_ids), field_size=len(entrants)
     )
     await uncut_draw(db, [event.id])
     db.add_all(

--- a/api/tests/test_draw_structure.py
+++ b/api/tests/test_draw_structure.py
@@ -42,6 +42,11 @@ strings. The wording is the cut's own, and it is already pinned verbatim by
 copy here would pin nothing those do not. What these calls *do* pin is which builder the
 derivation reaches for and **which numbers it hands it** — a swapped pair of arguments
 reds.
+
+**The unseated-entrants sentence is the exception, and is pinned verbatim at the foot
+of this file.** It is new copy with no older home (chore 5c), so calling its builder
+here and again at the cut would pin nobody's words. This file is the one place it is
+typed out.
 """
 
 from dataclasses import dataclass
@@ -62,6 +67,7 @@ from app.draw_structure import (
     pool_too_small_for_pool_size_message,
     pool_too_small_message,
     too_many_qualifiers_message,
+    unseated_entrants_message,
 )
 
 AUTOMATIC = SettingOwnership.automatic
@@ -717,3 +723,53 @@ def test_a_possible_structure_says_so() -> None:
     impossible = derive_draw_structure(_vector("field too small").options)
     assert possible.is_impossible is False
     assert impossible.is_impossible is True
+
+
+# ----- the unseated sentence, which is the cut's alone (chore 5c) --------------------
+#
+# Unlike the three impossible messages, this copy is **new** and has no other file
+# pinning it, so it is pinned verbatim here — from the vector's own disagreement, so a
+# swapped ``seats``/``field_size`` reds rather than reading plausibly.
+#
+# There is no empty-seats sentence to pin. Only the ``unseated`` direction refuses a
+# cut, so only that direction has words on this side; the empty-seats copy is the
+# client's panel's, and the client writes it (see ``unseated_entrants_message``).
+
+
+def test_the_unseated_sentence_states_the_arithmetic_and_refuses_to_choose() -> None:
+    """The ADR's own sentence: what the structure seats, what the field is, and how many
+    entrants have nowhere to go — then who has to decide.
+
+    Deliberately **not** the impossible-competition wording. Nothing here is unplayable:
+    six pools of five is a fine competition, it is simply not one for forty players, and
+    the way out is the director picking a number rather than making a number legal.
+    """
+    disagreement = derive_draw_structure(
+        _vector("both manual and disagreeing").options
+    ).disagreement
+    assert disagreement is not None
+    assert unseated_entrants_message(disagreement) == (
+        "6 pools of 5 seat 30, and this event has 40 entrants — 10 entrants have "
+        "nowhere to go. Cutting would have to change one of those numbers for you, "
+        "so change the pool count or the pool size, then cut again."
+    )
+
+
+def test_every_noun_and_verb_in_the_sentence_inflects() -> None:
+    """One pool and one entrant are both reachable — a manual ``1`` is a number a
+    director can type — and a refusal reading ``1 pools of 1 seat 1`` would be the app's
+    own carelessness quoted back at somebody it is refusing."""
+    assert unseated_entrants_message(
+        DrawStructureDisagreement(
+            pool_count=1,
+            pool_size=1,
+            seats=1,
+            field_size=2,
+            direction=DisagreementDirection.unseated,
+            count=1,
+        )
+    ) == (
+        "1 pool of 1 seats 1, and this event has 2 entrants — 1 entrant has nowhere "
+        "to go. Cutting would have to change one of those numbers for you, so change "
+        "the pool count or the pool size, then cut again."
+    )

--- a/api/tests/test_rr_then_ko.py
+++ b/api/tests/test_rr_then_ko.py
@@ -30,6 +30,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import match_calls
+from app.draw_structure import (
+    DisagreementDirection,
+    DrawStructureDisagreement,
+    unseated_entrants_message,
+)
 from app.match_voiding import void_match
 from app.models import (
     DrawType,
@@ -770,6 +775,158 @@ async def test_cutting_for_more_qualifiers_than_the_smallest_pool_holds_is_refus
     )
     assert await _fixtures(db_session, event_id) == [], (
         "a refused cut writes nothing at all"
+    )
+
+
+# ----- a saved structure that does not seat the field (#1320, chore 5c) -------------
+#
+# A **disagreement** is the director's two manual numbers not multiplying out to their
+# field. It is deliberately savable — they may be mid-thought, and ADR "a structural
+# setting is owned by the director or derived by the system" says the app states the
+# arithmetic and keeps both numbers rather than moving one. The CUT is what cannot
+# proceed, because it has to seat every entrant somewhere and every somewhere available
+# to it contradicts one of the two numbers.
+#
+# **Only one direction refuses.** Entrants with nowhere to go cannot be dealt. Seats to
+# spare can: three pools of five over eleven entrants deals 4, 4, 3, which is the uneven
+# split this app calls legal — and refusing it would dead-end a director who applied the
+# app's own resolution, since ``Use ceil(field / size) pools of {size}`` rounds up. The
+# asymmetry is deliberate and the tests below are what red if it is tidied away.
+#
+# **The cut judges the real registered field**, not the preview's cap-or-16. Every event
+# below is capped at 64, so all three disagree with the *preview* field; what separates
+# them is who actually entered. See
+# ``app.event_draw_structure.entrants_with_nowhere_to_go`` for the argument.
+#
+# The sentence itself is pinned verbatim in ``test_draw_structure.py`` — its one home —
+# and built here from the numbers this cut must have judged, so a guard that quoted the
+# 64-player cap would red on the numbers rather than on the words.
+
+
+async def _event_of_manual_pools(
+    client: AsyncClient,
+    db: AsyncSession,
+    *,
+    pool_count: int,
+    pool_size: int,
+    entrants: int = 12,
+) -> tuple[str, str]:
+    """An event whose director owns **both** structural numbers, with a real field.
+
+    Asserts the create itself, because "saving stays available" is half of what this
+    section is about: the guard belongs to the cut alone, and a copy of it on the write
+    would make every one of these events unsavable instead.
+    """
+    tournament_id = await _tournament(client)
+    created = await _create_event(
+        client,
+        tournament_id,
+        pools=list(POOLS[:pool_count]),
+        draw_structure={
+            "pool_count_mode": "manual",
+            "manual_pool_count": pool_count,
+            "pool_size_mode": "manual",
+            "manual_pool_size": pool_size,
+        },
+    )
+    assert created.status_code == 201, (
+        f"{pool_count} pools of {pool_size} disagrees with this event's field, and a "
+        f"disagreement saves: {created.text}"
+    )
+    event_id: str = created.json()["id"]
+    for n in range(1, entrants + 1):
+        await _enter(db, event_id, await make_user(db, f"seat{n}"), seed=n, minutes=n)
+    return tournament_id, event_id
+
+
+async def test_cutting_a_structure_that_leaves_entrants_unseated_is_refused(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """Three pools of three seat nine. Twelve entered. Three have nowhere to go.
+
+    The cut is the act that would have to answer the question the director left open:
+    the snake would deal 4, 4, 4 and call it the pools of three they asked for. So it
+    refuses in the same 422 shape as every other cut refusal, naming the arithmetic
+    rather than an impossible competition — nothing here is unplayable, and a director
+    told "a pool would have one player" would go hunting for a defect that is not there.
+    """
+    client, _ = authed_client
+    tournament_id, event_id = await _event_of_manual_pools(
+        client, db_session, pool_count=3, pool_size=3
+    )
+
+    response = await _cut(client, tournament_id, event_id)
+
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"] == unseated_entrants_message(
+        DrawStructureDisagreement(
+            pool_count=3,
+            pool_size=3,
+            seats=9,
+            field_size=12,
+            direction=DisagreementDirection.unseated,
+            count=3,
+        )
+    )
+    assert await _fixtures(db_session, event_id) == [], (
+        "a refused cut writes nothing at all"
+    )
+
+
+async def test_a_structure_with_seats_to_spare_still_cuts(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """**The asymmetry, pinned.** Three pools of five seat fifteen and eleven people
+    entered — and the cut goes ahead, dealing 4, 4, 3.
+
+    Nothing has to be invented that this app does not already do openly: an uneven split
+    is legal, is previewed as legal, and is described as legal one slice over. Refusing
+    it would also close the last door on the director, because the resolution the app
+    itself offers for a disagreement (``Use ceil(field / size) pools of {size}``,
+    labelled "Everyone gets a seat.") rounds **up** and so lands them here whenever the
+    size does not divide the field. This test is what reds if the guard is ever tidied
+    into a symmetric one.
+    """
+    client, _ = authed_client
+    tournament_id, event_id = await _event_of_manual_pools(
+        client, db_session, pool_count=3, pool_size=5, entrants=11
+    )
+
+    response = await _cut(client, tournament_id, event_id)
+
+    assert response.status_code == 201, response.text
+    pooled = [f for f in await _fixtures(db_session, event_id) if f.pool_id is not None]
+    # Pools of 4, 4 and 3 play 6, 6 and 3 pairings: 15 in all, and the odd pool out is
+    # the smaller one.
+    per_pool = sorted(
+        len([f for f in pooled if f.pool_id == pool_id])
+        for pool_id in await _pool_ids(db_session, event_id)
+    )
+    assert per_pool == [3, 6, 6]
+
+
+async def test_a_structure_that_seats_the_real_field_exactly_still_cuts(
+    authed_client: tuple[AsyncClient, User], db_session: AsyncSession
+) -> None:
+    """**The regression test for which field the cut judges.**
+
+    Three pools of four seat twelve, and twelve people entered, so nothing has to be
+    invented and the director gets exactly the pools they asked for. Against the
+    *preview* field this event disagrees as loudly as the two above — its cap is 64 —
+    so this is the case that reds if anybody ever wires ``preview_field_size`` back into
+    the cut's guard. Six fixtures per pool is a pool of four playing everybody.
+    """
+    client, _ = authed_client
+    tournament_id, event_id = await _event_of_manual_pools(
+        client, db_session, pool_count=3, pool_size=4
+    )
+
+    response = await _cut(client, tournament_id, event_id)
+
+    assert response.status_code == 201, response.text
+    pooled = [f for f in await _fixtures(db_session, event_id) if f.pool_id is not None]
+    assert sorted(str(f.pool_id) for f in pooled) == sorted(
+        [str(pool_id) for pool_id in await _pool_ids(db_session, event_id)] * 6
     )
 
 

--- a/e2e/page-objects/tournament-detail.page.ts
+++ b/e2e/page-objects/tournament-detail.page.ts
@@ -282,6 +282,26 @@ export class TournamentDetailPage {
     return this.page.getByTestId(`draw-panel-${eventId}`)
   }
 
+  /**
+   * **The refusal a rejected cut leaves on the card** — an `Alert`, where the click was,
+   * rather than a toast that carries the one sentence away after four seconds.
+   *
+   * Its description is the **server's own** words: the route hands a `DegenerateDraw`
+   * through as the 422's `detail` (`_draw_refusal`, `app/tournaments.py`) and the panel
+   * renders `error.detail` unchanged (`drawRefusalNotice`, `data/draw.ts`). So a spec that
+   * reads this is reading the API's sentence on the director's screen, which is the only
+   * place the two can be shown to be the same one.
+   *
+   * ⚠️ **Suppressed once the draw verbs freeze**, and it is cleared when the next attempt
+   * starts — so assert it *before* the cut that succeeds, never after. "The notice is gone"
+   * is not evidence of anything: it is also what a freeze looks like.
+   *
+   * Addressed by testid rather than by role, exactly as the panel's own comment asks: the
+   * frozen notice beside it is an `Alert` too, so "the alert" names neither. */
+  drawNotice(eventId: string): Locator {
+    return this.page.getByTestId(`draw-notice-${eventId}`)
+  }
+
   /** The "View match" deep-link a fixture grows once it materializes at go-live. */
   viewMatchLink(eventId: string): Locator {
     return this.drawPanel(eventId).getByRole('link', { name: /View match/ })

--- a/e2e/tests/tournament-draw-structure.spec.ts
+++ b/e2e/tests/tournament-draw-structure.spec.ts
@@ -8,7 +8,10 @@ import {
   addEvent,
   createTournament,
   findEventByName,
+  getEventPools,
   patchEventDrawRaw,
+  seedEntrants,
+  transitionTournament,
   validationDetails,
   type PoolSpec,
   type StoredTable,
@@ -191,6 +194,159 @@ const SERVER_ONE_PLAYER_KNOCKOUT_REFUSAL =
   'knockout stage, who would have nobody to play — take more qualifiers ' +
   'from each pool, or configure more pools.'
 
+// ----- the fourth spec's numbers: two manual numbers that DISAGREE -----------
+//
+// The reference's own worked example, and the ADR's: six pools of five seat thirty, and a
+// field of forty leaves ten entrants with nowhere to go. Nothing here is shared with the
+// three scenarios above, for the reason none of those share anything with each other —
+// every number below is an input to, or a consequence of, one standoff.
+
+/** The cap this standoff is measured against. **Forty**, and it has to be a number the
+ * manual pair misses: 32 over six pools of five would be a *two*-seat overshoot in the
+ * other direction, which is the half of the disagreement that changes nothing anywhere. */
+const DISAGREEMENT_FIELD_CAP = 40
+/** Six pool rows, reserving no tables. Six because the director's manual count agrees with
+ * their pool rows here — the standoff under test is between the count and the *size*, and a
+ * count that also disagreed with the rows would be a second argument in the same panel. */
+const DISAGREEMENT_POOLS: ReadonlyArray<PoolSpec> = [
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+].map((letter) => ({ name: `Pool ${letter}`, tableLabels: [] }))
+const MANUAL_POOL_COUNT = 6
+/** The size the director types over the seven the row was showing (`Set myself` seeds the
+ * **largest** derived pool, and 40 across 6 is `7,7,7,7,6,6`). */
+const DISAGREEING_POOL_SIZE = 5
+/** `6 × 5` — what the structure actually seats. */
+const SEATS = MANUAL_POOL_COUNT * DISAGREEING_POOL_SIZE
+/** `40 − 30`, the entrants the structure has no seat for. */
+const UNSEATED = DISAGREEMENT_FIELD_CAP - SEATS
+
+/** The uneven notice the tab shows **before** either setting is taken — the control that
+ * makes the disagreement below a change of state rather than a panel that was there all
+ * along. 40 across 6 pool rows is `7,7,7,7,6,6`, which this app calls legal and says so.
+ *
+ * A **middle dot** (`·`, U+00B7) between the tallies, and note it is *not* the ` and ` of
+ * `Allow uneven pools`'s detail line: the same two numbers are written two ways a few
+ * pixels apart and both are the reference's. */
+const UNEVEN_TOPLINE = 'Legal, but uneven'
+const UNEVEN_TITLE = '4 pools of 7 · 2 pools of 6'
+
+/** **The topline of a notice that is not a refusal.** `Needs your call`, over a `status`
+ * role: the numbers disagree, the app says so, and nothing is disabled. */
+const NEEDS_YOUR_CALL = 'Needs your call'
+/** **The standoff, in the reference's own sentence** — both of the director's numbers
+ * printed back at them unchanged, and the product they make. Unpluralised throughout,
+ * which is the reference's transcription rather than an improvement on it. */
+const DISAGREEMENT_TITLE = `${MANUAL_POOL_COUNT} pools of ${DISAGREEING_POOL_SIZE} seat ${SEATS}. Your field is ${DISAGREEMENT_FIELD_CAP}.`
+/** …and the promise under it. A right single quote (`U+2019`) in `won’t`, as the reference
+ * writes every apostrophe but `today's behaviour`. */
+const DISAGREEMENT_BODY = `${UNSEATED} entrants have nowhere to go. We won’t change your numbers behind your back.`
+/** The preview's verdict and badge while the two numbers disagree — neither the `Sound`
+ * of a draw that adds up nor the `Impossible` of one nobody can play. */
+const DISAGREEMENT_VERDICT = 'Your numbers disagree'
+const DISAGREEMENT_BADGE = 'Your call'
+
+/** `6 × 2` qualifiers into the next power of two. Asserted because the preview describes
+ * the structure the director **typed**, not one the app quietly rounded into shape. */
+const DISAGREEING_BRACKET_SIZE = 12
+const DISAGREEING_BYES = 4
+/** `6 × C(5,2)`. */
+const DISAGREEING_POOL_MATCHES = 60
+
+/** **The three ways out, in the panel's order**, and the line under each.
+ *
+ * Every label carries a number the derivation worked out: `30` is the seats, `8` is
+ * `ceil(40 / 5)`, and the split phrase is `tallyBalancedSplit(40, 6)` written with a
+ * multiplication sign (`×`, U+00D7) and joined with ` and `. The README states that last
+ * one as its own worked example, so it is pinned twice on purpose. */
+const CAP_THE_FIELD = `Cap the field at ${SEATS}`
+const CAP_THE_FIELD_DETAIL = 'Your structure stays exact.'
+const SEAT_EVERYONE = `Use 8 pools of ${DISAGREEING_POOL_SIZE}`
+const SEAT_EVERYONE_DETAIL = 'Everyone gets a seat.'
+const ALLOW_UNEVEN = 'Allow uneven pools'
+const ALLOW_UNEVEN_DETAIL = '4 × 7 and 2 × 6 players.'
+
+/** What `Use 8 pools of 5` leaves behind: eight pool **rows**, because a pool count is its
+ * rows (ADR 20260808) and the fix writes through the same `reconcilePoolsToCount` the Pool
+ * count box types through. `8 × 5` is exactly 40, so the standoff is over. */
+const SEATED_POOL_COUNT = 8
+
+// ----- the fifth spec's numbers: the CUT, which cannot wait for an answer ----
+//
+// Smaller than the scenario above, and deliberately its own event: the cut judges the
+// **real registered field**, not the cap, so every entrant this scenario needs is a guest
+// minted and entered one at a time. Ten is the smallest field that states the case with
+// every noun plural in both directions.
+
+/** The cap, and the field: exactly ten enter, so the tab's preview field and the cut's real
+ * field are the same number — which is what lets one sentence on screen and one from the
+ * API be compared as statements about one standoff. */
+const CUT_FIELD = 10
+/** Two pool rows, matching the manual count below. */
+const CUT_POOLS: ReadonlyArray<PoolSpec> = ['A', 'B'].map((letter) => ({
+  name: `Pool ${letter}`,
+  tableLabels: [],
+}))
+const CUT_MANUAL_POOL_COUNT = 2
+const CUT_MANUAL_POOL_SIZE = 4
+/** `2 × 4`, against a field of ten: two entrants with nowhere to go. */
+const CUT_SEATS = CUT_MANUAL_POOL_COUNT * CUT_MANUAL_POOL_SIZE
+const CUT_UNSEATED = CUT_FIELD - CUT_SEATS
+
+/** **K as this event stores it**, and the reason it is two rather than the derivation's
+ * number: the strategy judges the *stored* count against the smallest pool the snake really
+ * deals (`RrThenKoStrategy.plan_initial`), and it runs **before** the unseated guard. Ten
+ * entrants across three rows deal `4,3,3`, so a stored count above three would refuse the
+ * second cut for a different reason entirely — a green-looking red that says `qualifiers`
+ * where this spec claims `nowhere to go`. Two clears every pool in both states, and it is
+ * read back off the server before each cut so a wrong-reason refusal names itself. */
+const CUT_QUALIFIERS = 2
+
+/** The tab's own sentence about the standoff, before anybody cuts anything. */
+const CUT_DISAGREEMENT_TITLE = `${CUT_MANUAL_POOL_COUNT} pools of ${CUT_MANUAL_POOL_SIZE} seat ${CUT_SEATS}. Your field is ${CUT_FIELD}.`
+const CUT_DISAGREEMENT_BODY = `${CUT_UNSEATED} entrants have nowhere to go. We won’t change your numbers behind your back.`
+
+/** **The server's refusal at the cut, verbatim** (`app.draw_structure.unseated_entrants_
+ * message`) — quoted source, transcribed rather than tidied.
+ *
+ * An **em dash** (`—`, U+2014) before the shortfall, and the same numbers the tab was
+ * showing: what the structure seats, what the field is, how many have nowhere to go. It is
+ * longer than the panel's, and for the panel's own reason — the API has no button to offer,
+ * so the way out has to be inside the sentence. */
+const SERVER_UNSEATED_REFUSAL =
+  `${CUT_MANUAL_POOL_COUNT} pools of ${CUT_MANUAL_POOL_SIZE} seat ${CUT_SEATS}, ` +
+  `and this event has ${CUT_FIELD} entrants — ${CUT_UNSEATED} entrants have ` +
+  'nowhere to go. Cutting would have to change one of those numbers for you, ' +
+  'so change the pool count or the pool size, then cut again.'
+/** The heading the card's refusal alert puts over that sentence.
+ *
+ * ⚠️ A **straight** apostrophe (U+0027) in `can't`. This one is the *client's* own literal
+ * (`drawRefusalNotice`, `data/draw.ts`) and not the design reference's copy, so the
+ * `U+2019` rule that governs `Can’t save` does not reach it. Copied byte for byte from the
+ * file rather than typed. */
+const CUT_REFUSAL_TITLE = "This event can't be drawn yet"
+
+/** The resolution this spec takes: `ceil(10 / 4)` pools, keeping the size. */
+const CUT_RESOLUTION = `Use 3 pools of ${CUT_MANUAL_POOL_SIZE}`
+const RESOLVED_POOL_COUNT = 3
+/** …and **the state it lands in, which is still a disagreement** — `3 × 4` seats twelve
+ * against a field of ten. The fix's detail line promises only that everyone gets a seat,
+ * and the ceiling is why two of them are spare.
+ *
+ * ⚠️ **This is the asymmetry, and it is load-bearing — do not tidy it into symmetry.** The
+ * tab still says `Needs your call`, and the cut goes through anyway: only the `unseated`
+ * direction stops a cut, because empty seats deal the legal uneven split this app already
+ * calls legal one panel over (`entrants_with_nowhere_to_go`). Refusing them would dead-end
+ * the director on the app's own offered fix. */
+const RESOLVED_SEATS = RESOLVED_POOL_COUNT * CUT_MANUAL_POOL_SIZE
+const SPARE_SEATS = RESOLVED_SEATS - CUT_FIELD
+const SPARE_SEATS_TITLE = `${RESOLVED_POOL_COUNT} pools of ${CUT_MANUAL_POOL_SIZE} seat ${RESOLVED_SEATS}. Your field is ${CUT_FIELD}.`
+const SPARE_SEATS_BODY = `${SPARE_SEATS} seats would be empty. We won’t change your numbers behind your back.`
+
 /**
  * The tournament both specs are about: one `rr-then-ko` event, capped at 32, over four
  * pool rows that reserve no tables — the state the whole tab is derived from.
@@ -203,17 +359,21 @@ const SERVER_ONE_PLAYER_KNOCKOUT_REFUSAL =
  * having rendered at all — the hero's `h1` — and the catalogue because a second event is
  * added against it.
  *
- * **The two overrides are the pool rows and K, and no others.** They are the pair the
- * derivation's whole answer turns on, so a scenario about a different draw shape changes
- * them and leaves the cap, the draw type and the name alone — which is what keeps every
- * number this file asserts traceable to one of the two. Both default to the four-pool
- * event the first two specs read.
+ * **The three overrides are the pool rows, K and the cap, and no others.** They are what
+ * the derivation's whole answer turns on, so a scenario about a different draw shape
+ * changes them and leaves the draw type and the name alone — which is what keeps every
+ * number this file asserts traceable to one of the three. All three default to the
+ * four-pool, 32-player event the first two specs read.
+ *
+ * The cap is a knob because a **disagreement** is a statement about the field: the manual
+ * pair has to miss it, and 32 is divisible by too much of what these scenarios type.
  */
 async function seedTwoStageTournament(
   page: Page,
   options: {
     readonly pools?: ReadonlyArray<PoolSpec>
     readonly qualifiersPerPool?: number
+    readonly maxPlayers?: number
   } = {},
 ): Promise<{
   director: Guest
@@ -232,7 +392,7 @@ async function seedTwoStageTournament(
     name: RR_KO_EVENT,
     drawType: 'rr-then-ko',
     qualifiersPerPool: options.qualifiersPerPool ?? STORED_QUALIFIERS_PER_POOL,
-    maxPlayers: FIELD_CAP,
+    maxPlayers: options.maxPlayers ?? FIELD_CAP,
     pools: options.pools ?? POOLS,
   })
 
@@ -747,5 +907,377 @@ test.describe('Tournament — the rr-then-ko draw structure', () => {
     const saved = await findEventByName(director, tournamentId, RR_KO_EVENT)
     expect(saved.qualifiers_per_pool).toBe(FIXED_QUALIFIERS)
     expect(saved.draw_structure?.qualifiers_mode).toBe('manual')
+  })
+
+  /**
+   * **Two numbers the director typed that do not seat their field — reported, and nothing
+   * touched.**
+   *
+   * Six pools of five seat thirty. Their field is forty. Ten entrants have nowhere to go,
+   * and the app says exactly that and then does nothing else: both numbers stay as typed,
+   * the save stays available, and the way out is three named acts the director chooses
+   * between (ADR 20260808 — report, do not reshape).
+   *
+   * ## Why this is not the refusal one spec up
+   *
+   * It looks like one and is deliberately not one, and every discriminator is asserted:
+   *
+   * | | Refusal | This |
+   * | --- | --- | --- |
+   * | Role | `alert` | **`status`** |
+   * | Topline | `Can’t save` | **`Needs your call`** |
+   * | Save | withheld, and says why | **available, and it works** |
+   * | Verdict | `This draw can’t work yet` | **`Your numbers disagree`** |
+   *
+   * The save is the one that matters most and the one a screen cannot state: a disagreement
+   * is two playable numbers that miss each other, and a director may be mid-thought. So the
+   * event is really saved, and read back off the server holding **both** manual numbers —
+   * which is also the only way to tell "the tab kept them on screen" from "the write kept
+   * them".
+   *
+   * ## What only this suite can say
+   *
+   * That `Use 8 pools of 5` **is eight pool rows**. The fix carries a number, but ADR
+   * 20260808 says a pool count is its rows, so applying it has to create two
+   * `tournament_event_pools` — and the only place that claim can be tested as a claim about
+   * pools rather than about a number is a stack where the Table pools tab and the server's
+   * own pool list can be read after the save. A unit test can only watch a callback fire
+   * with an eight in it.
+   */
+  test('a director whose six pools of five miss a forty-player field is told so, and offered three ways out', async ({
+    page,
+    baseURL,
+  }) => {
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    const { director, tournamentId, name, eventId } = await seedTwoStageTournament(
+      page,
+      { pools: DISAGREEMENT_POOLS, maxPlayers: DISAGREEMENT_FIELD_CAP },
+    )
+
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    // The long timeout is the composed web-client's first compile of this route, not the
+    // app — see the same wait in the three specs above.
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    const editor = await detail.openEvent(RR_KO_EVENT)
+    const drawStructure = await editor.openDrawStructure()
+    await expect(drawStructure.section).toBeVisible()
+
+    // ----- 1. the control: nobody owns anything, and the draw is LEGAL -------
+    // 40 across six pool rows is `7,7,7,7,6,6` — uneven, which this app calls legal and
+    // says so in its own panel. Asserted first because the whole claim below is that the
+    // notice *changed*, and a panel that was there all along would satisfy every
+    // "the panel is visible" reading on its own.
+    await expect(drawStructure.fieldSize).toHaveText(String(DISAGREEMENT_FIELD_CAP))
+    await expect(drawStructure.issue).toHaveRole('status')
+    await expect(drawStructure.issue).toContainText(UNEVEN_TOPLINE)
+    await expect(drawStructure.issueTitle).toHaveText(UNEVEN_TITLE)
+    await expect(drawStructure.previewVerdict).toHaveText('Ready to save')
+    await expect(drawStructure.previewBadge).toHaveText('Sound')
+
+    // ----- 2. the director takes the pool count — and it is still legal ------
+    // Six, which is the number the row was already showing. One manual setting is not a
+    // disagreement: it takes two to disagree, and this half-way state is what says the
+    // panel below is about the pair rather than about either number alone.
+    await drawStructure.setManually('Pool count', MANUAL_POOL_COUNT)
+    await expect(drawStructure.issue).toContainText(UNEVEN_TOPLINE)
+    await expect(drawStructure.issue).not.toContainText(NEEDS_YOUR_CALL)
+    // The same split as before it was taken, tally for tally: taking a setting changes the
+    // OWNER, not the number, so nothing about the draw moved on that click.
+    await expect(drawStructure.issueTitle).toHaveText(UNEVEN_TITLE)
+
+    // ----- 3. …and then the pool size, which is where they stop agreeing -----
+    await drawStructure.setManually('Pool size', DISAGREEING_POOL_SIZE)
+
+    // ----- 4. THE ASSERTION: the standoff, stated and not resolved -----------
+    await expect(drawStructure.issue).toBeVisible()
+    // A `status`, not an `alert`: this one interrupts nothing, because it blocks nothing.
+    await expect(drawStructure.issue).toHaveRole('status')
+    await expect(drawStructure.issue).toContainText(NEEDS_YOUR_CALL)
+    await expect(drawStructure.issueTitle).toHaveText(DISAGREEMENT_TITLE)
+    await expect(drawStructure.issueBody).toHaveText(DISAGREEMENT_BODY)
+    // The negative half, said out loud rather than left to the exactness above: the panel
+    // is neither of the other two, and both of those strings are reachable copy on this
+    // very tab.
+    await expect(drawStructure.issue).not.toContainText(CANT_SAVE)
+    await expect(drawStructure.issue).not.toContainText(UNEVEN_TOPLINE)
+    await expect(drawStructure.previewVerdict).toHaveText(DISAGREEMENT_VERDICT)
+    await expect(drawStructure.previewBadge).toHaveText(DISAGREEMENT_BADGE)
+
+    // ----- 5. NOTHING WAS RESHAPED, which is this slice's whole claim --------
+    // Both numbers, exactly as typed, under badges saying whose they are. A `6` that had
+    // become a `7`, or a `5` quietly grown to seat the field, would leave every reading
+    // above true and the ADR broken.
+    await expect(drawStructure.settingInput('Pool count')).toHaveValue(
+      String(MANUAL_POOL_COUNT),
+    )
+    await expect(drawStructure.settingOwnership('Pool count')).toHaveText('Yours')
+    await expect(drawStructure.settingInput('Pool size')).toHaveValue(
+      String(DISAGREEING_POOL_SIZE),
+    )
+    await expect(drawStructure.settingOwnership('Pool size')).toHaveText('Yours')
+    // …and the preview describes the structure they typed, not one rounded into shape:
+    // six pools of five, the twelve-player bracket that follows and the 60 pool matches
+    // it takes — none of which is the draw a forty-player field would have got.
+    await expect(drawStructure.previewEquation).toHaveText(
+      `${DISAGREEMENT_FIELD_CAP} players ÷ ${MANUAL_POOL_COUNT} pools = ${DISAGREEING_POOL_SIZE} per pool`,
+    )
+    await expect(drawStructure.previewPoolCards).toHaveCount(MANUAL_POOL_COUNT)
+    await expect(drawStructure.previewKnockout).toContainText(
+      `${DISAGREEING_BRACKET_SIZE}-player bracket`,
+    )
+    await expect(drawStructure.previewKnockout).toContainText(
+      `${DISAGREEING_BYES} first-round byes`,
+    )
+    await expect(drawStructure.previewKnockout).toContainText(
+      `${DISAGREEING_POOL_MATCHES} pool matches`,
+    )
+
+    // ----- 6. the three ways out, in order, with their costs -----------------
+    // One statement pinning the labels, the count and the order — `Cap the field at 30`
+    // alone would be equally true of a panel that had lost the other two.
+    await expect(drawStructure.issueFixLabels).toHaveText([
+      CAP_THE_FIELD,
+      SEAT_EVERYONE,
+      ALLOW_UNEVEN,
+    ])
+    await expect(drawStructure.issueFixDetail(CAP_THE_FIELD)).toHaveText(
+      CAP_THE_FIELD_DETAIL,
+    )
+    await expect(drawStructure.issueFixDetail(SEAT_EVERYONE)).toHaveText(
+      SEAT_EVERYONE_DETAIL,
+    )
+    await expect(drawStructure.issueFixDetail(ALLOW_UNEVEN)).toHaveText(
+      ALLOW_UNEVEN_DETAIL,
+    )
+
+    // ----- 7. SAVING STAYS AVAILABLE, and actually lands ---------------------
+    // The discriminator no screen can state and no fixture can fake. Both halves: the
+    // refusal's furniture is absent, and the save really happens.
+    await expect(editor.blockedSaveButton).toHaveCount(0)
+    await expect(editor.saveBlockedReason).toHaveCount(0)
+    await expect(editor.saveChangesButton).toBeEnabled()
+    await editor.saveChanges()
+
+    // Both manual numbers, off the server. A save that had "helped" by writing 7, or by
+    // dropping one of the modes, answers 200 just as happily.
+    const stored = await findEventByName(director, tournamentId, RR_KO_EVENT)
+    expect(stored.draw_structure?.pool_count_mode).toBe('manual')
+    expect(stored.draw_structure?.manual_pool_count).toBe(MANUAL_POOL_COUNT)
+    expect(stored.draw_structure?.pool_size_mode).toBe('manual')
+    expect(stored.draw_structure?.manual_pool_size).toBe(DISAGREEING_POOL_SIZE)
+    // The pool ROWS were not touched either: the panel offers to add two and nobody has
+    // pressed it yet.
+    expect(await getEventPools(director, tournamentId, eventId)).toHaveLength(
+      MANUAL_POOL_COUNT,
+    )
+
+    // ----- 8. reopen, and take the second way out ----------------------------
+    // Reloaded rather than re-clicking through the closing sheet — the same reason the
+    // spec above reloads: the modal's overlay covers the card it was opened from.
+    await detail.reload(tournamentId)
+    await expect(detail.title).toContainText(name)
+    const reopened = await detail.openEvent(RR_KO_EVENT)
+    const reloaded = await reopened.openDrawStructure()
+    // The standoff came back with the numbers, which is what makes the fix below an act
+    // on a stored state rather than on an unsaved draft.
+    await expect(reloaded.issueTitle).toHaveText(DISAGREEMENT_TITLE)
+    await reloaded.applyFix(SEAT_EVERYONE).click()
+
+    // ----- 9. …and it is EIGHT POOL ROWS, not a number in a box --------------
+    await expect(reloaded.settingInput('Pool count')).toHaveValue(
+      String(SEATED_POOL_COUNT),
+    )
+    // The size is untouched — this resolution keeps it and moves the count, which is the
+    // half of the offer that distinguishes it from `Cap the field at 30`.
+    await expect(reloaded.settingInput('Pool size')).toHaveValue(
+      String(DISAGREEING_POOL_SIZE),
+    )
+    // `8 × 5` is exactly the field, so the standoff is over — and no *other* notice
+    // replaced it, which is what a resolution that traded one problem for another would
+    // leave behind.
+    await expect(reloaded.issue).toHaveCount(0)
+    await expect(reloaded.previewVerdict).toHaveText('Ready to save')
+    await expect(reloaded.previewBadge).toHaveText('Sound')
+    await expect(reloaded.previewEquation).toHaveText(
+      `${DISAGREEMENT_FIELD_CAP} players ÷ ${SEATED_POOL_COUNT} pools = ${DISAGREEING_POOL_SIZE} per pool`,
+    )
+    await expect(reloaded.previewPoolCards).toHaveCount(SEATED_POOL_COUNT)
+
+    // **The ADR's rule, on the tab that owns pools.** Eight cards in the pool section, not
+    // eight in a projection: the preview above draws a card per derived pool whatever the
+    // event holds, so only this count says two rows were really created.
+    await reopened.poolsTab.click()
+    await expect(reopened.poolCards).toHaveCount(SEATED_POOL_COUNT)
+
+    await reopened.saveChanges()
+    // …and the server holds eight pools, which is the same claim with the client removed.
+    expect(await getEventPools(director, tournamentId, eventId)).toHaveLength(
+      SEATED_POOL_COUNT,
+    )
+    const resized = await findEventByName(director, tournamentId, RR_KO_EVENT)
+    expect(resized.draw_structure?.manual_pool_count).toBe(SEATED_POOL_COUNT)
+    expect(resized.draw_structure?.manual_pool_size).toBe(DISAGREEING_POOL_SIZE)
+  })
+
+  /**
+   * **The cut cannot wait for an answer — and only in one direction.**
+   *
+   * A save may carry a standoff (the spec above), because a director may be mid-thought.
+   * A **cut** may not: it has to seat every entrant somewhere, and every somewhere
+   * available to it contradicts one of the two numbers the director typed. So two pools of
+   * four against ten entrants is refused at the cut, in the derivation's own numbers, on the
+   * card where the click was.
+   *
+   * ## …and seats to spare still cut, which is the correction worth pinning
+   *
+   * The resolution the app itself offers — `Use ceil(field / size) pools of {size}`,
+   * labelled "Everyone gets a seat." — **rounds up**. Three pools of four seat twelve
+   * against a field of ten, so applying it lands on a disagreement in the *other*
+   * direction, and the tab goes on saying `Needs your call`. That draw cuts anyway: it
+   * deals `4,3,3`, the legal uneven split this app already calls legal one panel over. A
+   * guard tidied into symmetry would refuse the director's escape at the exact moment they
+   * took the app's own advice, so the asymmetry is asserted rather than left implied — the
+   * tab's `Needs your call` and the cut's `201`, three lines apart.
+   *
+   * ## Why the field is ten real entrants and not a cap
+   *
+   * The cut judges the field it actually deals (`entrants_with_nowhere_to_go`), so ten
+   * guests are minted and director-entered one at a time. The cap is set to the same ten so
+   * the tab's preview field and the cut's real field are one number — which is what lets
+   * the sentence on screen before the cut and the sentence in the refusal be compared as
+   * two statements about the same standoff rather than about two different fields.
+   *
+   * ## What only this suite can say
+   *
+   * That the two implementations of one rule agree **at two different moments**. The tab
+   * refuses nothing and says so; the API refuses the cut and says why; and the numbers in
+   * the two sentences are the same numbers. Nothing short of a real field in a real
+   * database, cut through the real button, can put those beside each other.
+   */
+  test('a cut is refused while entrants have nowhere to go, and goes through once seats are spare', async ({
+    page,
+    baseURL,
+  }) => {
+    // Ten guests are minted and entered one at a time — see the seed's own note. The
+    // budget is the seed's, not the app's.
+    test.setTimeout(300_000)
+    expect(baseURL, 'baseURL must be set for the API seed').toBeTruthy()
+
+    const { director, tournamentId, eventId, name } = await seedTwoStageTournament(
+      page,
+      {
+        pools: CUT_POOLS,
+        maxPlayers: CUT_FIELD,
+        qualifiersPerPool: CUT_QUALIFIERS,
+      },
+    )
+
+    // ----- 1. a real field, over the API -------------------------------------
+    // Registration has to be open before anybody can be entered, and the entries are
+    // scaffolding: what is under test is the cut.
+    await transitionTournament(director, tournamentId, 'published')
+    await seedEntrants(director, baseURL!, tournamentId, eventId, CUT_FIELD)
+    // Asked of the SERVER, never counted off the roster on screen — that list truncates at
+    // eight chips and a `+N more` line.
+    const filled = await findEventByName(director, tournamentId, RR_KO_EVENT)
+    expect(filled.entered).toBe(CUT_FIELD)
+
+    const detail = await TournamentDetailPage.navigateTo(page, tournamentId)
+    // The long timeout is the composed web-client's first compile of this route.
+    await expect(detail.title).toContainText(name, { timeout: 60_000 })
+
+    // ----- 2. the director types the two numbers, and saves them -------------
+    const editor = await detail.openEvent(RR_KO_EVENT)
+    const drawStructure = await editor.openDrawStructure()
+    await expect(drawStructure.section).toBeVisible()
+    await drawStructure.setManually('Pool count', CUT_MANUAL_POOL_COUNT)
+    await drawStructure.setManually('Pool size', CUT_MANUAL_POOL_SIZE)
+
+    // The same standoff the spec above states at forty, at the scale a real field can be
+    // seeded to. Read here so the sentence the API is about to write can be compared with
+    // the one the director was looking at.
+    await expect(drawStructure.issue).toHaveRole('status')
+    await expect(drawStructure.issue).toContainText(NEEDS_YOUR_CALL)
+    await expect(drawStructure.issueTitle).toHaveText(CUT_DISAGREEMENT_TITLE)
+    await expect(drawStructure.issueBody).toHaveText(CUT_DISAGREEMENT_BODY)
+    // A disagreement is not a refusal — of the save.
+    await expect(editor.blockedSaveButton).toHaveCount(0)
+    await editor.saveChanges()
+
+    const saved = await findEventByName(director, tournamentId, RR_KO_EVENT)
+    expect(saved.draw_structure?.manual_pool_count).toBe(CUT_MANUAL_POOL_COUNT)
+    expect(saved.draw_structure?.manual_pool_size).toBe(CUT_MANUAL_POOL_SIZE)
+    // **The stored K, before the cut is attempted.** The strategy judges this number
+    // against the smallest pool it deals, and it runs *before* the unseated guard — so a
+    // count that had drifted would refuse the cut below for a cause this spec is not
+    // about, and the 422 would look like a pass.
+    expect(saved.qualifiers_per_pool).toBe(CUT_QUALIFIERS)
+
+    // ----- 3. THE REFUSAL: the cut will not choose for them ------------------
+    await detail.reload(tournamentId)
+    const refusedPost = page.waitForResponse(
+      (r) => r.url().endsWith('/draw') && r.request().method() === 'POST',
+    )
+    await detail.generateDrawButton(RR_KO_EVENT).click()
+    const refused = await refusedPost
+    expect(refused.status()).toBe(422)
+    // The server's own sentence, whole. Its numbers are the tab's numbers, in the order
+    // the ADR states them: what the structure seats, what the field is, who is left over.
+    expect(((await refused.json()) as { detail: string }).detail).toBe(
+      SERVER_UNSEATED_REFUSAL,
+    )
+    // …and the director READS it, which is the half a raw request cannot show: the panel
+    // renders the API's `detail` unchanged, so this is the same sentence on the card.
+    await expect(detail.drawNotice(eventId)).toContainText(CUT_REFUSAL_TITLE)
+    await expect(detail.drawNotice(eventId)).toContainText(SERVER_UNSEATED_REFUSAL)
+    // A refusal writes nothing: no pool of the draw exists, and the verb is still on offer.
+    await expect(detail.poolDraws(eventId)).toHaveCount(0)
+    await expect(detail.generateDrawButton(RR_KO_EVENT)).toBeVisible()
+
+    // ----- 4. the director takes the way out the app offers ------------------
+    await detail.reload(tournamentId)
+    const reopened = await detail.openEvent(RR_KO_EVENT)
+    const reloaded = await reopened.openDrawStructure()
+    await expect(reloaded.issueTitle).toHaveText(CUT_DISAGREEMENT_TITLE)
+    await reloaded.applyFix(CUT_RESOLUTION).click()
+
+    // ----- 5. …which lands on a disagreement the OTHER way round -------------
+    // `ceil(10 / 4)` is three, and three pools of four seat twelve. The tab still asks for
+    // a call, and the numbers say why. **This is the state the cut below succeeds from** —
+    // do not "fix" the ceiling, and do not expect the panel to be gone.
+    await expect(reloaded.settingInput('Pool count')).toHaveValue(
+      String(RESOLVED_POOL_COUNT),
+    )
+    await expect(reloaded.issue).toContainText(NEEDS_YOUR_CALL)
+    await expect(reloaded.issueTitle).toHaveText(SPARE_SEATS_TITLE)
+    await expect(reloaded.issueBody).toHaveText(SPARE_SEATS_BODY)
+    await expect(reloaded.previewVerdict).toHaveText(DISAGREEMENT_VERDICT)
+
+    await reopened.poolsTab.click()
+    await expect(reopened.poolCards).toHaveCount(RESOLVED_POOL_COUNT)
+    await reopened.saveChanges()
+
+    const resolved = await findEventByName(director, tournamentId, RR_KO_EVENT)
+    expect(resolved.draw_structure?.manual_pool_count).toBe(RESOLVED_POOL_COUNT)
+    // K again, before the second cut: `4,3,3` leaves a smallest pool of three, so the two
+    // this event stores is what keeps the 201 below a statement about the unseated guard.
+    expect(resolved.qualifiers_per_pool).toBe(CUT_QUALIFIERS)
+
+    // ----- 6. THE ASYMMETRY: empty seats do not stop a cut -------------------
+    await detail.reload(tournamentId)
+    const cutPost = page.waitForResponse(
+      (r) => r.url().endsWith('/draw') && r.request().method() === 'POST',
+    )
+    await detail.generateDrawButton(RR_KO_EVENT).click()
+    const cut = await cutPost
+    expect(
+      cut.status(),
+      `cutting the draw was refused: ${await cut.text()}`,
+    ).toBe(201)
+    // Three pools on the page, dealt `4,3,3` out of a structure that offered twelve seats
+    // to ten players. The 201 alone would also be answered by a cut that produced nothing.
+    await expect(detail.poolDraws(eventId)).toHaveCount(RESOLVED_POOL_COUNT)
   })
 })

--- a/web-client/src/components/tournaments/data/draw-structure.ts
+++ b/web-client/src/components/tournaments/data/draw-structure.ts
@@ -204,6 +204,26 @@ function greedySizes(fieldSize: number, poolCount: number, poolSize: number): nu
   })
 }
 
+/**
+ * What the balanced split of `fieldSize` across `poolCount` pools would tally to, largest
+ * pool first — `4 × 7 and 2 × 6` for 40 across 6.
+ *
+ * **No new arithmetic.** It composes the two functions the derivation already uses, and
+ * both are pinned by the shared vectors through `poolSizes` and `unevenDistribution`. The
+ * disagreement panel's `Allow uneven pools` has to say what that resolution would produce
+ * *before* the director takes it, and re-dividing the field in the renderer would be a
+ * second implementation of the split with no vector holding it to this one.
+ *
+ * **At most two entries, always**: a balanced split is `base` and `base + 1` and nothing
+ * else. A caller joining them can rely on that.
+ */
+export function tallyBalancedSplit(
+  fieldSize: number,
+  poolCount: number,
+): PoolSizeTally[] {
+  return tallySizes(balancedSizes(fieldSize, atLeastOne(poolCount)))
+}
+
 /** The size tally the uneven notice reads out, largest pool first. */
 function tallySizes(sizes: number[]): PoolSizeTally[] {
   const counts = new Map<number, number>()

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.test.tsx
@@ -44,6 +44,27 @@ const eventTooSmallForItsPools = (
     ...overrides,
   })
 
+/**
+ * The reference's **"Numbers disagree"** state
+ * (`docs/designs/rr-then-ko-draw-structure/numbers-disagree-panel.png`), and #1320's
+ * required case: a field of **40** against **six** manual pools of **five** manual, which
+ * seat thirty and leave ten entrants with nowhere to go.
+ *
+ * ⚠️ It keeps the "Nothing set" event's **four** pool rows, and that gap is deliberate: a
+ * derived count in excess of the rows is reported, never materialised (ADR 20260808's point
+ * 3). `Use 8 pools of 5` is the one act that closes it.
+ */
+const numbersDisagree = (overrides: Partial<Omit<TournamentEvent, 'entered'>> = {}) =>
+  eventOwning(
+    {
+      poolCountMode: 'manual',
+      manualPoolCount: 6,
+      poolSizeMode: 'manual',
+      manualPoolSize: 5,
+    },
+    { maxPlayers: 40, ...overrides },
+  )
+
 describe('DrawStructureSection', () => {
   it('says what the tab is for, in the reference’s words', () => {
     drawStructureSectionPage.render()
@@ -772,9 +793,9 @@ describe('DrawStructureSection', () => {
      * invented, and a projection in excess of the rows is reported, never materialised.
      * Here 32 players in pools of 5 projects 7 pools over 4 reservations.
      *
-     * Chore 5b's disagreement panel is what reports the gap, and its
-     * `Use {n} pools of {size}` is what appends the rows — through the same
-     * `reconcilePoolsToCount` the box types through.
+     * The disagreement panel is what reports the gap, and its `Use {n} pools of {size}` is
+     * what appends the rows — through the same `reconcilePoolsToCount` the box types
+     * through.
      */
     it('creates no pool row when the director merely takes the setting', async () => {
       const onPoolsChange = vi.fn()
@@ -1146,33 +1167,26 @@ describe('DrawStructureSection', () => {
     })
 
     /**
-     * ⚠️ **The reference's "Numbers disagree" state, reachable for the first time in this
-     * chore** — a disagreement needs pool count AND pool size both manual, which nothing
-     * could set until now. 40 players over 6 pools of 5 seats 30.
+     * ⚠️ **The reference's "Numbers disagree" state** — 40 players over 6 pools of 5 seats
+     * 30, and #1320's required case. A disagreement needs pool count AND pool size both
+     * manual.
      *
-     * The panel for it is chore 5a, so the tab shows **nothing** rather than a
-     * half-written notice — and the director is not left guessing, because the preview
-     * beside it says so in the reference's words. This test is the guard on that split:
-     * it reds the day a panel appears here without its `Apply` fixes, and it reds the day
-     * the preview stops saying it.
+     * The notice and the preview say the same thing about the same draw, in the two
+     * registers the tab has: the panel asks the question under the settings that raise it,
+     * and the badge states the verdict beside them.
      */
-    it('leaves the disagreement to the preview — 6 pools of 5, 40 players', () => {
-      drawStructureSectionPage.render({
-        event: eventOwning(
-          {
-            poolCountMode: 'manual',
-            manualPoolCount: 6,
-            poolSizeMode: 'manual',
-            manualPoolSize: 5,
-          },
-          { maxPlayers: 40 },
-        ),
-      })
+    it('asks for a decision — 6 pools of 5, 40 players', () => {
+      drawStructureSectionPage.render({ event: numbersDisagree() })
 
       expect(drawStructureSectionPage.preview.getVerdict()).toHaveTextContent(
         'Your numbers disagree',
       )
-      expect(drawStructureSectionPage.issuePanel.queryPanel()).toBeNull()
+      expect(
+        drawStructureSectionPage.issuePanel.getPanel(),
+      ).toHaveAttribute('data-issue-kind', 'disagreement')
+      expect(drawStructureSectionPage.issuePanel.getTitle()).toHaveTextContent(
+        '6 pools of 5 seat 30. Your field is 40.',
+      )
       // Both of the director's numbers stand, unedited — the app states the arithmetic
       // rather than moving one of them (ADR 20260808).
       expect(drawStructureSectionPage.preview.getEquation()).toHaveTextContent(
@@ -1183,6 +1197,61 @@ describe('DrawStructureSection', () => {
       expect(
         drawStructureSectionPage.preview.getFact('Pool reservations'),
       ).toHaveTextContent('4')
+    })
+
+    /**
+     * ⚠️ **The claim the whole variant exists for.** Nothing on this tab may add a pool or
+     * enlarge one to make the arithmetic come out: reporting a standoff is not an occasion
+     * to resolve it (ADR 20260808 — report, do not reshape).
+     *
+     * The rows and the boxes are necessary but not sufficient — a write that landed and was
+     * then re-derived away would leave both looking right. The teeth are that rendering
+     * this state writes **nothing at all**: no event, no pool list.
+     */
+    it('writes neither number, and mints no pool, merely by reporting it', () => {
+      const onChange = vi.fn()
+      const onPoolsChange = vi.fn()
+      drawStructureSectionPage.render({
+        event: numbersDisagree(),
+        onChange,
+        onPoolsChange,
+      })
+
+      expect(onChange).not.toHaveBeenCalled()
+      expect(onPoolsChange).not.toHaveBeenCalled()
+      // Both boxes still read what the director typed…
+      expect(
+        drawStructureSectionPage.setting('Pool count').getInput(),
+      ).toHaveValue('6')
+      expect(
+        drawStructureSectionPage.setting('Pool size').getInput(),
+      ).toHaveValue('5')
+      // …and the six pools are six pools of five, not five and a bigger one.
+      expect(drawStructureSectionPage.preview.getPoolCards()).toHaveLength(6)
+    })
+
+    /**
+     * A reader gets a **view** (ADR-0015): the standoff is stated, because a preview
+     * reading `Your call` with no cause beside it is a dead end — and nothing is offered,
+     * because none of these settings is theirs to resolve.
+     *
+     * ⚠️ **Not a duplicate of the refusal's reader guard.** This is the only read-only
+     * state on the tab where **both** dimension settings are the director's, so it is the
+     * one guard that proves the two manual boxes are gated on `canEdit` and not merely on
+     * the stored mode. The refusal's guard runs on an event that owns nothing, and has no
+     * box to leak.
+     */
+    it('offers a reader no resolution, and still states the standoff', () => {
+      drawStructureSectionPage.render({
+        event: numbersDisagree(),
+        canEdit: false,
+      })
+
+      expect(drawStructureSectionPage.issuePanel.getTitle()).toHaveTextContent(
+        '6 pools of 5 seat 30. Your field is 40.',
+      )
+      expect(drawStructureSectionPage.issuePanel.getFixes()).toHaveLength(0)
+      expect(drawStructureSectionPage.getFormElements()).toHaveLength(0)
     })
 
     /**
@@ -1494,6 +1563,264 @@ describe('DrawStructureSection', () => {
         expect(
           drawStructureSectionPage.issuePanel.getPanel(),
         ).toHaveAttribute('data-issue-kind', 'uneven')
+        expect(drawStructureSectionPage.preview.getVerdict()).toHaveTextContent(
+          'Ready to save',
+        )
+      })
+    })
+
+    /**
+     * **The reference's "Numbers disagree" state, resolved three ways** — 40 players over
+     * six pools of five, which seat thirty.
+     *
+     * Every one of the three is a named act the director chooses, and the two they do not
+     * choose leave their numbers exactly as they were. The labels and their arithmetic are
+     * pinned by `draw-issue-fix.test.ts`; what these pin is what a click *does*, and that
+     * the draw it leaves behind no longer disagrees.
+     */
+    describe('numbers that disagree — 6 pools of 5, 40 players', () => {
+      const renderDisagreement = (
+        overrides: Partial<Parameters<typeof drawStructureSectionPage.render>[0]> = {},
+      ) => {
+        const onChange = vi.fn()
+        const onPoolsChange = vi.fn()
+        const event = numbersDisagree()
+        drawStructureSectionPage.render({
+          event,
+          onChange,
+          onPoolsChange,
+          ...overrides,
+        })
+        return { onChange, onPoolsChange, event }
+      }
+
+      it('offers all three of the reference’s resolutions, in order', () => {
+        renderDisagreement()
+
+        expect(drawStructureSectionPage.issuePanel.getFixLabels()).toEqual([
+          'Cap the field at 30',
+          'Use 8 pools of 5',
+          'Allow uneven pools',
+        ])
+      })
+
+      /** The field moves to the structure. `Your structure stays exact.` is literal: the
+       * cap is the only thing written, and both of the director's numbers survive it. */
+      it('caps the field without touching either of the director’s numbers', async () => {
+        const { onChange, onPoolsChange } = renderDisagreement()
+
+        await userEvent.click(
+          drawStructureSectionPage.issuePanel.getApplyButton('Cap the field at 30'),
+        )
+
+        expect(onChange.mock.lastCall?.[0].maxPlayers).toBe(30)
+        expect(onChange.mock.lastCall?.[0].drawOwnership).toEqual(
+          expect.objectContaining({
+            poolCountMode: 'manual',
+            manualPoolCount: 6,
+            poolSizeMode: 'manual',
+            manualPoolSize: 5,
+          }),
+        )
+        expect(onPoolsChange).not.toHaveBeenCalled()
+        expect(drawStructureSectionPage.confirm.queryDialog()).toBeNull()
+      })
+
+      it('leaves a draw whose numbers agree', async () => {
+        const { onChange, onPoolsChange, event } = renderDisagreement()
+
+        await userEvent.click(
+          drawStructureSectionPage.issuePanel.getApplyButton('Cap the field at 30'),
+        )
+        rerenderOn(onChange, onPoolsChange, {
+          event,
+          pools: keepPools(event.pools),
+        })
+
+        // 6 pools of 5 seat exactly the 30 the field now holds.
+        expect(drawStructureSectionPage.issuePanel.queryPanel()).toBeNull()
+        expect(drawStructureSectionPage.preview.getVerdict()).toHaveTextContent(
+          'Ready to save',
+        )
+      })
+
+      /**
+       * ⚠️ **`Use 8 pools of 5` is eight pool RESERVATIONS**, not a number written into the
+       * ownership record beside four rows (ADR 20260808). This is the resolution that
+       * materialises the projection `Set myself` deliberately does not, and it does it
+       * through `reconcilePoolsToCount` — the seam the Pool count box types through.
+       */
+      it('appends the pool rows the count needs, in the same act as the count', async () => {
+        const { onChange, onPoolsChange } = renderDisagreement()
+
+        await userEvent.click(
+          drawStructureSectionPage.issuePanel.getApplyButton('Use 8 pools of 5'),
+        )
+
+        expect(onChange.mock.lastCall?.[0].drawOwnership.manualPoolCount).toBe(8)
+        expect(
+          onPoolsChange.mock.lastCall?.[0].map((pool: PoolEntry) => pool.name),
+        ).toEqual([
+          'Pool A',
+          'Pool B',
+          'Pool C',
+          'Pool D',
+          'Pool E',
+          'Pool F',
+          'Pool G',
+          'Pool H',
+        ])
+      })
+
+      it('leaves a draw whose numbers agree, and a reservation for every pool', async () => {
+        const { onChange, onPoolsChange, event } = renderDisagreement()
+
+        await userEvent.click(
+          drawStructureSectionPage.issuePanel.getApplyButton('Use 8 pools of 5'),
+        )
+        rerenderOn(onChange, onPoolsChange, {
+          event,
+          pools: keepPools(event.pools),
+        })
+
+        expect(drawStructureSectionPage.issuePanel.queryPanel()).toBeNull()
+        expect(drawStructureSectionPage.preview.getVerdict()).toHaveTextContent(
+          'Ready to save',
+        )
+        // The gap this resolution exists to close: eight pools, eight reservations.
+        expect(
+          drawStructureSectionPage.preview.getFact('Pool reservations'),
+        ).toHaveTextContent('8')
+      })
+
+      /**
+       * ⚠️ **The pool count is the director's and survives.** `Allow uneven pools` is an
+       * answer about the pool *size*: it hands that one setting back and touches nothing
+       * else — not the count, not the count's mode, and not a pool row. Clearing the count
+       * with it would discard a number they typed to answer a question about a different
+       * one.
+       *
+       * The size they typed is remembered, unset rather than erased, exactly as the Pool
+       * size row's own `Use automatic` leaves it (`data/draw-ownership`).
+       */
+      it('hands the pool SIZE back, and keeps the count the director typed', async () => {
+        const { onChange, onPoolsChange } = renderDisagreement()
+
+        await userEvent.click(
+          drawStructureSectionPage.issuePanel.getApplyButton('Allow uneven pools'),
+        )
+
+        expect(onChange.mock.lastCall?.[0].drawOwnership).toEqual(
+          expect.objectContaining({
+            poolSizeMode: 'automatic',
+            poolCountMode: 'manual',
+            manualPoolCount: 6,
+            manualPoolSize: 5,
+          }),
+        )
+        expect(onChange.mock.lastCall?.[0].maxPlayers).toBe(40)
+        expect(onPoolsChange).not.toHaveBeenCalled()
+      })
+
+      /** …and the split it promised is the split it produces: 40 across the director's six
+       * pools is `7, 7, 7, 7, 6, 6`. Uneven is the point — the resolution is called
+       * `Allow uneven pools` — so the tab goes on saying so, in the notice for a legal
+       * split. What it stops saying is that the numbers disagree. */
+      it('leaves the 4 × 7 and 2 × 6 it promised, legal and merely uneven', async () => {
+        const { onChange, onPoolsChange, event } = renderDisagreement()
+
+        await userEvent.click(
+          drawStructureSectionPage.issuePanel.getApplyButton('Allow uneven pools'),
+        )
+        rerenderOn(onChange, onPoolsChange, {
+          event,
+          pools: keepPools(event.pools),
+        })
+
+        expect(
+          drawStructureSectionPage.issuePanel.getPanel(),
+        ).toHaveAttribute('data-issue-kind', 'uneven')
+        expect(drawStructureSectionPage.issuePanel.getTitle()).toHaveTextContent(
+          '4 pools of 7 · 2 pools of 6',
+        )
+        expect(
+          drawStructureSectionPage.setting('Pool size').getValue(),
+        ).toHaveTextContent('6–7')
+        expect(drawStructureSectionPage.preview.getVerdict()).toHaveTextContent(
+          'Ready to save',
+        )
+      })
+    })
+
+    /**
+     * ⚠️ **A resolution that lowers the pool count is priced like every other lowered pool
+     * count.** 12 players over six pools of three seat eighteen, and `Use 4 pools of 3`
+     * discards two reservations — so it goes through the *same* gate (`requestPoolCount`)
+     * and the same confirm the box does, naming them before any of them goes (ADR
+     * 20260806). Without this vector the required case only ever appends, and "the fix
+     * reuses the gate" would be an inheritance rather than a claim.
+     */
+    describe('a resolution that drops reservations — 12 players, 6 pools of 3', () => {
+      const renderCostly = () => {
+        const onChange = vi.fn()
+        const onPoolsChange = vi.fn()
+        const event = eventOwning(
+          {
+            poolCountMode: 'manual',
+            manualPoolCount: 6,
+            poolSizeMode: 'manual',
+            manualPoolSize: 3,
+          },
+          {
+            maxPlayers: 12,
+            pools: Array.from({ length: 6 }, (_, i) =>
+              buildPool({
+                id: `p-${poolLetter(i).toLowerCase()}`,
+                name: `Pool ${poolLetter(i)}`,
+                position: i,
+              }),
+            ),
+          },
+        )
+        drawStructureSectionPage.render({ event, onChange, onPoolsChange })
+        return { onChange, onPoolsChange, event }
+      }
+
+      it('names the reservations it would drop, and writes nothing yet', async () => {
+        const { onChange, onPoolsChange } = renderCostly()
+
+        await userEvent.click(
+          drawStructureSectionPage.issuePanel.getApplyButton('Use 4 pools of 3'),
+        )
+
+        expect(drawStructureSectionPage.confirm.getDialog()).toHaveTextContent(
+          'Pool E',
+        )
+        expect(drawStructureSectionPage.confirm.getDialog()).toHaveTextContent(
+          'Pool F',
+        )
+        expect(onChange).not.toHaveBeenCalled()
+        expect(onPoolsChange).not.toHaveBeenCalled()
+      })
+
+      it('drops them on the confirm, and leaves a draw whose numbers agree', async () => {
+        const { onChange, onPoolsChange, event } = renderCostly()
+
+        await userEvent.click(
+          drawStructureSectionPage.issuePanel.getApplyButton('Use 4 pools of 3'),
+        )
+        await userEvent.click(drawStructureSectionPage.confirm.getConfirmButton())
+
+        expect(onChange.mock.lastCall?.[0].drawOwnership.manualPoolCount).toBe(4)
+        expect(
+          onPoolsChange.mock.lastCall?.[0].map((pool: PoolEntry) => pool.name),
+        ).toEqual(['Pool A', 'Pool B', 'Pool C', 'Pool D'])
+
+        rerenderOn(onChange, onPoolsChange, {
+          event,
+          pools: keepPools(event.pools),
+        })
+        expect(drawStructureSectionPage.issuePanel.queryPanel()).toBeNull()
         expect(drawStructureSectionPage.preview.getVerdict()).toHaveTextContent(
           'Ready to save',
         )

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section.tsx
@@ -19,6 +19,7 @@ import {
 } from '../confirm-irreversible-act-dialog'
 import { drawIssueFor } from './draw-structure-section/draw-issue'
 import {
+  disagreementFixes,
   impossibleFixes,
   type DrawStructureFix,
 } from './draw-structure-section/draw-issue-fix'
@@ -181,9 +182,9 @@ export interface DrawStructureSectionProps {
  * - **`Set myself`.** It seeds the box from the *derived* count, which is a projection —
  *   and a projection in excess of the rows is reported, never materialised (the ADR's
  *   point 3). Creating four reservations off a field the app invented is precisely what
- *   that rule forbids. The gap is chore 5b's disagreement panel to report, and its
- *   `Use {n} pools of {size}` resolution appends through `reconcilePoolsToCount` — the
- *   same seam this row types through.
+ *   that rule forbids. The disagreement panel is what reports the gap, and its
+ *   `Use {n} pools of {size}` resolution is what materialises it — appending through
+ *   `reconcilePoolsToCount`, the same seam this row types through.
  *
  * ## The arithmetic is not here
  *
@@ -318,7 +319,7 @@ export const DrawStructureSection = ({
   }
 
   /**
-   * Apply one of the refusal panel's named ways out.
+   * Apply one of the notice's named ways out — a refusal's, or a disagreement's.
    *
    * **Every arm writes through a seam that already exists**, and that is the point: a fix
    * is a shortcut to a setting the director could have changed themselves, not a second
@@ -326,12 +327,20 @@ export const DrawStructureSection = ({
    *
    * - `pool-count` goes through `requestPoolCount`, so it creates or removes pool rows in
    *   the one act ADR 20260808 demands, and buys any removal with the same confirm the
-   *   Pool count box does.
+   *   Pool count box does. `Use 8 pools of 5` is not a number written somewhere: it is
+   *   eight pool reservations.
    * - `player-limit` writes the event's cap, which lives on Basics — the same `onChange`
    *   the Basics tab writes through, so the limit has one owner and this tab is not it.
+   *   Both `Raise the player limit to 12` and `Cap the field at 30` are this one act.
    * - `qualifiers` **takes the setting** as well as setting the number. The director asked
    *   for this count, so the row must say `Yours`: left automatic, the derivation would go
    *   on aiming at a bracket of eight and hand the number straight back.
+   * - `automatic-pool-size` gives one setting back and touches nothing else. It is the Pool
+   *   size row's own `Use automatic`, which keeps the director's number for the next time
+   *   they take it (`data/draw-ownership`) — and it must leave `poolCountMode`,
+   *   `manualPoolCount` and every pool row exactly where they are. The count is theirs;
+   *   `Allow uneven pools` is a choice about the *size*, and clearing the count with it
+   *   would discard a number they typed to answer a question about a different one.
    */
   const applyFix = (fix: DrawStructureFix) => {
     switch (fix.kind) {
@@ -343,6 +352,9 @@ export const DrawStructureSection = ({
         return
       case 'qualifiers':
         own({ qualifiersMode: 'manual' }, fix.qualifiersPerPool)
+        return
+      case 'automatic-pool-size':
+        own({ poolSizeMode: 'automatic' })
     }
   }
 
@@ -361,14 +373,17 @@ export const DrawStructureSection = ({
   // never re-derives it.
   const issue = drawIssueFor(structure)
 
-  // The named ways out of a refusal, and **nothing for a reader**: a read-only surface is
-  // a view, not a disabled form (ADR-0015), so the panel still states the cause and offers
-  // no button to press. The other two kinds carry no fixes at all — the uneven notice has
-  // nothing to fix, and the disagreement's three resolutions are chore 5b.
-  const fixes: DrawStructureFix[] =
-    canEdit && issue?.kind === 'impossible'
+  // The named ways out, and **nothing for a reader**: a read-only surface is a view, not a
+  // disabled form (ADR-0015), so the panel still states the cause and offers no button to
+  // press. The uneven notice carries no fixes in any case — a legal split has nothing to
+  // fix, and saying so is the whole notice.
+  const fixes: DrawStructureFix[] = !canEdit
+    ? []
+    : issue?.kind === 'impossible'
       ? impossibleFixes(issue.problem, structure, fieldSize)
-      : []
+      : issue?.kind === 'disagreement'
+        ? disagreementFixes(issue.disagreement)
+        : []
 
   return (
     <div className="flex flex-col gap-6" data-testid="draw-structure-section">
@@ -484,10 +499,10 @@ export const DrawStructureSection = ({
                         // Seeded from the count the row was already showing — and, again,
                         // **no row is created**. That count is a projection while pool size
                         // is manual, and a projection in excess of the rows is reported,
-                        // never materialised (ADR 20260808, point 3). Chore 5b's
-                        // disagreement panel is what reports it, and its
-                        // `Use {n} pools of {size}` is what appends the rows, through the
-                        // same `reconcilePoolsToCount` this row types through.
+                        // never materialised (ADR 20260808, point 3). The disagreement
+                        // panel is what reports it, and its `Use {n} pools of {size}` is
+                        // what appends the rows, through the same `reconcilePoolsToCount`
+                        // this row types through.
                         onClick: () =>
                           own({
                             poolCountMode: 'manual',

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-fix.test.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-fix.test.ts
@@ -2,7 +2,7 @@ import {
   deriveDrawStructure,
   type DrawStructureOptions,
 } from '../../../data/draw-structure'
-import { impossibleFixes } from './draw-issue-fix'
+import { disagreementFixes, impossibleFixes } from './draw-issue-fix'
 
 /** The eight inputs, stated in full at every vector — the derivation has no defaults
  * builder on purpose, and a fix computed off a hidden default would be a fix for a draw
@@ -148,5 +148,177 @@ describe('impossibleFixes', () => {
         },
       ])
     })
+  })
+})
+
+/** The disagreement a real derivation reports for these inputs — asserted against the
+ * derivation rather than a hand-built `DrawStructureDisagreement`, so a vector cannot offer
+ * resolutions for a standoff the derivation would not have reported. A vector whose numbers
+ * agree is a broken vector, not a case with no fixes. */
+const disagreementFor = (options: Partial<DrawStructureOptions>, fieldSize: number) => {
+  const { disagreement } = structureFor({ ...options, previewFieldSize: fieldSize })
+  if (disagreement === null) {
+    throw new Error('these inputs do not disagree — the vector is wrong, not the fix')
+  }
+  return disagreement
+}
+
+const resolutionsFor = (options: Partial<DrawStructureOptions>, fieldSize: number) =>
+  disagreementFixes(disagreementFor(options, fieldSize))
+
+describe('disagreementFixes', () => {
+  /**
+   * The reference's **"Numbers disagree"** state
+   * (`docs/designs/rr-then-ko-draw-structure/numbers-disagree-panel.png`), and #1320's
+   * required case: 40 players, six pools of five, which seat thirty.
+   */
+  describe('the field is bigger — 40 players, 6 pools of 5', () => {
+    const both = { poolCountMode: 'manual', poolSizeMode: 'manual' } as const
+    const fixes = () =>
+      resolutionsFor({ ...both, manualPoolCount: 6, manualPoolSize: 5 }, 40)
+
+    it('offers all three, and picks none', () => {
+      expect(fixes()).toHaveLength(3)
+    })
+
+    /** Move the field to the structure: the cap becomes the seats the director's two
+     * numbers already make, so **neither of their numbers moves**. */
+    it('offers to cap the field at the seats they have', () => {
+      expect(fixes()[0]).toEqual({
+        kind: 'player-limit',
+        label: 'Cap the field at 30',
+        detail: 'Your structure stays exact.',
+        maxPlayers: 30,
+      })
+    })
+
+    /** …or move the structure to the field, keeping the pool size and taking as many pools
+     * as it needs. `pool-count`, so the tab routes it to the pool ROWS (ADR 20260808). */
+    it('offers as many pools of their size as the field needs', () => {
+      expect(fixes()[1]).toEqual({
+        kind: 'pool-count',
+        label: 'Use 8 pools of 5',
+        detail: 'Everyone gets a seat.',
+        poolCount: 8,
+      })
+    })
+
+    /**
+     * …or keep the count and hand the size back. The detail states the split that would
+     * produce, so the director reads the answer before taking it.
+     *
+     * ⚠️ A **multiplication sign** (`U+00D7`), not the letter `x`, joined with ` and `. The
+     * uneven notice states the same two numbers as `4 pools of 7 · 2 pools of 6` — two
+     * formats for one split, both the reference's, and neither is normalised into the
+     * other.
+     */
+    it('offers the balanced split, tallied largest first', () => {
+      expect(fixes()[2]).toEqual({
+        kind: 'automatic-pool-size',
+        label: 'Allow uneven pools',
+        detail: '4 × 7 and 2 × 6 players.',
+      })
+    })
+  })
+
+  /**
+   * The other direction: eight pools of six seat 48 and the field is 40, so eight seats go
+   * empty rather than eight entrants going unseated.
+   */
+  describe('the field is smaller — 40 players, 8 pools of 6', () => {
+    const fixes = () =>
+      resolutionsFor(
+        {
+          poolCountMode: 'manual',
+          manualPoolCount: 8,
+          poolSizeMode: 'manual',
+          manualPoolSize: 6,
+        },
+        40,
+      )
+
+    it('caps the field at the seats, downward as readily as upward', () => {
+      expect(fixes()[0]).toEqual({
+        kind: 'player-limit',
+        label: 'Cap the field at 48',
+        detail: 'Your structure stays exact.',
+        maxPlayers: 48,
+      })
+    })
+
+    /**
+     * ⚠️ **`Everyone gets a seat.` is all this promises, and here it is all it delivers.**
+     * 40 players in pools of six needs seven pools, and seven pools of six seat 42 — so the
+     * panel comes back with the same question and smaller numbers. That is the reference's
+     * `ceil`, and a `floor` "fix" would seat 36 of the 40.
+     */
+    it('rounds the pool count UP, and leaves a smaller disagreement behind', () => {
+      expect(fixes()[1]).toEqual({
+        kind: 'pool-count',
+        label: 'Use 7 pools of 6',
+        detail: 'Everyone gets a seat.',
+        poolCount: 7,
+      })
+
+      const after = disagreementFor(
+        {
+          poolCountMode: 'manual',
+          manualPoolCount: 7,
+          poolSizeMode: 'manual',
+          manualPoolSize: 6,
+        },
+        40,
+      )
+      expect(after.direction).toBe('empty-seats')
+      expect(after.count).toBe(2)
+    })
+
+    /** One term, not two: 40 across 8 is five apiece, so the balanced split has one size in
+     * it and there is nothing to join. */
+    it('says one term when the split comes out even', () => {
+      expect(fixes()[2]).toEqual({
+        kind: 'automatic-pool-size',
+        label: 'Allow uneven pools',
+        detail: '8 × 5 players.',
+      })
+    })
+  })
+
+  /**
+   * ⚠️ **`Use 1 pools of 5` is reachable, and it is unpluralised.** Four players in pools of
+   * five need one pool, and the reference does not pluralise this label any more than it
+   * pluralises `Use 1 pools` above — where the argument for transcribing rather than
+   * improving is written out in full.
+   */
+  it('says `Use 1 pools of 5`, unpluralised, when one pool holds the field', () => {
+    expect(
+      resolutionsFor(
+        {
+          poolCountMode: 'manual',
+          manualPoolCount: 2,
+          poolSizeMode: 'manual',
+          manualPoolSize: 5,
+        },
+        4,
+      ),
+    ).toEqual([
+      {
+        kind: 'player-limit',
+        label: 'Cap the field at 10',
+        detail: 'Your structure stays exact.',
+        maxPlayers: 10,
+      },
+      {
+        kind: 'pool-count',
+        label: 'Use 1 pools of 5',
+        detail: 'Everyone gets a seat.',
+        poolCount: 1,
+      },
+      {
+        kind: 'automatic-pool-size',
+        label: 'Allow uneven pools',
+        detail: '2 × 2 players.',
+      },
+    ])
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-fix.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-fix.ts
@@ -1,23 +1,29 @@
-// **The named ways out of a refusal** (#1320): what the `Can’t save` panel offers, in the
-// reference's words and with the reference's arithmetic.
+// **The named ways out** (#1320): what the `Can’t save` and `Needs your call` panels offer,
+// in the reference's words and with the reference's arithmetic.
 //
 // The derivation (`../../../data/draw-structure`) reports the three impossible
-// competitions and stops there, deliberately: a fix is a button, and a button is not a
-// derivation. This module is the other half — the label, the detail line, and **the number
-// the fix would write** — and it is data rather than a handler, so the panel can render a
-// fix without knowing how to apply one and the tab can apply one without re-deriving its
-// label.
+// competitions and the disagreement, and stops there, deliberately: a fix is a button, and
+// a button is not a derivation. This module is the other half — the label, the detail line,
+// and **the number the fix would write** — and it is data rather than a handler, so the
+// panel can render a fix without knowing how to apply one and the tab can apply one without
+// re-deriving its label.
 //
-// The copy and the maths are the README's "Impossible" section
+// The copy and the maths are the README's "Impossible" and "Disagreement" sections
 // (`docs/designs/rr-then-ko-draw-structure/README.md`), verbatim.
 //
 // ⚠️ **A fix is not a promise that the draw becomes legal.** `Use {floor(field / 2)} pools`
 // against a manual pool size of one leaves every pool at one player, because both numbers
 // are the director's and the app does not silently move the other one. That is the
 // reference's arithmetic and it stays: the panel offers the named way out, the derivation
-// re-runs, and if the draw is still impossible it says so again.
+// re-runs, and if the draw is still impossible it says so again. The same holds for
+// `Use {ceil(field / size)} pools of {size}` — see `disagreementFixes`.
 
-import type { DrawStructure, ImpossibleProblem } from '../../../data/draw-structure'
+import {
+  tallyBalancedSplit,
+  type DrawStructure,
+  type DrawStructureDisagreement,
+  type ImpossibleProblem,
+} from '../../../data/draw-structure'
 
 /**
  * One offered fix: what it says, and what it would set.
@@ -49,6 +55,20 @@ export type DrawStructureFix =
       detail: string
       /** How many finishers come out of each pool. */
       qualifiersPerPool: number
+    }
+  | {
+      /**
+       * Hand the **pool size** back to the system, and nothing else: the director's pool
+       * count stands, and the field splits across it.
+       *
+       * It carries no number, and that is the point — it is the one resolution that resolves
+       * a disagreement by *un*-setting a number rather than by writing one. The other two
+       * arms write; this one gives a setting back, through the same `Use automatic` the Pool
+       * size row already offers.
+       */
+      kind: 'automatic-pool-size'
+      label: string
+      detail: string
     }
 
 /**
@@ -114,4 +134,75 @@ export function impossibleFixes(
       ]
     }
   }
+}
+
+/**
+ * The balanced split written out the way `Allow uneven pools` says it — `4 × 7 and 2 × 6`.
+ *
+ * ⚠️ **A multiplication sign** (`U+00D7`), not the letter `x`, and joined with ` and `
+ * rather than the uneven notice's ` · `. The same two numbers are stated in two formats a
+ * few pixels apart (`4 pools of 7 · 2 pools of 6` in the notice's title), and both are the
+ * reference's. Do not unify them.
+ *
+ * A balanced split holds `base` and `base + 1` and nothing else, so this is one term or
+ * two. There is no n-way join, because there is no split that would use one.
+ */
+function balancedSplitPhrase(fieldSize: number, poolCount: number): string {
+  return tallyBalancedSplit(fieldSize, poolCount)
+    .map((tally) => `${tally.pools} × ${tally.size}`)
+    .join(' and ')
+}
+
+/**
+ * The three resolutions for **numbers that disagree** — the reference's "Disagreement"
+ * panel, in its order.
+ *
+ * The director set a pool count and a pool size whose product misses their field. Both
+ * numbers were typed on purpose, so nothing here moves one of them on its own: each
+ * resolution is a named act the director chooses, and the two they did not choose leave
+ * their numbers exactly as they are.
+ *
+ * 1. **`Cap the field at {seats}`** moves the *field* to the structure — the player limit,
+ *    which lives on Basics. `Your structure stays exact.` is literal: both of their numbers
+ *    survive untouched.
+ * 2. **`Use {ceil(field / size)} pools of {size}`** keeps the size and takes as many pools
+ *    as the field needs — and therefore that many pool ROWS (ADR 20260808).
+ * 3. **`Allow uneven pools`** keeps the count and hands the *size* back to the system, which
+ *    splits the field across it. The detail states the split that would produce, so the
+ *    director reads the answer before taking it.
+ *
+ * ⚠️ **`Use {ceil(field / size)} pools of {size}` does not always clear the disagreement**,
+ * and the ceiling is why: 40 players in pools of 6 needs 7 pools, and 7 pools of 6 seat 42.
+ * Everyone gets a seat — which is exactly what the detail line promises, and all it promises
+ * — and two of them are empty, so the panel says so again with smaller numbers. That is the
+ * reference's arithmetic, and correcting it to `floor` would seat 36 of the 40.
+ *
+ * Nothing is pluralised. `1 pools of 5` is reachable and is what the reference writes, for
+ * the reason `Use 1 pools` is pinned above.
+ */
+export function disagreementFixes(
+  disagreement: DrawStructureDisagreement,
+): DrawStructureFix[] {
+  const { poolCount, poolSize, seats, fieldSize } = disagreement
+  const pooledCount = Math.max(1, Math.ceil(fieldSize / poolSize))
+  return [
+    {
+      kind: 'player-limit',
+      label: `Cap the field at ${seats}`,
+      detail: 'Your structure stays exact.',
+      maxPlayers: seats,
+    },
+    {
+      kind: 'pool-count',
+      label: `Use ${pooledCount} pools of ${poolSize}`,
+      detail: 'Everyone gets a seat.',
+      poolCount: pooledCount,
+    },
+    {
+      kind: 'automatic-pool-size',
+      label: 'Allow uneven pools',
+      // The count the director keeps, split across the field they have.
+      detail: `${balancedSplitPhrase(fieldSize, poolCount)} players.`,
+    },
+  ]
 }

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.factory.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.factory.tsx
@@ -68,6 +68,58 @@ export function buildImpossibleDrawFixes(): DrawStructureFix[] {
 }
 
 /**
+ * The reference's **"Numbers disagree"** state
+ * (`docs/designs/rr-then-ko-draw-structure/numbers-disagree-panel.png`), and #1320's
+ * required case: a field of 40 against six manual pools of five manual, which seat thirty
+ * and leave ten entrants with nowhere to go.
+ *
+ * The numbers are the derivation's, and `data/draw-structure.test.ts` pins that it produces
+ * exactly these for these inputs — a fixture cannot invent a standoff the derivation would
+ * not report.
+ */
+export function buildDisagreementDrawIssue(
+  overrides: Partial<Extract<DrawIssue, { kind: 'disagreement' }>['disagreement']> = {},
+): DrawIssue {
+  return {
+    kind: 'disagreement',
+    disagreement: {
+      poolCount: 6,
+      poolSize: 5,
+      seats: 30,
+      fieldSize: 40,
+      direction: 'unseated',
+      count: 10,
+      ...overrides,
+    },
+  }
+}
+
+/** The three resolutions that same state offers — `disagreementFixes` computes them
+ * (`./draw-issue-fix.test.ts` pins that), and this is what they come out as for 40 players
+ * over 6 pools of 5. */
+export function buildDisagreementDrawFixes(): DrawStructureFix[] {
+  return [
+    {
+      kind: 'player-limit',
+      label: 'Cap the field at 30',
+      detail: 'Your structure stays exact.',
+      maxPlayers: 30,
+    },
+    {
+      kind: 'pool-count',
+      label: 'Use 8 pools of 5',
+      detail: 'Everyone gets a seat.',
+      poolCount: 8,
+    },
+    {
+      kind: 'automatic-pool-size',
+      label: 'Allow uneven pools',
+      detail: '4 × 7 and 2 × 6 players.',
+    },
+  ]
+}
+
+/**
  * Props for `DrawIssuePanel` — the uneven notice above, which is the variant with nothing
  * to apply.
  *

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.page.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.page.tsx
@@ -29,22 +29,22 @@ const scoped = (container: Container) => ({
     return container.getByTestId('draw-issue-panel')
   },
   /** The panel, or `null` — **the accessor the precedence claims use**. Only one notice
-   * shows at a time, and the one unbuilt kind (chore 5a) shows none at all, so "there is
+   * shows at a time, and a draw whose numbers divide evenly gets none at all, so "there is
    * no panel" is a state a test has to be able to state. */
   queryPanel() {
     return container.queryByTestId('draw-issue-panel')
   },
-  /** The topline — `Can’t save` or `Legal, but uneven`. Read as TEXT: the dot beside it
-   * is decoration, and a notice whose meaning is a colour has no meaning to a screen
-   * reader. */
+  /** The topline — `Can’t save`, `Needs your call` or `Legal, but uneven`. Read as TEXT:
+   * the dot beside it is decoration, and a notice whose meaning is a colour has no meaning
+   * to a screen reader. */
   getTopline(words: string) {
     return container.getByText(words)
   },
   queryTopline(words: string) {
     return container.queryByText(words)
   },
-  /** The size tally (`2 pools of 6 · 2 pools of 5`), or the refusal's cause
-   * (`Pool C would have one player`). */
+  /** The size tally (`2 pools of 6 · 2 pools of 5`), the refusal's cause (`Pool C would
+   * have one player`), or the standoff (`6 pools of 5 seat 30. Your field is 40.`). */
   getTitle() {
     return container.getByTestId('draw-issue-panel-title')
   },

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.test.tsx
@@ -1,6 +1,8 @@
 import userEvent from '@testing-library/user-event'
 
 import {
+  buildDisagreementDrawFixes,
+  buildDisagreementDrawIssue,
   buildImpossibleDrawFixes,
   buildImpossibleDrawIssue,
   buildUnevenDrawIssue,
@@ -211,26 +213,136 @@ describe('DrawIssuePanel', () => {
     })
   })
 
-  // The disagreement's panel comes with three resolutions no derivation can supply, so the
-  // tab shows nothing rather than half of one. The live preview beside it already reads
-  // `Your numbers disagree`, so the state is not silent.
-  describe('the variant that is not built yet', () => {
-    it('renders nothing for the disagreement kind (chore 5a)', () => {
+  /**
+   * The reference's **"Numbers disagree"** state
+   * (`docs/designs/rr-then-ko-draw-structure/numbers-disagree-panel.png`): 40 players
+   * against six manual pools of five manual, which seat thirty.
+   */
+  describe('the disagreement', () => {
+    const renderDisagreement = (
+      overrides: Parameters<typeof drawIssuePanelPage.render>[0] = {},
+    ) => {
+      const onApplyFix = vi.fn()
       drawIssuePanelPage.render({
-        issue: {
-          kind: 'disagreement',
-          disagreement: {
-            poolCount: 6,
-            poolSize: 5,
-            seats: 30,
-            fieldSize: 40,
-            direction: 'unseated',
-            count: 10,
-          },
-        },
+        issue: buildDisagreementDrawIssue(),
+        fixes: buildDisagreementDrawFixes(),
+        onApplyFix,
+        ...overrides,
+      })
+      return { onApplyFix }
+    }
+
+    it('asks for a decision, in words rather than in a colour', () => {
+      renderDisagreement()
+
+      expect(
+        drawIssuePanelPage.getTopline('Needs your call'),
+      ).toBeInTheDocument()
+    })
+
+    /**
+     * ⚠️ **Both of the director's numbers, read back at them exactly as typed**, and the
+     * product they make. This is the claim the whole panel exists for: the app states the
+     * standoff and never resolves it by moving one of the two numbers (ADR 20260808 —
+     * report, do not reshape).
+     */
+    it('states both of the director’s numbers, and what they seat', () => {
+      renderDisagreement()
+
+      expect(drawIssuePanelPage.getTitle()).toHaveTextContent(
+        '6 pools of 5 seat 30. Your field is 40.',
+      )
+    })
+
+    it('counts the entrants with nowhere to go, and promises not to move a number', () => {
+      renderDisagreement()
+
+      expect(drawIssuePanelPage.getBody()).toHaveTextContent(
+        '10 entrants have nowhere to go. We won’t change your numbers behind your back.',
+      )
+    })
+
+    /** The other direction: eight pools of six seat 48 against a field of 40, so seats go
+     * empty rather than entrants going unseated. The same promise, and no negative number
+     * read aloud. */
+    it('counts the empty seats instead, when the structure is the bigger one', () => {
+      renderDisagreement({
+        issue: buildDisagreementDrawIssue({
+          poolCount: 8,
+          poolSize: 6,
+          seats: 48,
+          direction: 'empty-seats',
+          count: 8,
+        }),
       })
 
-      expect(drawIssuePanelPage.queryPanel()).toBeNull()
+      expect(drawIssuePanelPage.getTitle()).toHaveTextContent(
+        '8 pools of 6 seat 48. Your field is 40.',
+      )
+      expect(drawIssuePanelPage.getBody()).toHaveTextContent(
+        '8 seats would be empty. We won’t change your numbers behind your back.',
+      )
+    })
+
+    /**
+     * `status`, not `alert`. **This is legal**: the save gate reads `impossibleProblems`
+     * only (`event-draw-structure.ts`), so a draw whose numbers disagree saves as it
+     * stands. The director is being asked, not stopped, and a question that interrupted
+     * what they were reading would be answering it for them.
+     */
+    it('asks politely, as a status and not an alert', () => {
+      renderDisagreement()
+
+      expect(drawIssuePanelPage.getPanel()).toHaveAttribute('role', 'status')
+      expect(drawIssuePanelPage.getPanel()).not.toHaveAttribute('role', 'alert')
+    })
+
+    /** Three ways out, in the reference's order — cap the field, add the pools, or hand
+     * the size back. A test that only counted the rows would pass on any order. */
+    it('lists all three resolutions it was handed, in order', () => {
+      renderDisagreement()
+
+      expect(drawIssuePanelPage.getFixLabels()).toEqual([
+        'Cap the field at 30',
+        'Use 8 pools of 5',
+        'Allow uneven pools',
+      ])
+    })
+
+    /** The third one says what it would produce before it is taken — `4 × 7 and 2 × 6`, a
+     * multiplication sign and not the letter x. */
+    it('states the split `Allow uneven pools` would make', () => {
+      renderDisagreement()
+
+      const [, , uneven] = drawIssuePanelPage.getFixes()
+      expect(uneven.getDetail()).toHaveTextContent('4 × 7 and 2 × 6 players.')
+      expect(uneven.getApply()).toHaveTextContent('Apply')
+    })
+
+    it('names each resolution in its button’s accessible name', async () => {
+      const { onApplyFix } = renderDisagreement()
+
+      await userEvent.click(
+        drawIssuePanelPage.getApplyButton('Allow uneven pools'),
+      )
+
+      expect(onApplyFix).toHaveBeenCalledWith({
+        kind: 'automatic-pool-size',
+        label: 'Allow uneven pools',
+        detail: '4 × 7 and 2 × 6 players.',
+      })
+    })
+
+    /** A reader is handed no resolutions (ADR-0015 — a read-only surface is a view, not a
+     * disabled form), and the standoff still has to be stated: a preview badge reading
+     * `Your call` with no cause beside it is the dead end that rule exists to avoid. */
+    it('still states the standoff when there is nothing to offer', () => {
+      renderDisagreement({ fixes: [] })
+
+      expect(drawIssuePanelPage.getTitle()).toHaveTextContent(
+        '6 pools of 5 seat 30. Your field is 40.',
+      )
+      expect(drawIssuePanelPage.getFixes()).toHaveLength(0)
     })
   })
 })

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue-panel.tsx
@@ -6,13 +6,85 @@ import { Button } from '@/components/ui/button'
 import type { DrawIssue } from './draw-issue'
 import type { DrawStructureFix } from './draw-issue-fix'
 
+/**
+ * The offered ways out, as a list of rows: a label, a detail line, and one `Apply`.
+ *
+ * **One list, two panels.** The refusal offers up to two and the disagreement offers three,
+ * which is a `columns` apart and nothing else — and the a11y-critical part (the per-fix
+ * `aria-label`, because every visible button reads only `Apply`) is exactly the part that
+ * forks when identical markup is copied. This repo has measured that fork: see the
+ * `interactiveElementsIn` note in `web-client/CLAUDE.md`, where one sweep copy-pasted three
+ * ways left six of eight guards with a hole in them.
+ *
+ * Renders nothing for an empty list, which is the usual case: an uneven split has nothing
+ * to fix, and a reader is offered nothing anywhere on this tab (ADR-0015).
+ */
+const FixList = ({
+  fixes,
+  columns,
+  onApplyFix,
+}: {
+  fixes: DrawStructureFix[]
+  /** The grid at `sm` and up — as many columns as the panel has fixes. Below `sm` they
+   * stack: a row of a label, a detail line and a button does not fit a phone beside
+   * another one. */
+  columns: string
+  onApplyFix: (fix: DrawStructureFix) => void
+}) => {
+  if (fixes.length === 0) return null
+  return (
+    <ul className={`mt-3 grid grid-cols-1 gap-2 ${columns}`}>
+      {fixes.map((fix) => (
+        // Keyed by the label, which is the fix: two fixes for one problem never read the
+        // same, and an index key would reattach the wrong button the moment the problem
+        // changed under it.
+        <li
+          key={fix.label}
+          data-testid="draw-issue-fix"
+          className="flex items-start justify-between gap-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)] px-3 py-2"
+        >
+          <div className="min-w-0">
+            <p
+              data-testid="draw-issue-fix-label"
+              className="text-[13px] leading-snug font-semibold text-[color:var(--fg-1)]"
+            >
+              {fix.label}
+            </p>
+            <p
+              data-testid="draw-issue-fix-detail"
+              className="mt-0.5 text-[12px] leading-snug text-[color:var(--fg-3)]"
+            >
+              {fix.detail}
+            </p>
+          </div>
+          <Button
+            variant="link"
+            size="sm"
+            data-testid="draw-issue-fix-apply"
+            className="h-auto shrink-0 p-0 text-[13px]"
+            // Every one of these buttons says `Apply`, so the visible words alone name no
+            // fix — and a list of buttons is how a screen-reader user meets them. The
+            // visible word comes FIRST, so what a director says out loud to a voice-control
+            // tool still matches (the `SettingRow` action's rule).
+            aria-label={`Apply ${fix.label}`}
+            onClick={() => onApplyFix(fix)}
+          >
+            Apply
+          </Button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
 export interface DrawIssuePanelProps {
   /** The issue to state, already chosen by `drawIssueFor`. The panel never picks: given
    * one it renders one, which is what keeps the precedence in a single place. */
   issue: DrawIssue
   /**
-   * The named ways out, already worked out by `impossibleFixes` (`./draw-issue-fix`) —
-   * their labels, their detail lines, and the numbers they would write.
+   * The named ways out, already worked out by `impossibleFixes` or `disagreementFixes`
+   * (`./draw-issue-fix`) — their labels, their detail lines, and the numbers they would
+   * write.
    *
    * **Empty is a real answer, and it is the usual one**: an uneven split has nothing to
    * fix, and a reader (`canEdit: false`) is offered nothing anywhere on this tab (ADR-0015
@@ -53,12 +125,14 @@ export interface DrawIssuePanelProps {
  * decoration on top of them, so a reader who cannot separate red from blue reads the same
  * notice everyone else does.
  *
- * ## What this chore renders
+ * ## The three variants
  *
- * The **impossible** and **uneven** variants. `Needs your call` — the disagreement, with
- * its three resolutions — is chore 5a; until then the tab shows nothing in that state
- * rather than a half-written panel, and the director is not left guessing, because the
- * live preview beside it already reads `Your numbers disagree`.
+ * `Can’t save` reports a blocked act, so it is an `alert` and wears the refusal's colour.
+ * `Needs your call` and `Legal, but uneven` are both `status`: neither disables anything,
+ * and a draw whose numbers disagree still saves (`event-draw-structure.ts` — the gate reads
+ * `impossibleProblems` only). What separates those two is that the disagreement is a
+ * question — it carries three resolutions and a warning tint — while the uneven notice is
+ * an observation and carries neither.
  */
 export const DrawIssuePanel = ({
   issue,
@@ -106,59 +180,70 @@ export const DrawIssuePanel = ({
           {issue.problem.body}
         </p>
 
-        {fixes.length > 0 && (
-          // Side by side above `sm`, stacked below it — the pool case offers two, and two
-          // rows of a label, a detail line and a button do not fit a phone in one line.
-          <ul className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
-            {fixes.map((fix) => (
-              // Keyed by the label, which is the fix: two fixes for one problem never
-              // read the same, and an index key would reattach the wrong button the
-              // moment the problem changed under it.
-              <li
-                key={fix.label}
-                data-testid="draw-issue-fix"
-                className="flex items-start justify-between gap-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--bg-panel)] px-3 py-2"
-              >
-                <div className="min-w-0">
-                  <p
-                    data-testid="draw-issue-fix-label"
-                    className="text-[13px] leading-snug font-semibold text-[color:var(--fg-1)]"
-                  >
-                    {fix.label}
-                  </p>
-                  <p
-                    data-testid="draw-issue-fix-detail"
-                    className="mt-0.5 text-[12px] leading-snug text-[color:var(--fg-3)]"
-                  >
-                    {fix.detail}
-                  </p>
-                </div>
-                <Button
-                  variant="link"
-                  size="sm"
-                  data-testid="draw-issue-fix-apply"
-                  className="h-auto shrink-0 p-0 text-[13px]"
-                  // Every one of these buttons says `Apply`, so the visible words alone
-                  // name no fix — and a list of buttons is how a screen-reader user meets
-                  // them. The visible word comes FIRST, so what a director says out loud
-                  // to a voice-control tool still matches (the `SettingRow` action's rule).
-                  aria-label={`Apply ${fix.label}`}
-                  onClick={() => onApplyFix(fix)}
-                >
-                  Apply
-                </Button>
-              </li>
-            ))}
-          </ul>
-        )}
+        {/* Two ways out at most, so two columns. */}
+        <FixList fixes={fixes} columns="sm:grid-cols-2" onApplyFix={onApplyFix} />
       </div>
     )
   }
 
-  // Chore 5a (disagreement, role `status`, yellow dot, three fixes) renders here. Until
-  // then the tab shows nothing in that state rather than a half-written panel: the live
-  // preview beside it already reads `Your numbers disagree`, so the state is not silent.
-  if (issue.kind !== 'uneven') return null
+  if (issue.kind === 'disagreement') {
+    const { poolCount, poolSize, seats, fieldSize, direction, count } =
+      issue.disagreement
+    return (
+      // `status`, not `alert`. **This is legal**: the save gate reads `impossibleProblems`
+      // only, so a draw whose numbers disagree saves exactly as it stands. The director is
+      // being asked a question, not stopped, and a question that interrupts what they were
+      // reading would be answering it for them.
+      <div
+        role="status"
+        data-testid="draw-issue-panel"
+        data-issue-kind={issue.kind}
+        // Tinted, like the refusal and unlike the uneven notice: the reference draws this
+        // one in its `Your call` colour, the same `--warn` the preview's badge wears. On
+        // top of the words, never instead of them.
+        className="rounded-xl border border-[color:var(--warn)]/40 bg-[color:var(--warn)]/5 px-4 py-3"
+      >
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden="true"
+            className="size-1.5 shrink-0 rounded-full bg-[color:var(--warn)]"
+          />
+          {/* No colour of its own: `.fortymm-theme .fortymm-overline` is unlayered and
+              beats a Tailwind text-colour utility set here anyway. */}
+          <Overline as="span">Needs your call</Overline>
+        </div>
+
+        {/* ⚠️ **Both of the director's numbers, printed back at them unchanged**, and the
+            product they actually make. Nothing on this panel adds a pool or enlarges one to
+            make the arithmetic come out: the app states the standoff and offers three named
+            ways out of it (ADR 20260808 — report, do not reshape).
+
+            Unpluralised, so `1 pools of 5 seat 5.` is reachable. That is the reference's
+            string, transcribed rather than improved, for the reason `Use 1 pools` is pinned
+            in `./draw-issue-fix.test.ts`. */}
+        <p
+          data-testid="draw-issue-panel-title"
+          className="mt-1.5 text-[15px] leading-snug font-semibold text-[color:var(--fg-1)]"
+        >
+          {`${poolCount} pools of ${poolSize} seat ${seats}. Your field is ${fieldSize}.`}
+        </p>
+        {/* The shortfall in the direction it actually runs — entrants with nowhere to go,
+            or seats nobody fills. `direction` carries the sign so neither sentence has to
+            read a negative number aloud. */}
+        <p
+          data-testid="draw-issue-panel-body"
+          className="mt-1 text-[13px] leading-snug text-[color:var(--fg-3)]"
+        >
+          {direction === 'unseated'
+            ? `${count} entrants have nowhere to go. We won’t change your numbers behind your back.`
+            : `${count} seats would be empty. We won’t change your numbers behind your back.`}
+        </p>
+
+        {/* Three resolutions, so three columns. */}
+        <FixList fixes={fixes} columns="sm:grid-cols-3" onApplyFix={onApplyFix} />
+      </div>
+    )
+  }
 
   return (
     // `status`, not `alert`: an uneven split is legal. It is announced when the reader

--- a/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue.ts
+++ b/web-client/src/components/tournaments/tournament-detail-page/event-editor/draw-structure-section/draw-issue.ts
@@ -4,9 +4,8 @@
 // independently and says out loud that it will not order them: more than one holds at
 // once routinely, and picking between them is a layout question a derivation has no
 // business answering. This module is the answer, and it is the ONLY place the answer
-// exists — `DrawIssuePanel` renders whichever kind it is handed, the live preview reads
-// its verdict badge off the same call, and chore 5a adds the last variant to that
-// renderer without touching this file.
+// exists — `DrawIssuePanel` renders whichever kind it is handed, and the live preview reads
+// its verdict badge off the same call.
 
 import type {
   DrawStructure,


### PR DESCRIPTION
Slice 5 of the #1320 arc, stacked on #1336. The last slice.

Six pools of five seat thirty. Against a field of forty, ten entrants have nowhere to go. The app now says exactly that and **changes nothing** — because a numeric disagreement is the director's call, not an error, and the app has no business quietly adding a pool to make the arithmetic work.

## What a director sees

Topline `Needs your call`, a `status` rather than an alert, and the shortfall stated plainly:

> `6 pools of 5 seat 30. Your field is 40.`
> `10 entrants have nowhere to go. We won’t change your numbers behind your back.`

Both numbers stay exactly as typed. **Saving stays available** — the save gate deliberately reads impossibility alone, and a test on each side holds that line.

Three resolutions, and each really resolves. `Cap the field at 30` changes the limit on Basics. `Use 8 pools of 5` changes the count **and moves the reservations with it**, through the same seam a typed count uses, buying the same confirm when it drops one. `Allow uneven pools` keeps the count the director chose and hands only the size back, producing `7, 7, 7, 7, 6, 6`.

## On the server

Cutting is refused while entrants have nowhere to go, in the shape every other cut refusal takes, stating what the structure seats and how many entrants it leaves out.

It judges the **real registered field**, never the invented preview one. Once you are cutting, the entrants exist and they are what the cut deals; judging the preview would get both cases backwards and quote a number the director cannot check against the entrant list in front of them.

**Only one direction refuses**, and this is the part worth reading twice. Entrants with nowhere to go cannot be dealt. Seats left *empty* are not a problem at all — seven pools of six against a field of forty deals a legal uneven split, which the app calls legal one slice over. A symmetric guard would also dead-end a director who applied the resolution the app itself offered, since `Use {ceil(field / size)} pools` rounds up. Three comments say not to tidy the asymmetry away, and both a unit test and an e2e spec hold it.

Going live now waits on an unresolved disagreement, because go-live requires a draw. That follows from the same rule and is intended — worth knowing before someone reports it as a bug.

## Verification

- api **2317 passed**, `mypy --strict` clean, `ruff` clean. `openapi.json` verified unchanged by dumping it before and after and diffing, so no regen is owed.
- web **336 files / 3950 tests**, `tsc -b --force` clean, `eslint` clean.
- Root e2e **36/36** against the composed stack. The new specs prove the numbers survive a save and a read-back, that `Use 8 pools of 5` leaves eight cards on the Table pools tab *and* eight pools on the server, and that a refused cut and a permitted one differ only by direction.

Four falsifications on the last spec, each swapping the disagreement copy for the refusal copy — all four red by assertion. Distinguishing "a panel appeared" from "the *right* panel appeared" is this arc's recurring failure mode, and #1320 is a report of exactly that.

## One thing pinned rather than smoothed

`Use {ceil(field / size)} pools of {size}` rounds up, as the reference does, so a field of forty in pools of six asks for seven pools and seats forty-two. Everyone gets a seat, which is what the offer promises, and the two spare seats are reported as the milder disagreement they are — and, per the asymmetry above, do not block the cut.

Refs #1320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcvZ6Zh6w6vxj6uAaizmuF
