### PR TITLE
Pin planning to a frontier model, implementation to Sonnet

### DIFF
--- a/.claude/agents/api.md
+++ b/.claude/agents/api.md
@@ -2,6 +2,7 @@
 name: api
 description: Domain expert for the api/ FastAPI unit — routes, Pydantic schemas, async SQLAlchemy models, Alembic migrations, the RQ/ortools solver worker, and account-merge/rating logic. Delegate api/ implementation and bug-fixing here. Does not open PRs or run the cross-layer openapi/type-regen dance.
 tools: Read, Edit, Write, Bash, Grep, Glob
+model: sonnet
 ---
 
 You are a domain expert for the `api/` unit of the fortymm monorepo: a FastAPI

--- a/.claude/agents/e2e.md
+++ b/.claude/agents/e2e.md
@@ -2,6 +2,7 @@
 name: e2e
 description: Domain expert for the root e2e/ Playwright suite — the COMPOSED full-stack integration tests (real api + web-client behind nginx, no mocks), driven through a real browser via docker compose. Delegate root e2e/ spec + page-object work here. Owns ONLY root e2e/, NOT the web-client-only web-client/e2e/ suite. Implements and self-verifies by running the suite; does not open PRs.
 tools: Read, Edit, Write, Bash, Grep, Glob
+model: sonnet
 ---
 
 You are the domain expert for the root `e2e/` unit of the fortymm monorepo: the

--- a/.claude/agents/infra.md
+++ b/.claude/agents/infra.md
@@ -2,6 +2,7 @@
 name: infra
 description: Infra/devops expert — Helm/k3d UAT chart, docker-compose stacks, CI workflows, nginx, mise. Delegate infra/deploy work here.
 tools: Read, Edit, Write, Bash, Grep, Glob
+model: sonnet
 ---
 
 You are the fortymm infra/devops expert. Your surface spans `deploy/` (the k3d/Helm

--- a/.claude/agents/ios.md
+++ b/.claude/agents/ios.md
@@ -2,6 +2,7 @@
 name: ios
 description: Native Swift/SwiftUI iOS app expert — delegate any implementation work under ios/ here.
 tools: Read, Edit, Write, Bash, Grep, Glob
+model: sonnet
 ---
 
 You are the iOS domain expert for the fortymm monorepo's native Swift/SwiftUI app.

--- a/.claude/agents/web-client.md
+++ b/.claude/agents/web-client.md
@@ -2,6 +2,7 @@
 name: web-client
 description: Domain expert for the web-client/ SPA (Vite + React 19 + TypeScript). Delegate here for anything under web-client/ — TanStack Router (file-based) + TanStack Query, Zod boundary validation, Tailwind 4, shadcn (radix-nova/lucide), MSW mocks, and RHF+Zod forms. Owns the web-client-only Playwright suite (web-client/e2e/) but NOT the root e2e/ suite. Implements and self-verifies (vitest, tsc, lint); does not open PRs.
 tools: Read, Edit, Write, Bash, Grep, Glob
+model: sonnet
 ---
 
 You are the domain expert for the `web-client/` unit of the fortymm monorepo. You

--- a/.claude/skills/do-chores/SKILL.md
+++ b/.claude/skills/do-chores/SKILL.md
@@ -83,6 +83,13 @@ Repeat until every chore is ticked or every remaining chore is blocked:
      (`api`, `web-client`, `ios`, `infra`, `e2e`). Give the agent the chore's
      "what to build", scope, and **Read-first** pointers. The agents **implement
      but do not ship** — they return a summary, they don't commit or open PRs.
+     **Never pass a `model` on the Agent call** — each expert pins `model: sonnet`
+     in its own frontmatter, and an override on the call silently wins over it.
+     Implementation runs on Sonnet by design; the thinking that decided *what* to
+     build already happened upstream, on a frontier model, in `/grill-with-docs`
+     and `/to-chores`. A chore that seems to need more than Sonnet is a chore that
+     wasn't decomposed far enough — send it back to `/to-chores` rather than
+     upgrading the model.
    - **Parallelize** ready chores that touch **different trees** — dispatch at
      most one chore per tree at a time, so a batch never exceeds the number of
      experts actually in play. **Serialize across every `[main]` seam** — never

--- a/.claude/skills/domain-modeling/SKILL.md
+++ b/.claude/skills/domain-modeling/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: domain-modeling
 description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain the domain model.
+model: opus
 ---
 
 # Domain Modeling

--- a/.claude/skills/epic/SKILL.md
+++ b/.claude/skills/epic/SKILL.md
@@ -2,6 +2,7 @@
 name: epic
 description: Drive a change end-to-end through the fortymm arc — /grill-with-docs → /to-chores → /do-chores → /land-the-plane — as a GATED conductor. It sequences the four phases and carries the plan→work-order→stacked-PR artifact chain, stopping for your decision at every phase boundary; the work ships as one commit per chore and one stacked PR per slice, merged bottom-up by /land-the-plane's own gated step, and once the whole stack lands the arc moves the work order's tickets to Done. Use to run a whole feature/bugfix through the arc from one entry point; use the individual skills when you only want one phase.
 argument-hint: "[the goal to drive — an issue ref, a plan/PRD path, or a one-line description]"
+model: opus
 ---
 
 # Epic — a gated conductor for the fortymm arc

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: grill-with-docs
 description: A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.
+model: opus
 ---
 
 Run a `/grilling` interview, applying the `/domain-modeling` discipline

--- a/.claude/skills/grilling/SKILL.md
+++ b/.claude/skills/grilling/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: grilling
 description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+model: opus
 ---
 
 Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.

--- a/.claude/skills/to-chores/SKILL.md
+++ b/.claude/skills/to-chores/SKILL.md
@@ -2,6 +2,7 @@
 name: to-chores
 description: Break an agreed plan into a work order of small, agent-tagged chores grouped under tracer-bullet slices, for the domain-expert subagents to implement. Decompose-only — writes the work order and stops; run /do-chores to drive it.
 argument-hint: "[optional path to a plan/PRD/issue, else uses the plan in context]"
+model: opus
 ---
 
 # To Chores

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,19 @@ units (e.g. an API route + its web client), the main session coordinates the
 experts and does the regen itself. Destructive shared-cluster/stack ops stay with
 the operator — the `infra` expert flags them, it does not run them.
 
+**Frontier model plans, Sonnet implements.** The split is pinned in frontmatter, not
+left to whatever `/model` happens to be set to. The skills that *decide* — `/grilling`,
+`/grill-with-docs`, `/domain-modeling`, `/to-chores`, `/epic` — carry `model: opus`, so
+the interview, the ADRs, the decomposition and the gates get the frontier model. The
+five domain experts carry `model: sonnet`, so the chores they implement run cheaper and
+faster. `/do-chores` itself has no override: it inherits the session model, because it
+drives the stack and does the `[main]` cross-layer seams (regen, integration, PRs) that
+the experts are deliberately kept out of. **Don't pass `model` on an Agent call** — a
+call-site override beats the agent's frontmatter and quietly undoes this.
+
+The split only pays off if the plan carries the thinking. A chore that needs a frontier
+model to implement is under-decomposed: fix it in `/to-chores`, don't upgrade the agent.
+
 **Sharding a plan across the experts:** `/to-chores` breaks an agreed plan into a
 gitignored `.claude/work-order.md` — a checkbox list of small, agent-tagged
 **chores** grouped under demoable **tracer-bullet** slices, with `[main]` steps at


### PR DESCRIPTION
Model selection across the arc was implicit — whatever `/model` happened to be set to ran both the grilling and the chores. This pins the split in frontmatter so it holds regardless of the session model.

## What changed

**Planning gets the frontier model** — `model: opus` on the skills that *decide*:

| Skill | Why |
| --- | --- |
| `/grilling` | the relentless interview |
| `/grill-with-docs` | interview + ADR/glossary capture |
| `/domain-modeling` | the domain model and its decisions |
| `/to-chores` | decomposition into slices and chores |
| `/epic` | the conductor and its gates |

**Implementation gets Sonnet** — `model: sonnet` on all five domain experts (`api`, `web-client`, `ios`, `infra`, `e2e`). They implement chores whose "what" and "why" were already settled upstream.

**`/do-chores` keeps inheriting the session model.** No override: it drives the stack and does the `[main]` cross-layer seams — OpenAPI/type regen, integration glue, commits and PRs — which are exactly the work the experts are deliberately kept out of.

## Two notes added to the docs

- **A call-site `model` override beats the agent's frontmatter.** `/do-chores` now says explicitly not to pass `model` on an Agent call, since doing so would silently undo the pin.
- **A chore that needs more than Sonnet is under-decomposed.** The fix is in `/to-chores`, not an agent upgrade. Stated in both `/do-chores` and `CLAUDE.md` so the split doesn't erode one exception at a time.

`CLAUDE.md` gains a short "Frontier model plans, Sonnet implements" section next to the domain-expert table.

## Verification

Skills and agents are declarative config, so there is no suite to run against this. What was checked:

- Both `model:` fields are documented and supported — [skill frontmatter reference](https://code.claude.com/docs/en/skills) (accepts `/model`'s values or `inherit`) and [subagent frontmatter reference](https://code.claude.com/docs/en/sub-agents) (`sonnet`, `opus`, `haiku`, `fable`, a full model ID, or `inherit`).
- Every touched file's frontmatter still parses and terminates correctly, and each resolves to the intended model — confirmed by re-parsing all skills and agents, and by the skill listing reloading with descriptions intact after the edits.
- No behavior change lands until a session restarts: skills and agents register at launch.

Out of scope: `/land-the-plane` and `/qa-review` are review/ship rather than planning, so they keep inheriting. Worth a follow-up decision if you want the review gates pinned to a frontier model too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBj3g1b1yAu7uezMV38zgg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBj3g1b1yAu7uezMV38zgg)_