### PR TITLE
Untrack the self-referential root node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-node_modules/
+# No trailing slash: also ignores a symlink named node_modules, which a
+# trailing-slash (directory-only) pattern lets git track (#1342).
+node_modules
 .DS_Store
 .env
 .playwright-cli/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/ryan/Development/fortymm/node_modules


### PR DESCRIPTION
## What

`node_modules` was tracked in git at the repo root as a symlink whose target is an absolute path to itself (`/Users/ryan/Development/fortymm/node_modules`). In the main checkout it resolves to itself, so every tool that walks it gets `ELOOP`: `npm ci` fails, Playwright's `webServer` spawn exits 194, and `mise exec -- node_modules/.bin/<tool>` dies with "Too many levels of symbolic links".

## Fix

- `git rm node_modules` — untrack the symlink.
- `.gitignore`: change `node_modules/` to `node_modules`. The trailing-slash form matches directories only, so it never covered the symlink. The new form covers both.

## Verified

- Recreated a symlink named `node_modules` after the change. `git status` ignores it, and `git check-ignore -v` matches the new pattern.
- `git ls-files | grep node_modules` returns nothing.

## After merge

In an existing checkout, the pull deletes the symlink. Run `npm ci --ignore-scripts` at the root to create a real `node_modules`. Fresh worktrees no longer get a symlink to the main checkout's install. If worktrees should share the root install, add that as a local setup step in `scripts/install_tools.sh`, per the issue.

Closes #1342

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198KTDWfcjdfCVPNVyRCZnP