### PR TITLE
Give the MSW dev seed UUID tournament ids

### DIFF
--- a/web-client/src/components/tournaments/data/api.hooks.test.tsx
+++ b/web-client/src/components/tournaments/data/api.hooks.test.tsx
@@ -35,6 +35,10 @@ import {
   buildTournamentFixtureRead,
 } from '@/mocks/factories/tournaments/tournament.factory'
 import type { CodedErrorBody } from '@/mocks/endpoints/error-body'
+import {
+  BAY_AREA_OPEN_ID,
+  SUMMER_SLAM_ID,
+} from '@/mocks/factories/tournaments/tournament-ids'
 import { server } from '@/mocks/server'
 import {
   cutDraw,
@@ -469,7 +473,7 @@ describe('useUpdateEvent — the draw configuration on the wire', () => {
  */
 describe('an added pool, through the mock’s id-keyed diff', () => {
   // The seed's owned, published tournament and its two-pool event.
-  const TOURNAMENT = 'bay-area-open-2026'
+  const TOURNAMENT = BAY_AREA_OPEN_ID
   const EVENT = 'ev-open-singles'
 
   beforeEach(() => resetTournamentsStore())
@@ -681,7 +685,7 @@ describe('useTransitionTournament', () => {
 describe('the lifecycle, against the stateful mock store', () => {
   beforeEach(() => resetTournamentsStore())
 
-  const DRAFT = 'summer-slam-2026' // seeded `draft`, owned by the dev user
+  const DRAFT = SUMMER_SLAM_ID // seeded `draft`, owned by the dev user
 
   it('walks draft → published → live → archived, and the detail reads back each move', async () => {
     const { wrapper } = setupClient()
@@ -1177,7 +1181,7 @@ describe('useWithdrawEntry', () => {
 describe('entering and withdrawing, against the stateful mock store', () => {
   beforeEach(() => resetTournamentsStore())
 
-  const TOURNAMENT = 'bay-area-open-2026'
+  const TOURNAMENT = BAY_AREA_OPEN_ID
   const EVENT = 'ev-u1500' // seeded with nobody in it
 
   it('adds the entrant and increments the count; withdrawing reverses both', async () => {
@@ -1639,7 +1643,7 @@ describe('useRequestScheduleSolve', () => {
 describe('cutting and un-cutting, against the stateful mock store', () => {
   beforeEach(() => resetTournamentsStore())
 
-  const TOURNAMENT = 'bay-area-open-2026'
+  const TOURNAMENT = BAY_AREA_OPEN_ID
   /** The seed's ONE cuttable event: round-robin (the only draw type with a generator),
    * two pools, nine entrants — and seeded already drawn. */
   const DRAWN = 'ev-u1200'

--- a/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
+++ b/web-client/src/components/tournaments/tournament-detail-page/tables-tab.test.tsx
@@ -2,6 +2,7 @@ import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 
 import { server } from '@/mocks/server'
+import { SUMMER_SLAM_ID } from '@/mocks/factories/tournaments/tournament-ids'
 import {
   findTournament,
   placeFixture,
@@ -235,7 +236,7 @@ describe('TablesTab', () => {
 /** The seeded, owned `draft` tournament — a catalogue of `t1`… tables and one drawn
  * event whose fixtures start UNPLACED. Its size is read from the store rather than
  * written down here: what these tests assert is the DELTA an edit makes. */
-const SLAM = 'summer-slam-2026'
+const SLAM = SUMMER_SLAM_ID
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 

--- a/web-client/src/mocks/factories/tournaments/tournament-ids.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament-ids.ts
@@ -1,0 +1,24 @@
+/** Stable UUID ids for the tournaments seeded into the dev world (#1229, duplicates
+ * #1211, #1323).
+ *
+ * The route Zod-validates `$tournamentId` as a uuid at the boundary, BEFORE any fetch
+ * (`tournaments.$tournamentId.tsx`, ADR-1001) — a non-uuid segment throws `notFound()`.
+ * A hand-written slug id (`bay-area-open-2026`) therefore 404s its own detail page
+ * under `npm run dev` even though the seed exists — the same class of bug `mockUuid`
+ * fixed for matches (#958). `mockUuid` derives a deterministic v4-shaped id from a
+ * readable label, so a seed keeps the same id across reloads while call sites still
+ * say what the tournament *is*.
+ *
+ * Kept in their own module rather than `tournaments-store.ts`: the admin solve-ledger
+ * seed (`buildAdminSolveLedgerSeed` below) needs the same ids so its tournament links
+ * resolve too, and `tournaments-store.ts` already imports FROM this factory file —
+ * exporting the ids from the store instead would create an import cycle.
+ */
+import { mockUuid } from '@/mocks/mock-uuid'
+
+export const BAY_AREA_OPEN_ID = mockUuid('bay-area-open-2026')
+export const SUMMER_SLAM_ID = mockUuid('summer-slam-2026')
+export const CLUB_CHAMPS_ID = mockUuid('club-champs-2026')
+export const GARAGE_INVITATIONAL_ID = mockUuid('garage-invitational-2026')
+export const GOLDEN_STATE_CLASSIC_ID = mockUuid('golden-state-classic-2026')
+export const LEAGUE_OFFICE_DRAFT_ID = mockUuid('league-office-draft-2027')

--- a/web-client/src/mocks/factories/tournaments/tournament.factory.ts
+++ b/web-client/src/mocks/factories/tournaments/tournament.factory.ts
@@ -1,6 +1,10 @@
 import type { components } from '@/api/schema'
 import { FORTYMM_LEAGUE_ID } from '@/mocks/factories/players/player-league.factory'
 import { simFixtureTime } from '@/mocks/factories/tournaments/solver-sim'
+import {
+  BAY_AREA_OPEN_ID,
+  SUMMER_SLAM_ID,
+} from '@/mocks/factories/tournaments/tournament-ids'
 
 type TournamentDetailRead = components['schemas']['TournamentDetailRead']
 type DrawTypeRead = components['schemas']['DrawTypeRead']
@@ -288,8 +292,8 @@ export function pageAdminScheduleSolves(
  */
 export function buildAdminSolveLedgerSeed(): AdminScheduleSolveRead[] {
   const tournaments = [
-    { id: 'bay-area-open-2026', name: 'Bay Area Open 2026' },
-    { id: 'summer-slam-2026', name: 'Summer Slam 2026' },
+    { id: BAY_AREA_OPEN_ID, name: 'Bay Area Open 2026' },
+    { id: SUMMER_SLAM_ID, name: 'Summer Slam 2026' },
   ] as const
   // Newest first: minute 59 down to 26.
   const runs = Array.from({ length: 34 }, (_, i) => {

--- a/web-client/src/mocks/tournaments-handlers.test.ts
+++ b/web-client/src/mocks/tournaments-handlers.test.ts
@@ -21,6 +21,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type { components } from '@/api/schema'
+import {
+  BAY_AREA_OPEN_ID,
+  CLUB_CHAMPS_ID,
+  GARAGE_INVITATIONAL_ID,
+  GOLDEN_STATE_CLASSIC_ID,
+  SUMMER_SLAM_ID,
+} from '@/mocks/factories/tournaments/tournament-ids'
 import { DRAW_SETTINGS_REFUSALS } from './handlers'
 import { resetTournamentsStore } from './tournaments-store'
 
@@ -31,15 +38,15 @@ type TournamentEventRead = components['schemas']['TournamentEventRead']
 // rounds to 0 and the radii read like a map.
 const BERKELEY = { lat: 37.8715, lng: -122.273 }
 
-const BAY_AREA = 'bay-area-open-2026' // Berkeley
-const SUMMER_SLAM = 'summer-slam-2026' // Palo Alto, ~30.5 mi
-const CLUB_CHAMPS = 'club-champs-2026' // San Jose, ~42.5 mi
+const BAY_AREA = BAY_AREA_OPEN_ID // Berkeley
+const SUMMER_SLAM = SUMMER_SLAM_ID // Palo Alto, ~30.5 mi
+const CLUB_CHAMPS = CLUB_CHAMPS_ID // San Jose, ~42.5 mi
 /** The seed's venue-less tournament (`address: null`) — visible in the plain list,
  * and never in a near-me one. */
-const GARAGE = 'garage-invitational-2026'
+const GARAGE = GARAGE_INVITATIONAL_ID
 /** The seed's two-stage tournament (ADR 20260727) — Los Angeles, ~345 mi, i.e. outside
  * every radius these tests search and inside the deliberately absurd one below. */
-const GOLDEN_STATE = 'golden-state-classic-2026'
+const GOLDEN_STATE = GOLDEN_STATE_CLASSIC_ID
 
 async function listTournaments(query = ''): Promise<{
   status: number

--- a/web-client/src/mocks/tournaments-store.test.ts
+++ b/web-client/src/mocks/tournaments-store.test.ts
@@ -3,12 +3,20 @@
 // withdrawing frees the player to enter again.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
 
 import {
   buildFixtureTimeRead,
   DRAW_TYPE_CATALOGUE,
   planDraw,
 } from '@/mocks/factories/tournaments/tournament.factory'
+import {
+  BAY_AREA_OPEN_ID,
+  CLUB_CHAMPS_ID,
+  GOLDEN_STATE_CLASSIC_ID,
+  LEAGUE_OFFICE_DRAFT_ID,
+  SUMMER_SLAM_ID,
+} from '@/mocks/factories/tournaments/tournament-ids'
 import {
   createEvent,
   createTournament,
@@ -37,8 +45,8 @@ type TournamentStatus = components['schemas']['TournamentStatus']
 type TournamentTable = components['schemas']['TournamentTable']
 type TournamentTableUpsert = components['schemas']['TournamentTableUpsert']
 
-const TOURNAMENT = 'bay-area-open-2026' // seeded `published`, owned
-const DRAFT_TOURNAMENT = 'summer-slam-2026' // seeded `draft`, owned, one drawn event
+const TOURNAMENT = BAY_AREA_OPEN_ID // seeded `published`, owned
+const DRAFT_TOURNAMENT = SUMMER_SLAM_ID // seeded `draft`, owned, one drawn event
 const EMPTY_SINGLES = 'ev-u1500' // seeded with no entrants
 const FULLISH_SINGLES = 'ev-open-singles' // seeded with 52 other players, cap 64
 const FULL_SINGLES = 'ev-champ-singles' // seeded 16 of 16 — no room (#783)
@@ -205,6 +213,35 @@ describe('the seeded read shape', () => {
   })
 })
 
+// #1229 (duplicates #1211, #1323): the `$tournamentId` route Zod-validates the segment
+// as a `z.string().uuid()` BEFORE any fetch (`tournaments.$tournamentId.tsx`, ADR-1001),
+// so a mock tournament whose id is a slug 404s its own detail page under `npm run dev`
+// before MSW ever sees the request. This pins the CLASS of bug, not just the six ids
+// fixed here — a future seed row (or `createTournament` mint) that reverts to a
+// hand-written slug reds this immediately, rather than waiting for someone to click
+// through `npm run dev` and notice.
+describe('every tournament id is uuid-shaped (#1229)', () => {
+  const uuid = z.string().uuid()
+
+  it('every id `listTournaments` (i.e. the dev seed) hands out', () => {
+    for (const tournament of listTournaments()) {
+      expect(uuid.safeParse(tournament.id).success).toBe(true)
+    }
+  })
+
+  it('the id `createTournament` mints', () => {
+    const created = createTournament({
+      name: 'Newly Minted',
+      description: null,
+      start_date: null,
+      end_date: null,
+      address: null,
+      table_catalogue: [],
+    })
+    expect(uuid.safeParse(created.id).success).toBe(true)
+  })
+})
+
 // #783: the two refusals the EVENT itself makes. A mock that 201'd them would be
 // more permissive than the server, and a UI that kept offering Enter on a full
 // event would look perfect in `npm run dev`.
@@ -350,14 +387,14 @@ describe('enterEvent', () => {
   it('is allowed on a tournament the entrant does not own — entry is not creator-gated', () => {
     // Published (so the window is open) but owned by the league office: what is
     // being proved here is that ownership has nothing to do with entering.
-    const notMine = findTournament('club-champs-2026')!
+    const notMine = findTournament(CLUB_CHAMPS_ID)!
     expect(notMine.can_edit).toBe(false)
     expect(notMine.status).toBe('published')
 
-    const result = enterEvent('club-champs-2026', 'ev-cc-open')
+    const result = enterEvent(CLUB_CHAMPS_ID, 'ev-cc-open')
 
     expect(result.ok).toBe(true)
-    const found = findTournament('club-champs-2026')!.events.find(
+    const found = findTournament(CLUB_CHAMPS_ID)!.events.find(
       (e) => e.id === 'ev-cc-open',
     )!
     expect(found.entered).toBe(29)
@@ -709,9 +746,9 @@ describe('the rest of the event surface still holds', () => {
 // looser one: a mock that permitted an illegal edge would let a broken UI look
 // fine in dev and in vitest, which is the entire point of mirroring it.
 describe('transitionTournament', () => {
-  const DRAFT = 'summer-slam-2026' // seeded `draft`, owned
-  const PUBLISHED = 'bay-area-open-2026' // seeded `published`, owned
-  const NOT_MINE = 'club-champs-2026' // seeded `published`, can_edit: false
+  const DRAFT = SUMMER_SLAM_ID // seeded `draft`, owned
+  const PUBLISHED = BAY_AREA_OPEN_ID // seeded `published`, owned
+  const NOT_MINE = CLUB_CHAMPS_ID // seeded `published`, can_edit: false
   /** `DRAFT`'s only event: round-robin, 8 entrants, a draw already cut across its two
    * pools — i.e. the one seeded event whose draw is CURRENT, which is what makes that
    * tournament the only one in the seed that can go live at all. */
@@ -1017,9 +1054,9 @@ describe('transitionTournament', () => {
 // are the tests that make the predicate real. Without them (and without that seeded
 // row) the filter is dead code that could be deleted and stay green.
 describe('draft visibility', () => {
-  const FOREIGN_DRAFT = 'league-office-draft-2027' // seeded `draft`, u-office
-  const FOREIGN_PUBLISHED = 'club-champs-2026' // seeded `published`, u-office
-  const OWN_DRAFT = 'summer-slam-2026' // seeded `draft`, the dev user's
+  const FOREIGN_DRAFT = LEAGUE_OFFICE_DRAFT_ID // seeded `draft`, u-office
+  const FOREIGN_PUBLISHED = CLUB_CHAMPS_ID // seeded `published`, u-office
+  const OWN_DRAFT = SUMMER_SLAM_ID // seeded `draft`, the dev user's
 
   const listedIds = () => listTournaments().map((t) => t.id)
 
@@ -1080,7 +1117,7 @@ describe('draft visibility', () => {
 describe('cutting and un-cutting a draw', () => {
   beforeEach(() => resetTournamentsStore())
 
-  const FOREIGN = 'club-champs-2026' // `u-office`'s, published: readable, not writable
+  const FOREIGN = CLUB_CHAMPS_ID // `u-office`'s, published: readable, not writable
   const FOREIGN_EVENT = 'ev-cc-open'
   /** Round-robin, two pools, nine entrants — the seed's one cuttable (and pre-cut)
    * event, because round-robin is the only draw type with a generator today. */
@@ -2344,7 +2381,7 @@ describe('the venue on a create/update', () => {
 describe('the seeded two-stage (rr-then-ko) events', () => {
   beforeEach(() => resetTournamentsStore())
 
-  const GOLDEN_STATE = 'golden-state-classic-2026'
+  const GOLDEN_STATE = GOLDEN_STATE_CLASSIC_ID
   const FINISHED = 'ev-challenge-cup' // pools decided, bracket decided, champion crowned
   const MID_FLIGHT = 'ev-shield' // pools decided, the final still to be played
 

--- a/web-client/src/mocks/tournaments-store.ts
+++ b/web-client/src/mocks/tournaments-store.ts
@@ -38,6 +38,14 @@ import {
   stepScheduleSolve,
 } from '@/mocks/factories/tournaments/solver-sim'
 import { mockUuid } from '@/mocks/mock-uuid'
+import {
+  BAY_AREA_OPEN_ID,
+  CLUB_CHAMPS_ID,
+  GARAGE_INVITATIONAL_ID,
+  GOLDEN_STATE_CLASSIC_ID,
+  LEAGUE_OFFICE_DRAFT_ID,
+  SUMMER_SLAM_ID,
+} from '@/mocks/factories/tournaments/tournament-ids'
 import { conjoinWithAnd, hasVenue } from '@/components/tournaments/data/helpers'
 import type { TournamentsNearMe } from '@/components/tournaments/data/api'
 
@@ -270,7 +278,7 @@ const SLAM_POOLS: Pool[] = [
 /** The tournament both two-stage events run at: **live**, mid-weekend, with one event
  * finished and one still playing. It is also the seed's only `live` row, so `npm run dev`
  * gets a started tournament for free. */
-const GOLDEN_STATE_ID = 'golden-state-classic-2026'
+const GOLDEN_STATE_ID = GOLDEN_STATE_CLASSIC_ID
 
 const CUP_EVENT_ID = 'ev-challenge-cup'
 const SHIELD_EVENT_ID = 'ev-shield'
@@ -536,7 +544,7 @@ const SHIELD_KNOCKOUT_FIXTURES: TournamentFixtureRead[] = [
 function seed(): StoredTournament[] {
   return [
     {
-      id: 'bay-area-open-2026',
+      id: BAY_AREA_OPEN_ID,
       name: 'Bay Area Open 2026',
       description: 'Two-day open. USATT-sanctioned, ratings-eligible.',
       status: 'published',
@@ -567,7 +575,7 @@ function seed(): StoredTournament[] {
       events: [
         {
           id: 'ev-open-singles',
-          tournament_id: 'bay-area-open-2026',
+          tournament_id: BAY_AREA_OPEN_ID,
           name: 'Open Singles',
           format: 'singles',
           draw_type: 'round-robin',
@@ -615,7 +623,7 @@ function seed(): StoredTournament[] {
           // back, with a strategy, since #1227). `pools: []` replaces it, and it is
           // permanent: "A round-robin draw needs at least one pool." Do not give it pools.
           id: 'ev-u1500',
-          tournament_id: 'bay-area-open-2026',
+          tournament_id: BAY_AREA_OPEN_ID,
           name: 'U1500 Singles',
           format: 'singles',
           draw_type: 'round-robin',
@@ -640,7 +648,7 @@ function seed(): StoredTournament[] {
           // says why instead (ADR-0015; #783). Seeded so `npm run dev` can show the
           // state without anyone having to click Enter sixteen times.
           id: 'ev-champ-singles',
-          tournament_id: 'bay-area-open-2026',
+          tournament_id: BAY_AREA_OPEN_ID,
           name: 'Championship Singles',
           format: 'singles',
           draw_type: 'single-elim',
@@ -676,7 +684,7 @@ function seed(): StoredTournament[] {
           // sitting out, and a bye is visible for what it is: the ABSENCE of a fixture,
           // not a fixture with an empty side.
           id: 'ev-u1200',
-          tournament_id: 'bay-area-open-2026',
+          tournament_id: BAY_AREA_OPEN_ID,
           name: 'U1200 Singles',
           format: 'singles',
           draw_type: 'round-robin',
@@ -741,7 +749,7 @@ function seed(): StoredTournament[] {
           // cannot express a pairing — ADR-0016), so the API 400s here and the
           // UI offers no Enter control. Seeded so that case is visible in dev.
           id: 'ev-mixed-doubles',
-          tournament_id: 'bay-area-open-2026',
+          tournament_id: BAY_AREA_OPEN_ID,
           name: 'Mixed Doubles',
           format: 'doubles',
           draw_type: 'single-elim',
@@ -763,7 +771,7 @@ function seed(): StoredTournament[] {
       ],
     },
     {
-      id: 'summer-slam-2026',
+      id: SUMMER_SLAM_ID,
       name: 'Summer Slam 2026',
       description: null,
       status: 'draft',
@@ -801,7 +809,7 @@ function seed(): StoredTournament[] {
           // tournament and Start works; publish the Bay Area Open — four of whose five
           // events have no draw — and Start is refused, by name. The seed holds both.
           id: 'ev-slam-open',
-          tournament_id: 'summer-slam-2026',
+          tournament_id: SUMMER_SLAM_ID,
           name: 'Slam Open Singles',
           format: 'singles',
           draw_type: 'round-robin',
@@ -828,7 +836,7 @@ function seed(): StoredTournament[] {
       ],
     },
     {
-      id: 'club-champs-2026',
+      id: CLUB_CHAMPS_ID,
       name: 'Club Championship',
       description: 'Run by the league office — view only.',
       // `published`, not `live`: registration is open only while a tournament is
@@ -864,7 +872,7 @@ function seed(): StoredTournament[] {
           // entering is gated on the `tournament.enter` permission, not on
           // ownership, so Enter still shows.
           id: 'ev-cc-open',
-          tournament_id: 'club-champs-2026',
+          tournament_id: CLUB_CHAMPS_ID,
           name: "Women's Championship Singles",
           format: 'singles',
           draw_type: 'single-elim',
@@ -944,7 +952,7 @@ function seed(): StoredTournament[] {
       //
       // Owned by the dev user, so the Details tab opens editable and the six empty
       // venue boxes are reachable.
-      id: 'garage-invitational-2026',
+      id: GARAGE_INVITATIONAL_ID,
       name: 'Garage Invitational',
       description: 'Address shared with entrants after registration.',
       status: 'published',
@@ -962,7 +970,7 @@ function seed(): StoredTournament[] {
       events: [
         {
           id: 'ev-garage-open',
-          tournament_id: 'garage-invitational-2026',
+          tournament_id: GARAGE_INVITATIONAL_ID,
           name: 'Garage Singles',
           format: 'singles',
           draw_type: 'round-robin',
@@ -1202,7 +1210,7 @@ function seed(): StoredTournament[] {
       // Its observable behaviour is the API's: absent from the list, and a 404 —
       // not a 403 — from the detail route, because a draft you cannot see must be
       // indistinguishable from one that does not exist.
-      id: 'league-office-draft-2027',
+      id: LEAGUE_OFFICE_DRAFT_ID,
       league_id: DEFAULT_LEAGUE_ID,
       name: 'League Office Draft 2027',
       description: 'Not announced yet — and not the dev user’s to see.',
@@ -1445,7 +1453,17 @@ export function findTournament(id: string): TournamentDetailRead | undefined {
 
 let createCounter = 0
 
-function slugId(name: string): string {
+/** A brand-new tournament's id — the mock's `gen_random_uuid()`.
+ *
+ * UUID-shaped (`mockUuid`, #1229) because the wire says so (`Tournament.id` is
+ * `format: uuid`) and because the `$tournamentId` route Zod-validates the segment as
+ * one BEFORE any fetch (ADR-1001): a slug id here would make the tournament this very
+ * call just created 404 on its own detail page the moment `NewTournamentModal`
+ * navigates to it. Keyed on a slug of the name PLUS a counter, not the name alone, so
+ * two tournaments created with the same name (nothing stops a director from doing
+ * that) still get distinct ids — the counter deliberately does NOT reset with the
+ * store, for the same reason `mintTable`'s doesn't. */
+function mintTournamentId(name: string): string {
   const base =
     name
       .toLowerCase()
@@ -1453,7 +1471,7 @@ function slugId(name: string): string {
       .replace(/^-+|-+$/g, '')
       .slice(0, 40) || 'tournament'
   createCounter += 1
-  return `${base}-${createCounter}`
+  return mockUuid(`tournament:${base}-${createCounter}`)
 }
 
 /** Create a bare tournament owned by the dev user (so it's editable). Returns
@@ -1659,7 +1677,7 @@ function applyTableCatalogue(
 
 export function createTournament(body: TournamentCreate): TournamentRead {
   const now = new Date().toISOString()
-  const id = slugId(body.name)
+  const id = mintTournamentId(body.name)
   const created: StoredTournament = {
     id,
     name: body.name,


### PR DESCRIPTION
## What

Under `npm run dev` (MSW on), every seeded tournament's detail page 404'd: the route parses `$tournamentId` with `z.string().uuid()`, and the seed minted slug ids (`bay-area-open-2026`, …). The guard was right; the seed was lying. Creating a tournament through the UI hit the same wall via `slugId()`.

## Fix

- New `src/mocks/factories/tournaments/tournament-ids.ts`: six stable `mockUuid`-derived ids (the #958 matches-side pattern), in their own module to avoid a store↔factory import cycle.
- `tournaments-store.ts`: seed uses the shared UUID consts; `slugId()` → `mintTournamentId`, which wraps the slug base in `mockUuid(...)` so UI-created tournaments are routable too.
- `tournament.factory.ts`: the admin solve-ledger seed's tournament links point at the shared ids.
- Four store-coupled test files updated to import the same consts.
- Regression test: every id from `listTournaments()` and a fresh `createTournament(...)` must parse against the same `z.string().uuid()` the route uses — pins the class of bug.

Route schema untouched. Test-only factory defaults that still use slugs were deliberately left (they never render through the router; `solve-ledger-page.test.tsx` asserts one verbatim).

## Verified

- vitest (after clearing `node_modules/.vite`): 346/346 files, 3868/3868 tests, collected count matches ran. `tsc -b` clean, eslint clean.
- Falsified both ways: reverting a seed id to its slug reds the `listTournaments` arm; reverting `mintTournamentId` reds the `createTournament` arm.
- Real-browser check against `npm run dev` (headless chromium — the surface no automated suite covers): clicking a seeded card renders detail at a UUID URL, a hard deep-link to that UUID renders (no 404, zero-request throw gone), and a UI-created tournament lands on a working UUID detail page.

Closes #1229
Closes #1211
Closes #1323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198KTDWfcjdfCVPNVyRCZnP