### PR TITLE
Sort the dashboard's "Your matches" path by scheduled time, not draw order

### DIFF
--- a/api/app/dashboard_tournaments.py
+++ b/api/app/dashboard_tournaments.py
@@ -30,7 +30,7 @@ import logging
 import uuid
 from collections import defaultdict
 from collections.abc import Sequence
-from datetime import date
+from datetime import UTC, date, datetime
 from typing import assert_never
 
 from pydantic import ValidationError
@@ -61,6 +61,7 @@ from app.schemas.dashboard import (
 )
 from app.schemas.tournament import (
     Address,
+    FixtureTimeRead,
     MatchSettings,
     StandingsResultsRead,
     StandingsThenFinishesResultsRead,
@@ -79,6 +80,11 @@ from app.tournament_queries import (
 from app.tournament_serialization import event_results
 
 log = logging.getLogger(__name__)
+
+# Sort key for a fixture with no effective time (:func:`_effective_fixture_time`) in
+# :func:`_sorted_by_effective_time` — larger than any real instant, so untimed
+# fixtures always sort after every timed one.
+_UNTIMED_SORTS_LAST = datetime.max.replace(tzinfo=UTC)
 
 
 async def build_tournament_panels(
@@ -106,14 +112,19 @@ async def build_tournament_panels(
     fixtures = await fixtures_by_event(db, event_ids)
     game_counts = await game_counts_by_match(db, completed_match_ids(fixtures))
 
-    # The caller's own fixtures, in draw order, per event — the path list, and the
-    # pool the focus match is chosen out of.
+    # The caller's own fixtures, per event — the path list, and the pool the focus
+    # match is chosen out of. Sorted chronologically (#1297): a player reading the
+    # path top-to-bottom must meet their matches in the order they are actually
+    # played, not in draw order (pool -> round -> position, ADR-0786), which can
+    # and does run out of time order once fixtures are called onto real tables.
     my_fixtures = {
-        event_id: [
-            fixture
-            for fixture in fixtures[event_id]
-            if _my_side(fixture, my_entry_id_by_event[event_id]) is not None
-        ]
+        event_id: _sorted_by_effective_time(
+            [
+                fixture
+                for fixture in fixtures[event_id]
+                if _my_side(fixture, my_entry_id_by_event[event_id]) is not None
+            ]
+        )
         for event_id in event_ids
     }
     focus = {event_id: _focus_fixture(rows) for event_id, rows in my_fixtures.items()}
@@ -247,8 +258,11 @@ def _focus_fixture(
     point of the panel — a player mid-match must never have to scroll past a result to
     find the game they are standing at a table for.
 
-    Among the not-yet-played, the earliest in draw order wins (the list arrives in
-    pool → round → position order, ADR-0786); among the finished, the latest. ``None``
+    Among the not-yet-played, the earliest by effective time (``pinned_at or
+    scheduled_start``) wins, untimed fixtures falling back to draw order (pool ->
+    round -> position, ADR-0786) among themselves — the same chronological ordering
+    the path list itself now uses (#1297), so the focus match is always the top row
+    of "Your matches". Among the finished, the latest by that same ordering. ``None``
     for an event whose draw has not been cut, which has no fixtures at all."""
     live = [f for f in my_fixtures if f.match_status is MatchStatus.in_progress]
     if live:
@@ -684,18 +698,47 @@ def _table_label(
     return table.label if table is not None else None
 
 
-def _time_label(fixture: TournamentFixtureRead) -> str | None:
-    """The fixture's start as one display string in the venue's timezone (e.g.
-    ``"4:30 PM CDT"``), already rendered server-side — clients do no timezone math (ADR
-    "tournament times are timezone-aware instants").
+def _effective_fixture_time(fixture: TournamentFixtureRead) -> FixtureTimeRead | None:
+    """The one time a fixture is judged by, everywhere the panel needs a single
+    instant rather than the two raw columns: display (:func:`_time_label`) and the
+    path list's chronological sort (:func:`_sorted_by_effective_time`).
 
     The **pinned** time wins over the predicted one when there is one: a pinned
     placement is a promise the players were notified of, and a panel that showed the
-    solver's newer estimate instead would contradict the call they were sent."""
-    time = fixture.pinned_at or fixture.scheduled_start
+    solver's newer estimate instead would contradict the call they were sent. ``None``
+    when the fixture carries neither — unplaced, or placed with no time yet."""
+    return fixture.pinned_at or fixture.scheduled_start
+
+
+def _time_label(fixture: TournamentFixtureRead) -> str | None:
+    """The fixture's start as one display string in the venue's timezone (e.g.
+    ``"4:30 PM CDT"``), already rendered server-side — clients do no timezone math (ADR
+    "tournament times are timezone-aware instants")."""
+    time = _effective_fixture_time(fixture)
     if time is None:
         return None
     return f"{time.local_label} {time.tz_abbrev}"
+
+
+def _sorted_by_effective_time(
+    fixtures: list[TournamentFixtureRead],
+) -> list[TournamentFixtureRead]:
+    """The caller's path list, ordered by :func:`_effective_fixture_time` ascending
+    (#1297) rather than the draw order it arrives in.
+
+    A player reading "Your matches" top-to-bottom must meet their matches in the
+    order they are actually played — a fixture called for 9:00 AM has to outrank one
+    called for noon regardless of which round or pool it belongs to. Fixtures with no
+    time at all (not yet placed) sort LAST, after every timed one, via a
+    ``datetime.max`` sentinel key, and keep their relative draw order (pool -> round
+    -> position, ADR-0786) among themselves — :func:`sorted` is stable, so that
+    fallback needs no extra code, only an equal sort key for every untimed fixture."""
+
+    def key(fixture: TournamentFixtureRead) -> datetime:
+        time = _effective_fixture_time(fixture)
+        return time.instant if time is not None else _UNTIMED_SORTS_LAST
+
+    return sorted(fixtures, key=key)
 
 
 def _subtitle(tournament: Tournament) -> str:

--- a/api/app/schemas/dashboard.py
+++ b/api/app/schemas/dashboard.py
@@ -244,7 +244,8 @@ class DashboardTournamentMatch(BaseModel):
 
 class DashboardTournamentFixtureRow(BaseModel):
     """One line of the panel's "Your matches" path — every fixture in this event the
-    caller is a side of, in draw order.
+    caller is a side of, ordered by scheduled time ascending (untimed fixtures last,
+    in draw order among themselves — #1297).
 
     ``detail`` is the row's right-hand text, composed server-side because what belongs
     there changes with ``state`` (a result, "In progress", or a time and table). The

--- a/api/tests/test_dashboard_tournaments.py
+++ b/api/tests/test_dashboard_tournaments.py
@@ -25,6 +25,7 @@ from app.models import (
     MatchStatus,
     Tournament,
     TournamentEntryStatus,
+    TournamentFixture,
     TournamentStatus,
     User,
 )
@@ -1004,3 +1005,162 @@ async def test_an_rr_then_ko_panel_names_the_stage_each_fixture_is_in(
     )
     assert ko_event["stage_label"] == "In play"
     assert [row["label"] for row in ko_event["fixtures"]] == ["M1", "M2"]
+
+
+async def test_the_path_list_sorts_by_scheduled_time_not_draw_order(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """#1297: "Your matches" reads top-to-bottom in the order the caller actually
+    plays it, not in draw order (pool -> round -> position, ADR-0786).
+
+    A three-entrant round-robin pool seats the caller (seed 1) into two of the
+    draw's three rounds. Placed IN draw order they would already read correctly, so
+    the fixtures are placed OUT of it on purpose — the later round scheduled for the
+    earlier time, exactly the shape the issue reports (a noon ``M1`` ahead of a
+    9 AM ``M2``) — and the panel must still list the 9 AM one first."""
+    client, owner = authed_client
+    async with (
+        opponent_session(db_session, "sched-opp-2") as (_client_2, user_2),
+        opponent_session(db_session, "sched-opp-3") as (_client_3, user_3),
+    ):
+        tournament_id, (event,) = await _tournament_with_events(
+            client,
+            _rr_payload(
+                POOL_A,
+                match_settings={"rated": False, "length_games": 3},
+                predicates=[],
+            ),
+        )
+        base = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+        owner_entry, entry_2, entry_3 = [
+            await _enter(
+                db_session,
+                event["id"],
+                user,
+                seed=seed,
+                created_at=base + timedelta(minutes=seed),
+            )
+            for seed, user in ((1, owner), (2, user_2), (3, user_3))
+        ]
+        username_by_entry = {
+            owner_entry.id: owner.username,
+            entry_2.id: user_2.username,
+            entry_3.id: user_3.username,
+        }
+        await _cut_the_draw(client, tournament_id, event["id"])
+        await _set_status(db_session, tournament_id, TournamentStatus.published)
+        assert (await _go_live(client, tournament_id)).status_code == 201
+
+        rows = await _fixture_rows(db_session, event["id"])
+        my_fixtures = sorted(
+            (f for f in rows if owner_entry.id in (f.entry_a_id, f.entry_b_id)),
+            key=lambda f: f.round,
+        )
+        assert len(my_fixtures) == 2, "seed 1 sits out exactly one of the 3 rounds"
+        draw_first, draw_second = my_fixtures
+
+        # Out of draw order: the fixture draw-ordered SECOND gets the EARLIER time.
+        draw_first.scheduled_start = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+        draw_second.scheduled_start = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+        await db_session.commit()
+
+        def opponent_of(fixture: TournamentFixture) -> str:
+            other_id = (
+                fixture.entry_b_id
+                if fixture.entry_a_id == owner_entry.id
+                else fixture.entry_a_id
+            )
+            assert other_id is not None
+            return username_by_entry[other_id]
+
+        (panel,) = await _panels(client)
+
+    (event_out,) = panel["events"]
+    assert [row["opponent_username"] for row in event_out["fixtures"]] == [
+        opponent_of(draw_second),
+        opponent_of(draw_first),
+    ], (
+        "the 9 AM fixture (draw-ordered second) must lead the path list ahead of "
+        "the noon fixture (draw-ordered first) — time order, not draw order"
+    )
+
+
+async def test_untimed_fixtures_sort_last_and_keep_draw_order_among_themselves(
+    authed_client: tuple[AsyncClient, User],
+    db_session: AsyncSession,
+) -> None:
+    """A fixture with no time at all is not "soonest" by default — it sorts AFTER
+    every timed fixture, and untimed fixtures keep their relative draw order among
+    themselves (#1297).
+
+    A four-entrant round-robin pool seats the caller into all three rounds. Only
+    the middle one is given a time; the other two stay unplaced and must still come
+    out in draw order (round 1 before round 3), both trailing the one timed match."""
+    client, owner = authed_client
+    async with (
+        opponent_session(db_session, "sched-opp-4b") as (_client_2, user_2),
+        opponent_session(db_session, "sched-opp-4c") as (_client_3, user_3),
+        opponent_session(db_session, "sched-opp-4d") as (_client_4, user_4),
+    ):
+        tournament_id, (event,) = await _tournament_with_events(
+            client,
+            _rr_payload(
+                POOL_A,
+                match_settings={"rated": False, "length_games": 3},
+                predicates=[],
+            ),
+        )
+        base = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+        owner_entry, entry_2, entry_3, entry_4 = [
+            await _enter(
+                db_session,
+                event["id"],
+                user,
+                seed=seed,
+                created_at=base + timedelta(minutes=seed),
+            )
+            for seed, user in ((1, owner), (2, user_2), (3, user_3), (4, user_4))
+        ]
+        username_by_entry = {
+            owner_entry.id: owner.username,
+            entry_2.id: user_2.username,
+            entry_3.id: user_3.username,
+            entry_4.id: user_4.username,
+        }
+        await _cut_the_draw(client, tournament_id, event["id"])
+        await _set_status(db_session, tournament_id, TournamentStatus.published)
+        assert (await _go_live(client, tournament_id)).status_code == 201
+
+        rows = await _fixture_rows(db_session, event["id"])
+        my_fixtures = sorted(
+            (f for f in rows if owner_entry.id in (f.entry_a_id, f.entry_b_id)),
+            key=lambda f: f.round,
+        )
+        assert len(my_fixtures) == 3, "a 4-entrant pool plays every round"
+        round_1, round_2, round_3 = my_fixtures
+
+        # Only the middle round gets a time; rounds 1 and 3 stay unplaced.
+        round_2.scheduled_start = datetime(2026, 6, 1, 9, 0, tzinfo=UTC)
+        await db_session.commit()
+
+        def opponent_of(fixture: TournamentFixture) -> str:
+            other_id = (
+                fixture.entry_b_id
+                if fixture.entry_a_id == owner_entry.id
+                else fixture.entry_a_id
+            )
+            assert other_id is not None
+            return username_by_entry[other_id]
+
+        (panel,) = await _panels(client)
+
+    (event_out,) = panel["events"]
+    assert [row["opponent_username"] for row in event_out["fixtures"]] == [
+        opponent_of(round_2),
+        opponent_of(round_1),
+        opponent_of(round_3),
+    ], (
+        "the timed fixture leads; the two untimed ones trail it in draw order "
+        "(round 1 before round 3), not swapped or interleaved"
+    )

--- a/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
+++ b/docs/adr/0786-a-draw-is-cut-explicitly-and-advanced-idempotently.md
@@ -8,6 +8,12 @@ concurrent worktrees, as the duplicate 0008s in this directory attest)
 Accepted — design for slices B/C of epic #780 (#785, #786, #788, #789), decided
 before implementation.
 
+Amended for one consumer by `20260815-the-dashboards-your-matches-path-sorts-
+by-time-not-draw-order.md` (#1297): the dashboard's "Your matches" path list
+sorts by scheduled time rather than by this ADR's pool → round → position
+order. `fixtures_by_event`'s own ordering, and every other reader of it, is
+unchanged.
+
 ## Context
 
 `DrawType` (single-elim / double-elim / round-robin / rr-then-ko / swiss) has

--- a/docs/adr/20260815-the-dashboards-your-matches-path-sorts-by-time-not-draw-order.md
+++ b/docs/adr/20260815-the-dashboards-your-matches-path-sorts-by-time-not-draw-order.md
@@ -1,0 +1,54 @@
+# The dashboard's "Your matches" path sorts by time, not draw order
+
+Date: 2026-08-15 (date-numbered — sequential numbers collide across concurrent
+worktrees; see `scripts/check-adr-numbering.sh`)
+
+## Status
+
+Accepted. Fixes #1297. Amends ADR-0786 (`0786-a-draw-is-cut-explicitly-and-
+advanced-idempotently.md`) for one consumer only — see Scope below.
+
+## Context
+
+`app.dashboard_tournaments.build_tournament_panels` builds each event's "Your
+matches" path — the caller's own fixtures, listed as `M1`, `M2`, `M3`, ... — from
+`fixtures_by_event`, which returns every event's draw in **pool → round →
+position** order (ADR-0786). The path list inherited that order unchanged.
+
+Draw order is not schedule order once a director calls fixtures onto real
+tables: `M1` might be called for noon, `M2` for 9:00 AM, `M3` for 9:45 AM. A
+player reading the path top-to-bottom to see what is next went to the noon
+match and missed the 9:00 AM one.
+
+## Decision
+
+**The path list is sorted by effective time ascending** — `pinned_at`, falling
+back to `scheduled_start`, the same precedence the card's own time label already
+uses (ADR "the schedule is solved, the call is pinned"). A fixture with neither
+sorts LAST, after every timed one, keeping its relative draw order among other
+untimed fixtures — so a not-yet-placed fixture does not jump to the top just for
+lacking a time.
+
+The focus-match pick (`_focus_fixture`) is unchanged in structure but now reads
+consistently off the sorted list: among not-yet-played fixtures, the earliest by
+effective time wins, with untimed fixtures falling back to draw order among
+themselves.
+
+## Scope — this does not touch `fixtures_by_event`
+
+`fixtures_by_event`'s pool → round → position order stays exactly as ADR-0786
+specifies it. That loader is shared with bracket rendering and other consumers
+that need the draw's own topology, not a schedule. Only
+`dashboard_tournaments.py`'s caller-scoped `my_fixtures` list — built from that
+loader's output — is re-sorted, in the dashboard module, after the shared query
+runs. Nothing about the query, the migration, or ADR-0786's fixture model
+changes.
+
+## Consequences
+
+- A player's own schedule reads top-to-bottom in the order they will actually
+  play it, regardless of which pool or round a fixture belongs to.
+- Two fixtures that happen to share a placed time keep their draw-order relative
+  position (a stable sort), so the ordering is still deterministic.
+- Any other reader of `fixtures_by_event` is unaffected; this decision is scoped
+  to the dashboard's own projection.

--- a/ios/Fortymm/Generated/Types.swift
+++ b/ios/Fortymm/Generated/Types.swift
@@ -4291,7 +4291,8 @@ internal enum Components {
             }
         }
         /// One line of the panel's "Your matches" path — every fixture in this event the
-        /// caller is a side of, in draw order.
+        /// caller is a side of, ordered by scheduled time ascending (untimed fixtures last,
+        /// in draw order among themselves — #1297).
         ///
         /// ``detail`` is the row's right-hand text, composed server-side because what belongs
         /// there changes with ``state`` (a result, "In progress", or a time and table). The

--- a/web-client/src/api/schema.d.ts
+++ b/web-client/src/api/schema.d.ts
@@ -2315,7 +2315,8 @@ export interface components {
         /**
          * DashboardTournamentFixtureRow
          * @description One line of the panel's "Your matches" path — every fixture in this event the
-         *     caller is a side of, in draw order.
+         *     caller is a side of, ordered by scheduled time ascending (untimed fixtures last,
+         *     in draw order among themselves — #1297).
          *
          *     ``detail`` is the row's right-hand text, composed server-side because what belongs
          *     there changes with ``state`` (a result, "In progress", or a time and table). The


### PR DESCRIPTION
## What

The dashboard's "Your matches" list rendered a player's fixtures in draw order (pool → round → position), so scheduled times ran out of order — a player reading top-to-bottom would head to the noon match and miss the 9:00 AM one. The times are the actionable content on that surface.

## Fix (server-side, in the BFF)

- `api/app/dashboard_tournaments.py`: each event's caller-scoped path list is now stable-sorted by effective time (`pinned_at or scheduled_start`, the same value the row has always displayed). Untimed fixtures sort last, keeping draw order among themselves. The underlying `fixtures_by_event` query order is untouched — other consumers (bracket rendering) still get draw order.
- `_focus_fixture` needed no code change (it reads the pre-sorted list); its docstring now states the chronological behavior.
- ADR `20260815-the-dashboards-your-matches-path-sorts-by-time-not-draw-order` records the ordering decision, with a linking amendment note in ADR 0786 (no rewrite of the original).
- `DashboardTournamentFixtureRow`'s pydantic docstring changed, so `schema.d.ts` and iOS `Types.swift` are regenerated in this PR (description-only diff).

## Verified

- Two new tests in `test_dashboard_tournaments.py`: draw order and time order disagree → response arrives time-ordered; untimed fixtures trail the timed one in draw order. Both falsified — with the fix stashed, each fails for exactly the stated reason.
- Full api suite: 2349 passed. mypy: clean over 172 files. ruff check + format: clean. `scripts/check-adr-numbering.sh`: clean.
- Drift confirmed empirically before regen by reading `app.openapi()`'s description for the changed schema.

Closes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198KTDWfcjdfCVPNVyRCZnP